### PR TITLE
fix(qwen35): correct hd256 paged prefill tile count

### DIFF
--- a/scripts/hf_qwen35_full_attn_internal_dump.py
+++ b/scripts/hf_qwen35_full_attn_internal_dump.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+
+import torch
+from transformers import AutoModelForCausalLM
+
+
+def load_tokens(path: Path) -> list[int]:
+    data = json.loads(path.read_text())
+    if isinstance(data, list):
+        return [int(x) for x in data]
+    return [int(x) for x in data["token_ids"]]
+
+
+def flatten_last_token(x: torch.Tensor) -> list[float]:
+    return x[0, -1].reshape(-1).float().cpu().tolist()
+
+
+def split_q_and_gate(q_full_last: list[float], head_dim: int) -> tuple[list[float], list[float]]:
+    assert len(q_full_last) % (2 * head_dim) == 0, len(q_full_last)
+    q_only = []
+    gate_sigmoid = []
+    for head_start in range(0, len(q_full_last), 2 * head_dim):
+        q_chunk = q_full_last[head_start : head_start + head_dim]
+        gate_chunk = q_full_last[head_start + head_dim : head_start + 2 * head_dim]
+        q_only.extend(q_chunk)
+        gate_sigmoid.extend([1.0 / (1.0 + torch.exp(torch.tensor(-x)).item()) for x in gate_chunk])
+    return q_only, gate_sigmoid
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--tokens-file", required=True)
+    parser.add_argument("--prompt-len", type=int, required=True)
+    parser.add_argument("--layer-idx", type=int, required=True)
+    parser.add_argument("--out")
+    args = parser.parse_args()
+
+    token_ids = load_tokens(Path(args.tokens_file))
+    assert 0 < args.prompt_len <= len(token_ids), args.prompt_len
+
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model_path,
+        torch_dtype=torch.bfloat16,
+        device_map="cuda",
+        trust_remote_code=True,
+    )
+    model.eval()
+
+    attn = model.model.layers[args.layer_idx].self_attn
+    captured: dict[str, list[float]] = {}
+
+    hooks = [
+        attn.q_proj.register_forward_hook(
+            lambda _m, _inp, out: captured.__setitem__("q_full_last", flatten_last_token(out))
+        ),
+        attn.k_proj.register_forward_hook(
+            lambda _m, _inp, out: captured.__setitem__("k_proj_last", flatten_last_token(out))
+        ),
+        attn.v_proj.register_forward_hook(
+            lambda _m, _inp, out: captured.__setitem__("v_proj_last", flatten_last_token(out))
+        ),
+        attn.q_norm.register_forward_hook(
+            lambda _m, _inp, out: captured.__setitem__("q_norm_last", flatten_last_token(out))
+        ),
+        attn.o_proj.register_forward_pre_hook(
+            lambda _m, inp: captured.__setitem__("gated_attn_last", flatten_last_token(inp[0]))
+        ),
+        attn.o_proj.register_forward_hook(
+            lambda _m, _inp, out: captured.__setitem__("o_proj_last", flatten_last_token(out))
+        ),
+    ]
+
+    input_ids = torch.tensor([token_ids[: args.prompt_len]], device="cuda", dtype=torch.long)
+    with torch.no_grad():
+        model(input_ids=input_ids, use_cache=False)
+
+    for hook in hooks:
+        hook.remove()
+
+    q_only_last, gate_sigmoid_last = split_q_and_gate(captured["q_full_last"], attn.head_dim)
+    attn_pre_gate_last = [
+        0.0 if gate == 0.0 else val / gate
+        for val, gate in zip(captured["gated_attn_last"], gate_sigmoid_last)
+    ]
+
+    payload = {
+        "prompt_len": args.prompt_len,
+        "layer_idx": args.layer_idx,
+        "q_full_last": captured["q_full_last"],
+        "q_only_last": q_only_last,
+        "gate_sigmoid_last": gate_sigmoid_last,
+        "k_proj_last": captured["k_proj_last"],
+        "v_proj_last": captured["v_proj_last"],
+        "q_norm_last": captured["q_norm_last"],
+        "attn_pre_gate_last": attn_pre_gate_last,
+        "gated_attn_last": captured["gated_attn_last"],
+        "o_proj_last": captured["o_proj_last"],
+    }
+    text = json.dumps(payload, ensure_ascii=False, indent=2)
+    if args.out:
+        Path(args.out).write_text(text)
+    else:
+        print(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hf_qwen35_hidden_dump.py
+++ b/scripts/hf_qwen35_hidden_dump.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+
+import torch
+from transformers import AutoModelForCausalLM
+
+
+def load_tokens(path: Path) -> list[int]:
+    data = json.loads(path.read_text())
+    if isinstance(data, list):
+        return [int(x) for x in data]
+    return [int(x) for x in data["token_ids"]]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--tokens-file", required=True)
+    parser.add_argument("--prompt-len", type=int, required=True)
+    parser.add_argument("--out")
+    args = parser.parse_args()
+
+    token_ids = load_tokens(Path(args.tokens_file))
+    assert 0 < args.prompt_len <= len(token_ids), args.prompt_len
+
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model_path,
+        torch_dtype=torch.bfloat16,
+        device_map="cuda",
+        trust_remote_code=True,
+    )
+    model.eval()
+
+    input_ids = torch.tensor([token_ids[: args.prompt_len]], device="cuda", dtype=torch.long)
+    with torch.no_grad():
+        outputs = model(input_ids=input_ids, output_hidden_states=True, use_cache=False)
+
+    hidden_states = outputs.hidden_states
+    payload = {
+        "prompt_len": args.prompt_len,
+        "embedding_last": hidden_states[0][0, -1].float().cpu().tolist(),
+        "layers_last": [h[0, -1].float().cpu().tolist() for h in hidden_states[1:]],
+    }
+    text = json.dumps(payload, ensure_ascii=False, indent=2)
+    if args.out:
+        Path(args.out).write_text(text)
+    else:
+        print(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hf_qwen35_layer_stage_dump.py
+++ b/scripts/hf_qwen35_layer_stage_dump.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+
+import torch
+from transformers import AutoModelForCausalLM
+
+
+def load_tokens(path: Path) -> list[int]:
+    data = json.loads(path.read_text())
+    if isinstance(data, list):
+        return [int(x) for x in data]
+    return [int(x) for x in data["token_ids"]]
+
+
+def last_token(x):
+    return x[0, -1].float().cpu().tolist()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--tokens-file", required=True)
+    parser.add_argument("--prompt-len", type=int, required=True)
+    parser.add_argument("--layer-idx", type=int, required=True)
+    parser.add_argument("--out")
+    args = parser.parse_args()
+
+    token_ids = load_tokens(Path(args.tokens_file))
+    assert 0 < args.prompt_len <= len(token_ids), args.prompt_len
+
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model_path,
+        torch_dtype=torch.bfloat16,
+        device_map="cuda",
+        trust_remote_code=True,
+    )
+    model.eval()
+
+    layer = model.model.layers[args.layer_idx]
+    captured = {}
+
+    hooks = [
+        layer.input_layernorm.register_forward_hook(
+            lambda _m, _inp, out: captured.__setitem__("input_layernorm_last", last_token(out))
+        ),
+        layer.self_attn.register_forward_hook(
+            lambda _m, _inp, out: captured.__setitem__("attn_out_last", last_token(out[0] if isinstance(out, tuple) else out))
+        ),
+        layer.post_attention_layernorm.register_forward_hook(
+            lambda _m, _inp, out: captured.__setitem__("post_attention_layernorm_last", last_token(out))
+        ),
+        layer.mlp.register_forward_hook(
+            lambda _m, _inp, out: captured.__setitem__("mlp_out_last", last_token(out))
+        ),
+        layer.register_forward_hook(
+            lambda _m, _inp, out: captured.__setitem__("layer_out_last", last_token(out[0] if isinstance(out, tuple) else out))
+        ),
+    ]
+
+    input_ids = torch.tensor([token_ids[: args.prompt_len]], device="cuda", dtype=torch.long)
+    with torch.no_grad():
+        model(input_ids=input_ids, use_cache=False)
+
+    for hook in hooks:
+        hook.remove()
+
+    payload = {
+        "prompt_len": args.prompt_len,
+        "layer_idx": args.layer_idx,
+        "layer_type": "full_attention" if hasattr(layer, "self_attn") else "linear_attention",
+        "input_layernorm_last": captured["input_layernorm_last"],
+        "attn_out_last": captured["attn_out_last"],
+        "hidden_plus_attn_last": None,
+        "post_attention_layernorm_last": captured["post_attention_layernorm_last"],
+        "mlp_out_last": captured["mlp_out_last"],
+        "layer_out_last": captured["layer_out_last"],
+    }
+    # hidden_plus_attn is the input to post_attention_layernorm.
+    # That input is the module input captured by a pre-hook; easiest is reconstruct from layer_out = residual+mlp_out? skip here.
+    text = json.dumps(payload, ensure_ascii=False, indent=2)
+    if args.out:
+        Path(args.out).write_text(text)
+    else:
+        print(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hf_qwen35_prefill_probe.py
+++ b/scripts/hf_qwen35_prefill_probe.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+def load_tokens(path: Path) -> list[int]:
+    data = json.loads(path.read_text())
+    if isinstance(data, list):
+        return [int(x) for x in data]
+    return [int(x) for x in data["token_ids"]]
+
+
+def decode_one(tokenizer, token_id: int) -> str:
+    try:
+        return tokenizer.decode([token_id], skip_special_tokens=False)
+    except Exception:
+        return f"<decode_error:{token_id}>"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--tokens-file", required=True)
+    parser.add_argument("--lengths", required=True, help="comma-separated prompt lengths")
+    parser.add_argument("--top-k", type=int, default=10)
+    parser.add_argument("--out")
+    args = parser.parse_args()
+
+    token_ids = load_tokens(Path(args.tokens_file))
+    lengths = [int(x) for x in args.lengths.split(",") if x]
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model_path, trust_remote_code=True)
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model_path,
+        torch_dtype=torch.bfloat16,
+        device_map="cuda",
+        trust_remote_code=True,
+    )
+    model.eval()
+
+    results = []
+    with torch.no_grad():
+        for prompt_len in lengths:
+            assert 0 < prompt_len <= len(token_ids), prompt_len
+            input_ids = torch.tensor([token_ids[:prompt_len]], device="cuda", dtype=torch.long)
+            logits = model(input_ids).logits[0, -1].float()
+            logprobs = torch.log_softmax(logits, dim=-1)
+            top_logprobs, top_ids = torch.topk(logprobs, k=args.top_k)
+            generated_token = int(top_ids[0].item())
+            results.append(
+                {
+                    "prompt_len": prompt_len,
+                    "last_prompt_token": int(token_ids[prompt_len - 1]),
+                    "generated_token": generated_token,
+                    "generated_text": decode_one(tokenizer, generated_token),
+                    "generated_logprob": float(top_logprobs[0].item()),
+                    "top_logprobs": [
+                        {
+                            "id": int(tok.item()),
+                            "text": decode_one(tokenizer, int(tok.item())),
+                            "logprob": float(lp.item()),
+                        }
+                        for tok, lp in zip(top_ids, top_logprobs, strict=True)
+                    ],
+                }
+            )
+
+    payload = json.dumps(results, ensure_ascii=False, indent=2)
+    if args.out:
+        Path(args.out).write_text(payload)
+    else:
+        print(payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bin/qwen35_full_attn_internal_dump.rs
+++ b/src/bin/qwen35_full_attn_internal_dump.rs
@@ -1,0 +1,99 @@
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use pegainfer::model::Qwen35Model;
+use serde::Serialize;
+
+#[derive(Parser, Debug)]
+struct Cli {
+    #[arg(long)]
+    model_path: String,
+    #[arg(long)]
+    tokens_file: PathBuf,
+    #[arg(long)]
+    prompt_len: usize,
+    #[arg(long)]
+    layer_idx: usize,
+    #[arg(long)]
+    out: Option<PathBuf>,
+}
+
+#[derive(Serialize)]
+struct InternalDump {
+    prompt_len: usize,
+    layer_idx: usize,
+    input_layernorm_last: Vec<f32>,
+    q_full_last: Vec<f32>,
+    k_proj_last: Vec<f32>,
+    v_proj_last: Vec<f32>,
+    q_prepped_last: Vec<f32>,
+    attn_pre_gate_last: Vec<f32>,
+    gated_attn_last: Vec<f32>,
+    o_proj_last: Vec<f32>,
+}
+
+fn load_tokens(path: &PathBuf) -> Result<Vec<u32>> {
+    let text = fs::read_to_string(path)
+        .with_context(|| format!("failed to read tokens file {}", path.display()))?;
+    if let Ok(ids) = serde_json::from_str::<Vec<u32>>(&text) {
+        return Ok(ids);
+    }
+    #[derive(serde::Deserialize)]
+    struct Wrapper {
+        token_ids: Vec<u32>,
+    }
+    let wrapper: Wrapper =
+        serde_json::from_str(&text).with_context(|| format!("failed to parse {}", path.display()))?;
+    Ok(wrapper.token_ids)
+}
+
+fn main() -> Result<()> {
+    pegainfer::logging::init_stderr("info");
+    let cli = Cli::parse();
+    let tokens = load_tokens(&cli.tokens_file)?;
+    anyhow::ensure!(
+        cli.prompt_len > 0 && cli.prompt_len <= tokens.len(),
+        "prompt_len {} out of range for {} tokens",
+        cli.prompt_len,
+        tokens.len()
+    );
+
+    let model = Qwen35Model::from_safetensors_with_options(&cli.model_path, true)
+        .context("failed to load Qwen3.5 model")?;
+    let (
+        input_layernorm_last,
+        q_full_last,
+        k_proj_last,
+        v_proj_last,
+        q_prepped_last,
+        attn_pre_gate_last,
+        gated_attn_last,
+        o_proj_last,
+    ) = model.debug_prefill_full_attention_internal_last_hidden(
+        &tokens[..cli.prompt_len],
+        cli.layer_idx,
+    )?;
+
+    let dump = InternalDump {
+        prompt_len: cli.prompt_len,
+        layer_idx: cli.layer_idx,
+        input_layernorm_last,
+        q_full_last,
+        k_proj_last,
+        v_proj_last,
+        q_prepped_last,
+        attn_pre_gate_last,
+        gated_attn_last,
+        o_proj_last,
+    };
+
+    let json = serde_json::to_string_pretty(&dump)?;
+    if let Some(out) = cli.out {
+        fs::write(&out, json).with_context(|| format!("failed to write {}", out.display()))?;
+    } else {
+        println!("{json}");
+    }
+    Ok(())
+}

--- a/src/bin/qwen35_hidden_dump.rs
+++ b/src/bin/qwen35_hidden_dump.rs
@@ -1,0 +1,74 @@
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use pegainfer::model::Qwen35Model;
+use serde::Serialize;
+
+#[derive(Parser, Debug)]
+struct Cli {
+    #[arg(long)]
+    model_path: String,
+    #[arg(long)]
+    tokens_file: PathBuf,
+    #[arg(long)]
+    prompt_len: usize,
+    #[arg(long)]
+    out: Option<PathBuf>,
+}
+
+#[derive(Serialize)]
+struct HiddenDump {
+    prompt_len: usize,
+    layer_types: Vec<String>,
+    embedding_last: Vec<f32>,
+    layers_last: Vec<Vec<f32>>,
+}
+
+fn load_tokens(path: &PathBuf) -> Result<Vec<u32>> {
+    let text = fs::read_to_string(path)
+        .with_context(|| format!("failed to read tokens file {}", path.display()))?;
+    if let Ok(ids) = serde_json::from_str::<Vec<u32>>(&text) {
+        return Ok(ids);
+    }
+    #[derive(serde::Deserialize)]
+    struct Wrapper {
+        token_ids: Vec<u32>,
+    }
+    let wrapper: Wrapper =
+        serde_json::from_str(&text).with_context(|| format!("failed to parse {}", path.display()))?;
+    Ok(wrapper.token_ids)
+}
+
+fn main() -> Result<()> {
+    pegainfer::logging::init_stderr("info");
+    let cli = Cli::parse();
+    let tokens = load_tokens(&cli.tokens_file)?;
+    anyhow::ensure!(
+        cli.prompt_len > 0 && cli.prompt_len <= tokens.len(),
+        "prompt_len {} out of range for {} tokens",
+        cli.prompt_len,
+        tokens.len()
+    );
+
+    let model = Qwen35Model::from_safetensors_with_options(&cli.model_path, true)
+        .context("failed to load Qwen3.5 model")?;
+    let (embedding_last, layers_last, layer_types) =
+        model.debug_prefill_last_hidden_by_layer(&tokens[..cli.prompt_len])?;
+
+    let dump = HiddenDump {
+        prompt_len: cli.prompt_len,
+        layer_types,
+        embedding_last,
+        layers_last,
+    };
+
+    let json = serde_json::to_string_pretty(&dump)?;
+    if let Some(out) = cli.out {
+        fs::write(&out, json).with_context(|| format!("failed to write {}", out.display()))?;
+    } else {
+        println!("{json}");
+    }
+    Ok(())
+}

--- a/src/bin/qwen35_layer_stage_dump.rs
+++ b/src/bin/qwen35_layer_stage_dump.rs
@@ -1,0 +1,86 @@
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use pegainfer::model::Qwen35Model;
+use serde::Serialize;
+
+#[derive(Parser, Debug)]
+struct Cli {
+    #[arg(long)]
+    model_path: String,
+    #[arg(long)]
+    tokens_file: PathBuf,
+    #[arg(long)]
+    prompt_len: usize,
+    #[arg(long)]
+    layer_idx: usize,
+    #[arg(long)]
+    out: Option<PathBuf>,
+}
+
+#[derive(Serialize)]
+struct StageDump {
+    prompt_len: usize,
+    layer_idx: usize,
+    layer_type: String,
+    input_layernorm_last: Vec<f32>,
+    attn_out_last: Vec<f32>,
+    hidden_plus_attn_last: Vec<f32>,
+    post_attention_layernorm_last: Vec<f32>,
+    mlp_out_last: Vec<f32>,
+    layer_out_last: Vec<f32>,
+}
+
+fn load_tokens(path: &PathBuf) -> Result<Vec<u32>> {
+    let text = fs::read_to_string(path)
+        .with_context(|| format!("failed to read tokens file {}", path.display()))?;
+    if let Ok(ids) = serde_json::from_str::<Vec<u32>>(&text) {
+        return Ok(ids);
+    }
+    #[derive(serde::Deserialize)]
+    struct Wrapper {
+        token_ids: Vec<u32>,
+    }
+    let wrapper: Wrapper =
+        serde_json::from_str(&text).with_context(|| format!("failed to parse {}", path.display()))?;
+    Ok(wrapper.token_ids)
+}
+
+fn main() -> Result<()> {
+    pegainfer::logging::init_stderr("info");
+    let cli = Cli::parse();
+    let tokens = load_tokens(&cli.tokens_file)?;
+    anyhow::ensure!(
+        cli.prompt_len > 0 && cli.prompt_len <= tokens.len(),
+        "prompt_len {} out of range for {} tokens",
+        cli.prompt_len,
+        tokens.len()
+    );
+
+    let model = Qwen35Model::from_safetensors_with_options(&cli.model_path, true)
+        .context("failed to load Qwen3.5 model")?;
+    let (layer_type, input_layernorm_last, attn_out_last, hidden_plus_attn_last, post_attention_layernorm_last, mlp_out_last, layer_out_last) =
+        model.debug_prefill_layer_stage_last_hidden(&tokens[..cli.prompt_len], cli.layer_idx)?;
+
+    let dump = StageDump {
+        prompt_len: cli.prompt_len,
+        layer_idx: cli.layer_idx,
+        layer_type,
+        input_layernorm_last,
+        attn_out_last,
+        hidden_plus_attn_last,
+        post_attention_layernorm_last,
+        mlp_out_last,
+        layer_out_last,
+    };
+
+    let json = serde_json::to_string_pretty(&dump)?;
+    if let Some(out) = cli.out {
+        fs::write(&out, json).with_context(|| format!("failed to write {}", out.display()))?;
+    } else {
+        println!("{json}");
+    }
+    Ok(())
+}

--- a/src/bin/qwen35_prefill_probe.rs
+++ b/src/bin/qwen35_prefill_probe.rs
@@ -1,0 +1,152 @@
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use pegainfer::model::Qwen35Model;
+use pegainfer::sampler::SamplingParams;
+use pegainfer::scheduler::{SchedulerRequest, TokenEvent};
+use pegainfer::scheduler_qwen35;
+use pegainfer::server_engine::TokenLogprob;
+use pegainfer::tokenizer::Tokenizer;
+use serde::Serialize;
+use tokio::sync::mpsc;
+
+#[derive(Parser, Debug)]
+struct Cli {
+    #[arg(long)]
+    model_path: String,
+    #[arg(long)]
+    tokens_file: PathBuf,
+    #[arg(long, value_delimiter = ',')]
+    lengths: Vec<usize>,
+    #[arg(long, default_value_t = 10)]
+    top_k: usize,
+    #[arg(long)]
+    out: Option<PathBuf>,
+}
+
+#[derive(Serialize)]
+struct ProbeTop {
+    id: u32,
+    text: String,
+    logprob: f32,
+}
+
+#[derive(Serialize)]
+struct ProbeResult {
+    prompt_len: usize,
+    last_prompt_token: u32,
+    generated_token: u32,
+    generated_text: String,
+    generated_logprob: Option<f32>,
+    top_logprobs: Vec<ProbeTop>,
+}
+
+fn load_tokens(path: &PathBuf) -> Result<Vec<u32>> {
+    let text = fs::read_to_string(path)
+        .with_context(|| format!("failed to read tokens file {}", path.display()))?;
+    if let Ok(ids) = serde_json::from_str::<Vec<u32>>(&text) {
+        return Ok(ids);
+    }
+    #[derive(serde::Deserialize)]
+    struct Wrapper {
+        token_ids: Vec<u32>,
+    }
+    let wrapper: Wrapper = serde_json::from_str(&text)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+    Ok(wrapper.token_ids)
+}
+
+fn decode_one(tokenizer: &Tokenizer, id: u32) -> String {
+    tokenizer
+        .decode(&[id])
+        .unwrap_or_else(|_| format!("<decode_error:{id}>"))
+}
+
+fn top_entries(tokenizer: &Tokenizer, lp: Option<TokenLogprob>) -> (Option<f32>, Vec<ProbeTop>) {
+    match lp {
+        Some(lp) => {
+            let top = lp
+                .top_logprobs
+                .into_iter()
+                .map(|(id, logprob)| ProbeTop {
+                    id,
+                    text: decode_one(tokenizer, id),
+                    logprob,
+                })
+                .collect();
+            (Some(lp.logprob), top)
+        }
+        None => (None, Vec::new()),
+    }
+}
+
+fn main() -> Result<()> {
+    pegainfer::logging::init_stderr("info");
+    let cli = Cli::parse();
+    let tokens = load_tokens(&cli.tokens_file)?;
+    anyhow::ensure!(!cli.lengths.is_empty(), "at least one prompt length is required");
+
+    let model = Qwen35Model::from_safetensors_with_options(&cli.model_path, true)
+        .context("failed to load Qwen3.5 model")?;
+    let tokenizer = Tokenizer::from_file(&cli.model_path).context("failed to load tokenizer")?;
+    let handle = scheduler_qwen35::start_with_capacity(model, 42, 1)
+        .context("failed to start Qwen3.5 scheduler")?;
+
+    let mut results = Vec::with_capacity(cli.lengths.len());
+    for &prompt_len in &cli.lengths {
+        anyhow::ensure!(
+            prompt_len > 0 && prompt_len <= tokens.len(),
+            "prompt_len {} out of range for {} tokens",
+            prompt_len,
+            tokens.len()
+        );
+        let prompt_tokens = tokens[..prompt_len].to_vec();
+        let last_prompt_token = *prompt_tokens.last().unwrap();
+        let (token_tx, mut token_rx) = mpsc::unbounded_channel();
+        handle
+            .submit(SchedulerRequest {
+                prompt_tokens,
+                params: SamplingParams::default(),
+                max_tokens: 1,
+                token_tx,
+                logprobs: cli.top_k,
+                echo: false,
+            })
+            .context("failed to submit scheduler request")?;
+
+        let mut generated_token = None;
+        let mut generated_lp = None;
+        loop {
+            match token_rx.blocking_recv() {
+                Some(TokenEvent::Token { id, logprob }) => {
+                    generated_token = Some(id);
+                    generated_lp = Some(logprob);
+                }
+                Some(TokenEvent::PromptTokens { .. }) => {}
+                Some(TokenEvent::Finished { .. }) => break,
+                None => anyhow::bail!("scheduler channel closed before Finished"),
+            }
+        }
+
+        let generated_token = generated_token.context("no generated token received")?;
+        let (generated_logprob, top_logprobs) = top_entries(&tokenizer, generated_lp.flatten());
+        results.push(ProbeResult {
+            prompt_len,
+            last_prompt_token,
+            generated_token,
+            generated_text: decode_one(&tokenizer, generated_token),
+            generated_logprob,
+            top_logprobs,
+        });
+    }
+
+    let json = serde_json::to_string_pretty(&results)?;
+    if let Some(out) = cli.out {
+        fs::write(&out, json).with_context(|| format!("failed to write {}", out.display()))?;
+    } else {
+        println!("{json}");
+    }
+    Ok(())
+}

--- a/src/model/qwen35/prefill.rs
+++ b/src/model/qwen35/prefill.rs
@@ -17,6 +17,487 @@ use crate::ops::PrefillPagedPlan;
 use crate::tensor::{DeviceVec, HiddenStates};
 
 impl Qwen35Model {
+    #[allow(clippy::type_complexity)]
+    pub fn debug_prefill_full_attention_internal_last_hidden(
+        &self,
+        token_ids: &[u32],
+        target_layer_idx: usize,
+    ) -> Result<(
+        Vec<f32>,
+        Vec<f32>,
+        Vec<f32>,
+        Vec<f32>,
+        Vec<f32>,
+        Vec<f32>,
+        Vec<f32>,
+        Vec<f32>,
+    )> {
+        let seq_len = token_ids.len();
+        anyhow::ensure!(
+            seq_len > 0,
+            "debug_prefill_full_attention_internal_last_hidden requires non-empty input"
+        );
+        anyhow::ensure!(
+            target_layer_idx < self.layers.len(),
+            "target_layer_idx {} out of range {}",
+            target_layer_idx,
+            self.layers.len()
+        );
+        let c = &self.config;
+
+        let token_ids_i32: Vec<i32> = token_ids.iter().map(|&x| x as i32).collect();
+        let token_ids_gpu = self
+            .ctx
+            .stream
+            .clone_htod(&token_ids_i32)
+            .map_err(|e| anyhow::anyhow!("H2D copy failed: {}", e))?;
+
+        let mut hidden_batch = HiddenStates::zeros(&self.ctx, c.hidden_size, seq_len)?;
+        ops::embedding_batch(
+            &self.ctx,
+            &self.embed_tokens,
+            &token_ids_gpu,
+            &mut hidden_batch,
+        )?;
+
+        let mut kv_cache = KVCache::new(c.num_full_attention_layers(), c.num_key_value_heads);
+        let mut kv_state = self.alloc_kv();
+        let mut recurrent = RecurrentState::new(&self.ctx, &self.config)?;
+
+        kv_cache.init_if_needed(&self.ctx, c.head_dim)?;
+        let base_pos = kv_state.seq_len();
+        kv_state.ensure_capacity(base_pos + seq_len)?;
+        kv_state.advance(seq_len);
+        let kv_desc = kv_state.desc();
+        let prefill_plan = PrefillPagedPlan::new(
+            &self.ctx,
+            &kv_desc,
+            base_pos,
+            seq_len,
+            c.num_attention_heads,
+            c.num_key_value_heads,
+            c.head_dim,
+        )?;
+
+        let mut linear_idx = 0usize;
+        let mut full_idx = 0usize;
+        let mut gdr_chunkwise_scratch = GdrChunkwiseScratch35::new(&self.ctx, c, seq_len)?;
+
+        for (layer_idx, layer) in self.layers.iter().enumerate() {
+            if layer_idx != target_layer_idx {
+                hidden_batch = self.prefill_layer(
+                    layer_idx,
+                    layer,
+                    &hidden_batch,
+                    &mut gdr_chunkwise_scratch,
+                    &mut linear_idx,
+                    &mut full_idx,
+                    &mut kv_cache,
+                    &kv_state,
+                    &prefill_plan,
+                    &mut recurrent,
+                )?;
+                continue;
+            }
+
+            let attn = match &layer.attn {
+                LayerKind::FullAttention(attn) => attn,
+                LayerKind::LinearAttention(_) => {
+                    anyhow::bail!("target layer {} is not full_attention", target_layer_idx)
+                }
+            };
+
+            let eps = c.rms_norm_eps;
+            const HEAD_DIM: usize = 256;
+            let input_normed =
+                self.batched_rms_norm_offset(&hidden_batch, &layer.input_layernorm, eps)?;
+            let q_full_batch = ops::gemm(&self.ctx, &attn.q_proj, &input_normed)?;
+            let k_batch = ops::gemm(&self.ctx, &attn.k_proj, &input_normed)?;
+            let v_batch = ops::gemm(&self.ctx, &attn.v_proj, &input_normed)?;
+            let attn_out_dim = c.full_attn_q_dim();
+
+            let base_pos = kv_cache.len();
+            let (kc, vc) = kv_cache.get_cache_mut(&self.ctx, full_idx)?;
+            let mut q_prepped = HiddenStates::zeros(&self.ctx, attn_out_dim, seq_len)?;
+            let mut attn_pre_gate_batch = HiddenStates::zeros(&self.ctx, attn_out_dim, seq_len)?;
+            let start_pos_cpu: CudaSlice<i32> = self
+                .ctx
+                .stream
+                .clone_htod(&[base_pos as i32])
+                .map_err(|e| anyhow::anyhow!("H2D start_pos failed: {e}"))?;
+
+            unsafe {
+                let (qf_ptr, _) = q_full_batch.data.device_ptr(&self.ctx.stream);
+                let (k_ptr, _) = k_batch.data.device_ptr(&self.ctx.stream);
+                let (v_ptr, _) = v_batch.data.device_ptr(&self.ctx.stream);
+                let (qn_ptr, _) = attn.q_norm.data.device_ptr(&self.ctx.stream);
+                let (kn_ptr, _) = attn.k_norm.data.device_ptr(&self.ctx.stream);
+                let (cos_ptr, _) = self.cos_cache.data.device_ptr(&self.ctx.stream);
+                let (sin_ptr, _) = self.sin_cache.data.device_ptr(&self.ctx.stream);
+                let (qp_ptr, _) = q_prepped.data.device_ptr_mut(&self.ctx.stream);
+                let (kc_ptr, _) = kc.data.device_ptr_mut(&self.ctx.stream);
+                let (vc_ptr, _) = vc.data.device_ptr_mut(&self.ctx.stream);
+                let (sp_ptr, _) = start_pos_cpu.device_ptr(&self.ctx.stream);
+                ffi::prefill_attention_hd256_prep_cuda(
+                    qf_ptr as *const ffi::Half,
+                    k_ptr as *const ffi::Half,
+                    v_ptr as *const ffi::Half,
+                    qn_ptr as *const ffi::Half,
+                    kn_ptr as *const ffi::Half,
+                    cos_ptr as *const ffi::Half,
+                    sin_ptr as *const ffi::Half,
+                    qp_ptr as *mut ffi::Half,
+                    kc_ptr as *mut ffi::Half,
+                    vc_ptr as *mut ffi::Half,
+                    c.num_attention_heads as i32,
+                    c.num_key_value_heads as i32,
+                    seq_len as i32,
+                    sp_ptr as *const i32,
+                    c.rotary_dim as i32,
+                    eps,
+                    MAX_SEQ as i32,
+                    self.ctx.stream.cu_stream(),
+                );
+            }
+
+            let layout = kv_state.layout();
+            let layer_k_off = (full_idx * layout.layer_stride) as i64;
+            let layer_v_off = layer_k_off + layout.kv_block_len as i64;
+            let stride_page = layout.page_stride as i64;
+            let src_stride_n = HEAD_DIM as i64;
+            let src_stride_h = (MAX_SEQ * HEAD_DIM) as i64;
+            {
+                let (buf_ptr, _gbuf) = kv_state.buffer().device_ptr(&self.ctx.stream);
+                let (kc_ptr, _gkc) = kc.data.device_ptr(&self.ctx.stream);
+                let (vc_ptr, _gvc) = vc.data.device_ptr(&self.ctx.stream);
+                let elem_off = base_pos as u64 * HEAD_DIM as u64 * 2;
+                let kc_scatter = (kc_ptr + elem_off) as *const ffi::Half;
+                let vc_scatter = (vc_ptr + elem_off) as *const ffi::Half;
+                let (pi_ptr, _gpi) = prefill_plan.page_indices_d().device_ptr(&self.ctx.stream);
+                let (pip_ptr, _gpip) = prefill_plan.page_indptr_d().device_ptr(&self.ctx.stream);
+                let (lpl_ptr, _glpl) = prefill_plan.last_page_len_d().device_ptr(&self.ctx.stream);
+                let (bi_ptr, _gbi) = prefill_plan.batch_indices_d().device_ptr(&self.ctx.stream);
+                let (pos_ptr, _gpos) = prefill_plan.positions_d().device_ptr(&self.ctx.stream);
+                let result = unsafe {
+                    ffi::paged_kv_scatter_cuda(
+                        buf_ptr as *const ffi::Half,
+                        layer_k_off,
+                        layer_v_off,
+                        pi_ptr as *const i32,
+                        pip_ptr as *const i32,
+                        lpl_ptr as *const i32,
+                        kc_scatter,
+                        vc_scatter,
+                        bi_ptr as *const i32,
+                        pos_ptr as *const i32,
+                        seq_len as i32,
+                        c.num_key_value_heads as i32,
+                        HEAD_DIM as i32,
+                        layout.page_size as i32,
+                        stride_page,
+                        src_stride_n,
+                        src_stride_h,
+                        self.ctx.stream.cu_stream(),
+                    )
+                };
+                anyhow::ensure!(
+                    result == 0,
+                    "paged_kv_scatter_cuda (debug prefill) failed: {result}"
+                );
+            }
+
+            let sm_scale = 1.0f32 / f32::sqrt(HEAD_DIM as f32);
+            {
+                let (buf_ptr, _gbuf) = kv_state.buffer().device_ptr(&self.ctx.stream);
+                let (qp_ptr, _gqp) = q_prepped.data.device_ptr(&self.ctx.stream);
+                let (out_ptr, _go) = attn_pre_gate_batch.data.device_ptr_mut(&self.ctx.stream);
+                let (pi_ptr, _gpi) = prefill_plan.page_indices_d().device_ptr(&self.ctx.stream);
+                let (pip_ptr, _gpip) = prefill_plan.page_indptr_d().device_ptr(&self.ctx.stream);
+                let (lpl_ptr, _glpl) = prefill_plan.last_page_len_d().device_ptr(&self.ctx.stream);
+                let (qi_ptr, _gqi) = prefill_plan.q_indptr_d().device_ptr(&self.ctx.stream);
+                let (ri_ptr, _gri) = prefill_plan
+                    .request_indices_d()
+                    .device_ptr(&self.ctx.stream);
+                let (qti_ptr, _gqti) = prefill_plan
+                    .qo_tile_indices_d()
+                    .device_ptr(&self.ctx.stream);
+                let (kti_ptr, _gkti) = prefill_plan
+                    .kv_tile_indices_d()
+                    .device_ptr(&self.ctx.stream);
+                let (kcs_ptr, _gkcs) = prefill_plan.kv_chunk_size_d().device_ptr(&self.ctx.stream);
+                let (tnr_ptr, _gtnr) = prefill_plan.total_num_rows_d().device_ptr(&self.ctx.stream);
+                let result = unsafe {
+                    ffi::batch_prefill_paged_cuda_hd256(
+                        qp_ptr as *const ffi::Half,
+                        out_ptr as *mut ffi::Half,
+                        buf_ptr as *const ffi::Half,
+                        layer_k_off,
+                        layer_v_off,
+                        pi_ptr as *const i32,
+                        pip_ptr as *const i32,
+                        lpl_ptr as *const i32,
+                        qi_ptr as *const i32,
+                        ri_ptr as *const i32,
+                        qti_ptr as *const i32,
+                        kti_ptr as *const i32,
+                        kcs_ptr as *const i32,
+                        tnr_ptr as *const u32,
+                        c.num_attention_heads as i32,
+                    c.num_key_value_heads as i32,
+                    HEAD_DIM as i32,
+                    layout.page_size as i32,
+                    seq_len as i32,
+                    prefill_plan.batch_size(),
+                    prefill_plan.num_tiles(),
+                    stride_page,
+                    sm_scale,
+                    self.ctx.stream.cu_stream(),
+                )
+            };
+                anyhow::ensure!(
+                    result == 0,
+                    "batch_prefill_paged_cuda_hd256 (debug) failed: {result}"
+                );
+            }
+
+            let attn_pre_gate_last =
+                ops::extract_vec(&self.ctx, &attn_pre_gate_batch, seq_len - 1)?.to_host(&self.ctx)?;
+
+            {
+                let (qf_ptr, _gqf) = q_full_batch.data.device_ptr(&self.ctx.stream);
+                let (out_ptr, _go) = attn_pre_gate_batch.data.device_ptr_mut(&self.ctx.stream);
+                unsafe {
+                    ffi::attention_gate_batch_hd256_cuda(
+                        qf_ptr as *const ffi::Half,
+                        out_ptr as *mut ffi::Half,
+                        c.num_attention_heads as i32,
+                        seq_len as i32,
+                        self.ctx.stream.cu_stream(),
+                    );
+                }
+            }
+
+            let gated_attn_last =
+                ops::extract_vec(&self.ctx, &attn_pre_gate_batch, seq_len - 1)?.to_host(&self.ctx)?;
+            let o_proj_last = ops::extract_vec(
+                &self.ctx,
+                &ops::gemm(&self.ctx, &attn.o_proj, &attn_pre_gate_batch)?,
+                seq_len - 1,
+            )?
+            .to_host(&self.ctx)?;
+
+            return Ok((
+                ops::extract_vec(&self.ctx, &input_normed, seq_len - 1)?.to_host(&self.ctx)?,
+                ops::extract_vec(&self.ctx, &q_full_batch, seq_len - 1)?.to_host(&self.ctx)?,
+                ops::extract_vec(&self.ctx, &k_batch, seq_len - 1)?.to_host(&self.ctx)?,
+                ops::extract_vec(&self.ctx, &v_batch, seq_len - 1)?.to_host(&self.ctx)?,
+                ops::extract_vec(&self.ctx, &q_prepped, seq_len - 1)?.to_host(&self.ctx)?,
+                attn_pre_gate_last,
+                gated_attn_last,
+                o_proj_last,
+            ));
+        }
+
+        unreachable!("target layer should have returned");
+    }
+
+    pub fn debug_prefill_layer_stage_last_hidden(
+        &self,
+        token_ids: &[u32],
+        target_layer_idx: usize,
+    ) -> Result<(String, Vec<f32>, Vec<f32>, Vec<f32>, Vec<f32>, Vec<f32>, Vec<f32>)> {
+        let seq_len = token_ids.len();
+        anyhow::ensure!(seq_len > 0, "debug_prefill_layer_stage_last_hidden requires non-empty input");
+        anyhow::ensure!(
+            target_layer_idx < self.layers.len(),
+            "target_layer_idx {} out of range {}",
+            target_layer_idx,
+            self.layers.len()
+        );
+        let c = &self.config;
+
+        let token_ids_i32: Vec<i32> = token_ids.iter().map(|&x| x as i32).collect();
+        let token_ids_gpu = self
+            .ctx
+            .stream
+            .clone_htod(&token_ids_i32)
+            .map_err(|e| anyhow::anyhow!("H2D copy failed: {}", e))?;
+
+        let mut hidden_batch = HiddenStates::zeros(&self.ctx, c.hidden_size, seq_len)?;
+        ops::embedding_batch(
+            &self.ctx,
+            &self.embed_tokens,
+            &token_ids_gpu,
+            &mut hidden_batch,
+        )?;
+
+        let mut kv_cache = KVCache::new(c.num_full_attention_layers(), c.num_key_value_heads);
+        let mut kv_state = self.alloc_kv();
+        let mut recurrent = RecurrentState::new(&self.ctx, &self.config)?;
+
+        kv_cache.init_if_needed(&self.ctx, c.head_dim)?;
+        let base_pos = kv_state.seq_len();
+        kv_state.ensure_capacity(base_pos + seq_len)?;
+        kv_state.advance(seq_len);
+        let kv_desc = kv_state.desc();
+        let prefill_plan = PrefillPagedPlan::new(
+            &self.ctx,
+            &kv_desc,
+            base_pos,
+            seq_len,
+            c.num_attention_heads,
+            c.num_key_value_heads,
+            c.head_dim,
+        )?;
+
+        let mut linear_idx = 0usize;
+        let mut full_idx = 0usize;
+        let mut gdr_chunkwise_scratch = GdrChunkwiseScratch35::new(&self.ctx, c, seq_len)?;
+
+        for (layer_idx, layer) in self.layers.iter().enumerate() {
+            if layer_idx != target_layer_idx {
+                hidden_batch = self.prefill_layer(
+                    layer_idx,
+                    layer,
+                    &hidden_batch,
+                    &mut gdr_chunkwise_scratch,
+                    &mut linear_idx,
+                    &mut full_idx,
+                    &mut kv_cache,
+                    &kv_state,
+                    &prefill_plan,
+                    &mut recurrent,
+                )?;
+                continue;
+            }
+
+            let eps = c.rms_norm_eps;
+            let input_normed =
+                self.batched_rms_norm_offset(&hidden_batch, &layer.input_layernorm, eps)?;
+
+            let attn_results = match &layer.attn {
+                LayerKind::FullAttention(attn) => self.prefill_full_attention(
+                    attn,
+                    &input_normed,
+                    &mut full_idx,
+                    &mut kv_cache,
+                    &kv_state,
+                    &prefill_plan,
+                    c.full_attn_q_dim(),
+                    seq_len,
+                )?,
+                LayerKind::LinearAttention(attn) => self.prefill_linear_attention(
+                    attn,
+                    &input_normed,
+                    &mut linear_idx,
+                    &mut recurrent,
+                    &mut gdr_chunkwise_scratch,
+                    seq_len,
+                )?,
+            };
+
+            let hidden_plus_attn = ops::add_batch(&self.ctx, &hidden_batch, &attn_results)?;
+            let post_attn_normed =
+                self.batched_rms_norm_offset(&hidden_plus_attn, &layer.post_attention_layernorm, eps)?;
+
+            let gate_out = ops::gemm(&self.ctx, &layer.mlp.gate_proj, &post_attn_normed)?;
+            let up_out = ops::gemm(&self.ctx, &layer.mlp.up_proj, &post_attn_normed)?;
+            let act_out = ops::silu_mul_batch(&self.ctx, &gate_out, &up_out)?;
+            let mlp_out = ops::gemm(&self.ctx, &layer.mlp.down_proj, &act_out)?;
+            let layer_out = ops::add_batch(&self.ctx, &hidden_plus_attn, &mlp_out)?;
+
+            let layer_type = match &layer.attn {
+                LayerKind::FullAttention(_) => "full_attention".to_string(),
+                LayerKind::LinearAttention(_) => "linear_attention".to_string(),
+            };
+            return Ok((
+                layer_type,
+                ops::extract_vec(&self.ctx, &input_normed, seq_len - 1)?.to_host(&self.ctx)?,
+                ops::extract_vec(&self.ctx, &attn_results, seq_len - 1)?.to_host(&self.ctx)?,
+                ops::extract_vec(&self.ctx, &hidden_plus_attn, seq_len - 1)?.to_host(&self.ctx)?,
+                ops::extract_vec(&self.ctx, &post_attn_normed, seq_len - 1)?.to_host(&self.ctx)?,
+                ops::extract_vec(&self.ctx, &mlp_out, seq_len - 1)?.to_host(&self.ctx)?,
+                ops::extract_vec(&self.ctx, &layer_out, seq_len - 1)?.to_host(&self.ctx)?,
+            ));
+        }
+
+        unreachable!("target layer should have returned");
+    }
+
+    pub fn debug_prefill_last_hidden_by_layer(
+        &self,
+        token_ids: &[u32],
+    ) -> Result<(Vec<f32>, Vec<Vec<f32>>, Vec<String>)> {
+        let seq_len = token_ids.len();
+        anyhow::ensure!(seq_len > 0, "debug_prefill_last_hidden_by_layer requires non-empty input");
+        let c = &self.config;
+
+        let token_ids_i32: Vec<i32> = token_ids.iter().map(|&x| x as i32).collect();
+        let token_ids_gpu = self
+            .ctx
+            .stream
+            .clone_htod(&token_ids_i32)
+            .map_err(|e| anyhow::anyhow!("H2D copy failed: {}", e))?;
+
+        let mut hidden_batch = HiddenStates::zeros(&self.ctx, c.hidden_size, seq_len)?;
+        ops::embedding_batch(
+            &self.ctx,
+            &self.embed_tokens,
+            &token_ids_gpu,
+            &mut hidden_batch,
+        )?;
+        let embedding_last = ops::extract_vec(&self.ctx, &hidden_batch, seq_len - 1)?.to_host(&self.ctx)?;
+
+        let mut kv_cache = KVCache::new(c.num_full_attention_layers(), c.num_key_value_heads);
+        let mut kv_state = self.alloc_kv();
+        let mut recurrent = RecurrentState::new(&self.ctx, &self.config)?;
+
+        kv_cache.init_if_needed(&self.ctx, c.head_dim)?;
+        let base_pos = kv_state.seq_len();
+        kv_state.ensure_capacity(base_pos + seq_len)?;
+        kv_state.advance(seq_len);
+        let kv_desc = kv_state.desc();
+        let prefill_plan = PrefillPagedPlan::new(
+            &self.ctx,
+            &kv_desc,
+            base_pos,
+            seq_len,
+            c.num_attention_heads,
+            c.num_key_value_heads,
+            c.head_dim,
+        )?;
+
+        let mut linear_idx = 0usize;
+        let mut full_idx = 0usize;
+        let mut gdr_chunkwise_scratch = GdrChunkwiseScratch35::new(&self.ctx, c, seq_len)?;
+        let mut layer_hiddens = Vec::with_capacity(self.layers.len());
+        let mut layer_types = Vec::with_capacity(self.layers.len());
+
+        for (layer_idx, layer) in self.layers.iter().enumerate() {
+            hidden_batch = self.prefill_layer(
+                layer_idx,
+                layer,
+                &hidden_batch,
+                &mut gdr_chunkwise_scratch,
+                &mut linear_idx,
+                &mut full_idx,
+                &mut kv_cache,
+                &kv_state,
+                &prefill_plan,
+                &mut recurrent,
+            )?;
+            layer_hiddens.push(
+                ops::extract_vec(&self.ctx, &hidden_batch, seq_len - 1)?.to_host(&self.ctx)?,
+            );
+            layer_types.push(match &layer.attn {
+                LayerKind::FullAttention(_) => "full_attention".to_string(),
+                LayerKind::LinearAttention(_) => "linear_attention".to_string(),
+            });
+        }
+
+        Ok((embedding_last, layer_hiddens, layer_types))
+    }
+
     pub(super) fn prefill_forward(
         &self,
         token_ids: &[u32],
@@ -334,17 +815,17 @@ impl Qwen35Model {
                     kcs_ptr as *const i32,
                     tnr_ptr as *const u32,
                     c.num_attention_heads as i32,
-                    c.num_key_value_heads as i32,
-                    HEAD_DIM as i32,
-                    layout.page_size as i32,
-                    seq_len as i32,
-                    prefill_plan.batch_size(),
-                    prefill_plan.batch_size(), // padded_batch_size = batch_size for single-req
-                    stride_page,
-                    sm_scale,
-                    self.ctx.stream.cu_stream(),
-                )
-            };
+                        c.num_key_value_heads as i32,
+                        HEAD_DIM as i32,
+                        layout.page_size as i32,
+                        seq_len as i32,
+                        prefill_plan.batch_size(),
+                        prefill_plan.num_tiles(),
+                        stride_page,
+                        sm_scale,
+                        self.ctx.stream.cu_stream(),
+                    )
+                };
             anyhow::ensure!(
                 result == 0,
                 "batch_prefill_paged_cuda_hd256 failed: {result}"
@@ -447,5 +928,627 @@ impl Qwen35Model {
         let mut out = HiddenStates::zeros(&self.ctx, x.hidden_dim, x.seq_len)?;
         ops::rms_norm_batch_offset_into(&self.ctx, x, weight, eps, &mut out)?;
         Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use half::bf16;
+
+    fn get_model_path() -> String {
+        std::env::var("PEGAINFER_TEST_MODEL_PATH")
+            .unwrap_or_else(|_| concat!(env!("CARGO_MANIFEST_DIR"), "/models/Qwen3.5-4B").into())
+    }
+
+    fn run_prefill_layers(
+        model: &Qwen35Model,
+        token_ids: &[u32],
+        layer_limit: usize,
+        kv_cache: &mut KVCache,
+        kv_state: &mut KvState,
+        recurrent: &mut RecurrentState,
+    ) -> Result<Vec<f32>> {
+        let seq_len = token_ids.len();
+        let c = &model.config;
+
+        kv_cache.init_if_needed(&model.ctx, c.head_dim)?;
+
+        let token_ids_i32: Vec<i32> = token_ids.iter().map(|&x| x as i32).collect();
+        let token_ids_gpu = model.ctx.stream.clone_htod(&token_ids_i32)?;
+
+        let mut hidden_batch = HiddenStates::zeros(&model.ctx, c.hidden_size, seq_len)?;
+        ops::embedding_batch(&model.ctx, &model.embed_tokens, &token_ids_gpu, &mut hidden_batch)?;
+
+        let base_pos = kv_state.seq_len();
+        kv_state.ensure_capacity(base_pos + seq_len)?;
+        kv_state.advance(seq_len);
+        let kv_desc = kv_state.desc();
+        let prefill_plan = PrefillPagedPlan::new(
+            &model.ctx,
+            &kv_desc,
+            base_pos,
+            seq_len,
+            c.num_attention_heads,
+            c.num_key_value_heads,
+            c.head_dim,
+        )?;
+
+        let mut linear_idx = 0usize;
+        let mut full_idx = 0usize;
+        let mut gdr_chunkwise_scratch = GdrChunkwiseScratch35::new(&model.ctx, c, seq_len)?;
+
+        for (layer_idx, layer) in model.layers.iter().enumerate().take(layer_limit) {
+            hidden_batch = model.prefill_layer(
+                layer_idx,
+                layer,
+                &hidden_batch,
+                &mut gdr_chunkwise_scratch,
+                &mut linear_idx,
+                &mut full_idx,
+                kv_cache,
+                kv_state,
+                &prefill_plan,
+                recurrent,
+            )?;
+        }
+
+        ops::extract_vec(&model.ctx, &hidden_batch, seq_len - 1)?.to_host(&model.ctx)
+    }
+
+    fn make_hidden_batch(model: &Qwen35Model, start_token: usize, seq_len: usize) -> HiddenStates {
+        let hidden = model.config.hidden_size;
+        let start = start_token * hidden;
+        let end = start + hidden * seq_len;
+        let host: Vec<bf16> = (start..end)
+            .map(|i| bf16::from_f32(((i % 113) as f32 - 56.0) * 0.03125))
+            .collect();
+        HiddenStates {
+            data: model.ctx.stream.clone_htod(&host).unwrap(),
+            hidden_dim: hidden,
+            seq_len,
+        }
+    }
+
+    #[test]
+    #[ignore = "debug helper for split-prefill layer localization"]
+    fn debug_prefill_split_layer_diffs() {
+        let model_path = get_model_path();
+        let model = Qwen35Model::from_safetensors_with_options(&model_path, true).unwrap();
+        let prompt: Vec<u32> = (0..128).map(|i| ((i % 1000) + 100) as u32).collect();
+        let split = 64;
+
+        for layer_limit in 1..=8 {
+            let full = {
+                let mut kv = model.alloc_kv();
+                let mut rec = RecurrentState::new(&model.ctx, &model.config).unwrap();
+                let mut kv_cache = KVCache::new(
+                    model.config.num_full_attention_layers(),
+                    model.config.num_key_value_heads,
+                );
+                run_prefill_layers(&model, &prompt, layer_limit, &mut kv_cache, &mut kv, &mut rec)
+                    .unwrap()
+            };
+
+            let split_out = {
+                let mut kv = model.alloc_kv();
+                let mut rec = RecurrentState::new(&model.ctx, &model.config).unwrap();
+                let mut kv_cache = KVCache::new(
+                    model.config.num_full_attention_layers(),
+                    model.config.num_key_value_heads,
+                );
+                run_prefill_layers(
+                    &model,
+                    &prompt[..split],
+                    layer_limit,
+                    &mut kv_cache,
+                    &mut kv,
+                    &mut rec,
+                )
+                .unwrap();
+                run_prefill_layers(
+                    &model,
+                    &prompt[split..],
+                    layer_limit,
+                    &mut kv_cache,
+                    &mut kv,
+                    &mut rec,
+                )
+                .unwrap()
+            };
+
+            let max_diff = full
+                .iter()
+                .zip(split_out.iter())
+                .map(|(a, b)| (a - b).abs())
+                .fold(0.0_f32, f32::max);
+            println!("layer_limit={layer_limit} max_diff={max_diff}");
+        }
+    }
+
+    #[test]
+    #[ignore = "debug helper to isolate full-attention split-prefill drift"]
+    fn debug_full_attention_split_vs_single() {
+        let model_path = get_model_path();
+        let model = Qwen35Model::from_safetensors_with_options(&model_path, true).unwrap();
+        let attn = model
+            .layers
+            .iter()
+            .find_map(|layer| match &layer.attn {
+                LayerKind::FullAttention(attn) => Some(attn),
+                LayerKind::LinearAttention(_) => None,
+            })
+            .unwrap();
+
+        let full_hidden = make_hidden_batch(&model, 0, 128);
+        let single_last = {
+            let mut kv = model.alloc_kv();
+            let mut kv_cache = KVCache::new(
+                model.config.num_full_attention_layers(),
+                model.config.num_key_value_heads,
+            );
+            kv_cache.init_if_needed(&model.ctx, model.config.head_dim).unwrap();
+            kv.ensure_capacity(128).unwrap();
+            kv.advance(128);
+            let plan = PrefillPagedPlan::new(
+                &model.ctx,
+                &kv.desc(),
+                0,
+                128,
+                model.config.num_attention_heads,
+                model.config.num_key_value_heads,
+                model.config.head_dim,
+            )
+            .unwrap();
+            let mut full_idx = 0usize;
+            let out = model
+                .prefill_full_attention(
+                    attn,
+                    &full_hidden,
+                    &mut full_idx,
+                    &mut kv_cache,
+                    &kv,
+                    &plan,
+                    model.config.full_attn_q_dim(),
+                    128,
+                )
+                .unwrap();
+            ops::extract_vec(&model.ctx, &out, 127)
+                .unwrap()
+                .to_host(&model.ctx)
+                .unwrap()
+        };
+
+        let split_last = {
+            let prefix_hidden = make_hidden_batch(&model, 0, 64);
+            let suffix_hidden = make_hidden_batch(&model, 64, 64);
+
+            let mut kv = model.alloc_kv();
+            let mut kv_cache = KVCache::new(
+                model.config.num_full_attention_layers(),
+                model.config.num_key_value_heads,
+            );
+            kv_cache.init_if_needed(&model.ctx, model.config.head_dim).unwrap();
+
+            kv.ensure_capacity(64).unwrap();
+            kv.advance(64);
+            let plan0 = PrefillPagedPlan::new(
+                &model.ctx,
+                &kv.desc(),
+                0,
+                64,
+                model.config.num_attention_heads,
+                model.config.num_key_value_heads,
+                model.config.head_dim,
+            )
+            .unwrap();
+            let mut full_idx = 0usize;
+            model.prefill_full_attention(
+                attn,
+                &prefix_hidden,
+                &mut full_idx,
+                &mut kv_cache,
+                &kv,
+                &plan0,
+                model.config.full_attn_q_dim(),
+                64,
+            )
+            .unwrap();
+
+            kv.ensure_capacity(128).unwrap();
+            kv.advance(64);
+            let plan1 = PrefillPagedPlan::new(
+                &model.ctx,
+                &kv.desc(),
+                64,
+                64,
+                model.config.num_attention_heads,
+                model.config.num_key_value_heads,
+                model.config.head_dim,
+            )
+            .unwrap();
+            let mut full_idx = 0usize;
+            let out = model
+                .prefill_full_attention(
+                    attn,
+                    &suffix_hidden,
+                    &mut full_idx,
+                    &mut kv_cache,
+                    &kv,
+                    &plan1,
+                    model.config.full_attn_q_dim(),
+                    64,
+                )
+                .unwrap();
+            ops::extract_vec(&model.ctx, &out, 63)
+                .unwrap()
+                .to_host(&model.ctx)
+                .unwrap()
+        };
+
+        let max_diff = single_last
+            .iter()
+            .zip(split_last.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0_f32, f32::max);
+        println!("full_attention_split_vs_single max_diff={max_diff}");
+    }
+
+    #[test]
+    #[ignore = "debug helper to isolate linear-attention split-prefill drift"]
+    fn debug_linear_attention_split_vs_single() {
+        let model_path = get_model_path();
+        let model = Qwen35Model::from_safetensors_with_options(&model_path, true).unwrap();
+        let attn = model
+            .layers
+            .iter()
+            .find_map(|layer| match &layer.attn {
+                LayerKind::LinearAttention(attn) => Some(attn),
+                LayerKind::FullAttention(_) => None,
+            })
+            .unwrap();
+
+        let full_hidden = make_hidden_batch(&model, 0, 128);
+        let single_last = {
+            let mut rec = RecurrentState::new(&model.ctx, &model.config).unwrap();
+            let mut scratch = GdrChunkwiseScratch35::new(&model.ctx, &model.config, 128).unwrap();
+            let mut linear_idx = 0usize;
+            let out = model
+                .prefill_linear_attention(attn, &full_hidden, &mut linear_idx, &mut rec, &mut scratch, 128)
+                .unwrap();
+            ops::extract_vec(&model.ctx, &out, 127)
+                .unwrap()
+                .to_host(&model.ctx)
+                .unwrap()
+        };
+
+        let split_last = {
+            let prefix_hidden = make_hidden_batch(&model, 0, 64);
+            let suffix_hidden = make_hidden_batch(&model, 64, 64);
+
+            let mut rec = RecurrentState::new(&model.ctx, &model.config).unwrap();
+            let mut linear_idx = 0usize;
+            let mut scratch0 = GdrChunkwiseScratch35::new(&model.ctx, &model.config, 64).unwrap();
+            model.prefill_linear_attention(
+                attn,
+                &prefix_hidden,
+                &mut linear_idx,
+                &mut rec,
+                &mut scratch0,
+                64,
+            )
+            .unwrap();
+
+            let mut linear_idx = 0usize;
+            let mut scratch1 = GdrChunkwiseScratch35::new(&model.ctx, &model.config, 64).unwrap();
+            let out = model
+                .prefill_linear_attention(
+                    attn,
+                    &suffix_hidden,
+                    &mut linear_idx,
+                    &mut rec,
+                    &mut scratch1,
+                    64,
+                )
+                .unwrap();
+            ops::extract_vec(&model.ctx, &out, 63)
+                .unwrap()
+                .to_host(&model.ctx)
+                .unwrap()
+        };
+
+        let max_diff = single_last
+            .iter()
+            .zip(split_last.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0_f32, f32::max);
+        println!("linear_attention_split_vs_single max_diff={max_diff}");
+    }
+
+    #[test]
+    #[ignore = "debug helper to localize linear-attention split-prefill drift by stage"]
+    fn debug_linear_attention_split_stage_diffs() {
+        let model_path = get_model_path();
+        let model = Qwen35Model::from_safetensors_with_options(&model_path, true).unwrap();
+        let attn = model
+            .layers
+            .iter()
+            .find_map(|layer| match &layer.attn {
+                LayerKind::LinearAttention(attn) => Some(attn),
+                LayerKind::FullAttention(_) => None,
+            })
+            .unwrap();
+        let c = &model.config;
+        let qkv_dim = c.linear_attn_qkv_dim();
+        let z_dim = c.linear_attn_z_dim();
+        let seq_full = 128usize;
+        let seq_half = 64usize;
+        let hidden_full = make_hidden_batch(&model, 0, seq_full);
+        let hidden_a = make_hidden_batch(&model, 0, seq_half);
+        let hidden_b = make_hidden_batch(&model, seq_half, seq_half);
+
+        let compare_stage =
+            |name: &str, full: &[f32], suffix_offset: usize, split: &[f32]| -> () {
+                let suffix = &full[suffix_offset..suffix_offset + split.len()];
+                let max_diff = suffix
+                    .iter()
+                    .zip(split.iter())
+                    .map(|(a, b)| (a - b).abs())
+                    .fold(0.0_f32, f32::max);
+                println!("{name} max_diff={max_diff}");
+            };
+
+        // Single 128-token run.
+        let qkv_full = ops::gemm(&model.ctx, &attn.in_proj_qkv, &hidden_full).unwrap();
+        let z_full = ops::gemm(&model.ctx, &attn.in_proj_z, &hidden_full).unwrap();
+        let b_full = ops::gemm(&model.ctx, &attn.in_proj_b, &hidden_full).unwrap();
+        let a_full = ops::gemm(&model.ctx, &attn.in_proj_a, &hidden_full).unwrap();
+        let mut rec_full = RecurrentState::new(&model.ctx, &model.config).unwrap();
+        let mut qkv_conv_full = HiddenStates::zeros(&model.ctx, qkv_dim, seq_full).unwrap();
+        ops::conv1d_prefill_batch_into(
+            &model.ctx,
+            &qkv_full,
+            &attn.conv1d_weight,
+            &mut rec_full.layers[0].conv_state,
+            &mut qkv_conv_full,
+            c.linear_conv_kernel_dim,
+        );
+        let mut scratch_full = GdrChunkwiseScratch35::new(&model.ctx, &model.config, seq_full).unwrap();
+        let mut gdr_out_full = HiddenStates::zeros(&model.ctx, z_dim, seq_full).unwrap();
+        ops::gated_delta_rule_prefill_chunkwise_into(
+            &model.ctx,
+            &qkv_conv_full,
+            &b_full,
+            &a_full,
+            &attn.dt_bias,
+            &attn.a_log,
+            &mut rec_full.layers[0].state,
+            &mut scratch_full,
+            &mut gdr_out_full,
+            c.linear_num_key_heads,
+            c.linear_num_value_heads,
+            c.linear_key_head_dim,
+            c.linear_value_head_dim,
+        )
+        .unwrap();
+        let mut normed_full = HiddenStates::zeros(&model.ctx, z_dim, seq_full).unwrap();
+        ops::rms_norm_gated_batch_into(
+            &model.ctx,
+            &gdr_out_full,
+            &attn.norm_weight,
+            &z_full,
+            &mut normed_full,
+            c.linear_num_value_heads,
+            c.linear_value_head_dim,
+            c.rms_norm_eps,
+        );
+        let out_full = ops::gemm(&model.ctx, &attn.out_proj, &normed_full).unwrap();
+
+        // Split 64 + 64 run with carried states.
+        let qkv_a = ops::gemm(&model.ctx, &attn.in_proj_qkv, &hidden_a).unwrap();
+        let _z_a = ops::gemm(&model.ctx, &attn.in_proj_z, &hidden_a).unwrap();
+        let b_a = ops::gemm(&model.ctx, &attn.in_proj_b, &hidden_a).unwrap();
+        let a_a = ops::gemm(&model.ctx, &attn.in_proj_a, &hidden_a).unwrap();
+        let qkv_b = ops::gemm(&model.ctx, &attn.in_proj_qkv, &hidden_b).unwrap();
+        let z_b = ops::gemm(&model.ctx, &attn.in_proj_z, &hidden_b).unwrap();
+        let b_b = ops::gemm(&model.ctx, &attn.in_proj_b, &hidden_b).unwrap();
+        let a_b = ops::gemm(&model.ctx, &attn.in_proj_a, &hidden_b).unwrap();
+
+        let mut rec_split = RecurrentState::new(&model.ctx, &model.config).unwrap();
+        let mut qkv_conv_a = HiddenStates::zeros(&model.ctx, qkv_dim, seq_half).unwrap();
+        ops::conv1d_prefill_batch_into(
+            &model.ctx,
+            &qkv_a,
+            &attn.conv1d_weight,
+            &mut rec_split.layers[0].conv_state,
+            &mut qkv_conv_a,
+            c.linear_conv_kernel_dim,
+        );
+        let mut qkv_conv_b = HiddenStates::zeros(&model.ctx, qkv_dim, seq_half).unwrap();
+        ops::conv1d_prefill_batch_into(
+            &model.ctx,
+            &qkv_b,
+            &attn.conv1d_weight,
+            &mut rec_split.layers[0].conv_state,
+            &mut qkv_conv_b,
+            c.linear_conv_kernel_dim,
+        );
+        let mut scratch_a = GdrChunkwiseScratch35::new(&model.ctx, &model.config, seq_half).unwrap();
+        let mut gdr_out_a = HiddenStates::zeros(&model.ctx, z_dim, seq_half).unwrap();
+        ops::gated_delta_rule_prefill_chunkwise_into(
+            &model.ctx,
+            &qkv_conv_a,
+            &b_a,
+            &a_a,
+            &attn.dt_bias,
+            &attn.a_log,
+            &mut rec_split.layers[0].state,
+            &mut scratch_a,
+            &mut gdr_out_a,
+            c.linear_num_key_heads,
+            c.linear_num_value_heads,
+            c.linear_key_head_dim,
+            c.linear_value_head_dim,
+        )
+        .unwrap();
+        let mut scratch_b = GdrChunkwiseScratch35::new(&model.ctx, &model.config, seq_half).unwrap();
+        let mut gdr_out_b = HiddenStates::zeros(&model.ctx, z_dim, seq_half).unwrap();
+        ops::gated_delta_rule_prefill_chunkwise_into(
+            &model.ctx,
+            &qkv_conv_b,
+            &b_b,
+            &a_b,
+            &attn.dt_bias,
+            &attn.a_log,
+            &mut rec_split.layers[0].state,
+            &mut scratch_b,
+            &mut gdr_out_b,
+            c.linear_num_key_heads,
+            c.linear_num_value_heads,
+            c.linear_key_head_dim,
+            c.linear_value_head_dim,
+        )
+        .unwrap();
+        let mut normed_b = HiddenStates::zeros(&model.ctx, z_dim, seq_half).unwrap();
+        ops::rms_norm_gated_batch_into(
+            &model.ctx,
+            &gdr_out_b,
+            &attn.norm_weight,
+            &z_b,
+            &mut normed_b,
+            c.linear_num_value_heads,
+            c.linear_value_head_dim,
+            c.rms_norm_eps,
+        );
+        let out_b = ops::gemm(&model.ctx, &attn.out_proj, &normed_b).unwrap();
+
+        let qkv_full_host: Vec<f32> = model
+            .ctx
+            .stream
+            .clone_dtoh(&qkv_full.data)
+            .unwrap()
+            .into_iter()
+            .map(|x| x.to_f32())
+            .collect();
+        let qkv_b_host: Vec<f32> = model
+            .ctx
+            .stream
+            .clone_dtoh(&qkv_b.data)
+            .unwrap()
+            .into_iter()
+            .map(|x| x.to_f32())
+            .collect();
+        let z_full_host: Vec<f32> = model
+            .ctx
+            .stream
+            .clone_dtoh(&z_full.data)
+            .unwrap()
+            .into_iter()
+            .map(|x| x.to_f32())
+            .collect();
+        let z_b_host: Vec<f32> = model
+            .ctx
+            .stream
+            .clone_dtoh(&z_b.data)
+            .unwrap()
+            .into_iter()
+            .map(|x| x.to_f32())
+            .collect();
+        let qkv_conv_full_host: Vec<f32> = model
+            .ctx
+            .stream
+            .clone_dtoh(&qkv_conv_full.data)
+            .unwrap()
+            .into_iter()
+            .map(|x| x.to_f32())
+            .collect();
+        let qkv_conv_b_host: Vec<f32> = model
+            .ctx
+            .stream
+            .clone_dtoh(&qkv_conv_b.data)
+            .unwrap()
+            .into_iter()
+            .map(|x| x.to_f32())
+            .collect();
+        let gdr_out_full_host: Vec<f32> = model
+            .ctx
+            .stream
+            .clone_dtoh(&gdr_out_full.data)
+            .unwrap()
+            .into_iter()
+            .map(|x| x.to_f32())
+            .collect();
+        let gdr_out_b_host: Vec<f32> = model
+            .ctx
+            .stream
+            .clone_dtoh(&gdr_out_b.data)
+            .unwrap()
+            .into_iter()
+            .map(|x| x.to_f32())
+            .collect();
+        let normed_full_host: Vec<f32> = model
+            .ctx
+            .stream
+            .clone_dtoh(&normed_full.data)
+            .unwrap()
+            .into_iter()
+            .map(|x| x.to_f32())
+            .collect();
+        let normed_b_host: Vec<f32> = model
+            .ctx
+            .stream
+            .clone_dtoh(&normed_b.data)
+            .unwrap()
+            .into_iter()
+            .map(|x| x.to_f32())
+            .collect();
+        let out_full_host: Vec<f32> = model
+            .ctx
+            .stream
+            .clone_dtoh(&out_full.data)
+            .unwrap()
+            .into_iter()
+            .map(|x| x.to_f32())
+            .collect();
+        let out_b_host: Vec<f32> = model
+            .ctx
+            .stream
+            .clone_dtoh(&out_b.data)
+            .unwrap()
+            .into_iter()
+            .map(|x| x.to_f32())
+            .collect();
+        let rec_state_full = model
+            .ctx
+            .stream
+            .clone_dtoh(&rec_full.layers[0].state)
+            .unwrap();
+        let rec_state_split = model
+            .ctx
+            .stream
+            .clone_dtoh(&rec_split.layers[0].state)
+            .unwrap();
+        let conv_state_full = rec_full.layers[0].conv_state.to_host(&model.ctx).unwrap();
+        let conv_state_split = rec_split.layers[0].conv_state.to_host(&model.ctx).unwrap();
+        model.ctx.sync().unwrap();
+
+        compare_stage("qkv_proj", &qkv_full_host, seq_half * qkv_dim, &qkv_b_host);
+        compare_stage("z_proj", &z_full_host, seq_half * z_dim, &z_b_host);
+        compare_stage("conv1d", &qkv_conv_full_host, seq_half * qkv_dim, &qkv_conv_b_host);
+        compare_stage("gdr_out", &gdr_out_full_host, seq_half * z_dim, &gdr_out_b_host);
+        compare_stage("normed", &normed_full_host, seq_half * z_dim, &normed_b_host);
+        compare_stage("out_proj", &out_full_host, seq_half * c.hidden_size, &out_b_host);
+        let rec_state_max = rec_state_full
+            .iter()
+            .zip(rec_state_split.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0_f32, f32::max);
+        let conv_state_max = conv_state_full
+            .iter()
+            .zip(conv_state_split.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0_f32, f32::max);
+        println!("recurrent_state max_diff={rec_state_max}");
+        println!("conv_state max_diff={conv_state_max}");
     }
 }

--- a/src/model/qwen35/unified_forward.rs
+++ b/src/model/qwen35/unified_forward.rs
@@ -259,4 +259,63 @@ mod tests {
             unified_tokens, ref_tokens
         );
     }
