### PR TITLE
feat(deepseek-v4): add direct kv ownership baseline

### DIFF
--- a/pegainfer-deepseek-v4/src/direct.rs
+++ b/pegainfer-deepseek-v4/src/direct.rs
@@ -4,5 +4,6 @@ mod worker;
 
 pub use scheduler::{
     DeepSeekV4DirectGenerator, DeepSeekV4RequestState, DirectDecodeStep, DirectGeneration,
-    start_engine,
+    DirectKvCacheActiveSnapshot, DirectKvCacheLease, DirectKvCacheReject,
+    DirectKvCacheRejectReason, DirectKvCacheSnapshot, start_engine,
 };

--- a/pegainfer-deepseek-v4/src/direct/scheduler.rs
+++ b/pegainfer-deepseek-v4/src/direct/scheduler.rs
@@ -349,11 +349,7 @@ impl DeepSeekV4DirectGenerator {
     }
 
     pub fn release_greedy_request(&mut self, state: &mut DeepSeekV4RequestState) -> Result<()> {
-        if let Some(kv_cache) = state.kv_cache.take() {
-            self.kv_cache.release(&kv_cache)?;
-        }
-        state.next_logits = None;
-        Ok(())
+        release_greedy_request_from(&mut self.kv_cache, state)
     }
 
     pub fn sample_greedy_step(&self, state: &DeepSeekV4RequestState) -> Result<DirectDecodeStep> {
@@ -402,40 +398,10 @@ impl DeepSeekV4DirectGenerator {
         state: &mut DeepSeekV4RequestState,
         step: &DirectDecodeStep,
     ) -> Result<()> {
-        ensure_step_matches_state(state, step)?;
-        if state.is_finished() {
-            return Ok(());
-        }
-
-        if let Some(finish_reason) = step.finish_reason()
-            && step.token().is_none()
-        {
-            state.next_logits = None;
-            state.finish_reason = Some(finish_reason);
-            self.release_greedy_request(state)?;
-            return Ok(());
-        }
-
-        let Some(token) = step.token() else {
-            bail!("DeepSeek V4 decode step without token or finish reason");
-        };
-        state
-            .next_logits
-            .take()
-            .ok_or_else(|| anyhow::anyhow!("DeepSeek V4 request state missing consumed logits"))?;
-        state.generated.push(token);
-        if let Some(finish_reason) = step.finish_reason() {
-            state.finish_reason = Some(finish_reason);
-            self.release_greedy_request(state)?;
-            return Ok(());
-        }
-        state.next_logits = Some(run_direct_decode_logits(
-            &mut self.runtime,
-            token,
-            step.start_pos(),
-        )?);
-
-        Ok(())
+        let runtime = &mut self.runtime;
+        advance_greedy_step_with_decode(&mut self.kv_cache, state, step, |token, start_pos| {
+            run_direct_decode_logits(runtime, token, start_pos)
+        })
     }
 
     pub fn decode_greedy_step(
@@ -663,6 +629,66 @@ impl DirectKvCacheManager {
             message: message.to_string(),
         }
         .into())
+    }
+}
+
+fn release_greedy_request_from(
+    kv_cache: &mut DirectKvCacheManager,
+    state: &mut DeepSeekV4RequestState,
+) -> Result<()> {
+    if let Some(lease) = state.kv_cache.take() {
+        kv_cache.release(&lease)?;
+    }
+    state.next_logits = None;
+    Ok(())
+}
+
+fn advance_greedy_step_with_decode<F>(
+    kv_cache: &mut DirectKvCacheManager,
+    state: &mut DeepSeekV4RequestState,
+    step: &DirectDecodeStep,
+    decode_next_logits: F,
+) -> Result<()>
+where
+    F: FnOnce(u32, usize) -> Result<Vec<f32>>,
+{
+    ensure_step_matches_state(state, step)?;
+    if state.is_finished() {
+        return Ok(());
+    }
+
+    if let Some(finish_reason) = step.finish_reason()
+        && step.token().is_none()
+    {
+        state.next_logits = None;
+        state.finish_reason = Some(finish_reason);
+        release_greedy_request_from(kv_cache, state)?;
+        return Ok(());
+    }
+
+    let Some(token) = step.token() else {
+        bail!("DeepSeek V4 decode step without token or finish reason");
+    };
+    state
+        .next_logits
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("DeepSeek V4 request state missing consumed logits"))?;
+    state.generated.push(token);
+    if let Some(finish_reason) = step.finish_reason() {
+        state.finish_reason = Some(finish_reason);
+        release_greedy_request_from(kv_cache, state)?;
+        return Ok(());
+    }
+
+    match decode_next_logits(token, step.start_pos()) {
+        Ok(next_logits) => {
+            state.next_logits = Some(next_logits);
+            Ok(())
+        }
+        Err(err) => {
+            release_greedy_request_from(kv_cache, state)?;
+            Err(err)
+        }
     }
 }
 
