### PR TITLE
bench: add RTX 4090 performance snapshots

### DIFF
--- a/bench_snapshots/rtx-4090/qwen3-4b.json
+++ b/bench_snapshots/rtx-4090/qwen3-4b.json
@@ -1,0 +1,84 @@
+{
+  "commit": "fedaf78",
+  "date": "2026-04-01",
+  "model": "Qwen3-4B",
+  "gpu": "NVIDIA GeForce RTX 4090",
+  "prefill_heavy": {
+    "prompt_len": 10000,
+    "output_len": 1,
+    "metrics": {
+      "ttft_ms": {
+        "avg_ms": 713.7508,
+        "p50_ms": 714.440971,
+        "p95_ms": 716.534288,
+        "p99_ms": 717.16038,
+        "max_ms": 717.16038,
+        "samples": 20
+      },
+      "first_decode_step_ms": null,
+      "steady_tpot_ms": null,
+      "e2e_ms": {
+        "avg_ms": 713.750842,
+        "p50_ms": 714.441011,
+        "p95_ms": 716.5343280000001,
+        "p99_ms": 717.16042,
+        "max_ms": 717.16042,
+        "samples": 20
+      },
+      "generated_tokens": {
+        "min": 1,
+        "max": 1,
+        "avg": 1.0,
+        "samples": 20
+      },
+      "request_tok_s": 1.4010491337243993,
+      "decode_tok_s": null
+    }
+  },
+  "decode_heavy": {
+    "prompt_len": 1024,
+    "output_len": 256,
+    "metrics": {
+      "ttft_ms": {
+        "avg_ms": 55.456686999999995,
+        "p50_ms": 55.489487,
+        "p95_ms": 55.66952,
+        "p99_ms": 55.669659,
+        "max_ms": 55.669659,
+        "samples": 20
+      },
+      "first_decode_step_ms": {
+        "avg_ms": 10.464103000000001,
+        "p50_ms": 10.462519,
+        "p95_ms": 10.5123,
+        "p99_ms": 10.544657,
+        "max_ms": 10.544657,
+        "samples": 20
+      },
+      "steady_tpot_ms": {
+        "avg_ms": 10.306977,
+        "p50_ms": 10.309364,
+        "p95_ms": 10.35396,
+        "p99_ms": 10.398598999999999,
+        "max_ms": 11.270107,
+        "samples": 5080
+      },
+      "e2e_ms": {
+        "avg_ms": 2683.893263,
+        "p50_ms": 2683.317073,
+        "p95_ms": 2687.099502,
+        "p99_ms": 2688.068651,
+        "max_ms": 2688.068651,
+        "samples": 20
+      },
+      "generated_tokens": {
+        "min": 256,
+        "max": 256,
+        "avg": 256.0,
+        "samples": 20
+      },
+      "request_tok_s": 95.38382299594471,
+      "decode_tok_s": 97.01585032997403
+    }
+  }
+}

--- a/bench_snapshots/rtx-4090/qwen3.5-4b.json
+++ b/bench_snapshots/rtx-4090/qwen3.5-4b.json
@@ -1,0 +1,84 @@
+{
+  "commit": "fedaf78",
+  "date": "2026-04-01",
+  "model": "Qwen3.5-4B",
+  "gpu": "NVIDIA GeForce RTX 4090",
+  "prefill_heavy": {
+    "prompt_len": 10000,
+    "output_len": 1,
+    "metrics": {
+      "ttft_ms": {
+        "avg_ms": 715.115763,
+        "p50_ms": 714.763214,
+        "p95_ms": 716.9821010000001,
+        "p99_ms": 725.3476290000001,
+        "max_ms": 725.3476290000001,
+        "samples": 20
+      },
+      "first_decode_step_ms": null,
+      "steady_tpot_ms": null,
+      "e2e_ms": {
+        "avg_ms": 715.118549,
+        "p50_ms": 714.764004,
+        "p95_ms": 716.98503,
+        "p99_ms": 725.350739,
+        "max_ms": 725.350739,
+        "samples": 20
+      },
+      "generated_tokens": {
+        "min": 1,
+        "max": 1,
+        "avg": 1.0,
+        "samples": 20
+      },
+      "request_tok_s": 1.3983695446282238,
+      "decode_tok_s": null
+    }
+  },
+  "decode_heavy": {
+    "prompt_len": 1024,
+    "output_len": 256,
+    "metrics": {
+      "ttft_ms": {
+        "avg_ms": 81.57310600000001,
+        "p50_ms": 81.618007,
+        "p95_ms": 82.00363800000001,
+        "p99_ms": 82.234808,
+        "max_ms": 82.234808,
+        "samples": 20
+      },
+      "first_decode_step_ms": {
+        "avg_ms": 12.139427,
+        "p50_ms": 12.140839,
+        "p95_ms": 12.193282,
+        "p99_ms": 12.194059,
+        "max_ms": 12.194059,
+        "samples": 20
+      },
+      "steady_tpot_ms": {
+        "avg_ms": 11.036597,
+        "p50_ms": 11.036314,
+        "p95_ms": 11.114743,
+        "p99_ms": 11.123159000000001,
+        "max_ms": 11.329658,
+        "samples": 5080
+      },
+      "e2e_ms": {
+        "avg_ms": 2897.011717,
+        "p50_ms": 2897.0166600000002,
+        "p95_ms": 2897.728661,
+        "p99_ms": 2898.117547,
+        "max_ms": 2898.117547,
+        "samples": 20
+      },
+      "generated_tokens": {
+        "min": 256,
+        "max": 256,
+        "avg": 256.0,
+        "samples": 20
+      },
+      "request_tok_s": 88.36691907512107,
+      "decode_tok_s": 90.5721412615664
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add bench_serving snapshots for Qwen3-4B and Qwen3.5-4B on RTX 4090
- Includes TTFT and TPOT metrics for prefill-heavy (10k tokens) and decode-heavy (1024→256) workloads

## RTX 4090 vs RTX 5070 Ti Comparison

### Qwen3-4B
| Metric | 5070 Ti | 4090 | Delta |
|--------|---------|------|-------|
| TTFT p50 (10k prefill) | 1190.24ms | 714.44ms | **-40.0%** |
| TTFT p50 (1k decode) | 96.41ms | 55.49ms | **-42.4%** |
| TPOT p50 | 12.35ms | 10.31ms | **-16.5%** |
| decode tok/s | 81.05 | 97.02 | **+19.7%** |

### Qwen3.5-4B
| Metric | 5070 Ti | 4090 | Delta |
|--------|---------|------|-------|
| TTFT p50 (10k prefill) | 1012.58ms | 714.76ms | **-29.4%** |
| TTFT p50 (1k decode) | 110.49ms | 81.62ms | **-26.1%** |
| TPOT p50 | 12.39ms | 11.04ms | **-10.9%** |
| decode tok/s | 80.68 | 90.57 | **+12.3%** |

**Key takeaway:** 4090 has significantly faster prefill (~30-40%) thanks to higher memory bandwidth. Decode improvement is more modest (~10-20%) as it's more compute-bound.

## Test plan
- [x] No OOM on 4090 (24GB)
- [x] Both models ran 20 iterations each
- [x] TTFT/TPOT data present and reasonable
- [x] Snapshot files valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)