### PR TITLE
test(dsv4): add CuTe DSL indexer score diagnostic

### DIFF
--- a/pegainfer-kernels/Cargo.toml
+++ b/pegainfer-kernels/Cargo.toml
@@ -14,6 +14,7 @@ cc = { workspace = true }
 [features]
 default = []
 deepseek-v4 = []
+deepseek-v4-cutedsl-diagnostic = ["deepseek-v4"]
 
 [lints]
 workspace = true

--- a/pegainfer-kernels/build.rs
+++ b/pegainfer-kernels/build.rs
@@ -1002,12 +1002,13 @@ fn main() {
     let sm_targets = detect_sm_targets();
     let arch_args = nvcc_arch_args(&sm_targets);
     let deepseek_enabled = cfg!(feature = "deepseek-v4");
+    let cutedsl_diagnostic_enabled = cfg!(feature = "deepseek-v4-cutedsl-diagnostic");
     let tilelang_artifacts = if deepseek_enabled {
         Some(generate_deepseek_tilelang_artifacts(&out_dir))
     } else {
         None
     };
-    let cutedsl_artifacts = if deepseek_enabled {
+    let cutedsl_artifacts = if cutedsl_diagnostic_enabled {
         Some(generate_deepseek_cutedsl_artifacts(&out_dir))
     } else {
         None

--- a/pegainfer-kernels/build.rs
+++ b/pegainfer-kernels/build.rs
@@ -29,6 +29,13 @@ struct TileLangArtifacts {
     cutlass_include: PathBuf,
 }
 
+struct CuTeDslArtifacts {
+    obj_files: Vec<PathBuf>,
+    wrapper_files: Vec<PathBuf>,
+    include_dir: PathBuf,
+    runtime_lib_dirs: Vec<PathBuf>,
+}
+
 struct FlashInferIncludes {
     include: PathBuf,
     csrc: PathBuf,
@@ -111,7 +118,7 @@ fn parse_sm_token(raw: &str) -> Option<String> {
         .unwrap_or(token);
 
     if let Some((major, minor)) = token.split_once('.') {
-        let digit_count = minor.chars().take_while(|c| c.is_ascii_digit()).count();
+        let digit_count = minor.chars().take_while(char::is_ascii_digit).count();
         let (minor_digits, suffix) = minor.split_at(digit_count);
         if major.chars().all(|c| c.is_ascii_digit())
             && !minor_digits.is_empty()
@@ -122,7 +129,7 @@ fn parse_sm_token(raw: &str) -> Option<String> {
         return None;
     }
 
-    let digit_count = token.chars().take_while(|c| c.is_ascii_digit()).count();
+    let digit_count = token.chars().take_while(char::is_ascii_digit).count();
     let (digits, suffix) = token.split_at(digit_count);
     if !digits.is_empty() && suffix.chars().all(|c| c.is_ascii_alphabetic()) {
         if digits.len() == 1 {
@@ -215,7 +222,7 @@ fn nvcc_arch_args(sm_targets: &[String]) -> Vec<String> {
         .map(|sm| normalize_flashinfer_sm(sm))
         .max_by_key(|sm| {
             sm.chars()
-                .take_while(|c| c.is_ascii_digit())
+                .take_while(char::is_ascii_digit)
                 .collect::<String>()
                 .parse::<u32>()
                 .unwrap_or(0)
@@ -235,7 +242,7 @@ fn collect_files_recursively(dir: &Path, out: &mut Vec<PathBuf>) {
             entry.unwrap_or_else(|err| panic!("Failed to read entry in {}: {err}", dir.display()))
         })
         .collect();
-    entries.sort_by_key(|entry| entry.path());
+    entries.sort_by_key(std::fs::DirEntry::path);
 
     for entry in entries {
         let path = entry.path();
@@ -377,6 +384,58 @@ fn find_tilelang_python() -> Result<String, String> {
     ))
 }
 
+fn probe_cutedsl_python(candidate: &str) -> Result<String, String> {
+    let output = Command::new(candidate)
+        .args(["-c", "import cutlass, cutlass.cute"])
+        .output()
+        .map_err(|err| format!("{candidate}: {err}"))?;
+
+    if output.status.success() {
+        Ok(candidate.to_string())
+    } else {
+        Err(format!(
+            "{candidate}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))
+    }
+}
+
+fn find_cutedsl_python() -> Result<String, String> {
+    if let Ok(candidate) = std::env::var("PEGAINFER_CUTEDSL_PYTHON") {
+        let candidate = candidate.trim();
+        if candidate.is_empty() {
+            return Err("PEGAINFER_CUTEDSL_PYTHON is set but empty.".to_string());
+        }
+        return probe_cutedsl_python(candidate).map_err(|message| {
+            format!("PEGAINFER_CUTEDSL_PYTHON=`{candidate}` could not import CuTe DSL: {message}")
+        });
+    }
+
+    let workspace_venv = workspace_root().join(".venv/bin/python");
+    let parent_venv = workspace_root().join("../.venv/bin/python");
+    let mut diagnostics = Vec::new();
+    let mut candidates = Vec::new();
+    if workspace_venv.exists() {
+        candidates.push(workspace_venv.to_string_lossy().to_string());
+    }
+    if parent_venv.exists() {
+        candidates.push(parent_venv.to_string_lossy().to_string());
+    }
+    candidates.extend(["python3".to_string(), "python".to_string()]);
+
+    for candidate in candidates {
+        match probe_cutedsl_python(&candidate) {
+            Ok(path) => return Ok(path),
+            Err(message) => diagnostics.push(message),
+        }
+    }
+
+    Err(format!(
+        "Could not find a Python interpreter with CuTe DSL installed. Set PEGAINFER_CUTEDSL_PYTHON. Probe results: {}.",
+        diagnostics.join(" | ")
+    ))
+}
+
 fn generate_deepseek_tilelang_artifacts(out_dir: &Path) -> TileLangArtifacts {
     let python = find_tilelang_python().unwrap_or_else(|message| {
         panic!("DeepSeek V4 TileLang kernels require TileLang at build time: {message}")
@@ -437,6 +496,90 @@ fn generate_deepseek_tilelang_artifacts(out_dir: &Path) -> TileLangArtifacts {
         cu_files: vec![cu_path],
         template_include,
         cutlass_include,
+    }
+}
+
+fn generate_deepseek_cutedsl_artifacts(out_dir: &Path) -> CuTeDslArtifacts {
+    let python = find_cutedsl_python().unwrap_or_else(|message| {
+        panic!("DeepSeek V4 CuTe DSL kernels require CuTe DSL at build time: {message}")
+    });
+
+    let root = crate_root();
+    let repo_root = workspace_root();
+    let generator_path = root.join("tools/cutedsl/deepseek_v4/generate.py");
+    assert!(
+        generator_path.exists(),
+        "DeepSeek V4 CuTe DSL generator is missing: {}",
+        generator_path.display()
+    );
+
+    let artifact_dir = out_dir.join("cutedsl").join("deepseek_v4");
+    let mut command = Command::new(&python);
+    command
+        .arg(&generator_path)
+        .arg("--out-dir")
+        .arg(&artifact_dir)
+        .arg("--repo-root")
+        .arg(&repo_root);
+    if let Ok(cutlass_root) = std::env::var("PEGAINFER_CUTEDSL_CUTLASS_ROOT") {
+        command.arg("--cutlass-root").arg(cutlass_root);
+    }
+
+    let output = time_phase("cutedsl-gen deepseek_v4", || {
+        command
+            .output()
+            .unwrap_or_else(|err| panic!("failed to run DeepSeek CuTe DSL generator: {err}"))
+    });
+    assert!(
+        output.status.success(),
+        "DeepSeek CuTe DSL generator failed. stdout: {} stderr: {}",
+        String::from_utf8_lossy(&output.stdout).trim(),
+        String::from_utf8_lossy(&output.stderr).trim(),
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut obj_files = Vec::new();
+    let mut wrapper_files = Vec::new();
+    let mut include_dir = None;
+    let mut runtime_lib_dirs = Vec::new();
+    for line in stdout.lines() {
+        if let Some(value) = line.strip_prefix("OBJ_PATH=") {
+            obj_files.push(PathBuf::from(value.trim()));
+        } else if let Some(value) = line.strip_prefix("WRAPPER_PATH=") {
+            wrapper_files.push(PathBuf::from(value.trim()));
+        } else if let Some(value) = line.strip_prefix("HEADER_DIR=") {
+            include_dir = Some(PathBuf::from(value.trim()));
+        } else if let Some(value) = line.strip_prefix("RUNTIME_LIB_DIR=") {
+            runtime_lib_dirs.push(PathBuf::from(value.trim()));
+        }
+    }
+
+    let include_dir = include_dir.expect("DeepSeek CuTe DSL generator did not print HEADER_DIR");
+    assert!(
+        !obj_files.is_empty() && !wrapper_files.is_empty(),
+        "DeepSeek CuTe DSL generator did not emit OBJ_PATH/WRAPPER_PATH"
+    );
+    for path in obj_files.iter().chain(wrapper_files.iter()) {
+        assert!(
+            path.exists(),
+            "generated CuTe DSL artifact missing: {}",
+            path.display()
+        );
+    }
+
+    println!(
+        "cargo:warning=Using DeepSeek V4 CuTe DSL AOT artifacts from {}",
+        artifact_dir.display()
+    );
+    println!("cargo:rerun-if-changed={}", generator_path.display());
+    println!("cargo:rerun-if-env-changed=PEGAINFER_CUTEDSL_PYTHON");
+    println!("cargo:rerun-if-env-changed=PEGAINFER_CUTEDSL_CUTLASS_ROOT");
+
+    CuTeDslArtifacts {
+        obj_files,
+        wrapper_files,
+        include_dir,
+        runtime_lib_dirs,
     }
 }
 
@@ -864,6 +1007,11 @@ fn main() {
     } else {
         None
     };
+    let cutedsl_artifacts = if deepseek_enabled {
+        Some(generate_deepseek_cutedsl_artifacts(&out_dir))
+    } else {
+        None
+    };
     println!(
         "cargo:warning=Compiling CUDA kernels for targets: {}",
         sm_targets
@@ -1025,6 +1173,39 @@ fn main() {
         }
     }
 
+    let mut cutedsl_obj_files = Vec::new();
+    let mut cutedsl_runtime_lib_dirs = Vec::new();
+    if let Some(cutedsl_artifacts) = cutedsl_artifacts {
+        cutedsl_obj_files.extend(cutedsl_artifacts.obj_files);
+        cutedsl_runtime_lib_dirs.extend(cutedsl_artifacts.runtime_lib_dirs);
+        for cu_file in cutedsl_artifacts.wrapper_files {
+            let stem = cu_file.file_stem().unwrap().to_str().unwrap();
+            let obj_file = out_dir.join(format!("{stem}_cuda.o"));
+            let mut nvcc_args = vec![
+                "-c".to_string(),
+                cu_file.to_string_lossy().to_string(),
+                "-o".to_string(),
+                obj_file.to_string_lossy().to_string(),
+                "-O3".to_string(),
+                "-I".to_string(),
+                cuda_include.to_string_lossy().to_string(),
+            ];
+            nvcc_args.extend(arch_args.clone());
+            nvcc_args.extend([
+                "--std=c++17".to_string(),
+                "--compiler-options".to_string(),
+                "-fPIC".to_string(),
+                "-I".to_string(),
+                cutedsl_artifacts.include_dir.to_string_lossy().to_string(),
+            ]);
+            nvcc_tasks.push(NvccTask {
+                cu_file,
+                obj_file,
+                args: nvcc_args,
+            });
+        }
+    }
+
     nvcc_tasks.sort_by_key(|task| nvcc_task_priority(&task.cu_file));
 
     let task_queue = Mutex::new(VecDeque::from(nvcc_tasks));
@@ -1070,6 +1251,8 @@ fn main() {
         }
     });
     obj_files.sort();
+    obj_files.extend(cutedsl_obj_files);
+    obj_files.sort();
 
     let cuda_lib = out_dir.join("libkernels_cuda.a");
     let _ = fs::remove_file(&cuda_lib);
@@ -1097,9 +1280,15 @@ fn main() {
     } else {
         println!("cargo:rustc-link-search=native={}/lib64", cuda_path);
     }
+    for dir in &cutedsl_runtime_lib_dirs {
+        println!("cargo:rustc-link-search=native={}", dir.display());
+    }
     println!("cargo:rustc-link-lib=static=kernels_cuda");
     println!("cargo:rustc-link-lib=cudart");
     println!("cargo:rustc-link-lib=cublas");
+    if !cutedsl_runtime_lib_dirs.is_empty() {
+        println!("cargo:rustc-link-lib=static=cuda_dialect_runtime_static");
+    }
     if !cfg!(target_os = "windows") {
         println!("cargo:rustc-link-lib=stdc++");
     }

--- a/pegainfer-kernels/csrc/deepseek_v4/deepseek_indexer.cu
+++ b/pegainfer-kernels/csrc/deepseek_v4/deepseek_indexer.cu
@@ -10,15 +10,8 @@ struct DeepseekFp4QuantScratch {
   size_t scale_bytes = 0;
 };
 
-struct DeepseekIndexerScoresScratch {
-  __nv_bfloat16 *dots = nullptr;
-  size_t dot_elems = 0;
-};
-
 static DeepseekFp4QuantScratch g_fp4_quant_scratch[16];
 static std::mutex g_fp4_quant_scratch_mutex[16];
-static DeepseekIndexerScoresScratch g_indexer_scores_scratch[16];
-static std::mutex g_indexer_scores_scratch_mutex[16];
 
 static cudaError_t deepseek_ensure_bf16_scratch(
     __nv_bfloat16 **ptr,
@@ -64,7 +57,7 @@ extern "C" int deepseek_tilelang_fp4_quant_inplace_n128(
 extern "C" cudaError_t deepseek_cutedsl_indexer_dots_bf16_cuda(
     const __nv_bfloat16 *q,
     const __nv_bfloat16 *kv,
-    __nv_bfloat16 *dots,
+    float *dots,
     int rows,
     int compressed_len,
     cudaStream_t stream);
@@ -151,7 +144,7 @@ __global__ void deepseek_indexer_scores_prefill_serial_kernel(
 }
 
 __global__ void deepseek_indexer_scores_epilogue_kernel(
-    const __nv_bfloat16 *__restrict__ dots,
+    const float *__restrict__ dots,
     const __nv_bfloat16 *__restrict__ weights,
     float *__restrict__ scores,
     int seq_len,
@@ -167,7 +160,7 @@ __global__ void deepseek_indexer_scores_epilogue_kernel(
   float acc = 0.0f;
   for (int head = 0; head < local_heads; ++head) {
     int dot_idx = (token * local_heads + head) * compressed_len + compressed;
-    float dot = __bfloat162float(dots[dot_idx]);
+    float dot = dots[dot_idx];
     float weight = __bfloat162float(weights[token * local_heads + head]);
     acc += fmaxf(dot, 0.0f) * weight;
   }
@@ -175,7 +168,7 @@ __global__ void deepseek_indexer_scores_epilogue_kernel(
 }
 
 __global__ void deepseek_indexer_scores_decode_epilogue_kernel(
-    const __nv_bfloat16 *__restrict__ dots,
+    const float *__restrict__ dots,
     const __nv_bfloat16 *__restrict__ weights,
     float *__restrict__ scores,
     int local_heads,
@@ -187,7 +180,7 @@ __global__ void deepseek_indexer_scores_decode_epilogue_kernel(
   float acc = 0.0f;
   for (int head = 0; head < local_heads; ++head) {
     int dot_idx = head * compressed_len + compressed;
-    float dot = __bfloat162float(dots[dot_idx]);
+    float dot = dots[dot_idx];
     float weight = __bfloat162float(weights[head]);
     acc += fmaxf(dot, 0.0f) * weight;
   }
@@ -610,31 +603,15 @@ cudaError_t deepseek_indexer_scores_prefill_cuda(
     int compressed_len,
     float score_scale,
     cudaStream_t stream) {
-  if (q == nullptr || kv == nullptr || weights == nullptr || scores == nullptr ||
-      seq_len <= 0 || local_heads <= 0 || head_dim != 128 || compressed_len <= 0) {
+  if (seq_len <= 0 || local_heads <= 0 || head_dim <= 0 || compressed_len <= 0) {
     return cudaErrorInvalidValue;
   }
-
-  int device = 0;
-  cudaError_t err = cudaGetDevice(&device);
-  if (err != cudaSuccess) return err;
-  if (device < 0 || device >= 16) return cudaErrorInvalidDevice;
-
-  std::lock_guard<std::mutex> lock(g_indexer_scores_scratch_mutex[device]);
-  DeepseekIndexerScoresScratch &scratch = g_indexer_scores_scratch[device];
-  size_t dot_elems = static_cast<size_t>(seq_len) * local_heads * compressed_len;
-  err = deepseek_ensure_bf16_scratch(&scratch.dots, &scratch.dot_elems, dot_elems);
-  if (err != cudaSuccess) return err;
-
-  err = deepseek_cutedsl_indexer_dots_bf16_cuda(
-      q, kv, scratch.dots, seq_len * local_heads, compressed_len, stream);
-  if (err != cudaSuccess) return err;
 
   constexpr int threads = 256;
   int total = seq_len * compressed_len;
   int blocks = (total + threads - 1) / threads;
-  deepseek_indexer_scores_epilogue_kernel<<<blocks, threads, 0, stream>>>(
-      scratch.dots, weights, scores, seq_len, local_heads, compressed_len, score_scale);
+  deepseek_indexer_scores_prefill_serial_kernel<<<blocks, threads, 0, stream>>>(
+      q, kv, weights, scores, seq_len, local_heads, head_dim, compressed_len, score_scale);
   return cudaGetLastError();
 }
 
@@ -669,25 +646,10 @@ cudaError_t deepseek_indexer_scores_decode_cuda(
     return cudaErrorInvalidValue;
   }
 
-  int device = 0;
-  cudaError_t err = cudaGetDevice(&device);
-  if (err != cudaSuccess) return err;
-  if (device < 0 || device >= 16) return cudaErrorInvalidDevice;
-
-  std::lock_guard<std::mutex> lock(g_indexer_scores_scratch_mutex[device]);
-  DeepseekIndexerScoresScratch &scratch = g_indexer_scores_scratch[device];
-  size_t dot_elems = static_cast<size_t>(local_heads) * compressed_len;
-  err = deepseek_ensure_bf16_scratch(&scratch.dots, &scratch.dot_elems, dot_elems);
-  if (err != cudaSuccess) return err;
-
-  err = deepseek_cutedsl_indexer_dots_bf16_cuda(
-      q, kv, scratch.dots, local_heads, compressed_len, stream);
-  if (err != cudaSuccess) return err;
-
   constexpr int threads = 256;
   int blocks = (compressed_len + threads - 1) / threads;
-  deepseek_indexer_scores_decode_epilogue_kernel<<<blocks, threads, 0, stream>>>(
-      scratch.dots, weights, scores, local_heads, compressed_len, score_scale);
+  deepseek_indexer_scores_decode_serial_kernel<<<blocks, threads, 0, stream>>>(
+      q, kv, weights, scores, local_heads, head_dim, compressed_len, score_scale);
   return cudaGetLastError();
 }
 

--- a/pegainfer-kernels/csrc/deepseek_v4/deepseek_indexer.cu
+++ b/pegainfer-kernels/csrc/deepseek_v4/deepseek_indexer.cu
@@ -642,7 +642,7 @@ cudaError_t deepseek_indexer_scores_decode_cuda(
     float score_scale,
     cudaStream_t stream) {
   if (q == nullptr || kv == nullptr || weights == nullptr || scores == nullptr ||
-      local_heads <= 0 || head_dim != 128 || compressed_len <= 0) {
+      local_heads <= 0 || head_dim <= 0 || compressed_len <= 0) {
     return cudaErrorInvalidValue;
   }
 

--- a/pegainfer-kernels/csrc/deepseek_v4/deepseek_indexer.cu
+++ b/pegainfer-kernels/csrc/deepseek_v4/deepseek_indexer.cu
@@ -10,8 +10,15 @@ struct DeepseekFp4QuantScratch {
   size_t scale_bytes = 0;
 };
 
+struct DeepseekIndexerScoresScratch {
+  __nv_bfloat16 *dots = nullptr;
+  size_t dot_elems = 0;
+};
+
 static DeepseekFp4QuantScratch g_fp4_quant_scratch[16];
 static std::mutex g_fp4_quant_scratch_mutex[16];
+static DeepseekIndexerScoresScratch g_indexer_scores_scratch[16];
+static std::mutex g_indexer_scores_scratch_mutex[16];
 
 static cudaError_t deepseek_ensure_bf16_scratch(
     __nv_bfloat16 **ptr,
@@ -52,6 +59,14 @@ extern "C" int deepseek_tilelang_fp4_quant_inplace_n128(
     void* y,
     void* scales,
     int m,
+    cudaStream_t stream);
+
+extern "C" cudaError_t deepseek_cutedsl_indexer_dots_bf16_cuda(
+    const __nv_bfloat16 *q,
+    const __nv_bfloat16 *kv,
+    __nv_bfloat16 *dots,
+    int rows,
+    int compressed_len,
     cudaStream_t stream);
 
 __global__ void deepseek_indexer_scores_prefill_kernel(
@@ -133,6 +148,50 @@ __global__ void deepseek_indexer_scores_prefill_serial_kernel(
   }
 
   scores[token * compressed_len + compressed] = acc * score_scale;
+}
+
+__global__ void deepseek_indexer_scores_epilogue_kernel(
+    const __nv_bfloat16 *__restrict__ dots,
+    const __nv_bfloat16 *__restrict__ weights,
+    float *__restrict__ scores,
+    int seq_len,
+    int local_heads,
+    int compressed_len,
+    float score_scale) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int total = seq_len * compressed_len;
+  if (idx >= total) return;
+
+  int token = idx / compressed_len;
+  int compressed = idx - token * compressed_len;
+  float acc = 0.0f;
+  for (int head = 0; head < local_heads; ++head) {
+    int dot_idx = (token * local_heads + head) * compressed_len + compressed;
+    float dot = __bfloat162float(dots[dot_idx]);
+    float weight = __bfloat162float(weights[token * local_heads + head]);
+    acc += fmaxf(dot, 0.0f) * weight;
+  }
+  scores[token * compressed_len + compressed] = acc * score_scale;
+}
+
+__global__ void deepseek_indexer_scores_decode_epilogue_kernel(
+    const __nv_bfloat16 *__restrict__ dots,
+    const __nv_bfloat16 *__restrict__ weights,
+    float *__restrict__ scores,
+    int local_heads,
+    int compressed_len,
+    float score_scale) {
+  int compressed = blockIdx.x * blockDim.x + threadIdx.x;
+  if (compressed >= compressed_len) return;
+
+  float acc = 0.0f;
+  for (int head = 0; head < local_heads; ++head) {
+    int dot_idx = head * compressed_len + compressed;
+    float dot = __bfloat162float(dots[dot_idx]);
+    float weight = __bfloat162float(weights[head]);
+    acc += fmaxf(dot, 0.0f) * weight;
+  }
+  scores[compressed] = acc * score_scale;
 }
 
 __global__ void deepseek_indexer_topk_prefill_kernel(
@@ -551,11 +610,31 @@ cudaError_t deepseek_indexer_scores_prefill_cuda(
     int compressed_len,
     float score_scale,
     cudaStream_t stream) {
+  if (q == nullptr || kv == nullptr || weights == nullptr || scores == nullptr ||
+      seq_len <= 0 || local_heads <= 0 || head_dim != 128 || compressed_len <= 0) {
+    return cudaErrorInvalidValue;
+  }
+
+  int device = 0;
+  cudaError_t err = cudaGetDevice(&device);
+  if (err != cudaSuccess) return err;
+  if (device < 0 || device >= 16) return cudaErrorInvalidDevice;
+
+  std::lock_guard<std::mutex> lock(g_indexer_scores_scratch_mutex[device]);
+  DeepseekIndexerScoresScratch &scratch = g_indexer_scores_scratch[device];
+  size_t dot_elems = static_cast<size_t>(seq_len) * local_heads * compressed_len;
+  err = deepseek_ensure_bf16_scratch(&scratch.dots, &scratch.dot_elems, dot_elems);
+  if (err != cudaSuccess) return err;
+
+  err = deepseek_cutedsl_indexer_dots_bf16_cuda(
+      q, kv, scratch.dots, seq_len * local_heads, compressed_len, stream);
+  if (err != cudaSuccess) return err;
+
   constexpr int threads = 256;
   int total = seq_len * compressed_len;
   int blocks = (total + threads - 1) / threads;
-  deepseek_indexer_scores_prefill_serial_kernel<<<blocks, threads, 0, stream>>>(
-      q, kv, weights, scores, seq_len, local_heads, head_dim, compressed_len, score_scale);
+  deepseek_indexer_scores_epilogue_kernel<<<blocks, threads, 0, stream>>>(
+      scratch.dots, weights, scores, seq_len, local_heads, compressed_len, score_scale);
   return cudaGetLastError();
 }
 
@@ -585,13 +664,30 @@ cudaError_t deepseek_indexer_scores_decode_cuda(
     int compressed_len,
     float score_scale,
     cudaStream_t stream) {
-  if (local_heads <= 0 || head_dim <= 0 || compressed_len <= 0) {
+  if (q == nullptr || kv == nullptr || weights == nullptr || scores == nullptr ||
+      local_heads <= 0 || head_dim != 128 || compressed_len <= 0) {
     return cudaErrorInvalidValue;
   }
+
+  int device = 0;
+  cudaError_t err = cudaGetDevice(&device);
+  if (err != cudaSuccess) return err;
+  if (device < 0 || device >= 16) return cudaErrorInvalidDevice;
+
+  std::lock_guard<std::mutex> lock(g_indexer_scores_scratch_mutex[device]);
+  DeepseekIndexerScoresScratch &scratch = g_indexer_scores_scratch[device];
+  size_t dot_elems = static_cast<size_t>(local_heads) * compressed_len;
+  err = deepseek_ensure_bf16_scratch(&scratch.dots, &scratch.dot_elems, dot_elems);
+  if (err != cudaSuccess) return err;
+
+  err = deepseek_cutedsl_indexer_dots_bf16_cuda(
+      q, kv, scratch.dots, local_heads, compressed_len, stream);
+  if (err != cudaSuccess) return err;
+
   constexpr int threads = 256;
   int blocks = (compressed_len + threads - 1) / threads;
-  deepseek_indexer_scores_decode_serial_kernel<<<blocks, threads, 0, stream>>>(
-      q, kv, weights, scores, local_heads, head_dim, compressed_len, score_scale);
+  deepseek_indexer_scores_decode_epilogue_kernel<<<blocks, threads, 0, stream>>>(
+      scratch.dots, weights, scores, local_heads, compressed_len, score_scale);
   return cudaGetLastError();
 }
 

--- a/pegainfer-kernels/tests/deepseek_cutedsl_indexer.rs
+++ b/pegainfer-kernels/tests/deepseek_cutedsl_indexer.rs
@@ -18,6 +18,15 @@ unsafe extern "C" {
     fn cudaFree(dev_ptr: *mut c_void) -> i32;
     fn cudaMemcpy(dst: *mut c_void, src: *const c_void, size: usize, kind: i32) -> i32;
     fn cudaDeviceSynchronize() -> i32;
+
+    fn deepseek_cutedsl_indexer_dots_bf16_cuda(
+        q: *const ffi::Half,
+        kv: *const ffi::Half,
+        dots: *mut f32,
+        rows: i32,
+        compressed_len: i32,
+        stream: CUstream,
+    ) -> CUresult;
 }
 
 struct DeviceBuffer<T> {
@@ -99,6 +108,20 @@ fn patterned_bf16(len: usize, scale: f32, bias: f32) -> Vec<bf16> {
         .collect()
 }
 
+fn lcg_bf16(len: usize, seed: u64, scale: f32, bias: f32) -> Vec<bf16> {
+    let mut state = seed;
+    (0..len)
+        .map(|_| {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            let bits = ((state >> 40) & 0xffff) as u32;
+            let centered = bits as f32 / 32768.0 - 1.0;
+            bf16::from_f32(centered * scale + bias)
+        })
+        .collect()
+}
+
 fn bf16_words(values: &[bf16]) -> Vec<ffi::Half> {
     values.iter().map(|v| v.to_bits()).collect()
 }
@@ -153,6 +176,46 @@ fn reference_decode(
     scores
 }
 
+fn cutedsl_scores(
+    q_d: &DeviceBuffer<ffi::Half>,
+    kv_d: &DeviceBuffer<ffi::Half>,
+    weights: &[bf16],
+    seq_len: usize,
+    local_heads: usize,
+    compressed_len: usize,
+    score_scale: f32,
+    stream: CUstream,
+) -> Result<Vec<f32>> {
+    let rows = seq_len * local_heads;
+    let mut dots_d = DeviceBuffer::from_host(&vec![0.0f32; rows * compressed_len])?;
+    let result = unsafe {
+        deepseek_cutedsl_indexer_dots_bf16_cuda(
+            q_d.as_ptr(),
+            kv_d.as_ptr(),
+            dots_d.as_mut_ptr(),
+            rows as i32,
+            compressed_len as i32,
+            stream,
+        )
+    };
+    assert_cuda_success(result);
+    cuda_check(unsafe { cudaDeviceSynchronize() })?;
+
+    let dots = dots_d.copy_to_host()?;
+    let mut scores = vec![0.0f32; seq_len * compressed_len];
+    for token in 0..seq_len {
+        for compressed in 0..compressed_len {
+            let mut acc = 0.0f32;
+            for head in 0..local_heads {
+                let row = token * local_heads + head;
+                acc += dots[row * compressed_len + compressed].max(0.0) * weights[row].to_f32();
+            }
+            scores[token * compressed_len + compressed] = acc * score_scale;
+        }
+    }
+    Ok(scores)
+}
+
 fn assert_close(got: &[f32], expected: &[f32]) {
     assert_eq!(got.len(), expected.len());
     for (idx, (&got, &expected)) in got.iter().zip(expected).enumerate() {
@@ -163,6 +226,39 @@ fn assert_close(got: &[f32], expected: &[f32]) {
             "mismatch at {idx}: got={got}, expected={expected}, diff={diff}, tol={tol}"
         );
     }
+}
+
+fn topk_indices(
+    scores: &[f32],
+    token: usize,
+    compressed_len: usize,
+    topk: usize,
+    ratio: usize,
+) -> Vec<i32> {
+    let valid = ((token + 1) / ratio).min(compressed_len);
+    let mut selected = vec![false; compressed_len];
+    let mut out = Vec::with_capacity(topk);
+    for _ in 0..topk {
+        let mut best_idx = None;
+        let mut best_score = f32::NEG_INFINITY;
+        for candidate in 0..valid {
+            if selected[candidate] {
+                continue;
+            }
+            let score = scores[token * compressed_len + candidate];
+            if score > best_score {
+                best_score = score;
+                best_idx = Some(candidate);
+            }
+        }
+        if let Some(idx) = best_idx {
+            selected[idx] = true;
+            out.push(idx as i32);
+        } else {
+            out.push(-1);
+        }
+    }
+    out
 }
 
 #[test]
@@ -188,16 +284,59 @@ fn indexer_scores_prefill_cutedsl_aot_matches_reference() -> Result<()> {
 
     let q_d = DeviceBuffer::from_host(&bf16_words(&q))?;
     let kv_d = DeviceBuffer::from_host(&bf16_words(&kv))?;
-    let weights_d = DeviceBuffer::from_host(&bf16_words(&weights))?;
-    let mut scores_d = DeviceBuffer::from_host(&vec![0.0f32; expected.len()])?;
     let stream: CUstream = ptr::null_mut();
 
+    let got = cutedsl_scores(
+        &q_d,
+        &kv_d,
+        &weights,
+        seq_len,
+        local_heads,
+        compressed_len,
+        score_scale,
+        stream,
+    )?;
+    assert_close(&got, &expected);
+    Ok(())
+}
+
+#[test]
+#[ignore = "diagnostic documents current CuTeDSL score drift before runtime enablement"]
+fn indexer_scores_prefill_cutedsl_serial_topk_diagnostic() -> Result<()> {
+    let seq_len = 512usize;
+    let local_heads = 64usize;
+    let compressed_len = 128usize;
+    let topk = 32usize;
+    let ratio = 4usize;
+    let score_scale = 0.125f32;
+    let rows = seq_len * local_heads;
+
+    let q = lcg_bf16(rows * HEAD_DIM, 0x3141_5926, 0.06, 0.0);
+    let kv = lcg_bf16(compressed_len * HEAD_DIM, 0x2718_2818, 0.06, 0.0);
+    let weights = lcg_bf16(rows, 0xfeed_beef, 0.08, 0.04);
+
+    let q_d = DeviceBuffer::from_host(&bf16_words(&q))?;
+    let kv_d = DeviceBuffer::from_host(&bf16_words(&kv))?;
+    let weights_d = DeviceBuffer::from_host(&bf16_words(&weights))?;
+    let mut serial_scores_d = DeviceBuffer::from_host(&vec![0.0f32; seq_len * compressed_len])?;
+    let stream: CUstream = ptr::null_mut();
+
+    let cutedsl = cutedsl_scores(
+        &q_d,
+        &kv_d,
+        &weights,
+        seq_len,
+        local_heads,
+        compressed_len,
+        score_scale,
+        stream,
+    )?;
     let result = unsafe {
         ffi::deepseek_indexer_scores_prefill_cuda(
             q_d.as_ptr(),
             kv_d.as_ptr(),
             weights_d.as_ptr(),
-            scores_d.as_mut_ptr(),
+            serial_scores_d.as_mut_ptr(),
             seq_len as i32,
             local_heads as i32,
             HEAD_DIM as i32,
@@ -209,8 +348,41 @@ fn indexer_scores_prefill_cutedsl_aot_matches_reference() -> Result<()> {
     assert_cuda_success(result);
     cuda_check(unsafe { cudaDeviceSynchronize() })?;
 
-    let got = scores_d.copy_to_host()?;
-    assert_close(&got, &expected);
+    let serial = serial_scores_d.copy_to_host()?;
+    let mut max_abs = 0.0f32;
+    let mut max_abs_idx = 0usize;
+    let mut max_rel = 0.0f32;
+    for (idx, (&got, &expected)) in cutedsl.iter().zip(&serial).enumerate() {
+        let abs = (got - expected).abs();
+        if abs > max_abs {
+            max_abs = abs;
+            max_abs_idx = idx;
+        }
+        let rel = abs / expected.abs().max(1e-6);
+        if rel > max_rel {
+            max_rel = rel;
+        }
+    }
+
+    let mut mismatches = Vec::new();
+    for token in 0..seq_len {
+        let cutedsl_topk = topk_indices(&cutedsl, token, compressed_len, topk, ratio);
+        let serial_topk = topk_indices(&serial, token, compressed_len, topk, ratio);
+        if cutedsl_topk != serial_topk {
+            mismatches.push((token, cutedsl_topk, serial_topk));
+            if mismatches.len() >= 5 {
+                break;
+            }
+        }
+    }
+
+    println!(
+        "CuTeDSL diagnostic: first_topk_mismatches={mismatches:?}, max_abs={max_abs} at {max_abs_idx}, max_rel={max_rel}"
+    );
+    assert!(
+        !mismatches.is_empty(),
+        "diagnostic expected to expose current CuTeDSL score/top-k drift"
+    );
     Ok(())
 }
 
@@ -227,27 +399,18 @@ fn indexer_scores_decode_cutedsl_aot_matches_reference() -> Result<()> {
 
     let q_d = DeviceBuffer::from_host(&bf16_words(&q))?;
     let kv_d = DeviceBuffer::from_host(&bf16_words(&kv))?;
-    let weights_d = DeviceBuffer::from_host(&bf16_words(&weights))?;
-    let mut scores_d = DeviceBuffer::from_host(&vec![0.0f32; expected.len()])?;
     let stream: CUstream = ptr::null_mut();
 
-    let result = unsafe {
-        ffi::deepseek_indexer_scores_decode_cuda(
-            q_d.as_ptr(),
-            kv_d.as_ptr(),
-            weights_d.as_ptr(),
-            scores_d.as_mut_ptr(),
-            local_heads as i32,
-            HEAD_DIM as i32,
-            compressed_len as i32,
-            score_scale,
-            stream,
-        )
-    };
-    assert_cuda_success(result);
-    cuda_check(unsafe { cudaDeviceSynchronize() })?;
-
-    let got = scores_d.copy_to_host()?;
+    let got = cutedsl_scores(
+        &q_d,
+        &kv_d,
+        &weights,
+        1,
+        local_heads,
+        compressed_len,
+        score_scale,
+        stream,
+    )?;
     assert_close(&got, &expected);
     Ok(())
 }
@@ -265,27 +428,18 @@ fn indexer_scores_decode_cutedsl_aot_handles_single_compressed_block() -> Result
 
     let q_d = DeviceBuffer::from_host(&bf16_words(&q))?;
     let kv_d = DeviceBuffer::from_host(&bf16_words(&kv))?;
-    let weights_d = DeviceBuffer::from_host(&bf16_words(&weights))?;
-    let mut scores_d = DeviceBuffer::from_host(&vec![0.0f32; expected.len()])?;
     let stream: CUstream = ptr::null_mut();
 
-    let result = unsafe {
-        ffi::deepseek_indexer_scores_decode_cuda(
-            q_d.as_ptr(),
-            kv_d.as_ptr(),
-            weights_d.as_ptr(),
-            scores_d.as_mut_ptr(),
-            local_heads as i32,
-            HEAD_DIM as i32,
-            compressed_len as i32,
-            score_scale,
-            stream,
-        )
-    };
-    assert_cuda_success(result);
-    cuda_check(unsafe { cudaDeviceSynchronize() })?;
-
-    let got = scores_d.copy_to_host()?;
+    let got = cutedsl_scores(
+        &q_d,
+        &kv_d,
+        &weights,
+        1,
+        local_heads,
+        compressed_len,
+        score_scale,
+        stream,
+    )?;
     assert_close(&got, &expected);
     Ok(())
 }

--- a/pegainfer-kernels/tests/deepseek_cutedsl_indexer.rs
+++ b/pegainfer-kernels/tests/deepseek_cutedsl_indexer.rs
@@ -1,0 +1,291 @@
+#![cfg(feature = "deepseek-v4")]
+
+use std::ffi::c_void;
+use std::mem::size_of;
+use std::ptr;
+
+use anyhow::{Result, ensure};
+use cudarc::driver::sys::{CUresult, CUstream};
+use half::bf16;
+use pegainfer_kernels::ffi;
+
+const HEAD_DIM: usize = 128;
+const CUDA_MEMCPY_HOST_TO_DEVICE: i32 = 1;
+const CUDA_MEMCPY_DEVICE_TO_HOST: i32 = 2;
+
+unsafe extern "C" {
+    fn cudaMalloc(dev_ptr: *mut *mut c_void, size: usize) -> i32;
+    fn cudaFree(dev_ptr: *mut c_void) -> i32;
+    fn cudaMemcpy(dst: *mut c_void, src: *const c_void, size: usize, kind: i32) -> i32;
+    fn cudaDeviceSynchronize() -> i32;
+}
+
+struct DeviceBuffer<T> {
+    ptr: *mut T,
+    len: usize,
+}
+
+impl<T: Copy + Default> DeviceBuffer<T> {
+    fn from_host(data: &[T]) -> Result<Self> {
+        let mut ptr = ptr::null_mut();
+        let bytes = data.len() * size_of::<T>();
+        cuda_check(unsafe { cudaMalloc(&mut ptr, bytes) })?;
+        if bytes > 0 {
+            cuda_check(unsafe {
+                cudaMemcpy(
+                    ptr,
+                    data.as_ptr().cast::<c_void>(),
+                    bytes,
+                    CUDA_MEMCPY_HOST_TO_DEVICE,
+                )
+            })?;
+        }
+        Ok(Self {
+            ptr: ptr.cast::<T>(),
+            len: data.len(),
+        })
+    }
+
+    fn copy_to_host(&self) -> Result<Vec<T>> {
+        let mut data = vec![T::default(); self.len];
+        let bytes = self.len * size_of::<T>();
+        if bytes > 0 {
+            cuda_check(unsafe {
+                cudaMemcpy(
+                    data.as_mut_ptr().cast::<c_void>(),
+                    self.ptr.cast::<c_void>(),
+                    bytes,
+                    CUDA_MEMCPY_DEVICE_TO_HOST,
+                )
+            })?;
+        }
+        Ok(data)
+    }
+
+    fn as_ptr(&self) -> *const T {
+        self.ptr
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut T {
+        self.ptr
+    }
+}
+
+impl<T> Drop for DeviceBuffer<T> {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            unsafe {
+                cudaFree(self.ptr.cast::<c_void>());
+            }
+        }
+    }
+}
+
+fn cuda_check(code: i32) -> Result<()> {
+    ensure!(code == 0, "CUDA runtime call failed with code {code}");
+    Ok(())
+}
+
+fn assert_cuda_success(result: CUresult) {
+    assert_eq!(result, CUresult::CUDA_SUCCESS);
+}
+
+fn patterned_bf16(len: usize, scale: f32, bias: f32) -> Vec<bf16> {
+    (0..len)
+        .map(|i| {
+            let v = ((i * 37 + 11) % 29) as f32 - 14.0;
+            bf16::from_f32(v * scale + bias)
+        })
+        .collect()
+}
+
+fn bf16_words(values: &[bf16]) -> Vec<ffi::Half> {
+    values.iter().map(|v| v.to_bits()).collect()
+}
+
+fn reference_prefill(
+    q: &[bf16],
+    kv: &[bf16],
+    weights: &[bf16],
+    seq_len: usize,
+    local_heads: usize,
+    compressed_len: usize,
+    score_scale: f32,
+) -> Vec<f32> {
+    let mut scores = vec![0.0f32; seq_len * compressed_len];
+    for token in 0..seq_len {
+        for compressed in 0..compressed_len {
+            let mut acc = 0.0f32;
+            for head in 0..local_heads {
+                let row = token * local_heads + head;
+                let mut dot = 0.0f32;
+                for k in 0..HEAD_DIM {
+                    dot += q[row * HEAD_DIM + k].to_f32() * kv[compressed * HEAD_DIM + k].to_f32();
+                }
+                acc += dot.max(0.0) * weights[row].to_f32();
+            }
+            scores[token * compressed_len + compressed] = acc * score_scale;
+        }
+    }
+    scores
+}
+
+fn reference_decode(
+    q: &[bf16],
+    kv: &[bf16],
+    weights: &[bf16],
+    local_heads: usize,
+    compressed_len: usize,
+    score_scale: f32,
+) -> Vec<f32> {
+    let mut scores = vec![0.0f32; compressed_len];
+    for compressed in 0..compressed_len {
+        let mut acc = 0.0f32;
+        for head in 0..local_heads {
+            let mut dot = 0.0f32;
+            for k in 0..HEAD_DIM {
+                dot += q[head * HEAD_DIM + k].to_f32() * kv[compressed * HEAD_DIM + k].to_f32();
+            }
+            acc += dot.max(0.0) * weights[head].to_f32();
+        }
+        scores[compressed] = acc * score_scale;
+    }
+    scores
+}
+
+fn assert_close(got: &[f32], expected: &[f32]) {
+    assert_eq!(got.len(), expected.len());
+    for (idx, (&got, &expected)) in got.iter().zip(expected).enumerate() {
+        let diff = (got - expected).abs();
+        let tol = 2.5e-3f32.max(expected.abs() * 2.5e-2);
+        assert!(
+            diff <= tol,
+            "mismatch at {idx}: got={got}, expected={expected}, diff={diff}, tol={tol}"
+        );
+    }
+}
+
+#[test]
+fn indexer_scores_prefill_cutedsl_aot_matches_reference() -> Result<()> {
+    let seq_len = 4usize;
+    let local_heads = 8usize;
+    let compressed_len = 16usize;
+    let score_scale = 0.125f32;
+    let rows = seq_len * local_heads;
+
+    let q = patterned_bf16(rows * HEAD_DIM, 0.003, 0.001);
+    let kv = patterned_bf16(compressed_len * HEAD_DIM, -0.002, 0.002);
+    let weights = patterned_bf16(rows, 0.01, 0.05);
+    let expected = reference_prefill(
+        &q,
+        &kv,
+        &weights,
+        seq_len,
+        local_heads,
+        compressed_len,
+        score_scale,
+    );
+
+    let q_d = DeviceBuffer::from_host(&bf16_words(&q))?;
+    let kv_d = DeviceBuffer::from_host(&bf16_words(&kv))?;
+    let weights_d = DeviceBuffer::from_host(&bf16_words(&weights))?;
+    let mut scores_d = DeviceBuffer::from_host(&vec![0.0f32; expected.len()])?;
+    let stream: CUstream = ptr::null_mut();
+
+    let result = unsafe {
+        ffi::deepseek_indexer_scores_prefill_cuda(
+            q_d.as_ptr(),
+            kv_d.as_ptr(),
+            weights_d.as_ptr(),
+            scores_d.as_mut_ptr(),
+            seq_len as i32,
+            local_heads as i32,
+            HEAD_DIM as i32,
+            compressed_len as i32,
+            score_scale,
+            stream,
+        )
+    };
+    assert_cuda_success(result);
+    cuda_check(unsafe { cudaDeviceSynchronize() })?;
+
+    let got = scores_d.copy_to_host()?;
+    assert_close(&got, &expected);
+    Ok(())
+}
+
+#[test]
+fn indexer_scores_decode_cutedsl_aot_matches_reference() -> Result<()> {
+    let local_heads = 8usize;
+    let compressed_len = 8usize;
+    let score_scale = 0.25f32;
+
+    let q = patterned_bf16(local_heads * HEAD_DIM, 0.002, -0.001);
+    let kv = patterned_bf16(compressed_len * HEAD_DIM, 0.003, 0.001);
+    let weights = patterned_bf16(local_heads, 0.02, 0.08);
+    let expected = reference_decode(&q, &kv, &weights, local_heads, compressed_len, score_scale);
+
+    let q_d = DeviceBuffer::from_host(&bf16_words(&q))?;
+    let kv_d = DeviceBuffer::from_host(&bf16_words(&kv))?;
+    let weights_d = DeviceBuffer::from_host(&bf16_words(&weights))?;
+    let mut scores_d = DeviceBuffer::from_host(&vec![0.0f32; expected.len()])?;
+    let stream: CUstream = ptr::null_mut();
+
+    let result = unsafe {
+        ffi::deepseek_indexer_scores_decode_cuda(
+            q_d.as_ptr(),
+            kv_d.as_ptr(),
+            weights_d.as_ptr(),
+            scores_d.as_mut_ptr(),
+            local_heads as i32,
+            HEAD_DIM as i32,
+            compressed_len as i32,
+            score_scale,
+            stream,
+        )
+    };
+    assert_cuda_success(result);
+    cuda_check(unsafe { cudaDeviceSynchronize() })?;
+
+    let got = scores_d.copy_to_host()?;
+    assert_close(&got, &expected);
+    Ok(())
+}
+
+#[test]
+fn indexer_scores_decode_cutedsl_aot_handles_single_compressed_block() -> Result<()> {
+    let local_heads = 8usize;
+    let compressed_len = 1usize;
+    let score_scale = 0.25f32;
+
+    let q = patterned_bf16(local_heads * HEAD_DIM, 0.002, -0.001);
+    let kv = patterned_bf16(compressed_len * HEAD_DIM, 0.003, 0.001);
+    let weights = patterned_bf16(local_heads, 0.02, 0.08);
+    let expected = reference_decode(&q, &kv, &weights, local_heads, compressed_len, score_scale);
+
+    let q_d = DeviceBuffer::from_host(&bf16_words(&q))?;
+    let kv_d = DeviceBuffer::from_host(&bf16_words(&kv))?;
+    let weights_d = DeviceBuffer::from_host(&bf16_words(&weights))?;
+    let mut scores_d = DeviceBuffer::from_host(&vec![0.0f32; expected.len()])?;
+    let stream: CUstream = ptr::null_mut();
+
+    let result = unsafe {
+        ffi::deepseek_indexer_scores_decode_cuda(
+            q_d.as_ptr(),
+            kv_d.as_ptr(),
+            weights_d.as_ptr(),
+            scores_d.as_mut_ptr(),
+            local_heads as i32,
+            HEAD_DIM as i32,
+            compressed_len as i32,
+            score_scale,
+            stream,
+        )
+    };
+    assert_cuda_success(result);
+    cuda_check(unsafe { cudaDeviceSynchronize() })?;
+
+    let got = scores_d.copy_to_host()?;
+    assert_close(&got, &expected);
+    Ok(())
+}

--- a/pegainfer-kernels/tests/deepseek_cutedsl_indexer.rs
+++ b/pegainfer-kernels/tests/deepseek_cutedsl_indexer.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "deepseek-v4")]
+#![cfg(feature = "deepseek-v4-cutedsl-diagnostic")]
 
 use std::ffi::c_void;
 use std::mem::size_of;

--- a/pegainfer-kernels/tools/cutedsl/deepseek_v4/generate.py
+++ b/pegainfer-kernels/tools/cutedsl/deepseek_v4/generate.py
@@ -7,8 +7,9 @@ The first production CuTe DSL target is the indexer score dot product:
         dot(q[token, head, :], kv[compressed, :])
 
 The original CUDA entry points keep their C ABI and run the small ReLU/weight
-epilogue in CUDA. This generator only exports the BF16 TensorCore GEMM used for
-the dot stage.
+epilogue in CUDA. This generator exports the TensorCore GEMM used for the dot
+stage and keeps the dot output in FP32 so the following top-k path sees the same
+precision class as the retired serial indexer-score kernel.
 """
 
 from __future__ import annotations
@@ -25,17 +26,26 @@ from cutlass.cute.runtime import make_fake_compact_tensor
 
 
 def load_sm120_gemm_class(cutlass_root: Path):
-    gemm_path = (
-        cutlass_root
-        / "examples/python/CuTeDSL/cute/blackwell_geforce/kernel/dense_gemm/dense_gemm.py"
-    )
-    if not gemm_path.exists():
-        raise FileNotFoundError(f"SM120 CuTe DSL dense_gemm.py not found: {gemm_path}")
+    gemm_path = find_sm120_dense_gemm_path(cutlass_root)
     spec = importlib.util.spec_from_file_location("pegainfer_cutedsl_sm120_dense_gemm", gemm_path)
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)
     return module.Sm120GemmKernel
+
+
+def find_sm120_dense_gemm_path(cutlass_root: Path) -> Path:
+    candidates = [
+        cutlass_root
+        / "examples/python/CuTeDSL/cute/blackwell_geforce/kernel/dense_gemm/dense_gemm.py",
+        cutlass_root / "examples/python/CuTeDSL/blackwell_geforce/dense_gemm.py",
+    ]
+    for gemm_path in candidates:
+        if gemm_path.exists():
+            return gemm_path
+    gemm_path = candidates[0]
+    if not gemm_path.exists():
+        raise FileNotFoundError(f"SM120 CuTe DSL dense_gemm.py not found: {gemm_path}")
 
 
 def find_cutlass_root(repo_root: Path, explicit: str | None) -> Path:
@@ -51,10 +61,14 @@ def find_cutlass_root(repo_root: Path, explicit: str | None) -> Path:
     )
     for candidate in candidates:
         candidate = candidate.resolve()
-        if (
-            candidate
-            / "examples/python/CuTeDSL/cute/blackwell_geforce/kernel/dense_gemm/dense_gemm.py"
-        ).exists():
+        if any(
+            path.exists()
+            for path in (
+                candidate
+                / "examples/python/CuTeDSL/cute/blackwell_geforce/kernel/dense_gemm/dense_gemm.py",
+                candidate / "examples/python/CuTeDSL/blackwell_geforce/dense_gemm.py",
+            )
+        ):
             return candidate
     raise FileNotFoundError(
         "Could not find CUTLASS CuTe DSL examples. Set PEGAINFER_CUTEDSL_CUTLASS_ROOT."
@@ -74,11 +88,40 @@ def write_wrapper(out_dir: Path) -> Path:
 
 namespace {
 
+constexpr int kMaxIndexerDotsWarmupShapes = 64;
+
+struct IndexerDotsWarmupShape {
+  int rows = 0;
+  int compressed_len = 0;
+  bool initialized = false;
+};
+
 idx_gemm_Kernel_Module_t g_indexer_dots_module;
 std::once_flag g_indexer_dots_once;
+std::mutex g_indexer_dots_launch_mutex;
+IndexerDotsWarmupShape g_indexer_dots_warmup_shapes[kMaxIndexerDotsWarmupShapes];
 
 void load_indexer_dots_module_once() {
   idx_gemm_Kernel_Module_Load(&g_indexer_dots_module);
+}
+
+bool mark_indexer_dots_shape_for_warmup(int rows, int compressed_len) {
+  for (int i = 0; i < kMaxIndexerDotsWarmupShapes; ++i) {
+    IndexerDotsWarmupShape &shape = g_indexer_dots_warmup_shapes[i];
+    if (shape.initialized && shape.rows == rows && shape.compressed_len == compressed_len) {
+      return false;
+    }
+  }
+  for (int i = 0; i < kMaxIndexerDotsWarmupShapes; ++i) {
+    IndexerDotsWarmupShape &shape = g_indexer_dots_warmup_shapes[i];
+    if (!shape.initialized) {
+      shape.rows = rows;
+      shape.compressed_len = compressed_len;
+      shape.initialized = true;
+      return true;
+    }
+  }
+  return false;
 }
 
 }  // namespace
@@ -86,7 +129,7 @@ void load_indexer_dots_module_once() {
 extern "C" cudaError_t deepseek_cutedsl_indexer_dots_bf16_cuda(
     const __nv_bfloat16 *q,
     const __nv_bfloat16 *kv,
-    __nv_bfloat16 *dots,
+    float *dots,
     int rows,
     int compressed_len,
     cudaStream_t stream) {
@@ -113,7 +156,21 @@ extern "C" cudaError_t deepseek_cutedsl_indexer_dots_bf16_cuda(
   c.dynamic_strides[0] = compressed_len;
   c.dynamic_strides[1] = 1;
 
-  int32_t ret = cute_dsl_idx_gemm_wrapper(&g_indexer_dots_module, &a, &b, &c, stream);
+  int32_t ret = 0;
+  {
+    std::lock_guard<std::mutex> guard(g_indexer_dots_launch_mutex);
+    if (mark_indexer_dots_shape_for_warmup(rows, compressed_len)) {
+      ret = cute_dsl_idx_gemm_wrapper(&g_indexer_dots_module, &a, &b, &c, stream);
+      if (ret != 0) {
+        return cudaErrorUnknown;
+      }
+      cudaError_t warmup_error = cudaStreamSynchronize(stream);
+      if (warmup_error != cudaSuccess) {
+        return warmup_error;
+      }
+    }
+    ret = cute_dsl_idx_gemm_wrapper(&g_indexer_dots_module, &a, &b, &c, stream);
+  }
   if (ret != 0) {
     return cudaErrorUnknown;
   }
@@ -152,7 +209,7 @@ def main() -> None:
         stride_order=(1, 0, 2),
     )
     dots = make_fake_compact_tensor(
-        cutlass.BFloat16,
+        cutlass.Float32,
         (rows, compressed_len, 1),
         stride_order=(1, 0, 2),
     )

--- a/pegainfer-kernels/tools/cutedsl/deepseek_v4/generate.py
+++ b/pegainfer-kernels/tools/cutedsl/deepseek_v4/generate.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Generate DeepSeek V4 CuTe DSL AOT artifacts.
+
+The first production CuTe DSL target is the indexer score dot product:
+
+    dots[(token * local_heads + head), compressed] =
+        dot(q[token, head, :], kv[compressed, :])
+
+The original CUDA entry points keep their C ABI and run the small ReLU/weight
+epilogue in CUDA. This generator only exports the BF16 TensorCore GEMM used for
+the dot stage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import shutil
+from pathlib import Path
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.runtime import make_fake_compact_tensor
+
+
+def load_sm120_gemm_class(cutlass_root: Path):
+    gemm_path = (
+        cutlass_root
+        / "examples/python/CuTeDSL/cute/blackwell_geforce/kernel/dense_gemm/dense_gemm.py"
+    )
+    if not gemm_path.exists():
+        raise FileNotFoundError(f"SM120 CuTe DSL dense_gemm.py not found: {gemm_path}")
+    spec = importlib.util.spec_from_file_location("pegainfer_cutedsl_sm120_dense_gemm", gemm_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module.Sm120GemmKernel
+
+
+def find_cutlass_root(repo_root: Path, explicit: str | None) -> Path:
+    candidates = []
+    if explicit:
+        candidates.append(Path(explicit))
+    candidates.extend(
+        [
+            repo_root / "../cutlass-upstream",
+            repo_root / "cutlass-upstream",
+            repo_root / "pegainfer-kernels/third_party/flashinfer/3rdparty/cutlass",
+        ]
+    )
+    for candidate in candidates:
+        candidate = candidate.resolve()
+        if (
+            candidate
+            / "examples/python/CuTeDSL/cute/blackwell_geforce/kernel/dense_gemm/dense_gemm.py"
+        ).exists():
+            return candidate
+    raise FileNotFoundError(
+        "Could not find CUTLASS CuTe DSL examples. Set PEGAINFER_CUTEDSL_CUTLASS_ROOT."
+    )
+
+
+def write_wrapper(out_dir: Path) -> Path:
+    wrapper = out_dir / "deepseek_v4_cutedsl_wrappers.cu"
+    wrapper.write_text(
+        r'''
+#include "deepseek_indexer_dots_gemm.h"
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+#include <mutex>
+
+namespace {
+
+idx_gemm_Kernel_Module_t g_indexer_dots_module;
+std::once_flag g_indexer_dots_once;
+
+void load_indexer_dots_module_once() {
+  idx_gemm_Kernel_Module_Load(&g_indexer_dots_module);
+}
+
+}  // namespace
+
+extern "C" cudaError_t deepseek_cutedsl_indexer_dots_bf16_cuda(
+    const __nv_bfloat16 *q,
+    const __nv_bfloat16 *kv,
+    __nv_bfloat16 *dots,
+    int rows,
+    int compressed_len,
+    cudaStream_t stream) {
+  if (q == nullptr || kv == nullptr || dots == nullptr || rows <= 0 || compressed_len <= 0) {
+    return cudaErrorInvalidValue;
+  }
+
+  std::call_once(g_indexer_dots_once, load_indexer_dots_module_once);
+
+  idx_gemm_Tensor_a_t a{};
+  a.data = const_cast<__nv_bfloat16 *>(q);
+  a.dynamic_shapes[0] = rows;
+  a.dynamic_strides[0] = 128;
+
+  idx_gemm_Tensor_b_t b{};
+  b.data = const_cast<__nv_bfloat16 *>(kv);
+  b.dynamic_shapes[0] = compressed_len;
+  b.dynamic_strides[0] = 128;
+
+  idx_gemm_Tensor_c_t c{};
+  c.data = dots;
+  c.dynamic_shapes[0] = rows;
+  c.dynamic_shapes[1] = compressed_len;
+  c.dynamic_strides[0] = compressed_len;
+  c.dynamic_strides[1] = 1;
+
+  int32_t ret = cute_dsl_idx_gemm_wrapper(&g_indexer_dots_module, &a, &b, &c, stream);
+  if (ret != 0) {
+    return cudaErrorUnknown;
+  }
+  return cudaGetLastError();
+}
+'''.lstrip()
+    )
+    return wrapper
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out-dir", required=True)
+    parser.add_argument("--repo-root", required=True)
+    parser.add_argument("--cutlass-root")
+    args = parser.parse_args()
+
+    out_dir = Path(args.out_dir).resolve()
+    shutil.rmtree(out_dir, ignore_errors=True)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    repo_root = Path(args.repo_root).resolve()
+    cutlass_root = find_cutlass_root(repo_root, args.cutlass_root)
+    Sm120GemmKernel = load_sm120_gemm_class(cutlass_root)
+
+    rows = cute.SymInt(divisibility=8)
+    compressed_len = cute.SymInt(divisibility=8)
+    q = make_fake_compact_tensor(
+        cutlass.BFloat16,
+        (rows, 128, 1),
+        stride_order=(1, 0, 2),
+    )
+    kv = make_fake_compact_tensor(
+        cutlass.BFloat16,
+        (compressed_len, 128, 1),
+        stride_order=(1, 0, 2),
+    )
+    dots = make_fake_compact_tensor(
+        cutlass.BFloat16,
+        (rows, compressed_len, 1),
+        stride_order=(1, 0, 2),
+    )
+    stream = cuda.CUstream(0)
+
+    kernel = Sm120GemmKernel(cutlass.Float32, (128, 128, 64))
+    compiled = cute.compile(kernel, q, kv, dots, 1, stream)
+    compiled.export_to_c(
+        file_path=str(out_dir),
+        file_name="deepseek_indexer_dots_gemm",
+        function_prefix="idx_gemm",
+    )
+    wrapper = write_wrapper(out_dir)
+
+    runtime_libs = cute.runtime.find_runtime_libraries(enable_tvm_ffi=False)
+    runtime_dirs = sorted({str(Path(path).resolve().parent) for path in runtime_libs})
+    print(f"OBJ_PATH={out_dir / 'deepseek_indexer_dots_gemm.o'}")
+    print(f"HEADER_DIR={out_dir}")
+    print(f"WRAPPER_PATH={wrapper}")
+    for runtime_dir in runtime_dirs:
+        print(f"RUNTIME_LIB_DIR={runtime_dir}")
+    print(f"CUTLASS_ROOT={cutlass_root}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR keeps the CuTe DSL indexer-score work as diagnostic infrastructure only.

- Adds/keeps the CuTe DSL BF16 indexer dot-product AOT wrapper behind the explicit `pegainfer-kernels/deepseek-v4-cutedsl-diagnostic` feature.
- Keeps the production DSV4 `indexer_scores_prefill` and `indexer_scores_decode` runtime on the existing serial CUDA score path.
- Adds a diagnostic ignored test that compares CuTe DSL prefill scores against the production serial GPU score path, then derives ratio-4 top-k from both score tensors.

This does not replace the production indexer score path and does not claim a performance win.

## Current finding

The diagnostic localizes the blocker before HTTP serving:

- shape: `seq_len=512`, `local_heads=64`, `compressed_len=128`, `topk=32`, `ratio=4`
- score drift: `max_abs=0.0032895803`, `max_rel=16.022202`
- first top-k divergence: token `9`
  - CuTe DSL-derived top-k starts `[0, 1, -1, ...]`
  - serial-derived top-k starts `[1, 0, -1, ...]`

So the remaining issue is score accumulation / numerical equivalence. Top-k and HTTP hash drift are downstream effects. The runtime replacement stays disabled until scores/top-k/token output align with the production gate.

## Validation

Production DSV4 build path does not generate CuTe DSL artifacts:

```bash
cargo check -p pegainfer-kernels --features deepseek-v4
# green; build log contains TileLang artifacts, no CuTe DSL / cutedsl generation
```

Regular CuTe DSL diagnostic tests:

```bash
cargo test -r -p pegainfer-kernels --features deepseek-v4-cutedsl-diagnostic --test deepseek_cutedsl_indexer -- --nocapture
# 3 passed; 0 failed; 1 ignored
```

Explicit ignored diagnostic:

```bash
cargo test -r -p pegainfer-kernels --features deepseek-v4-cutedsl-diagnostic --test deepseek_cutedsl_indexer \
  indexer_scores_prefill_cutedsl_serial_topk_diagnostic -- --ignored --nocapture
# prints the score/top-k divergence above and passes as a diagnostic
```

Local checks:

```bash
git diff --check
cargo fmt --check
```

`pre-commit run --files ...` is still blocked by the repository's existing `.pre-commit-config.yaml` invalid `repo='builtin'` entry missing `rev`; no hook was bypassed.

## Out of scope

- No production CuTe DSL runtime enablement.
- No HTTP hash/performance claim.
- No 10k prefill profile claim.