+
+    fn assert_prefill_split_matches_single(model: &Qwen35Model, prompt: &[u32], split: usize) {
+        assert!(split > 0 && split < prompt.len(), "invalid split {}", split);
+
+        let full_logits = {
+            let mut kv = model.alloc_kv();
+            let mut rec = RecurrentState::new(&model.ctx, &model.config).unwrap();
+            let mut kv_cache = KVCache::new(
+                model.config.num_full_attention_layers(),
+                model.config.num_key_value_heads,
+            );
+            model
+                .prefill_forward(prompt, &mut kv_cache, &mut kv, &mut rec)
+                .unwrap()
+                .to_host(&model.ctx)
+                .unwrap()
+        };
+
+        let split_logits = {
+            let mut kv = model.alloc_kv();
+            let mut rec = RecurrentState::new(&model.ctx, &model.config).unwrap();
+            let mut kv_cache = KVCache::new(
+                model.config.num_full_attention_layers(),
+                model.config.num_key_value_heads,
+            );
+            model
+                .prefill_forward(&prompt[..split], &mut kv_cache, &mut kv, &mut rec)
+                .unwrap();
+            model
+                .prefill_forward(&prompt[split..], &mut kv_cache, &mut kv, &mut rec)
+                .unwrap()
+                .to_host(&model.ctx)
+                .unwrap()
+        };
+
+        let max_diff = full_logits
+            .iter()
+            .zip(split_logits.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0_f32, f32::max);
+
+        assert!(
+            max_diff < 0.05,
+            "prefill split mismatch at split={split}: max logit diff {max_diff}"
+        );
+    }
+
+    #[test]
+    #[ignore = "debug repro for split-prefill divergence in Qwen3.5"]
+    fn debug_prefill_split_matches_single_across_chunk_boundaries() {
+        let model_path = get_model_path();
+        let model = Qwen35Model::from_safetensors_with_options(&model_path, true).unwrap();
+
+        let prompt: Vec<u32> = (0..1536).map(|i| ((i % 1000) + 100) as u32).collect();
+        assert_prefill_split_matches_single(&model, &prompt[..128], 64);
+        assert_prefill_split_matches_single(&model, &prompt[..129], 64);
+        assert_prefill_split_matches_single(&model, &prompt[..1025], 64);
+        assert_prefill_split_matches_single(&model, &prompt[..1025], 1024);
+    }
 }

