### PR TITLE
fix(server): enable TCP_NODELAY to eliminate 30ms SSE streaming latency

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,6 @@
 | Path | TL;DR |
 | --- | --- |
 | `projects/landing.md` | New-developer onboarding — toolchain, unified venv, build, tests, benchmark smoke test |
-| `projects/perf-parity-vllm.md` | Decode at parity, prefill 2x behind vLLM. Measured baseline and next steps |
+| `projects/perf-parity-vllm.md` | Decode and fixed overhead ahead of vLLM. Prefill 2x behind. TCP_NODELAY fix eliminated 30ms overhead |
 | `resources/profiling-guide.md` | GPU profiling playbook: nsys pitfalls, diagnostic paths, measured kernel comparisons |
 | `resources/bench-vs-vllm.md` | pegainfer vs vLLM comparative benchmarking: method, workflow, typical configs, gotchas |

--- a/docs/projects/perf-parity-vllm.md
+++ b/docs/projects/perf-parity-vllm.md
@@ -1,6 +1,6 @@
 # Performance Parity With vLLM
 
-> **TL;DR:** Decode is at parity. Prefill is 2x behind vLLM. Goal: match or exceed vLLM on all workloads.
+> **TL;DR:** Decode and fixed overhead both ahead of vLLM. Prefill is 2x behind. Goal: match or exceed vLLM on all workloads.
 >
 > **Status:** Active. Next action: investigate prefill GEMM strategy.
 
@@ -8,19 +8,29 @@
 
 pegainfer single-request latency >= vLLM on the same GPU, model, and workload. No regressions allowed — decode must stay at parity while prefill catches up.
 
-## Baseline (2026-03-13)
+## Current (2026-03-13, post TCP_NODELAY fix)
 
 GPU: RTX 5070 Ti, Model: Qwen3-4B, vLLM 0.17.1, single concurrency.
+
+### in=1, out=1 — Minimal overhead
+
+| Metric | pegainfer | vLLM | delta |
+|--------|-----------|------|-------|
+| TTFT median | 11.89ms | 19.29ms | **-38% faster** |
+| TTFT p99 | 12.54ms | 20.27ms | **-38% faster** |
+| req/s | 82.53 | 51.43 | **+60%** |
+
+Verdict: **pegainfer wins.** Fixed overhead eliminated by TCP_NODELAY.
 
 ### in=1024, out=256 — Realistic workload
 
 | Metric | pegainfer | vLLM | delta |
 |--------|-----------|------|-------|
-| TTFT median | 124.66ms | 118.23ms | +5% slower |
-| TTFT p99 | 350.95ms | 290.27ms | +21% |
+| TTFT median | 124.74ms | 118.23ms | +5% slower |
+| TTFT p99 | 308.71ms | 290.27ms | +6% |
 | TPOT median | 11.18ms | 11.51ms | **-3% faster** |
 | TPOT p99 | 11.19ms | 11.61ms | **-4% faster** |
-| Output tok/s | 85.61 | 83.50 | **+2.5%** |
+| Output tok/s | 85.69 | 83.50 | **+2.6%** |
 
 Verdict: parity. Decode slightly ahead, prefill slightly behind.
 
@@ -28,31 +38,37 @@ Verdict: parity. Decode slightly ahead, prefill slightly behind.
 
 | Metric | pegainfer | vLLM | delta |
 |--------|-----------|------|-------|
-| TTFT median | 42.45ms | 21.55ms | +97% slower |
-| TPOT median | 10.56ms | 11.46ms | **-8% faster** |
-| TPOT p99 | 10.58ms | 11.46ms | **-8% faster** |
-| Output tok/s | 94.13 | 87.33 | **+7.8%** |
+| TTFT median | 12.20ms | 21.55ms | **-43% faster** |
+| TPOT median | 10.62ms | 11.46ms | **-7% faster** |
+| TPOT p99 | 10.62ms | 11.46ms | **-7% faster** |
+| Output tok/s | 94.14 | 87.33 | **+7.8%** |
 
-Verdict: **decode wins.** pegainfer 8% faster TPOT on sustained decode. TTFT overhead same as in=1/out=1.
+Verdict: **decode wins.** pegainfer 7% faster TPOT, 43% faster TTFT.
 
 ### in=2048, out=32 — Prefill heavy
 
 | Metric | pegainfer | vLLM | delta |
 |--------|-----------|------|-------|
