### PR TITLE
fix(scheduler): gate prefill admission on kv budget

### DIFF
--- a/src/model/qwen3/weights.rs
+++ b/src/model/qwen3/weights.rs
@@ -275,6 +275,10 @@ impl Qwen3Model {
         self.kv_pool.alloc()
     }
 
+    pub(crate) fn kv_pool(&self) -> &crate::kv_pool::KvPool {
+        &self.kv_pool
+    }
+
     /// Create pre-allocated batch decode buffers.
     pub(crate) fn create_batch_decode_bufs(
         &self,

--- a/src/model/qwen35/weights.rs
+++ b/src/model/qwen35/weights.rs
@@ -359,6 +359,10 @@ impl Qwen35Model {
     pub(crate) fn alloc_kv(&self) -> crate::kv_pool::KvState {
         self.kv_pool.alloc()
     }
+
+    pub(crate) fn kv_pool(&self) -> &crate::kv_pool::KvPool {
+        &self.kv_pool
+    }
     /// Create a CUDA Graph batch decode state with a custom slot capacity.
     pub(crate) fn create_batch_decode_graph_state_with_capacity(
         &self,

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -146,30 +146,53 @@ fn scheduler_loop(
 ) {
     let mut rng = StdRng::seed_from_u64(seed);
     let mut active: Vec<ActiveRequest> = Vec::new();
+    // Requests that could not be admitted due to KV budget pressure.
+    // Held here so they aren't lost; re-evaluated every loop iteration.
+    let mut deferred: Vec<SchedulerRequest> = Vec::new();
 
     info!("Scheduler ready (max_batch={})", bufs.max_batch_size);
 
     loop {
-        // 1. Drain all pending requests
-        let mut pending: Vec<SchedulerRequest> = Vec::new();
+        // 1. Drain all incoming requests into deferred.
         while let Ok(req) = submit_rx.try_recv() {
-            pending.push(req);
+            deferred.push(req);
         }
 
-        // 2. Nothing active and nothing pending → block until a request arrives
-        if active.is_empty() && pending.is_empty() {
+        // 2. Nothing active and nothing deferred → block until a request arrives.
+        if active.is_empty() && deferred.is_empty() {
             match submit_rx.blocking_recv() {
-                Some(req) => pending.push(req),
+                Some(req) => deferred.push(req),
                 None => {
                     info!("Scheduler: all handles dropped, exiting");
                     return;
                 }
             }
-            // Drain any others that arrived while we were blocked
             while let Ok(req) = submit_rx.try_recv() {
-                pending.push(req);
+                deferred.push(req);
             }
         }
+
+        // 3. Admission control: admit deferred requests only if the KV pool
+        //    has enough pages for their prefill, after reserving one page per
+        //    active request for its next decode step.
+        let page_size = model.kv_pool().layout().page_size;
+        let decode_reserve = active.len(); // one page per active request
+        let mut budget = model
+            .kv_pool()
+            .available_pages()
+            .saturating_sub(decode_reserve);
+        let mut pending: Vec<SchedulerRequest> = Vec::new();
+        let mut still_deferred: Vec<SchedulerRequest> = Vec::new();
+        for req in deferred.drain(..) {
+            let needed = req.prompt_tokens.len().div_ceil(page_size);
+            if needed <= budget {
+                budget -= needed;
+                pending.push(req);
+            } else {
+                still_deferred.push(req);
+            }
+        }
+        deferred = still_deferred;
 
         let have_pending = !pending.is_empty();
 

--- a/src/scheduler_qwen35.rs
+++ b/src/scheduler_qwen35.rs
@@ -146,10 +146,29 @@ fn scheduler_loop(
             }
         }
 
-        // Cap pending to available slot capacity; defer overflow to next iteration.
-        let available = max_batch.saturating_sub(active.len());
-        if pending.len() > available {
-            deferred = pending.split_off(available);
+        // Admission control: cap by slot capacity AND KV page budget.
+        // Reserve one page per active decode request for its next step.
+        let page_size = model.kv_pool().layout().page_size;
+        let decode_reserve = active.len();
+        let mut page_budget = model
+            .kv_pool()
+            .available_pages()
+            .saturating_sub(decode_reserve);
+        let slot_budget = max_batch.saturating_sub(active.len());
+        let mut admitted = 0;
+        for req in &pending {
+            if admitted >= slot_budget {
+                break;
+            }
+            let needed = req.prompt_tokens.len().div_ceil(page_size);
+            if needed > page_budget {
+                break;
+            }
+            page_budget -= needed;
+            admitted += 1;
+        }
+        if admitted < pending.len() {
+            deferred = pending.split_off(admitted);
         }
 
         let have_pending = !pending.is_empty();


### PR DESCRIPTION
## Summary
- expose `kv_pool()` on both Qwen3 and Qwen3.5 models so the schedulers can inspect KV pool state
- keep scheduler submissions in a deferred queue and only admit prompts whose prefill fits within the current KV page budget after reserving one page per active decode request
- apply the same KV-budget admission gate to the Qwen3.5 scheduler alongside its existing slot-capacity limit

## Validation
- pre-commit hooks
- cargo fmt
- cargo clippy --release --all-targets