--- a/src/ops/tests.rs
+++ b/src/ops/tests.rs
@@ -3,6 +3,7 @@ use cudarc::driver::CudaSlice;
 use half::bf16;
 
 use super::*;
+use crate::model::qwen35::prefill_buffers::GdrChunkwiseScratch35;
 use crate::tensor::*;
 
 fn bf16_vec(data: &[f32]) -> Vec<bf16> {
@@ -407,5 +408,153 @@ fn test_conv1d_prefill_handoff_matches_single_prefill() -> Result<()> {
 
     assert!(max_out_diff < 0.02, "output diff {max_out_diff}");
     assert!(max_state_diff < 0.02, "state diff {max_state_diff}");
+    Ok(())
+}
+
+fn run_gdr_chunkwise_vs_recurrent(seq_len: usize) -> Result<(f32, f32)> {
+    let ctx = DeviceContext::new()?;
+
+    let num_key_heads = 16usize;
+    let num_value_heads = 32usize;
+    let key_dim = 128usize;
+    let value_dim = 128usize;
+    let qkv_dim = num_key_heads * key_dim * 2 + num_value_heads * value_dim;
+    let z_dim = num_value_heads * value_dim;
+    let state_len = num_value_heads * key_dim * value_dim;
+
+    let qkv_host = bf16_vec(
+        &(0..seq_len * qkv_dim)
+            .map(|i| ((i % 97) as f32 - 48.0) * 0.03125)
+            .collect::<Vec<_>>(),
+    );
+    let b_host = bf16_vec(
+        &(0..seq_len * num_value_heads)
+            .map(|i| ((i % 29) as f32 - 14.0) * 0.0625)
+            .collect::<Vec<_>>(),
+    );
+    let a_host = bf16_vec(
+        &(0..seq_len * num_value_heads)
+            .map(|i| ((i % 31) as f32 - 15.0) * 0.05)
+            .collect::<Vec<_>>(),
+    );
+    let dt_bias_host = bf16_vec(
+        &(0..num_value_heads)
+            .map(|i| ((i % 11) as f32 - 5.0) * 0.125)
+            .collect::<Vec<_>>(),
+    );
+    let a_log_host: Vec<f32> = (0..num_value_heads)
+        .map(|i| -1.0 + (i % 7) as f32 * 0.125)
+        .collect();
+
+    let qkv = HiddenStates {
+        data: ctx.stream.clone_htod(&qkv_host)?,
+        hidden_dim: qkv_dim,
+        seq_len,
+    };
+    let b_proj = HiddenStates {
+        data: ctx.stream.clone_htod(&b_host)?,
+        hidden_dim: num_value_heads,
+        seq_len,
+    };
+    let a_proj = HiddenStates {
+        data: ctx.stream.clone_htod(&a_host)?,
+        hidden_dim: num_value_heads,
+        seq_len,
+    };
+    let dt_bias = DeviceVec::from_host(&ctx, &dt_bias_host)?;
+    let a_log: CudaSlice<f32> = ctx.stream.clone_htod(&a_log_host)?;
+
+    let zero_state = vec![0.0_f32; state_len];
+    let mut state_chunkwise: CudaSlice<f32> = ctx.stream.clone_htod(&zero_state)?;
+    let mut state_recurrent: CudaSlice<f32> = ctx.stream.clone_htod(&zero_state)?;
+    let mut scratch =
+        GdrChunkwiseScratch35::from_dims(&ctx, num_value_heads, key_dim, value_dim, seq_len)?;
+    let mut out_chunkwise = HiddenStates::zeros(&ctx, z_dim, seq_len)?;
+
+    gated_delta_rule_prefill_chunkwise_into(
+        &ctx,
+        &qkv,
+        &b_proj,
+        &a_proj,
+        &dt_bias,
+        &a_log,
+        &mut state_chunkwise,
+        &mut scratch,
+        &mut out_chunkwise,
+        num_key_heads,
+        num_value_heads,
+        key_dim,
+        value_dim,
+    )?;
+
+    let mut out_recurrent_host = Vec::with_capacity(seq_len * z_dim);
+    for token_idx in 0..seq_len {
+        let qkv_t = DeviceVec::from_host(
+            &ctx,
+            &qkv_host[token_idx * qkv_dim..(token_idx + 1) * qkv_dim],
+        )?;
+        let b_t = DeviceVec::from_host(
+            &ctx,
+            &b_host[token_idx * num_value_heads..(token_idx + 1) * num_value_heads],
+        )?;
+        let a_t = DeviceVec::from_host(
+            &ctx,
+            &a_host[token_idx * num_value_heads..(token_idx + 1) * num_value_heads],
+        )?;
+        let mut out_t = DeviceVec::zeros(&ctx, z_dim)?;
+        gated_delta_rule_decode_vec_into(
+            &ctx,
+            &qkv_t,
+            &b_t,
+            &a_t,
+            &dt_bias,
+            &a_log,
+            &mut state_recurrent,
+            &mut out_t,
+            num_key_heads,
+            num_value_heads,
+            key_dim,
+            value_dim,
+        )?;
+        out_recurrent_host.extend(out_t.to_host(&ctx)?);
+    }
+
+    let out_chunkwise_host: Vec<f32> = ctx
+        .stream
+        .clone_dtoh(&out_chunkwise.data)?
+        .into_iter()
+        .map(|x| x.to_f32())
+        .collect();
+    let state_chunkwise_host = ctx.stream.clone_dtoh(&state_chunkwise)?;
+    let state_recurrent_host = ctx.stream.clone_dtoh(&state_recurrent)?;
+    ctx.sync()?;
+
+    let max_out_diff = out_chunkwise_host
+        .iter()
+        .zip(out_recurrent_host.iter())
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0_f32, f32::max);
+    let max_state_diff = state_chunkwise_host
+        .iter()
+        .zip(state_recurrent_host.iter())
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0_f32, f32::max);
+
+    Ok((max_out_diff, max_state_diff))
+}
+
+#[test]
+fn test_gdr_chunkwise_prefill_matches_recurrent_single_chunk() -> Result<()> {
+    let (max_out_diff, max_state_diff) = run_gdr_chunkwise_vs_recurrent(64)?;
+    assert!(max_out_diff < 0.05, "single-chunk output diff {max_out_diff}");
+    assert!(max_state_diff < 0.05, "single-chunk state diff {max_state_diff}");
+    Ok(())
+}
+
+#[test]
+fn test_gdr_chunkwise_prefill_matches_recurrent_cross_chunk() -> Result<()> {
+    let (max_out_diff, max_state_diff) = run_gdr_chunkwise_vs_recurrent(65)?;
+    assert!(max_out_diff < 0.05, "cross-chunk output diff {max_out_diff}");
+    assert!(max_state_diff < 0.05, "cross-chunk state diff {max_state_diff}");
     Ok(())
 }


### PR DESCRIPTION
## Summary
- fix Qwen3.5 HD256 paged prefill to pass `prefill_plan.num_tiles()` as `padded_batch_size`
- keep the probe utilities used to isolate the bug in this branch for traceability
- include targeted tests / dump helpers used to verify the fix against HF

## Root Cause
The HD256 prefill path called `batch_prefill_paged_cuda_hd256` with `prefill_plan.batch_size()` instead of the padded tile count. On single-request long prefill this caused the full-attention output to collapse to zero.

## Validation
- layer-4 full-attention `attn_out` max diff vs HF dropped from `1.515625` to `0.000977`
- 2048-token next-token probe now matches HF on the generated token, with top-10 candidate overlap `10/10`
- post-fix hidden-state rerun shows the old layer-4 divergence is gone
