### PR TITLE
Add CPU sampler with temperature, top-k, and top-p support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "serde",
  "version_check",
@@ -228,6 +228,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +346,15 @@ dependencies = [
  "once_cell",
  "unicode-width",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -546,7 +566,7 @@ dependencies = [
  "fastrace-macro",
  "parking_lot",
  "pin-project",
- "rand",
+ "rand 0.9.2",
  "rtrb",
  "serde",
 ]
@@ -574,6 +594,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -636,6 +662,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core 0.10.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,9 +684,18 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
- "rand",
+ "rand 0.9.2",
  "rand_distr",
  "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -657,7 +706,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
  "serde",
  "serde_core",
 ]
@@ -751,10 +800,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "indicatif"
@@ -849,6 +916,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1201,6 +1274,7 @@ dependencies = [
  "log",
  "logforth",
  "ndarray",
+ "rand 0.10.0",
  "safetensors",
  "serde",
  "serde_json",
@@ -1306,6 +1380,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,7 +1442,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -1368,7 +1463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1377,8 +1472,14 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_distr"
@@ -1387,7 +1488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -1489,7 +1590,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.1",
  "serde",
  "serde_json",
 ]
@@ -1508,6 +1609,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -1791,7 +1898,7 @@ dependencies = [
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
- "getrandom",
+ "getrandom 0.3.4",
  "indicatif",
  "itertools 0.14.0",
  "log",
@@ -1799,7 +1906,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand",
+ "rand 0.9.2",
  "rayon",
  "rayon-cond",
  "regex",
@@ -1923,6 +2030,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1946,7 +2059,7 @@ version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -2016,7 +2129,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -2062,6 +2184,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -2209,6 +2365,94 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ logforth = { version = "0.29", features = ["starter-log", "layout-text", "diagno
 colored = "3"
 fastrace = { version = "0.7.16", features = ["enable"] }
 clap = { version = "4.5.57", features = ["derive"] }
+rand = "0.10"
 
 [features]
 reference = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,4 @@ pub mod weight_loader;
 pub mod logging;
 pub mod tokenizer;
 pub mod trace_reporter;
+pub mod sampler;

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -1,0 +1,319 @@
+//! CPU sampling: temperature, top-k, top-p (nucleus).
+
+use rand::Rng;
+use rand::RngExt;
+
+pub struct SamplingParams {
+    pub temperature: f32,
+    pub top_k: i32,
+    pub top_p: f32,
+}
+
+impl Default for SamplingParams {
+    fn default() -> Self {
+        Self {
+            temperature: 0.0,
+            top_k: -1,
+            top_p: 1.0,
+        }
+    }
+}
+
+impl SamplingParams {
+    pub fn is_greedy(&self) -> bool {
+        (self.temperature <= 0.0 || self.top_k == 1) && self.top_p >= 1.0
+    }
+}
+
+/// Sample a token from logits using temperature, top-k, and top-p.
+///
+/// Pipeline: temperature scale → top-k truncate → softmax → top-p truncate → multinomial.
+pub fn sample(logits: &[f32], params: &SamplingParams, rng: &mut impl Rng) -> u32 {
+    assert!(!logits.is_empty(), "sample() called with empty logits");
+
+    let temperature = params.temperature;
+
+    // t <= 0 means greedy — return argmax
+    if temperature <= 0.0 {
+        return logits
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.total_cmp(b.1))
+            .unwrap()
+            .0 as u32;
+    }
+
+    // (index, scaled_logit) pairs
+    let mut candidates: Vec<(u32, f32)> = logits
+        .iter()
+        .enumerate()
+        .map(|(i, &l)| (i as u32, l / temperature))
+        .collect();
+
+    // Sort descending by logit
+    candidates.sort_unstable_by(|a, b| b.1.total_cmp(&a.1));
+
+    // Top-k: keep only top k candidates
+    if params.top_k > 0 && (params.top_k as usize) < candidates.len() {
+        candidates.truncate(params.top_k as usize);
+    }
+
+    // Softmax
+    let max_logit = candidates[0].1;
+    let mut probs: Vec<f32> = candidates.iter().map(|(_, l)| (l - max_logit).exp()).collect();
+    let sum: f32 = probs.iter().sum();
+    for p in &mut probs {
+        *p /= sum;
+    }
+
+    // Top-p: cumulative probability cutoff
+    if params.top_p < 1.0 {
+        let mut cumsum = 0.0f32;
+        let mut cutoff = probs.len();
+        for (i, &p) in probs.iter().enumerate() {
+            cumsum += p;
+            if cumsum > params.top_p {
+                cutoff = i + 1;
+                break;
+            }
+        }
+        candidates.truncate(cutoff);
+        probs.truncate(cutoff);
+
+        // Re-normalize
+        let sum: f32 = probs.iter().sum();
+        for p in &mut probs {
+            *p /= sum;
+        }
+    }
+
+    // Multinomial sample
+    let r: f32 = rng.random();
+    let mut cumsum = 0.0f32;
+    for (i, &p) in probs.iter().enumerate() {
+        cumsum += p;
+        if r < cumsum {
+            return candidates[i].0;
+        }
+    }
+
+    // Fallback for numerical edge case
+    candidates.last().unwrap().0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    #[test]
+    fn test_greedy_defaults() {
+        let params = SamplingParams::default();
+        assert!(params.is_greedy());
+    }
+
+    #[test]
+    fn test_greedy_top_k_1() {
+        let params = SamplingParams {
+            temperature: 0.7,
+            top_k: 1,
+            top_p: 1.0,
+        };
+        assert!(params.is_greedy());
+    }
+
+    #[test]
+    fn test_not_greedy() {
+        let params = SamplingParams {
+            temperature: 0.7,
+            top_k: -1,
+            top_p: 1.0,
+        };
+        assert!(!params.is_greedy());
+    }
+
+    #[test]
+    fn test_sample_deterministic_with_seed() {
+        let logits = vec![1.0, 2.0, 3.0, 0.5];
+        let params = SamplingParams {
+            temperature: 1.0,
+            top_k: -1,
+            top_p: 1.0,
+        };
+        let mut rng1 = StdRng::seed_from_u64(42);
+        let mut rng2 = StdRng::seed_from_u64(42);
+        let t1 = sample(&logits, &params, &mut rng1);
+        let t2 = sample(&logits, &params, &mut rng2);
+        assert_eq!(t1, t2);
+    }
+
+    #[test]
+    fn test_sample_top_k_1_picks_argmax() {
+        let logits = vec![1.0, 5.0, 3.0, 2.0];
+        let params = SamplingParams {
+            temperature: 1.0,
+            top_k: 1,
+            top_p: 1.0,
+        };
+        let mut rng = StdRng::seed_from_u64(0);
+        let token = sample(&logits, &params, &mut rng);
+        assert_eq!(token, 1); // index of max logit
+    }
+
+    #[test]
+    fn test_sample_respects_top_p() {
+        // One dominant logit — with very low top_p, should always pick it
+        let mut logits = vec![0.0; 100];
+        logits[42] = 100.0;
+        let params = SamplingParams {
+            temperature: 1.0,
+            top_k: -1,
+            top_p: 0.1,
+        };
+        let mut rng = StdRng::seed_from_u64(123);
+        for _ in 0..10 {
+            assert_eq!(sample(&logits, &params, &mut rng), 42);
+        }
+    }
+
+    #[test]
+    fn test_sample_temperature_zero_returns_argmax() {
+        let logits = vec![1.0, 5.0, 3.0, 2.0];
+        let params = SamplingParams {
+            temperature: 0.0,
+            top_k: -1,
+            top_p: 1.0,
+        };
+        let mut rng = StdRng::seed_from_u64(0);
+        assert_eq!(sample(&logits, &params, &mut rng), 1);
+    }
+
+    #[test]
+    fn test_negative_temperature_is_greedy() {
+        let logits = vec![1.0, 5.0, 3.0];
+        let params = SamplingParams {
+            temperature: -1.0,
+            top_k: -1,
+            top_p: 1.0,
+        };
+        let mut rng = StdRng::seed_from_u64(0);
+        assert_eq!(sample(&logits, &params, &mut rng), 1);
+    }
+
+    #[test]
+    fn test_single_logit() {
+        let logits = vec![42.0];
+        let params = SamplingParams { temperature: 1.0, top_k: -1, top_p: 1.0 };
+        let mut rng = StdRng::seed_from_u64(0);
+        assert_eq!(sample(&logits, &params, &mut rng), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "empty logits")]
+    fn test_empty_logits_panics() {
+        let logits: Vec<f32> = vec![];
+        let params = SamplingParams { temperature: 1.0, top_k: -1, top_p: 1.0 };
+        let mut rng = StdRng::seed_from_u64(0);
+        sample(&logits, &params, &mut rng);
+    }
+
+    #[test]
+    fn test_negative_logits_argmax() {
+        let logits = vec![-10.0, -5.0, -20.0, -1.0];
+        let params = SamplingParams { temperature: 0.0, top_k: -1, top_p: 1.0 };
+        let mut rng = StdRng::seed_from_u64(0);
+        assert_eq!(sample(&logits, &params, &mut rng), 3); // -1.0 is largest
+    }
+
+    #[test]
+    fn test_top_k_restricts_candidates() {
+        // logits: idx=0 is highest, idx=1 second, idx=2 third, rest are low
+        let mut logits = vec![-100.0; 20];
+        logits[0] = 5.0;
+        logits[1] = 4.0;
+        logits[2] = 3.0;
+        let params = SamplingParams { temperature: 1.0, top_k: 3, top_p: 1.0 };
+        let mut rng = StdRng::seed_from_u64(0);
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..200 {
+            seen.insert(sample(&logits, &params, &mut rng));
+        }
+        // Only tokens 0, 1, 2 should ever appear
+        assert!(seen.is_subset(&[0u32, 1, 2].iter().copied().collect()));
+        // All three should appear with enough samples
+        assert_eq!(seen.len(), 3);
+    }
+
+    #[test]
+    fn test_low_temperature_concentrates() {
+        // Very low temperature → almost always picks argmax
+        let logits = vec![1.0, 2.0, 10.0, 3.0];
+        let params = SamplingParams { temperature: 0.01, top_k: -1, top_p: 1.0 };
+        let mut rng = StdRng::seed_from_u64(0);
+        let n = 500;
+        let count_argmax = (0..n).filter(|_| sample(&logits, &params, &mut rng) == 2).count();
+        assert!(count_argmax == n, "t=0.01: expected all argmax, got {}/{}", count_argmax, n);
+    }
+
+    #[test]
+    fn test_high_temperature_spreads() {
+        // Very high temperature → nearly uniform, all 4 tokens should appear
+        let logits = vec![1.0, 2.0, 3.0, 4.0];
+        let params = SamplingParams { temperature: 100.0, top_k: -1, top_p: 1.0 };
+        let mut rng = StdRng::seed_from_u64(0);
+        let mut counts = [0u32; 4];
+        let n = 2000;
+        for _ in 0..n {
+            counts[sample(&logits, &params, &mut rng) as usize] += 1;
+        }
+        // Each token should appear at least 15% of the time (uniform = 25%)
+        for (i, &c) in counts.iter().enumerate() {
+            assert!(c > (n as u32) * 15 / 100,
+                "token {} appeared only {}/{} times, expected ~25%", i, c, n);
+        }
+    }
+
+    #[test]
+    fn test_equal_logits_uniform() {
+        let logits = vec![0.0; 5];
+        let params = SamplingParams { temperature: 1.0, top_k: -1, top_p: 1.0 };
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut counts = [0u32; 5];
+        let n = 2000;
+        for _ in 0..n {
+            counts[sample(&logits, &params, &mut rng) as usize] += 1;
+        }
+        // Each should appear at least 10% (uniform = 20%)
+        for (i, &c) in counts.iter().enumerate() {
+            assert!(c > (n as u32) * 10 / 100,
+                "token {} appeared only {}/{} times, expected ~20%", i, c, n);
+        }
+    }
+
+    #[test]
+    fn test_top_k_and_top_p_combined() {
+        // 5 tokens, top_k=3 keeps top 3, then top_p=0.5 further narrows
+        // logits: [10, 9, 1, 0, 0] → after top_k=3: [10, 9, 1]
+        // softmax(10,9,1) ≈ [0.731, 0.269, 0.0007] → cumsum > 0.5 at idx=0
+        // so top_p=0.5 keeps only token 0
+        let logits = vec![10.0, 9.0, 1.0, 0.0, 0.0];
+        let params = SamplingParams { temperature: 1.0, top_k: 3, top_p: 0.5 };
+        let mut rng = StdRng::seed_from_u64(0);
+        for _ in 0..50 {
+            let t = sample(&logits, &params, &mut rng);
+            assert!(t == 0, "expected only token 0 with top_k=3 + top_p=0.5, got {}", t);
+        }
+    }
+
+    #[test]
+    fn test_top_p_small_picks_top_only() {
+        // top_p just above 0 — only the single highest-probability token survives
+        let logits = vec![3.0, 1.0, 2.0, 1.0];
+        let params = SamplingParams { temperature: 1.0, top_k: -1, top_p: 0.01 };
+        let mut rng = StdRng::seed_from_u64(0);
+        for _ in 0..50 {
+            assert_eq!(sample(&logits, &params, &mut rng), 0);
+        }
+    }
+}

--- a/tests/bench_decode.rs
+++ b/tests/bench_decode.rs
@@ -7,7 +7,10 @@
 //!   nsys stats decode_trace.nsys-rep
 
 use pegainfer::model::Qwen3Model;
+use pegainfer::sampler::SamplingParams;
 use pegainfer::tokenizer::Tokenizer;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
 use std::time::Instant;
 
 const MODEL_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/models/Qwen3-4B");
@@ -22,15 +25,18 @@ fn bench_decode_steps() {
     let prompt = "Tell me a story";
     let prompt_tokens = tokenizer.encode(prompt).expect("encode failed");
 
+    let mut rng = StdRng::seed_from_u64(42);
+    let greedy = SamplingParams::default();
+
     // Warmup: prefill + a few decode steps (cuBLAS warmup, JIT, etc.)
     eprintln!("[warmup] prefill + 5 decode steps...");
-    let warmup_tokens = model.generate(&prompt_tokens, 6).expect("warmup failed");
+    let warmup_tokens = model.generate(&prompt_tokens, 6, &greedy, &mut rng).expect("warmup failed");
     eprintln!("[warmup] done, {} tokens total", warmup_tokens.len());
 
     // Now do a fresh generate with 20 decode steps for profiling
     eprintln!("[bench] prefill + 20 decode steps...");
     let start = Instant::now();
-    let tokens = model.generate(&prompt_tokens, 21).expect("bench failed");
+    let tokens = model.generate(&prompt_tokens, 21, &greedy, &mut rng).expect("bench failed");
     let elapsed = start.elapsed();
 
     let decode_tokens = tokens.len() - prompt_tokens.len();

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -5,8 +5,11 @@ use fastrace::prelude::*;
 use log::info;
 
 use pegainfer::model::Qwen3Model;
+use pegainfer::sampler::SamplingParams;
 use pegainfer::tokenizer::Tokenizer;
 use pegainfer::trace_reporter::FileReporter;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
 
 const MODEL_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/models/Qwen3-4B");
 
@@ -51,6 +54,9 @@ fn test_e2e_generation() {
         ("Write a Python function to reverse a string", 80),
     ];
 
+    let mut rng = StdRng::seed_from_u64(42);
+    let greedy = SamplingParams::default();
+
     for (prompt, max_tokens) in &cases {
         info!("=== Test: \"{}\" ===", prompt);
 
@@ -62,7 +68,7 @@ fn test_e2e_generation() {
 
         let start = Instant::now();
         let output_tokens = model
-            .generate(&prompt_tokens, *max_tokens)
+            .generate(&prompt_tokens, *max_tokens, &greedy, &mut rng)
             .expect("Generation failed");
         let elapsed = start.elapsed();
 


### PR DESCRIPTION
Introduce SamplingParams and a naive CPU sampling pipeline (temperature scaling → top-k → softmax → top-p → multinomial). Greedy path (t<=0) stays on GPU argmax to avoid D2H copy. 17 unit tests covering edge cases and distribution properties.