### PR TITLE
fix(dsv4): stabilize HTTP concurrency hashes

### DIFF
--- a/pegainfer-deepseek-v4/src/direct/scheduler.rs
+++ b/pegainfer-deepseek-v4/src/direct/scheduler.rs
@@ -1066,13 +1066,10 @@ pub fn start_engine(model_path: &Path, options: EngineLoadOptions) -> Result<Eng
             info!("DeepSeek V4 scheduler ready");
             while let Some(req) = submit_rx.blocking_recv() {
                 let mut wave = vec![req];
-                while wave.len() < 2 {
-                    match submit_rx.try_recv() {
-                        Ok(req) => wave.push(req),
-                        Err(tokio::sync::mpsc::error::TryRecvError::Empty) => break,
-                        Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => break,
-                    }
-                }
+                // HTTP serving keeps admission fail-closed to one request per
+                // scheduler turn until multi-step batch decode is deterministic
+                // across request pairings. The runtime batch primitive remains
+                // available behind direct tests and future wiring.
                 if wave.len() == 1 {
                     handle_request(
                         &mut generator,

--- a/pegainfer-deepseek-v4/src/runtime/attention.rs
+++ b/pegainfer-deepseek-v4/src/runtime/attention.rs
@@ -1273,9 +1273,12 @@ pub(crate) fn attention_decode_compressed_nonoverlap_rank_local_bf16_hidden_batc
             compressor_state,
             state_offset,
         )? {
-            let dst = config.sliding_window
-                + batch_meta.slot_ids_host[row] * compressed_slots
-                + batch_meta.start_pos_host[row] / ratio;
+            let dst = decode_cache_compressed_row(
+                config.sliding_window,
+                compressed_slots,
+                batch_meta.slot_ids_host[row],
+                batch_meta.start_pos_host[row] / ratio,
+            );
             copy_bf16_rows_to_cache(ctx, &compressed_kv, &mut cache.kv, 0, dst, 1)?;
         }
     }

--- a/pegainfer-deepseek-v4/src/runtime/block.rs
+++ b/pegainfer-deepseek-v4/src/runtime/block.rs
@@ -699,9 +699,12 @@ fn attention_decode_compressed_overlap_rank_local_collective_bf16_hidden_batch_w
             state_offset,
             false,
         )? {
-            let dst = config.sliding_window
-                + batch_meta.slot_ids_host[row] * compressed_slots
-                + batch_meta.start_pos_host[row] / 4;
+            let dst = decode_cache_compressed_row(
+                config.sliding_window,
+                compressed_slots,
+                batch_meta.slot_ids_host[row],
+                batch_meta.start_pos_host[row] / 4,
+            );
             copy_bf16_rows_to_cache(ctx, &compressed_kv, &mut cache.kv, 0, dst, 1)?;
         }
         if let Some(indexer_compressed_kv) = compressor_overlap_decode_bf16_hidden_with_dim_at(

--- a/pegainfer-deepseek-v4/src/runtime/state.rs
+++ b/pegainfer-deepseek-v4/src/runtime/state.rs
@@ -94,6 +94,15 @@ pub(crate) struct DecodeBatchMeta<'a> {
     pub(crate) slot_ids_host: &'a [usize],
 }
 
