### PR TITLE
chore(docs): refocus roadmap around non-standard attention

### DIFF
--- a/docs/archives/qwen3-4b-optimization.md
+++ b/docs/archives/qwen3-4b-optimization.md
@@ -1,8 +1,8 @@
 # Qwen3-4B Optimization
 
-> **TL;DR:** pegainfer leads vLLM on all 4 tested workloads. Prefill +7%, decode +7%, fixed overhead +38%. Current numbers from single-concurrency bench on RTX 5070 Ti only — needs broader stress testing (longer contexts, batch concurrency, other GPUs) before declaring victory.
+> **TL;DR:** pegainfer led the measured Qwen3-4B workloads on RTX 5070 Ti after the FlashAttention-2 + PrefillBuffers work. This doc is archived as a dense-attention optimization reference rather than an active project.
 >
-> **Status:** Active. Leads vLLM on measured workloads. Needs more diverse benchmarking to validate across wider conditions.
+> **Status:** Archived. Kept as a reference for dense-attention optimization work; no longer an active milestone.
 
 ## Goal
 

--- a/docs/archives/qwen35-gdr-chunkwise-plan.md
+++ b/docs/archives/qwen35-gdr-chunkwise-plan.md
@@ -1,8 +1,8 @@
 # Qwen3.5 GDR Chunk-Wise Plan
 
-> **TL;DR:** The current Triton fused-recurrent GDR prefill path solved the old host-side launch disaster, but it is now clearly register / occupancy bound. `ncu` shows `254` registers per thread, `16.67%` theoretical occupancy, and `14.19%` achieved occupancy, while DRAM throughput is only `0.75%`. Chunk-wise prefill is the next serious path forward. FlashInfer provides a useful CUDA engineering reference for launcher, workspace, and state continuation; Flash Linear Attention (FLA) provides a Triton decomposition and correctness model. The first delivery target should be batch=`1`, forward-only, fixed Qwen3.5 shape.
+> **TL;DR:** The chunk-wise GDR prefill plan landed in the real Qwen3.5 runtime, restored `e2e_qwen35`, and brought `(2048,1)` TTFT down to the `~222ms` range. This doc is archived because the plan has been executed and its outcome is now reflected in the broader Qwen3.5 optimization record.
 >
-> **Status:** Active. The chunk-wise path now runs end-to-end in the real Rust Qwen3.5 prefill path. TTFT at `(2048,1)` is `~222ms`, and `e2e_qwen35` passes again after fixing the key chunk-state bug: `v_new` was being written after gating, while FLA semantics require ungated `v_new` writeback and gated `v_new` only for the recurrent state update. Regenerating `test_data/Qwen3.5-4B.json` still changes `6/13` prompts relative to the old `HEAD` baseline, but that refreshed baseline is now explicitly accepted.
+> **Status:** Archived. The plan is complete and superseded by the runtime state documented in `projects/qwen35-4b-optimization.md`.
 
 ## Goal
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,10 +2,12 @@
 
 | Path | TL;DR |
 | --- | --- |
-| `projects/landing.md` | New-developer onboarding — toolchain, unified venv, build, tests, benchmark smoke test |
-| `projects/qwen3-4b-optimization.md` | Leads vLLM on 4 workloads (single-concurrency, RTX 5070 Ti). Needs broader stress testing |
-| `projects/qwen35-gdr-chunkwise-plan.md` | Chunk-wise GDR prefill plan for Qwen3.5: Rust path is live, root cause was v_new write order, e2e passes, and the refreshed 6/13-drift baseline is accepted |
+| `projects/nonstandard-attention-milestone.md` | Milestone direction: pegainfer focuses on non-standard attention models, with emphasis on model-family readiness, service experience, framework debt repayment, and disciplined evaluation |
 | `projects/qwen35-4b-optimization.md` | Hybrid 24 linear + 8 full attn. Chunk-wise Rust GDR prefill now reaches ~222ms TTFT(2048,1), passes e2e_qwen35, and ships with an accepted refreshed JSON baseline |
