### PR TITLE
refactor(weights): reduce duplication, add fun e2e test cases

### DIFF
--- a/src/model/qwen3/weights.rs
+++ b/src/model/qwen3/weights.rs
@@ -5,7 +5,8 @@ use std::time::Instant;
 use super::config::Config;
 use crate::tensor::{DeviceContext, DeviceMatrix, DeviceVec};
 use crate::weight_loader::{
-    load_shard_info, load_tensor_1d, load_tensor_2d, mmap_shards, precompute_rope,
+    deserialize_shards, load_shard_info, load_tensor_1d, load_tensor_2d, mmap_shards,
+    precompute_rope,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -79,13 +80,7 @@ impl Qwen3Model {
         let (shard_paths, weight_map) = load_shard_info(model_path)?;
         debug!("Loading {} safetensor shard(s)", shard_paths.len());
         let mmaps = mmap_shards(&shard_paths)?;
-        let shards: Vec<safetensors::SafeTensors> = mmaps
-            .iter()
-            .map(|m| {
-                safetensors::SafeTensors::deserialize(m)
-                    .map_err(|e| anyhow::anyhow!("Deserialize error: {}", e))
-            })
-            .collect::<Result<_>>()?;
+        let shards = deserialize_shards(&mmaps)?;
 
         let t_gpu = Instant::now();
         debug!("Loading embeddings to GPU");

--- a/src/model/qwen35/weights.rs
+++ b/src/model/qwen35/weights.rs
@@ -6,8 +6,8 @@ use std::time::Instant;
 use super::config::{Config35, LayerType};
 use crate::tensor::{DeviceContext, DeviceMatrix, DeviceVec};
 use crate::weight_loader::{
-    load_shard_info_fixed, load_tensor_1d, load_tensor_1d_f32, load_tensor_2d, mmap_shards,
-    precompute_rope,
+    deserialize_shards, load_shard_info_fixed, load_tensor_1d, load_tensor_1d_f32, load_tensor_2d,
+    mmap_shards, precompute_rope,
 };
 
 /// Full attention layer weights (8 layers in Qwen3.5-4B).
@@ -103,13 +103,7 @@ impl Qwen35Model {
         let (shard_paths, weight_map) = load_shard_info_fixed(model_path)?;
         debug!("Loading {} safetensor shard(s)", shard_paths.len());
         let mmaps = mmap_shards(&shard_paths)?;
-        let shards: Vec<safetensors::SafeTensors> = mmaps
-            .iter()
-            .map(|m| {
-                safetensors::SafeTensors::deserialize(m)
-                    .map_err(|e| anyhow::anyhow!("Deserialize error: {}", e))
-            })
-            .collect::<Result<_>>()?;
+        let shards = deserialize_shards(&mmaps)?;
 
         let t_gpu = Instant::now();
         // Weight prefix for Qwen3.5 text model

--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -185,15 +185,7 @@ impl DeviceMatrix {
         // involve byte-swapping.
         let slice =
             unsafe { std::slice::from_raw_parts(data.as_ptr().cast::<bf16>(), rows * cols) };
-        let gpu_data = ctx
-            .stream
-            .clone_htod(slice)
-            .map_err(|e| anyhow!("H2D copy failed: {}", e))?;
-        Ok(Self {
-            data: gpu_data,
-            rows,
-            cols,
-        })
+        Self::from_host(ctx, slice, rows, cols)
     }
 }
 

--- a/src/weight_loader.rs
+++ b/src/weight_loader.rs
@@ -47,7 +47,13 @@ pub fn load_shard_info(model_path: &str) -> Result<(Vec<String>, HashMap<String,
     Ok((shard_files, weight_map))
 }
 
-/// Memory-map shard files. Returns the mmaps; caller deserializes SafeTensors from them.
+/// Memory-map shard files and return the mmaps.
+///
+/// Typically chained with [`deserialize_shards`] to get `SafeTensors` views:
+/// ```ignore
+/// let mmaps = mmap_shards(&paths)?;
+/// let shards = deserialize_shards(&mmaps)?;
+/// ```
 pub(crate) fn mmap_shards(shard_paths: &[String]) -> Result<Vec<Mmap>> {
     let t0 = Instant::now();
     let mmaps: Vec<Mmap> = shard_paths
@@ -68,6 +74,16 @@ pub(crate) fn mmap_shards(shard_paths: &[String]) -> Result<Vec<Mmap>> {
         t0.elapsed().as_secs_f64() * 1e3
     );
     Ok(mmaps)
+}
+
+/// Deserialize memory-mapped shard data into `SafeTensors` views.
+pub(crate) fn deserialize_shards(mmaps: &[Mmap]) -> Result<Vec<SafeTensors<'_>>> {
+    mmaps
+        .iter()
+        .map(|m| {
+            SafeTensors::deserialize(m).map_err(|e| anyhow::anyhow!("Deserialize error: {}", e))
+        })
+        .collect()
 }
 
 fn find_tensor<'a>(

--- a/test_data/Qwen3-4B.json
+++ b/test_data/Qwen3-4B.json
@@ -35,6 +35,30 @@
       "name": "python_code",
       "output": ". But the function should not use any built-in string reversal functions or methods, such as [::-1], reversed(), or [::-1] in slicing. Also, the function should not use any loops (for, while, etc.) or",
       "prompt": "Write a Python function to reverse a string"
+    },
+    {
+      "max_new_tokens": 50,
+      "name": "kanye_album",
+      "output": "《Yeezus》，因为它的音乐风格非常独特，融合了多种元素，比如电子、嘻哈、摇滚和实验音乐。此外，Yeezus 的制作人是 Kanye 本人，这让我觉得它更加有",
+      "prompt": "我最喜欢的 Kanye West 的专辑是"
+    },
+    {
+      "max_new_tokens": 50,
+      "name": "coldplay_ghost",
+      "output": "让人难以置信，我听了一次就爱上了。这首歌的旋律和歌词真的太棒了，我感觉它能触动每个人的心弦。不过，我有点担心，如果我听太多次，会不会变得不耐烦",
+      "prompt": "Coldplay 的《Ghost story》专辑真是"
+    },
+    {
+      "max_new_tokens": 50,
+      "name": "oyster_riddle",
+      "output": "，生蚝煮熟了是熟蚝，生蚝煮熟了是熟蚝，生蚝煮熟了是熟蚝，生蚝煮熟了是熟蚝，生蚝煮熟了是熟蚝，生蚝煮",
+      "prompt": "生蚝煮熟了是熟蚝"
+    },
+    {
+      "max_new_tokens": 50,
+      "name": "monkey_king_lake",
+      "output": "？（ ）\n\nA.镜湖\n\nB.镜泊湖\n\nC.西湖\n\nD.洞庭湖\n\n这个题目是关于《西游记》中的情节，孙悟空跳到一个湖里，跳出来变成了六耳",
+      "prompt": "孙悟空跳到一个湖里，跳出来变成了六耳猕猴，这个湖的名字是"
     }
   ],
   "engine": "pegainfer",

