### PR TITLE
perf(dsv4): reuse prefill window topk

### DIFF
--- a/docs/projects/deepseek-v4/http-serving-benchmark.md
+++ b/docs/projects/deepseek-v4/http-serving-benchmark.md
@@ -209,6 +209,36 @@ the compressed attention / indexer / compressor path. A candidate reuse of the
 ratio-4 indexer compressed KV was evaluated and rejected because it changed the
 HTTP output hash gate; it is not included in this PR.
 
+### P2 Ratio-4 Block-Prefill Optimization
+
+The first accepted optimization removes repeated generation of the same prefill
+window top-k index table from the layer loop. The table depends only on
+`seq_len` and `sliding_window`, not on the layer. The direct prefill path now
+builds it once per request and reuses it for non-compressed sparse attention and
+ratio-4 compressed attention layers.
+
+HTTP correctness remains the gate. The same c1/c2/c4/c8 sweep still passes with
+`failed=0`, `timeout=0`, and combined hash `22706877075acde0` across all three
+repeats:
+
+| Concurrency | QPS (3 runs) | TTFT avg ms (3 runs) | TPOT avg ms (3 runs) |
+| --- | --- | --- | --- |
+| `1` | `1.737`, `1.730`, `1.744` | `156.5`, `154.6`, `153.2` | `27.92`, `28.20`, `28.00` |
+| `2` | `1.746`, `1.748`, `1.747` | `653.3`, `652.9`, `653.9` | `28.01`, `27.98`, `27.97` |
+| `4` | `1.746`, `1.746`, `1.748` | `1441.7`, `1442.6`, `1441.2` | `27.97`, `28.00`, `27.98` |
+| `8` | `1.745`, `1.746`, `1.747` | `2162.5`, `2159.2`, `2157.3` | `28.01`, `27.97`, `27.99` |
+
+Rank-0 profile shows the clearest long-prompt improvement in the ratio-4 bucket:
+
+| Prompt tokens | P1 ratio-4 `block_prefill` ms | P2 ratio-4 `block_prefill` ms | Delta |
+| ---: | ---: | ---: | ---: |
+| `661` | `200.7` | `207.3` | noisy / no win |
+| `2645` | `818.6` | `815.4` | `-3.2ms` |
+| `10580` | `6902.4` | `6729.9` | `-172.5ms` |
+
+Profile-mode TTFT is still a synchronized diagnostic measurement, not a serving
+number. The serving-number evidence remains the non-profile HTTP sweep above.
+
 ## Boundary
 
 This PR establishes a benchmark gate and one real HTTP run. It does not claim

