### PR TITLE
bench(dsv4): profile HTTP TTFT and prefill path

### DIFF
--- a/docs/projects/deepseek-v4/http-serving-benchmark.md
+++ b/docs/projects/deepseek-v4/http-serving-benchmark.md
@@ -53,6 +53,18 @@ $CARGO_TARGET_DIR/release/pegainfer \
   --port 18118 2>&1 | tee /tmp/dsv4_http_server.log
 ```
 
+For prefill phase attribution, start the endpoint with profiling enabled:
+
+```bash
+$CARGO_TARGET_DIR/release/pegainfer \
+  --model-path /data/DeepSeek-V4-Flash \
+  --port 18118 \
+  --deepseek-prefill-profile 2>&1 | tee /tmp/dsv4_http_server_profile.log
+```
+
+Profiling inserts CUDA synchronization around rank-0 prefill phases. Use it to
+rank phases and kernel families; use the non-profile server for serving numbers.
+
 Verify the model endpoint:
 
 ```bash
@@ -92,6 +104,23 @@ python3 scripts/bench_http_sweep.py \
   --out-dir /tmp/dsv4_http_sweep_task4
 ```
 
+Run the prompt-length sweep that feeds the prefill optimization target:
+
+```bash
+python3 scripts/bench_http_sweep.py \
+  --base-url http://127.0.0.1:18118 \
+  --model /data/DeepSeek-V4-Flash \
+  --warmup 1 \
+  --num-requests 1 \
+  --concurrency 1 \
+  --max-tokens 1 \
+  --repeats 1 \
+  --prompt-words 16,128,512,2048 \
+  --timeout 600 \
+  --server-log /tmp/dsv4_http_server_profile.log \
+  --out-dir /tmp/dsv4_http_prompt_profile_task4
+```
+
 The script is intentionally model-server agnostic at the HTTP layer. It only
 requires an OpenAI-compatible `/v1/completions` endpoint that supports streaming
 responses.
@@ -127,18 +156,58 @@ the same prompt shape and `max_tokens=16`, repeats each concurrency point three
 times, and treats per-request hash drift as a correctness failure before any
 performance interpretation.
 
-| Concurrency | Correctness | QPS (3 runs) | TTFT avg ms (3 runs) | TPOT avg ms (3 runs) | Dominant trace attribution |
+| Concurrency | Correctness | QPS (3 runs) | TTFT avg ms (3 runs) | TPOT avg ms (3 runs) | Trace attribution |
 | --- | --- | --- | --- | --- | --- |
-| `1` | pass; failed `0`, timeout `0`, combined hash `22706877075acde0` in all runs | `1.649`, `1.638`, `1.642` | `165.9`, `167.3`, `168.8` | `29.36`, `29.52`, `29.34` | admission queue avg `0.0ms`; prefill avg `~165ms` |
-| `2` | pass; failed `0`, timeout `0`, combined hash `22706877075acde0` in all runs | `1.650`, `1.649`, `1.651` | `696.8`, `697.6`, `695.9` | `29.34`, `29.34`, `29.32` | admission queue avg `~530ms`; prefill avg `~166ms` |
-| `4` | pass; failed `0`, timeout `0`, combined hash `22706877075acde0` in all runs | `1.649`, `1.646`, `1.651` | `1531.3`, `1536.2`, `1530.2` | `29.35`, `29.34`, `29.30` | admission queue avg `~1365ms`; prefill avg `~166ms` |
-| `8` | pass; failed `0`, timeout `0`, combined hash `22706877075acde0` in all runs | `1.649`, `1.648`, `1.652` | `2291.7`, `2290.4`, `2285.0` | `29.29`, `29.35`, `29.30` | admission queue avg `~2124ms`; prefill avg `~167ms` |
+| `1` | pass; failed `0`, timeout `0`, combined hash `22706877075acde0` in all runs | `1.609`, `1.613`, `1.617` | `180.7`, `177.6`, `177.7` | `29.37`, `29.49`, `29.37` | admission queue avg `~0.0ms`; prefill avg `~178ms` |
+| `2` | pass; failed `0`, timeout `0`, combined hash `22706877075acde0` in all runs | `1.620`, `1.620`, `1.622` | `717.4`, `717.9`, `716.5` | `29.34`, `29.35`, `29.33` | admission queue avg `~540ms`; prefill avg `~177ms` |
+| `4` | pass; failed `0`, timeout `0`, combined hash `22706877075acde0` in all runs | `1.618`, `1.610`, `1.620` | `1568.9`, `1574.0`, `1566.5` | `29.36`, `29.58`, `29.35` | admission queue avg `~1392ms`; prefill avg `~177ms` |
+| `8` | pass; failed `0`, timeout `0`, combined hash `22706877075acde0` in all runs | `1.618`, `1.619`, `1.620` | `2338.6`, `2342.3`, `2339.4` | `29.38`, `29.36`, `29.38` | admission queue avg `~2162ms`; prefill avg `~177ms` |
 
-Trace attribution shows that the c1 to c8 TTFT increase is dominated by
-admission queue time under the current HTTP serving path, while `prefill_ms`,
-`first_decode_ms`, `stream_flush_ms`, and TPOT remain roughly stable. This is
-diagnostic evidence for the current single-request scheduler turn used by HTTP
-serving; it is not a throughput optimization result.
+Trace attribution separates two different bottlenecks:
+
+- Absolute single-request service time is still high. At concurrency `1`, TTFT
+  is already `~178ms` and is dominated by DSV4 direct prefill plus decode-cache
+  seeding. Each request then spends roughly `15 * 29ms` on remaining decode
+  tokens, so the current endpoint tops out near `1.6` requests/s before any
+  queueing analysis.
+- Increasing concurrency mostly adds admission queue time because HTTP serving
+  currently uses a single-request scheduler turn after the correctness fallback.
+  The sweep shows queue time growing from `0ms` at c1 to `~2162ms` at c8, while
+  prefill, first-decode, stream flush, and TPOT stay roughly stable.
+
+The evidence therefore points to prefill/decode kernel service time as the next
+performance target, with admission queue time as the concurrency amplification
+of that baseline. This PR only adds the trace/sweep gate; it is not a throughput
+optimization result.
+
+### P1 Prompt-Length And Prefill Profile
+
+Prompt-length sweep, measured with profiling enabled and `max_tokens=1`, shows
+TTFT tracking DSV4 direct prefill time:
+
+| Prompt words | Prompt tokens | QPS | TTFT avg ms | Prefill avg ms | failed / timeout |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `16` | `22` | `5.433` | `183.6` | `181.7` | `0 / 0` |
+| `128` | `164-165` | `4.243` | `235.3` | `234.5` | `0 / 0` |
+| `512` | `660-661` | `2.637` | `378.9` | `378.0` | `0 / 0` |
+| `2048` | `2644-2645` | `0.758` | `1318.2` | `1316.9` | `0 / 0` |
+| `8192` | `10580` | `0.111` | `9029.0` | `9014.0` | `0 / 0` |
+
+Rank-0 prefill profile records show `block_prefill` dominates the profiled
+prefill window. The table groups block-prefill time by DSV4 compress ratio:
+
+| Prompt tokens | Profiled prefill ms | `block_prefill` ms | ratio `0` ms | ratio `4` ms | ratio `128` ms | Top block-prefill layers |
+| ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| `22` | `150.4` | `149.6` | `5.1` | `80.9` | `63.6` | ratio-4 layers around `4-5ms` each |
+| `165` | `203.2` | `202.3` | `8.7` | `100.2` | `93.4` | ratio-4/128 layers around `5-6ms` each |
+| `661` | `343.0` | `342.2` | `15.3` | `200.7` | `126.2` | ratio-4 layers around `10ms` each |
+| `2645` | `1266.2` | `1260.3` | `37.9` | `818.6` | `403.9` | ratio-4 layers around `39-40ms` each |
+| `10580` | `8956.7` | `8940.6` | `134.8` | `6902.4` | `1903.3` | ratio-4 layers dominate, top layer `~500ms` |
+
+This points the first optimization target at ratio-4 `block_prefill`, especially
+the compressed attention / indexer / compressor path. A candidate reuse of the
+ratio-4 indexer compressed KV was evaluated and rejected because it changed the
+HTTP output hash gate; it is not included in this PR.
 
 ## Boundary
 

--- a/docs/projects/deepseek-v4/http-serving-benchmark.md
+++ b/docs/projects/deepseek-v4/http-serving-benchmark.md
@@ -2,7 +2,7 @@
 
 **Created**: 2026-05-14
 **Status**: active
-**Canonical task**: task #18
+**Canonical task**: task #18; P1 TTFT/sweep extension in `#Dsv4性能调优` task #4
 
 ## Purpose
 
@@ -16,6 +16,18 @@ The benchmark client sends streaming `/v1/completions` requests and records:
 - ITL and TPOT from streamed text chunks.
 - End-to-end latency percentiles.
 - Per-request output hashes plus a combined output hash for reproducibility.
+
+The P1 sweep extension adds server-log trace attribution for successful
+requests:
+
+- `frontend_to_queue_ms`: client request start to engine queue timestamp. This
+  includes HTTP ingress, tokenization, and vLLM request submission.
+- `admission_queue_ms`: engine queued to scheduled.
+- `prefill_ms`: DSV4 direct prefill plus decode-cache seeding.
+- `first_decode_ms`: first decode step after the first streamed token. In the
+  current direct path, the first streamed token is sampled from prefill logits,
+  so this phase explains early TPOT rather than TTFT.
+- `stream_flush_ms`: server first-token emission to client first text chunk.
 
 ## Reproducible Commands
 