@@ -906,5 +932,47 @@ mod tests {
         assert_eq!(snapshot.total_allocations(), 1);
         assert_eq!(snapshot.total_resets(), 2);
         assert_eq!(snapshot.total_reuses(), 1);
+    }
+
+    #[test]
+    fn decode_runtime_error_releases_active_kv_lease() {
+        let mut manager = DirectKvCacheManager::new(16);
+        let lease = manager.reserve(1, 4, 4).unwrap();
+        manager.attach_prepared(&lease).unwrap();
+        let mut state = DeepSeekV4RequestState {
+            request_epoch: 1,
+            kv_cache: Some(lease),
+            prompt_len: 4,
+            max_new_tokens: 4,
+            ignore_eos: true,
+            generated: Vec::new(),
+            next_logits: Some(vec![0.0, 1.0]),
+            finish_reason: None,
+        };
+        let step = DirectDecodeStep {
+            request_epoch: 1,
+            generated_len_before: 0,
+            prompt_len: 4,
+            token: Some(1),
+            finish_reason: None,
+        };
+
+        let err = advance_greedy_step_with_decode(&mut manager, &mut state, &step, |_, _| {
+            Err(anyhow::anyhow!("synthetic decode failure"))
+        })
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("synthetic decode failure"));
+        assert!(state.kv_cache_lease().is_none());
+        assert!(state.next_logits.is_none());
+        assert_eq!(state.generated(), &[1]);
+        let snapshot = manager.snapshot();
+        assert!(snapshot.active().is_none());
+        assert_eq!(snapshot.total_releases(), 1);
+
+        let next = manager.reserve(2, 2, 2).unwrap();
+        manager.attach_prepared(&next).unwrap();
+        assert!(manager.snapshot().active().is_some());
     }
 }

