### PR TITLE
perf: mmap safetensors for >2x faster startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,6 +1159,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1353,6 +1362,7 @@ dependencies = [
  "half",
  "log",
  "logforth",
+ "memmap2",
  "ndarray",
  "rand 0.10.0",
  "safetensors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ cudarc = { version = "0.18", features = [
     "cuda-12080",
     "f16",
 ] }
+memmap2 = "0.9"
 log = "0.4"
 logforth = { version = "0.29", features = ["starter-log", "layout-text", "diagnostic-task-local"] }
 colored = "3"

--- a/src/model.rs
+++ b/src/model.rs
@@ -3,8 +3,6 @@
 use anyhow::Result;
 use fastrace::local::LocalSpan;
 use log::{debug, info};
-use safetensors::SafeTensors;
-use std::fs;
 use std::time::Instant;
 
 use rand::RngExt;
@@ -158,20 +156,16 @@ impl Qwen3Model {
 
         let (shard_paths, weight_map) = load_shard_info(model_path)?;
         debug!("Loading {} safetensor shard(s)", shard_paths.len());
-        let shard_data: Vec<Vec<u8>> = shard_paths
+        let mmaps = mmap_shards(&shard_paths)?;
+        let shards: Vec<safetensors::SafeTensors> = mmaps
             .iter()
-            .map(|p| {
-                debug!("Reading shard: {}", p);
-                fs::read(p)
-            })
-            .collect::<std::io::Result<_>>()?;
-        let shards: Vec<SafeTensors> = shard_data
-            .iter()
-            .map(|d| {
-                SafeTensors::deserialize(d).map_err(|e| anyhow::anyhow!("Deserialize error: {}", e))
+            .map(|m| {
+                safetensors::SafeTensors::deserialize(m)
+                    .map_err(|e| anyhow::anyhow!("Deserialize error: {}", e))
             })
             .collect::<Result<_>>()?;
 
+        let t_gpu = Instant::now();
         debug!("Loading embeddings to GPU");
         let embed_tokens = load_tensor_2d(&ctx, &shards, &weight_map, "model.embed_tokens.weight")?;
         let lm_head = if config.tie_word_embeddings {
@@ -277,6 +271,10 @@ impl Qwen3Model {
             precompute_rope(&ctx, config.head_dim, 4096, config.rope_theta)?;
 
         ctx.sync()?;
+        info!(
+            "GPU transfer complete in {:.0}ms",
+            t_gpu.elapsed().as_secs_f64() * 1e3
+        );
         info!("GPU model loaded successfully");
 
         let model = Self {

--- a/src/qwen35_model.rs
+++ b/src/qwen35_model.rs
@@ -12,8 +12,6 @@ use cudarc::driver::sys::CUstreamCaptureMode_enum::CU_STREAM_CAPTURE_MODE_THREAD
 use log::{debug, info};
 use rand::RngExt;
 use rand::rngs::StdRng;
-use safetensors::SafeTensors;
-use std::fs;
 use std::time::Instant;
 
 use crate::decode_buffers35::DecodeBuffers35;
@@ -133,20 +131,16 @@ impl Qwen35Model {
 
         let (shard_paths, weight_map) = load_shard_info_fixed(model_path)?;
         debug!("Loading {} safetensor shard(s)", shard_paths.len());
-        let shard_data: Vec<Vec<u8>> = shard_paths
+        let mmaps = mmap_shards(&shard_paths)?;
+        let shards: Vec<safetensors::SafeTensors> = mmaps
             .iter()
-            .map(|p| {
-                debug!("Reading shard: {}", p);
-                fs::read(p)
-            })
-            .collect::<std::io::Result<_>>()?;
-        let shards: Vec<SafeTensors> = shard_data
-            .iter()
-            .map(|d| {
-                SafeTensors::deserialize(d).map_err(|e| anyhow::anyhow!("Deserialize error: {}", e))
+            .map(|m| {
+                safetensors::SafeTensors::deserialize(m)
+                    .map_err(|e| anyhow::anyhow!("Deserialize error: {}", e))
             })
             .collect::<Result<_>>()?;
 
+        let t_gpu = Instant::now();
         // Weight prefix for Qwen3.5 text model
         let wp = "model.language_model";
 
@@ -329,6 +323,10 @@ impl Qwen35Model {
             precompute_rope(&ctx, config.rotary_dim, 4096, config.rope_theta)?;
 
         ctx.sync()?;
+        info!(
+            "GPU transfer complete in {:.0}ms",
+            t_gpu.elapsed().as_secs_f64() * 1e3
+        );
         info!("Qwen3.5 GPU model loaded successfully");
         if enable_cuda_graph {
             debug!("Decode path CUDA Graph is enabled");

--- a/src/weight_loader.rs
+++ b/src/weight_loader.rs
@@ -3,9 +3,12 @@
 use anyhow::Result;
 use cudarc::driver::CudaSlice;
 use half::bf16;
+use log::info;
+use memmap2::Mmap;
 use safetensors::SafeTensors;
 use std::collections::HashMap;
 use std::fs;
+use std::time::Instant;
 
 use crate::tensor::*;
 
@@ -42,6 +45,29 @@ pub fn load_shard_info(model_path: &str) -> Result<(Vec<String>, HashMap<String,
     }
 
     Ok((shard_files, weight_map))
+}
+
+/// Memory-map shard files. Returns the mmaps; caller deserializes SafeTensors from them.
+pub fn mmap_shards(shard_paths: &[String]) -> Result<Vec<Mmap>> {
+    let t0 = Instant::now();
+    let mmaps: Vec<Mmap> = shard_paths
+        .iter()
+        .map(|p| {
+            let file = fs::File::open(p)?;
+            // SAFETY: we keep the Mmap alive for the duration of model loading,
+            // and the file is not modified concurrently.
+            unsafe { Mmap::map(&file) }
+        })
+        .collect::<std::io::Result<_>>()?;
+
+    let total_bytes: usize = mmaps.iter().map(|m| m.len()).sum();
+    info!(
+        "Memory-mapped {} shard(s) ({:.1} MB) in {:.0}ms",
+        mmaps.len(),
+        total_bytes as f64 / 1e6,
+        t0.elapsed().as_secs_f64() * 1e3
+    );
+    Ok(mmaps)
 }
 
 pub fn find_tensor<'a>(


### PR DESCRIPTION
Replace fs::read() with memmap2 for weight loading. The OS maps file pages on demand during H2D transfer, eliminating a ~4GB heap copy.

Qwen3-1.7B startup on R7 5800H + RTX 3060 laptop:
- first time no cache: ~13500ms → ~5300ms (2.5x faster)
- following times: ~5500ms → ~2400ms (2.3x faster)