### PR TITLE
[Phase 1b] Add FlashInfer HD256 paged decode wrapper

### DIFF
--- a/csrc/paged_attention.cu
+++ b/csrc/paged_attention.cu
@@ -145,6 +145,81 @@ int paged_attention_decode_cuda(
 }
 
 // ---------------------------------------------------------------------------
+// Paged attention decode for HEAD_DIM=256 — wraps FlashInfer BatchDecodeWithPagedKVCache.
+//
+// Identical to paged_attention_decode_cuda but instantiated with HEAD_DIM=256.
+// This is the Phase 1b wrapper for Qwen3.5 paged decode; Rust integration lands
+// later with the paged-KV decode path in Phase 2d-e.
+// ---------------------------------------------------------------------------
+int paged_attention_decode_cuda_hd256(
+    // Q and output
+    void*    q,                    // [num_qo_heads * 256] bf16, device
+    void*    output,               // [num_qo_heads * 256] bf16, device
+    // KV pool buffer (entire pool)
+    void*    kv_data,
+    int64_t  k_offset_elems,       // element offset: base → layer's K in page 0
+    int64_t  v_offset_elems,       // element offset: base → layer's V in page 0
+    // Paged KV metadata (GPU arrays)
+    int32_t* page_indices,         // [num_pages_this_request]
+    int32_t* page_indptr,          // [batch_size + 1]
+    int32_t* last_page_len_d,      // [batch_size]
+    // Plan metadata (GPU arrays — trivial for non-partition bs=1)
+    int32_t* request_indices,      // [padded_batch_size], e.g. [0]
+    int32_t* kv_tile_indices,      // [padded_batch_size], e.g. [0]
+    int32_t* kv_chunk_size_ptr,    // GPU ptr → 1 int32 (kv_len)
+    // Dimensions
+    int32_t  num_qo_heads,
+    int32_t  num_kv_heads,
+    int32_t  page_size,
+    int32_t  batch_size,
+    int64_t  stride_page,          // KvLayout.page_stride
+    float    sm_scale,             // typically 1/sqrt(256)
+    // Stream
+    void*    stream)
+{
+    auto paged_kv = make_paged_kv(
+        kv_data, k_offset_elems, v_offset_elems,
+        page_indices, page_indptr, last_page_len_d,
+        num_kv_heads, /*head_dim=*/256, page_size, batch_size, stride_page);
+
+    ParamsT params(
+        reinterpret_cast<DType*>(q),
+        /*q_rope_offset=*/nullptr,
+        paged_kv,
+        reinterpret_cast<DType*>(output),
+        /*lse=*/nullptr,
+        /*maybe_alibi_slopes=*/nullptr,
+        num_qo_heads,
+        /*q_stride_n=*/num_qo_heads * 256,
+        /*q_stride_h=*/256,
+        /*window_left=*/-1,
+        /*logits_soft_cap=*/0.0f,
+        sm_scale,
+        /*rope_scale=*/1.0f,
+        /*rope_theta=*/1e6f);
+
+    params.padded_batch_size = batch_size;
+    params.request_indices   = request_indices;
+    params.kv_tile_indices   = kv_tile_indices;
+    params.o_indptr          = nullptr;
+    params.kv_chunk_size_ptr = kv_chunk_size_ptr;
+    params.block_valid_mask  = nullptr;
+    params.partition_kv      = false;
+
+    return static_cast<int>(
+        BatchDecodeWithPagedKVCacheDispatched<
+            /*HEAD_DIM=*/256,
+            PosEncodingMode::kNone,
+            Variant,
+            ParamsT>(
+            params,
+            /*tmp_v=*/nullptr,
+            /*tmp_s=*/nullptr,
+            /*enable_pdl=*/false,
+            reinterpret_cast<cudaStream_t>(stream)));
+}
+
+// ---------------------------------------------------------------------------
 // Paged KV append — writes one K and one V token per request to paged cache.
 //
 // Must be called AFTER RMSNorm + RoPE on K, and BEFORE the attention decode.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -513,4 +513,28 @@ unsafe extern "C" {
         stream: CUstream,
     ) -> i32;
 
+    // Paged attention decode for HEAD_DIM=256 (FlashInfer BatchDecode, no partition-KV).
+    // Phase 1b wrapper only; Rust integration lands later with the Qwen3.5 paged decode path.
+    #[allow(dead_code)]
+    pub(crate) fn paged_attention_decode_cuda_hd256(
+        q: *const Half,
+        output: *mut Half,
+        kv_data: *const Half,
+        k_offset_elems: i64,
+        v_offset_elems: i64,
+        page_indices: *const i32,
+        page_indptr: *const i32,
+        last_page_len_d: *const i32,
+        request_indices: *const i32,
+        kv_tile_indices: *const i32,
+        kv_chunk_size_ptr: *const i32,
+        num_qo_heads: i32,
+        num_kv_heads: i32,
+        page_size: i32,
+        batch_size: i32,
+        stride_page: i64,
+        sm_scale: f32,
+        stream: CUstream,
+    ) -> i32;
+
 }


### PR DESCRIPTION
## What changed
- add `paged_attention_decode_cuda_hd256` in `csrc/paged_attention.cu`
- expose the new Phase 1b wrapper through `src/ffi.rs`
- keep the existing HD128 decode path unchanged; this PR only prepares the HD256 FlashInfer entrypoint for later Rust-side wiring

## Why
Phase 1b needs the HD256 paged decode wrapper available independently from the larger Phase 2 paged-KV integration. This keeps the low-level FlashInfer instantiation ready while avoiding premature changes in the model and scheduler paths.

## Scope boundary
- no Rust call-site integration yet
- no behavior change in current decode flows
- actual Qwen3.5 paged decode wiring is deferred to Phase 2d-e

## Root cause addressed
The codebase had an HD256 FlashInfer prefill wrapper from Phase 1a, but no matching HD256 paged decode wrapper for the later paged-KV decode path.

## Validation
- `PEGAINFER_TRITON_PYTHON=/data/workspace-axel/.venv/bin/python cargo test --release --lib`
- `PEGAINFER_TRITON_PYTHON=/data/workspace-axel/.venv/bin/python cargo test --release --test paged_attention`