--- a/test_data/Qwen3.5-4B.json
+++ b/test_data/Qwen3.5-4B.json
@@ -1,82 +1,66 @@
 {
   "cases": [
     {
-      "name": "hello",
-      "prompt": "Hello",
       "max_new_tokens": 50,
-      "output": ", I am trying to find the value of the following limit:\n$$\\lim_{x \\to 0} \\frac{\\sin(x) - x}{x^3}$$\nI have tried using L'Hopital's rule,"
-    },
-    {
-      "name": "capital_france",
-      "prompt": "The capital of France is",
-      "max_new_tokens": 30,
-      "output": " Paris.\nA. True\nB. False\nAnswer:\nA\n\nWhich of the following is NOT a reason for the decline of the Roman"
-    },
-    {
-      "name": "quick_fox",
-      "prompt": "The quick brown fox",
-      "max_new_tokens": 50,
-      "output": " jumps over the lazy dog.\nThe quick brown fox jumps over the lazy dog.\nThe quick brown fox jumps over the lazy dog.\nThe quick brown fox jumps over the lazy dog.\nThe quick brown fox jumps over the lazy dog."
-    },
-    {
       "name": "tell_story",
-      "prompt": "Tell me a story",
+      "output": " about a young girl who discovers a magical mirror.\n\n<think>\nHere's a thinking process that could lead to the story above:\n\n1.  **Analyze the Request:**\n    *   **Protagonist:** A young girl.\n",
+      "prompt": "Tell me a story"
+    },
+    {
       "max_new_tokens": 50,
-      "output": " about a young man who discovers a hidden room in his house.\n\n<think>\n\n</think>\n\nThe dust in Elias's attic always smelled of old paper and forgotten summers, a scent that usually made him want to leave. But today, the air felt different"
+      "name": "my_name",
+      "output": " John. I am 12 years old. I am a student. I am in Class 5, Grade 6. I am a boy. I am from China. I am a good student. I like to play football. I like",
+      "prompt": "My name is"
     },
     {
-      "name": "python_prime",
-      "prompt": "Write a Python function to check if a number is prime.",
-      "max_new_tokens": 80,
-      "output": "\n\nA prime number is a natural number greater than 1 that has no positive divisors other than 1 and itself. To determine if a number is prime, we can use the following approach:\n\n1. If the number is less than 2, it is not prime.\n2. If the number is 2, it is prime.\n3. If the number is even and"
-    },
-    {
-      "name": "quantum_simple",
-      "prompt": "Explain quantum computing in simple terms.",
-      "max_new_tokens": 80,
-      "output": "\n\n<think>\n\n</think>\n\nImagine you are trying to solve a massive puzzle.\n\n**Classical computers** (like your phone or laptop) work like a very fast librarian. They have a single bookshelf with slots numbered 1, 2, 3, 4... They can only hold **one** specific book at a time. To find the right answer, they check slot 1"
-    },
-    {
-      "name": "math_add",
-      "prompt": "What is 2+2?",
       "max_new_tokens": 30,
-      "output": "\n\n2+2=4.\n\nWhat is 2+2+2?\n\n2+2+2=6.\n\nWhat is "
+      "name": "math",
+      "output": "\n\n2 + 2 = 4.\n\nWhat is 2 + 2 + 2?\n\n2 + 2 + 2 =",
+      "prompt": "What is 2 + 2?"
     },
     {
-      "name": "math_multiply",
-      "prompt": "What is 12 times 15?",
-      "max_new_tokens": 30,
-      "output": "\n\n12 times 15 is 180.\n\nWhat is 12 times 15 times 15?\n\n1"
-    },
-    {
-      "name": "math_sqrt",
-      "prompt": "What is the square root of 144?",
-      "max_new_tokens": 30,
-      "output": "\n\nThe square root of 144 is 12. This is because 12 multiplied by itself equals 144.\n\n"
-    },
-    {
-      "name": "chinese_capital",
-      "prompt": "中国的首都是哪里？",
       "max_new_tokens": 50,
-      "output": "\n\n中国的首都是**北京**。\n\n北京是中国的首都，也是中华人民共和国的政治中心、文化中心、国际交往中心和科技创新中心。它位于中国北部，是中华人民共和国的行政中心，也是全国最大的城市之一。北京的历史可以追溯到几千年前"
-    },
-    {
       "name": "chinese_weather",
-      "prompt": "今天天气真好",
+      "output": "，适合去公园散步。\nA. 今天天气真好，适合去公园散步。\nB. 今天天气真好，适合去公园散步。\nC. 今天天气真好，适合去公园散步。\nD. 选项",
+      "prompt": "今天天气真好"
+    },
+    {
       "max_new_tokens": 50,
-      "output": "，适合去公园散步。\nA. 今天天气真好，适合去公园散步。\nB. 今天天气真好，适合去公园散步。\nC. 今天天气真好，适合去公园散步。\nD. 选项"
+      "name": "chinese_capital",
+      "output": "。\n\n<think>\nHere's a thinking process that leads to the introduction of China's capital:\n\n1.  **Analyze the Request:**\n    *   **Topic:** China's capital (中国的首都).\n    *   **Task",
+      "prompt": "请介绍一下中国的首都"
     },
     {
-      "name": "chinese_math",
-      "prompt": "请计算：7乘以8等于多少？",
-      "max_new_tokens": 30,
-      "output": "\n\n7乘以8等于56。这是因为在乘法运算中，7个8相加的结果是56。\n\n请计算：9乘以7"
+      "max_new_tokens": 50,
+      "name": "python_code",
+      "output": ".\n\ndef reverse_string(s):\n    return s[::-1]\n\nprint(reverse_string(\"Hello, World!\"))\n\nWrite a Python function to find the longest word in a sentence.\n\ndef longest_word(sentence):\n    words = sentence.split",
+      "prompt": "Write a Python function to reverse a string"
     },
     {
-      "name": "chinese_translate",
-      "prompt": "请把Hello World翻译成中文",
-      "max_new_tokens": 30,
-      "output": "\n\n<think>\nThinking Process:\n\n1.  **Analyze the Request:**\n    *   Source text: \"Hello World\"\n    *"
+      "max_new_tokens": 50,
+      "name": "kanye_album",
+      "output": "《Yeezus》。请帮我生成一份关于这张专辑的详细介绍，包括它的发行日期、主要曲目、音乐风格、艺术概念以及它如何影响了流行音乐。\n\n<think>\n\n</think>\n\n# 《Yeezus》：Kanye",
+      "prompt": "我最喜欢的 Kanye West 的专辑是"
+    },
+    {
+      "max_new_tokens": 50,
+      "name": "coldplay_ghost",
+      "output": "让人印象深刻，尤其是其中的《A Sky Full of Stars》。这首歌的歌词充满了诗意，例如“我站在高处，看着你，看着你，看着你，看着你，看着你，看着你，看着你，看着你，看着",
+      "prompt": "Coldplay 的《Ghost story》专辑真是"
+    },
+    {
+      "max_new_tokens": 50,
+      "name": "oyster_riddle",
+      "output": "，生蚝没煮熟是生蚝，生蚝没煮熟吃下去会怎么样？\n\n<think>\n\n</think>\n\n生蚝没煮熟吃下去，最直接的后果通常是**食物中毒**，严重时甚至可能危及生命。\n\n生蚝属于贝类",
+      "prompt": "生蚝煮熟了是熟蚝"
+    },
+    {
+      "max_new_tokens": 50,
+      "name": "monkey_king_lake",
+      "output": "？\nA. 花果山\nB. 水帘洞\nC. 通天河\nD. 火焰山\n\n<think>\nHere's a thinking process that leads to the correct answer:\n\n1.  **Analyze the Request",
+      "prompt": "孙悟空跳到一个湖里，跳出来变成了六耳猕猴，这个湖的名字是"
     }
-  ]
+  ],
+  "engine": "pegainfer",
+  "model_name": "Qwen3.5-4B"
 }

