### PR TITLE
feat(bench): snapshot/compare subcommands for regression tracking

### DIFF
--- a/bench_snapshots/qwen3-4b.json
+++ b/bench_snapshots/qwen3-4b.json
@@ -1,0 +1,84 @@
+{
+  "commit": "117a963",
+  "date": "2026-03-30",
+  "model": "Qwen3-4B",
+  "gpu": "NVIDIA GeForce RTX 5070 Ti",
+  "prefill_heavy": {
+    "prompt_len": 10000,
+    "output_len": 1,
+    "metrics": {
+      "ttft_ms": {
+        "avg_ms": 1189.449883,
+        "p50_ms": 1189.580495,
+        "p95_ms": 1189.917083,
+        "p99_ms": 1190.320677,
+        "max_ms": 1190.320677,
+        "samples": 20
+      },
+      "first_decode_step_ms": null,
+      "steady_tpot_ms": null,
+      "e2e_ms": {
+        "avg_ms": 1189.4499299999998,
+        "p50_ms": 1189.5805349999998,
+        "p95_ms": 1189.917133,
+        "p99_ms": 1190.320727,
+        "max_ms": 1190.320727,
+        "samples": 20
+      },
+      "generated_tokens": {
+        "min": 1,
+        "max": 1,
+        "avg": 1.0,
+        "samples": 20
+      },
+      "request_tok_s": 0.8407247538193033,
+      "decode_tok_s": null
+    }
+  },
+  "decode_heavy": {
+    "prompt_len": 1024,
+    "output_len": 256,
+    "metrics": {
+      "ttft_ms": {
+        "avg_ms": 96.009244,
+        "p50_ms": 95.99871399999999,
+        "p95_ms": 96.148716,
+        "p99_ms": 96.157562,
+        "max_ms": 96.157562,
+        "samples": 20
+      },
+      "first_decode_step_ms": {
+        "avg_ms": 12.486932,
+        "p50_ms": 12.485714999999999,
+        "p95_ms": 12.514985,
+        "p99_ms": 12.520754,
+        "max_ms": 12.520754,
+        "samples": 20
+      },
+      "steady_tpot_ms": {
+        "avg_ms": 12.33255,
+        "p50_ms": 12.34353,
+        "p95_ms": 12.385101,
+        "p99_ms": 12.428761999999999,
+        "max_ms": 12.739472,
+        "samples": 5080
+      },
+      "e2e_ms": {
+        "avg_ms": 3240.964195,
+        "p50_ms": 3241.105896,
+        "p95_ms": 3243.02651,
+        "p99_ms": 3243.7379229999997,
+        "max_ms": 3243.7379229999997,
+        "samples": 20
+      },
+      "generated_tokens": {
+        "min": 256,
+        "max": 256,
+        "avg": 256.0,
+        "samples": 20
+      },
+      "request_tok_s": 78.98883930499613,
+      "decode_tok_s": 81.08224519009015
+    }
+  }
+}

