### PR TITLE
docs(readme): clarify root server entry after Qwen3 crate split

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ export PEGAINFER_TRITON_PYTHON=.venv/bin/python
 cargo run --release
 ```
 
-> Workspace layout: the server CLI lives in the root `pegainfer` package. The model crates under `crates/` (e.g. `pegainfer-qwen3-4b`, `pegainfer-kernels`, `pegainfer-core`) own model, runtime, and kernel code plus diagnostic bins only; they are not server entrypoints. `cargo run --release` (or `cargo run --release --bin pegainfer`) is what you want. A natural-looking `cargo run --package pegainfer-qwen3-4b --bin pegainfer-qwen3-4b` does not exist and will fail with `no bin target named ...`.
+> **Note**: The server CLI is in the root `pegainfer` package. Crates under `crates/` (e.g., `pegainfer-qwen3-4b`, `pegainfer-kernels`) contain model logic and diagnostic tools but are not server entrypoints. Use `cargo run --release` (or `cargo run --release --bin pegainfer`) from the root. Running with `--package pegainfer-qwen3-4b` will fail with `no bin target named ...`.
 
 ```bash
 # Try it

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ export PEGAINFER_TRITON_PYTHON=.venv/bin/python
 cargo run --release
 ```
 
+> Workspace layout: the server CLI lives in the root `pegainfer` package. The model crates under `crates/` (e.g. `pegainfer-qwen3-4b`, `pegainfer-kernels`, `pegainfer-core`) own model, runtime, and kernel code plus diagnostic bins only; they are not server entrypoints. `cargo run --release` (or `cargo run --release --bin pegainfer`) is what you want. A natural-looking `cargo run --package pegainfer-qwen3-4b --bin pegainfer-qwen3-4b` does not exist and will fail with `no bin target named ...`.
+
 ```bash
 # Try it
 curl -s http://localhost:8000/v1/completions \


### PR DESCRIPTION
Closes #83.

After the Qwen3 model code moved into `crates/pegainfer-qwen3-4b` (PR #77), users who try the natural-looking `cargo run --package pegainfer-qwen3-4b --bin pegainfer-qwen3-4b` get:

```
error: no bin target named `pegainfer-qwen3-4b` in `pegainfer-qwen3-4b` package
help: available bin targets:
    qwen3_decode_context
    qwen3_kernel_report
```

That crate is a model/runtime crate with diagnostic bins only; the OpenAI/vLLM server lives in the root `pegainfer` package and is what `cargo run --release` (the command already shown in Quickstart) actually starts.

This adds a short callout right after the existing Quickstart `cargo run --release` so the workspace boundary is explicit:

- Root `pegainfer` package owns the server CLI / vLLM frontend.
- `pegainfer-qwen3-4b`, `pegainfer-kernels`, and `pegainfer-core` own model / kernel / runtime code (and diagnostic bins), but are not server entrypoints.
- The "obvious" per-package invocation does not exist and will fail.

Following `CLAUDE.md` ("Refactor over append... integrate it into the document body"), the note slots into the existing Quickstart flow rather than adding a new section. The acceptance-criteria onboarding doc (`docs/resources/developer-onboarding.md`) already uses `cargo run --release -- --port 8000` against the root binary, so no change there.

## Test plan

- [x] `cargo metadata --no-deps` still succeeds (README-only change).
- [x] Diff is +2 lines, scoped to README Quickstart.