@@ -38,7 +50,7 @@ Start the OpenAI-compatible HTTP endpoint:
 ```bash
 $CARGO_TARGET_DIR/release/pegainfer \
   --model-path /data/DeepSeek-V4-Flash \
-  --port 18118
+  --port 18118 2>&1 | tee /tmp/dsv4_http_server.log
 ```
 
 Verify the model endpoint:
@@ -59,12 +71,35 @@ python3 scripts/bench_http_serving.py \
   --prompt-words 16 \
   --max-tokens 16 \
   --timeout 240 \
+  --server-log /tmp/dsv4_http_server.log \
   --out /tmp/dsv4_http_bench_task18.json
+```
+
+Run the P1 concurrency / max-token sweep:
+
+```bash
+python3 scripts/bench_http_sweep.py \
+  --base-url http://127.0.0.1:18118 \
+  --model /data/DeepSeek-V4-Flash \
+  --warmup 2 \
+  --num-requests 8 \
+  --concurrency 1,2,4,8 \
+  --max-tokens 16 \
+  --repeats 3 \
+  --prompt-words 16 \
+  --timeout 240 \
+  --server-log /tmp/dsv4_http_server.log \
+  --out-dir /tmp/dsv4_http_sweep_task4
 ```
 
 The script is intentionally model-server agnostic at the HTTP layer. It only
 requires an OpenAI-compatible `/v1/completions` endpoint that supports streaming
 responses.
+
+The server trace columns are pegainfer-specific and require a pegainfer server
+log containing `pegainfer_http_trace` lines. The sweep fails when any cell has
+request failures/timeouts or per-request output hashes that change across
+repeats.
 
 ## Current Evidence
 
@@ -84,6 +119,26 @@ host. It describes only this commit, machine, endpoint, and harness.
 | TPOT | avg `28.78ms`, p50 `28.81ms`, p95 `28.88ms`, p99 `28.88ms` |
 | ITL | avg `28.78ms`, p50 `28.28ms`, p95 `30.57ms`, p99 `30.74ms` |
 | Output stability | output chunks `128`, unique output hashes `8`, combined output hash `22706877075acde0` |
+
+### P1 TTFT Trace And Concurrency Sweep
+
+The P1 sweep was collected after the HTTP correctness gate stabilized. It keeps
+the same prompt shape and `max_tokens=16`, repeats each concurrency point three
+times, and treats per-request hash drift as a correctness failure before any
+performance interpretation.
+
+| Concurrency | Correctness | QPS (3 runs) | TTFT avg ms (3 runs) | TPOT avg ms (3 runs) | Dominant trace attribution |
+| --- | --- | --- | --- | --- | --- |
+| `1` | pass; failed `0`, timeout `0`, combined hash `22706877075acde0` in all runs | `1.649`, `1.638`, `1.642` | `165.9`, `167.3`, `168.8` | `29.36`, `29.52`, `29.34` | admission queue avg `0.0ms`; prefill avg `~165ms` |
+| `2` | pass; failed `0`, timeout `0`, combined hash `22706877075acde0` in all runs | `1.650`, `1.649`, `1.651` | `696.8`, `697.6`, `695.9` | `29.34`, `29.34`, `29.32` | admission queue avg `~530ms`; prefill avg `~166ms` |
+| `4` | pass; failed `0`, timeout `0`, combined hash `22706877075acde0` in all runs | `1.649`, `1.646`, `1.651` | `1531.3`, `1536.2`, `1530.2` | `29.35`, `29.34`, `29.30` | admission queue avg `~1365ms`; prefill avg `~166ms` |
+| `8` | pass; failed `0`, timeout `0`, combined hash `22706877075acde0` in all runs | `1.649`, `1.648`, `1.652` | `2291.7`, `2290.4`, `2285.0` | `29.29`, `29.35`, `29.30` | admission queue avg `~2124ms`; prefill avg `~167ms` |
+
+Trace attribution shows that the c1 to c8 TTFT increase is dominated by
+admission queue time under the current HTTP serving path, while `prefill_ms`,
+`first_decode_ms`, `stream_flush_ms`, and TPOT remain roughly stable. This is
+diagnostic evidence for the current single-request scheduler turn used by HTTP
+serving; it is not a throughput optimization result.
 
 ## Boundary
 

--- a/pegainfer-core/src/engine.rs
+++ b/pegainfer-core/src/engine.rs
@@ -43,6 +43,8 @@ pub enum FinishReason {
 }
 
 pub struct GenerateRequest {
+    pub request_id: Option<String>,
+    pub queued_at_unix_s: Option<f64>,
     pub prompt_tokens: Vec<u32>,
     pub params: SamplingParams,
     pub max_tokens: usize,
@@ -52,6 +54,11 @@ pub struct GenerateRequest {
 }
 
 pub enum TokenEvent {
+    Scheduled {
+        queued_at_unix_s: f64,
+        scheduled_at_unix_s: f64,
+        prompt_tokens: usize,
+    },
     Token {
         id: u32,
         logprob: Option<TokenLogprob>,

--- a/pegainfer-core/src/engine.rs
+++ b/pegainfer-core/src/engine.rs
@@ -7,6 +7,7 @@ use crate::sampler::SamplingParams;
 #[derive(Clone, Debug)]
 pub struct EngineLoadOptions {
     pub enable_cuda_graph: bool,
+    pub enable_prefill_profile: bool,
     pub device_ordinals: Vec<usize>,
     pub seed: u64,
 }
@@ -15,6 +16,7 @@ impl Default for EngineLoadOptions {
     fn default() -> Self {
         Self {
             enable_cuda_graph: true,
+            enable_prefill_profile: false,
             device_ordinals: vec![0],
             seed: 42,
         }

--- a/pegainfer-deepseek-v4/src/direct/scheduler.rs
+++ b/pegainfer-deepseek-v4/src/direct/scheduler.rs
@@ -1,4 +1,11 @@
-use std::{error::Error, fmt, path::Path, sync::mpsc as std_mpsc, thread};
+use std::{
+    error::Error,
+    fmt,
+    path::Path,
+    sync::mpsc as std_mpsc,
+    thread,
+    time::{Instant, SystemTime, UNIX_EPOCH},
+};
 
 use anyhow::{Context, Result, bail, ensure};
 use log::{info, warn};
@@ -1091,6 +1098,17 @@ pub fn start_engine(model_path: &Path, options: EngineLoadOptions) -> Result<Eng
 
 fn handle_request(generator: &mut DeepSeekV4DirectGenerator, req: GenerateRequest) {
     let prompt_len = req.prompt_tokens.len();
+    let request_id = req
+        .request_id
+        .clone()
+        .unwrap_or_else(|| "unknown".to_string());
+    let queued_at_unix_s = req.queued_at_unix_s.unwrap_or_else(unix_secs_f64);
+    let scheduled_at_unix_s = unix_secs_f64();
+    let _ = req.token_tx.send(TokenEvent::Scheduled {
+        queued_at_unix_s,
+        scheduled_at_unix_s,
+        prompt_tokens: prompt_len,
+    });
     if req.echo {
         let _ = req.token_tx.send(TokenEvent::PromptTokens {
             ids: req.prompt_tokens.clone(),
@@ -1117,29 +1135,13 @@ fn handle_request(generator: &mut DeepSeekV4DirectGenerator, req: GenerateReques
         return;
     }
 
-    let token_tx = req.token_tx.clone();
-    let result = generator.generate_greedy(
+    let prefill_start = Instant::now();
+    let mut state = match generator.start_greedy_request(
         &req.prompt_tokens,
         req.max_tokens,
         req.params.ignore_eos,
-        |token| {
-            token_tx
-                .send(TokenEvent::Token {
-                    id: token,
-                    logprob: None,
-                })
-                .map_err(|_| anyhow::anyhow!("request receiver dropped"))?;
-            Ok(())
-        },
-    );
-    match result {
-        Ok(generation) => {
-            let _ = req.token_tx.send(TokenEvent::Finished {
-                finish_reason: generation.finish_reason,
-                prompt_tokens: prompt_len,
-                completion_tokens: generation.generated.len(),
-            });
-        }
+    ) {
+        Ok(state) => state,
         Err(err) => {
             if let Some(kv_err) = err.downcast_ref::<DirectKvCacheReservationError>() {
                 reject_request(
@@ -1160,8 +1162,91 @@ fn handle_request(generator: &mut DeepSeekV4DirectGenerator, req: GenerateReques
                 prompt_tokens: prompt_len,
                 completion_tokens: 0,
             });
+            return;
+        }
+    };
+    let prefill_done_unix_s = unix_secs_f64();
+    let prefill_ms = prefill_start.elapsed().as_secs_f64() * 1000.0;
+    let mut first_token_emit_unix_s = None;
+    let mut first_decode_ms = None;
+
+    while !state.is_finished() {
+        let step = match generator.sample_greedy_step(&state) {
+            Ok(step) => step,
+            Err(err) => {
+                if let Err(release_err) = generator.release_greedy_request(&mut state) {
+                    warn!(
+                        "failed to release DeepSeek V4 KV cache after sample error: {release_err:#}"
+                    );
+                }
+                let message = format!("DeepSeek V4 direct request failed: {err:#}");
+                warn!("{message}");
+                let _ = req.token_tx.send(TokenEvent::Error {
+                    message,
+                    prompt_tokens: prompt_len,
+                    completion_tokens: state.generated().len(),
+                });
+                return;
+            }
+        };
+        if let Some(token) = step.token() {
+            if first_token_emit_unix_s.is_none() {
+                first_token_emit_unix_s = Some(unix_secs_f64());
+            }
+            if req
+                .token_tx
+                .send(TokenEvent::Token {
+                    id: token,
+                    logprob: None,
+                })
+                .is_err()
+            {
+                if let Err(release_err) = generator.release_greedy_request(&mut state) {
+                    warn!(
+                        "failed to release DeepSeek V4 KV cache after receiver drop: {release_err:#}"
+                    );
+                }
+                return;
+            }
+        }
+
+        let decode_start = Instant::now();
+        if let Err(err) = generator.advance_greedy_step(&mut state, &step) {
+            let message = format!("DeepSeek V4 direct request failed: {err:#}");
+            warn!("{message}");
+            let _ = req.token_tx.send(TokenEvent::Error {
+                message,
+                prompt_tokens: prompt_len,
+                completion_tokens: state.generated().len(),
+            });
+            return;
+        }
+        if first_decode_ms.is_none() && step.token().is_some() && step.finish_reason().is_none() {
+            first_decode_ms = Some(decode_start.elapsed().as_secs_f64() * 1000.0);
         }
     }
+
+    info!(
+        "pegainfer_http_trace {}",
+        serde_json::json!({
+            "request_id": request_id,
+            "queued_at_unix_s": queued_at_unix_s,
+            "scheduled_at_unix_s": scheduled_at_unix_s,
+            "prefill_done_unix_s": prefill_done_unix_s,
+            "first_token_emit_unix_s": first_token_emit_unix_s,
+            "prefill_ms": prefill_ms,
+            "first_decode_ms": first_decode_ms,
+            "prompt_tokens": prompt_len,
+            "completion_tokens": state.generated().len(),
+        })
+    );
+    let _ = req.token_tx.send(TokenEvent::Finished {
+        finish_reason: state
+            .finish_reason()
+            .expect("DeepSeek V4 request state must finish after greedy generation"),
+        prompt_tokens: prompt_len,
+        completion_tokens: state.generated().len(),
+    });
 }
 
 struct PendingDirectRequest {
@@ -1445,6 +1530,13 @@ fn send_request_error(
         prompt_tokens: prompt_len,
         completion_tokens,
     });
+}
+
+fn unix_secs_f64() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before unix epoch")
+        .as_secs_f64()
 }
 
 fn argmax_f32(values: &[f32]) -> usize {

--- a/pegainfer-deepseek-v4/src/direct/scheduler.rs
+++ b/pegainfer-deepseek-v4/src/direct/scheduler.rs
@@ -271,6 +271,13 @@ pub struct DeepSeekV4DirectGenerator {
 
 impl DeepSeekV4DirectGenerator {
     pub fn from_model_dir(model_path: &Path) -> Result<Self> {
+        Self::from_model_dir_with_prefill_profile(model_path, false)
+    }
+
+    pub fn from_model_dir_with_prefill_profile(
+        model_path: &Path,
+        enable_prefill_profile: bool,
+    ) -> Result<Self> {
         let config = Box::leak(Box::new(Config::from_model_dir(model_path).with_context(
             || {
                 format!(
@@ -279,7 +286,7 @@ impl DeepSeekV4DirectGenerator {
                 )
             },
         )?));
-        let runtime = load_full_direct_runtime(model_path, config)?;
+        let runtime = load_full_direct_runtime(model_path, config, enable_prefill_profile)?;
         Ok(Self {
             config,
             runtime,
@@ -1060,7 +1067,10 @@ pub fn start_engine(model_path: &Path, options: EngineLoadOptions) -> Result<Eng
     thread::Builder::new()
         .name("deepseek-v4-scheduler".into())
         .spawn(move || {
-            let mut generator = match DeepSeekV4DirectGenerator::from_model_dir(&model_path) {
+            let mut generator = match DeepSeekV4DirectGenerator::from_model_dir_with_prefill_profile(
+                &model_path,
+                options.enable_prefill_profile,
+            ) {
                 Ok(generator) => {
                     let _ = init_tx.send(Ok(()));
                     generator

--- a/pegainfer-deepseek-v4/src/direct/worker.rs
+++ b/pegainfer-deepseek-v4/src/direct/worker.rs
@@ -1,8 +1,9 @@
-use std::{path::Path, thread};
+use std::{path::Path, thread, time::Instant};
 
 use anyhow::{Context, Result, ensure};
 use crossbeam_channel as channel;
 use cudarc::driver::{CudaSlice, DevicePtrMut, DeviceRepr, result as cuda_result};
+use log::info;
 
 use crate::{
     Config, DeepSeekRopeCache, F32Logits, LayerDecodeCache, RankGpuContext, RankWeightView,
@@ -35,6 +36,7 @@ pub(super) struct DirectBatchDecodeEntry {
 
 pub(super) struct FullDirectRuntime {
     workers: Vec<RankWorker>,
+    prefill_profile: bool,
 }
 
 enum RankCommand {
@@ -51,6 +53,7 @@ enum RankCommand {
     },
     Prefill {
         prompt_tokens: Vec<u32>,
+        profile: bool,
         resp: channel::Sender<Result<RankResult>>,
     },
     Decode {
@@ -331,6 +334,7 @@ impl RankWorker {
                                 }
                                 RankCommand::Prefill {
                                     prompt_tokens,
+                                    profile,
                                     resp,
                                 } => {
                                     let result = run_prefill_on_rank_lane(
@@ -343,6 +347,7 @@ impl RankWorker {
                                         config,
                                         &prompt_tokens,
                                         &mut caches,
+                                        profile,
                                     )
                                     .map(|logits| (rank, logits));
                                     let _ = resp.send(result);
@@ -515,11 +520,16 @@ impl RankWorker {
             .map_err(|_| anyhow::anyhow!("DeepSeek rank worker dropped ResetCacheSlot response"))?
     }
 
-    fn prefill(&self, prompt_tokens: Vec<u32>) -> Result<channel::Receiver<Result<RankResult>>> {
+    fn prefill(
+        &self,
+        prompt_tokens: Vec<u32>,
+        profile: bool,
+    ) -> Result<channel::Receiver<Result<RankResult>>> {
         let (resp_tx, resp_rx) = channel::bounded(1);
         self.tx
             .send(RankCommand::Prefill {
                 prompt_tokens,
+                profile,
                 resp: resp_tx,
             })
             .map_err(|_| anyhow::anyhow!("DeepSeek rank worker channel closed on Prefill"))?;
@@ -553,6 +563,7 @@ fn bind_rank_thread(ctx: &RankGpuContext) -> Result<()> {
 pub(super) fn load_full_direct_runtime(
     model_path: &Path,
     config: &'static Config,
+    prefill_profile: bool,
 ) -> Result<FullDirectRuntime> {
     let mut contexts = Vec::with_capacity(8);
     for rank in 0..8 {
@@ -597,7 +608,10 @@ pub(super) fn load_full_direct_runtime(
     {
         workers.push(RankWorker::spawn(rank, ctx, view, comm, moe_comm, config)?);
     }
-    Ok(FullDirectRuntime { workers })
+    Ok(FullDirectRuntime {
+        workers,
+        prefill_profile,
+    })
 }
 
 fn allocate_rank_decode_caches(
@@ -1320,6 +1334,7 @@ fn run_prefill_on_rank_lane(
     config: &Config,
     prompt_tokens: &[u32],
     caches: &mut [LayerDecodeCache],
+    profile: bool,
 ) -> Result<Option<Vec<f32>>> {
     ensure!(
         !prompt_tokens.is_empty(),
@@ -1340,18 +1355,68 @@ fn run_prefill_on_rank_lane(
 
     ctx.set_current()?;
     let seq_len = prompt_tokens.len();
+    let mut profile_phases = Vec::new();
+
+    let phase_start = Instant::now();
     let token_ids = ctx
         .stream
         .clone_htod(prompt_tokens)
         .with_context(|| format!("copy prompt tokens to rank {rank}"))?;
+    record_prefill_profile_phase(
+        ctx,
+        profile,
+        rank,
+        &mut profile_phases,
+        "token_h2d",
+        None,
+        None,
+        phase_start,
+    )?;
+
+    let phase_start = Instant::now();
     let mut hidden = embedding_rank_local(ctx, config, weights, &token_ids, seq_len)
         .with_context(|| format!("embedding rank {rank}"))?;
+    record_prefill_profile_phase(
+        ctx,
+        profile,
+        rank,
+        &mut profile_phases,
+        "embedding",
+        None,
+        None,
+        phase_start,
+    )?;
+
+    let phase_start = Instant::now();
     all_reduce_hidden_in_place(&mut hidden, comm)
         .with_context(|| format!("embedding all_reduce rank {rank}"))?;
+    record_prefill_profile_phase(
+        ctx,
+        profile,
+        rank,
+        &mut profile_phases,
+        "embedding_all_reduce",
+        None,
+        None,
+        phase_start,
+    )?;
+
+    let phase_start = Instant::now();
     let mut hc = hc_expand_bf16_hidden(ctx, &hidden, config.hc_mult)
         .with_context(|| format!("hc_expand rank {rank}"))?;
+    record_prefill_profile_phase(
+        ctx,
+        profile,
+        rank,
+        &mut profile_phases,
+        "hc_expand",
+        None,
+        None,
+        phase_start,
+    )?;
 
     for layer in 0..config.n_layers {
+        let phase_start = Instant::now();
         hc = block_prefill_rank_lane_bf16_hidden_with_decode_cache(
             ctx,
             weights,
@@ -1366,12 +1431,79 @@ fn run_prefill_on_rank_lane(
             &mut caches[layer],
         )
         .with_context(|| format!("prefill layer {layer} rank {rank}"))?;
+        record_prefill_profile_phase(
+            ctx,
+            profile,
+            rank,
+            &mut profile_phases,
+            "block_prefill",
+            Some(layer),
+            Some(config.compress_ratios[layer]),
+            phase_start,
+        )?;
     }
 
+    let phase_start = Instant::now();
     let local_logits = final_logits_rank_local_bf16_hidden(ctx, config, weights, &hc)
         .with_context(|| format!("prefill final logits rank {rank}"))?;
-    gather_logits_for_sampling(rank, ctx, comm, weights, &local_logits)
-        .with_context(|| format!("prefill final logits all_gather rank {rank}"))
+    record_prefill_profile_phase(
+        ctx,
+        profile,
+        rank,
+        &mut profile_phases,
+        "final_logits",
+        None,
+        None,
+        phase_start,
+    )?;
+
+    let phase_start = Instant::now();
+    let logits = gather_logits_for_sampling(rank, ctx, comm, weights, &local_logits)
+        .with_context(|| format!("prefill final logits all_gather rank {rank}"))?;
+    record_prefill_profile_phase(
+        ctx,
+        profile,
+        rank,
+        &mut profile_phases,
+        "final_logits_all_gather",
+        None,
+        None,
+        phase_start,
+    )?;
+    if profile && rank == 0 {
+        info!(
+            "pegainfer_prefill_profile {}",
+            serde_json::json!({
+                "rank": rank,
+                "prompt_tokens": seq_len,
+                "phases": profile_phases,
+            })
+        );
+    }
+    Ok(logits)
+}
+
+fn record_prefill_profile_phase(
+    ctx: &RankGpuContext,
+    profile: bool,
+    rank: usize,
+    phases: &mut Vec<serde_json::Value>,
+    name: &str,
+    layer: Option<usize>,
+    compress_ratio: Option<usize>,
+    started_at: Instant,
+) -> Result<()> {
+    if !profile || rank != 0 {
+        return Ok(());
+    }
+    ctx.sync()?;
+    phases.push(serde_json::json!({
+        "name": name,
+        "layer": layer,
+        "compress_ratio": compress_ratio,
+        "ms": started_at.elapsed().as_secs_f64() * 1000.0,
+    }));
+    Ok(())
 }
 
 fn final_batch_logits_rank_local_bf16_hidden(
@@ -1590,7 +1722,7 @@ pub(super) fn run_prefill_logits_and_seed_decode_cache(
         .enumerate()
         .map(|(rank, worker)| {
             worker
-                .prefill(prompt_tokens.to_vec())
+                .prefill(prompt_tokens.to_vec(), runtime.prefill_profile)
                 .with_context(|| format!("dispatch prefill rank {rank}"))
         })
         .collect::<Result<Vec<_>>>()?;

--- a/pegainfer-deepseek-v4/src/e2e_runner.rs
+++ b/pegainfer-deepseek-v4/src/e2e_runner.rs
@@ -204,6 +204,8 @@ fn generate_text(
 
     handle
         .submit(GenerateRequest {
+            request_id: None,
+            queued_at_unix_s: None,
             prompt_tokens,
             params: SamplingParams::default(),
             max_tokens,
@@ -250,6 +252,7 @@ fn collect_generation_events(
                 }
             }
             Some(TokenEvent::PromptTokens { .. }) => {}
+            Some(TokenEvent::Scheduled { .. }) => {}
             Some(TokenEvent::Finished { .. }) => break,
             Some(TokenEvent::Error { message, .. }) => bail!("generation failed: {message}"),
             Some(TokenEvent::Rejected { message, .. }) => bail!("generation rejected: {message}"),

--- a/pegainfer-deepseek-v4/src/e2e_runner.rs
+++ b/pegainfer-deepseek-v4/src/e2e_runner.rs
@@ -105,6 +105,7 @@ pub fn run(options: &E2eOptions) -> Result<E2eSummary> {
             &options.model_path,
             EngineLoadOptions {
                 enable_cuda_graph: options.enable_cuda_graph,
+                enable_prefill_profile: false,
                 device_ordinals: options.device_ordinals.clone(),
                 seed: options.seed,
             },

--- a/pegainfer-qwen3-4b/src/lib.rs
+++ b/pegainfer-qwen3-4b/src/lib.rs
@@ -57,6 +57,7 @@ pub fn start_engine(model_path: &Path, options: EngineLoadOptions) -> Result<Eng
         enable_cuda_graph,
         device_ordinals,
         seed,
+        ..
     } = options;
     let model_path = model_path
         .to_str()

--- a/pegainfer-qwen3-4b/tests/e2e.rs
+++ b/pegainfer-qwen3-4b/tests/e2e.rs
@@ -117,6 +117,7 @@ fn test_e2e_generation() {
         Path::new(&model_path),
         EngineLoadOptions {
             enable_cuda_graph: true,
+            enable_prefill_profile: false,
             device_ordinals: vec![0],
             seed: 42,
         },

--- a/pegainfer-qwen3-4b/tests/e2e.rs
+++ b/pegainfer-qwen3-4b/tests/e2e.rs
@@ -75,6 +75,8 @@ fn generate_tokens(
 
     handle
         .submit(GenerateRequest {
+            request_id: None,
+            queued_at_unix_s: None,
             prompt_tokens,
             params: SamplingParams::default(), // greedy
             max_tokens,
@@ -90,6 +92,7 @@ fn generate_tokens(
         match token_rx.blocking_recv() {
             Some(TokenEvent::Token { id, .. }) => tokens.push(id),
             Some(TokenEvent::PromptTokens { .. }) => {}
+            Some(TokenEvent::Scheduled { .. }) => {}
             Some(TokenEvent::Finished { finish_reason, .. }) => {
                 return (tokens, finish_reason);
             }
@@ -194,6 +197,8 @@ fn test_e2e_generation() {
         // Submit should succeed — scheduler will notice send error and retire the request
         handle
             .submit(GenerateRequest {
+                request_id: None,
+                queued_at_unix_s: None,
                 prompt_tokens,
                 params: SamplingParams::default(),
                 max_tokens: 10,

--- a/pegainfer-qwen3-4b/tests/regen_test_data.rs
+++ b/pegainfer-qwen3-4b/tests/regen_test_data.rs
@@ -133,6 +133,7 @@ fn regen_test_data() {
         Path::new(&model_path),
         EngineLoadOptions {
             enable_cuda_graph: true,
+            enable_prefill_profile: false,
             device_ordinals: vec![0],
             seed: 42,
         },

--- a/pegainfer-qwen3-4b/tests/regen_test_data.rs
+++ b/pegainfer-qwen3-4b/tests/regen_test_data.rs
@@ -94,6 +94,8 @@ fn generate_text_scheduler(
 
     handle
         .submit(GenerateRequest {
+            request_id: None,
+            queued_at_unix_s: None,
             prompt_tokens,
             params: SamplingParams::default(),
             max_tokens,
@@ -108,6 +110,7 @@ fn generate_text_scheduler(
         match token_rx.blocking_recv() {
             Some(TokenEvent::Token { id, .. }) => tokens.push(id),
             Some(TokenEvent::PromptTokens { .. }) => {}
+            Some(TokenEvent::Scheduled { .. }) => {}
             Some(TokenEvent::Finished { .. }) => break,
             Some(TokenEvent::Error { message, .. }) => panic!("generation failed: {message}"),
             Some(TokenEvent::Rejected { message, .. }) => panic!("generation rejected: {message}"),

--- a/pegainfer-qwen35-4b/src/lib.rs
+++ b/pegainfer-qwen35-4b/src/lib.rs
@@ -74,6 +74,7 @@ pub fn start_engine_with_capacity(
         enable_cuda_graph,
         device_ordinals,
         seed,
+        ..
     } = options;
     let device_ordinal = match device_ordinals.as_slice() {
         [] => 0,

--- a/pegainfer-qwen35-4b/tests/e2e.rs
+++ b/pegainfer-qwen35-4b/tests/e2e.rs
@@ -65,6 +65,8 @@ fn generate_text(
 
     handle
         .submit(GenerateRequest {
+            request_id: None,
+            queued_at_unix_s: None,
             prompt_tokens,
             params: SamplingParams::default(),
             max_tokens,
@@ -79,6 +81,7 @@ fn generate_text(
         match token_rx.blocking_recv() {
             Some(TokenEvent::Token { id, .. }) => out.push(id),
             Some(TokenEvent::PromptTokens { .. }) => {}
+            Some(TokenEvent::Scheduled { .. }) => {}
             Some(TokenEvent::Finished { .. }) => break,
             Some(TokenEvent::Error { message, .. }) => panic!("generation failed: {message}"),
             Some(TokenEvent::Rejected { message, .. }) => panic!("generation rejected: {message}"),

--- a/pegainfer-qwen35-4b/tests/e2e.rs
+++ b/pegainfer-qwen35-4b/tests/e2e.rs
@@ -106,6 +106,7 @@ fn test_e2e_qwen35_generation() {
         Path::new(&model_path),
         EngineLoadOptions {
             enable_cuda_graph: true,
+            enable_prefill_profile: false,
             device_ordinals: vec![0],
             seed: 42,
         },

--- a/pegainfer-qwen35-4b/tests/e2e_scheduler.rs
+++ b/pegainfer-qwen35-4b/tests/e2e_scheduler.rs
@@ -62,6 +62,8 @@ fn generate_tokens(
 
     handle
         .submit(GenerateRequest {
+            request_id: None,
+            queued_at_unix_s: None,
             prompt_tokens,
             params: SamplingParams::default(),
             max_tokens,
@@ -76,6 +78,7 @@ fn generate_tokens(
         match token_rx.blocking_recv() {
             Some(TokenEvent::Token { id, .. }) => tokens.push(id),
             Some(TokenEvent::PromptTokens { .. }) => {}
+            Some(TokenEvent::Scheduled { .. }) => {}
             Some(TokenEvent::Finished { finish_reason, .. }) => {
                 return (tokens, finish_reason);
             }
@@ -159,6 +162,8 @@ fn test_e2e_qwen35_scheduler() {
             let (token_tx, token_rx) = mpsc::unbounded_channel();
             handle
                 .submit(GenerateRequest {
+                    request_id: None,
+                    queued_at_unix_s: None,
                     prompt_tokens,
                     params: SamplingParams::default(),
                     max_tokens: case.max_new_tokens,
@@ -177,6 +182,7 @@ fn test_e2e_qwen35_scheduler() {
                 match rx.blocking_recv() {
                     Some(TokenEvent::Token { id, .. }) => tokens.push(id),
                     Some(TokenEvent::PromptTokens { .. }) => {}
+                    Some(TokenEvent::Scheduled { .. }) => {}
                     Some(TokenEvent::Finished { .. }) => break,
                     Some(TokenEvent::Error { message, .. }) => {
                         panic!("generation failed: {message}")
@@ -201,6 +207,8 @@ fn test_e2e_qwen35_scheduler() {
         drop(rx);
         handle
             .submit(GenerateRequest {
+                request_id: None,
+                queued_at_unix_s: None,
                 prompt_tokens,
                 params: SamplingParams::default(),
                 max_tokens: 10,

--- a/pegainfer-qwen35-4b/tests/regen_test_data.rs
+++ b/pegainfer-qwen35-4b/tests/regen_test_data.rs
@@ -194,6 +194,7 @@ fn regen_test_data_qwen35() {
         Path::new(&model_path),
         EngineLoadOptions {
             enable_cuda_graph: true,
+            enable_prefill_profile: false,
             device_ordinals: vec![0],
             seed: 42,
         },

--- a/pegainfer-qwen35-4b/tests/regen_test_data.rs
+++ b/pegainfer-qwen35-4b/tests/regen_test_data.rs
@@ -121,6 +121,8 @@ fn generate_text_scheduler(
 
     handle
         .submit(GenerateRequest {
+            request_id: None,
+            queued_at_unix_s: None,
             prompt_tokens,
             params: SamplingParams::default(),
             max_tokens,
@@ -135,6 +137,7 @@ fn generate_text_scheduler(
         match token_rx.blocking_recv() {
             Some(TokenEvent::Token { id, .. }) => tokens.push(id),
             Some(TokenEvent::PromptTokens { .. }) => {}
+            Some(TokenEvent::Scheduled { .. }) => {}
             Some(TokenEvent::Finished { .. }) => break,
             Some(TokenEvent::Error { message, .. }) => panic!("generation failed: {message}"),
             Some(TokenEvent::Rejected { message, .. }) => panic!("generation rejected: {message}"),

--- a/pegainfer-server/src/bin/bench_serving.rs
+++ b/pegainfer-server/src/bin/bench_serving.rs
@@ -910,6 +910,8 @@ impl BenchModel for SchedulerBenchModel {
             let (token_tx, mut token_rx) = mpsc::unbounded_channel();
             self.handle
                 .submit(SchedulerRequest {
+                    request_id: None,
+                    queued_at_unix_s: None,
                     prompt_tokens: toks.to_vec(),
                     params: SamplingParams {
                         temperature: sampling.temperature,
@@ -932,6 +934,7 @@ impl BenchModel for SchedulerBenchModel {
                         }
                     }
                     Some(TokenEvent::PromptTokens { .. }) => {}
+                    Some(TokenEvent::Scheduled { .. }) => {}
                     Some(TokenEvent::Finished { .. }) => break,
                     Some(TokenEvent::Error { message, .. }) => {
                         anyhow::bail!("scheduler request failed: {message}");

--- a/pegainfer-server/src/bin/bench_serving.rs
+++ b/pegainfer-server/src/bin/bench_serving.rs
@@ -1690,6 +1690,7 @@ fn main() -> Result<()> {
                 Path::new(&cli.model_path),
                 EngineLoadOptions {
                     enable_cuda_graph: false,
+                    enable_prefill_profile: false,
                     device_ordinals: (0..8).collect(),
                     seed: command_seed(&cli),
                 },
@@ -1704,6 +1705,7 @@ fn main() -> Result<()> {
                 Path::new(&cli.model_path),
                 EngineLoadOptions {
                     enable_cuda_graph: cli.cuda_graph,
+                    enable_prefill_profile: false,
                     device_ordinals: vec![0],
                     seed: command_seed(&cli),
                 },
@@ -1718,6 +1720,7 @@ fn main() -> Result<()> {
                 Path::new(&cli.model_path),
                 EngineLoadOptions {
                     enable_cuda_graph: cli.cuda_graph,
+                    enable_prefill_profile: false,
                     device_ordinals: vec![0],
                     seed: command_seed(&cli),
                 },

--- a/pegainfer-server/src/main.rs
+++ b/pegainfer-server/src/main.rs
@@ -31,6 +31,10 @@ struct Args {
     /// Tensor-parallel world size for Qwen3
     #[arg(long, default_value_t = 1)]
     tp_size: usize,
+
+    /// Emit synchronized DeepSeek V4 prefill phase timing records.
+    #[arg(long, default_value_t = false)]
+    deepseek_prefill_profile: bool,
 }
 
 #[tokio::main]
@@ -63,6 +67,7 @@ async fn main() -> anyhow::Result<()> {
                 &args.model_path,
                 EngineLoadOptions {
                     enable_cuda_graph: false,
+                    enable_prefill_profile: args.deepseek_prefill_profile,
                     device_ordinals: (0..8).collect(),
                     seed: 42,
                 },
@@ -83,6 +88,7 @@ async fn main() -> anyhow::Result<()> {
                 &args.model_path,
                 EngineLoadOptions {
                     enable_cuda_graph: args.cuda_graph,
+                    enable_prefill_profile: false,
                     device_ordinals,
                     seed: 42,
                 },
@@ -98,6 +104,7 @@ async fn main() -> anyhow::Result<()> {
                 &args.model_path,
                 EngineLoadOptions {
                     enable_cuda_graph: args.cuda_graph,
+                    enable_prefill_profile: false,
                     device_ordinals: vec![args.device_ordinal],
                     seed: 42,
                 },

--- a/pegainfer-server/src/vllm_frontend.rs
+++ b/pegainfer-server/src/vllm_frontend.rs
@@ -10,10 +10,10 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use vllm_engine_core_client::protocol::handshake::EngineCoreReadyResponse;
 use vllm_engine_core_client::protocol::{
-    EngineCoreFinishReason, EngineCoreOutput, EngineCoreOutputs, EngineCoreRequest,
-    EngineCoreRequestType, EngineCoreSamplingParams, Logprobs, MaybeWireLogprobs, PositionLogprobs,
-    StopReason, TokenLogprob as WireTokenLogprob, UtilityOutput, UtilityResultEnvelope,
-    encode_msgpack,
+    EngineCoreEvent, EngineCoreEventType, EngineCoreFinishReason, EngineCoreOutput,
+    EngineCoreOutputs, EngineCoreRequest, EngineCoreRequestType, EngineCoreSamplingParams,
+    Logprobs, MaybeWireLogprobs, PositionLogprobs, StopReason, TokenLogprob as WireTokenLogprob,
+    UtilityOutput, UtilityResultEnvelope, encode_msgpack, stats::PrefillStats,
 };
 use vllm_engine_core_client::{EngineId, TransportMode};
 use vllm_server::{
@@ -194,6 +194,8 @@ impl LocalEngineBridge {
         let (token_tx, token_rx) = mpsc::unbounded_channel();
         self.handle
             .submit(GenerateRequest {
+                request_id: Some(request_id.clone()),
+                queued_at_unix_s: Some(request.arrival_time),
                 prompt_tokens,
                 params: convert_sampling(&sampling_params),
                 max_tokens: sampling_params.max_tokens as usize,
@@ -275,10 +277,44 @@ async fn run_request_stream(
     mut token_rx: mpsc::UnboundedReceiver<TokenEvent>,
     output_tx: mpsc::UnboundedSender<EngineCoreOutputs>,
 ) {
+    let mut first_token_events = None;
+    let mut first_token_prefill_stats = None;
     while let Some(event) = token_rx.recv().await {
         match event {
+            TokenEvent::Scheduled {
+                queued_at_unix_s,
+                scheduled_at_unix_s,
+                prompt_tokens,
+            } => {
+                first_token_events = Some(vec![
+                    EngineCoreEvent {
+                        r#type: EngineCoreEventType::Queued,
+                        timestamp: queued_at_unix_s,
+                    },
+                    EngineCoreEvent {
+                        r#type: EngineCoreEventType::Scheduled,
+                        timestamp: scheduled_at_unix_s,
+                    },
+                ]);
+                first_token_prefill_stats = Some(PrefillStats {
+                    num_prompt_tokens: prompt_tokens as u32,
+                    num_computed_tokens: prompt_tokens as u32,
+                    num_cached_tokens: 0,
+                    num_local_cached_tokens: 0,
+                    num_external_cached_tokens: 0,
+                });
+            }
             TokenEvent::Token { id, logprob } => {
-                if send_token_output(&output_tx, &request_id, id, logprob).is_err() {
+                if send_token_output(
+                    &output_tx,
+                    &request_id,
+                    id,
+                    logprob,
+                    first_token_events.take(),
+                    first_token_prefill_stats.take(),
+                )
+                .is_err()
+                {
                     return;
                 }
             }
@@ -334,6 +370,8 @@ fn send_token_output(
     request_id: &str,
     token_id: u32,
     logprob: Option<TokenLogprob>,
+    events: Option<Vec<EngineCoreEvent>>,
+    prefill_stats: Option<PrefillStats>,
 ) -> Result<()> {
     send_outputs(
         output_tx,
@@ -345,6 +383,8 @@ fn send_token_output(
                 to_wire_logprobs(token_id, logprob),
                 None,
                 None,
+                events,
+                prefill_stats,
             )],
             timestamp: now_secs_f64(),
             ..Default::default()
@@ -368,6 +408,8 @@ fn send_terminal_output(
                 None,
                 Some(finish_reason),
                 stop_reason,
+                None,
+                None,
             )],
             finished_requests: Some(BTreeSet::from([request_id])),
             timestamp: now_secs_f64(),
@@ -419,6 +461,8 @@ fn engine_output(
     new_logprobs: Option<MaybeWireLogprobs>,
     finish_reason: Option<EngineCoreFinishReason>,
     stop_reason: Option<StopReason>,
+    events: Option<Vec<EngineCoreEvent>>,
+    prefill_stats: Option<PrefillStats>,
 ) -> EngineCoreOutput {
     EngineCoreOutput {
         request_id,
@@ -428,10 +472,10 @@ fn engine_output(
         pooling_output: None,
         finish_reason,
         stop_reason,
-        events: None,
+        events,
         kv_transfer_params: None,
         trace_headers: None,
-        prefill_stats: None,
+        prefill_stats,
         routed_experts: None,
         num_nans_in_logits: 0,
     }

--- a/scripts/bench_http_serving.py
+++ b/scripts/bench_http_serving.py
@@ -13,6 +13,7 @@ import concurrent.futures
 import hashlib
 import http.client
 import json
+import re
 import socket
 import statistics
 import time
@@ -31,13 +32,17 @@ DEFAULT_PROMPT_WORDS = (
 @dataclass
 class RequestResult:
     index: int
+    request_id: str
     ok: bool
     status: int | None
     error: str | None
     timed_out: bool
     start_s: float
+    start_wall_s: float
     first_token_s: float | None
+    first_token_wall_s: float | None
     end_s: float
+    end_wall_s: float
     latency_ms: float
     ttft_ms: float | None
     tpot_ms: float | None
@@ -46,6 +51,7 @@ class RequestResult:
     output_chars: int
     output_hash: str
     text_prefix: str
+    server_trace: dict[str, Any] | None = None
 
 
 def percentile(sorted_values: list[float], pct: float) -> float:
@@ -76,6 +82,31 @@ def summarize(values: list[float]) -> dict[str, float | int | None]:
     }
 
 
+def summarize_trace_ms(measured: list[RequestResult]) -> dict[str, Any]:
+    fields = [
+        "frontend_to_queue_ms",
+        "admission_queue_ms",
+        "prefill_ms",
+        "first_decode_ms",
+        "stream_flush_ms",
+    ]
+    phase_summary: dict[str, Any] = {}
+    for field in fields:
+        values = [
+            float(result.server_trace[field])
+            for result in measured
+            if result.server_trace is not None and isinstance(result.server_trace.get(field), (int, float))
+        ]
+        phase_summary[field] = summarize(values)
+    traced = [result for result in measured if result.server_trace is not None]
+    return {
+        "source": "server log lines matching `pegainfer_http_trace`; frontend_to_queue includes HTTP ingress, tokenization, and vLLM submit before engine queue",
+        "traced_requests": len(traced),
+        "missing_traces": [result.request_id for result in measured if result.server_trace is None],
+        "phases_ms": phase_summary,
+    }
+
+
 def make_prompt(index: int, prompt_words: int) -> str:
     words = [
         DEFAULT_PROMPT_WORDS[(index + offset) % len(DEFAULT_PROMPT_WORDS)]
@@ -97,6 +128,7 @@ def parse_sse_text(payload: dict[str, Any]) -> str:
 
 def request_once(
     index: int,
+    request_id: str,
     url: urllib.parse.ParseResult,
     model: str,
     prompt: str,
@@ -106,7 +138,9 @@ def request_once(
     ignore_eos: bool,
 ) -> RequestResult:
     start = time.perf_counter()
+    start_wall = time.time()
     first_token: float | None = None
+    first_token_wall: float | None = None
     last_token: float | None = None
     inter_token_ms: list[float] = []
     chunks: list[str] = []
@@ -124,6 +158,7 @@ def request_once(
             "temperature": temperature,
             "stream": True,
             "ignore_eos": ignore_eos,
+            "request_id": request_id,
         }
         conn.request(
             "POST",
@@ -154,6 +189,7 @@ def request_once(
             now = time.perf_counter()
             if first_token is None:
                 first_token = now
+                first_token_wall = time.time()
             if last_token is not None:
                 inter_token_ms.append((now - last_token) * 1000.0)
             last_token = now
@@ -162,6 +198,7 @@ def request_once(
         if max_tokens > 0 and not chunks:
             raise RuntimeError("stream completed without streamed text chunks")
         end = time.perf_counter()
+        end_wall = time.time()
         text = "".join(chunks)
         output_hash = hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
         latency_ms = (end - start) * 1000.0
@@ -171,13 +208,17 @@ def request_once(
             tpot_ms = (last_token - first_token) * 1000.0 / (len(chunks) - 1)
         return RequestResult(
             index=index,
+            request_id=request_id,
             ok=True,
             status=status,
             error=None,
             timed_out=False,
             start_s=start,
+            start_wall_s=start_wall,
             first_token_s=first_token,
+            first_token_wall_s=first_token_wall,
             end_s=end,
+            end_wall_s=end_wall,
             latency_ms=latency_ms,
             ttft_ms=ttft_ms,
             tpot_ms=tpot_ms,
@@ -189,29 +230,36 @@ def request_once(
         )
     except (TimeoutError, socket.timeout) as exc:
         end = time.perf_counter()
-        return failed_result(index, status, start, end, str(exc), timed_out=True)
+        return failed_result(index, request_id, status, start, start_wall, end, str(exc), timed_out=True)
     except Exception as exc:  # noqa: BLE001 - benchmark reports the error string.
         end = time.perf_counter()
-        return failed_result(index, status, start, end, str(exc), timed_out=False)
+        return failed_result(index, request_id, status, start, start_wall, end, str(exc), timed_out=False)
 
 
 def failed_result(
     index: int,
+    request_id: str,
     status: int | None,
     start: float,
+    start_wall: float,
     end: float,
     error: str,
     timed_out: bool,
 ) -> RequestResult:
+    end_wall = time.time()
     return RequestResult(
         index=index,
+        request_id=request_id,
         ok=False,
         status=status,
         error=error,
         timed_out=timed_out,
         start_s=start,
+        start_wall_s=start_wall,
         first_token_s=None,
+        first_token_wall_s=None,
         end_s=end,
+        end_wall_s=end_wall,
         latency_ms=(end - start) * 1000.0,
         ttft_ms=None,
         tpot_ms=None,
@@ -223,6 +271,72 @@ def failed_result(
     )
 
 
+TRACE_RE = re.compile(r"pegainfer_http_trace\s+(\{.*\})")
+
+
+def load_server_traces(path: Path | None) -> dict[str, dict[str, Any]]:
+    if path is None or not path.exists():
+        return {}
+    traces: dict[str, dict[str, Any]] = {}
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        match = TRACE_RE.search(line)
+        if not match:
+            continue
+        try:
+            trace = json.loads(match.group(1))
+        except json.JSONDecodeError:
+            continue
+        request_id = trace.get("request_id")
+        if isinstance(request_id, str):
+            traces[request_id] = trace
+    return traces
+
+
+def attach_server_traces(results: list[RequestResult], traces: dict[str, dict[str, Any]]) -> None:
+    for result in results:
+        trace = find_server_trace(result.request_id, result.start_wall_s, traces)
+        if trace is None:
+            continue
+        result.server_trace = trace
+        if result.ok and result.first_token_wall_s is not None:
+            emit_at = trace.get("first_token_emit_unix_s")
+            if isinstance(emit_at, (int, float)):
+                trace["stream_flush_ms"] = max(0.0, (result.first_token_wall_s - float(emit_at)) * 1000.0)
+            queued_at = trace.get("queued_at_unix_s")
+            if isinstance(queued_at, (int, float)):
+                trace["frontend_to_queue_ms"] = max(0.0, (float(queued_at) - result.start_wall_s) * 1000.0)
+            scheduled_at = trace.get("scheduled_at_unix_s")
+            if isinstance(queued_at, (int, float)) and isinstance(scheduled_at, (int, float)):
+                trace["admission_queue_ms"] = max(0.0, (float(scheduled_at) - float(queued_at)) * 1000.0)
+
+
+def find_server_trace(
+    request_id: str,
+    start_wall_s: float,
+    traces: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    prefix = f"cmpl-{request_id}-"
+    matches = [
+        trace
+        for trace_id, trace in traces.items()
+        if trace_id == request_id or trace_id == f"cmpl-{request_id}" or trace_id.startswith(prefix)
+    ]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        timed_matches = [
+            trace
+            for trace in matches
+            if isinstance(trace.get("queued_at_unix_s"), (int, float))
+        ]
+        if timed_matches:
+            return min(
+                timed_matches,
+                key=lambda trace: abs(float(trace["queued_at_unix_s"]) - start_wall_s),
+            )
+    return None
+
+
 def run_batch(args: argparse.Namespace, measured: bool) -> tuple[list[RequestResult], float]:
     url = urllib.parse.urlparse(args.base_url)
     if url.scheme not in {"http", "https"} or not url.hostname:
@@ -230,6 +344,7 @@ def run_batch(args: argparse.Namespace, measured: bool) -> tuple[list[RequestRes
 
     offset = args.warmup if measured else 0
     count = args.num_requests if measured else args.warmup
+    label = "measured" if measured else "warmup"
     prompts = [make_prompt(offset + idx, args.prompt_words) for idx in range(count)]
     started = time.perf_counter()
     with concurrent.futures.ThreadPoolExecutor(max_workers=args.concurrency) as pool:
@@ -237,6 +352,7 @@ def run_batch(args: argparse.Namespace, measured: bool) -> tuple[list[RequestRes
             pool.submit(
                 request_once,
                 idx,
+                f"pegainfer-bench-{label}-{offset + idx}",
                 url,
                 args.model,
                 prompt,
@@ -305,6 +421,7 @@ def build_report(args: argparse.Namespace, measured: list[RequestResult], wall_s
             "tpot": summarize(tpots),
             "itl": summarize(itls),
         },
+        "server_trace": summarize_trace_ms(measured),
         "requests": [asdict(result) for result in measured],
     }
 
@@ -321,6 +438,11 @@ def main() -> None:
     parser.add_argument("--temperature", type=float, default=0.0)
     parser.add_argument("--timeout", type=float, default=120.0)
     parser.add_argument("--ignore-eos", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument(
+        "--server-log",
+        type=Path,
+        help="Optional pegainfer server log containing pegainfer_http_trace lines for TTFT phase attribution.",
+    )
     parser.add_argument("--out", type=Path)
     args = parser.parse_args()
 
@@ -335,6 +457,7 @@ def main() -> None:
             raise SystemExit(f"warmup failed: {failed[0].error}")
 
     measured, wall_s = run_batch(args, measured=True)
+    attach_server_traces(measured, load_server_traces(args.server_log))
     report = build_report(args, measured, wall_s)
     rendered = json.dumps(report, indent=2, sort_keys=True)
     if args.out:

--- a/scripts/bench_http_sweep.py
+++ b/scripts/bench_http_sweep.py
@@ -29,8 +29,14 @@ def request_hashes(report: dict[str, Any]) -> list[str]:
     return [request["output_hash"] for request in report["requests"] if request["ok"]]
 
 
-def run_one(args: argparse.Namespace, concurrency: int, max_tokens: int, repeat: int) -> dict[str, Any]:
-    out = args.out_dir / f"c{concurrency}_mt{max_tokens}_r{repeat}.json"
+def run_one(
+    args: argparse.Namespace,
+    prompt_words: int,
+    concurrency: int,
+    max_tokens: int,
+    repeat: int,
+) -> dict[str, Any]:
+    out = args.out_dir / f"pw{prompt_words}_c{concurrency}_mt{max_tokens}_r{repeat}.json"
     cmd = [
         sys.executable,
         str(BENCH),
@@ -45,7 +51,7 @@ def run_one(args: argparse.Namespace, concurrency: int, max_tokens: int, repeat:
         "--warmup",
         str(args.warmup),
         "--prompt-words",
-        str(args.prompt_words),
+        str(prompt_words),
         "--max-tokens",
         str(max_tokens),
         "--temperature",
@@ -64,15 +70,15 @@ def run_one(args: argparse.Namespace, concurrency: int, max_tokens: int, repeat:
 
 
 def build_summary(args: argparse.Namespace, reports: list[dict[str, Any]]) -> dict[str, Any]:
-    cells: dict[tuple[int, int], list[dict[str, Any]]] = {}
+    cells: dict[tuple[int, int, int], list[dict[str, Any]]] = {}
     for report in reports:
         workload = report["workload"]
-        key = (workload["concurrency"], workload["max_tokens"])
+        key = (workload["prompt_words"], workload["concurrency"], workload["max_tokens"])
         cells.setdefault(key, []).append(report)
 
     rows = []
     correctness_ok = True
-    for (concurrency, max_tokens), cell_reports in sorted(cells.items()):
+    for (prompt_words, concurrency, max_tokens), cell_reports in sorted(cells.items()):
         baseline = request_hashes(cell_reports[0])
         stable = True
         for report in cell_reports:
@@ -84,6 +90,7 @@ def build_summary(args: argparse.Namespace, reports: list[dict[str, Any]]) -> di
         rows.append(
             {
                 "concurrency": concurrency,
+                "prompt_words": prompt_words,
                 "max_tokens": max_tokens,
                 "repeats": len(cell_reports),
                 "stable_per_request_hashes": stable,
@@ -124,7 +131,7 @@ def build_summary(args: argparse.Namespace, reports: list[dict[str, Any]]) -> di
         },
         "correctness_gate": {
             "passed": correctness_ok,
-            "rule": "failed=0, timeout=0, and per-request output_hash list stable across repeats for each concurrency/max_tokens cell",
+            "rule": "failed=0, timeout=0, and per-request output_hash list stable across repeats for each prompt_words/concurrency/max_tokens cell",
         },
         "rows": rows,
     }
@@ -136,7 +143,7 @@ def main() -> None:
     parser.add_argument("--model", required=True)
     parser.add_argument("--num-requests", type=int, default=8)
     parser.add_argument("--warmup", type=int, default=2)
-    parser.add_argument("--prompt-words", type=int, default=16)
+    parser.add_argument("--prompt-words", type=parse_int_list, default=[16])
     parser.add_argument("--temperature", type=float, default=0.0)
     parser.add_argument("--timeout", type=float, default=240.0)
     parser.add_argument("--no-ignore-eos", action="store_true")
@@ -152,10 +159,11 @@ def main() -> None:
     args.out_dir.mkdir(parents=True, exist_ok=True)
 
     reports = []
-    for max_tokens in args.max_tokens:
-        for concurrency in args.concurrency:
-            for repeat in range(args.repeats):
-                reports.append(run_one(args, concurrency, max_tokens, repeat))
+    for prompt_words in args.prompt_words:
+        for max_tokens in args.max_tokens:
+            for concurrency in args.concurrency:
+                for repeat in range(args.repeats):
+                    reports.append(run_one(args, prompt_words, concurrency, max_tokens, repeat))
 
     summary = build_summary(args, reports)
     (args.out_dir / "sweep_summary.json").write_text(

--- a/scripts/bench_http_sweep.py
+++ b/scripts/bench_http_sweep.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Run a reproducible HTTP serving sweep over concurrency and max_tokens."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+BENCH = SCRIPT_DIR / "bench_http_serving.py"
+
+
+def parse_int_list(value: str) -> list[int]:
+    items = [item.strip() for item in value.split(",") if item.strip()]
+    if not items:
+        raise argparse.ArgumentTypeError("list must not be empty")
+    parsed = [int(item) for item in items]
+    if any(item <= 0 for item in parsed):
+        raise argparse.ArgumentTypeError("all values must be positive")
+    return parsed
+
+
+def request_hashes(report: dict[str, Any]) -> list[str]:
+    return [request["output_hash"] for request in report["requests"] if request["ok"]]
+
+
+def run_one(args: argparse.Namespace, concurrency: int, max_tokens: int, repeat: int) -> dict[str, Any]:
+    out = args.out_dir / f"c{concurrency}_mt{max_tokens}_r{repeat}.json"
+    cmd = [
+        sys.executable,
+        str(BENCH),
+        "--base-url",
+        args.base_url,
+        "--model",
+        args.model,
+        "--num-requests",
+        str(args.num_requests),
+        "--concurrency",
+        str(concurrency),
+        "--warmup",
+        str(args.warmup),
+        "--prompt-words",
+        str(args.prompt_words),
+        "--max-tokens",
+        str(max_tokens),
+        "--temperature",
+        str(args.temperature),
+        "--timeout",
+        str(args.timeout),
+        "--out",
+        str(out),
+    ]
+    if args.no_ignore_eos:
+        cmd.append("--no-ignore-eos")
+    if args.server_log:
+        cmd.extend(["--server-log", str(args.server_log)])
+    subprocess.run(cmd, check=True)
+    return json.loads(out.read_text(encoding="utf-8"))
+
+
+def build_summary(args: argparse.Namespace, reports: list[dict[str, Any]]) -> dict[str, Any]:
+    cells: dict[tuple[int, int], list[dict[str, Any]]] = {}
+    for report in reports:
+        workload = report["workload"]
+        key = (workload["concurrency"], workload["max_tokens"])
+        cells.setdefault(key, []).append(report)
+
+    rows = []
+    correctness_ok = True
+    for (concurrency, max_tokens), cell_reports in sorted(cells.items()):
+        baseline = request_hashes(cell_reports[0])
+        stable = True
+        for report in cell_reports:
+            summary = report["summary"]
+            hashes = request_hashes(report)
+            if summary["failed"] or summary["timeouts"] or hashes != baseline:
+                stable = False
+        correctness_ok = correctness_ok and stable
+        rows.append(
+            {
+                "concurrency": concurrency,
+                "max_tokens": max_tokens,
+                "repeats": len(cell_reports),
+                "stable_per_request_hashes": stable,
+                "combined_output_hashes": [
+                    report["summary"]["combined_output_hash"] for report in cell_reports
+                ],
+                "qps": [report["summary"]["qps"] for report in cell_reports],
+                "ttft_avg_ms": [report["metrics"]["ttft"]["avg_ms"] for report in cell_reports],
+                "tpot_avg_ms": [report["metrics"]["tpot"]["avg_ms"] for report in cell_reports],
+                "itl_avg_ms": [report["metrics"]["itl"]["avg_ms"] for report in cell_reports],
+                "failed": [report["summary"]["failed"] for report in cell_reports],
+                "timeouts": [report["summary"]["timeouts"] for report in cell_reports],
+                "trace_phases_avg_ms": [
+                    {
+                        phase: stats["avg_ms"]
+                        for phase, stats in report["server_trace"]["phases_ms"].items()
+                    }
+                    for report in cell_reports
+                ],
+            }
+        )
+
+    return {
+        "schema_version": 1,
+        "kind": "openai_http_completions_sweep",
+        "base_url": args.base_url,
+        "model": args.model,
+        "workload": {
+            "num_requests": args.num_requests,
+            "warmup": args.warmup,
+            "prompt_words": args.prompt_words,
+            "temperature": args.temperature,
+            "ignore_eos": not args.no_ignore_eos,
+            "timeout_s": args.timeout,
+            "concurrency": args.concurrency,
+            "max_tokens": args.max_tokens,
+            "repeats": args.repeats,
+        },
+        "correctness_gate": {
+            "passed": correctness_ok,
+            "rule": "failed=0, timeout=0, and per-request output_hash list stable across repeats for each concurrency/max_tokens cell",
+        },
+        "rows": rows,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:8000")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--num-requests", type=int, default=8)
+    parser.add_argument("--warmup", type=int, default=2)
+    parser.add_argument("--prompt-words", type=int, default=16)
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--timeout", type=float, default=240.0)
+    parser.add_argument("--no-ignore-eos", action="store_true")
+    parser.add_argument("--concurrency", type=parse_int_list, default=[1, 2, 4, 8])
+    parser.add_argument("--max-tokens", type=parse_int_list, default=[16])
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--server-log", type=Path)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    if args.repeats <= 0:
+        raise SystemExit("--repeats must be positive")
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    reports = []
+    for max_tokens in args.max_tokens:
+        for concurrency in args.concurrency:
+            for repeat in range(args.repeats):
+                reports.append(run_one(args, concurrency, max_tokens, repeat))
+
+    summary = build_summary(args, reports)
+    (args.out_dir / "sweep_summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    if not summary["correctness_gate"]["passed"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_bench_http_serving.py
+++ b/tests/test_bench_http_serving.py
@@ -8,6 +8,7 @@ import sys
 import threading
 import unittest
 import urllib.parse
+import tempfile
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
@@ -47,6 +48,7 @@ class BenchHttpServingTests(unittest.TestCase):
     def test_done_only_stream_fails_when_tokens_requested(self) -> None:
         result = bench_http_serving.request_once(
             index=0,
+            request_id="req-empty",
             url=self.url,
             model="fake-model",
             prompt="hello",
@@ -60,6 +62,47 @@ class BenchHttpServingTests(unittest.TestCase):
         self.assertEqual(result.status, 200)
         self.assertIn("without streamed text chunks", result.error or "")
         self.assertEqual(result.output_chunks, 0)
+
+    def test_server_trace_log_is_attached_by_vllm_completion_id_prefix(self) -> None:
+        result = bench_http_serving.RequestResult(
+            index=0,
+            request_id="bench-1",
+            ok=True,
+            status=200,
+            error=None,
+            timed_out=False,
+            start_s=1.0,
+            start_wall_s=100.0,
+            first_token_s=1.2,
+            first_token_wall_s=100.25,
+            end_s=1.4,
+            end_wall_s=100.4,
+            latency_ms=400.0,
+            ttft_ms=200.0,
+            tpot_ms=20.0,
+            itl_ms=[20.0],
+            output_chunks=2,
+            output_chars=4,
+            output_hash="abcd",
+            text_prefix="text",
+        )
+        line = (
+            'INFO pegainfer_http_trace {"request_id":"cmpl-bench-1-generated",'
+            '"queued_at_unix_s":100.01,"scheduled_at_unix_s":100.03,'
+            '"first_token_emit_unix_s":100.20,"prefill_ms":170.0,'
+            '"first_decode_ms":28.0}\\n'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "server.log"
+            path.write_text(line, encoding="utf-8")
+            traces = bench_http_serving.load_server_traces(path)
+            bench_http_serving.attach_server_traces([result], traces)
+
+        self.assertIsNotNone(result.server_trace)
+        assert result.server_trace is not None
+        self.assertAlmostEqual(result.server_trace["admission_queue_ms"], 20.0, places=3)
+        self.assertAlmostEqual(result.server_trace["stream_flush_ms"], 50.0, places=3)
+        self.assertAlmostEqual(result.server_trace["frontend_to_queue_ms"], 10.0, places=3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds the P1 DSV4 HTTP TTFT trace + prefill profiling gate after the P0 concurrency correctness fix.

- threads request id and engine queue timestamp through the HTTP bridge into `GenerateRequest`
- emits `pegainfer_http_trace` records from the DSV4 direct scheduler with queue, prefill, first-decode, and first-token timing
- adds `--deepseek-prefill-profile`, which emits rank-0 `pegainfer_prefill_profile` phase records for DSV4 prefill
- extends `scripts/bench_http_serving.py` to attach server traces and report phase summaries
- extends `scripts/bench_http_sweep.py` to sweep concurrency, max_tokens, and prompt length with per-request hash stability as the correctness gate
- updates the HTTP serving benchmark doc with concurrency, prompt-length, and prefill-profile evidence

## Scope

This PR is diagnostic / benchmark infrastructure plus prefill phase attribution. It does not tune performance, re-enable HTTP wave batching, change paged/prefix KV, or claim serving parity. Hash stability remains the gate: any drift fails the sweep before interpreting TTFT or throughput.

The important interpretation change from the initial PR body: admission queue is a concurrency amplification term, not the root cause for low throughput. The current single-request service time is already high: short-prompt c1 TTFT is about `178ms`, and the remaining decode path is about `29ms/token`. The next optimization target is prefill/decode service time, with priority on the DSV4 prefill kernel/runtime path.

A candidate ratio-4 indexer compressed-KV reuse was tested and rejected because it changed the HTTP output hash gate. It is not included in this PR.

## Evidence

Commit: `1be57cc6d5af4d2cd31c125a4df16b39dc2b348b`

Local checks:

- `git diff --check` passed
- `cargo fmt --check` passed
- `python3 -m py_compile scripts/bench_http_serving.py scripts/bench_http_sweep.py` passed
- `python3 -m unittest tests/test_bench_http_serving.py` passed

Remote build checks on the validation host:

- `cargo check -p pegainfer-server --features deepseek-v4` passed
- `cargo build --release -p pegainfer-server --features deepseek-v4 --bin pegainfer` passed
- `/v1/models` smoke passed against the release server

HTTP correctness / concurrency sweep command:

```bash
python3 scripts/bench_http_sweep.py \
  --base-url http://127.0.0.1:18118 \
  --model /data/DeepSeek-V4-Flash \
  --warmup 2 \
  --num-requests 8 \
  --concurrency 1,2,4,8 \
  --max-tokens 16 \
  --repeats 3 \
  --prompt-words 16 \
  --timeout 240 \
  --server-log /tmp/dsv4_http_server_task4_final.log \
  --out-dir /tmp/dsv4_http_sweep_task4_final
