### PR TITLE
[codex] isolate regen fixture generation

### DIFF
--- a/tests/regen_test_data.rs
+++ b/tests/regen_test_data.rs
@@ -1,5 +1,6 @@
 /// Regenerate model-specific golden data in test_data/<model_name>.json using greedy decoding.
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
 
 use pegainfer::model::{
     GenerationState, ModelForward, ModelRuntimeConfig, Qwen3Model, Qwen35Model,
@@ -13,6 +14,7 @@ use tokio::sync::mpsc;
 
 const DEFAULT_MODEL_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/models/Qwen3-4B");
 const DEFAULT_QWEN35_MODEL_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/models/Qwen3.5-4B");
+static GPU_REGEN_TEST_LOCK: Mutex<()> = Mutex::new(());
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 enum PromptStyle {
@@ -192,8 +194,17 @@ fn write_golden_json(output_path: &Path, model_name: &str, cases_json: Vec<serde
     eprintln!("Wrote {}", output_path.display());
 }
 
+fn lock_gpu_regen_test() -> MutexGuard<'static, ()> {
+    // These tests each load a full model onto the same GPU, so they must not run concurrently.
+    GPU_REGEN_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 #[test]
+#[ignore = "regenerates checked-in golden data; run manually when fixtures need refresh"]
 fn regen_test_data() {
+    let _guard = lock_gpu_regen_test();
     pegainfer::logging::init_stderr("info");
 
     let model_path = std::env::var("PEGAINFER_E2E_MODEL_PATH")
@@ -240,7 +251,9 @@ fn regen_test_data() {
 }
 
 #[test]
+#[ignore = "regenerates checked-in golden data; run manually when fixtures need refresh"]
 fn regen_test_data_qwen35() {
+    let _guard = lock_gpu_regen_test();
     pegainfer::logging::init_stderr("info");
 
     let model_path = std::env::var("PEGAINFER_E2E_MODEL_PATH")


### PR DESCRIPTION
## What changed
- mark `regen_test_data` and `regen_test_data_qwen35` as ignored so normal `cargo test --release` does not rewrite checked-in golden fixtures
- serialize the two regen paths with a process-local `Mutex` when they are invoked manually together
- recover the regen lock after a poisoned panic so one failed manual regen does not cascade into a second lock failure

## Why
`regen_test_data*` are fixture-generation utilities rather than ordinary correctness tests. Running them by default in `cargo test --release` is risky because they are GPU-heavy, they mutate `test_data/*.json`, and they previously could OOM by loading both large models concurrently in the same test binary.

## Impact
- normal test runs stay on the validation path and skip fixture regeneration
- manual fixture refresh remains available via:
  - `PEGAINFER_TRITON_PYTHON=/data/workspace-axel/.venv/bin/python cargo test --release --test regen_test_data -- --ignored`
- concurrent manual regen no longer fights for the same GPU in one test process

## Root cause
Rust's test harness ran both regen tests concurrently. Each test loads a full model onto the same GPU, so the pair could exhaust VRAM and fail with CUDA OOM.

## Validation
- `PEGAINFER_TRITON_PYTHON=/data/workspace-axel/.venv/bin/python cargo test --release`
- `PEGAINFER_TRITON_PYTHON=/data/workspace-axel/.venv/bin/python cargo test --release --test regen_test_data -- --ignored`