--- a/pegainfer-deepseek-v4/src/direct/worker.rs
+++ b/pegainfer-deepseek-v4/src/direct/worker.rs
@@ -13,8 +13,8 @@ use crate::{
     runtime::{
         AttentionAuxScratch, AttentionIndexScratch, AttentionOutputScratch,
         AttentionProjectionScratch, DecodeBatchMeta, DecodeEntryScratch, F32BatchLogits,
-        FinalLogitsScratch, HcPostScratch, HcPreNormScratch, MoeAgRsScratch, SharedExpertScratch,
-        all_gather_logits, all_gather_logits_into,
+        FinalLogitsScratch, HcPostScratch, HcPreNormScratch, MoeAgRsScratch, PrefillWindowTopk,
+        SharedExpertScratch, all_gather_logits, all_gather_logits_into,
         block_decode_rank_lane_bf16_hidden_batch_with_scratch,
         block_decode_rank_lane_bf16_hidden_with_scratch,
         block_prefill_rank_lane_bf16_hidden_with_decode_cache, embedding_rank_local_into,
@@ -1356,6 +1356,8 @@ fn run_prefill_on_rank_lane(
     ctx.set_current()?;
     let seq_len = prompt_tokens.len();
     let mut profile_phases = Vec::new();
+    let prefill_window_topk = PrefillWindowTopk::new(ctx, seq_len, config.sliding_window)
+        .with_context(|| format!("prefill window topk rank {rank}"))?;
 
     let phase_start = Instant::now();
     let token_ids = ctx
@@ -1429,6 +1431,7 @@ fn run_prefill_on_rank_lane(
             &ropes[layer],
             0,
             &mut caches[layer],
+            &prefill_window_topk,
         )
         .with_context(|| format!("prefill layer {layer} rank {rank}"))?;
         record_prefill_profile_phase(

--- a/pegainfer-deepseek-v4/src/runtime/attention.rs
+++ b/pegainfer-deepseek-v4/src/runtime/attention.rs
@@ -289,6 +289,7 @@ pub(crate) fn attention_prefill_compressed_overlap_rank_local_collective_bf16_hi
     start_pos: usize,
     cache: &mut LayerDecodeCache,
     comm: &Comm,
+    prefill_window_topk: &PrefillWindowTopk,
 ) -> Result<Bf16HiddenStates> {
     ensure!(
         config.compress_ratios[layer] == 4,
@@ -346,7 +347,16 @@ pub(crate) fn attention_prefill_compressed_overlap_rank_local_collective_bf16_hi
     .with_context(|| format!("ratio-4 rank-lane indexer tail layer {layer}"))?;
 
     if input.seq_len < 4 {
-        let mut attn_out = sparse_attention_prefill_bf16_hidden(ctx, config, &projections, attn)?;
+        let (topk_idxs, topk) =
+            prefill_window_topk.parts(projections.q.seq_len, config.sliding_window)?;
+        let mut attn_out = sparse_attention_prefill_bf16_hidden_with_topk(
+            ctx,
+            config,
+            &projections,
+            attn,
+            topk_idxs,
+            topk,
+        )?;
         return attention_output_project_bf16_hidden(
             ctx,
             &mut attn_out,
@@ -400,7 +410,7 @@ pub(crate) fn attention_prefill_compressed_overlap_rank_local_collective_bf16_hi
         .map_err(|err| anyhow::anyhow!("NCCL indexer score all-reduce failed: {err:?}"))?;
 
     let (window_idxs, window_topk) =
-        window_topk_indices(ctx, input.seq_len, config.sliding_window)?;
+        prefill_window_topk.parts(input.seq_len, config.sliding_window)?;
     let (compress_idxs, compress_topk) = indexer_topk_indices_prefill(
         ctx,
         config,
@@ -819,6 +829,7 @@ pub(crate) fn attention_prefill_rank_local_bf16_hidden_with_cache(
     rope: &DeepSeekRopeCache,
     start_pos: usize,
     kv_cache: &mut Bf16Cache,
+    prefill_window_topk: &PrefillWindowTopk,
 ) -> Result<Bf16HiddenStates> {
     ctx.set_current()?;
     ensure!(
@@ -833,7 +844,16 @@ pub(crate) fn attention_prefill_rank_local_bf16_hidden_with_cache(
     let mut projections = attention_project_bf16_hidden(ctx, config, input, attn)?;
     apply_rope_attention_projections(ctx, &mut projections, rope, start_pos)?;
     copy_window_prefill_to_ring_cache(ctx, &projections.kv, kv_cache, config.sliding_window)?;
-    let mut attn_out = sparse_attention_prefill_bf16_hidden(ctx, config, &projections, attn)?;
+    let (topk_idxs, topk) =
+        prefill_window_topk.parts(projections.q.seq_len, config.sliding_window)?;
+    let mut attn_out = sparse_attention_prefill_bf16_hidden_with_topk(
+        ctx,
+        config,
+        &projections,
+        attn,
+        topk_idxs,
+        topk,
+    )?;
     attention_output_project_bf16_hidden(
         ctx,
         &mut attn_out,

--- a/pegainfer-deepseek-v4/src/runtime/attention_base.rs
+++ b/pegainfer-deepseek-v4/src/runtime/attention_base.rs
@@ -621,7 +621,53 @@ pub fn sparse_attention_prefill_bf16_hidden(
     attn: &AttentionWeights<'_>,
 ) -> Result<Bf16HiddenStates> {
     let (topk_idxs, topk) = window_topk_indices(ctx, projections.q.seq_len, config.sliding_window)?;
-    indexed_attention_prefill_bf16_hidden(ctx, config, projections, attn, &topk_idxs, topk)
+    sparse_attention_prefill_bf16_hidden_with_topk(ctx, config, projections, attn, &topk_idxs, topk)
+}
+
+pub(crate) fn sparse_attention_prefill_bf16_hidden_with_topk(
+    ctx: &RankGpuContext,
+    config: &Config,
+    projections: &AttentionProjections,
+    attn: &AttentionWeights<'_>,
+    topk_idxs: &CudaSlice<i32>,
+    topk: usize,
+) -> Result<Bf16HiddenStates> {
+    indexed_attention_prefill_bf16_hidden(ctx, config, projections, attn, topk_idxs, topk)
+}
+
+pub(crate) struct PrefillWindowTopk {
+    indices: CudaSlice<i32>,
+    topk: usize,
+    seq_len: usize,
+    window_size: usize,
+}
+
+impl PrefillWindowTopk {
+    pub(crate) fn new(ctx: &RankGpuContext, seq_len: usize, window_size: usize) -> Result<Self> {
+        let (indices, topk) = window_topk_indices(ctx, seq_len, window_size)?;
+        Ok(Self {
+            indices,
+            topk,
+            seq_len,
+            window_size,
+        })
+    }
+
+    pub(crate) fn parts(
+        &self,
+        seq_len: usize,
+        window_size: usize,
+    ) -> Result<(&CudaSlice<i32>, usize)> {
+        ensure!(
+            self.seq_len == seq_len && self.window_size == window_size,
+            "prefill window topk mismatch: cached seq_len={}, window_size={}, requested seq_len={}, window_size={}",
+            self.seq_len,
+            self.window_size,
+            seq_len,
+            window_size
+        );
+        Ok((&self.indices, self.topk))
+    }
 }
 
 pub fn window_topk_indices(

--- a/pegainfer-deepseek-v4/src/runtime/block.rs
+++ b/pegainfer-deepseek-v4/src/runtime/block.rs
@@ -60,6 +60,7 @@ pub(crate) fn block_prefill_rank_lane_bf16_hidden_with_decode_cache(
     rope: &DeepSeekRopeCache,
     start_pos: usize,
     cache: &mut LayerDecodeCache,
+    prefill_window_topk: &PrefillWindowTopk,
 ) -> Result<HcHiddenStates> {
     ensure!(
         layer < config.n_layers,
@@ -88,6 +89,7 @@ pub(crate) fn block_prefill_rank_lane_bf16_hidden_with_decode_cache(
             rope,
             start_pos,
             &mut cache.kv,
+            prefill_window_topk,
         )?,
         4 => attention_prefill_compressed_overlap_rank_local_collective_bf16_hidden_with_cache(
             ctx,
@@ -99,6 +101,7 @@ pub(crate) fn block_prefill_rank_lane_bf16_hidden_with_decode_cache(
             start_pos,
             cache,
             comm,
+            prefill_window_topk,
         )?,
         _ => attention_prefill_compressed_nonoverlap_rank_local_bf16_hidden_with_cache(
             ctx,


### PR DESCRIPTION
## Summary

Optimizes DSV4 direct prefill by reusing the prefill window top-k index table across layers.

The table depends only on `(seq_len, sliding_window)`, but the previous rank-lane prefill path regenerated it inside each sparse / ratio-4 attention layer. This PR builds it once per prefill request and passes it through the block/attention path. It does not reuse or mutate compressed KV values; the ratio-4 indexer/compressor math stays unchanged.

## Scope

- first ratio-4 `block_prefill` optimization after PR #111 profiling
- no HTTP wave batching change
- no paged/prefix KV or P/D changes
- no serving parity or production claim

## Evidence

Commit: `8a5886ea164e04bf247255dae2afc2b858c1705f`

Local checks:

- `git diff --check` passed
- `cargo fmt --check` passed
- `python3 -m py_compile scripts/bench_http_serving.py scripts/bench_http_sweep.py` passed
- `python3 -m unittest tests/test_bench_http_serving.py` passed

Build checks on the validation host:

- `cargo check -p pegainfer-server --features deepseek-v4` passed
- `cargo build --release -p pegainfer-server --features deepseek-v4 --bin pegainfer` passed
- `/v1/models` smoke passed against the release server

HTTP correctness sweep, non-profile server:

```bash
python3 scripts/bench_http_sweep.py \
  --base-url http://127.0.0.1:18118 \
  --model /data/DeepSeek-V4-Flash \
  --warmup 2 \
  --num-requests 8 \
  --concurrency 1,2,4,8 \
  --max-tokens 16 \
  --repeats 3 \
  --prompt-words 16 \
  --timeout 240 \
  --server-log /tmp/dsv4_http_server_task5_opt.log \
  --out-dir /tmp/dsv4_http_sweep_task5_opt
```

All cells passed the correctness gate: failed `0`, timeout `0`, combined hash `22706877075acde0` in all three repeats.

| Concurrency | QPS (3 runs) | TTFT avg ms (3 runs) | TPOT avg ms (3 runs) |
| --- | --- | --- | --- |
| `1` | `1.737`, `1.730`, `1.744` | `156.5`, `154.6`, `153.2` | `27.92`, `28.20`, `28.00` |
| `2` | `1.746`, `1.748`, `1.747` | `653.3`, `652.9`, `653.9` | `28.01`, `27.98`, `27.97` |
| `4` | `1.746`, `1.746`, `1.748` | `1441.7`, `1442.6`, `1441.2` | `27.97`, `28.00`, `27.98` |
| `8` | `1.745`, `1.746`, `1.747` | `2162.5`, `2159.2`, `2157.3` | `28.01`, `27.97`, `27.99` |

Profile-mode evidence uses `--deepseek-prefill-profile`, which synchronizes CUDA phases and is not a serving-number source. It is used only to compare the ratio-4 `block_prefill` bucket against the PR #111 profile baseline.

| Prompt tokens | PR #111 ratio-4 `block_prefill` ms | This PR ratio-4 `block_prefill` ms | Delta |
| ---: | ---: | ---: | ---: |
| `661` | `200.7` | `207.3` | noisy / no win |
| `2645` | `818.6` | `815.4` | `-3.2ms` |
| `10580` | `6902.4` | `6729.9` | `-172.5ms` |

The clearest gain is at the long-prompt point where repeated window-index generation was most expensive. Shorter prompt profile points remain noisy, so this PR does not claim a broad TTFT improvement beyond the measured long-prompt ratio-4 bucket reduction and the non-profile HTTP correctness/QPS evidence above.