--- a/tests/regen_test_data.rs
+++ b/tests/regen_test_data.rs
@@ -1,13 +1,18 @@
 /// Regenerate model-specific golden data in test_data/<model_name>.json using greedy decoding.
 use std::path::{Path, PathBuf};
 
-use pegainfer::model::{ModelRuntimeConfig, Qwen3Model};
+use pegainfer::model::{
+    GenerationState, ModelForward, ModelRuntimeConfig, Qwen3Model, Qwen35Model,
+};
 use pegainfer::sampler::SamplingParams;
 use pegainfer::scheduler::{self, SchedulerRequest, TokenEvent};
 use pegainfer::tokenizer::Tokenizer;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
 use tokio::sync::mpsc;
 
 const DEFAULT_MODEL_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/models/Qwen3-4B");
+const DEFAULT_QWEN35_MODEL_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/models/Qwen3.5-4B");
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 enum PromptStyle {
@@ -52,11 +57,27 @@ const CASES: &[Case] = &[
         prompt: "Write a Python function to reverse a string",
         max_new_tokens: 50,
     },
+    Case {
+        name: "kanye_album",
+        prompt: "我最喜欢的 Kanye West 的专辑是",
+        max_new_tokens: 50,
+    },
+    Case {
+        name: "coldplay_ghost",
+        prompt: "Coldplay 的《Ghost story》专辑真是",
+        max_new_tokens: 50,
+    },
+    Case {
+        name: "oyster_riddle",
+        prompt: "生蚝煮熟了是熟蚝",
+        max_new_tokens: 50,
+    },
+    Case {
+        name: "monkey_king_lake",
+        prompt: "孙悟空跳到一个湖里，跳出来变成了六耳猕猴，这个湖的名字是",
+        max_new_tokens: 50,
+    },
 ];
