### PR TITLE
perf(decode): capture argmax inside CUDA Graph

### DIFF
--- a/src/decode_buffers.rs
+++ b/src/decode_buffers.rs
@@ -37,6 +37,8 @@ pub(crate) struct DecodeBuffers {
     pub(crate) decode_meta: CudaSlice<i32>,
     /// FP32 scratch buffer for GPU sampling softmax (vocab_size)
     pub(crate) sample_probs: CudaSlice<f32>,
+    /// Pre-allocated argmax output (1 element) — lives inside CUDA Graph
+    pub(crate) argmax_out: CudaSlice<i32>,
     /// Split-KV partial output accumulator: [num_qheads * NUM_KV_SPLITS * HEAD_DIM] f32
     pub(crate) partial_out: CudaSlice<f32>,
     /// Split-KV partial max: [num_qheads * NUM_KV_SPLITS] f32
@@ -74,6 +76,10 @@ impl DecodeBuffers {
                 .stream
                 .alloc_zeros(config.vocab_size)
                 .map_err(|e| anyhow::anyhow!("Alloc sample_probs failed: {}", e))?,
+            argmax_out: ctx
+                .stream
+                .alloc_zeros(1)
+                .map_err(|e| anyhow::anyhow!("Alloc argmax_out failed: {}", e))?,
             partial_out: ctx
                 .stream
                 .alloc_zeros(num_qheads * Self::NUM_KV_SPLITS * config.head_dim)

--- a/src/decode_buffers35.rs
+++ b/src/decode_buffers35.rs
@@ -56,6 +56,8 @@ pub(crate) struct DecodeBuffers35 {
     pub(crate) decode_meta: CudaSlice<i32>,
     /// FP32 scratch buffer for GPU sampling softmax (vocab_size)
     pub(crate) sample_probs: CudaSlice<f32>,
+    /// Pre-allocated argmax output (1 element) — lives inside CUDA Graph
+    pub(crate) argmax_out: CudaSlice<i32>,
 }
 
 impl DecodeBuffers35 {
@@ -95,6 +97,10 @@ impl DecodeBuffers35 {
                 .stream
                 .alloc_zeros(config.vocab_size)
                 .map_err(|e| anyhow::anyhow!("Alloc sample_probs failed: {}", e))?,
+            argmax_out: ctx
+                .stream
+                .alloc_zeros(1)
+                .map_err(|e| anyhow::anyhow!("Alloc argmax_out failed: {}", e))?,
         })
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -709,6 +709,9 @@ impl Qwen3Model {
             &mut bufs.logits,
         )?;
 
+        // 5. Argmax (pre-allocated, captured inside CUDA Graph)
+        ops::argmax_into(&self.ctx, &bufs.logits, &mut bufs.argmax_out);
+
         Ok(())
     }
 
@@ -859,7 +862,11 @@ impl Qwen3Model {
             let _span = LocalSpan::enter_with_local_parent("prefill_decode")
                 .with_property(|| ("prompt_tokens", "1".to_string()));
             self.decode_one_token(prompt_tokens[0], &mut kv_cache, &mut bufs, &mut graph_state)?;
-            self.select_token(&bufs.logits, params, rng, Some(&mut bufs.sample_probs))?
+            if params.is_greedy() {
+                ops::read_argmax(&self.ctx, &bufs.argmax_out)?
+            } else {
+                self.select_token(&bufs.logits, params, rng, Some(&mut bufs.sample_probs))?
+            }
         } else {
             // Multi-token prompt: batch prefill (GEMM)
             let _span = LocalSpan::enter_with_local_parent("prefill")
@@ -903,7 +910,11 @@ impl Qwen3Model {
                     &mut bufs,
                     &mut graph_state,
                 )?;
-                self.select_token(&bufs.logits, params, rng, Some(&mut bufs.sample_probs))?
+                if params.is_greedy() {
+                    ops::read_argmax(&self.ctx, &bufs.argmax_out)?
+                } else {
+                    self.select_token(&bufs.logits, params, rng, Some(&mut bufs.sample_probs))?
+                }
             };
 
             if !params.ignore_eos && self.config.is_stop_token(next_token) {
@@ -980,7 +991,11 @@ impl Qwen3Model {
             let _span = LocalSpan::enter_with_local_parent("prefill_decode")
                 .with_property(|| ("prompt_tokens", "1".to_string()));
             self.decode_one_token(prompt_tokens[0], &mut kv_cache, &mut bufs, &mut graph_state)?;
-            self.select_token(&bufs.logits, params, rng, Some(&mut bufs.sample_probs))?
+            if params.is_greedy() {
+                ops::read_argmax(&self.ctx, &bufs.argmax_out)?
+            } else {
+                self.select_token(&bufs.logits, params, rng, Some(&mut bufs.sample_probs))?
+            }
         } else {
             let _span = LocalSpan::enter_with_local_parent("prefill")
                 .with_property(|| ("prompt_tokens", prompt_tokens.len().to_string()));
@@ -1034,7 +1049,11 @@ impl Qwen3Model {
                     &mut bufs,
                     &mut graph_state,
                 )?;
-                self.select_token(&bufs.logits, params, rng, Some(&mut bufs.sample_probs))?
+                if params.is_greedy() {
+                    ops::read_argmax(&self.ctx, &bufs.argmax_out)?
+                } else {
+                    self.select_token(&bufs.logits, params, rng, Some(&mut bufs.sample_probs))?
+                }
             };
 
             if !params.ignore_eos && self.config.is_stop_token(next_token) {

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -25,7 +25,7 @@ pub use norm::{
 pub use recurrent::{
     conv1d_decode_into, gated_delta_rule_decode_into, gated_delta_rule_prefill_chunkwise_into,
 };
-pub use sampling::{argmax, gpu_sample};
+pub use sampling::{argmax, argmax_into, gpu_sample, read_argmax};
 
 // pub(crate) re-exports
 #[cfg(test)]

--- a/src/ops/sampling.rs
+++ b/src/ops/sampling.rs
@@ -36,6 +36,32 @@ pub fn argmax(ctx: &DeviceContext, x: &DeviceVec) -> Result<u32> {
     Ok(result[0] as u32)
 }
 
+/// Argmax into a pre-allocated output buffer (no alloc, no sync).
+/// Safe for CUDA Graph capture.
+pub fn argmax_into(ctx: &DeviceContext, x: &DeviceVec, out: &mut CudaSlice<i32>) {
+    let (x_ptr, _gx) = x.data.device_ptr(&ctx.stream);
+    let (out_ptr, _go) = out.device_ptr_mut(&ctx.stream);
+
+    unsafe {
+        ffi::argmax_cuda(
+            x_ptr as *const ffi::Half,
+            out_ptr as *mut i32,
+            x.len as i32,
+            ctx.stream.cu_stream(),
+        );
+    }
+}
+
+/// Read a pre-computed argmax result from GPU (sync + D2H).
+pub fn read_argmax(ctx: &DeviceContext, out: &CudaSlice<i32>) -> Result<u32> {
+    ctx.sync()?;
+    let result = ctx
+        .stream
+        .clone_dtoh(out)
+        .map_err(|e| anyhow!("D2H argmax read failed: {}", e))?;
+    Ok(result[0] as u32)
+}
+
 /// GPU sampling: temperature → softmax → top-k → top-p → multinomial.
 /// Runs entirely on GPU. Only the final token ID (4 bytes) is transferred D2H.
 pub fn gpu_sample(

--- a/src/qwen35_model.rs
+++ b/src/qwen35_model.rs
@@ -509,6 +509,9 @@ impl Qwen35Model {
             &mut bufs.logits,
         )?;
 
+        // 5. Argmax (pre-allocated, captured inside CUDA Graph)
+        ops::argmax_into(&self.ctx, &bufs.logits, &mut bufs.argmax_out);
+
         Ok(())
     }
 
@@ -940,7 +943,11 @@ impl Qwen35Model {
                 &mut bufs,
                 &mut graph_state,
             )?;
-            self.select_token(&bufs.logits, params, rng, Some(&mut bufs.sample_probs))?
+            if params.is_greedy() {
+                ops::read_argmax(&self.ctx, &bufs.argmax_out)?
+            } else {
+                self.select_token(&bufs.logits, params, rng, Some(&mut bufs.sample_probs))?
+            }
         } else {
             // Multi-token: batch prefill
             let logits = self.prefill_forward(prompt_tokens, &mut kv_cache, &mut recurrent)?;
@@ -967,8 +974,11 @@ impl Qwen35Model {
                 &mut bufs,
                 &mut graph_state,
             )?;
-            let next_token =
-                self.select_token(&bufs.logits, params, rng, Some(&mut bufs.sample_probs))?;
+            let next_token = if params.is_greedy() {
+                ops::read_argmax(&self.ctx, &bufs.argmax_out)?
+            } else {
+                self.select_token(&bufs.logits, params, rng, Some(&mut bufs.sample_probs))?
+            };
 
             if !params.ignore_eos && next_token == self.config.eos_token_id {
                 break;
@@ -1028,7 +1038,11 @@ impl Qwen35Model {
                 &mut bufs,
                 &mut graph_state,
             )?;
-            self.select_token(&bufs.logits, params, rng, Some(&mut bufs.sample_probs))?
+            if params.is_greedy() {
+                ops::read_argmax(&self.ctx, &bufs.argmax_out)?
+            } else {
+                self.select_token(&bufs.logits, params, rng, Some(&mut bufs.sample_probs))?
+            }
         } else {
             let logits = self.prefill_forward(prompt_tokens, &mut kv_cache, &mut recurrent)?;
             self.select_token(&logits, params, rng, None)?
@@ -1067,8 +1081,11 @@ impl Qwen35Model {
                 &mut bufs,
                 &mut graph_state,
             )?;
-            let next_token =
-                self.select_token(&bufs.logits, params, rng, Some(&mut bufs.sample_probs))?;
+            let next_token = if params.is_greedy() {
+                ops::read_argmax(&self.ctx, &bufs.argmax_out)?
+            } else {
+                self.select_token(&bufs.logits, params, rng, Some(&mut bufs.sample_probs))?
+            };
 
             if !params.ignore_eos && next_token == self.config.eos_token_id {
                 hit_eos = true;


### PR DESCRIPTION
## Summary

- Pre-allocate `argmax_out` in `DecodeBuffers` / `DecodeBuffers35`, call `argmax_into()` at the end of `decode_kernels()` so the argmax kernel is captured inside the CUDA Graph
- Greedy decode path now reads the result via `read_argmax()` (sync + D2H of 1 int) instead of the full alloc → launch → sync → free cycle
- Applies to both Qwen3 and Qwen3.5 models

## Measured impact (Qwen3.5-4B, prompt=1, output=128)

Per-token overhead eliminated:
- 1× `cudaLaunchKernel` (~argmax dispatch)
- 1× `cuMemAllocAsync` + `cuMemFreeAsync` + `cuMemsetD8Async`

nsys before/after (no graph-trace, real timing):
| Metric | Before | After |
|---|---|---|
| `cudaLaunchKernel` calls | 618 | 363 (-255) |
| `cuMemAllocAsync` calls | 765 | 510 (-255) |
| `cuMemFreeAsync` calls | 765 | 510 (-255) |
| standalone `argmax_kernel` | 256 instances | 0 (inside graph) |
| steady TPOT | 12.59ms | 12.53ms |

## Test plan

- [x] `cargo test --release --test e2e` — Qwen3 greedy regression, bit-exact
- [x] `cargo test --release --test e2e_qwen35` — Qwen3.5 greedy regression, bit-exact
- [x] nsys profile confirms argmax no longer appears as standalone kernel launch
- [x] `cargo clippy --release` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)