-| TTFT median | 269.12ms | 133.00ms | **+102% slower** |
-| TTFT p99 | 276.03ms | 230.96ms | +20% |
-| TPOT median | 11.83ms | 11.59ms | +2% |
-| TPOT p99 | 11.84ms | 11.64ms | +2% |
+| TTFT median | 270.69ms | 133.00ms | **+103% slower** |
+| TTFT p99 | 274.11ms | 230.96ms | +19% |
+| TPOT median | 11.86ms | 11.59ms | +2% |
+| TPOT p99 | 11.87ms | 11.64ms | +2% |
 
 Verdict: **prefill is 2x behind.** This is the main gap.
 
-### in=1, out=1 — Minimal overhead
+## Changelog
 
-| Metric | pegainfer | vLLM | delta |
-|--------|-----------|------|-------|
-| TTFT median | 41.89ms | 19.29ms | **+117% slower** |
-| TTFT p99 | 42.89ms | 20.27ms | +112% |
-| req/s | 23.78 | 51.43 | -54% |
+### 2026-03-13: TCP_NODELAY fix
 
-Verdict: **fixed overhead is 2x higher.** Likely CUDA Graph capture or first-token path cost.
+**Root cause:** axum's default TCP socket lacked `TCP_NODELAY`. With HTTP keep-alive, Nagle's algorithm buffered the final SSE bytes, waiting ~30ms for a delayed ACK before the client could reuse the connection.
 
+**Diagnosis path:** bench_serving (in-process) showed 10.36ms TTFT while `vllm bench serve` (HTTP) showed 42ms. Isolated with curl (11ms) vs Python aiohttp shared session (41ms vs 11ms with new session per request). This pinpointed TCP buffering on keep-alive connections.
+
+**Fix:** One line — `tcp_stream.set_nodelay(true)` via `axum::serve::ListenerExt::tap_io`.
+
+**Impact on in=1, out=1:**
+- TTFT: 41.89ms → 11.89ms (3.5x)
+- req/s: 23.78 → 82.53 (3.5x)
+- Now 38% faster than vLLM (was 117% slower)
+
+No regression on decode or prefill workloads.

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,10 +91,15 @@ async fn main() {
     info!("Server listening on {}", addr);
 
     let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
-        .await
-        .unwrap();
+    axum::serve(
+        axum::serve::ListenerExt::tap_io(listener, |tcp_stream| {
+            let _ = tcp_stream.set_nodelay(true);
+        }),
+        app,
+    )
+    .with_graceful_shutdown(shutdown_signal())
+    .await
+    .unwrap();
 
     if args.trace_output_path.is_some() {
         info!("Flushing pending traces...");


### PR DESCRIPTION
## Summary

- Enable `TCP_NODELAY` on accepted connections via `axum::serve::ListenerExt::tap_io`
- Nagle's algorithm was buffering the final SSE bytes on keep-alive connections, causing a ~30ms delayed-ACK penalty per request
- Update benchmark baseline and docs with new measurements

## Results (vllm bench serve, Qwen3-4B, RTX 5070 Ti, single concurrency)

| Config | Metric | Before | After | vLLM | vs vLLM |
|--------|--------|--------|-------|------|---------|
| **in=1, out=1** | TTFT median | 41.89ms | **11.89ms** | 19.29ms | **-38%** |
| | req/s | 23.78 | **82.53** | 51.43 | **+60%** |
| in=1024, out=256 | TPOT median | 11.18ms | 11.18ms | 11.51ms | -3% |
| in=1, out=512 | TTFT median | 42.45ms | **12.20ms** | 21.55ms | **-43%** |
| in=2048, out=32 | TTFT median | 269.12ms | 270.69ms | 133.00ms | no change |

No regressions on any workload. Decode and fixed overhead now ahead of vLLM; prefill remains the gap.

## Diagnosis path

1. `bench_serving` (in-process) showed 10.36ms TTFT — GPU path is fine
2. `curl` showed 11ms total — HTTP overhead minimal
3. `vllm bench serve` showed 42ms — overhead in bench tool interaction
4. Isolated: aiohttp shared session = 41ms, new session per request = 11ms
5. Root cause: TCP Nagle + delayed ACK on keep-alive SSE connections

## Test plan

- [x] `cargo test --release` — all pass
- [x] `vllm bench serve` all 4 configs — no regressions
- [x] `bench_serving request --prompt-len 1 --output-len 1` — 10.36ms unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)