--- a/pegainfer-deepseek-v4/src/direct/scheduler.rs
+++ b/pegainfer-deepseek-v4/src/direct/scheduler.rs
@@ -1,6 +1,6 @@
-use std::{path::Path, sync::mpsc as std_mpsc, thread};
+use std::{error::Error, fmt, path::Path, sync::mpsc as std_mpsc, thread};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, bail, ensure};
 use log::{info, warn};
 use pegainfer_core::engine::{
     EngineHandle, EngineLoadOptions, FinishReason, GenerateRequest, TokenEvent,
@@ -18,8 +18,163 @@ pub struct DirectGeneration {
     pub finish_reason: FinishReason,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DirectKvCacheRejectReason {
+    ActiveRequest,
+    CapacityExceeded,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DirectKvCacheReject {
+    reason: DirectKvCacheRejectReason,
+    requested_seq_len: usize,
+    capacity_seq_len: usize,
+}
+
+impl DirectKvCacheReject {
+    pub fn reason(&self) -> DirectKvCacheRejectReason {
+        self.reason
+    }
+
+    pub fn requested_seq_len(&self) -> usize {
+        self.requested_seq_len
+    }
+
+    pub fn capacity_seq_len(&self) -> usize {
+        self.capacity_seq_len
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DirectKvCacheActiveSnapshot {
+    request_epoch: u64,
+    prompt_len: usize,
+    max_new_tokens: usize,
+    reserved_seq_len: usize,
+    attached: bool,
+}
+
+impl DirectKvCacheActiveSnapshot {
+    pub fn request_epoch(&self) -> u64 {
+        self.request_epoch
+    }
+
+    pub fn prompt_len(&self) -> usize {
+        self.prompt_len
+    }
+
+    pub fn max_new_tokens(&self) -> usize {
+        self.max_new_tokens
+    }
+
+    pub fn reserved_seq_len(&self) -> usize {
+        self.reserved_seq_len
+    }
+
+    pub fn attached(&self) -> bool {
+        self.attached
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DirectKvCacheSnapshot {
+    capacity_seq_len: usize,
+    allocated_seq_len: usize,
+    active: Option<DirectKvCacheActiveSnapshot>,
+    total_reservations: u64,
+    total_releases: u64,
+    total_rejections: u64,
+    total_allocations: u64,
+    total_resets: u64,
+    total_reuses: u64,
+    last_reject: Option<DirectKvCacheReject>,
+}
+
+impl DirectKvCacheSnapshot {
+    pub fn capacity_seq_len(&self) -> usize {
+        self.capacity_seq_len
+    }
+
+    pub fn allocated_seq_len(&self) -> usize {
+        self.allocated_seq_len
+    }
+
+    pub fn active(&self) -> Option<&DirectKvCacheActiveSnapshot> {
+        self.active.as_ref()
+    }
+
+    pub fn total_reservations(&self) -> u64 {
+        self.total_reservations
+    }
+
+    pub fn total_releases(&self) -> u64 {
+        self.total_releases
+    }
+
+    pub fn total_rejections(&self) -> u64 {
+        self.total_rejections
+    }
+
+    pub fn total_allocations(&self) -> u64 {
+        self.total_allocations
+    }
+
+    pub fn total_resets(&self) -> u64 {
+        self.total_resets
+    }
+
+    pub fn total_reuses(&self) -> u64 {
+        self.total_reuses
+    }
+
+    pub fn last_reject(&self) -> Option<&DirectKvCacheReject> {
+        self.last_reject.as_ref()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DirectKvCacheLease {
+    request_epoch: u64,
+    prompt_len: usize,
+    max_new_tokens: usize,
+    reserved_seq_len: usize,
+}
+
+impl DirectKvCacheLease {
+    pub fn request_epoch(&self) -> u64 {
+        self.request_epoch
+    }
+
+    pub fn prompt_len(&self) -> usize {
+        self.prompt_len
+    }
+
+    pub fn max_new_tokens(&self) -> usize {
+        self.max_new_tokens
+    }
+
+    pub fn reserved_seq_len(&self) -> usize {
+        self.reserved_seq_len
+    }
+}
+
+#[derive(Debug)]
+struct DirectKvCacheReservationError {
+    reject: DirectKvCacheReject,
+    message: String,
+}
+
+impl fmt::Display for DirectKvCacheReservationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl Error for DirectKvCacheReservationError {}
+
 pub struct DeepSeekV4RequestState {
     request_epoch: u64,
+    kv_cache: Option<DirectKvCacheLease>,
     prompt_len: usize,
     max_new_tokens: usize,
     ignore_eos: bool,
@@ -68,6 +223,10 @@ impl DeepSeekV4RequestState {
         self.generated.len()
     }
 
+    pub fn kv_cache_lease(&self) -> Option<&DirectKvCacheLease> {
+        self.kv_cache.as_ref()
+    }
+
     pub fn finish_reason(&self) -> Option<FinishReason> {
         self.finish_reason
     }
@@ -81,6 +240,7 @@ pub struct DeepSeekV4DirectGenerator {
     config: &'static Config,
     runtime: FullDirectRuntime,
     next_request_epoch: u64,
+    kv_cache: DirectKvCacheManager,
 }
 
 impl DeepSeekV4DirectGenerator {
@@ -98,6 +258,7 @@ impl DeepSeekV4DirectGenerator {
             config,
             runtime,
             next_request_epoch: 0,
+            kv_cache: DirectKvCacheManager::new(config.max_position_embeddings),
         })
     }
 
@@ -123,6 +284,7 @@ impl DeepSeekV4DirectGenerator {
         if max_new_tokens == 0 {
             return Ok(DeepSeekV4RequestState {
                 request_epoch,
+                kv_cache: None,
                 prompt_len: prompt_tokens.len(),
                 max_new_tokens,
                 ignore_eos,
@@ -132,20 +294,47 @@ impl DeepSeekV4DirectGenerator {
             });
         }
 
-        ensure_direct_decode_caches(
-            &mut self.runtime,
-            self.config,
-            prompt_tokens.len() + max_new_tokens,
-        )?;
+        let kv_cache = self
+            .kv_cache
+            .reserve(request_epoch, prompt_tokens.len(), max_new_tokens)?;
+        if let Err(err) =
+            ensure_direct_decode_caches(&mut self.runtime, self.config, kv_cache.reserved_seq_len())
+        {
+            if let Err(release_err) = self.kv_cache.release(&kv_cache) {
+                warn!(
+                    "failed to release DeepSeek V4 KV cache after cache prepare error: {release_err:#}"
+                );
+            }
+            return Err(err);
+        }
+        if let Err(err) = self.kv_cache.attach_prepared(&kv_cache) {
+            if let Err(release_err) = self.kv_cache.release(&kv_cache) {
+                warn!(
+                    "failed to release DeepSeek V4 KV cache after cache attach error: {release_err:#}"
+                );
+            }
+            return Err(err);
+        }
 
-        let next_logits = run_prefill_logits_and_seed_decode_cache(
+        let next_logits = match run_prefill_logits_and_seed_decode_cache(
             &mut self.runtime,
             self.config,
             prompt_tokens,
-        )?;
+        ) {
+            Ok(next_logits) => next_logits,
+            Err(err) => {
+                if let Err(release_err) = self.kv_cache.release(&kv_cache) {
+                    warn!(
+                        "failed to release DeepSeek V4 KV cache after prefill error: {release_err:#}"
+                    );
+                }
+                return Err(err);
+            }
+        };
 
         Ok(DeepSeekV4RequestState {
             request_epoch,
+            kv_cache: Some(kv_cache),
             prompt_len: prompt_tokens.len(),
             max_new_tokens,
             ignore_eos,
@@ -153,6 +342,18 @@ impl DeepSeekV4DirectGenerator {
             next_logits: Some(next_logits),
             finish_reason: None,
         })
+    }
+
+    pub fn kv_cache_snapshot(&self) -> DirectKvCacheSnapshot {
+        self.kv_cache.snapshot()
+    }
+
+    pub fn release_greedy_request(&mut self, state: &mut DeepSeekV4RequestState) -> Result<()> {
+        if let Some(kv_cache) = state.kv_cache.take() {
+            self.kv_cache.release(&kv_cache)?;
+        }
+        state.next_logits = None;
+        Ok(())
     }
 
     pub fn sample_greedy_step(&self, state: &DeepSeekV4RequestState) -> Result<DirectDecodeStep> {
@@ -170,6 +371,10 @@ impl DeepSeekV4DirectGenerator {
             .next_logits
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("DeepSeek V4 request state missing next logits"))?;
+        ensure!(
+            state.kv_cache.is_some(),
+            "DeepSeek V4 active request state missing KV cache lease"
+        );
         let token = argmax_f32(&next_logits) as u32;
         if !state.ignore_eos && token as usize == self.config.eos_token_id {
             return Ok(DirectDecodeStep {
@@ -207,6 +412,7 @@ impl DeepSeekV4DirectGenerator {
         {
             state.next_logits = None;
             state.finish_reason = Some(finish_reason);
+            self.release_greedy_request(state)?;
             return Ok(());
         }
 
@@ -220,6 +426,7 @@ impl DeepSeekV4DirectGenerator {
         state.generated.push(token);
         if let Some(finish_reason) = step.finish_reason() {
             state.finish_reason = Some(finish_reason);
+            self.release_greedy_request(state)?;
             return Ok(());
         }
         state.next_logits = Some(run_direct_decode_logits(
@@ -254,9 +461,23 @@ impl DeepSeekV4DirectGenerator {
         while !state.is_finished() {
             let step = self.sample_greedy_step(&state)?;
             if let Some(token) = step.token() {
-                on_token(token)?;
+                if let Err(err) = on_token(token) {
+                    if let Err(release_err) = self.release_greedy_request(&mut state) {
+                        warn!(
+                            "failed to release DeepSeek V4 KV cache after token callback error: {release_err:#}"
+                        );
+                    }
+                    return Err(err);
+                }
             }
-            self.advance_greedy_step(&mut state, &step)?;
+            if let Err(err) = self.advance_greedy_step(&mut state, &step) {
+                if let Err(release_err) = self.release_greedy_request(&mut state) {
+                    warn!(
+                        "failed to release DeepSeek V4 KV cache after decode error: {release_err:#}"
+                    );
+                }
+                return Err(err);
+            }
         }
         Ok(DirectGeneration {
             generated: state.generated,
@@ -264,6 +485,184 @@ impl DeepSeekV4DirectGenerator {
                 .finish_reason
                 .expect("DeepSeek V4 request state must finish after greedy generation"),
         })
+    }
+}
+
+#[derive(Clone, Debug)]
+struct DirectKvCacheActive {
+    request_epoch: u64,
+    prompt_len: usize,
+    max_new_tokens: usize,
+    reserved_seq_len: usize,
+    attached: bool,
+    reused_capacity: bool,
+}
+
+struct DirectKvCacheManager {
+    capacity_seq_len: usize,
+    allocated_seq_len: usize,
+    active: Option<DirectKvCacheActive>,
+    total_reservations: u64,
+    total_releases: u64,
+    total_rejections: u64,
+    total_allocations: u64,
+    total_resets: u64,
+    total_reuses: u64,
+    last_reject: Option<DirectKvCacheReject>,
+}
+
+impl DirectKvCacheManager {
+    fn new(capacity_seq_len: usize) -> Self {
+        Self {
+            capacity_seq_len,
+            allocated_seq_len: 0,
+            active: None,
+            total_reservations: 0,
+            total_releases: 0,
+            total_rejections: 0,
+            total_allocations: 0,
+            total_resets: 0,
+            total_reuses: 0,
+            last_reject: None,
+        }
+    }
+
+    fn reserve(
+        &mut self,
+        request_epoch: u64,
+        prompt_len: usize,
+        max_new_tokens: usize,
+    ) -> Result<DirectKvCacheLease> {
+        let reserved_seq_len = prompt_len
+            .checked_add(max_new_tokens)
+            .ok_or_else(|| anyhow::anyhow!("DeepSeek V4 KV cache reservation length overflow"))?;
+        if self.active.is_some() {
+            return self.reject(
+                DirectKvCacheRejectReason::ActiveRequest,
+                reserved_seq_len,
+                "DeepSeek V4 KV cache already has an active request",
+            );
+        }
+        if reserved_seq_len > self.capacity_seq_len {
+            return self.reject(
+                DirectKvCacheRejectReason::CapacityExceeded,
+                reserved_seq_len,
+                &format!(
+                    "DeepSeek V4 KV cache reservation {reserved_seq_len} exceeds capacity {}",
+                    self.capacity_seq_len
+                ),
+            );
+        }
+
+        let lease = DirectKvCacheLease {
+            request_epoch,
+            prompt_len,
+            max_new_tokens,
+            reserved_seq_len,
+        };
+        self.active = Some(DirectKvCacheActive {
+            request_epoch,
+            prompt_len,
+            max_new_tokens,
+            reserved_seq_len,
+            attached: false,
+            reused_capacity: self.allocated_seq_len >= reserved_seq_len,
+        });
+        self.total_reservations += 1;
+        Ok(lease)
+    }
+
+    fn attach_prepared(&mut self, lease: &DirectKvCacheLease) -> Result<()> {
+        let active = self
+            .active
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("DeepSeek V4 KV cache attach without reservation"))?;
+        ensure!(
+            active.request_epoch == lease.request_epoch,
+            "DeepSeek V4 KV cache attach epoch mismatch: active={}, lease={}",
+            active.request_epoch,
+            lease.request_epoch
+        );
+        ensure!(
+            active.reserved_seq_len == lease.reserved_seq_len,
+            "DeepSeek V4 KV cache attach length mismatch: active={}, lease={}",
+            active.reserved_seq_len,
+            lease.reserved_seq_len
+        );
+        active.attached = true;
+        self.total_resets += 1;
+        if active.reused_capacity {
+            self.total_reuses += 1;
+        } else {
+            self.total_allocations += 1;
+            self.allocated_seq_len = self.allocated_seq_len.max(active.reserved_seq_len);
+        }
+        Ok(())
+    }
+
+    fn release(&mut self, lease: &DirectKvCacheLease) -> Result<()> {
+        let active = self
+            .active
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("DeepSeek V4 KV cache release without active lease"))?;
+        ensure!(
+            active.request_epoch == lease.request_epoch,
+            "DeepSeek V4 KV cache release epoch mismatch: active={}, lease={}",
+            active.request_epoch,
+            lease.request_epoch
+        );
+        ensure!(
+            active.reserved_seq_len == lease.reserved_seq_len,
+            "DeepSeek V4 KV cache release length mismatch: active={}, lease={}",
+            active.reserved_seq_len,
+            lease.reserved_seq_len
+        );
+        self.total_releases += 1;
+        Ok(())
+    }
+
+    fn snapshot(&self) -> DirectKvCacheSnapshot {
+        DirectKvCacheSnapshot {
+            capacity_seq_len: self.capacity_seq_len,
+            allocated_seq_len: self.allocated_seq_len,
+            active: self
+                .active
+                .as_ref()
+                .map(|active| DirectKvCacheActiveSnapshot {
+                    request_epoch: active.request_epoch,
+                    prompt_len: active.prompt_len,
+                    max_new_tokens: active.max_new_tokens,
+                    reserved_seq_len: active.reserved_seq_len,
+                    attached: active.attached,
+                }),
+            total_reservations: self.total_reservations,
+            total_releases: self.total_releases,
+            total_rejections: self.total_rejections,
+            total_allocations: self.total_allocations,
+            total_resets: self.total_resets,
+            total_reuses: self.total_reuses,
+            last_reject: self.last_reject.clone(),
+        }
+    }
+
+    fn reject<T>(
+        &mut self,
+        reason: DirectKvCacheRejectReason,
+        requested_seq_len: usize,
+        message: &str,
+    ) -> Result<T> {
+        self.total_rejections += 1;
+        let reject = DirectKvCacheReject {
+            reason,
+            requested_seq_len,
+            capacity_seq_len: self.capacity_seq_len,
+        };
+        self.last_reject = Some(reject.clone());
+        Err(DirectKvCacheReservationError {
+            reject,
+            message: message.to_string(),
+        }
+        .into())
     }
 }
 
@@ -358,6 +757,18 @@ fn handle_request(generator: &mut DeepSeekV4DirectGenerator, req: GenerateReques
             });
         }
         Err(err) => {
+            if let Some(kv_err) = err.downcast_ref::<DirectKvCacheReservationError>() {
+                reject_request(
+                    &req,
+                    prompt_len,
+                    format!(
+                        "DeepSeek V4 direct request rejected by KV cache ownership gate ({:?}): {}",
+                        kv_err.reject.reason(),
+                        kv_err
+                    ),
+                );
+                return;
+            }
             let message = format!("DeepSeek V4 direct request failed: {err:#}");
             warn!("{message}");
             let _ = req.token_tx.send(TokenEvent::Error {
@@ -373,6 +784,23 @@ fn ensure_step_matches_state(
     state: &DeepSeekV4RequestState,
     step: &DirectDecodeStep,
 ) -> Result<()> {
+    if !state.is_finished() {
+        let lease = state.kv_cache.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("DeepSeek V4 active request state missing KV cache lease")
+        })?;
+        ensure!(
+            lease.request_epoch == state.request_epoch,
+            "DeepSeek V4 KV cache lease epoch mismatch: lease={}, state={}",
+            lease.request_epoch,
+            state.request_epoch
+        );
+        ensure!(
+            lease.prompt_len == state.prompt_len,
+            "DeepSeek V4 KV cache lease prompt length mismatch: lease={}, state={}",
+            lease.prompt_len,
+            state.prompt_len
+        );
+    }
     if step.request_epoch != state.request_epoch {
         bail!(
             "DeepSeek V4 decode step request epoch mismatch: step={}, state={}",
@@ -416,4 +844,67 @@ fn argmax_f32(values: &[f32]) -> usize {
         }
     }
     best_idx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kv_cache_manager_rejects_active_request_until_release() {
+        let mut manager = DirectKvCacheManager::new(16);
+        let lease = manager.reserve(1, 4, 4).unwrap();
+        manager.attach_prepared(&lease).unwrap();
+
+        let err = manager.reserve(2, 4, 4).unwrap_err().to_string();
+        assert!(err.contains("active request"));
+        let snapshot = manager.snapshot();
+        assert_eq!(snapshot.total_reservations(), 1);
+        assert_eq!(snapshot.total_rejections(), 1);
+        assert_eq!(
+            snapshot.last_reject().unwrap().reason(),
+            DirectKvCacheRejectReason::ActiveRequest
+        );
+
+        manager.release(&lease).unwrap();
+        let snapshot = manager.snapshot();
+        assert!(snapshot.active().is_none());
+        assert_eq!(snapshot.total_releases(), 1);
+    }
+
+    #[test]
+    fn kv_cache_manager_rejects_over_capacity_request() {
+        let mut manager = DirectKvCacheManager::new(8);
+        let err = manager.reserve(1, 6, 3).unwrap_err().to_string();
+        assert!(err.contains("exceeds capacity"));
+
+        let snapshot = manager.snapshot();
+        assert_eq!(snapshot.total_reservations(), 0);
+        assert_eq!(snapshot.total_rejections(), 1);
+        assert_eq!(
+            snapshot.last_reject().unwrap().reason(),
+            DirectKvCacheRejectReason::CapacityExceeded
+        );
+        assert_eq!(snapshot.last_reject().unwrap().requested_seq_len(), 9);
+    }
+
+    #[test]
+    fn kv_cache_manager_tracks_allocate_reset_and_reuse() {
+        let mut manager = DirectKvCacheManager::new(16);
+        let first = manager.reserve(1, 4, 4).unwrap();
+        manager.attach_prepared(&first).unwrap();
+        manager.release(&first).unwrap();
+
+        let second = manager.reserve(2, 2, 2).unwrap();
+        manager.attach_prepared(&second).unwrap();
+        manager.release(&second).unwrap();
+
+        let snapshot = manager.snapshot();
+        assert_eq!(snapshot.allocated_seq_len(), 8);
+        assert_eq!(snapshot.total_reservations(), 2);
+        assert_eq!(snapshot.total_releases(), 2);
+        assert_eq!(snapshot.total_allocations(), 1);
+        assert_eq!(snapshot.total_resets(), 2);
+        assert_eq!(snapshot.total_reuses(), 1);
+    }
 }

--- a/pegainfer-deepseek-v4/src/lib.rs
+++ b/pegainfer-deepseek-v4/src/lib.rs
@@ -8,7 +8,8 @@ mod weights;
 pub use config::{Config, RopeScaling, TensorParallelConfig};
 pub use direct::{
     DeepSeekV4DirectGenerator, DeepSeekV4RequestState, DirectDecodeStep, DirectGeneration,
-    start_engine,
+    DirectKvCacheActiveSnapshot, DirectKvCacheLease, DirectKvCacheReject,
+    DirectKvCacheRejectReason, DirectKvCacheSnapshot, start_engine,
 };
 pub use model::{
     AttentionWeightNames, AttentionWeights, BlockWeightNames, BlockWeights, CompressorWeightNames,


### PR DESCRIPTION
## Summary

- Add a direct DeepSeek V4 KV cache ownership baseline around the single-request direct generator.
- Introduce explicit KV cache lease, reject reason, and snapshot types so callers can inspect capacity, active reservation, release/reuse/reset counters, and the last reject reason.
- Route request start through reserve → prepare/reset → attach → prefill, and release the lease on finish or error, including decode-step runtime errors after a token has been consumed.
- Keep the existing single-request greedy path and request-state step API unchanged from the caller perspective.

## Scope

This is task #16 / P2 only. It does not add prefix cache, paged KV, cross-request KV reuse, P/D KV handles, bs>1 scheduling, or HTTP serving benchmarks.

## Validation

- Head: `f0ca636`
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p pegainfer-deepseek-v4 --features deepseek-v4 direct::scheduler::tests -- --nocapture` (4 tests; includes decode runtime error releasing the active KV lease)
- `cargo check --release -p pegainfer-deepseek-v4 --features deepseek-v4`
- `cargo check --release -p pegainfer-server --features deepseek-v4 --bin pegainfer`
- 5090 exact E2E: `All 20 DeepSeek V4 exact cases passed`
- 5090 fixed direct bench: steady TPOT avg `28.5047ms`, hashes `6346f03343d75a65` for all 3 measured iterations
- `pre-commit run --files pegainfer-deepseek-v4/src/direct/scheduler.rs` is blocked by the repo's existing invalid `.pre-commit-config.yaml` (`repo='builtin'` missing `rev`); no hook was bypassed.