### PR TITLE
Investigate TPOT gap and fix benchmark accounting

### DIFF
--- a/src/http_server/mod.rs
+++ b/src/http_server/mod.rs
@@ -9,15 +9,14 @@ use axum::response::{IntoResponse, Response};
 use axum::{Json, Router, extract::State, http::StatusCode, routing::post};
 use fastrace::local::LocalSpan;
 use fastrace::prelude::*;
-use futures_util::stream;
+use futures_util::{StreamExt, stream};
 use log::{error, info, warn};
 use tokio::sync::Mutex;
-use tokio_stream::StreamExt;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use crate::sampler::SamplingParams;
 use crate::server_engine::{CompleteRequest, ServerEngine};
-use openai_v1::{CompletionRequest, CompletionResponse, StreamChunk};
+use openai_v1::{CompletionRequest, CompletionResponse, StreamChunk, StreamUsageChunk};
 
 struct AppState {
     engine: Mutex<Box<dyn ServerEngine>>,
@@ -36,6 +35,7 @@ async fn completions(
 ) -> Result<Response, StatusCode> {
     let max_tokens = req.max_tokens_or_default();
     let stream = req.stream_or_default();
+    let include_usage = req.include_usage_or_default();
     let requested_model = req.model.clone();
     let loaded_model = {
         let guard = state.engine.lock().await;
@@ -92,10 +92,24 @@ async fn completions(
             }
         });
 
-        let stream = UnboundedReceiverStream::new(rx).map(move |delta| {
+        let stream = UnboundedReceiverStream::new(rx).flat_map(move |delta| {
+            let usage = delta.usage;
+            let is_terminal = delta.finish_reason.is_some();
+
             let chunk = StreamChunk::from_delta(&request_id, created, &loaded_model, delta);
-            let json = serde_json::to_string(&chunk).unwrap();
-            Ok::<_, Infallible>(Event::default().data(json))
+            let mut events = vec![Ok::<_, Infallible>(
+                Event::default().data(serde_json::to_string(&chunk).unwrap()),
+            )];
+
+            if include_usage && is_terminal && let Some(usage) = usage {
+                let usage_chunk =
+                    StreamUsageChunk::from_usage(&request_id, created, &loaded_model, usage);
+                events.push(Ok(Event::default().data(
+                    serde_json::to_string(&usage_chunk).unwrap(),
+                )));
+            }
+
+            stream::iter(events)
         });
 
         let done_stream =
@@ -190,10 +204,16 @@ mod tests {
             let _ = tx.send(StreamDelta {
                 text_delta: "ok".to_string(),
                 finish_reason: None,
+                usage: None,
             });
             let _ = tx.send(StreamDelta {
                 text_delta: String::new(),
                 finish_reason: Some(FinishReason::Stop),
+                usage: Some(Usage {
+                    prompt_tokens: 1,
+                    completion_tokens: 1,
+                    total_tokens: 2,
+                }),
             });
             Ok(())
         }
@@ -248,5 +268,26 @@ mod tests {
             "payload={payload}"
         );
         assert!(payload.contains("[DONE]"));
+    }
+
+    #[tokio::test]
+    async fn streaming_response_includes_usage_when_requested() {
+        let app = build_app(Box::new(MockEngine::new("Qwen3-4B")));
+        let request = Request::builder()
+            .method("POST")
+            .uri("/v1/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"model":"qwen3-4b","prompt":"hello","max_tokens":1,"stream":true,"stream_options":{"include_usage":true}}"#,
+            ))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let payload = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(payload.contains(r#""usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}"#), "payload={payload}");
     }
 }

--- a/src/http_server/openai_v1.rs
+++ b/src/http_server/openai_v1.rs
@@ -14,8 +14,14 @@ pub(super) struct CompletionRequest {
     #[allow(dead_code)]
     pub(super) n: Option<usize>,
     pub(super) stream: Option<bool>,
+    pub(super) stream_options: Option<StreamOptions>,
     #[allow(dead_code)]
     pub(super) stop: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct StreamOptions {
+    pub(super) include_usage: Option<bool>,
 }
 
 impl CompletionRequest {
@@ -25,6 +31,13 @@ impl CompletionRequest {
 
     pub(super) fn stream_or_default(&self) -> bool {
         self.stream.unwrap_or(false)
+    }
+
+    pub(super) fn include_usage_or_default(&self) -> bool {
+        self.stream_options
+            .as_ref()
+            .and_then(|options| options.include_usage)
+            .unwrap_or(false)
     }
 }
 
@@ -113,6 +126,36 @@ impl StreamChunk {
                     .finish_reason
                     .map(|reason| reason.as_openai_str().to_string()),
             }],
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct StreamUsageChunk {
+    id: String,
+    object: &'static str,
+    created: u64,
+    model: String,
+    usage: Usage,
+}
+
+impl StreamUsageChunk {
+    pub(super) fn from_usage(
+        request_id: &str,
+        created: u64,
+        model: &str,
+        usage: crate::server_engine::Usage,
+    ) -> Self {
+        Self {
+            id: request_id.to_string(),
+            object: "text_completion",
+            created,
+            model: model.to_string(),
+            usage: Usage {
+                prompt_tokens: usage.prompt_tokens,
+                completion_tokens: usage.completion_tokens,
+                total_tokens: usage.total_tokens,
+            },
         }
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -747,9 +747,7 @@ impl Qwen3Model {
 
         tokens.push(next_token);
 
-        // Take persistent decode state from self (avoids borrow conflicts)
-        let mut bufs = self.take_decode_bufs()?;
-        let mut graph_state = self.take_graph_state();
+        // Reuse the decode state and captured CUDA graph from the first token.
 
         // Generate new tokens using pre-allocated buffers + CUDA Graph
         let tpot_start = Instant::now();

--- a/src/server_engine.rs
+++ b/src/server_engine.rs
@@ -38,6 +38,7 @@ pub struct CompleteOutput {
     pub usage: Usage,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Usage {
     pub prompt_tokens: usize,
     pub completion_tokens: usize,
@@ -47,6 +48,7 @@ pub struct Usage {
 pub struct StreamDelta {
     pub text_delta: String,
     pub finish_reason: Option<FinishReason>,
+    pub usage: Option<Usage>,
 }
 
 pub trait ServerEngine: Send {
@@ -241,6 +243,7 @@ impl<M: GenerativeModel> ServerEngine for GenericServerEngine<M> {
                     .send(StreamDelta {
                         text_delta,
                         finish_reason: None,
+                        usage: None,
                     })
                     .is_ok(),
                 Ok(None) => true,
@@ -263,6 +266,7 @@ impl<M: GenerativeModel> ServerEngine for GenericServerEngine<M> {
             let _ = tx.send(StreamDelta {
                 text_delta,
                 finish_reason: None,
+                usage: None,
             });
         }
 
@@ -275,6 +279,11 @@ impl<M: GenerativeModel> ServerEngine for GenericServerEngine<M> {
         let _ = tx.send(StreamDelta {
             text_delta: String::new(),
             finish_reason: Some(finish_reason),
+            usage: Some(Usage {
+                prompt_tokens: prompt_tokens.len(),
+                completion_tokens: stats.emitted_tokens,
+                total_tokens: prompt_tokens.len() + stats.emitted_tokens,
+            }),
         });
 
         Ok(())


### PR DESCRIPTION
## Summary
- explain the TPOT gap with concrete repro paths and benchmark evidence
- reuse the captured CUDA graph in Qwen3 non-streaming decode instead of recapturing every request
- emit streamed usage chunks when `stream_options.include_usage=true` so `vllm bench serve` uses real completion token counts

## Evidence
- exact benchmark harness: `/home/node/.openclaw/workspace/out/benchmarks/20260308-145932-pega-vllm-4b-http/run_matrix.sh`
- reproduced benchmark result on the live server: `vllm bench serve` at `1 -> 256` still shows ~14ms class TPOT because decode cost rises with sequence length
- sweep on the same live server showed output-length dependence: ~9.9ms at 32, ~10.9ms at 64, ~13.8ms at 128, ~14.8ms at 256
- benchmark client computes TPOT from `(latency - ttft) / (output_len - 1)` and, without streamed usage, falls back to re-tokenizing generated text
- after adding streamed usage, the same `1 -> 256` benchmark dropped from ~14.8ms to ~13.4ms for the sampled run, much closer to pegainfer's internal per-request TPOT mix

## Validation
- `cargo build --release --offline`
- live GPU validation against patched server:
  - second non-streaming request no longer recaptures the CUDA graph
  - streaming responses now emit a usage chunk before `[DONE]` when requested
  - reran `vllm bench serve` against the patched server to confirm benchmark accounting improvement

## Notes
- The remaining gap is mostly not HTTP overhead; it is a mix of benchmark methodology (first visible text chunk / text-token counting) and real long-context decode scaling in attention.
- I stopped short of kernel changes because the evidence points there for the remaining gap, and that would be a risky optimization path.