+| `projects/runtime-complexity-paydown.md` | Project to reduce model-specific runtime fragmentation before more non-standard attention families are added |
+| `archives/qwen3-4b-optimization.md` | Dense-attention Qwen3-4B optimization record; archived as reference material after pegainfer led the measured RTX 5070 Ti workloads |
+| `archives/qwen35-gdr-chunkwise-plan.md` | Qwen3.5 chunk-wise GDR plan and validation history; archived after the plan landed in the real runtime and rolled into the broader Qwen3.5 optimization record |
+| `resources/developer-onboarding.md` | New-developer onboarding — toolchain, unified venv, build, tests, benchmark smoke test |
 | `resources/profiling-guide.md` | GPU profiling playbook: nsys pitfalls, diagnostic paths, measured kernel comparisons |
 | `resources/bench-vs-vllm.md` | pegainfer vs vLLM comparative benchmarking: method, workflow, typical configs, gotchas |
 | `resources/model-optimization-pipeline.md` | Per-model optimization methodology: 2 standard profiles, vLLM baseline, e2e dashboard + append-only optimization log |

--- a/docs/projects/nonstandard-attention-milestone.md
+++ b/docs/projects/nonstandard-attention-milestone.md
@@ -1,0 +1,39 @@
+# Milestone: Non-Standard Attention Focus
+
+**Status**: Active
+**TL;DR**: pegainfer is focused on inference and serving for non-standard attention models, especially linear attention and sparse attention. This milestone prioritizes model-family readiness, service experience, framework debt repayment, and disciplined correctness/performance evaluation.
+
+---
+
+## Goal
+
+pegainfer should become a strong runtime and serving foundation for non-standard attention models.
+
+The primary battlefield is:
+
+- linear attention
+- sparse attention
+- hybrid variants that mix dense and non-dense attention patterns
+
+This milestone is not about being a general-purpose LLM serving stack. It is about being good at the class of models that will matter more as attention patterns diversify.
+
+## Direction
+
+- Focus on model-family readiness, not one-off wins on a single model.
+- Keep service experience strong: TTFT, TPOT, p99, startup, and correctness should stay competitive for linear-attention models.
+- Repay framework-level complexity so new non-standard attention models do not require a fresh end-to-end runtime each time.
+- Treat evaluation as a first-class system: performance, correctness drift, and serving behavior must be measured together.
+
+## What Good Looks Like
+
+- A new linear or sparse attention model can be integrated with predictable effort.
+- Serving quality for non-standard attention models is stable and credible, not just fast in a narrow benchmark.
+- The codebase gets more reusable as model diversity increases, instead of more fragmented.
+
+## Next Action
+
+Turn this milestone into a short execution plan with:
+
+- the target model families to support next
+- the service metrics that define acceptable experience
+- the framework debt that must be repaid before model coverage expands further

--- a/docs/projects/runtime-complexity-paydown.md
+++ b/docs/projects/runtime-complexity-paydown.md
@@ -1,0 +1,28 @@
+# Project: Runtime Complexity Paydown
+
+**Status**: Active
+**TL;DR**: pegainfer now has enough model-specific runtime branching that complexity itself is becoming a delivery risk. This project exists to reduce fragmentation before support for more non-standard attention families expands further.
+
+---
+
+## Goal
+
+Bring runtime complexity back under control before the next wave of model-family support.
+
+The point is not abstraction for its own sake. The point is to make future model integration more predictable, keep the serving path coherent, and avoid growing a separate runtime for every new attention pattern.
+
+## Focus
+
+- reduce runtime branching across model families
+- stabilize the core runtime contracts that serving depends on
+- lower the marginal cost of integrating the next non-standard attention model
+
+## Success
+
+- new model-family work starts from a shared runtime foundation, not a fresh execution stack
+- runtime behavior is easier to reason about across prefill, decode, state, and serving
+- framework debt stops compounding faster than model coverage
+
+## Next Action
+
+Identify the runtime surfaces where fragmentation is already slowing delivery, then turn that into a small, ordered payoff plan.

--- a/docs/resources/developer-onboarding.md
+++ b/docs/resources/developer-onboarding.md
@@ -1,4 +1,4 @@
-# Landing: Setting Up the pegainfer Dev Environment from Scratch
+# Developer Onboarding: Setting Up the pegainfer Dev Environment from Scratch
 
 **Status**: Complete
 **TL;DR**: Full new-developer onboarding — toolchain check, unified venv, build, tests, benchmark smoke test.


### PR DESCRIPTION
## Summary
- add a milestone doc that positions pegainfer around non-standard attention models
- add a project doc for runtime complexity paydown
- archive completed Qwen3/Qwen3.5 optimization docs and move onboarding into resources
- refresh `docs/index.md` to match the new routing

## Why
This keeps the docs aligned with the current project direction:
- focus on linear, sparse, and hybrid non-standard attention models
- treat runtime complexity as an explicit delivery risk before model-family support expands further
- keep completed optimization records as reference material instead of active projects

## Testing
- not run (docs-only)
