### PR TITLE
feat(frontend): bridge generated-token logprobs through vllm engine-core

### DIFF
--- a/pegainfer-server/src/vllm_frontend.rs
+++ b/pegainfer-server/src/vllm_frontend.rs
@@ -11,8 +11,9 @@ use tokio_util::sync::CancellationToken;
 use vllm_engine_core_client::protocol::handshake::EngineCoreReadyResponse;
 use vllm_engine_core_client::protocol::{
     EngineCoreFinishReason, EngineCoreOutput, EngineCoreOutputs, EngineCoreRequest,
-    EngineCoreRequestType, EngineCoreSamplingParams, StopReason, UtilityOutput,
-    UtilityResultEnvelope, encode_msgpack,
+    EngineCoreRequestType, EngineCoreSamplingParams, Logprobs, MaybeWireLogprobs, PositionLogprobs,
+    StopReason, TokenLogprob as WireTokenLogprob, UtilityOutput, UtilityResultEnvelope,
+    encode_msgpack,
 };
 use vllm_engine_core_client::{EngineId, TransportMode};
 use vllm_server::{
@@ -24,7 +25,9 @@ use zeromq::util::PeerIdentity;
 use zeromq::{DealerSocket, PushSocket, SocketOptions, ZmqMessage};
 
 use crate::sampler::SamplingParams;
-use pegainfer_core::engine::{EngineHandle, FinishReason, GenerateRequest, TokenEvent};
+use pegainfer_core::engine::{
+    EngineHandle, FinishReason, GenerateRequest, TokenEvent, TokenLogprob,
+};
 
 const ENGINE_INDEX: u32 = 0;
 
@@ -274,8 +277,8 @@ async fn run_request_stream(
 ) {
     while let Some(event) = token_rx.recv().await {
         match event {
-            TokenEvent::Token { id, .. } => {
-                if send_token_output(&output_tx, &request_id, id).is_err() {
+            TokenEvent::Token { id, logprob } => {
+                if send_token_output(&output_tx, &request_id, id, logprob).is_err() {
                     return;
                 }
             }
@@ -328,6 +331,7 @@ fn send_token_output(
     output_tx: &mpsc::UnboundedSender<EngineCoreOutputs>,
     request_id: &str,
     token_id: u32,
+    logprob: Option<TokenLogprob>,
 ) -> Result<()> {
     send_outputs(
         output_tx,
@@ -336,6 +340,7 @@ fn send_token_output(
             outputs: vec![engine_output(
                 request_id.to_string(),
                 vec![token_id],
+                to_wire_logprobs(token_id, logprob),
                 None,
                 None,
             )],
@@ -358,6 +363,7 @@ fn send_terminal_output(
             outputs: vec![engine_output(
                 request_id.clone(),
                 Vec::new(),
+                None,
                 Some(finish_reason),
                 stop_reason,
             )],
@@ -408,13 +414,14 @@ fn send_outputs(
 fn engine_output(
     request_id: String,
     new_token_ids: Vec<u32>,
+    new_logprobs: Option<MaybeWireLogprobs>,
     finish_reason: Option<EngineCoreFinishReason>,
     stop_reason: Option<StopReason>,
 ) -> EngineCoreOutput {
     EngineCoreOutput {
         request_id,
         new_token_ids,
-        new_logprobs: None,
+        new_logprobs,
         new_prompt_logprobs_tensors: None,
         pooling_output: None,
         finish_reason,
@@ -426,6 +433,29 @@ fn engine_output(
         routed_experts: None,
         num_nans_in_logits: 0,
     }
+}
+
+fn to_wire_logprobs(token_id: u32, logprob: Option<TokenLogprob>) -> Option<MaybeWireLogprobs> {
+    let lp = logprob?;
+    let mut entries = Vec::with_capacity(1 + lp.top_logprobs.len());
+    // The sampled/selected token. pegainfer-core does not track its actual vocab
+    // rank, so we record rank=1 (correct for greedy sampling and a reasonable
+    // default for sampling).
+    entries.push(WireTokenLogprob {
+        token_id,
+        logprob: lp.logprob,
+        rank: 1,
+    });
+    for (index, (alt_id, alt_logprob)) in lp.top_logprobs.into_iter().enumerate() {
+        entries.push(WireTokenLogprob {
+            token_id: alt_id,
+            logprob: alt_logprob,
+            rank: (index + 1) as u32,
+        });
+    }
+    Some(MaybeWireLogprobs::Direct(Logprobs {
+        positions: vec![PositionLogprobs { entries }],
+    }))
 }
 
 fn convert_sampling(params: &EngineCoreSamplingParams) -> SamplingParams {
@@ -520,4 +550,38 @@ pub fn shutdown_token_from_ctrl_c() -> CancellationToken {
         shutdown.cancel();
     });
     token
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_wire_logprobs_returns_none_when_input_is_none() {
+        assert!(to_wire_logprobs(7, None).is_none());
+    }
+
+    #[test]
+    fn to_wire_logprobs_emits_sampled_then_alternatives() {
+        let lp = TokenLogprob {
+            logprob: -0.5,
+            top_logprobs: vec![(7, -0.5), (42, -1.5)],
+        };
+        let wire = to_wire_logprobs(7, Some(lp)).expect("logprob payload");
+        let direct = match wire {
+            MaybeWireLogprobs::Direct(d) => d,
+            MaybeWireLogprobs::Wire(_) => panic!("expected Direct logprobs"),
+        };
+        assert_eq!(direct.positions.len(), 1);
+        let entries = &direct.positions[0].entries;
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].token_id, 7);
+        assert_eq!(entries[0].logprob, -0.5);
+        assert_eq!(entries[0].rank, 1);
+        assert_eq!(entries[1].token_id, 7);
+        assert_eq!(entries[1].rank, 1);
+        assert_eq!(entries[2].token_id, 42);
+        assert_eq!(entries[2].logprob, -1.5);
+        assert_eq!(entries[2].rank, 2);
+    }
 }

--- a/pegainfer-server/src/vllm_frontend.rs
+++ b/pegainfer-server/src/vllm_frontend.rs
@@ -282,7 +282,9 @@ async fn run_request_stream(
                     return;
                 }
             }
-            TokenEvent::PromptTokens { .. } => {}
+            TokenEvent::PromptTokens { .. } => {
+                // Prompt logprobs are intentionally deferred for this bridge.
+            }
             TokenEvent::Finished { finish_reason, .. } => {
                 let _ = send_terminal_output(
                     &output_tx,
@@ -438,15 +440,19 @@ fn engine_output(
 fn to_wire_logprobs(token_id: u32, logprob: Option<TokenLogprob>) -> Option<MaybeWireLogprobs> {
     let lp = logprob?;
     let mut entries = Vec::with_capacity(1 + lp.top_logprobs.len());
-    // The sampled/selected token. pegainfer-core does not track its actual vocab
-    // rank, so we record rank=1 (correct for greedy sampling and a reasonable
-    // default for sampling).
+    // pegainfer-core does not currently expose the sampled token's vocab rank.
+    // rank: 1 is correct for greedy sampling, where the sampled token is top-1,
+    // and is a lossy placeholder for non-greedy sampling.
+    // See discussion on PR #96.
     entries.push(WireTokenLogprob {
         token_id,
         logprob: lp.logprob,
         rank: 1,
     });
     for (index, (alt_id, alt_logprob)) in lp.top_logprobs.into_iter().enumerate() {
+        if alt_id == token_id {
+            continue;
+        }
         entries.push(WireTokenLogprob {
             token_id: alt_id,
             logprob: alt_logprob,
@@ -574,13 +580,36 @@ mod tests {
         };
         assert_eq!(direct.positions.len(), 1);
         let entries = &direct.positions[0].entries;
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].token_id, 7);
+        assert_eq!(entries[0].logprob, -0.5);
+        assert_eq!(entries[0].rank, 1);
+        assert_eq!(entries[1].token_id, 42);
+        assert_eq!(entries[1].logprob, -1.5);
+        assert_eq!(entries[1].rank, 2);
+    }
+
+    #[test]
+    fn to_wire_logprobs_keeps_distinct_top_k_alternatives() {
+        let lp = TokenLogprob {
+            logprob: -0.5,
+            top_logprobs: vec![(8, -1.0), (9, -1.5)],
+        };
+        let wire = to_wire_logprobs(7, Some(lp)).expect("logprob payload");
+        let direct = match wire {
+            MaybeWireLogprobs::Direct(d) => d,
+            MaybeWireLogprobs::Wire(_) => panic!("expected Direct logprobs"),
+        };
+        assert_eq!(direct.positions.len(), 1);
+        let entries = &direct.positions[0].entries;
         assert_eq!(entries.len(), 3);
         assert_eq!(entries[0].token_id, 7);
         assert_eq!(entries[0].logprob, -0.5);
         assert_eq!(entries[0].rank, 1);
-        assert_eq!(entries[1].token_id, 7);
+        assert_eq!(entries[1].token_id, 8);
+        assert_eq!(entries[1].logprob, -1.0);
         assert_eq!(entries[1].rank, 1);
-        assert_eq!(entries[2].token_id, 42);
+        assert_eq!(entries[2].token_id, 9);
         assert_eq!(entries[2].logprob, -1.5);
         assert_eq!(entries[2].rank, 2);
     }


### PR DESCRIPTION
Closes #81.

## Summary

Threads generated-token logprobs from `pegainfer_core::engine::TokenEvent::Token`
through the vLLM frontend bridge so OpenAI requests asking for `logprobs` receive
the metadata pegainfer already computes, instead of having `engine_output` drop
it on the floor.

## Why this matters

`pegainfer-server/src/vllm_frontend.rs:277` previously matched `TokenEvent::Token { id, .. }`
and called `send_token_output(&output_tx, &request_id, id)`, which built every
`EngineCoreOutput` via `engine_output` at line 408 with `new_logprobs: None`
hardcoded. The schedulers were already populating `TokenLogprob { logprob,
top_logprobs }`, so the data existed; nothing on the bridge side knew how to
ship it.

## Changes (all in `pegainfer-server/src/vllm_frontend.rs`)

- Add a private `to_wire_logprobs(token_id, logprob)` helper that maps
  `pegainfer_core::engine::TokenLogprob` into
  `vllm_engine_core_client::protocol::MaybeWireLogprobs::Direct(Logprobs { ... })`
  with one `PositionLogprobs` per generated token. The sampled token uses
  `rank: 1` (pegainfer-core does not currently expose the actual sampled vocab
  rank; rank 1 is correct for greedy and a reasonable default for sampling),
  and top-k alternatives use 1-based ranks per the protocol's
  `from_decoded_row` convention.
- Bind `logprob` in `run_request_stream`'s `TokenEvent::Token` arm and forward
  it through `send_token_output`.
- Add `logprob: Option<TokenLogprob>` to `send_token_output` and
  `new_logprobs: Option<MaybeWireLogprobs>` to `engine_output`. Update
  `send_terminal_output` callers to pass `None`.
- Import the wire types (`Logprobs`, `MaybeWireLogprobs`, `PositionLogprobs`,
  `TokenLogprob as WireTokenLogprob`) from
  `vllm_engine_core_client::protocol`.

## Tests

Added a `#[cfg(test)] mod tests` block at the bottom of `vllm_frontend.rs`:

- `to_wire_logprobs_returns_none_when_input_is_none` covers the no-logprobs
  path so requests without `logprobs` keep their current response shape.
- `to_wire_logprobs_emits_sampled_then_alternatives` builds a `TokenLogprob`
  with two top-k entries and asserts the resulting `PositionLogprobs` has the
  sampled token first (rank 1) followed by alternatives at ranks 1 and 2 in
  insertion order.

## Scope split

The issue body (and acceptance criterion 3) explicitly allow shipping
completion-token logprobs first and splitting prompt logprobs into a
follow-up. This PR does that: `TokenEvent::PromptTokens` still falls through
unchanged and `new_prompt_logprobs_tensors` stays `None`.

## Verification

- `cargo fmt --all --check` passes (acceptance criterion).
- `cargo metadata --no-deps --format-version 1` passes (acceptance
  criterion).
- `cargo build`/`cargo test` could not be run locally because
  `pegainfer-kernels/build.rs` requires nvcc/CUDA, which I do not have on this
  machine. The added test module is pure `Vec`/struct manipulation and does
  not touch the GPU path; happy to amend if it surfaces any issue on a CUDA
  box.