```

Sweep result summary:

| Concurrency | Correctness | QPS (3 runs) | TTFT avg ms (3 runs) | TPOT avg ms (3 runs) | Trace attribution |
| --- | --- | --- | --- | --- | --- |
| `1` | pass; failed `0`, timeout `0`, combined hash `22706877075acde0` in all runs | `1.609`, `1.613`, `1.617` | `180.7`, `177.6`, `177.7` | `29.37`, `29.49`, `29.37` | admission queue avg `~0.0ms`; prefill avg `~178ms` |
| `2` | pass; failed `0`, timeout `0`, combined hash `22706877075acde0` in all runs | `1.620`, `1.620`, `1.622` | `717.4`, `717.9`, `716.5` | `29.34`, `29.35`, `29.33` | admission queue avg `~540ms`; prefill avg `~177ms` |
| `4` | pass; failed `0`, timeout `0`, combined hash `22706877075acde0` in all runs | `1.618`, `1.610`, `1.620` | `1568.9`, `1574.0`, `1566.5` | `29.36`, `29.58`, `29.35` | admission queue avg `~1392ms`; prefill avg `~177ms` |
| `8` | pass; failed `0`, timeout `0`, combined hash `22706877075acde0` in all runs | `1.618`, `1.619`, `1.620` | `2338.6`, `2342.3`, `2339.4` | `29.38`, `29.36`, `29.38` | admission queue avg `~2162ms`; prefill avg `~177ms` |

Prompt-length sweep with profiling enabled (`max_tokens=1`, `concurrency=1`):

| Prompt words | Prompt tokens | QPS | TTFT avg ms | Prefill avg ms | failed / timeout |
| --- | ---: | ---: | ---: | ---: | --- |
| `16` | `22` | `5.433` | `183.6` | `181.7` | `0 / 0` |
| `128` | `164-165` | `4.243` | `235.3` | `234.5` | `0 / 0` |
| `512` | `660-661` | `2.637` | `378.9` | `378.0` | `0 / 0` |
| `2048` | `2644-2645` | `0.758` | `1318.2` | `1316.9` | `0 / 0` |
| `8192` | `10580` | `0.111` | `9029.0` | `9014.0` | `0 / 0` |

Rank-0 prefill profile (`--deepseek-prefill-profile`) groups block-prefill time by DSV4 compress ratio:

| Prompt tokens | Profiled prefill ms | `block_prefill` ms | ratio `0` ms | ratio `4` ms | ratio `128` ms | Top block-prefill layers |
| ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `22` | `150.4` | `149.6` | `5.1` | `80.9` | `63.6` | ratio-4 layers around `4-5ms` each |
| `165` | `203.2` | `202.3` | `8.7` | `100.2` | `93.4` | ratio-4/128 layers around `5-6ms` each |
| `661` | `343.0` | `342.2` | `15.3` | `200.7` | `126.2` | ratio-4 layers around `10ms` each |
| `2645` | `1266.2` | `1260.3` | `37.9` | `818.6` | `403.9` | ratio-4 layers around `39-40ms` each |
| `10580` | `8956.7` | `8940.6` | `134.8` | `6902.4` | `1903.3` | ratio-4 layers dominate, top layer `~500ms` |

## Interpretation

- c1 TTFT is already dominated by direct prefill + decode-cache seeding, before queueing is relevant.
- c2/c4/c8 TTFT growth is mostly admission queue time because HTTP serving currently runs one request per scheduler turn after the P0 correctness fallback.
- Prompt-length sweep shows TTFT tracks prefill time; long prompts make prefill the visible service-time limiter.
- Rank-0 profile points the first kernel/runtime target at ratio-4 `block_prefill`, especially compressed attention / indexer / compressor work.

This PR provides the trace and profile gate for the optimization work. It does not claim a throughput improvement.