--- a/docs/areas/bench-regression.md
+++ b/docs/areas/bench-regression.md
@@ -1,0 +1,110 @@
+# Benchmark Regression Tracking
+
+> **TL;DR:** One JSON snapshot per model in `bench_snapshots/`, git history is the timeline. `snapshot` generates, `compare` diffs against git. Thresholds: TPOT p50 >2%, TTFT p50 >3%.
+>
+> **Status:** Active.
+
+## Concept
+
+Each model has one snapshot file (`bench_snapshots/{model}.json`), always the latest. Git is the history — `git log -p bench_snapshots/` is the timeline. Both `snapshot` and `compare` run inference in-process, no server needed.
+
+## Standard Profiles
+
+| Name | prompt_len | output_len | Key metric |
+|------|-----------|------------|------------|
+| prefill_heavy | 10000 | 1 | TTFT |
+| decode_heavy | 1024 | 256 | TPOT (steady, excluding first decode step) |
+
+Hardcoded in `snapshot`. `compare` checks shape consistency — if you change the constants, it will error until you re-baseline.
+
+`prefill_heavy` with `output_len=1` produces no steady decode steps: `steady_tpot_ms` is `null` in the JSON. This is expected.
+
+## Workflow
+
+### Bootstrapping (first time)
+
+```bash
+cargo run -r --bin bench_serving -- --model-path models/Qwen3-4B snapshot --warmup 5 --iters 20
+git add bench_snapshots/qwen3-4b.json
+git commit -m "chore: establish benchmark baseline for Qwen3-4B"
+```
+
+### Before merging a PR
+
+```bash
+# 1. Generate snapshot
+cargo run -r --bin bench_serving -- --model-path models/Qwen3-4B snapshot --warmup 5 --iters 20
+
+# 2. Compare against last committed version (exits non-zero if no baseline)
+cargo run -r --bin bench_serving -- compare bench_snapshots/qwen3-4b.json --baseline HEAD
+
+# 3. If clean, commit with the PR
+git add bench_snapshots/qwen3-4b.json
+```
+
+Qwen3.5-4B:
+```bash
+cargo run -r --bin bench_serving -- --model-path models/Qwen3.5-4B snapshot --warmup 5 --iters 20
+cargo run -r --bin bench_serving -- compare bench_snapshots/qwen3.5-4b.json --baseline HEAD
+```
+
+Compare against older ref:
+```bash
+cargo run -r --bin bench_serving -- compare bench_snapshots/qwen3-4b.json --baseline HEAD~5
+cargo run -r --bin bench_serving -- compare bench_snapshots/qwen3-4b.json --baseline main
+```
+
+## Regression Thresholds
+
+| Metric | Threshold | Rationale |
+|--------|-----------|-----------|
+| TPOT p50 | >2% | Decode is the hot path; measurement noise ~1% at iters=20 |
+| TTFT p50 | >3% | Prefill has higher variance from kernel launch jitter |
+
+Thresholds trigger on **p50 only**. The comparison table also shows p99 for manual inspection. A threshold firing means "investigate", not "reject" — run twice if it barely fires, thermal variance accounts for 1–2%.
+
+## Investigating a Regression
+
+1. Which metric regressed? Check the `compare` output.
+2. TPOT: likely decode kernels, CUDA graph, MLP/GEMV. Profile with `nsys` using the decode-heavy shape (see [profiling-guide](../resources/profiling-guide.md)).
+3. TTFT: likely prefill, cuBLAS, or Triton kernels. Profile with the prefill-heavy shape.
+4. Both: suspect a fundamental change (memory layout, kernel launch, data flow).
+
+## Snapshot JSON Schema
+
+Filename: model directory name, lowercased (`models/Qwen3.5-4B` → `qwen3.5-4b.json`).
+
+```json
+{
+  "commit": "117a963",
+  "date": "2026-03-30",
+  "model": "Qwen3-4B",
+  "gpu": "NVIDIA GeForce RTX 5070 Ti",
+  "prefill_heavy": {
+    "prompt_len": 10000,
+    "output_len": 1,
+    "metrics": {
+      "ttft_ms":              { "avg_ms": 0, "p50_ms": 0, "p95_ms": 0, "p99_ms": 0, "max_ms": 0, "samples": 20 },
+      "first_decode_step_ms": null,
+      "steady_tpot_ms":       null,
+      "e2e_ms":               { "avg_ms": 0, "p50_ms": 0, "p95_ms": 0, "p99_ms": 0, "max_ms": 0, "samples": 20 },
+      "generated_tokens":     { "min": 1, "max": 1, "avg": 1.0, "samples": 20 },
+      "request_tok_s":        0.0,
+      "decode_tok_s":         null
+    }
+  },
+  "decode_heavy": {
+    "prompt_len": 1024,
+    "output_len": 256,
+    "metrics": {
+      "ttft_ms":              { "avg_ms": 0, "p50_ms": 0, "p95_ms": 0, "p99_ms": 0, "max_ms": 0, "samples": 20 },
+      "first_decode_step_ms": { "avg_ms": 0, "p50_ms": 0, "p95_ms": 0, "p99_ms": 0, "max_ms": 0, "samples": 20 },
+      "steady_tpot_ms":       { "avg_ms": 0, "p50_ms": 0, "p95_ms": 0, "p99_ms": 0, "max_ms": 0, "samples": 20 },
+      "e2e_ms":               { "avg_ms": 0, "p50_ms": 0, "p95_ms": 0, "p99_ms": 0, "max_ms": 0, "samples": 20 },
+      "generated_tokens":     { "min": 256, "max": 256, "avg": 256.0, "samples": 20 },
+      "request_tok_s":        0.0,
+      "decode_tok_s":         0.0
+    }
+  }
+}
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@
 | `archives/pure-gpu-decode-loop.md` | Concluded: CPU overhead is ~0.6% of TPOT (~77μs/token). Batch launch saves ~1ms/128tok. Not worth further investment — TPOT is GPU-compute bound |
 | `archives/qwen3-4b-optimization.md` | Dense-attention Qwen3-4B optimization record; archived as reference material after pegainfer led the measured RTX 5070 Ti workloads |
 | `archives/qwen35-gdr-chunkwise-plan.md` | Qwen3.5 chunk-wise GDR plan and validation history; archived after the plan landed in the real runtime and rolled into the broader Qwen3.5 optimization record |
+| `areas/bench-regression.md` | Benchmark regression tracking: one snapshot per model, git-tracked history, TPOT >2% / TTFT >3% thresholds |
 | `resources/accuracy-parity-playbook.md` | Accuracy debugging playbook: truth-source rules, first-diff workflow, bf16 rounding traps, and verified Qwen3.5 parity commands |
 | `resources/developer-onboarding.md` | New-developer onboarding — toolchain, unified venv, build, tests, benchmark smoke test |
 | `resources/profiling-guide.md` | GPU profiling playbook: nsys pitfalls, diagnostic paths, measured kernel comparisons |

--- a/src/bin/bench_serving.rs
+++ b/src/bin/bench_serving.rs
@@ -12,6 +12,7 @@
 use std::fmt::Write as _;
 use std::fs;
 use std::io::{IsTerminal, stdout};
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, ensure};
@@ -29,7 +30,15 @@ use pegainfer::server_engine::{ModelType, detect_model_type};
 use pegainfer::tokenizer::Tokenizer;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+
+const SNAPSHOT_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/bench_snapshots");
+const SNAPSHOT_PREFILL_PROMPT_LEN: usize = 10_000;
+const SNAPSHOT_PREFILL_OUTPUT_LEN: usize = 1;
+const SNAPSHOT_DECODE_PROMPT_LEN: usize = 1024;
+const SNAPSHOT_DECODE_OUTPUT_LEN: usize = 256;
+const REGRESSION_TPOT_PCT: f64 = 2.0;
+const REGRESSION_TTFT_PCT: f64 = 3.0;
 
 const DEFAULT_MODEL_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/models/Qwen3-4B");
 const DEFAULT_REQUEST_PROMPT: &str = "Tell me a story";
@@ -42,7 +51,9 @@ Examples:
   cargo run -r --bin bench_serving -- request --prompt-len 512 --output-len 64
   cargo run -r --bin bench_serving -- matrix --prompt-lens 32,128,512,2048 --output-lens 32,128,256
   cargo run -r --bin bench_serving -- curve --prompt-len 1024 --output-len 256 --window 32
-  cargo run -r --bin bench_serving -- --format json --out bench.json request --prompt-len 512 --output-len 64";
+  cargo run -r --bin bench_serving -- --format json --out bench.json request --prompt-len 512 --output-len 64
+  cargo run -r --bin bench_serving -- snapshot
+  cargo run -r --bin bench_serving -- compare bench_snapshots/qwen3-4b.json";
 const REQUEST_EXAMPLES: &str = "\
 Examples:
   cargo run -r --bin bench_serving -- request
@@ -59,6 +70,14 @@ Examples:
   cargo run -r --bin bench_serving -- curve
   cargo run -r --bin bench_serving -- curve --prompt-len 1024 --output-len 256 --window 32
   cargo run -r --bin bench_serving -- curve --prompt \"Summarize KV cache behavior\" --output-len 128 --window 16";
+const SNAPSHOT_EXAMPLES: &str = "\
+Examples:
+  cargo run -r --bin bench_serving -- snapshot
+  cargo run -r --bin bench_serving -- snapshot --warmup 3 --iters 10";
+const COMPARE_EXAMPLES: &str = "\
+Examples:
+  cargo run -r --bin bench_serving -- compare bench_snapshots/qwen3-4b.json
+  cargo run -r --bin bench_serving -- compare bench_snapshots/qwen3-4b.json --baseline HEAD~3";
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
 enum OutputFormat {
@@ -77,6 +96,12 @@ enum Command {
     /// Measure TPOT as context grows during decode.
     #[command(after_help = CURVE_EXAMPLES)]
     Curve(CurveArgs),
+    /// Run standard profiles and write a regression-trackable snapshot.
+    #[command(after_help = SNAPSHOT_EXAMPLES)]
+    Snapshot(SnapshotArgs),
+    /// Compare a snapshot against its git baseline.
+    #[command(after_help = COMPARE_EXAMPLES)]
+    Compare(CompareArgs),
 }
 
 #[derive(Parser, Debug)]
@@ -184,6 +209,22 @@ struct CurveArgs {
     run: RunArgs,
 }
 
+#[derive(Debug, ClapArgs)]
+struct SnapshotArgs {
+    #[command(flatten)]
+    run: RunArgs,
+}
+
+#[derive(Debug, ClapArgs)]
+struct CompareArgs {
+    /// Path to snapshot JSON file
+    path: String,
+
+    /// Git ref to compare against
+    #[arg(long, default_value = "HEAD")]
+    baseline: String,
+}
+
 #[derive(Debug, Clone, Serialize)]
 struct RunInfo {
     command: &'static str,
@@ -201,7 +242,7 @@ struct PromptDescriptor {
     prompt_preview: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct DurationStats {
     avg_ms: f64,
     p50_ms: f64,
@@ -211,7 +252,7 @@ struct DurationStats {
     samples: usize,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct CountStats {
     min: usize,
     max: usize,
@@ -228,7 +269,7 @@ struct RequestWorkload {
     seed: u64,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct RequestMetrics {
     ttft_ms: DurationStats,
     first_decode_step_ms: Option<DurationStats>,
@@ -237,6 +278,23 @@ struct RequestMetrics {
     generated_tokens: CountStats,
     request_tok_s: Option<f64>,
     decode_tok_s: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SnapshotProfile {
+    prompt_len: usize,
+    output_len: usize,
+    metrics: RequestMetrics,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SnapshotReport {
+    commit: String,
+    date: String,
+    model: String,
+    gpu: String,
+    prefill_heavy: SnapshotProfile,
+    decode_heavy: SnapshotProfile,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1135,6 +1193,317 @@ fn run_command(
         Command::Request(args) => bench_request(model, tokenizer, cli, model_type, load_ms, args),
         Command::Matrix(args) => bench_matrix(model, cli, model_type, load_ms, args),
         Command::Curve(args) => bench_curve(model, tokenizer, cli, model_type, load_ms, args),
+        Command::Snapshot(_) | Command::Compare(_) => unreachable!(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot / Compare
+// ---------------------------------------------------------------------------
+
+fn shell_output(program: &str, args: &[&str]) -> Option<String> {
+    std::process::Command::new(program)
+        .args(args)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+}
+
+fn git_short_commit() -> String {
+    shell_output("git", &["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "unknown".into())
+}
+
+fn gpu_name() -> String {
+    shell_output(
+        "nvidia-smi",
+        &["--query-gpu=name", "--format=csv,noheader", "--id=0"],
+    )
+    .unwrap_or_else(|| "unknown".into())
+}
+
+fn today_date() -> String {
+    shell_output("date", &["+%Y-%m-%d"]).unwrap_or_else(|| "unknown".into())
+}
+
+fn model_display_name(model_path: &str) -> String {
+    Path::new(model_path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+fn delta_pct(current: f64, baseline: f64) -> f64 {
+    if baseline == 0.0 {
+        return 0.0;
+    }
+    (current - baseline) / baseline * 100.0
+}
+
+fn format_delta(pct: f64) -> String {
+    if pct >= 0.0 {
+        format!("+{pct:.1}%")
+    } else {
+        format!("{pct:.1}%")
+    }
+}
+
+fn run_snapshot(model: &mut dyn BenchModel, cli: &Cli, args: &SnapshotArgs) -> Result<()> {
+    info!("Running prefill-heavy ({SNAPSHOT_PREFILL_PROMPT_LEN},{SNAPSHOT_PREFILL_OUTPUT_LEN})");
+    let prefill_tokens = synthetic_prompt_tokens(SNAPSHOT_PREFILL_PROMPT_LEN);
+    let prefill_timings = measure_timings(
+        model,
+        &prefill_tokens,
+        SNAPSHOT_PREFILL_OUTPUT_LEN,
+        &args.run,
+    )?;
+    let prefill_metrics = build_request_metrics(&prefill_timings);
+
+    info!("Running decode-heavy ({SNAPSHOT_DECODE_PROMPT_LEN},{SNAPSHOT_DECODE_OUTPUT_LEN})");
+    let decode_tokens = synthetic_prompt_tokens(SNAPSHOT_DECODE_PROMPT_LEN);
+    let decode_timings =
+        measure_timings(model, &decode_tokens, SNAPSHOT_DECODE_OUTPUT_LEN, &args.run)?;
+    let decode_metrics = build_request_metrics(&decode_timings);
+
+    let model_name = model_display_name(&cli.model_path);
+    let report = SnapshotReport {
+        commit: git_short_commit(),
+        date: today_date(),
+        model: model_name.clone(),
+        gpu: gpu_name(),
+        prefill_heavy: SnapshotProfile {
+            prompt_len: SNAPSHOT_PREFILL_PROMPT_LEN,
+            output_len: SNAPSHOT_PREFILL_OUTPUT_LEN,
+            metrics: prefill_metrics,
+        },
+        decode_heavy: SnapshotProfile {
+            prompt_len: SNAPSHOT_DECODE_PROMPT_LEN,
+            output_len: SNAPSHOT_DECODE_OUTPUT_LEN,
+            metrics: decode_metrics,
+        },
+    };
+
+    let dir = Path::new(SNAPSHOT_DIR);
+    fs::create_dir_all(dir)?;
+    let filename = model_name.to_lowercase();
+    let path = dir.join(format!("{filename}.json"));
+    fs::write(&path, serde_json::to_string_pretty(&report)?)?;
+
+    println!("{}", render_snapshot_text(&report, &path));
+    Ok(())
+}
+
+fn render_snapshot_text(report: &SnapshotReport, path: &Path) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "bench_serving snapshot\n");
+    let _ = writeln!(out, "model:  {}", report.model);
+    let _ = writeln!(out, "gpu:    {}", report.gpu);
+    let _ = writeln!(out, "commit: {}\n", report.commit);
+    let _ = writeln!(
+        out,
+        "prefill_heavy ({},{}):",
+        report.prefill_heavy.prompt_len, report.prefill_heavy.output_len
+    );
+    let _ = writeln!(
+        out,
+        "  TTFT  p50={:.2}ms  p99={:.2}ms",
+        report.prefill_heavy.metrics.ttft_ms.p50_ms, report.prefill_heavy.metrics.ttft_ms.p99_ms
+    );
+    let _ = writeln!(
+        out,
+        "\ndecode_heavy ({},{}):",
+        report.decode_heavy.prompt_len, report.decode_heavy.output_len
+    );
+    if let Some(tpot) = &report.decode_heavy.metrics.steady_tpot_ms {
+        let _ = writeln!(
+            out,
+            "  TPOT  p50={:.2}ms  p99={:.2}ms",
+            tpot.p50_ms, tpot.p99_ms
+        );
+    }
+    let _ = writeln!(out, "\nwritten to {}", path.display());
+    out
+}
+
+fn run_compare(args: &CompareArgs) -> Result<()> {
+    let current_content = fs::read_to_string(&args.path).with_context(|| {
+        format!(
+            "snapshot not found: {}\nrun `bench_serving snapshot` first",
+            args.path
+        )
+    })?;
+    let current: SnapshotReport =
+        serde_json::from_str(&current_content).context("failed to parse current snapshot")?;
+
+    // Resolve repo-root-relative path for git show
+    let abs_path = fs::canonicalize(&args.path)?;
+    let toplevel =
+        shell_output("git", &["rev-parse", "--show-toplevel"]).context("not a git repository")?;
+    let root = PathBuf::from(&toplevel);
+    let rel_path = abs_path
+        .strip_prefix(&root)
+        .context("snapshot file is outside the git repository")?;
+
+    let git_output = std::process::Command::new("git")
+        .args(["show", &format!("{}:{}", args.baseline, rel_path.display())])
+        .output()
+        .context("failed to run git show")?;
+
+    if !git_output.status.success() {
+        anyhow::bail!(
+            "no baseline at {}:{}\ncommit the current snapshot to establish a baseline",
+            args.baseline,
+            rel_path.display()
+        );
+    }
+
+    let baseline: SnapshotReport =
+        serde_json::from_slice(&git_output.stdout).context("failed to parse baseline snapshot")?;
+
+    // Guard against comparing snapshots with different profile shapes
+    ensure!(
+        current.prefill_heavy.prompt_len == baseline.prefill_heavy.prompt_len
+            && current.prefill_heavy.output_len == baseline.prefill_heavy.output_len
+            && current.decode_heavy.prompt_len == baseline.decode_heavy.prompt_len
+            && current.decode_heavy.output_len == baseline.decode_heavy.output_len,
+        "profile shape mismatch: current ({},{}) + ({},{}) vs baseline ({},{}) + ({},{})\n\
+         the snapshot profiles were changed — re-baseline by committing a fresh snapshot",
+        current.prefill_heavy.prompt_len,
+        current.prefill_heavy.output_len,
+        current.decode_heavy.prompt_len,
+        current.decode_heavy.output_len,
+        baseline.prefill_heavy.prompt_len,
+        baseline.prefill_heavy.output_len,
+        baseline.decode_heavy.prompt_len,
+        baseline.decode_heavy.output_len,
+    );
+
+    println!("{}", render_comparison(&current, &baseline, &args.baseline));
+    Ok(())
+}
+
+fn render_comparison(
+    current: &SnapshotReport,
+    baseline: &SnapshotReport,
+    ref_name: &str,
+) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "bench_serving compare\n");
+    let _ = writeln!(
+        out,
+        "comparing {} (working tree) vs {} ({ref_name})\n",
+        current.commit, baseline.commit
+    );
+
+    let mut table = new_table();
+    table.set_header(vec![
+        Cell::new("metric"),
+        Cell::new("current").set_alignment(CellAlignment::Right),
+        Cell::new("baseline").set_alignment(CellAlignment::Right),
+        Cell::new("delta").set_alignment(CellAlignment::Right),
+    ]);
+
+    let pf = &current.prefill_heavy;
+    let pf_b = &baseline.prefill_heavy;
+    let pf_label = format!("({},{})", pf.prompt_len, pf.output_len);
+
+    for (stat, cur, base) in [
+        (
+            "p50",
+            pf.metrics.ttft_ms.p50_ms,
+            pf_b.metrics.ttft_ms.p50_ms,
+        ),
+        (
+            "p99",
+            pf.metrics.ttft_ms.p99_ms,
+            pf_b.metrics.ttft_ms.p99_ms,
+        ),
+    ] {
+        table.add_row(vec![
+            key_cell(format!("TTFT {stat} {pf_label}")),
+            numeric_cell(format!("{cur:.2}ms")),
+            numeric_cell(format!("{base:.2}ms")),
+            numeric_cell(format_delta(delta_pct(cur, base))),
+        ]);
+    }
+
+    let dc_label = format!(
+        "({},{})",
+        current.decode_heavy.prompt_len, current.decode_heavy.output_len
+    );
+    if let (Some(cur_tpot), Some(base_tpot)) = (
+        &current.decode_heavy.metrics.steady_tpot_ms,
+        &baseline.decode_heavy.metrics.steady_tpot_ms,
+    ) {
+        for (stat, cur, base) in [
+            ("p50", cur_tpot.p50_ms, base_tpot.p50_ms),
+            ("p99", cur_tpot.p99_ms, base_tpot.p99_ms),
+        ] {
+            table.add_row(vec![
+                key_cell(format!("TPOT {stat} {dc_label}")),
+                numeric_cell(format!("{cur:.2}ms")),
+                numeric_cell(format!("{base:.2}ms")),
+                numeric_cell(format_delta(delta_pct(cur, base))),
+            ]);
+        }
+    }
+
+    push_table(&mut out, &table);
+
+    // Regression check
+    let mut regressions = Vec::new();
+    let ttft_d = delta_pct(
+        current.prefill_heavy.metrics.ttft_ms.p50_ms,
+        baseline.prefill_heavy.metrics.ttft_ms.p50_ms,
+    );
+    if ttft_d > REGRESSION_TTFT_PCT {
+        regressions.push(format!(
+            "TTFT p50 {ttft_d:+.1}% > {REGRESSION_TTFT_PCT}% threshold"
+        ));
+    }
+    if let (Some(cur), Some(base)) = (
+        &current.decode_heavy.metrics.steady_tpot_ms,
+        &baseline.decode_heavy.metrics.steady_tpot_ms,
+    ) {
+        let tpot_d = delta_pct(cur.p50_ms, base.p50_ms);
+        if tpot_d > REGRESSION_TPOT_PCT {
+            regressions.push(format!(
+                "TPOT p50 {tpot_d:+.1}% > {REGRESSION_TPOT_PCT}% threshold"
+            ));
+        }
+    }
+
+    out.push('\n');
+    if regressions.is_empty() {
+        let _ = writeln!(
+            out,
+            "no regression detected (threshold: TPOT >{REGRESSION_TPOT_PCT}%, TTFT >{REGRESSION_TTFT_PCT}%)"
+        );
+    } else {
+        let _ = writeln!(out, "REGRESSION DETECTED:");
+        for r in &regressions {
+            let _ = writeln!(out, "  {r}");
+        }
+    }
+
+    out
+}
+
+fn dispatch(
+    cli: &Cli,
+    model_type: ModelType,
+    load_ms: f64,
+    model: &mut dyn BenchModel,
+    tokenizer: &Tokenizer,
+) -> Result<()> {
+    match &cli.command {
+        Command::Snapshot(args) => run_snapshot(model, cli, args),
+        _ => {
+            let report = run_command(cli, model_type, load_ms, model, tokenizer)?;
+            emit_report(cli, &report)
+        }
     }
 }
 
@@ -1142,12 +1511,20 @@ fn main() -> Result<()> {
     logging::init_default();
 
     let cli = Cli::parse();
+
+    // Compare needs no model loading
+    if let Command::Compare(ref args) = cli.command {
+        return run_compare(args);
+    }
+
     debug!(
         "bench_serving starting: command={} model_path={} cuda_graph={} format={:?}",
         match &cli.command {
             Command::Request(_) => "request",
             Command::Matrix(_) => "matrix",
             Command::Curve(_) => "curve",
+            Command::Snapshot(_) => "snapshot",
+            Command::Compare(_) => "compare",
         },
         cli.model_path,
         cli.cuda_graph,
@@ -1160,14 +1537,14 @@ fn main() -> Result<()> {
     };
     let load_start = Instant::now();
 
-    let report = match model_type {
+    match model_type {
         ModelType::Qwen3 => {
             let model = Qwen3Model::from_safetensors_with_runtime(&cli.model_path, runtime)?;
             let state = model.create_state()?;
             let tokenizer = Tokenizer::from_file(&cli.model_path)?;
             let load_ms = dur_ms(load_start.elapsed());
             let mut bench = ModelWithState { model, state };
-            run_command(&cli, model_type, load_ms, &mut bench, &tokenizer)?
+            dispatch(&cli, model_type, load_ms, &mut bench, &tokenizer)
         }
         ModelType::Qwen35 => {
             let model = Qwen35Model::from_safetensors_with_options(
@@ -1178,9 +1555,7 @@ fn main() -> Result<()> {
             let tokenizer = Tokenizer::from_file(&cli.model_path)?;
             let load_ms = dur_ms(load_start.elapsed());
             let mut bench = ModelWithState { model, state };
-            run_command(&cli, model_type, load_ms, &mut bench, &tokenizer)?
+            dispatch(&cli, model_type, load_ms, &mut bench, &tokenizer)
         }
-    };
-
-    emit_report(&cli, &report)
+    }
 }


### PR DESCRIPTION
## Summary

- New `bench_serving snapshot` subcommand: runs standard profiles `(10000,1)` + `(1024,256)`, writes combined JSON to `bench_snapshots/{model}.json` with commit/date/GPU metadata
- New `bench_serving compare` subcommand: diffs working-tree snapshot against `git show {ref}:path` (default `HEAD`), prints delta table, exits non-zero on missing baseline or profile shape mismatch
- Regression thresholds: TPOT p50 >2%, TTFT p50 >3%
- Includes Qwen3-4B baseline snapshot and workflow doc (`docs/areas/bench-regression.md`)

Design: one file per model, git history is the timeline. No accumulation.

## Test plan

- [x] `cargo check --release` passes (clippy clean)
- [x] `bench_serving snapshot` produces valid JSON for Qwen3-4B
- [ ] `bench_serving compare` against HEAD after committing baseline
- [ ] Qwen3.5-4B snapshot (blocked by 10k prefill OOM — separate fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)