+pub(crate) fn decode_cache_compressed_row(
+    sliding_window: usize,
+    compressed_slots: usize,
+    slot_id: usize,
+    compressed_row: usize,
+) -> usize {
+    slot_id * (sliding_window + compressed_slots) + sliding_window + compressed_row
+}
+
 pub(crate) struct HcPostScratch {
     pub(crate) attention_reduce_temp: CudaSlice<f32>,
     pub(crate) attention_out: HcHiddenStates,
@@ -1013,5 +1022,25 @@ impl F32Logits {
         let host = ctx.stream.clone_dtoh(&self.data)?;
         ctx.sync()?;
         Ok(host)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode_cache_compressed_row;
+
+    #[test]
+    fn compressed_rows_follow_per_slot_window_then_compressed_layout() {
+        let sliding_window = 128;
+        let compressed_slots = 32;
+
+        assert_eq!(
+            decode_cache_compressed_row(sliding_window, compressed_slots, 0, 3),
+            131
+        );
+        assert_eq!(
+            decode_cache_compressed_row(sliding_window, compressed_slots, 1, 3),
+            291
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes the P0 HTTP concurrency correctness regression seen in the DSV4 serving sweep: concurrency 4/8 could return different per-request output hashes across repeated runs with the same prompt set.

Changes:
- fixes compressed KV writeback row computation for batch decode slot 1 by using the per-slot layout `slot * (sliding_window + compressed_slots) + sliding_window + compressed_row`;
- adds a unit regression for the slot0/slot1 compressed row layout helper;
- keeps HTTP serving admission fail-closed to one request per scheduler turn until multi-step runtime batch decode is deterministic across arbitrary request pairings / slot reuse.

This PR is a correctness gate only. It does not claim TTFT or throughput improvement. The runtime batch primitive remains available behind direct tests and future wiring, but HTTP serving does not use scheduler wave batching in this PR.

## Root cause / classification

The initial sweep showed c1/c2 stable and c4/c8 hash drift. Debug split:
- `max_tokens=1/2/4/8` was stable under c4;
- `max_tokens=16` drifted;
- hard-disabling scheduler wave batching made c4/max_tokens=16 stable.

That places the issue in the multi-step active-set / batch decode path rather than HTTP stream aggregation or request-index mapping. One concrete bug found and fixed here was the compressed-cache row calculation for nonzero slots. Even after that fix, broader multi-step batch decode pairing still needs follow-up hardening before HTTP serving can safely use it, so this PR disables wave batching at the HTTP scheduler boundary.

## Validation

Local:
- `git diff --check origin/main...HEAD` ✅
- `cargo fmt --check` ✅

Remote GPU validation:
- `cargo check -p pegainfer-deepseek-v4 --features deepseek-v4` ✅
- `cargo test -p pegainfer-deepseek-v4 --features deepseek-v4 runtime::state::tests::compressed_rows_follow_per_slot_window_then_compressed_layout` ✅

HTTP correctness gate (`/v1/completions`, `/data/DeepSeek-V4-Flash`, prompt_words=16, max_tokens=16, num_requests=8, warmup=0, repeated 3x per concurrency):

| Concurrency | Run | Failed / timeout | Combined hash | Per-request hashes |
|---|---:|---:|---|---|
| 1 | 1 | 0 / 0 | `a07fcd6a09c88ec7` | `8355f726b60e2268`, `8a18cbe8ee7ed99d`, `104cbc0d610d7df1`, `67f7fadd817c79f2`, `e21138834a3f4c99`, `696b4446c9e3984e`, `cfa4336dcdfca1ce`, `385cd1037535f422` |
| 1 | 2 | 0 / 0 | `a07fcd6a09c88ec7` | same as run 1 |
| 1 | 3 | 0 / 0 | `a07fcd6a09c88ec7` | same as run 1 |
| 2 | 1 | 0 / 0 | `a07fcd6a09c88ec7` | same as c1 run 1 |
| 2 | 2 | 0 / 0 | `a07fcd6a09c88ec7` | same as c1 run 1 |
| 2 | 3 | 0 / 0 | `a07fcd6a09c88ec7` | same as c1 run 1 |
| 4 | 1 | 0 / 0 | `a07fcd6a09c88ec7` | same as c1 run 1 |
| 4 | 2 | 0 / 0 | `a07fcd6a09c88ec7` | same as c1 run 1 |
| 4 | 3 | 0 / 0 | `a07fcd6a09c88ec7` | same as c1 run 1 |
| 8 | 1 | 0 / 0 | `a07fcd6a09c88ec7` | same as c1 run 1 |
| 8 | 2 | 0 / 0 | `a07fcd6a09c88ec7` | same as c1 run 1 |
| 8 | 3 | 0 / 0 | `a07fcd6a09c88ec7` | same as c1 run 1 |

Observed TTFT still increases with concurrency because requests queue behind the single-request scheduler path. That is intentionally left to the follow-up TTFT trace / serving sweep task after this correctness gate.
