### PR TITLE
feat(dsv4): add runtime bs2 decode batch path

### DIFF
--- a/pegainfer-deepseek-v4/src/direct/scheduler.rs
+++ b/pegainfer-deepseek-v4/src/direct/scheduler.rs
@@ -8,8 +8,14 @@ use pegainfer_core::engine::{
 use tokio::sync::mpsc;
 
 use super::worker::{
-    FullDirectRuntime, ensure_direct_decode_caches, load_full_direct_runtime,
-    run_direct_decode_logits, run_prefill_logits_and_seed_decode_cache,
+    DirectBatchDecodeEntry, FullDirectRuntime, ensure_direct_decode_caches,
+    load_full_direct_runtime, run_direct_decode_batch_logits, run_direct_decode_logits,
+    run_prefill_logits_and_seed_decode_cache,
+};
+#[cfg(test)]
+use super::worker::{
+    clone_direct_decode_cache_slot_for_test, ensure_direct_decode_batch_caches_for_test,
+    reset_direct_decode_cache_slot_for_test,
 };
 use crate::Config;
 
@@ -411,6 +417,45 @@ impl DeepSeekV4DirectGenerator {
         let step = self.sample_greedy_step(state)?;
         self.advance_greedy_step(state, &step)?;
         Ok(step)
+    }
+
+    #[allow(dead_code)] // PR A lands the runtime batch path before scheduler wiring.
+    pub(crate) fn decode_batch_logits_for_test(
+        &mut self,
+        entries: &[(u32, usize, usize)],
+    ) -> Result<Vec<Vec<f32>>> {
+        let entries = entries
+            .iter()
+            .map(|(token_id, start_pos, slot_id)| DirectBatchDecodeEntry {
+                token_id: *token_id,
+                start_pos: *start_pos,
+                slot_id: *slot_id,
+            })
+            .collect::<Vec<_>>();
+        run_direct_decode_batch_logits(&mut self.runtime, &entries)
+    }
+
+    #[cfg(test)]
+    fn prepare_batch_decode_slots_for_test(&mut self, max_seq_len: usize) -> Result<()> {
+        ensure_direct_decode_batch_caches_for_test(&mut self.runtime, self.config, max_seq_len)
+    }
+
+    #[cfg(test)]
+    fn seed_decode_slot_for_test(
+        &mut self,
+        prompt_tokens: &[u32],
+        slot_id: usize,
+    ) -> Result<Vec<f32>> {
+        reset_direct_decode_cache_slot_for_test(&mut self.runtime, 0)?;
+        let logits = run_prefill_logits_and_seed_decode_cache(
+            &mut self.runtime,
+            self.config,
+            prompt_tokens,
+        )?;
+        if slot_id != 0 {
+            clone_direct_decode_cache_slot_for_test(&mut self.runtime, 0, slot_id)?;
+        }
+        Ok(logits)
     }
 
     pub fn generate_greedy<F>(
@@ -875,6 +920,7 @@ fn argmax_f32(values: &[f32]) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::{env, path::PathBuf};
 
     #[test]
     fn kv_cache_manager_rejects_active_request_until_release() {
@@ -974,5 +1020,76 @@ mod tests {
         let next = manager.reserve(2, 2, 2).unwrap();
         manager.attach_prepared(&next).unwrap();
         assert!(manager.snapshot().active().is_some());
+    }
+
+    #[test]
+    #[ignore = "requires 8 GPUs and DeepSeek-V4-Flash weights"]
+    fn batch_decode_logits_match_two_single_decode_rows() -> Result<()> {
+        let model_path = env::var_os("PEGAINFER_TEST_MODEL_PATH")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("models/DeepSeek-V4-Flash"));
+        let mut generator = DeepSeekV4DirectGenerator::from_model_dir(&model_path)?;
+        let prompt_a = (1000..1128).collect::<Vec<u32>>();
+        let prompt_b = (2000..2128).collect::<Vec<u32>>();
+
+        generator.prepare_batch_decode_slots_for_test(prompt_a.len() + 2)?;
+        let prefill_a = generator.seed_decode_slot_for_test(&prompt_a, 1)?;
+        let prefill_b = generator.seed_decode_slot_for_test(&prompt_b, 0)?;
+        let token_a = argmax_f32(&prefill_a) as u32;
+        let token_b = argmax_f32(&prefill_b) as u32;
+
+        let batch = generator.decode_batch_logits_for_test(&[
+            (token_a, prompt_a.len(), 1),
+            (token_b, prompt_b.len(), 0),
+        ])?;
+        assert_eq!(batch.len(), 2);
+
+        let single_a = decode_logits_for_token(&mut generator, &prompt_a, token_a)?;
+        let single_b = decode_logits_for_token(&mut generator, &prompt_b, token_b)?;
+        assert_logits_close("row0 prompt A", &single_a, &batch[0]);
+        assert_logits_close("row1 prompt B", &single_b, &batch[1]);
+        Ok(())
+    }
+
+    fn decode_logits_for_token(
+        generator: &mut DeepSeekV4DirectGenerator,
+        prompt_tokens: &[u32],
+        token: u32,
+    ) -> Result<Vec<f32>> {
+        let mut state = generator.start_greedy_request(prompt_tokens, 2, true)?;
+        let step = generator.sample_greedy_step(&state)?;
+        assert_eq!(step.start_pos(), prompt_tokens.len());
+        let logits = run_direct_decode_logits(&mut generator.runtime, token, prompt_tokens.len())?;
+        generator.release_greedy_request(&mut state)?;
+        Ok(logits)
+    }
+
+    fn assert_logits_close(label: &str, expected: &[f32], actual: &[f32]) {
+        assert_eq!(
+            expected.len(),
+            actual.len(),
+            "{label} vocab length mismatch"
+        );
+        assert_eq!(
+            argmax_f32(expected),
+            argmax_f32(actual),
+            "{label} top token mismatch"
+        );
+        let max_abs = expected
+            .iter()
+            .zip(actual)
+            .map(|(lhs, rhs)| (lhs - rhs).abs())
+            .fold(0.0f32, f32::max);
+        let mean_abs = expected
+            .iter()
+            .zip(actual)
+            .map(|(lhs, rhs)| (lhs - rhs).abs())
+            .sum::<f32>()
+            / expected.len() as f32;
+        assert!(max_abs <= 1.5, "{label} max_abs diff too large: {max_abs}");
+        assert!(
+            mean_abs <= 0.2,
+            "{label} mean_abs diff too large: {mean_abs}"
+        );
     }
 }

--- a/pegainfer-deepseek-v4/src/direct/worker.rs
+++ b/pegainfer-deepseek-v4/src/direct/worker.rs
@@ -2,6 +2,8 @@ use std::{path::Path, thread};
 
 use anyhow::{Context, Result, ensure};
 use crossbeam_channel as channel;
+#[cfg(test)]
+use cudarc::driver::DeviceRepr;
 use cudarc::driver::{CudaSlice, DevicePtrMut, result as cuda_result};
 
 use crate::{
@@ -11,15 +13,27 @@ use crate::{
     load_rank_to_gpu, precompute_rope_cache,
     runtime::{
         AttentionAuxScratch, AttentionIndexScratch, AttentionOutputScratch,
-        AttentionProjectionScratch, DecodeEntryScratch, FinalLogitsScratch, HcPostScratch,
-        HcPreNormScratch, MoeAgRsScratch, SharedExpertScratch, all_gather_logits,
-        all_gather_logits_into, block_decode_rank_lane_bf16_hidden_with_scratch,
+        AttentionProjectionScratch, DecodeBatchMeta, DecodeEntryScratch, F32BatchLogits,
+        FinalLogitsScratch, HcPostScratch, HcPreNormScratch, MoeAgRsScratch, SharedExpertScratch,
+        all_gather_logits, all_gather_logits_into,
+        block_decode_rank_lane_bf16_hidden_batch_with_scratch,
+        block_decode_rank_lane_bf16_hidden_with_scratch,
         block_prefill_rank_lane_bf16_hidden_with_decode_cache, embedding_rank_local_into,
-        final_logits_rank_local_bf16_hidden_into, hc_expand_bf16_hidden_into,
+        final_logits_rank_local_bf16_hidden_into, hc_expand_bf16_hidden_into, hc_head_bf16_hidden,
+        rank_local_logits_from_hidden_all, rms_norm_bf16_hidden,
     },
 };
 
 type RankResult = (usize, Option<Vec<f32>>);
+type RankBatchResult = (usize, Option<Vec<Vec<f32>>>);
+const DIRECT_BATCH_DECODE_CAPACITY: usize = 2;
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct DirectBatchDecodeEntry {
+    pub(super) token_id: u32,
+    pub(super) start_pos: usize,
+    pub(super) slot_id: usize,
+}
 
 pub(super) struct FullDirectRuntime {
     workers: Vec<RankWorker>,
@@ -31,6 +45,7 @@ enum RankCommand {
     // a temporary bridge while DeepSeek V4 still uses its direct generator.
     EnsureCaches {
         max_seq_len: usize,
+        request_slots: usize,
         resp: channel::Sender<Result<()>>,
     },
     ResetCaches {
@@ -44,6 +59,22 @@ enum RankCommand {
         token_id: u32,
         start_pos: usize,
         resp: channel::Sender<Result<RankResult>>,
+    },
+    #[allow(dead_code)] // PR A lands the runtime batch path before scheduler wiring.
+    DecodeBatch {
+        entries: Vec<DirectBatchDecodeEntry>,
+        resp: channel::Sender<Result<RankBatchResult>>,
+    },
+    #[cfg(test)]
+    CloneCacheSlot {
+        src_slot: usize,
+        dst_slot: usize,
+        resp: channel::Sender<Result<()>>,
+    },
+    #[cfg(test)]
+    ResetCacheSlot {
+        slot_id: usize,
+        resp: channel::Sender<Result<()>>,
     },
     Shutdown,
 }
@@ -67,6 +98,15 @@ impl OwnedRankComm {
 
 struct RankDecodeScratch {
     token_ids: CudaSlice<u32>,
+    batch_token_ids: CudaSlice<u32>,
+    start_pos: CudaSlice<i32>,
+    src_rows: CudaSlice<i32>,
+    window_dst_rows: CudaSlice<i32>,
+    window_base: CudaSlice<i32>,
+    compressed_base: CudaSlice<i32>,
+    compressed_len: CudaSlice<i32>,
+    start_pos_host: Vec<usize>,
+    slot_ids_host: Vec<usize>,
     entry: DecodeEntryScratch,
     hc_post: HcPostScratch,
     final_logits: FinalLogitsScratch,
@@ -82,19 +122,37 @@ struct RankDecodeScratch {
 impl RankDecodeScratch {
     fn new(ctx: &RankGpuContext, config: &Config, world_size: usize) -> Result<Self> {
         ctx.set_current()?;
+        let seq_capacity = DIRECT_BATCH_DECODE_CAPACITY;
         let token_ids = unsafe { ctx.stream.alloc(1)? };
-        let entry = DecodeEntryScratch::new(ctx, config, 1)?;
-        let hc_post = HcPostScratch::new(ctx, config, 1)?;
-        let final_logits = FinalLogitsScratch::new(ctx, config, world_size, 1)?;
-        let hc_pre_norm = HcPreNormScratch::new(ctx, config, 1)?;
-        let shared_expert = SharedExpertScratch::new(ctx, config, 1)?;
-        let moe_ag_rs = MoeAgRsScratch::new(ctx, config, world_size, 1)?;
-        let attention_projection = AttentionProjectionScratch::new(ctx, config, world_size, 1)?;
-        let attention_output = AttentionOutputScratch::new(ctx, config, world_size, 1)?;
-        let attention_index = AttentionIndexScratch::new(ctx, config)?;
-        let attention_aux = AttentionAuxScratch::new(ctx, config, world_size)?;
+        let batch_token_ids = unsafe { ctx.stream.alloc(seq_capacity)? };
+        let start_pos = unsafe { ctx.stream.alloc(seq_capacity)? };
+        let src_rows = unsafe { ctx.stream.alloc(seq_capacity)? };
+        let window_dst_rows = unsafe { ctx.stream.alloc(seq_capacity)? };
+        let window_base = unsafe { ctx.stream.alloc(seq_capacity)? };
+        let compressed_base = unsafe { ctx.stream.alloc(seq_capacity)? };
+        let compressed_len = unsafe { ctx.stream.alloc(seq_capacity)? };
+        let entry = DecodeEntryScratch::new(ctx, config, seq_capacity)?;
+        let hc_post = HcPostScratch::new(ctx, config, seq_capacity)?;
+        let final_logits = FinalLogitsScratch::new(ctx, config, world_size, seq_capacity)?;
+        let hc_pre_norm = HcPreNormScratch::new(ctx, config, seq_capacity)?;
+        let shared_expert = SharedExpertScratch::new(ctx, config, seq_capacity)?;
+        let moe_ag_rs = MoeAgRsScratch::new(ctx, config, world_size, seq_capacity)?;
+        let attention_projection =
+            AttentionProjectionScratch::new(ctx, config, world_size, seq_capacity)?;
+        let attention_output = AttentionOutputScratch::new(ctx, config, world_size, seq_capacity)?;
+        let attention_index = AttentionIndexScratch::new(ctx, config, seq_capacity)?;
+        let attention_aux = AttentionAuxScratch::new(ctx, config, world_size, seq_capacity)?;
         Ok(Self {
             token_ids,
+            batch_token_ids,
+            start_pos,
+            src_rows,
+            window_dst_rows,
+            window_base,
+            compressed_base,
+            compressed_len,
+            start_pos_host: Vec::with_capacity(seq_capacity),
+            slot_ids_host: Vec::with_capacity(seq_capacity),
             entry,
             hc_post,
             final_logits,
@@ -113,6 +171,112 @@ impl RankDecodeScratch {
         ctx.stream.memcpy_htod(&[token_id], &mut self.token_ids)?;
         Ok(&self.token_ids)
     }
+}
+
+fn fill_decode_batch_metadata(
+    ctx: &RankGpuContext,
+    config: &Config,
+    layer: usize,
+    slot_stride: usize,
+    compressed_slots: usize,
+    entries: &[DirectBatchDecodeEntry],
+    token_ids: &mut CudaSlice<u32>,
+    start_pos_slice: &mut CudaSlice<i32>,
+    src_rows_slice: &mut CudaSlice<i32>,
+    window_dst_rows_slice: &mut CudaSlice<i32>,
+    window_base_slice: &mut CudaSlice<i32>,
+    compressed_base_slice: &mut CudaSlice<i32>,
+    compressed_len_slice: &mut CudaSlice<i32>,
+    start_pos_host: &mut Vec<usize>,
+    slot_ids_host: &mut Vec<usize>,
+) -> Result<()> {
+    ctx.set_current()?;
+    ensure!(
+        !entries.is_empty(),
+        "direct batch decode entries must not be empty"
+    );
+    ensure!(
+        entries.len() <= DIRECT_BATCH_DECODE_CAPACITY,
+        "direct batch decode capacity exceeded: entries={}, capacity={DIRECT_BATCH_DECODE_CAPACITY}",
+        entries.len()
+    );
+    ensure!(
+        layer < config.compress_ratios.len(),
+        "batch meta layer {layer} out of range"
+    );
+    let ratio = config.compress_ratios[layer];
+    ensure!(
+        slot_stride >= config.sliding_window,
+        "batch decode slot stride {} smaller than sliding window {}",
+        slot_stride,
+        config.sliding_window
+    );
+    ensure!(
+        ratio == 0 || compressed_slots > 0,
+        "batch decode compressed layer {layer} has no compressed cache slots"
+    );
+    ensure!(
+        ratio > 0 || compressed_slots == 0,
+        "batch decode non-compressed layer {layer} unexpectedly has {compressed_slots} compressed slots"
+    );
+    ensure!(
+        slot_stride == config.sliding_window + compressed_slots,
+        "batch decode slot stride mismatch: stride={}, window={}, compressed={}",
+        slot_stride,
+        config.sliding_window,
+        compressed_slots
+    );
+    let mut token_ids_host = Vec::with_capacity(entries.len());
+    let mut start_pos = Vec::with_capacity(entries.len());
+    let mut src_rows = Vec::with_capacity(entries.len());
+    let mut window_dst_rows = Vec::with_capacity(entries.len());
+    let mut window_base = Vec::with_capacity(entries.len());
+    let mut compressed_base = Vec::with_capacity(entries.len());
+    let mut compressed_len = Vec::with_capacity(entries.len());
+    start_pos_host.clear();
+    slot_ids_host.clear();
+    for (row, entry) in entries.iter().enumerate() {
+        ensure!(
+            entry.slot_id < DIRECT_BATCH_DECODE_CAPACITY,
+            "batch decode slot {} exceeds capacity {DIRECT_BATCH_DECODE_CAPACITY}",
+            entry.slot_id
+        );
+        token_ids_host.push(entry.token_id);
+        start_pos.push(entry.start_pos as i32);
+        src_rows.push(row as i32);
+        let base = entry.slot_id * slot_stride;
+        window_base.push(base as i32);
+        window_dst_rows.push((base + entry.start_pos % config.sliding_window) as i32);
+        let c_base = base + config.sliding_window;
+        compressed_base.push(c_base as i32);
+        if ratio > 0 {
+            ensure!(
+                entry.start_pos / ratio < compressed_slots,
+                "batch decode compressed dst out of range: start_pos={}, ratio={}, compressed_slots={}",
+                entry.start_pos,
+                ratio,
+                compressed_slots
+            );
+        }
+        compressed_len.push(if ratio > 0 {
+            ((entry.start_pos + 1) / ratio) as i32
+        } else {
+            0
+        });
+        start_pos_host.push(entry.start_pos);
+        slot_ids_host.push(entry.slot_id);
+    }
+    ctx.stream.memcpy_htod(&token_ids_host, token_ids)?;
+    ctx.stream.memcpy_htod(&start_pos, start_pos_slice)?;
+    ctx.stream.memcpy_htod(&src_rows, src_rows_slice)?;
+    ctx.stream
+        .memcpy_htod(&window_dst_rows, window_dst_rows_slice)?;
+    ctx.stream.memcpy_htod(&window_base, window_base_slice)?;
+    ctx.stream
+        .memcpy_htod(&compressed_base, compressed_base_slice)?;
+    ctx.stream
+        .memcpy_htod(&compressed_len, compressed_len_slice)?;
+    Ok(())
 }
 
 impl RankWorker {
@@ -135,6 +299,7 @@ impl RankWorker {
                 let mut ropes = Vec::new();
                 let mut caches = Vec::new();
                 let mut max_cache_seq_len = 0usize;
+                let mut cache_request_slots = 0usize;
                 let startup = bind_rank_thread(&ctx).and_then(|()| {
                     let ptr_cache = build_moe_expert_ptr_cache(&ctx, config, &weights)?;
                     let decode_scratch =
@@ -146,14 +311,20 @@ impl RankWorker {
                         let _ = startup_tx.send(Ok(()));
                         while let Ok(cmd) = rx.recv() {
                             match cmd {
-                                RankCommand::EnsureCaches { max_seq_len, resp } => {
+                                RankCommand::EnsureCaches {
+                                    max_seq_len,
+                                    request_slots,
+                                    resp,
+                                } => {
                                     let result = ensure_rank_worker_caches(
                                         &ctx,
                                         config,
                                         max_seq_len,
+                                        request_slots,
                                         &mut caches,
                                         &mut ropes,
                                         &mut max_cache_seq_len,
+                                        &mut cache_request_slots,
                                     );
                                     let _ = resp.send(result);
                                 }
@@ -201,6 +372,47 @@ impl RankWorker {
                                     .map(|logits| (rank, logits));
                                     let _ = resp.send(result);
                                 }
+                                RankCommand::DecodeBatch { entries, resp } => {
+                                    let result = run_decode_batch_on_rank_lane(
+                                        rank,
+                                        &ctx,
+                                        &weights,
+                                        &ptr_cache,
+                                        comm.get(),
+                                        moe_comm.get(),
+                                        &ropes,
+                                        config,
+                                        &entries,
+                                        &mut caches,
+                                        &mut decode_scratch,
+                                    )
+                                    .map(|logits| (rank, logits));
+                                    let _ = resp.send(result);
+                                }
+                                #[cfg(test)]
+                                RankCommand::CloneCacheSlot {
+                                    src_slot,
+                                    dst_slot,
+                                    resp,
+                                } => {
+                                    let result = clone_rank_decode_cache_slot_for_test(
+                                        &ctx,
+                                        config,
+                                        &mut caches,
+                                        src_slot,
+                                        dst_slot,
+                                    );
+                                    let _ = resp.send(result);
+                                }
+                                #[cfg(test)]
+                                RankCommand::ResetCacheSlot { slot_id, resp } => {
+                                    let result = reset_rank_decode_cache_slot_for_test(
+                                        &ctx,
+                                        &mut caches,
+                                        slot_id,
+                                    );
+                                    let _ = resp.send(result);
+                                }
                                 RankCommand::Shutdown => break,
                             }
                         }
@@ -236,11 +448,27 @@ impl RankWorker {
         Ok(resp_rx)
     }
 
-    fn ensure_caches(&self, max_seq_len: usize) -> Result<()> {
+    #[allow(dead_code)] // PR A lands the runtime batch path before scheduler wiring.
+    fn decode_batch(
+        &self,
+        entries: Vec<DirectBatchDecodeEntry>,
+    ) -> Result<channel::Receiver<Result<RankBatchResult>>> {
+        let (resp_tx, resp_rx) = channel::bounded(1);
+        self.tx
+            .send(RankCommand::DecodeBatch {
+                entries,
+                resp: resp_tx,
+            })
+            .map_err(|_| anyhow::anyhow!("DeepSeek rank worker channel closed"))?;
+        Ok(resp_rx)
+    }
+
+    fn ensure_caches(&self, max_seq_len: usize, request_slots: usize) -> Result<()> {
         let (resp_tx, resp_rx) = channel::bounded(1);
         self.tx
             .send(RankCommand::EnsureCaches {
                 max_seq_len,
+                request_slots,
                 resp: resp_tx,
             })
             .map_err(|_| anyhow::anyhow!("DeepSeek rank worker channel closed on EnsureCaches"))?;
@@ -257,6 +485,39 @@ impl RankWorker {
         resp_rx
             .recv()
             .map_err(|_| anyhow::anyhow!("DeepSeek rank worker dropped ResetCaches response"))?
+    }
+
+    #[cfg(test)]
+    fn clone_cache_slot_for_test(&self, src_slot: usize, dst_slot: usize) -> Result<()> {
+        let (resp_tx, resp_rx) = channel::bounded(1);
+        self.tx
+            .send(RankCommand::CloneCacheSlot {
+                src_slot,
+                dst_slot,
+                resp: resp_tx,
+            })
+            .map_err(|_| {
+                anyhow::anyhow!("DeepSeek rank worker channel closed on CloneCacheSlot")
+            })?;
+        resp_rx
+            .recv()
+            .map_err(|_| anyhow::anyhow!("DeepSeek rank worker dropped CloneCacheSlot response"))?
+    }
+
+    #[cfg(test)]
+    fn reset_cache_slot_for_test(&self, slot_id: usize) -> Result<()> {
+        let (resp_tx, resp_rx) = channel::bounded(1);
+        self.tx
+            .send(RankCommand::ResetCacheSlot {
+                slot_id,
+                resp: resp_tx,
+            })
+            .map_err(|_| {
+                anyhow::anyhow!("DeepSeek rank worker channel closed on ResetCacheSlot")
+            })?;
+        resp_rx
+            .recv()
+            .map_err(|_| anyhow::anyhow!("DeepSeek rank worker dropped ResetCacheSlot response"))?
     }
 
     fn prefill(&self, prompt_tokens: Vec<u32>) -> Result<channel::Receiver<Result<RankResult>>> {
@@ -348,14 +609,16 @@ fn allocate_rank_decode_caches(
     ctx: &RankGpuContext,
     config: &Config,
     max_seq_len: usize,
+    request_slots: usize,
 ) -> Result<Vec<LayerDecodeCache>> {
     let mut caches = Vec::with_capacity(config.n_layers);
     for layer in 0..config.n_layers {
-        caches.push(LayerDecodeCache::zeros_with_max_seq(
+        caches.push(LayerDecodeCache::zeros_with_max_seq_and_slots(
             ctx,
             config,
             layer,
             max_seq_len,
+            request_slots,
         )?);
     }
     Ok(caches)
@@ -378,13 +641,40 @@ pub(super) fn ensure_direct_decode_caches(
     config: &Config,
     max_seq_len: usize,
 ) -> Result<()> {
+    ensure_direct_decode_caches_with_slots(runtime, config, max_seq_len, 1)
+}
+
+#[cfg(test)]
+pub(super) fn ensure_direct_decode_batch_caches_for_test(
+    runtime: &mut FullDirectRuntime,
+    config: &Config,
+    max_seq_len: usize,
+) -> Result<()> {
+    ensure_direct_decode_caches_with_slots(
+        runtime,
+        config,
+        max_seq_len,
+        DIRECT_BATCH_DECODE_CAPACITY,
+    )
+}
+
+fn ensure_direct_decode_caches_with_slots(
+    runtime: &mut FullDirectRuntime,
+    config: &Config,
+    max_seq_len: usize,
+    request_slots: usize,
+) -> Result<()> {
     ensure!(
         runtime.workers.len() == 8,
         "DeepSeek V4 direct runtime expects 8 rank workers"
     );
+    ensure!(
+        request_slots > 0,
+        "DeepSeek V4 direct runtime cache request slots must be positive"
+    );
     for (rank, worker) in runtime.workers.iter().enumerate() {
         worker
-            .ensure_caches(max_seq_len)
+            .ensure_caches(max_seq_len, request_slots)
             .with_context(|| format!("ensure rank worker caches rank {rank}"))?;
         worker
             .reset_caches()
@@ -398,14 +688,20 @@ fn ensure_rank_worker_caches(
     ctx: &RankGpuContext,
     config: &Config,
     max_seq_len: usize,
+    request_slots: usize,
     caches: &mut Vec<LayerDecodeCache>,
     ropes: &mut Vec<DeepSeekRopeCache>,
     max_cache_seq_len: &mut usize,
+    cache_request_slots: &mut usize,
 ) -> Result<()> {
-    if caches.len() != config.n_layers || *max_cache_seq_len < max_seq_len {
-        *caches = allocate_rank_decode_caches(ctx, config, max_seq_len)?;
+    if caches.len() != config.n_layers
+        || *max_cache_seq_len < max_seq_len
+        || *cache_request_slots != request_slots
+    {
+        *caches = allocate_rank_decode_caches(ctx, config, max_seq_len, request_slots)?;
         *ropes = allocate_rank_rope_caches(ctx, config, max_seq_len)?;
         *max_cache_seq_len = max_seq_len;
+        *cache_request_slots = request_slots;
     }
     Ok(())
 }
@@ -425,6 +721,239 @@ fn reset_rank_decode_caches(ctx: &RankGpuContext, caches: &mut [LayerDecodeCache
             fill_f32_cuda_slice(ctx, &mut indexer_compressor.score, f32::NEG_INFINITY)?;
         }
     }
+    Ok(())
+}
+
+#[cfg(test)]
+fn reset_rank_decode_cache_slot_for_test(
+    ctx: &RankGpuContext,
+    caches: &mut [LayerDecodeCache],
+    slot_id: usize,
+) -> Result<()> {
+    ensure!(
+        slot_id < DIRECT_BATCH_DECODE_CAPACITY,
+        "reset cache slot out of range: slot={slot_id}, capacity={DIRECT_BATCH_DECODE_CAPACITY}",
+    );
+    for (layer, cache) in caches.iter_mut().enumerate() {
+        reset_slot_rows(
+            ctx,
+            &mut cache.kv.data,
+            cache.kv.hidden_dim,
+            cache.kv.slots / DIRECT_BATCH_DECODE_CAPACITY,
+            slot_id,
+            half::bf16::ZERO,
+        )
+        .with_context(|| format!("reset layer {layer} KV cache slot"))?;
+        if let Some(compressor) = cache.compressor.as_mut() {
+            let rows_per_slot = compressor.slots / DIRECT_BATCH_DECODE_CAPACITY;
+            reset_slot_rows(
+                ctx,
+                &mut compressor.kv,
+                compressor.hidden_dim,
+                rows_per_slot,
+                slot_id,
+                0.0,
+            )
+            .with_context(|| format!("reset layer {layer} compressor KV slot"))?;
+            reset_slot_rows(
+                ctx,
+                &mut compressor.score,
+                compressor.hidden_dim,
+                rows_per_slot,
+                slot_id,
+                f32::NEG_INFINITY,
+            )
+            .with_context(|| format!("reset layer {layer} compressor score slot"))?;
+        }
+        if let Some(indexer_kv) = cache.indexer_kv.as_mut() {
+            reset_slot_rows(
+                ctx,
+                &mut indexer_kv.data,
+                indexer_kv.hidden_dim,
+                indexer_kv.slots / DIRECT_BATCH_DECODE_CAPACITY,
+                slot_id,
+                half::bf16::ZERO,
+            )
+            .with_context(|| format!("reset layer {layer} indexer KV slot"))?;
+        }
+        if let Some(indexer_compressor) = cache.indexer_compressor.as_mut() {
+            let rows_per_slot = indexer_compressor.slots / DIRECT_BATCH_DECODE_CAPACITY;
+            reset_slot_rows(
+                ctx,
+                &mut indexer_compressor.kv,
+                indexer_compressor.hidden_dim,
+                rows_per_slot,
+                slot_id,
+                0.0,
+            )
+            .with_context(|| format!("reset layer {layer} indexer compressor KV slot"))?;
+            reset_slot_rows(
+                ctx,
+                &mut indexer_compressor.score,
+                indexer_compressor.hidden_dim,
+                rows_per_slot,
+                slot_id,
+                f32::NEG_INFINITY,
+            )
+            .with_context(|| format!("reset layer {layer} indexer compressor score slot"))?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+fn clone_rank_decode_cache_slot_for_test(
+    ctx: &RankGpuContext,
+    config: &Config,
+    caches: &mut [LayerDecodeCache],
+    src_slot: usize,
+    dst_slot: usize,
+) -> Result<()> {
+    ensure!(
+        src_slot < DIRECT_BATCH_DECODE_CAPACITY && dst_slot < DIRECT_BATCH_DECODE_CAPACITY,
+        "clone cache slot out of range: src={src_slot}, dst={dst_slot}, capacity={DIRECT_BATCH_DECODE_CAPACITY}",
+    );
+    ensure!(
+        caches.len() == config.n_layers,
+        "clone cache slot layer mismatch: have {}, need {}",
+        caches.len(),
+        config.n_layers
+    );
+    if src_slot == dst_slot {
+        return Ok(());
+    }
+    for (layer, cache) in caches.iter_mut().enumerate() {
+        clone_slot_rows(
+            ctx,
+            &mut cache.kv.data,
+            cache.kv.hidden_dim,
+            cache.kv.slots / DIRECT_BATCH_DECODE_CAPACITY,
+            src_slot,
+            dst_slot,
+        )
+        .with_context(|| format!("clone layer {layer} KV cache slot"))?;
+        if let Some(compressor) = cache.compressor.as_mut() {
+            let rows_per_slot = compressor.slots / DIRECT_BATCH_DECODE_CAPACITY;
+            clone_slot_rows(
+                ctx,
+                &mut compressor.kv,
+                compressor.hidden_dim,
+                rows_per_slot,
+                src_slot,
+                dst_slot,
+            )
+            .with_context(|| format!("clone layer {layer} compressor KV slot"))?;
+            clone_slot_rows(
+                ctx,
+                &mut compressor.score,
+                compressor.hidden_dim,
+                rows_per_slot,
+                src_slot,
+                dst_slot,
+            )
+            .with_context(|| format!("clone layer {layer} compressor score slot"))?;
+        }
+        if let Some(indexer_kv) = cache.indexer_kv.as_mut() {
+            clone_slot_rows(
+                ctx,
+                &mut indexer_kv.data,
+                indexer_kv.hidden_dim,
+                indexer_kv.slots / DIRECT_BATCH_DECODE_CAPACITY,
+                src_slot,
+                dst_slot,
+            )
+            .with_context(|| format!("clone layer {layer} indexer KV slot"))?;
+        }
+        if let Some(indexer_compressor) = cache.indexer_compressor.as_mut() {
+            let rows_per_slot = indexer_compressor.slots / DIRECT_BATCH_DECODE_CAPACITY;
+            clone_slot_rows(
+                ctx,
+                &mut indexer_compressor.kv,
+                indexer_compressor.hidden_dim,
+                rows_per_slot,
+                src_slot,
+                dst_slot,
+            )
+            .with_context(|| format!("clone layer {layer} indexer compressor KV slot"))?;
+            clone_slot_rows(
+                ctx,
+                &mut indexer_compressor.score,
+                indexer_compressor.hidden_dim,
+                rows_per_slot,
+                src_slot,
+                dst_slot,
+            )
+            .with_context(|| format!("clone layer {layer} indexer compressor score slot"))?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+fn clone_slot_rows<T>(
+    ctx: &RankGpuContext,
+    data: &mut CudaSlice<T>,
+    row_width: usize,
+    rows_per_slot: usize,
+    src_slot: usize,
+    dst_slot: usize,
+) -> Result<()>
+where
+    T: Copy + DeviceRepr,
+{
+    ctx.set_current()?;
+    ensure!(row_width > 0, "clone cache row width must be positive");
+    ensure!(
+        rows_per_slot > 0,
+        "clone cache rows_per_slot must be positive"
+    );
+    let slot_len = row_width * rows_per_slot;
+    let src_start = src_slot * slot_len;
+    let dst_start = dst_slot * slot_len;
+    ensure!(
+        src_start + slot_len <= data.len() && dst_start + slot_len <= data.len(),
+        "clone cache slot copy out of range: len={}, slot_len={}, src={}, dst={}",
+        data.len(),
+        slot_len,
+        src_slot,
+        dst_slot
+    );
+    let mut host = ctx.stream.clone_dtoh(data)?;
+    host.copy_within(src_start..src_start + slot_len, dst_start);
+    ctx.stream.memcpy_htod(&host, data)?;
+    Ok(())
+}
+
+#[cfg(test)]
+fn reset_slot_rows<T>(
+    ctx: &RankGpuContext,
+    data: &mut CudaSlice<T>,
+    row_width: usize,
+    rows_per_slot: usize,
+    slot_id: usize,
+    fill: T,
+) -> Result<()>
+where
+    T: Copy + DeviceRepr,
+{
+    ctx.set_current()?;
+    ensure!(row_width > 0, "reset cache row width must be positive");
+    ensure!(
+        rows_per_slot > 0,
+        "reset cache rows_per_slot must be positive"
+    );
+    let slot_len = row_width * rows_per_slot;
+    let start = slot_id * slot_len;
+    ensure!(
+        start + slot_len <= data.len(),
+        "reset cache slot out of range: len={}, slot_len={}, slot={}",
+        data.len(),
+        slot_len,
+        slot_id
+    );
+    let mut host = ctx.stream.clone_dtoh(data)?;
+    host[start..start + slot_len].fill(fill);
+    ctx.stream.memcpy_htod(&host, data)?;
     Ok(())
 }
 
@@ -585,6 +1114,187 @@ fn run_decode_on_rank_lane(
         .with_context(|| format!("final logits all_gather rank {rank}"))
 }
 
+fn run_decode_batch_on_rank_lane(
+    rank: usize,
+    ctx: &RankGpuContext,
+    weights: &RankWeightView<'_>,
+    ptr_cache: &crate::MoeGroupedPtrCache,
+    comm: &cudarc::nccl::safe::Comm,
+    moe_comm: &cudarc::nccl::safe::Comm,
+    ropes: &[DeepSeekRopeCache],
+    config: &Config,
+    entries: &[DirectBatchDecodeEntry],
+    caches: &mut [LayerDecodeCache],
+    scratch: &mut RankDecodeScratch,
+) -> Result<Option<Vec<Vec<f32>>>> {
+    ensure!(
+        !entries.is_empty(),
+        "rank {rank} batch decode must have at least one entry"
+    );
+    ensure!(
+        entries.len() <= DIRECT_BATCH_DECODE_CAPACITY,
+        "rank {rank} batch decode entries={} exceeds capacity {DIRECT_BATCH_DECODE_CAPACITY}",
+        entries.len()
+    );
+    ensure!(
+        ropes.len() == config.n_layers,
+        "rank {rank} rope cache layer mismatch: have {}, need {}",
+        ropes.len(),
+        config.n_layers
+    );
+    ensure!(
+        caches.len() == config.n_layers,
+        "rank {rank} decode cache layer mismatch: have {}, need {}",
+        caches.len(),
+        config.n_layers
+    );
+
+    ctx.set_current()?;
+    let token_ids_host = entries
+        .iter()
+        .map(|entry| entry.token_id)
+        .collect::<Vec<_>>();
+    ctx.stream
+        .memcpy_htod(&token_ids_host, &mut scratch.batch_token_ids)?;
+    embedding_rank_local_into(
+        ctx,
+        config,
+        weights,
+        &scratch.batch_token_ids,
+        entries.len(),
+        &mut scratch.entry.embedding,
+    )
+    .with_context(|| format!("batch embedding rank {rank}"))?;
+    all_reduce_hidden_in_place(&mut scratch.entry.embedding, comm)
+        .with_context(|| format!("batch embedding all_reduce rank {rank}"))?;
+    hc_expand_bf16_hidden_into(
+        ctx,
+        &scratch.entry.embedding,
+        config.hc_mult,
+        &mut scratch.entry.hc_expand,
+    )
+    .with_context(|| format!("batch hc_expand rank {rank}"))?;
+
+    let mut current_hc_slot = None;
+    for layer in 0..config.n_layers {
+        let output_slot = current_hc_slot.map_or(0, |slot| 1 - slot);
+        let slot_stride = caches[layer].kv.slots / DIRECT_BATCH_DECODE_CAPACITY;
+        let compressed_slots = slot_stride
+            .checked_sub(config.sliding_window)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "batch decode layer {layer} cache slots per request {} smaller than sliding window {}",
+                    slot_stride,
+                    config.sliding_window
+                )
+            })?;
+        fill_decode_batch_metadata(
+            ctx,
+            config,
+            layer,
+            slot_stride,
+            compressed_slots,
+            entries,
+            &mut scratch.batch_token_ids,
+            &mut scratch.start_pos,
+            &mut scratch.src_rows,
+            &mut scratch.window_dst_rows,
+            &mut scratch.window_base,
+            &mut scratch.compressed_base,
+            &mut scratch.compressed_len,
+            &mut scratch.start_pos_host,
+            &mut scratch.slot_ids_host,
+        )?;
+        let token_ids = &scratch.batch_token_ids;
+        let batch_meta = DecodeBatchMeta {
+            batch: entries.len(),
+            compressed_slots,
+            start_pos: &scratch.start_pos,
+            src_rows: &scratch.src_rows,
+            window_dst_rows: &scratch.window_dst_rows,
+            window_base: &scratch.window_base,
+            compressed_base: &scratch.compressed_base,
+            compressed_len: &scratch.compressed_len,
+            start_pos_host: &scratch.start_pos_host,
+            slot_ids_host: &scratch.slot_ids_host,
+        };
+        if let Some(input_slot) = current_hc_slot {
+            let (attention_reduce_temp, attention_hc_out, layer_outputs) = (
+                &mut scratch.hc_post.attention_reduce_temp,
+                &mut scratch.hc_post.attention_out,
+                &mut scratch.hc_post.layer_outputs,
+            );
+            let (hc_input, layer_out) =
+                split_hc_input_output(layer_outputs, input_slot, output_slot)?;
+            block_decode_rank_lane_bf16_hidden_batch_with_scratch(
+                ctx,
+                weights,
+                ptr_cache,
+                comm,
+                moe_comm,
+                config,
+                layer,
+                hc_input,
+                token_ids,
+                &ropes[layer],
+                &batch_meta,
+                &mut caches[layer],
+                &mut scratch.hc_pre_norm,
+                &mut scratch.shared_expert,
+                &mut scratch.moe_ag_rs,
+                &mut scratch.attention_projection,
+                &mut scratch.attention_output,
+                &mut scratch.attention_index,
+                &mut scratch.attention_aux,
+                attention_reduce_temp,
+                attention_hc_out,
+                layer_out,
+            )
+            .with_context(|| format!("batch decode layer {layer} rank {rank}"))?;
+        } else {
+            let layer_out = scratch
+                .hc_post
+                .layer_outputs
+                .get_mut(output_slot)
+                .ok_or_else(|| anyhow::anyhow!("missing HC post output slot {output_slot}"))?;
+            block_decode_rank_lane_bf16_hidden_batch_with_scratch(
+                ctx,
+                weights,
+                ptr_cache,
+                comm,
+                moe_comm,
+                config,
+                layer,
+                &scratch.entry.hc_expand,
+                token_ids,
+                &ropes[layer],
+                &batch_meta,
+                &mut caches[layer],
+                &mut scratch.hc_pre_norm,
+                &mut scratch.shared_expert,
+                &mut scratch.moe_ag_rs,
+                &mut scratch.attention_projection,
+                &mut scratch.attention_output,
+                &mut scratch.attention_index,
+                &mut scratch.attention_aux,
+                &mut scratch.hc_post.attention_reduce_temp,
+                &mut scratch.hc_post.attention_out,
+                layer_out,
+            )
+            .with_context(|| format!("batch decode layer {layer} rank {rank}"))?;
+        }
+        current_hc_slot = Some(output_slot);
+    }
+
+    let final_hc = current_hc_slot
+        .and_then(|slot| scratch.hc_post.layer_outputs.get(slot))
+        .unwrap_or(&scratch.entry.hc_expand);
+    let local_logits = final_batch_logits_rank_local_bf16_hidden(ctx, config, weights, final_hc)
+        .with_context(|| format!("batch final logits rank {rank}"))?;
+    gather_batch_logits_for_sampling(rank, ctx, comm, weights, &local_logits)
+        .with_context(|| format!("batch final logits all_gather rank {rank}"))
+}
+
 fn split_hc_input_output(
     layer_outputs: &mut [crate::HcHiddenStates],
     input_slot: usize,
@@ -672,6 +1382,58 @@ fn run_prefill_on_rank_lane(
         .with_context(|| format!("prefill final logits all_gather rank {rank}"))
 }
 
+fn final_batch_logits_rank_local_bf16_hidden(
+    ctx: &RankGpuContext,
+    config: &Config,
+    weights: &RankWeightView<'_>,
+    input: &crate::HcHiddenStates,
+) -> Result<F32BatchLogits> {
+    ctx.set_current()?;
+    let hidden = hc_head_bf16_hidden(
+        ctx,
+        config,
+        input,
+        &weights.hc_head_fn()?,
+        &weights.hc_head_scale()?,
+        &weights.hc_head_base()?,
+    )?;
+    let normed = rms_norm_bf16_hidden(ctx, &hidden, &weights.norm()?, config.rms_norm_eps)?;
+    rank_local_logits_from_hidden_all(ctx, &normed, &weights.head()?)
+}
+
+fn gather_batch_logits_for_sampling(
+    rank: usize,
+    ctx: &RankGpuContext,
+    comm: &cudarc::nccl::safe::Comm,
+    weights: &RankWeightView<'_>,
+    local_logits: &F32BatchLogits,
+) -> Result<Option<Vec<Vec<f32>>>> {
+    ctx.set_current()?;
+    let world_size = weights.world_size();
+    ensure!(world_size > 0, "batch logits world size must be positive");
+    let gathered_len = local_logits.data.len() * world_size;
+    let mut gathered = unsafe { ctx.stream.alloc(gathered_len)? };
+    comm.all_gather(&local_logits.data, &mut gathered)
+        .map_err(|err| anyhow::anyhow!("NCCL batch logits all-gather failed: {err:?}"))?;
+    if rank != 0 {
+        return Ok(None);
+    }
+    let host = ctx.stream.clone_dtoh(&gathered)?;
+    ctx.sync()?;
+    let local_vocab = local_logits.vocab_size;
+    let seq_len = local_logits.seq_len;
+    let mut rows = (0..seq_len)
+        .map(|_| Vec::with_capacity(local_vocab * world_size))
+        .collect::<Vec<_>>();
+    for row in 0..seq_len {
+        for rank in 0..world_size {
+            let start = rank * seq_len * local_vocab + row * local_vocab;
+            rows[row].extend_from_slice(&host[start..start + local_vocab]);
+        }
+    }
+    Ok(Some(rows))
+}
+
 fn gather_logits_for_sampling(
     rank: usize,
     ctx: &RankGpuContext,
@@ -741,6 +1503,81 @@ pub(super) fn run_direct_decode_logits(
     rank0_logits(results)
 }
 
+#[allow(dead_code)] // PR A lands the runtime batch path before scheduler wiring.
+pub(super) fn run_direct_decode_batch_logits(
+    runtime: &mut FullDirectRuntime,
+    entries: &[DirectBatchDecodeEntry],
+) -> Result<Vec<Vec<f32>>> {
+    ensure!(
+        runtime.workers.len() == 8,
+        "DeepSeek V4 direct batch decode expects 8 workers"
+    );
+    ensure!(
+        !entries.is_empty(),
+        "DeepSeek V4 direct batch decode entries must not be empty"
+    );
+    ensure!(
+        entries.len() <= DIRECT_BATCH_DECODE_CAPACITY,
+        "DeepSeek V4 direct batch decode capacity exceeded: entries={}, capacity={DIRECT_BATCH_DECODE_CAPACITY}",
+        entries.len()
+    );
+    let rank_count = runtime.workers.len();
+    let pending = runtime
+        .workers
+        .iter()
+        .enumerate()
+        .map(|(rank, worker)| {
+            worker
+                .decode_batch(entries.to_vec())
+                .with_context(|| format!("dispatch batch decode rank {rank}"))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut results = Vec::with_capacity(rank_count);
+    for recv in pending {
+        results.push(recv.recv().map_err(|_| {
+            anyhow::anyhow!("DeepSeek rank worker dropped batch decode response")
+        })??);
+    }
+    results.sort_by_key(|(rank, _)| *rank);
+    rank0_batch_logits(results)
+}
+
+#[cfg(test)]
+pub(super) fn clone_direct_decode_cache_slot_for_test(
+    runtime: &mut FullDirectRuntime,
+    src_slot: usize,
+    dst_slot: usize,
+) -> Result<()> {
+    ensure!(
+        runtime.workers.len() == 8,
+        "DeepSeek V4 direct cache clone expects 8 workers"
+    );
+    for (rank, worker) in runtime.workers.iter().enumerate() {
+        worker
+            .clone_cache_slot_for_test(src_slot, dst_slot)
+            .with_context(|| format!("clone rank worker cache slot rank {rank}"))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+pub(super) fn reset_direct_decode_cache_slot_for_test(
+    runtime: &mut FullDirectRuntime,
+    slot_id: usize,
+) -> Result<()> {
+    ensure!(
+        runtime.workers.len() == 8,
+        "DeepSeek V4 direct cache slot reset expects 8 workers"
+    );
+    for (rank, worker) in runtime.workers.iter().enumerate() {
+        worker
+            .reset_cache_slot_for_test(slot_id)
+            .with_context(|| format!("reset rank worker cache slot rank {rank}"))?;
+    }
+    Ok(())
+}
+
 pub(super) fn run_prefill_logits_and_seed_decode_cache(
     runtime: &mut FullDirectRuntime,
     config: &Config,
@@ -784,4 +1621,13 @@ fn rank0_logits(results: Vec<RankResult>) -> Result<Vec<f32>> {
         .find_map(|(rank, logits)| (rank == 0).then_some(logits))
         .flatten()
         .ok_or_else(|| anyhow::anyhow!("rank 0 did not return gathered logits"))
+}
+
+#[allow(dead_code)] // PR A lands the runtime batch path before scheduler wiring.
+fn rank0_batch_logits(results: Vec<RankBatchResult>) -> Result<Vec<Vec<f32>>> {
+    results
+        .into_iter()
+        .find_map(|(rank, logits)| (rank == 0).then_some(logits))
+        .flatten()
+        .ok_or_else(|| anyhow::anyhow!("rank 0 did not return gathered batch logits"))
 }

--- a/pegainfer-deepseek-v4/src/runtime/attention.rs
+++ b/pegainfer-deepseek-v4/src/runtime/attention.rs
@@ -500,20 +500,15 @@ pub fn indexed_attention_cache_bf16_hidden(
     ctx.set_current()?;
     ensure!(topk > 0, "indexed cache attention topk must be positive");
     ensure!(
-        projections.q.seq_len == 1,
-        "indexed cache attention currently expects decode seq_len=1, got {}",
-        projections.q.seq_len
-    );
-    ensure!(
         kv_cache.hidden_dim == projections.head_dim,
         "kv cache hidden dim mismatch: expected {}, got {}",
         projections.head_dim,
         kv_cache.hidden_dim
     );
     ensure!(
-        topk_idxs.len() >= topk,
+        topk_idxs.len() >= projections.q.seq_len * topk,
         "indexed cache attention topk capacity too small: need {}, have {}",
-        topk,
+        projections.q.seq_len * topk,
         topk_idxs.len()
     );
     ensure!(
@@ -557,20 +552,15 @@ pub(crate) fn indexed_attention_cache_bf16_hidden_into(
     ctx.set_current()?;
     ensure!(topk > 0, "indexed cache attention topk must be positive");
     ensure!(
-        projections.q.seq_len == 1,
-        "indexed cache attention currently expects decode seq_len=1, got {}",
-        projections.q.seq_len
-    );
-    ensure!(
         kv_cache.hidden_dim == projections.head_dim,
         "kv cache hidden dim mismatch: expected {}, got {}",
         projections.head_dim,
         kv_cache.hidden_dim
     );
     ensure!(
-        topk_idxs.len() >= topk,
+        topk_idxs.len() >= projections.q.seq_len * topk,
         "indexed cache attention topk capacity too small: need {}, have {}",
-        topk,
+        projections.q.seq_len * topk,
         topk_idxs.len()
     );
     ensure!(
@@ -639,20 +629,15 @@ pub(crate) fn indexed_attention_cache_bf16_hidden_view_into(
     ctx.set_current()?;
     ensure!(topk > 0, "indexed cache attention topk must be positive");
     ensure!(
-        projections.q.seq_len == 1,
-        "indexed cache attention currently expects decode seq_len=1, got {}",
-        projections.q.seq_len
-    );
-    ensure!(
         kv_cache.hidden_dim == projections.head_dim,
         "kv cache hidden dim mismatch: expected {}, got {}",
         projections.head_dim,
         kv_cache.hidden_dim
     );
     ensure!(
-        topk_idxs.len() >= topk,
+        topk_idxs.len() >= topk * projections.q.seq_len,
         "indexed cache attention topk capacity too small: need {}, have {}",
-        topk,
+        topk * projections.q.seq_len,
         topk_idxs.len()
     );
     ensure!(
@@ -738,6 +723,47 @@ pub(crate) fn attention_output_project_bf16_hidden_scratch<'a>(
         scratch.seq_capacity
     );
     apply_rope_hidden_in_place(
+        ctx,
+        &mut scratch.attn_out,
+        rope,
+        scratch.local_heads,
+        scratch.head_dim,
+        start_pos,
+        true,
+    )?;
+    bf16_linear_bf16_hidden_into(ctx, &scratch.attn_out, &attn.wo_a, &mut scratch.low_rank)?;
+    fp8_linear_bf16_hidden_into(ctx, &scratch.low_rank, &attn.wo_b, &mut scratch.out)?;
+    Ok(&scratch.out)
+}
+
+pub(crate) fn attention_output_project_bf16_hidden_batch_scratch<'a>(
+    ctx: &RankGpuContext,
+    attn: &AttentionWeights<'_>,
+    rope: &DeepSeekRopeCache,
+    start_pos: &CudaSlice<i32>,
+    batch: usize,
+    scratch: &'a mut AttentionOutputScratch,
+) -> Result<&'a Bf16HiddenStates> {
+    ctx.set_current()?;
+    ensure!(batch > 0, "attention output batch must be positive");
+    ensure!(
+        scratch.attn_out.seq_len == batch,
+        "attention output batch mismatch: attn_out seq_len={}, batch={batch}",
+        scratch.attn_out.seq_len
+    );
+    ensure!(
+        start_pos.len() >= batch,
+        "attention output start_pos capacity too small: need {}, have {}",
+        batch,
+        start_pos.len()
+    );
+    ensure!(
+        batch <= scratch.seq_capacity,
+        "attention output scratch capacity too small: need {}, have {}",
+        batch,
+        scratch.seq_capacity
+    );
+    apply_rope_hidden_batch_in_place(
         ctx,
         &mut scratch.attn_out,
         rope,
@@ -974,6 +1000,96 @@ pub(crate) fn attention_decode_rank_local_bf16_hidden_with_scratch<'a>(
     .with_context(|| format!("attention_output_project layer {layer}"))
 }
 
+pub(crate) fn attention_decode_rank_local_bf16_hidden_batch_with_scratch<'a>(
+    ctx: &RankGpuContext,
+    config: &Config,
+    layer: usize,
+    input: &Bf16HiddenStates,
+    attn: &AttentionWeights<'_>,
+    rope: &DeepSeekRopeCache,
+    batch_meta: &DecodeBatchMeta<'_>,
+    kv_cache: &mut Bf16Cache,
+    attention_projection_scratch: &mut AttentionProjectionScratch,
+    attention_output_scratch: &'a mut AttentionOutputScratch,
+    attention_index_scratch: &mut AttentionIndexScratch,
+) -> Result<&'a Bf16HiddenStates> {
+    ctx.set_current()?;
+    ensure!(
+        config.compress_ratios[layer] == 0,
+        "rank-local batch decode only supports non-compressed layers, layer {layer} has compress_ratio={}",
+        config.compress_ratios[layer]
+    );
+    ensure!(
+        input.seq_len == batch_meta.batch,
+        "rank-local batch decode input seq_len mismatch: input={}, batch={}",
+        input.seq_len,
+        batch_meta.batch
+    );
+    ensure!(
+        kv_cache.hidden_dim == config.head_dim,
+        "batch decode kv cache hidden dim mismatch: expected {}, got {}",
+        config.head_dim,
+        kv_cache.hidden_dim
+    );
+
+    let projections = attention_project_bf16_hidden_scratch(
+        ctx,
+        config,
+        input,
+        attn,
+        attention_projection_scratch,
+    )
+    .with_context(|| format!("attention_project batch layer {layer}"))?;
+    apply_rope_q_kv_batch_in_place(
+        ctx,
+        projections.q,
+        projections.kv,
+        rope,
+        projections.local_heads,
+        projections.head_dim,
+        batch_meta.start_pos,
+    )
+    .with_context(|| format!("apply_rope_attention_projections batch layer {layer}"))?;
+    copy_bf16_rows_to_cache_indexed(
+        ctx,
+        projections.kv,
+        kv_cache,
+        batch_meta.src_rows,
+        batch_meta.window_dst_rows,
+        batch_meta.batch,
+    )
+    .with_context(|| format!("copy batch kv to cache layer {layer}"))?;
+    let topk = window_topk_indices_decode_batch_into(
+        ctx,
+        batch_meta.start_pos,
+        batch_meta.window_base,
+        batch_meta.batch,
+        config.sliding_window,
+        &mut attention_index_scratch.window_idxs,
+    )
+    .with_context(|| format!("window_topk_indices_decode batch layer {layer}"))?;
+    indexed_attention_cache_bf16_hidden_view_into(
+        ctx,
+        config,
+        &projections,
+        kv_cache,
+        attn,
+        &attention_index_scratch.window_idxs,
+        topk,
+        &mut attention_output_scratch.attn_out,
+    )
+    .with_context(|| format!("indexed_attention_cache batch layer {layer} topk {topk}"))?;
+    attention_output_project_bf16_hidden_batch_scratch(
+        ctx,
+        attn,
+        rope,
+        batch_meta.start_pos,
+        batch_meta.batch,
+        attention_output_scratch,
+    )
+    .with_context(|| format!("attention_output_project batch layer {layer}"))
+}
+
 pub(crate) fn attention_decode_compressed_nonoverlap_rank_local_bf16_hidden(
     ctx: &RankGpuContext,
     config: &Config,
@@ -1076,5 +1192,149 @@ pub(crate) fn attention_decode_compressed_nonoverlap_rank_local_bf16_hidden(
         projections.local_heads,
         projections.head_dim,
         start_pos,
+    )
+}
+
+pub(crate) fn attention_decode_compressed_nonoverlap_rank_local_bf16_hidden_batch_with_scratch<
+    'a,
+>(
+    ctx: &RankGpuContext,
+    config: &Config,
+    layer: usize,
+    input: &Bf16HiddenStates,
+    attn: &AttentionWeights<'_>,
+    rope: &DeepSeekRopeCache,
+    batch_meta: &DecodeBatchMeta<'_>,
+    cache: &mut LayerDecodeCache,
+    attention_projection_scratch: &mut AttentionProjectionScratch,
+    attention_output_scratch: &'a mut AttentionOutputScratch,
+    attention_index_scratch: &mut AttentionIndexScratch,
+) -> Result<&'a Bf16HiddenStates> {
+    ensure!(
+        input.seq_len == batch_meta.batch,
+        "compressed non-overlap batch decode seq_len mismatch: input={}, batch={}",
+        input.seq_len,
+        batch_meta.batch
+    );
+    ensure!(
+        layer < config.compress_ratios.len(),
+        "compressed batch decode layer {layer} out of range"
+    );
+    let ratio = config.compress_ratios[layer];
+    ensure!(
+        ratio > 0 && ratio != 4,
+        "non-overlap batch decode called for ratio {ratio}"
+    );
+    let compressor = attn
+        .compressor
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("layer {layer} missing compressor weights"))?;
+    let compressor_state = cache
+        .compressor
+        .as_mut()
+        .ok_or_else(|| anyhow::anyhow!("layer {layer} missing compressor decode state"))?;
+
+    let projections = attention_project_bf16_hidden_scratch(
+        ctx,
+        config,
+        input,
+        attn,
+        attention_projection_scratch,
+    )?;
+    apply_rope_q_kv_batch_in_place(
+        ctx,
+        projections.q,
+        projections.kv,
+        rope,
+        projections.local_heads,
+        projections.head_dim,
+        batch_meta.start_pos,
+    )?;
+    copy_bf16_rows_to_cache_indexed(
+        ctx,
+        projections.kv,
+        &mut cache.kv,
+        batch_meta.src_rows,
+        batch_meta.window_dst_rows,
+        batch_meta.batch,
+    )?;
+    let compressed_slots = batch_meta.compressed_slots;
+    for row in 0..batch_meta.batch {
+        let row_input = copy_bf16_row_to_hidden(ctx, input, row)?;
+        let state_offset = batch_meta.slot_ids_host[row] * ratio;
+        if let Some(compressed_kv) = compressor_nonoverlap_decode_bf16_hidden_at(
+            ctx,
+            config,
+            &row_input,
+            compressor,
+            ratio,
+            rope,
+            batch_meta.start_pos_host[row],
+            compressor_state,
+            state_offset,
+        )? {
+            let dst = config.sliding_window
+                + batch_meta.slot_ids_host[row] * compressed_slots
+                + batch_meta.start_pos_host[row] / ratio;
+            copy_bf16_rows_to_cache(ctx, &compressed_kv, &mut cache.kv, 0, dst, 1)?;
+        }
+    }
+
+    let window_topk = window_topk_indices_decode_batch_into(
+        ctx,
+        batch_meta.start_pos,
+        batch_meta.window_base,
+        batch_meta.batch,
+        config.sliding_window,
+        &mut attention_index_scratch.window_idxs,
+    )?;
+    let max_compressed_len = batch_meta
+        .start_pos_host
+        .iter()
+        .map(|pos| (pos + 1) / ratio)
+        .max()
+        .unwrap_or(0);
+    let (topk_idxs, topk) = if max_compressed_len > 0 {
+        let compress_topk = compress_topk_indices_decode_batch_into(
+            ctx,
+            batch_meta.compressed_len,
+            batch_meta.compressed_base,
+            batch_meta.batch,
+            max_compressed_len,
+            &mut attention_index_scratch.compress_idxs,
+        )?;
+        concat_topk_indices_into(
+            ctx,
+            &attention_index_scratch.window_idxs,
+            window_topk,
+            &attention_index_scratch.compress_idxs,
+            compress_topk,
+            batch_meta.batch,
+            &mut attention_index_scratch.topk_idxs,
+        )?;
+        (
+            &attention_index_scratch.topk_idxs,
+            window_topk + compress_topk,
+        )
+    } else {
+        (&attention_index_scratch.window_idxs, window_topk)
+    };
+    indexed_attention_cache_bf16_hidden_view_into(
+        ctx,
+        config,
+        &projections,
+        &cache.kv,
+        attn,
+        topk_idxs,
+        topk,
+        &mut attention_output_scratch.attn_out,
+    )?;
+    attention_output_project_bf16_hidden_batch_scratch(
+        ctx,
+        attn,
+        rope,
+        batch_meta.start_pos,
+        batch_meta.batch,
+        attention_output_scratch,
     )
 }

--- a/pegainfer-deepseek-v4/src/runtime/attention_base.rs
+++ b/pegainfer-deepseek-v4/src/runtime/attention_base.rs
@@ -338,6 +338,72 @@ pub(crate) fn apply_rope_q_kv_in_place(
     Ok(())
 }
 
+pub(crate) fn apply_rope_q_kv_batch_in_place(
+    ctx: &RankGpuContext,
+    q: &mut Bf16HiddenStates,
+    kv: &mut Bf16HiddenStates,
+    rope: &DeepSeekRopeCache,
+    local_heads: usize,
+    head_dim: usize,
+    start_pos: &CudaSlice<i32>,
+) -> Result<()> {
+    ctx.set_current()?;
+    ensure!(
+        q.hidden_dim == local_heads * head_dim,
+        "batch RoPE q hidden dim mismatch: expected {}, got {}",
+        local_heads * head_dim,
+        q.hidden_dim
+    );
+    ensure!(
+        kv.hidden_dim == head_dim,
+        "batch RoPE kv hidden dim mismatch: expected {}, got {}",
+        head_dim,
+        kv.hidden_dim
+    );
+    ensure!(
+        q.seq_len == kv.seq_len,
+        "batch RoPE q/kv seq_len mismatch: q={}, kv={}",
+        q.seq_len,
+        kv.seq_len
+    );
+    ensure!(
+        start_pos.len() >= q.seq_len,
+        "batch RoPE start_pos capacity too small: need {}, have {}",
+        q.seq_len,
+        start_pos.len()
+    );
+    ensure!(
+        rope.rotary_dim <= head_dim,
+        "rotary_dim {} exceeds head_dim {}",
+        rope.rotary_dim,
+        head_dim
+    );
+
+    {
+        let (q_ptr, _q_guard) = q.data.device_ptr_mut(&ctx.stream);
+        let (kv_ptr, _kv_guard) = kv.data.device_ptr_mut(&ctx.stream);
+        let (cos_ptr, _cos_guard) = rope.cos.device_ptr(&ctx.stream);
+        let (sin_ptr, _sin_guard) = rope.sin.device_ptr(&ctx.stream);
+        let (start_ptr, _start_guard) = start_pos.device_ptr(&ctx.stream);
+        let result = unsafe {
+            ffi::deepseek_apply_rope_q_kv_batch_cuda(
+                q_ptr as *mut ffi::Half,
+                kv_ptr as *mut ffi::Half,
+                cos_ptr as *const f32,
+                sin_ptr as *const f32,
+                start_ptr as *const i32,
+                q.seq_len as i32,
+                local_heads as i32,
+                head_dim as i32,
+                rope.rotary_dim as i32,
+                ctx.stream.cu_stream(),
+            )
+        };
+        result.result()?;
+    }
+    Ok(())
+}
+
 pub fn fp8_act_quant_nope_bf16_hidden_in_place(
     ctx: &RankGpuContext,
     hidden: &mut Bf16HiddenStates,
@@ -429,6 +495,59 @@ pub fn apply_rope_hidden_in_place(
                 head_dim as i32,
                 rope.rotary_dim as i32,
                 start_pos as i32,
+                if inverse { 1 } else { 0 },
+                ctx.stream.cu_stream(),
+            )
+        };
+        result.result()?;
+    }
+    Ok(())
+}
+
+pub(crate) fn apply_rope_hidden_batch_in_place(
+    ctx: &RankGpuContext,
+    hidden: &mut Bf16HiddenStates,
+    rope: &DeepSeekRopeCache,
+    local_heads: usize,
+    head_dim: usize,
+    start_pos: &CudaSlice<i32>,
+    inverse: bool,
+) -> Result<()> {
+    ctx.set_current()?;
+    ensure!(
+        hidden.hidden_dim == local_heads * head_dim,
+        "batch RoPE hidden dim mismatch: expected {}, got {}",
+        local_heads * head_dim,
+        hidden.hidden_dim
+    );
+    ensure!(
+        start_pos.len() >= hidden.seq_len,
+        "batch RoPE hidden start_pos capacity too small: need {}, have {}",
+        hidden.seq_len,
+        start_pos.len()
+    );
+    ensure!(
+        rope.rotary_dim <= head_dim,
+        "rotary_dim {} exceeds head_dim {}",
+        rope.rotary_dim,
+        head_dim
+    );
+
+    {
+        let (x_ptr, _x_guard) = hidden.data.device_ptr_mut(&ctx.stream);
+        let (cos_ptr, _cos_guard) = rope.cos.device_ptr(&ctx.stream);
+        let (sin_ptr, _sin_guard) = rope.sin.device_ptr(&ctx.stream);
+        let (start_ptr, _start_guard) = start_pos.device_ptr(&ctx.stream);
+        let result = unsafe {
+            ffi::deepseek_apply_rope_hidden_batch_cuda(
+                x_ptr as *mut ffi::Half,
+                cos_ptr as *const f32,
+                sin_ptr as *const f32,
+                start_ptr as *const i32,
+                hidden.seq_len as i32,
+                local_heads as i32,
+                head_dim as i32,
+                rope.rotary_dim as i32,
                 if inverse { 1 } else { 0 },
                 ctx.stream.cu_stream(),
             )
@@ -572,6 +691,55 @@ pub(crate) fn window_topk_indices_decode_into(
     Ok(window_size)
 }
 
+pub(crate) fn window_topk_indices_decode_batch_into(
+    ctx: &RankGpuContext,
+    start_pos: &CudaSlice<i32>,
+    cache_base: &CudaSlice<i32>,
+    batch: usize,
+    window_size: usize,
+    out: &mut CudaSlice<i32>,
+) -> Result<usize> {
+    ctx.set_current()?;
+    ensure!(batch > 0, "window top-k decode batch must be positive");
+    ensure!(window_size > 0, "window_size must be positive");
+    ensure!(
+        start_pos.len() >= batch,
+        "window top-k batch start_pos capacity too small: need {}, have {}",
+        batch,
+        start_pos.len()
+    );
+    ensure!(
+        cache_base.len() >= batch,
+        "window top-k batch cache_base capacity too small: need {}, have {}",
+        batch,
+        cache_base.len()
+    );
+    ensure!(
+        out.len() >= batch * window_size,
+        "window top-k batch output capacity too small: need {}, have {}",
+        batch * window_size,
+        out.len()
+    );
+    {
+        let (out_ptr, _out_guard) = out.device_ptr_mut(&ctx.stream);
+        let (start_ptr, _start_guard) = start_pos.device_ptr(&ctx.stream);
+        let (base_ptr, _base_guard) = cache_base.device_ptr(&ctx.stream);
+        let result = unsafe {
+            ffi::deepseek_window_topk_indices_decode_batch_cuda(
+                out_ptr as *mut i32,
+                start_ptr as *const i32,
+                base_ptr as *const i32,
+                batch as i32,
+                window_size as i32,
+                window_size as i32,
+                ctx.stream.cu_stream(),
+            )
+        };
+        result.result()?;
+    }
+    Ok(window_size)
+}
+
 pub fn compress_topk_indices(
     ctx: &RankGpuContext,
     seq_len: usize,
@@ -627,6 +795,53 @@ pub fn compress_topk_indices_decode(
         result.result()?;
     }
     Ok((data, compressed))
+}
+
+pub(crate) fn compress_topk_indices_decode_batch_into(
+    ctx: &RankGpuContext,
+    compressed_len: &CudaSlice<i32>,
+    cache_base: &CudaSlice<i32>,
+    batch: usize,
+    topk: usize,
+    out: &mut CudaSlice<i32>,
+) -> Result<usize> {
+    ctx.set_current()?;
+    ensure!(batch > 0, "compress top-k decode batch must be positive");
+    ensure!(
+        compressed_len.len() >= batch,
+        "compress top-k batch compressed_len capacity too small: need {}, have {}",
+        batch,
+        compressed_len.len()
+    );
+    ensure!(
+        cache_base.len() >= batch,
+        "compress top-k batch cache_base capacity too small: need {}, have {}",
+        batch,
+        cache_base.len()
+    );
+    ensure!(
+        out.len() >= batch * topk,
+        "compress top-k batch output capacity too small: need {}, have {}",
+        batch * topk,
+        out.len()
+    );
+    {
+        let (out_ptr, _out_guard) = out.device_ptr_mut(&ctx.stream);
+        let (compressed_ptr, _compressed_guard) = compressed_len.device_ptr(&ctx.stream);
+        let (base_ptr, _base_guard) = cache_base.device_ptr(&ctx.stream);
+        let result = unsafe {
+            ffi::deepseek_compress_topk_indices_decode_batch_cuda(
+                out_ptr as *mut i32,
+                compressed_ptr as *const i32,
+                base_ptr as *const i32,
+                batch as i32,
+                topk as i32,
+                ctx.stream.cu_stream(),
+            )
+        };
+        result.result()?;
+    }
+    Ok(topk)
 }
 
 pub fn window_and_compress_topk_indices(

--- a/pegainfer-deepseek-v4/src/runtime/block.rs
+++ b/pegainfer-deepseek-v4/src/runtime/block.rs
@@ -290,6 +290,172 @@ pub(crate) fn block_decode_rank_lane_bf16_hidden_with_scratch(
     Ok(())
 }
 
+pub(crate) fn block_decode_rank_lane_bf16_hidden_batch_with_scratch(
+    ctx: &RankGpuContext,
+    weights: &RankWeightView<'_>,
+    ptr_cache: &MoeGroupedPtrCache,
+    comm: &Comm,
+    moe_comm: &Comm,
+    config: &Config,
+    layer: usize,
+    input: &HcHiddenStates,
+    token_ids: &CudaSlice<u32>,
+    rope: &DeepSeekRopeCache,
+    batch_meta: &DecodeBatchMeta<'_>,
+    cache: &mut LayerDecodeCache,
+    hc_pre_norm_scratch: &mut HcPreNormScratch,
+    shared_expert_scratch: &mut SharedExpertScratch,
+    moe_ag_rs_scratch: &mut MoeAgRsScratch,
+    attention_projection_scratch: &mut AttentionProjectionScratch,
+    attention_output_scratch: &mut AttentionOutputScratch,
+    attention_index_scratch: &mut AttentionIndexScratch,
+    _attention_aux_scratch: &mut AttentionAuxScratch,
+    attention_hc_post_scratch: &mut CudaSlice<f32>,
+    attention_hc_out: &mut HcHiddenStates,
+    layer_out: &mut HcHiddenStates,
+) -> Result<()> {
+    ensure!(
+        input.seq_len == batch_meta.batch,
+        "rank lane block batch decode seq_len mismatch: input={}, batch={}",
+        input.seq_len,
+        batch_meta.batch
+    );
+    ensure!(
+        token_ids.len() >= batch_meta.batch,
+        "rank lane block batch token capacity too small: need {}, have {}",
+        batch_meta.batch,
+        token_ids.len()
+    );
+    ensure!(
+        layer < config.n_layers,
+        "rank lane block batch decode layer {layer} out of range"
+    );
+    let block = weights.block(layer)?;
+
+    let (attn_norm, attn_hc) = hc_pre_norm_bf16_hidden_scratch(
+        ctx,
+        config,
+        input,
+        &block.hc_attn_fn,
+        &block.hc_attn_scale,
+        &block.hc_attn_base,
+        &block.attn_norm,
+        hc_pre_norm_scratch,
+    )
+    .with_context(|| format!("hc_pre_norm batch attention layer {layer}"))?;
+    match config.compress_ratios[layer] {
+        0 => {
+            let attn_out = attention_decode_rank_local_bf16_hidden_batch_with_scratch(
+                ctx,
+                config,
+                layer,
+                attn_norm,
+                &block.attn,
+                rope,
+                batch_meta,
+                &mut cache.kv,
+                attention_projection_scratch,
+                attention_output_scratch,
+                attention_index_scratch,
+            )
+            .with_context(|| format!("attention batch decode layer {layer}"))?;
+            all_reduce_hidden_fp32_hc_post_view_into(
+                ctx,
+                attn_out,
+                input,
+                &attn_hc,
+                comm,
+                attention_hc_post_scratch,
+                attention_hc_out,
+            )
+        }
+        4 => {
+            let attn_out =
+                attention_decode_compressed_overlap_rank_local_collective_bf16_hidden_batch_with_scratch(
+                    ctx,
+                    config,
+                    layer,
+                    attn_norm,
+                    &block.attn,
+                    rope,
+                    batch_meta,
+                    cache,
+                    comm,
+                    attention_projection_scratch,
+                    attention_output_scratch,
+                    attention_index_scratch,
+                    _attention_aux_scratch,
+                )
+                .with_context(|| format!("attention overlap batch decode layer {layer}"))?;
+            all_reduce_hidden_fp32_hc_post_view_into(
+                ctx,
+                attn_out,
+                input,
+                &attn_hc,
+                comm,
+                attention_hc_post_scratch,
+                attention_hc_out,
+            )
+        }
+        _ => {
+            let attn_out =
+                attention_decode_compressed_nonoverlap_rank_local_bf16_hidden_batch_with_scratch(
+                    ctx,
+                    config,
+                    layer,
+                    attn_norm,
+                    &block.attn,
+                    rope,
+                    batch_meta,
+                    cache,
+                    attention_projection_scratch,
+                    attention_output_scratch,
+                    attention_index_scratch,
+                )
+                .with_context(|| format!("attention compressed batch decode layer {layer}"))?;
+            all_reduce_hidden_fp32_hc_post_view_into(
+                ctx,
+                attn_out,
+                input,
+                &attn_hc,
+                comm,
+                attention_hc_post_scratch,
+                attention_hc_out,
+            )
+        }
+    }
+    .with_context(|| format!("attention all_reduce batch hc_post layer {layer}"))?;
+
+    let (ffn_norm, ffn_hc) = hc_pre_norm_bf16_hidden_scratch(
+        ctx,
+        config,
+        attention_hc_out,
+        &block.hc_ffn_fn,
+        &block.hc_ffn_scale,
+        &block.hc_ffn_base,
+        &block.ffn_norm,
+        hc_pre_norm_scratch,
+    )
+    .with_context(|| format!("hc_pre_norm batch ffn layer {layer}"))?;
+
+    let ffn_out = decode_moe_ag_rs_bf16_hidden_with_scratch(
+        ctx,
+        config,
+        weights,
+        ptr_cache,
+        moe_comm,
+        layer,
+        ffn_norm,
+        token_ids,
+        shared_expert_scratch,
+        moe_ag_rs_scratch,
+    )
+    .with_context(|| format!("decode batch MoE AG/RS layer {layer}"))?;
+    hc_post_bf16_hidden_view_into(ctx, ffn_out, attention_hc_out, &ffn_hc, layer_out)
+        .with_context(|| format!("hc_post batch ffn layer {layer}"))?;
+    Ok(())
+}
+
 fn attention_decode_compressed_overlap_rank_local_collective_bf16_hidden_with_scratch<'a>(
     ctx: &RankGpuContext,
     config: &Config,
@@ -442,6 +608,225 @@ fn attention_decode_compressed_overlap_rank_local_collective_bf16_hidden_with_sc
         attn,
         rope,
         start_pos,
+        attention_output_scratch,
+    )
+}
+
+fn attention_decode_compressed_overlap_rank_local_collective_bf16_hidden_batch_with_scratch<'a>(
+    ctx: &RankGpuContext,
+    config: &Config,
+    layer: usize,
+    input: &Bf16HiddenStates,
+    attn: &AttentionWeights<'_>,
+    rope: &DeepSeekRopeCache,
+    batch_meta: &DecodeBatchMeta<'_>,
+    cache: &mut LayerDecodeCache,
+    comm: &Comm,
+    attention_projection_scratch: &mut AttentionProjectionScratch,
+    attention_output_scratch: &'a mut AttentionOutputScratch,
+    attention_index_scratch: &mut AttentionIndexScratch,
+    attention_aux_scratch: &mut AttentionAuxScratch,
+) -> Result<&'a Bf16HiddenStates> {
+    ensure!(
+        input.seq_len == batch_meta.batch,
+        "ratio-4 batch decode seq_len mismatch: input={}, batch={}",
+        input.seq_len,
+        batch_meta.batch
+    );
+    ensure!(
+        config.compress_ratios[layer] == 4,
+        "ratio-4 batch decode called for layer {layer} with ratio {}",
+        config.compress_ratios[layer]
+    );
+    let compressor = attn
+        .compressor
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("layer {layer} missing overlap compressor weights"))?;
+    let indexer = attn
+        .indexer
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("layer {layer} missing ratio-4 indexer weights"))?;
+    let compressor_state = cache
+        .compressor
+        .as_mut()
+        .ok_or_else(|| anyhow::anyhow!("layer {layer} missing overlap compressor state"))?;
+    let indexer_kv = cache
+        .indexer_kv
+        .as_mut()
+        .ok_or_else(|| anyhow::anyhow!("layer {layer} missing indexer kv cache"))?;
+    let indexer_state = cache
+        .indexer_compressor
+        .as_mut()
+        .ok_or_else(|| anyhow::anyhow!("layer {layer} missing indexer compressor state"))?;
+
+    let projections = attention_project_bf16_hidden_scratch(
+        ctx,
+        config,
+        input,
+        attn,
+        attention_projection_scratch,
+    )?;
+    apply_rope_q_kv_batch_in_place(
+        ctx,
+        projections.q,
+        projections.kv,
+        rope,
+        projections.local_heads,
+        projections.head_dim,
+        batch_meta.start_pos,
+    )?;
+    copy_bf16_rows_to_cache_indexed(
+        ctx,
+        projections.kv,
+        &mut cache.kv,
+        batch_meta.src_rows,
+        batch_meta.window_dst_rows,
+        batch_meta.batch,
+    )?;
+    let compressed_slots = batch_meta.compressed_slots;
+    for row in 0..batch_meta.batch {
+        let row_input = copy_bf16_row_to_hidden(ctx, input, row)?;
+        let state_offset = batch_meta.slot_ids_host[row] * 8;
+        if let Some(compressed_kv) = compressor_overlap_decode_bf16_hidden_with_dim_at(
+            ctx,
+            config,
+            &row_input,
+            compressor,
+            rope,
+            batch_meta.start_pos_host[row],
+            config.head_dim,
+            compressor_state,
+            state_offset,
+            false,
+        )? {
+            let dst = config.sliding_window
+                + batch_meta.slot_ids_host[row] * compressed_slots
+                + batch_meta.start_pos_host[row] / 4;
+            copy_bf16_rows_to_cache(ctx, &compressed_kv, &mut cache.kv, 0, dst, 1)?;
+        }
+        if let Some(indexer_compressed_kv) = compressor_overlap_decode_bf16_hidden_with_dim_at(
+            ctx,
+            config,
+            &row_input,
+            &indexer.compressor,
+            rope,
+            batch_meta.start_pos_host[row],
+            config.index_head_dim,
+            indexer_state,
+            state_offset,
+            true,
+        )? {
+            let dst = batch_meta.slot_ids_host[row] * compressed_slots
+                + batch_meta.start_pos_host[row] / 4;
+            copy_bf16_rows_to_cache(ctx, &indexer_compressed_kv, indexer_kv, 0, dst, 1)?;
+        }
+    }
+
+    let max_compressed_len = batch_meta
+        .start_pos_host
+        .iter()
+        .map(|pos| (pos + 1) / 4)
+        .max()
+        .unwrap_or(0);
+    let window_topk = window_topk_indices_decode_batch_into(
+        ctx,
+        batch_meta.start_pos,
+        batch_meta.window_base,
+        batch_meta.batch,
+        config.sliding_window,
+        &mut attention_index_scratch.window_idxs,
+    )?;
+    let (topk_idxs, topk) = if max_compressed_len > 0 {
+        let local_heads = attention_aux_scratch.local_index_heads;
+        fp8_linear_bf16_hidden_into(
+            ctx,
+            projections.qr,
+            &indexer.wq_b,
+            &mut attention_aux_scratch.indexer_q,
+        )?;
+        apply_rope_hidden_batch_in_place(
+            ctx,
+            &mut attention_aux_scratch.indexer_q,
+            rope,
+            local_heads,
+            config.index_head_dim,
+            batch_meta.start_pos,
+            false,
+        )?;
+        hadamard_fp4_quant_bf16_hidden_in_place(
+            ctx,
+            &mut attention_aux_scratch.indexer_q,
+            local_heads,
+            config.index_head_dim,
+        )?;
+        bf16_linear_bf16_hidden_into(
+            ctx,
+            input,
+            &indexer.weights_proj,
+            &mut attention_aux_scratch.indexer_weights,
+        )?;
+        indexer_scores_decode_batch_into(
+            ctx,
+            config,
+            IndexerDecodeBatchInputs {
+                q: &attention_aux_scratch.indexer_q,
+                kv_cache: indexer_kv,
+                weights: &attention_aux_scratch.indexer_weights,
+                compressed_len: batch_meta.compressed_len,
+                cache_base: batch_meta.compressed_base,
+                batch: batch_meta.batch,
+                max_compressed_len,
+            },
+            &mut attention_aux_scratch.indexer_scores,
+        )?;
+        let score_len = batch_meta.batch * max_compressed_len;
+        let mut scores = attention_aux_scratch.indexer_scores.slice_mut(0..score_len);
+        comm.all_reduce_in_place(&mut scores, &ReduceOp::Sum)
+            .map_err(|err| {
+                anyhow::anyhow!("NCCL batch decode indexer score all-reduce failed: {err:?}")
+            })?;
+        let compress_topk = indexer_topk_indices_decode_batch_into(
+            ctx,
+            config,
+            &attention_aux_scratch.indexer_scores,
+            batch_meta.compressed_len,
+            batch_meta.compressed_base,
+            batch_meta.batch,
+            max_compressed_len,
+            &mut attention_index_scratch.compress_idxs,
+        )?;
+        concat_topk_indices_into(
+            ctx,
+            &attention_index_scratch.window_idxs,
+            window_topk,
+            &attention_index_scratch.compress_idxs,
+            compress_topk,
+            batch_meta.batch,
+            &mut attention_index_scratch.topk_idxs,
+        )?;
+        (
+            &attention_index_scratch.topk_idxs,
+            window_topk + compress_topk,
+        )
+    } else {
+        (&attention_index_scratch.window_idxs, window_topk)
+    };
+    indexed_attention_cache_bf16_hidden_view_into(
+        ctx,
+        config,
+        &projections,
+        &cache.kv,
+        attn,
+        topk_idxs,
+        topk,
+        &mut attention_output_scratch.attn_out,
+    )?;
+    attention_output_project_bf16_hidden_batch_scratch(
+        ctx,
+        attn,
+        rope,
+        batch_meta.start_pos,
+        batch_meta.batch,
         attention_output_scratch,
     )
 }

--- a/pegainfer-deepseek-v4/src/runtime/compressor.rs
+++ b/pegainfer-deepseek-v4/src/runtime/compressor.rs
@@ -280,6 +280,22 @@ pub fn compressor_nonoverlap_decode_bf16_hidden(
     start_pos: usize,
     state: &mut CompressorDecodeState,
 ) -> Result<Option<Bf16HiddenStates>> {
+    compressor_nonoverlap_decode_bf16_hidden_at(
+        ctx, config, input, compressor, ratio, rope, start_pos, state, 0,
+    )
+}
+
+pub(crate) fn compressor_nonoverlap_decode_bf16_hidden_at(
+    ctx: &RankGpuContext,
+    config: &Config,
+    input: &Bf16HiddenStates,
+    compressor: &CompressorWeights<'_>,
+    ratio: usize,
+    rope: &DeepSeekRopeCache,
+    start_pos: usize,
+    state: &mut CompressorDecodeState,
+    state_offset: usize,
+) -> Result<Option<Bf16HiddenStates>> {
     ctx.set_current()?;
     ensure!(ratio > 1, "compress ratio must be > 1");
     ensure!(ratio != 4, "ratio=4 uses the overlap compressor path");
@@ -295,11 +311,11 @@ pub fn compressor_nonoverlap_decode_bf16_hidden(
         input.seq_len
     );
     ensure!(
-        state.hidden_dim == config.head_dim && state.slots == ratio,
-        "decode compressor state mismatch: hidden_dim={}, slots={}, expected {}x{}",
+        state.hidden_dim == config.head_dim && state_offset + ratio <= state.slots,
+        "decode compressor state mismatch: hidden_dim={}, slots={}, offset={}, need {} rows",
         state.hidden_dim,
         state.slots,
-        config.head_dim,
+        state_offset,
         ratio
     );
 
@@ -335,7 +351,7 @@ pub fn compressor_nonoverlap_decode_bf16_hidden(
             (ptr::null_mut(), None)
         };
         let result = unsafe {
-            ffi::deepseek_compressor_nonoverlap_decode_cuda(
+            ffi::deepseek_compressor_nonoverlap_decode_at_cuda(
                 x_ptr as *const ffi::Half,
                 wkv_ptr as *const ffi::Half,
                 wgate_ptr as *const ffi::Half,
@@ -349,6 +365,7 @@ pub fn compressor_nonoverlap_decode_bf16_hidden(
                 input.hidden_dim as i32,
                 config.head_dim as i32,
                 ratio as i32,
+                state_offset as i32,
                 config.rms_norm_eps,
                 ctx.stream.cu_stream(),
             )
@@ -393,6 +410,23 @@ pub fn compressor_overlap_decode_bf16_hidden_with_dim(
     state: &mut CompressorDecodeState,
     rotate_fp4: bool,
 ) -> Result<Option<Bf16HiddenStates>> {
+    compressor_overlap_decode_bf16_hidden_with_dim_at(
+        ctx, config, input, compressor, rope, start_pos, head_dim, state, 0, rotate_fp4,
+    )
+}
+
+pub(crate) fn compressor_overlap_decode_bf16_hidden_with_dim_at(
+    ctx: &RankGpuContext,
+    config: &Config,
+    input: &Bf16HiddenStates,
+    compressor: &CompressorWeights<'_>,
+    rope: &DeepSeekRopeCache,
+    start_pos: usize,
+    head_dim: usize,
+    state: &mut CompressorDecodeState,
+    state_offset: usize,
+    rotate_fp4: bool,
+) -> Result<Option<Bf16HiddenStates>> {
     ctx.set_current()?;
     ensure!(
         input.hidden_dim == config.dim,
@@ -406,11 +440,11 @@ pub fn compressor_overlap_decode_bf16_hidden_with_dim(
         input.seq_len
     );
     ensure!(
-        state.hidden_dim == 2 * head_dim && state.slots == 8,
-        "overlap decode compressor state mismatch: hidden_dim={}, slots={}, expected {}x8",
+        state.hidden_dim == 2 * head_dim && state_offset + 8 <= state.slots,
+        "overlap decode compressor state mismatch: hidden_dim={}, slots={}, offset={}, need 8 rows",
         state.hidden_dim,
         state.slots,
-        2 * head_dim
+        state_offset
     );
 
     let should_compress = (start_pos + 1).is_multiple_of(4);
@@ -445,7 +479,7 @@ pub fn compressor_overlap_decode_bf16_hidden_with_dim(
             (ptr::null_mut(), None)
         };
         let result = unsafe {
-            ffi::deepseek_compressor_overlap_decode_cuda(
+            ffi::deepseek_compressor_overlap_decode_at_cuda(
                 x_ptr as *const ffi::Half,
                 wkv_ptr as *const ffi::Half,
                 wgate_ptr as *const ffi::Half,
@@ -458,6 +492,7 @@ pub fn compressor_overlap_decode_bf16_hidden_with_dim(
                 start_pos as i32,
                 input.hidden_dim as i32,
                 head_dim as i32,
+                state_offset as i32,
                 config.rms_norm_eps,
                 ctx.stream.cu_stream(),
             )
@@ -511,8 +546,8 @@ pub(crate) fn compressor_overlap_decode_bf16_hidden_with_dim_scratch<'a>(
         input.seq_len
     );
     ensure!(
-        state.hidden_dim == 2 * head_dim && state.slots == 8,
-        "overlap decode compressor state mismatch: hidden_dim={}, slots={}, expected {}x8",
+        state.hidden_dim == 2 * head_dim && state.slots >= 8,
+        "overlap decode compressor state mismatch: hidden_dim={}, slots={}, expected at least {}x8",
         state.hidden_dim,
         state.slots,
         2 * head_dim

--- a/pegainfer-deepseek-v4/src/runtime/core.rs
+++ b/pegainfer-deepseek-v4/src/runtime/core.rs
@@ -452,6 +452,58 @@ pub(crate) fn rank_local_logits_from_hidden_into(
     Ok(())
 }
 
+pub(crate) fn rank_local_logits_from_hidden_all(
+    ctx: &RankGpuContext,
+    input: &Bf16HiddenStates,
+    head: &TensorRef<'_>,
+) -> Result<F32BatchLogits> {
+    ctx.set_current()?;
+    ensure!(
+        head.tensor.dtype == safetensors::Dtype::BF16,
+        "head weight {} must be BF16, got {:?}",
+        head.name,
+        head.tensor.dtype
+    );
+    ensure!(
+        head.tensor.shape.len() == 2,
+        "head weight {} must be rank-2, got {:?}",
+        head.name,
+        head.tensor.shape
+    );
+    let vocab_size = head.tensor.shape[0];
+    let hidden_dim = head.tensor.shape[1];
+    ensure!(
+        hidden_dim == input.hidden_dim,
+        "head input dim mismatch: head expects {}, got {}",
+        hidden_dim,
+        input.hidden_dim
+    );
+    ensure!(input.seq_len > 0, "logits input seq_len must be positive");
+    let mut out = unsafe { ctx.stream.alloc(input.seq_len * vocab_size)? };
+    {
+        let (x_ptr, _x_guard) = input.data.device_ptr(&ctx.stream);
+        let (head_ptr, _head_guard) = head.tensor.data.device_ptr(&ctx.stream);
+        let (out_ptr, _out_guard) = out.device_ptr_mut(&ctx.stream);
+        let result = unsafe {
+            ffi::deepseek_bf16_logits_cuda(
+                x_ptr as *const ffi::Half,
+                head_ptr as *const ffi::Half,
+                out_ptr as *mut f32,
+                input.seq_len as i32,
+                input.hidden_dim as i32,
+                vocab_size as i32,
+                ctx.stream.cu_stream(),
+            )
+        };
+        result.result()?;
+    }
+    Ok(F32BatchLogits {
+        data: out,
+        vocab_size,
+        seq_len: input.seq_len,
+    })
+}
+
 pub fn final_logits_rank_local_bf16_hidden(
     ctx: &RankGpuContext,
     config: &Config,

--- a/pegainfer-deepseek-v4/src/runtime/indexer.rs
+++ b/pegainfer-deepseek-v4/src/runtime/indexer.rs
@@ -430,6 +430,103 @@ pub(crate) fn indexer_scores_decode_bf16_hidden_scratch(
     Ok(Some(compressed_len))
 }
 
+pub(crate) struct IndexerDecodeBatchInputs<'a> {
+    pub(crate) q: &'a Bf16HiddenStates,
+    pub(crate) kv_cache: &'a Bf16Cache,
+    pub(crate) weights: &'a Bf16HiddenStates,
+    pub(crate) compressed_len: &'a CudaSlice<i32>,
+    pub(crate) cache_base: &'a CudaSlice<i32>,
+    pub(crate) batch: usize,
+    pub(crate) max_compressed_len: usize,
+}
+
+pub(crate) fn indexer_scores_decode_batch_into(
+    ctx: &RankGpuContext,
+    config: &Config,
+    input: IndexerDecodeBatchInputs<'_>,
+    scores: &mut CudaSlice<f32>,
+) -> Result<()> {
+    ctx.set_current()?;
+    ensure!(input.batch > 0, "indexer decode batch must be positive");
+    ensure!(
+        input.q.seq_len == input.batch,
+        "indexer batch q seq_len mismatch: expected {}, got {}",
+        input.batch,
+        input.q.seq_len
+    );
+    ensure!(
+        input.weights.seq_len == input.batch,
+        "indexer batch weights seq_len mismatch: expected {}, got {}",
+        input.batch,
+        input.weights.seq_len
+    );
+    ensure!(
+        input.kv_cache.hidden_dim == config.index_head_dim,
+        "indexer batch kv cache dim mismatch: expected {}, got {}",
+        config.index_head_dim,
+        input.kv_cache.hidden_dim
+    );
+    ensure!(
+        input.compressed_len.len() >= input.batch,
+        "indexer batch compressed_len capacity too small: need {}, have {}",
+        input.batch,
+        input.compressed_len.len()
+    );
+    ensure!(
+        input.cache_base.len() >= input.batch,
+        "indexer batch cache_base capacity too small: need {}, have {}",
+        input.batch,
+        input.cache_base.len()
+    );
+    ensure!(
+        scores.len() >= input.batch * input.max_compressed_len,
+        "indexer batch scores capacity too small: need {}, have {}",
+        input.batch * input.max_compressed_len,
+        scores.len()
+    );
+    let local_heads = config.index_n_heads / 8;
+    ensure!(
+        input.q.hidden_dim == local_heads * config.index_head_dim,
+        "indexer batch q hidden mismatch: expected {}, got {}",
+        local_heads * config.index_head_dim,
+        input.q.hidden_dim
+    );
+    ensure!(
+        input.weights.hidden_dim == local_heads,
+        "indexer batch weights hidden mismatch: expected {}, got {}",
+        local_heads,
+        input.weights.hidden_dim
+    );
+    {
+        let (q_ptr, _q_guard) = input.q.data.device_ptr(&ctx.stream);
+        let (kv_ptr, _kv_guard) = input.kv_cache.data.device_ptr(&ctx.stream);
+        let (weights_ptr, _weights_guard) = input.weights.data.device_ptr(&ctx.stream);
+        let (compressed_ptr, _compressed_guard) = input.compressed_len.device_ptr(&ctx.stream);
+        let (base_ptr, _base_guard) = input.cache_base.device_ptr(&ctx.stream);
+        let (scores_ptr, _scores_guard) = scores.device_ptr_mut(&ctx.stream);
+        let score_scale =
+            1.0f32 / (config.index_head_dim as f32).sqrt() / (config.index_n_heads as f32).sqrt();
+        let result = unsafe {
+            ffi::deepseek_indexer_scores_decode_batch_cuda(
+                q_ptr as *const ffi::Half,
+                kv_ptr as *const ffi::Half,
+                weights_ptr as *const ffi::Half,
+                compressed_ptr as *const i32,
+                base_ptr as *const i32,
+                scores_ptr as *mut f32,
+                input.batch as i32,
+                local_heads as i32,
+                config.index_head_dim as i32,
+                input.max_compressed_len as i32,
+                score_scale,
+                ctx.stream.cu_stream(),
+            )
+        };
+        result.result()?;
+    }
+    Ok(())
+}
+
 pub fn indexer_topk_indices_decode(
     ctx: &RankGpuContext,
     config: &Config,
@@ -487,6 +584,69 @@ where
                 compressed_len as i32,
                 topk as i32,
                 offset as i32,
+                ctx.stream.cu_stream(),
+            )
+        };
+        result.result()?;
+    }
+    Ok(topk)
+}
+
+pub(crate) fn indexer_topk_indices_decode_batch_into(
+    ctx: &RankGpuContext,
+    config: &Config,
+    scores: &CudaSlice<f32>,
+    compressed_len: &CudaSlice<i32>,
+    cache_base: &CudaSlice<i32>,
+    batch: usize,
+    max_compressed_len: usize,
+    topk_idxs: &mut CudaSlice<i32>,
+) -> Result<usize> {
+    ctx.set_current()?;
+    ensure!(batch > 0, "indexer top-k decode batch must be positive");
+    ensure!(
+        max_compressed_len > 0,
+        "indexer top-k max_compressed_len must be positive"
+    );
+    ensure!(
+        scores.len() >= batch * max_compressed_len,
+        "indexer top-k batch scores capacity too small: need {}, have {}",
+        batch * max_compressed_len,
+        scores.len()
+    );
+    ensure!(
+        compressed_len.len() >= batch,
+        "indexer top-k compressed_len capacity too small: need {}, have {}",
+        batch,
+        compressed_len.len()
+    );
+    ensure!(
+        cache_base.len() >= batch,
+        "indexer top-k cache_base capacity too small: need {}, have {}",
+        batch,
+        cache_base.len()
+    );
+    let topk = config.index_topk.min(max_compressed_len);
+    ensure!(
+        topk_idxs.len() >= batch * topk,
+        "indexer top-k output capacity too small: need {}, have {}",
+        batch * topk,
+        topk_idxs.len()
+    );
+    {
+        let (scores_ptr, _scores_guard) = scores.device_ptr(&ctx.stream);
+        let (topk_ptr, _topk_guard) = topk_idxs.device_ptr_mut(&ctx.stream);
+        let (compressed_ptr, _compressed_guard) = compressed_len.device_ptr(&ctx.stream);
+        let (base_ptr, _base_guard) = cache_base.device_ptr(&ctx.stream);
+        let result = unsafe {
+            ffi::deepseek_indexer_topk_decode_batch_cuda(
+                scores_ptr as *const f32,
+                topk_ptr as *mut i32,
+                compressed_ptr as *const i32,
+                base_ptr as *const i32,
+                batch as i32,
+                max_compressed_len as i32,
+                topk as i32,
                 ctx.stream.cu_stream(),
             )
         };

--- a/pegainfer-deepseek-v4/src/runtime/state.rs
+++ b/pegainfer-deepseek-v4/src/runtime/state.rs
@@ -81,6 +81,19 @@ pub(crate) struct DecodeEntryScratch {
     pub(crate) hc_expand: HcHiddenStates,
 }
 
+pub(crate) struct DecodeBatchMeta<'a> {
+    pub(crate) batch: usize,
+    pub(crate) compressed_slots: usize,
+    pub(crate) start_pos: &'a CudaSlice<i32>,
+    pub(crate) src_rows: &'a CudaSlice<i32>,
+    pub(crate) window_dst_rows: &'a CudaSlice<i32>,
+    pub(crate) window_base: &'a CudaSlice<i32>,
+    pub(crate) compressed_base: &'a CudaSlice<i32>,
+    pub(crate) compressed_len: &'a CudaSlice<i32>,
+    pub(crate) start_pos_host: &'a [usize],
+    pub(crate) slot_ids_host: &'a [usize],
+}
+
 pub(crate) struct HcPostScratch {
     pub(crate) attention_reduce_temp: CudaSlice<f32>,
     pub(crate) attention_out: HcHiddenStates,
@@ -156,6 +169,12 @@ pub(crate) struct AttentionAuxScratch {
 pub struct F32Logits {
     pub data: CudaSlice<f32>,
     pub vocab_size: usize,
+}
+
+pub(crate) struct F32BatchLogits {
+    pub(crate) data: CudaSlice<f32>,
+    pub(crate) vocab_size: usize,
+    pub(crate) seq_len: usize,
 }
 
 pub struct RoutedExperts {
@@ -557,14 +576,19 @@ impl AttentionOutputScratch {
 }
 
 impl AttentionIndexScratch {
-    pub(crate) fn new(ctx: &RankGpuContext, config: &Config) -> Result<Self> {
+    pub(crate) fn new(ctx: &RankGpuContext, config: &Config, seq_capacity: usize) -> Result<Self> {
         ctx.set_current()?;
         ensure!(
             config.sliding_window > 0,
             "attention index scratch sliding_window must be positive"
         );
-        let window_capacity = config.sliding_window;
-        let compress_capacity = config.index_topk;
+        ensure!(
+            seq_capacity > 0,
+            "attention index scratch seq_capacity must be positive"
+        );
+        let window_capacity = seq_capacity * config.sliding_window;
+        let max_compressed_len = config.max_position_embeddings.div_ceil(4).max(1);
+        let compress_capacity = seq_capacity * max_compressed_len;
         let compress_alloc = compress_capacity.max(1);
         let window_idxs = unsafe { ctx.stream.alloc(window_capacity)? };
         let compress_idxs = unsafe { ctx.stream.alloc(compress_alloc)? };
@@ -578,11 +602,20 @@ impl AttentionIndexScratch {
 }
 
 impl AttentionAuxScratch {
-    pub(crate) fn new(ctx: &RankGpuContext, config: &Config, world_size: usize) -> Result<Self> {
+    pub(crate) fn new(
+        ctx: &RankGpuContext,
+        config: &Config,
+        world_size: usize,
+        seq_capacity: usize,
+    ) -> Result<Self> {
         ctx.set_current()?;
         ensure!(
             world_size > 0,
             "attention aux scratch world size must be positive"
+        );
+        ensure!(
+            seq_capacity > 0,
+            "attention aux scratch seq_capacity must be positive"
         );
         ensure!(
             config.index_n_heads.is_multiple_of(world_size),
@@ -596,9 +629,9 @@ impl AttentionAuxScratch {
         let compressor_weighted = unsafe { ctx.stream.alloc(max_head_dim)? };
         let compressor_out = Bf16HiddenStates::uninit(ctx, max_head_dim, 1)?;
         let indexer_q =
-            Bf16HiddenStates::uninit(ctx, local_index_heads * config.index_head_dim, 1)?;
-        let indexer_weights = Bf16HiddenStates::uninit(ctx, local_index_heads, 1)?;
-        let indexer_scores = unsafe { ctx.stream.alloc(max_compressed_len)? };
+            Bf16HiddenStates::uninit(ctx, local_index_heads * config.index_head_dim, seq_capacity)?;
+        let indexer_weights = Bf16HiddenStates::uninit(ctx, local_index_heads, seq_capacity)?;
+        let indexer_scores = unsafe { ctx.stream.alloc(seq_capacity * max_compressed_len)? };
         Ok(Self {
             compressor_weighted,
             compressor_out,
@@ -701,12 +734,26 @@ impl LayerDecodeCache {
         layer: usize,
         max_seq_len: usize,
     ) -> Result<Self> {
+        Self::zeros_with_max_seq_and_slots(ctx, config, layer, max_seq_len, 1)
+    }
+
+    pub(crate) fn zeros_with_max_seq_and_slots(
+        ctx: &RankGpuContext,
+        config: &Config,
+        layer: usize,
+        max_seq_len: usize,
+        request_slots: usize,
+    ) -> Result<Self> {
         ctx.set_current()?;
         ensure!(
             layer < config.compress_ratios.len(),
             "decode cache layer {layer} out of range"
         );
         ensure!(max_seq_len > 0, "decode cache max_seq_len must be positive");
+        ensure!(
+            request_slots > 0,
+            "decode cache request slots must be positive"
+        );
         let ratio = config.compress_ratios[layer];
         let compressed_slots = if ratio > 0 {
             max_seq_len.div_ceil(ratio)
@@ -716,7 +763,7 @@ impl LayerDecodeCache {
         let kv = Bf16Cache::zeros(
             ctx,
             config.head_dim,
-            config.sliding_window + compressed_slots,
+            request_slots * (config.sliding_window + compressed_slots),
         )?;
         let compressor = if ratio == 0 {
             None
@@ -724,14 +771,14 @@ impl LayerDecodeCache {
             Some(CompressorDecodeState::zeros(
                 ctx,
                 2 * config.head_dim,
-                2 * ratio,
+                request_slots * 2 * ratio,
                 f32::NEG_INFINITY,
             )?)
         } else {
             Some(CompressorDecodeState::zeros(
                 ctx,
                 config.head_dim,
-                ratio,
+                request_slots * ratio,
                 f32::NEG_INFINITY,
             )?)
         };
@@ -739,7 +786,7 @@ impl LayerDecodeCache {
             Some(Bf16Cache::zeros(
                 ctx,
                 config.index_head_dim,
-                max_seq_len.div_ceil(ratio),
+                request_slots * max_seq_len.div_ceil(ratio),
             )?)
         } else {
             None
@@ -748,7 +795,7 @@ impl LayerDecodeCache {
             Some(CompressorDecodeState::zeros(
                 ctx,
                 2 * config.index_head_dim,
-                2 * ratio,
+                request_slots * 2 * ratio,
                 f32::NEG_INFINITY,
             )?)
         } else {
@@ -803,6 +850,54 @@ pub fn copy_bf16_rows_to_cache(
                 rows as i32,
                 src_start_row as i32,
                 dst_start_row as i32,
+                ctx.stream.cu_stream(),
+            )
+        };
+        result.result()?;
+    }
+    Ok(())
+}
+
+pub(crate) fn copy_bf16_rows_to_cache_indexed(
+    ctx: &RankGpuContext,
+    src: &Bf16HiddenStates,
+    cache: &mut Bf16Cache,
+    src_rows: &CudaSlice<i32>,
+    dst_rows: &CudaSlice<i32>,
+    rows: usize,
+) -> Result<()> {
+    ctx.set_current()?;
+    ensure!(
+        src.hidden_dim == cache.hidden_dim,
+        "indexed copy rows hidden mismatch: src={}, cache={}",
+        src.hidden_dim,
+        cache.hidden_dim
+    );
+    ensure!(
+        src_rows.len() >= rows,
+        "indexed copy source rows capacity too small: need {}, have {}",
+        rows,
+        src_rows.len()
+    );
+    ensure!(
+        dst_rows.len() >= rows,
+        "indexed copy destination rows capacity too small: need {}, have {}",
+        rows,
+        dst_rows.len()
+    );
+    {
+        let (src_ptr, _src_guard) = src.data.device_ptr(&ctx.stream);
+        let (dst_ptr, _dst_guard) = cache.data.device_ptr_mut(&ctx.stream);
+        let (src_rows_ptr, _src_rows_guard) = src_rows.device_ptr(&ctx.stream);
+        let (dst_rows_ptr, _dst_rows_guard) = dst_rows.device_ptr(&ctx.stream);
+        let result = unsafe {
+            ffi::deepseek_bf16_copy_rows_indexed_cuda(
+                src_ptr as *const ffi::Half,
+                dst_ptr as *mut ffi::Half,
+                src_rows_ptr as *const i32,
+                dst_rows_ptr as *const i32,
+                cache.hidden_dim as i32,
+                rows as i32,
                 ctx.stream.cu_stream(),
             )
         };

--- a/pegainfer-kernels/csrc/deepseek_v4/deepseek_attention.cu
+++ b/pegainfer-kernels/csrc/deepseek_v4/deepseek_attention.cu
@@ -145,6 +145,47 @@ __global__ void deepseek_apply_rope_q_kv_kernel(
   }
 }
 
+__global__ void deepseek_apply_rope_q_kv_batch_kernel(
+    __nv_bfloat16 *__restrict__ q,
+    __nv_bfloat16 *__restrict__ kv,
+    const float *__restrict__ cos_cache,
+    const float *__restrict__ sin_cache,
+    const int *__restrict__ start_pos,
+    int seq_len,
+    int local_heads,
+    int head_dim,
+    int rotary_dim) {
+  int pair = blockIdx.x * blockDim.x + threadIdx.x;
+  int total_q_pairs = seq_len * local_heads * (rotary_dim / 2);
+  int nope_dim = head_dim - rotary_dim;
+
+  if (pair < total_q_pairs) {
+    int rotary_pair = pair % (rotary_dim / 2);
+    int tmp = pair / (rotary_dim / 2);
+    int head = tmp % local_heads;
+    int token = tmp / local_heads;
+    int pos = start_pos[token];
+    if (pos < 0) return;
+    int q_offset = token * local_heads * head_dim + head * head_dim + nope_dim + 2 * rotary_pair;
+    deepseek_apply_rope_pair(
+        q, q_offset, cos_cache[pos * (rotary_dim / 2) + rotary_pair],
+        sin_cache[pos * (rotary_dim / 2) + rotary_pair], false);
+  }
+
+  int kv_pair = pair - total_q_pairs;
+  int total_kv_pairs = seq_len * (rotary_dim / 2);
+  if (kv_pair >= 0 && kv_pair < total_kv_pairs) {
+    int rotary_pair = kv_pair % (rotary_dim / 2);
+    int token = kv_pair / (rotary_dim / 2);
+    int pos = start_pos[token];
+    if (pos < 0) return;
+    int kv_offset = token * head_dim + nope_dim + 2 * rotary_pair;
+    deepseek_apply_rope_pair(
+        kv, kv_offset, cos_cache[pos * (rotary_dim / 2) + rotary_pair],
+        sin_cache[pos * (rotary_dim / 2) + rotary_pair], false);
+  }
+}
+
 __global__ void deepseek_fill_rope_cache_kernel(
     const float *__restrict__ inv_freq,
     float *__restrict__ cos_cache,
@@ -276,6 +317,30 @@ cudaError_t deepseek_apply_rope_q_kv_cuda(
   int blocks = (total_pairs + threads - 1) / threads;
   deepseek_apply_rope_q_kv_kernel<<<blocks, threads, 0, stream>>>(
       q, kv, cos_cache, sin_cache, seq_len, local_heads, head_dim, rotary_dim, start_pos);
+  return cudaGetLastError();
+}
+
+cudaError_t deepseek_apply_rope_q_kv_batch_cuda(
+    __nv_bfloat16 *q,
+    __nv_bfloat16 *kv,
+    const float *cos_cache,
+    const float *sin_cache,
+    const int *start_pos,
+    int seq_len,
+    int local_heads,
+    int head_dim,
+    int rotary_dim,
+    cudaStream_t stream) {
+  if (q == nullptr || kv == nullptr || cos_cache == nullptr || sin_cache == nullptr ||
+      start_pos == nullptr || seq_len <= 0 || local_heads <= 0 || head_dim <= 0 ||
+      rotary_dim <= 0 || rotary_dim > head_dim || (rotary_dim % 2) != 0) {
+    return cudaErrorInvalidValue;
+  }
+  constexpr int threads = 256;
+  int total_pairs = seq_len * (local_heads + 1) * (rotary_dim / 2);
+  int blocks = (total_pairs + threads - 1) / threads;
+  deepseek_apply_rope_q_kv_batch_kernel<<<blocks, threads, 0, stream>>>(
+      q, kv, cos_cache, sin_cache, start_pos, seq_len, local_heads, head_dim, rotary_dim);
   return cudaGetLastError();
 }
 

--- a/pegainfer-kernels/csrc/deepseek_v4/deepseek_compressor.cu
+++ b/pegainfer-kernels/csrc/deepseek_v4/deepseek_compressor.cu
@@ -90,6 +90,33 @@ __global__ void deepseek_apply_rope_hidden_kernel(
       sin_cache[pos * (rotary_dim / 2) + rotary_pair], inverse != 0);
 }
 
+__global__ void deepseek_apply_rope_hidden_batch_kernel(
+    __nv_bfloat16 *__restrict__ x,
+    const float *__restrict__ cos_cache,
+    const float *__restrict__ sin_cache,
+    const int *__restrict__ start_pos,
+    int seq_len,
+    int local_heads,
+    int head_dim,
+    int rotary_dim,
+    int inverse) {
+  int pair = blockIdx.x * blockDim.x + threadIdx.x;
+  int total_pairs = seq_len * local_heads * (rotary_dim / 2);
+  if (pair >= total_pairs) return;
+
+  int rotary_pair = pair % (rotary_dim / 2);
+  int tmp = pair / (rotary_dim / 2);
+  int head = tmp % local_heads;
+  int token = tmp / local_heads;
+  int nope_dim = head_dim - rotary_dim;
+  int pos = start_pos[token];
+  if (pos < 0) return;
+  int offset = token * local_heads * head_dim + head * head_dim + nope_dim + 2 * rotary_pair;
+  deepseek_apply_rope_pair(
+      x, offset, cos_cache[pos * (rotary_dim / 2) + rotary_pair],
+      sin_cache[pos * (rotary_dim / 2) + rotary_pair], inverse != 0);
+}
+
 __global__ void deepseek_apply_rope_hidden_strided_kernel(
     __nv_bfloat16 *__restrict__ x,
     const float *__restrict__ cos_cache,
@@ -680,6 +707,30 @@ cudaError_t deepseek_apply_rope_hidden_cuda(
   return cudaGetLastError();
 }
 
+cudaError_t deepseek_apply_rope_hidden_batch_cuda(
+    __nv_bfloat16 *x,
+    const float *cos_cache,
+    const float *sin_cache,
+    const int *start_pos,
+    int seq_len,
+    int local_heads,
+    int head_dim,
+    int rotary_dim,
+    int inverse,
+    cudaStream_t stream) {
+  if (x == nullptr || cos_cache == nullptr || sin_cache == nullptr || start_pos == nullptr ||
+      seq_len <= 0 || local_heads <= 0 || head_dim <= 0 || rotary_dim <= 0 ||
+      rotary_dim > head_dim || (rotary_dim % 2) != 0) {
+    return cudaErrorInvalidValue;
+  }
+  constexpr int threads = 256;
+  int total_pairs = seq_len * local_heads * (rotary_dim / 2);
+  int blocks = (total_pairs + threads - 1) / threads;
+  deepseek_apply_rope_hidden_batch_kernel<<<blocks, threads, 0, stream>>>(
+      x, cos_cache, sin_cache, start_pos, seq_len, local_heads, head_dim, rotary_dim, inverse);
+  return cudaGetLastError();
+}
+
 cudaError_t deepseek_apply_rope_hidden_strided_cuda(
     __nv_bfloat16 *x,
     const float *cos_cache,
@@ -851,6 +902,53 @@ cudaError_t deepseek_compressor_nonoverlap_decode_cuda(
   return cudaGetLastError();
 }
 
+cudaError_t deepseek_compressor_nonoverlap_decode_at_cuda(
+    const __nv_bfloat16 *x,
+    const __nv_bfloat16 *wkv,
+    const __nv_bfloat16 *wgate,
+    const float *ape,
+    const __nv_bfloat16 *norm,
+    float *kv_state,
+    float *score_state,
+    float *weighted,
+    __nv_bfloat16 *out,
+    int start_pos,
+    int hidden_dim,
+    int head_dim,
+    int ratio,
+    int state_offset,
+    float eps,
+    cudaStream_t stream) {
+  if (start_pos < 0 || hidden_dim <= 0 || head_dim <= 0 || ratio <= 1 || ratio > 128 ||
+      state_offset < 0) {
+    return cudaErrorInvalidValue;
+  }
+  constexpr int threads = 256;
+  size_t project_shared = 2 * threads * sizeof(float);
+  deepseek_compressor_decode_project_kernel<<<head_dim, threads, project_shared, stream>>>(
+      x, wkv, wgate, ape, kv_state, score_state, start_pos, hidden_dim, head_dim, ratio,
+      state_offset);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) return err;
+
+  bool should_compress = ((start_pos + 1) % ratio) == 0;
+  if (!should_compress) return cudaSuccess;
+  if (weighted == nullptr || out == nullptr) return cudaErrorInvalidValue;
+
+  int blocks = (head_dim + threads - 1) / threads;
+  float *kv_slot = kv_state + state_offset * head_dim;
+  float *score_slot = score_state + state_offset * head_dim;
+  deepseek_compressor_nonoverlap_decode_weighted_kernel<<<blocks, threads, 0, stream>>>(
+      kv_slot, score_slot, weighted, head_dim, ratio);
+  err = cudaGetLastError();
+  if (err != cudaSuccess) return err;
+
+  int norm_blocks = (head_dim + threads - 1) / threads;
+  deepseek_compressor_norm_serial_kernel<<<norm_blocks, threads, 0, stream>>>(
+      weighted, norm, out, 1, head_dim, eps);
+  return cudaGetLastError();
+}
+
 cudaError_t deepseek_compressor_overlap_decode_cuda(
     const __nv_bfloat16 *x,
     const __nv_bfloat16 *wkv,
@@ -898,6 +996,60 @@ cudaError_t deepseek_compressor_overlap_decode_cuda(
   int shift_blocks = (shift_total + threads - 1) / threads;
   deepseek_compressor_overlap_shift_kernel<<<shift_blocks, threads, 0, stream>>>(
       kv_state, score_state, state_dim);
+  return cudaGetLastError();
+}
+
+cudaError_t deepseek_compressor_overlap_decode_at_cuda(
+    const __nv_bfloat16 *x,
+    const __nv_bfloat16 *wkv,
+    const __nv_bfloat16 *wgate,
+    const float *ape,
+    const __nv_bfloat16 *norm,
+    float *kv_state,
+    float *score_state,
+    float *weighted,
+    __nv_bfloat16 *out,
+    int start_pos,
+    int hidden_dim,
+    int head_dim,
+    int state_offset,
+    float eps,
+    cudaStream_t stream) {
+  if (start_pos < 0 || hidden_dim <= 0 || head_dim <= 0 || state_offset < 0) {
+    return cudaErrorInvalidValue;
+  }
+  constexpr int ratio = 4;
+  constexpr int threads = 256;
+  int state_dim = 2 * head_dim;
+  size_t project_shared = 2 * threads * sizeof(float);
+  deepseek_compressor_decode_project_kernel<<<state_dim, threads, project_shared, stream>>>(
+      x, wkv, wgate, ape, kv_state, score_state, start_pos, hidden_dim, state_dim, ratio,
+      state_offset + ratio);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) return err;
+
+  bool should_compress = ((start_pos + 1) % ratio) == 0;
+  if (!should_compress) return cudaSuccess;
+  if (weighted == nullptr || out == nullptr) return cudaErrorInvalidValue;
+
+  int blocks = (head_dim + threads - 1) / threads;
+  float *kv_slot = kv_state + state_offset * state_dim;
+  float *score_slot = score_state + state_offset * state_dim;
+  deepseek_compressor_overlap_decode_weighted_kernel<<<blocks, threads, 0, stream>>>(
+      kv_slot, score_slot, weighted, head_dim);
+  err = cudaGetLastError();
+  if (err != cudaSuccess) return err;
+
+  int norm_blocks = (head_dim + threads - 1) / threads;
+  deepseek_compressor_norm_serial_kernel<<<norm_blocks, threads, 0, stream>>>(
+      weighted, norm, out, 1, head_dim, eps);
+  err = cudaGetLastError();
+  if (err != cudaSuccess) return err;
+
+  int shift_total = ratio * state_dim;
+  int shift_blocks = (shift_total + threads - 1) / threads;
+  deepseek_compressor_overlap_shift_kernel<<<shift_blocks, threads, 0, stream>>>(
+      kv_slot, score_slot, state_dim);
   return cudaGetLastError();
 }
 

--- a/pegainfer-kernels/csrc/deepseek_v4/deepseek_hc.cu
+++ b/pegainfer-kernels/csrc/deepseek_v4/deepseek_hc.cu
@@ -689,6 +689,40 @@ __global__ void deepseek_last_token_bf16_logits_kernel(
   }
 }
 
+__global__ void deepseek_bf16_logits_kernel(
+    const __nv_bfloat16 *__restrict__ x,
+    const __nv_bfloat16 *__restrict__ weight,
+    float *__restrict__ out,
+    int seq_len,
+    int dim,
+    int vocab_size) {
+  int vocab = blockIdx.x;
+  int token = blockIdx.y;
+  int tid = threadIdx.x;
+  if (vocab >= vocab_size || token >= seq_len) return;
+
+  extern __shared__ float scratch[];
+  int token_base = token * dim;
+  float partial = 0.0f;
+  for (int k = tid; k < dim; k += blockDim.x) {
+    partial += __bfloat162float(x[token_base + k]) *
+               __bfloat162float(weight[vocab * dim + k]);
+  }
+  scratch[tid] = partial;
+  __syncthreads();
+
+  for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+    if (tid < stride) {
+      scratch[tid] += scratch[tid + stride];
+    }
+    __syncthreads();
+  }
+
+  if (tid == 0) {
+    out[token * vocab_size + vocab] = scratch[0];
+  }
+}
+
 extern "C" {
 
 cudaError_t deepseek_hc_expand_cuda(
@@ -1008,6 +1042,25 @@ cudaError_t deepseek_last_token_bf16_logits_cuda(
       1);
   if (status != CUBLAS_STATUS_SUCCESS) return cudaErrorUnknown;
   return cudaSuccess;
+}
+
+cudaError_t deepseek_bf16_logits_cuda(
+    const __nv_bfloat16 *x,
+    const __nv_bfloat16 *weight,
+    float *out,
+    int seq_len,
+    int dim,
+    int vocab_size,
+    cudaStream_t stream) {
+  if (seq_len <= 0 || dim <= 0 || vocab_size <= 0) {
+    return cudaErrorInvalidValue;
+  }
+  constexpr int threads = 256;
+  dim3 grid(vocab_size, seq_len);
+  size_t shared_bytes = threads * sizeof(float);
+  deepseek_bf16_logits_kernel<<<grid, threads, shared_bytes, stream>>>(
+      x, weight, out, seq_len, dim, vocab_size);
+  return cudaGetLastError();
 }
 
 }  // extern "C"

--- a/pegainfer-kernels/csrc/deepseek_v4/deepseek_indexer.cu
+++ b/pegainfer-kernels/csrc/deepseek_v4/deepseek_indexer.cu
@@ -247,6 +247,46 @@ __global__ void deepseek_indexer_scores_decode_serial_kernel(
   scores[compressed] = acc * score_scale;
 }
 
+__global__ void deepseek_indexer_scores_decode_batch_kernel(
+    const __nv_bfloat16 *__restrict__ q,
+    const __nv_bfloat16 *__restrict__ kv,
+    const __nv_bfloat16 *__restrict__ weights,
+    const int *__restrict__ compressed_len,
+    const int *__restrict__ cache_base,
+    float *__restrict__ scores,
+    int batch,
+    int local_heads,
+    int head_dim,
+    int max_compressed_len,
+    float score_scale) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int total = batch * max_compressed_len;
+  if (idx >= total) return;
+  int token = idx / max_compressed_len;
+  int compressed = idx - token * max_compressed_len;
+  int valid = compressed_len[token];
+  if (compressed >= valid) {
+    scores[idx] = -3.4028234663852886e38f;
+    return;
+  }
+
+  float acc = 0.0f;
+  for (int head = 0; head < local_heads; ++head) {
+    float dot = 0.0f;
+    int q_base = token * local_heads * head_dim + head * head_dim;
+    int kv_base = (cache_base[token] + compressed) * head_dim;
+    for (int dim = 0; dim < head_dim; ++dim) {
+      float qv = __bfloat162float(q[q_base + dim]);
+      float kvv = __bfloat162float(kv[kv_base + dim]);
+      dot += qv * kvv;
+    }
+    float weight = __bfloat162float(weights[token * local_heads + head]);
+    acc += fmaxf(dot, 0.0f) * weight;
+  }
+
+  scores[idx] = acc * score_scale;
+}
+
 __global__ void deepseek_indexer_topk_decode_kernel(
     const float *__restrict__ scores,
     int *__restrict__ topk_idxs,
@@ -272,6 +312,45 @@ __global__ void deepseek_indexer_topk_decode_kernel(
       }
       topk_idxs[route] =
           best_idx >= 0 && best_score > -3.0e38f ? best_idx + offset : -1;
+      if (best_idx >= 0) {
+        select_scores[best_idx] = -3.4028234663852886e38f;
+      }
+    }
+  }
+}
+
+__global__ void deepseek_indexer_topk_decode_batch_kernel(
+    const float *__restrict__ scores,
+    int *__restrict__ topk_idxs,
+    const int *__restrict__ compressed_len,
+    const int *__restrict__ cache_base,
+    int batch,
+    int max_compressed_len,
+    int topk) {
+  int token = blockIdx.x;
+  if (token >= batch) return;
+
+  extern __shared__ float select_scores[];
+  int valid = compressed_len[token];
+  for (int idx = threadIdx.x; idx < max_compressed_len; idx += blockDim.x) {
+    select_scores[idx] = idx < valid ? scores[token * max_compressed_len + idx]
+                                     : -3.4028234663852886e38f;
+  }
+  __syncthreads();
+
+  if (threadIdx.x == 0) {
+    for (int route = 0; route < topk; ++route) {
+      int best_idx = -1;
+      float best_score = -3.4028234663852886e38f;
+      for (int candidate = 0; candidate < max_compressed_len; ++candidate) {
+        float score = select_scores[candidate];
+        if (score > best_score) {
+          best_score = score;
+          best_idx = candidate;
+        }
+      }
+      topk_idxs[token * topk + route] =
+          best_idx >= 0 && best_score > -3.0e38f ? cache_base[token] + best_idx : -1;
       if (best_idx >= 0) {
         select_scores[best_idx] = -3.4028234663852886e38f;
       }
@@ -329,6 +408,34 @@ __global__ void deepseek_window_topk_indices_decode_kernel(
   }
 }
 
+__global__ void deepseek_window_topk_indices_decode_batch_kernel(
+    int *__restrict__ out,
+    const int *__restrict__ start_pos,
+    const int *__restrict__ cache_base,
+    int batch,
+    int window_size,
+    int topk) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int total = batch * topk;
+  if (idx >= total) return;
+  int token = idx / topk;
+  int route = idx - token * topk;
+  int pos = start_pos[token];
+  if (pos < 0) {
+    out[idx] = -1;
+    return;
+  }
+  int logical = -1;
+  if (pos >= window_size - 1) {
+    int ring_pos = pos % window_size;
+    int first_count = window_size - 1 - ring_pos;
+    logical = route < first_count ? ring_pos + 1 + route : route - first_count;
+  } else {
+    logical = route <= pos ? route : -1;
+  }
+  out[idx] = logical >= 0 ? cache_base[token] + logical : -1;
+}
+
 __global__ void deepseek_compress_topk_indices_kernel(
     int *__restrict__ out,
     int seq_len,
@@ -351,6 +458,21 @@ __global__ void deepseek_compress_topk_indices_decode_kernel(
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx >= compressed) return;
   out[idx] = offset + idx;
+}
+
+__global__ void deepseek_compress_topk_indices_decode_batch_kernel(
+    int *__restrict__ out,
+    const int *__restrict__ compressed_len,
+    const int *__restrict__ cache_base,
+    int batch,
+    int topk) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int total = batch * topk;
+  if (idx >= total) return;
+  int token = idx / topk;
+  int route = idx - token * topk;
+  int compressed = compressed_len[token];
+  out[idx] = route < compressed ? cache_base[token] + route : -1;
 }
 
 __global__ void deepseek_window_and_compress_topk_indices_kernel(
@@ -473,6 +595,33 @@ cudaError_t deepseek_indexer_scores_decode_cuda(
   return cudaGetLastError();
 }
 
+cudaError_t deepseek_indexer_scores_decode_batch_cuda(
+    const __nv_bfloat16 *q,
+    const __nv_bfloat16 *kv,
+    const __nv_bfloat16 *weights,
+    const int *compressed_len,
+    const int *cache_base,
+    float *scores,
+    int batch,
+    int local_heads,
+    int head_dim,
+    int max_compressed_len,
+    float score_scale,
+    cudaStream_t stream) {
+  if (q == nullptr || kv == nullptr || weights == nullptr || compressed_len == nullptr ||
+      cache_base == nullptr || scores == nullptr || batch <= 0 || local_heads <= 0 ||
+      head_dim <= 0 || max_compressed_len <= 0) {
+    return cudaErrorInvalidValue;
+  }
+  constexpr int threads = 256;
+  int total = batch * max_compressed_len;
+  int blocks = (total + threads - 1) / threads;
+  deepseek_indexer_scores_decode_batch_kernel<<<blocks, threads, 0, stream>>>(
+      q, kv, weights, compressed_len, cache_base, scores, batch, local_heads, head_dim,
+      max_compressed_len, score_scale);
+  return cudaGetLastError();
+}
+
 cudaError_t deepseek_indexer_topk_decode_cuda(
     const float *scores,
     int *topk_idxs,
@@ -487,6 +636,27 @@ cudaError_t deepseek_indexer_topk_decode_cuda(
   size_t shared_bytes = compressed_len * sizeof(float);
   deepseek_indexer_topk_decode_kernel<<<1, threads, shared_bytes, stream>>>(
       scores, topk_idxs, compressed_len, topk, offset);
+  return cudaGetLastError();
+}
+
+cudaError_t deepseek_indexer_topk_decode_batch_cuda(
+    const float *scores,
+    int *topk_idxs,
+    const int *compressed_len,
+    const int *cache_base,
+    int batch,
+    int max_compressed_len,
+    int topk,
+    cudaStream_t stream) {
+  if (scores == nullptr || topk_idxs == nullptr || compressed_len == nullptr ||
+      cache_base == nullptr || batch <= 0 || max_compressed_len <= 0 || topk <= 0 ||
+      topk > max_compressed_len) {
+    return cudaErrorInvalidValue;
+  }
+  constexpr int threads = 256;
+  size_t shared_bytes = max_compressed_len * sizeof(float);
+  deepseek_indexer_topk_decode_batch_kernel<<<batch, threads, shared_bytes, stream>>>(
+      scores, topk_idxs, compressed_len, cache_base, batch, max_compressed_len, topk);
   return cudaGetLastError();
 }
 
@@ -534,6 +704,26 @@ cudaError_t deepseek_window_topk_indices_decode_cuda(
   return cudaGetLastError();
 }
 
+cudaError_t deepseek_window_topk_indices_decode_batch_cuda(
+    int *out,
+    const int *start_pos,
+    const int *cache_base,
+    int batch,
+    int window_size,
+    int topk,
+    cudaStream_t stream) {
+  if (batch <= 0 || window_size <= 0 || topk <= 0 || start_pos == nullptr ||
+      cache_base == nullptr) {
+    return cudaErrorInvalidValue;
+  }
+  constexpr int threads = 256;
+  int total = batch * topk;
+  int blocks = (total + threads - 1) / threads;
+  deepseek_window_topk_indices_decode_batch_kernel<<<blocks, threads, 0, stream>>>(
+      out, start_pos, cache_base, batch, window_size, topk);
+  return cudaGetLastError();
+}
+
 cudaError_t deepseek_compress_topk_indices_cuda(
     int *out,
     int seq_len,
@@ -561,6 +751,25 @@ cudaError_t deepseek_compress_topk_indices_decode_cuda(
   int blocks = (compressed + threads - 1) / threads;
   deepseek_compress_topk_indices_decode_kernel<<<blocks, threads, 0, stream>>>(
       out, compressed, offset);
+  return cudaGetLastError();
+}
+
+cudaError_t deepseek_compress_topk_indices_decode_batch_cuda(
+    int *out,
+    const int *compressed_len,
+    const int *cache_base,
+    int batch,
+    int topk,
+    cudaStream_t stream) {
+  if (batch <= 0 || topk < 0 || compressed_len == nullptr || cache_base == nullptr) {
+    return cudaErrorInvalidValue;
+  }
+  if (topk == 0) return cudaSuccess;
+  constexpr int threads = 256;
+  int total = batch * topk;
+  int blocks = (total + threads - 1) / threads;
+  deepseek_compress_topk_indices_decode_batch_kernel<<<blocks, threads, 0, stream>>>(
+      out, compressed_len, cache_base, batch, topk);
   return cudaGetLastError();
 }
 

--- a/pegainfer-kernels/csrc/deepseek_v4/deepseek_quant.cu
+++ b/pegainfer-kernels/csrc/deepseek_v4/deepseek_quant.cu
@@ -349,6 +349,24 @@ __global__ void deepseek_bf16_copy_rows_kernel(
       src[(src_start_row + row) * hidden_dim + col];
 }
 
+__global__ void deepseek_bf16_copy_rows_indexed_kernel(
+    const __nv_bfloat16 *__restrict__ src,
+    __nv_bfloat16 *__restrict__ dst,
+    const int *__restrict__ src_rows,
+    const int *__restrict__ dst_rows,
+    int hidden_dim,
+    int rows) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int total = hidden_dim * rows;
+  if (idx >= total) return;
+  int row = idx / hidden_dim;
+  int col = idx - row * hidden_dim;
+  int src_row = src_rows[row];
+  int dst_row = dst_rows[row];
+  if (src_row < 0 || dst_row < 0) return;
+  dst[dst_row * hidden_dim + col] = src[src_row * hidden_dim + col];
+}
+
 extern "C" int deepseek_tilelang_act_quant_k4096(
     const void* x,
     void* y,
@@ -1009,6 +1027,26 @@ cudaError_t deepseek_bf16_copy_rows_cuda(
   int blocks = (total + threads - 1) / threads;
   deepseek_bf16_copy_rows_kernel<<<blocks, threads, 0, stream>>>(
       src, dst, hidden_dim, rows, src_start_row, dst_start_row);
+  return cudaGetLastError();
+}
+
+cudaError_t deepseek_bf16_copy_rows_indexed_cuda(
+    const __nv_bfloat16 *src,
+    __nv_bfloat16 *dst,
+    const int *src_rows,
+    const int *dst_rows,
+    int hidden_dim,
+    int rows,
+    cudaStream_t stream) {
+  if (hidden_dim <= 0 || rows < 0 || src_rows == nullptr || dst_rows == nullptr) {
+    return cudaErrorInvalidValue;
+  }
+  if (rows == 0) return cudaSuccess;
+  constexpr int threads = 256;
+  int total = hidden_dim * rows;
+  int blocks = (total + threads - 1) / threads;
+  deepseek_bf16_copy_rows_indexed_kernel<<<blocks, threads, 0, stream>>>(
+      src, dst, src_rows, dst_rows, hidden_dim, rows);
   return cudaGetLastError();
 }
 

--- a/pegainfer-kernels/src/ffi.rs
+++ b/pegainfer-kernels/src/ffi.rs
@@ -433,6 +433,19 @@ unsafe extern "C" {
         stream: CUstream,
     ) -> CUresult;
 
+    pub fn deepseek_apply_rope_q_kv_batch_cuda(
+        q: *mut Half,
+        kv: *mut Half,
+        cos_cache: *const f32,
+        sin_cache: *const f32,
+        start_pos: *const i32,
+        seq_len: i32,
+        local_heads: i32,
+        head_dim: i32,
+        rotary_dim: i32,
+        stream: CUstream,
+    ) -> CUresult;
+
     pub fn deepseek_fill_rope_cache_cuda(
         inv_freq: *const f32,
         cos_cache: *mut f32,
@@ -493,12 +506,38 @@ unsafe extern "C" {
         stream: CUstream,
     ) -> CUresult;
 
+    pub fn deepseek_indexer_scores_decode_batch_cuda(
+        q: *const Half,
+        kv: *const Half,
+        weights: *const Half,
+        compressed_len: *const i32,
+        cache_base: *const i32,
+        scores: *mut f32,
+        batch: i32,
+        local_heads: i32,
+        head_dim: i32,
+        max_compressed_len: i32,
+        score_scale: f32,
+        stream: CUstream,
+    ) -> CUresult;
+
     pub fn deepseek_indexer_topk_decode_cuda(
         scores: *const f32,
         topk_idxs: *mut i32,
         compressed_len: i32,
         topk: i32,
         offset: i32,
+        stream: CUstream,
+    ) -> CUresult;
+
+    pub fn deepseek_indexer_topk_decode_batch_cuda(
+        scores: *const f32,
+        topk_idxs: *mut i32,
+        compressed_len: *const i32,
+        cache_base: *const i32,
+        batch: i32,
+        max_compressed_len: i32,
+        topk: i32,
         stream: CUstream,
     ) -> CUresult;
 
@@ -527,6 +566,16 @@ unsafe extern "C" {
         stream: CUstream,
     ) -> CUresult;
 
+    pub fn deepseek_window_topk_indices_decode_batch_cuda(
+        out: *mut i32,
+        start_pos: *const i32,
+        cache_base: *const i32,
+        batch: i32,
+        window_size: i32,
+        topk: i32,
+        stream: CUstream,
+    ) -> CUresult;
+
     pub fn deepseek_compress_topk_indices_cuda(
         out: *mut i32,
         seq_len: i32,
@@ -540,6 +589,15 @@ unsafe extern "C" {
         out: *mut i32,
         compressed: i32,
         offset: i32,
+        stream: CUstream,
+    ) -> CUresult;
+
+    pub fn deepseek_compress_topk_indices_decode_batch_cuda(
+        out: *mut i32,
+        compressed_len: *const i32,
+        cache_base: *const i32,
+        batch: i32,
+        topk: i32,
         stream: CUstream,
     ) -> CUresult;
 
@@ -572,6 +630,19 @@ unsafe extern "C" {
         head_dim: i32,
         rotary_dim: i32,
         start_pos: i32,
+        inverse: i32,
+        stream: CUstream,
+    ) -> CUresult;
+
+    pub fn deepseek_apply_rope_hidden_batch_cuda(
+        x: *mut Half,
+        cos_cache: *const f32,
+        sin_cache: *const f32,
+        start_pos: *const i32,
+        seq_len: i32,
+        local_heads: i32,
+        head_dim: i32,
+        rotary_dim: i32,
         inverse: i32,
         stream: CUstream,
     ) -> CUresult;
@@ -617,6 +688,16 @@ unsafe extern "C" {
         rows: i32,
         src_start_row: i32,
         dst_start_row: i32,
+        stream: CUstream,
+    ) -> CUresult;
+
+    pub fn deepseek_bf16_copy_rows_indexed_cuda(
+        src: *const Half,
+        dst: *mut Half,
+        src_rows: *const i32,
+        dst_rows: *const i32,
+        hidden_dim: i32,
+        rows: i32,
         stream: CUstream,
     ) -> CUresult;
 
@@ -669,6 +750,25 @@ unsafe extern "C" {
         stream: CUstream,
     ) -> CUresult;
 
+    pub fn deepseek_compressor_nonoverlap_decode_at_cuda(
+        x: *const Half,
+        wkv: *const Half,
+        wgate: *const Half,
+        ape: *const f32,
+        norm: *const Half,
+        kv_state: *mut f32,
+        score_state: *mut f32,
+        weighted: *mut f32,
+        out: *mut Half,
+        start_pos: i32,
+        hidden_dim: i32,
+        head_dim: i32,
+        ratio: i32,
+        state_offset: i32,
+        eps: f32,
+        stream: CUstream,
+    ) -> CUresult;
+
     pub fn deepseek_compressor_overlap_decode_cuda(
         x: *const Half,
         wkv: *const Half,
@@ -682,6 +782,24 @@ unsafe extern "C" {
         start_pos: i32,
         hidden_dim: i32,
         head_dim: i32,
+        eps: f32,
+        stream: CUstream,
+    ) -> CUresult;
+
+    pub fn deepseek_compressor_overlap_decode_at_cuda(
+        x: *const Half,
+        wkv: *const Half,
+        wgate: *const Half,
+        ape: *const f32,
+        norm: *const Half,
+        kv_state: *mut f32,
+        score_state: *mut f32,
+        weighted: *mut f32,
+        out: *mut Half,
+        start_pos: i32,
+        hidden_dim: i32,
+        head_dim: i32,
+        state_offset: i32,
         eps: f32,
         stream: CUstream,
     ) -> CUresult;
@@ -813,6 +931,16 @@ unsafe extern "C" {
     ) -> CUresult;
 
     pub fn deepseek_last_token_bf16_logits_cuda(
+        x: *const Half,
+        weight: *const Half,
+        out: *mut f32,
+        seq_len: i32,
+        dim: i32,
+        vocab_size: i32,
+        stream: CUstream,
+    ) -> CUresult;
+
+    pub fn deepseek_bf16_logits_cuda(
         x: *const Half,
         weight: *const Half,
         out: *mut f32,


### PR DESCRIPTION
## Summary

Adds the first real DSV4 Flash runtime batch-decode path for homogeneous `bs=2` decode. This is the PR A runtime layer only: a single `DecodeBatch` worker command carries two `(token_id, start_pos, kv_slot)` rows through the same decode step and returns two gathered logits rows.

The implementation covers the DSV4 Flash decode paths used by the current ratio set `{0, 4, 128}`:

- per-row RoPE `start_pos` for hidden and q/kv states;
- slot-aware window and compressed-cache row metadata;
- batch top-k/indexer paths for overlap and non-overlap compressed layers;
- batch compressor decode state offsets;
- batch final-logits gather back to row-major logits.

## Scope

This PR intentionally does not add scheduler active-set serving, HTTP serving, performance claims, paged/prefix KV, P/D handoff, or larger batch support. It proves the runtime can execute a real same-step `bs=2` decode command; it is not a scheduler polling or alternating-step prototype.

Default single-request direct generation still allocates one KV/cache slot. The two-slot allocation is used only by the batch/test prepare path added in this PR, so the default `bs=1` memory behavior is not changed.

Current validation uses two different same-length prompts seeded into two independent KV slots, then one `bs=2` decode command is compared against two independent `bs=1` decode rows that use the same prompt-specific input token. That checks the slot-aware runtime batch path: if row metadata ignores `slot_id`, `window_base`, `compressed_base`, or per-row cache state, the row-specific comparison should fail. This still does not claim full cross-request serving semantics.

## Validation

- Head: `f0bd31e`.
- `cargo fmt --check` passed.
- `cargo check -p pegainfer-deepseek-v4 --features deepseek-v4` passed.
- `cargo test -p pegainfer-deepseek-v4 --features deepseek-v4 direct::scheduler::tests::batch_decode_logits_match_two_single_decode_rows --no-run` passed.
- `git diff --check` passed.
- Internal 8-GPU DeepSeek-V4-Flash validation machine:
  - `cargo test --release --lib -p pegainfer-deepseek-v4 --features deepseek-v4 direct::scheduler::tests::batch_decode_logits_match_two_single_decode_rows -- --ignored --nocapture`
  - result after default-slot fix and distinct-prompt test: `1 passed; 0 failed; finished in 37.67s`.
  - default `bs=1` exact E2E: `All 20 DeepSeek V4 exact cases passed`.
- `pre-commit run --files ...` is blocked by the existing repository `.pre-commit-config.yaml` invalid `repo='builtin'` entry missing `rev`; no hook was bypassed.

## Notes

The batch comparison checks vocab length, top-token equality, and numeric closeness between each batch row and its own independent `bs=1` row. The numeric tolerance is deliberately not treated as a performance or bitwise-equivalence claim; the key contract in this PR is same-command runtime batch decode with correct row routing and stable top-token behavior.
