### PR TITLE
fix(qwen35): correct hd256 prefill tile count

### DIFF
--- a/src/model/qwen35/prefill.rs
+++ b/src/model/qwen35/prefill.rs
@@ -339,7 +339,7 @@ impl Qwen35Model {
                     layout.page_size as i32,
                     seq_len as i32,
                     prefill_plan.batch_size(),
-                    prefill_plan.batch_size(), // padded_batch_size = batch_size for single-req
+                    prefill_plan.num_tiles(),
                     stride_page,
                     sm_scale,
                     self.ctx.stream.cu_stream(),


### PR DESCRIPTION
## Summary
- replace the HD256 prefill `padded_batch_size` argument with `prefill_plan.num_tiles()`
- keep the change scoped to the production fix only
- exclude all debug probes, binaries, helper methods, ignored tests, and unrelated formatting changes

## Validation
- `PEGAINFER_TRITON_PYTHON=/data/workspace-axel/.venv/bin/python cargo test --release --test e2e_qwen35 --no-run`
- `cargo test --release --test e2e_qwen35` could not run in this workspace because `/data/workspace-axel-longseq/models/Qwen3.5-4B` is absent

Supersedes #65 with a clean fix-only branch.