### PR TITLE
refactor(deepseek-v4): split direct greedy request state

### DIFF
--- a/pegainfer-deepseek-v4/src/direct.rs
+++ b/pegainfer-deepseek-v4/src/direct.rs
@@ -2,4 +2,7 @@ mod affinity;
 mod scheduler;
 mod worker;
 
-pub use scheduler::{DeepSeekV4DirectGenerator, DirectGeneration, start_engine};
+pub use scheduler::{
+    DeepSeekV4DirectGenerator, DeepSeekV4RequestState, DirectDecodeStep, DirectGeneration,
+    start_engine,
+};

--- a/pegainfer-deepseek-v4/src/direct/scheduler.rs
+++ b/pegainfer-deepseek-v4/src/direct/scheduler.rs
@@ -19,6 +19,7 @@ pub struct DirectGeneration {
 }
 
 pub struct DeepSeekV4RequestState {
+    request_epoch: u64,
     prompt_len: usize,
     max_new_tokens: usize,
     ignore_eos: bool,
@@ -29,6 +30,7 @@ pub struct DeepSeekV4RequestState {
 
 #[derive(Clone, Debug)]
 pub struct DirectDecodeStep {
+    request_epoch: u64,
     generated_len_before: usize,
     prompt_len: usize,
     token: Option<u32>,
@@ -78,6 +80,7 @@ impl DeepSeekV4RequestState {
 pub struct DeepSeekV4DirectGenerator {
     config: &'static Config,
     runtime: FullDirectRuntime,
+    next_request_epoch: u64,
 }
 
 impl DeepSeekV4DirectGenerator {
@@ -91,7 +94,11 @@ impl DeepSeekV4DirectGenerator {
             },
         )?));
         let runtime = load_full_direct_runtime(model_path, config)?;
-        Ok(Self { config, runtime })
+        Ok(Self {
+            config,
+            runtime,
+            next_request_epoch: 0,
+        })
     }
 
     pub fn eos_token_id(&self) -> usize {
@@ -107,8 +114,15 @@ impl DeepSeekV4DirectGenerator {
         if prompt_tokens.is_empty() {
             bail!("DeepSeek V4 request produced an empty prompt");
         }
+        let request_epoch = self.next_request_epoch;
+        self.next_request_epoch = self
+            .next_request_epoch
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("DeepSeek V4 request epoch exhausted"))?;
+
         if max_new_tokens == 0 {
             return Ok(DeepSeekV4RequestState {
+                request_epoch,
                 prompt_len: prompt_tokens.len(),
                 max_new_tokens,
                 ignore_eos,
@@ -131,6 +145,7 @@ impl DeepSeekV4DirectGenerator {
         )?;
 
         Ok(DeepSeekV4RequestState {
+            request_epoch,
             prompt_len: prompt_tokens.len(),
             max_new_tokens,
             ignore_eos,
@@ -143,6 +158,7 @@ impl DeepSeekV4DirectGenerator {
     pub fn sample_greedy_step(&self, state: &DeepSeekV4RequestState) -> Result<DirectDecodeStep> {
         if let Some(finish_reason) = state.finish_reason {
             return Ok(DirectDecodeStep {
+                request_epoch: state.request_epoch,
                 generated_len_before: state.generated.len(),
                 prompt_len: state.prompt_len,
                 token: None,
@@ -157,6 +173,7 @@ impl DeepSeekV4DirectGenerator {
         let token = argmax_f32(&next_logits) as u32;
         if !state.ignore_eos && token as usize == self.config.eos_token_id {
             return Ok(DirectDecodeStep {
+                request_epoch: state.request_epoch,
                 generated_len_before: state.generated.len(),
                 prompt_len: state.prompt_len,
                 token: None,
@@ -167,6 +184,7 @@ impl DeepSeekV4DirectGenerator {
         let finish_reason =
             (state.generated.len() + 1 == state.max_new_tokens).then_some(FinishReason::Length);
         Ok(DirectDecodeStep {
+            request_epoch: state.request_epoch,
             generated_len_before: state.generated.len(),
             prompt_len: state.prompt_len,
             token: Some(token),
@@ -355,6 +373,13 @@ fn ensure_step_matches_state(
     state: &DeepSeekV4RequestState,
     step: &DirectDecodeStep,
 ) -> Result<()> {
+    if step.request_epoch != state.request_epoch {
+        bail!(
+            "DeepSeek V4 decode step request epoch mismatch: step={}, state={}",
+            step.request_epoch,
+            state.request_epoch
+        );
+    }
     if step.prompt_len != state.prompt_len {
         bail!(
             "DeepSeek V4 decode step prompt length mismatch: step={}, state={}",

--- a/pegainfer-deepseek-v4/src/direct/scheduler.rs
+++ b/pegainfer-deepseek-v4/src/direct/scheduler.rs
@@ -18,6 +18,43 @@ pub struct DirectGeneration {
     pub finish_reason: FinishReason,
 }
 
+pub struct DeepSeekV4RequestState {
+    prompt_len: usize,
+    max_new_tokens: usize,
+    ignore_eos: bool,
+    generated: Vec<u32>,
+    next_logits: Option<Vec<f32>>,
+    finish_reason: Option<FinishReason>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct DirectDecodeStep {
+    pub token: Option<u32>,
+    pub finish_reason: Option<FinishReason>,
+}
+
+impl DeepSeekV4RequestState {
+    pub fn prompt_len(&self) -> usize {
+        self.prompt_len
+    }
+
+    pub fn generated(&self) -> &[u32] {
+        &self.generated
+    }
+
+    pub fn completion_tokens(&self) -> usize {
+        self.generated.len()
+    }
+
+    pub fn finish_reason(&self) -> Option<FinishReason> {
+        self.finish_reason
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.finish_reason.is_some()
+    }
+}
+
 pub struct DeepSeekV4DirectGenerator {
     config: &'static Config,
     runtime: FullDirectRuntime,
@@ -41,6 +78,124 @@ impl DeepSeekV4DirectGenerator {
         self.config.eos_token_id
     }
 
+    pub fn start_greedy_request(
+        &mut self,
+        prompt_tokens: &[u32],
+        max_new_tokens: usize,
+        ignore_eos: bool,
+    ) -> Result<DeepSeekV4RequestState> {
+        if prompt_tokens.is_empty() {
+            bail!("DeepSeek V4 request produced an empty prompt");
+        }
+        if max_new_tokens == 0 {
+            return Ok(DeepSeekV4RequestState {
+                prompt_len: prompt_tokens.len(),
+                max_new_tokens,
+                ignore_eos,
+                generated: Vec::new(),
+                next_logits: None,
+                finish_reason: Some(FinishReason::Length),
+            });
+        }
+
+        ensure_direct_decode_caches(
+            &mut self.runtime,
+            self.config,
+            prompt_tokens.len() + max_new_tokens,
+        )?;
+
+        let next_logits = run_prefill_logits_and_seed_decode_cache(
+            &mut self.runtime,
+            self.config,
+            prompt_tokens,
+        )?;
+
+        Ok(DeepSeekV4RequestState {
+            prompt_len: prompt_tokens.len(),
+            max_new_tokens,
+            ignore_eos,
+            generated: Vec::with_capacity(max_new_tokens),
+            next_logits: Some(next_logits),
+            finish_reason: None,
+        })
+    }
+
+    pub fn sample_greedy_step(&self, state: &DeepSeekV4RequestState) -> Result<DirectDecodeStep> {
+        if let Some(finish_reason) = state.finish_reason {
+            return Ok(DirectDecodeStep {
+                token: None,
+                finish_reason: Some(finish_reason),
+            });
+        }
+
+        let next_logits = state
+            .next_logits
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("DeepSeek V4 request state missing next logits"))?;
+        let token = argmax_f32(&next_logits) as u32;
+        if !state.ignore_eos && token as usize == self.config.eos_token_id {
+            return Ok(DirectDecodeStep {
+                token: None,
+                finish_reason: Some(FinishReason::Stop),
+            });
+        }
+
+        let finish_reason =
+            (state.generated.len() + 1 == state.max_new_tokens).then_some(FinishReason::Length);
+        Ok(DirectDecodeStep {
+            token: Some(token),
+            finish_reason,
+        })
+    }
+
+    pub fn advance_greedy_step(
+        &mut self,
+        state: &mut DeepSeekV4RequestState,
+        step: DirectDecodeStep,
+    ) -> Result<()> {
+        if state.is_finished() {
+            return Ok(());
+        }
+
+        if let Some(finish_reason) = step.finish_reason
+            && step.token.is_none()
+        {
+            state.next_logits = None;
+            state.finish_reason = Some(finish_reason);
+            return Ok(());
+        }
+
+        let Some(token) = step.token else {
+            bail!("DeepSeek V4 decode step without token or finish reason");
+        };
+        state
+            .next_logits
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("DeepSeek V4 request state missing consumed logits"))?;
+        state.generated.push(token);
+        if let Some(finish_reason) = step.finish_reason {
+            state.finish_reason = Some(finish_reason);
+            return Ok(());
+        }
+        let start_pos = state.prompt_len + state.generated.len() - 1;
+        state.next_logits = Some(run_direct_decode_logits(
+            &mut self.runtime,
+            token,
+            start_pos,
+        )?);
+
+        Ok(())
+    }
+
+    pub fn decode_greedy_step(
+        &mut self,
+        state: &mut DeepSeekV4RequestState,
+    ) -> Result<DirectDecodeStep> {
+        let step = self.sample_greedy_step(state)?;
+        self.advance_greedy_step(state, step)?;
+        Ok(step)
+    }
+
     pub fn generate_greedy<F>(
         &mut self,
         prompt_tokens: &[u32],
@@ -51,49 +206,19 @@ impl DeepSeekV4DirectGenerator {
     where
         F: FnMut(u32) -> Result<()>,
     {
-        if prompt_tokens.is_empty() {
-            bail!("DeepSeek V4 request produced an empty prompt");
-        }
-        if max_new_tokens == 0 {
-            return Ok(DirectGeneration {
-                generated: Vec::new(),
-                finish_reason: FinishReason::Length,
-            });
-        }
-
-        ensure_direct_decode_caches(
-            &mut self.runtime,
-            self.config,
-            prompt_tokens.len() + max_new_tokens,
-        )?;
-
-        let mut next_logits = run_prefill_logits_and_seed_decode_cache(
-            &mut self.runtime,
-            self.config,
-            prompt_tokens,
-        )?;
-        let mut generated = Vec::with_capacity(max_new_tokens);
-
-        for step in 0..max_new_tokens {
-            let token = argmax_f32(&next_logits) as u32;
-            if !ignore_eos && token as usize == self.config.eos_token_id {
-                return Ok(DirectGeneration {
-                    generated,
-                    finish_reason: FinishReason::Stop,
-                });
+        let mut state = self.start_greedy_request(prompt_tokens, max_new_tokens, ignore_eos)?;
+        while !state.is_finished() {
+            let step = self.sample_greedy_step(&state)?;
+            if let Some(token) = step.token {
+                on_token(token)?;
             }
-            on_token(token)?;
-            generated.push(token);
-            if step + 1 == max_new_tokens {
-                break;
-            }
-            next_logits =
-                run_direct_decode_logits(&mut self.runtime, token, prompt_tokens.len() + step)?;
+            self.advance_greedy_step(&mut state, step)?;
         }
-
         Ok(DirectGeneration {
-            generated,
-            finish_reason: FinishReason::Length,
+            generated: state.generated,
+            finish_reason: state
+                .finish_reason
+                .expect("DeepSeek V4 request state must finish after greedy generation"),
         })
     }
 }

--- a/pegainfer-deepseek-v4/src/direct/scheduler.rs
+++ b/pegainfer-deepseek-v4/src/direct/scheduler.rs
@@ -27,10 +27,30 @@ pub struct DeepSeekV4RequestState {
     finish_reason: Option<FinishReason>,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct DirectDecodeStep {
-    pub token: Option<u32>,
-    pub finish_reason: Option<FinishReason>,
+    generated_len_before: usize,
+    prompt_len: usize,
+    token: Option<u32>,
+    finish_reason: Option<FinishReason>,
+}
+
+impl DirectDecodeStep {
+    pub fn token(&self) -> Option<u32> {
+        self.token
+    }
+
+    pub fn finish_reason(&self) -> Option<FinishReason> {
+        self.finish_reason
+    }
+
+    pub fn generated_len_before(&self) -> usize {
+        self.generated_len_before
+    }
+
+    pub fn start_pos(&self) -> usize {
+        self.prompt_len + self.generated_len_before
+    }
 }
 
 impl DeepSeekV4RequestState {
@@ -123,6 +143,8 @@ impl DeepSeekV4DirectGenerator {
     pub fn sample_greedy_step(&self, state: &DeepSeekV4RequestState) -> Result<DirectDecodeStep> {
         if let Some(finish_reason) = state.finish_reason {
             return Ok(DirectDecodeStep {
+                generated_len_before: state.generated.len(),
+                prompt_len: state.prompt_len,
                 token: None,
                 finish_reason: Some(finish_reason),
             });
@@ -135,6 +157,8 @@ impl DeepSeekV4DirectGenerator {
         let token = argmax_f32(&next_logits) as u32;
         if !state.ignore_eos && token as usize == self.config.eos_token_id {
             return Ok(DirectDecodeStep {
+                generated_len_before: state.generated.len(),
+                prompt_len: state.prompt_len,
                 token: None,
                 finish_reason: Some(FinishReason::Stop),
             });
@@ -143,6 +167,8 @@ impl DeepSeekV4DirectGenerator {
         let finish_reason =
             (state.generated.len() + 1 == state.max_new_tokens).then_some(FinishReason::Length);
         Ok(DirectDecodeStep {
+            generated_len_before: state.generated.len(),
+            prompt_len: state.prompt_len,
             token: Some(token),
             finish_reason,
         })
@@ -151,21 +177,22 @@ impl DeepSeekV4DirectGenerator {
     pub fn advance_greedy_step(
         &mut self,
         state: &mut DeepSeekV4RequestState,
-        step: DirectDecodeStep,
+        step: &DirectDecodeStep,
     ) -> Result<()> {
+        ensure_step_matches_state(state, step)?;
         if state.is_finished() {
             return Ok(());
         }
 
-        if let Some(finish_reason) = step.finish_reason
-            && step.token.is_none()
+        if let Some(finish_reason) = step.finish_reason()
+            && step.token().is_none()
         {
             state.next_logits = None;
             state.finish_reason = Some(finish_reason);
             return Ok(());
         }
 
-        let Some(token) = step.token else {
+        let Some(token) = step.token() else {
             bail!("DeepSeek V4 decode step without token or finish reason");
         };
         state
@@ -173,15 +200,14 @@ impl DeepSeekV4DirectGenerator {
             .take()
             .ok_or_else(|| anyhow::anyhow!("DeepSeek V4 request state missing consumed logits"))?;
         state.generated.push(token);
-        if let Some(finish_reason) = step.finish_reason {
+        if let Some(finish_reason) = step.finish_reason() {
             state.finish_reason = Some(finish_reason);
             return Ok(());
         }
-        let start_pos = state.prompt_len + state.generated.len() - 1;
         state.next_logits = Some(run_direct_decode_logits(
             &mut self.runtime,
             token,
-            start_pos,
+            step.start_pos(),
         )?);
 
         Ok(())
@@ -192,7 +218,7 @@ impl DeepSeekV4DirectGenerator {
         state: &mut DeepSeekV4RequestState,
     ) -> Result<DirectDecodeStep> {
         let step = self.sample_greedy_step(state)?;
-        self.advance_greedy_step(state, step)?;
+        self.advance_greedy_step(state, &step)?;
         Ok(step)
     }
 
@@ -209,10 +235,10 @@ impl DeepSeekV4DirectGenerator {
         let mut state = self.start_greedy_request(prompt_tokens, max_new_tokens, ignore_eos)?;
         while !state.is_finished() {
             let step = self.sample_greedy_step(&state)?;
-            if let Some(token) = step.token {
+            if let Some(token) = step.token() {
                 on_token(token)?;
             }
-            self.advance_greedy_step(&mut state, step)?;
+            self.advance_greedy_step(&mut state, &step)?;
         }
         Ok(DirectGeneration {
             generated: state.generated,
@@ -323,6 +349,27 @@ fn handle_request(generator: &mut DeepSeekV4DirectGenerator, req: GenerateReques
             });
         }
     }
+}
+
+fn ensure_step_matches_state(
+    state: &DeepSeekV4RequestState,
+    step: &DirectDecodeStep,
+) -> Result<()> {
+    if step.prompt_len != state.prompt_len {
+        bail!(
+            "DeepSeek V4 decode step prompt length mismatch: step={}, state={}",
+            step.prompt_len,
+            state.prompt_len
+        );
+    }
+    if step.generated_len_before != state.generated.len() {
+        bail!(
+            "DeepSeek V4 decode step generated length mismatch: step={}, state={}",
+            step.generated_len_before,
+            state.generated.len()
+        );
+    }
+    Ok(())
 }
 
 fn reject_request(req: &GenerateRequest, prompt_len: usize, reason: String) {

--- a/pegainfer-deepseek-v4/src/lib.rs
+++ b/pegainfer-deepseek-v4/src/lib.rs
@@ -6,7 +6,10 @@ mod runtime;
 mod weights;
 
 pub use config::{Config, RopeScaling, TensorParallelConfig};
-pub use direct::{DeepSeekV4DirectGenerator, DirectGeneration, start_engine};
+pub use direct::{
+    DeepSeekV4DirectGenerator, DeepSeekV4RequestState, DirectDecodeStep, DirectGeneration,
+    start_engine,
+};
 pub use model::{
     AttentionWeightNames, AttentionWeights, BlockWeightNames, BlockWeights, CompressorWeightNames,
     CompressorWeights, DeepSeekRankModel, ExpertWeightNames, ExpertWeights, FfnWeightNames,


### PR DESCRIPTION
## Summary

- Add `DeepSeekV4RequestState` as the request-local state created after prefill.
- Add explicit greedy step APIs: sample the next token from cached logits, advance state after the token is accepted, and keep a combined `decode_greedy_step` helper for simple callers.
- Bind `DirectDecodeStep` to generator-issued request provenance before it can advance state, so external callers cannot silently replay stale steps or steps from another request.
- Reimplement existing `generate_greedy` through the new state/step path so the current single-request engine behavior remains the compatibility path.

## Scope

This is task #15 / P1 only. It does not add bs>1 scheduling, service-level KV ownership, prefix/paged KV, or HTTP serving benchmarks. Those remain task #16-#18.

## Validation

- Head: `e9e0f07`
- `cargo fmt --check`
- `git diff --check`
- `cargo check --release -p pegainfer-deepseek-v4 --features deepseek-v4`
- `cargo check --release -p pegainfer-server --features deepseek-v4 --bin pegainfer`
- 5090 exact E2E: `All 20 DeepSeek V4 exact cases passed`
- 5090 fixed direct bench: steady TPOT avg `29.260027ms`, hashes `6346f03343d75a65` for all 3 measured iterations
- `pre-commit run --files pegainfer-deepseek-v4/src/direct.rs pegainfer-deepseek-v4/src/direct/scheduler.rs pegainfer-deepseek-v4/src/lib.rs` is blocked by the repo's existing invalid `.pre-commit-config.yaml` (`repo='builtin'` missing `rev`); no hook was bypassed.