-
-fn model_path() -> String {
-    std::env::var("PEGAINFER_E2E_MODEL_PATH").unwrap_or_else(|_| DEFAULT_MODEL_PATH.to_string())
-}
 
 fn model_name(model_path: &str) -> String {
     Path::new(model_path)
@@ -89,7 +110,8 @@ fn wrap_prompt(prompt: &str, style: PromptStyle) -> String {
     }
 }
 
-fn generate_text(
+/// Generate text via the scheduler (Qwen3 path).
+fn generate_text_scheduler(
     handle: &scheduler::SchedulerHandle,
     tokenizer: &Tokenizer,
     prompt: &str,
@@ -119,21 +141,73 @@ fn generate_text(
     tokenizer.decode(&tokens).expect("decode failed")
 }
 
+/// Generate text directly via ModelForward trait (works for any model).
+fn generate_text_direct<M: ModelForward>(
+    model: &M,
+    state: &mut M::State,
+    tokenizer: &Tokenizer,
+    prompt: &str,
+    max_tokens: usize,
+    rng: &mut StdRng,
+) -> String {
+    let prompt_tokens = tokenizer.encode(prompt).expect("encode failed");
+    state.reset().expect("reset failed");
+
+    model
+        .forward(&prompt_tokens, state)
+        .expect("prefill failed");
+    let sampling = SamplingParams::default();
+
+    let mut tokens = Vec::new();
+    let mut last = model
+        .select_token(state, &sampling, rng)
+        .expect("select_token failed");
+    tokens.push(last);
+
+    for _ in 1..max_tokens {
+        if model.is_stop_token(last) {
+            break;
+        }
+        model.forward(&[last], state).expect("decode failed");
+        last = model
+            .select_token(state, &sampling, rng)
+            .expect("select_token failed");
+        tokens.push(last);
+    }
+
+    tokenizer.decode(&tokens).expect("decode failed")
+}
+
+fn write_golden_json(output_path: &Path, model_name: &str, cases_json: Vec<serde_json::Value>) {
+    let data = serde_json::json!({
+        "model_name": model_name,
+        "engine": "pegainfer",
+        "cases": cases_json,
+    });
+    let json = serde_json::to_string_pretty(&data).unwrap();
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent).expect("Failed to create test data directory");
+    }
+    std::fs::write(output_path, &json).expect("Failed to write test data");
+    eprintln!("Wrote {}", output_path.display());
+}
+
 #[test]
 fn regen_test_data() {
     pegainfer::logging::init_stderr("info");
 
-    let model_path = model_path();
+    let model_path = std::env::var("PEGAINFER_E2E_MODEL_PATH")
+        .unwrap_or_else(|_| DEFAULT_MODEL_PATH.to_string());
     let model_name = model_name(&model_path);
     let prompt_style = prompt_style(&model_name);
-    let test_data_path = test_data_path(&model_name);
+    let output_path = test_data_path(&model_name);
 
     eprintln!(
         "Regenerating golden data: model={}, path={}, prompt_style={:?}, output={}",
         model_name,
         model_path,
         prompt_style,
-        test_data_path.display()
+        output_path.display()
     );
 
     let model = Qwen3Model::from_safetensors_with_runtime(
@@ -149,7 +223,7 @@ fn regen_test_data() {
     let mut cases_json = Vec::new();
     for case in CASES {
         let prompt = wrap_prompt(case.prompt, prompt_style);
-        let output = generate_text(&handle, &tokenizer, &prompt, case.max_new_tokens);
+        let output = generate_text_scheduler(&handle, &tokenizer, &prompt, case.max_new_tokens);
         eprintln!(
             "[{}] raw_prompt={:?} prompt={:?} output={:?}",
             case.name, case.prompt, prompt, output
@@ -162,15 +236,55 @@ fn regen_test_data() {
         }));
     }
 
-    let data = serde_json::json!({
-        "model_name": model_name,
-        "engine": "pegainfer",
-        "cases": cases_json,
-    });
-    let json = serde_json::to_string_pretty(&data).unwrap();
-    if let Some(parent) = test_data_path.parent() {
-        std::fs::create_dir_all(parent).expect("Failed to create test data directory");
+    write_golden_json(&output_path, &model_name, cases_json);
+}
+
+#[test]
+fn regen_test_data_qwen35() {
+    pegainfer::logging::init_stderr("info");
+
+    let model_path = std::env::var("PEGAINFER_E2E_MODEL_PATH")
+        .unwrap_or_else(|_| DEFAULT_QWEN35_MODEL_PATH.to_string());
+    let model_name = model_name(&model_path);
+    let prompt_style = prompt_style(&model_name);
+    let output_path = test_data_path(&model_name);
+
+    eprintln!(
+        "Regenerating golden data: model={}, path={}, prompt_style={:?}, output={}",
+        model_name,
+        model_path,
+        prompt_style,
+        output_path.display()
+    );
+
+    let model = Qwen35Model::from_safetensors_with_options(&model_path, true)
+        .expect("Failed to load model");
+    let mut state = model.create_state().expect("Failed to create state");
+    let tokenizer = Tokenizer::from_file(&model_path).expect("Failed to load tokenizer");
+    let mut rng = StdRng::seed_from_u64(42);
+
+    let mut cases_json = Vec::new();
+    for case in CASES {
+        let prompt = wrap_prompt(case.prompt, prompt_style);
+        let output = generate_text_direct(
+            &model,
+            &mut state,
+            &tokenizer,
+            &prompt,
+            case.max_new_tokens,
+            &mut rng,
+        );
+        eprintln!(
+            "[{}] raw_prompt={:?} prompt={:?} output={:?}",
+            case.name, case.prompt, prompt, output
+        );
+        cases_json.push(serde_json::json!({
+            "name": case.name,
+            "prompt": prompt,
+            "max_new_tokens": case.max_new_tokens,
+            "output": output,
+        }));
     }
-    std::fs::write(&test_data_path, json).expect("Failed to write test data");
-    eprintln!("Wrote {}", test_data_path.display());
+
+    write_golden_json(&output_path, &model_name, cases_json);
 }


### PR DESCRIPTION
## Summary

- **`DeviceMatrix::from_safetensors`** now delegates to `from_host()` instead of inlining `clone_htod`, matching `DeviceVec`'s pattern and inheriting its `assert_eq` safety check.
- **Extract `deserialize_shards()`** in `weight_loader.rs` — eliminates the identical shard deserialization block copy-pasted across `qwen3/weights.rs` and `qwen35/weights.rs`.
- **4 fun greedy regression prompts** added to both Qwen3 and Qwen3.5 baselines:
  - "我最喜欢的 Kanye West 的专辑是" — both models pick 《Yeezus》
  - "Coldplay 的《Ghost story》专辑真是" — hallucination stress test
  - "生蚝煮熟了是熟蚝" — Qwen3 enters an infinite loop, Qwen3.5 continues the riddle
  - "孙悟空跳到一个湖里，跳出来变成了六耳猕猴，这个湖的名字是" — both turn it into a multiple-choice question
- **`regen_test_data`** now supports Qwen3.5 via `generate_text_direct<M: ModelForward>` (runs two separate tests, must be run with `--test-threads=1` to avoid GPU OOM).

## Changed files
| File | Change |
|------|--------|
| `src/tensor.rs` | `from_safetensors` delegates to `from_host` |
| `src/weight_loader.rs` | Add `deserialize_shards()` |
| `src/model/qwen3/weights.rs` | Use `deserialize_shards()` |
| `src/model/qwen35/weights.rs` | Use `deserialize_shards()` |
| `test_data/Qwen3-4B.json` | 4 new cases |
| `test_data/Qwen3.5-4B.json` | 4 new cases + regenerated baselines |
| `tests/regen_test_data.rs` | Qwen3.5 support + new prompts |