### PR TITLE
test(dsv4): add CuTeDSL exact indexer score gate

### DIFF
--- a/pegainfer-deepseek-v4/Cargo.toml
+++ b/pegainfer-deepseek-v4/Cargo.toml
@@ -9,6 +9,10 @@ autotests = false
 [features]
 default = []
 deepseek-v4 = ["pegainfer-kernels/deepseek-v4"]
+deepseek-v4-cutedsl-diagnostic = [
+    "deepseek-v4",
+    "pegainfer-kernels/deepseek-v4-cutedsl-diagnostic",
+]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/pegainfer-deepseek-v4/src/runtime/indexer.rs
+++ b/pegainfer-deepseek-v4/src/runtime/indexer.rs
@@ -126,6 +126,27 @@ pub fn indexer_scores_prefill_bf16_hidden(
         let (scores_ptr, _scores_guard) = scores.device_ptr_mut(&ctx.stream);
         let score_scale =
             1.0f32 / (config.index_head_dim as f32).sqrt() / (config.index_n_heads as f32).sqrt();
+        #[cfg(feature = "deepseek-v4-cutedsl-diagnostic")]
+        ensure!(
+            local_heads == 8 && config.index_head_dim == 128,
+            "CuTeDSL diagnostic indexer scores expect local_heads=8 and head_dim=128, got local_heads={} head_dim={}",
+            local_heads,
+            config.index_head_dim
+        );
+        #[cfg(feature = "deepseek-v4-cutedsl-diagnostic")]
+        let result = unsafe {
+            ffi::deepseek_cutedsl_indexer_scores_exact_bf16_cuda(
+                q_ptr as *const ffi::Half,
+                kv_ptr as *const ffi::Half,
+                weights_ptr as *const ffi::Half,
+                scores_ptr as *mut f32,
+                input.seq_len as i32,
+                compressed_len as i32,
+                score_scale,
+                ctx.stream.cu_stream(),
+            )
+        };
+        #[cfg(not(feature = "deepseek-v4-cutedsl-diagnostic"))]
         let result = unsafe {
             ffi::deepseek_indexer_scores_prefill_cuda(
                 q_ptr as *const ffi::Half,

--- a/pegainfer-kernels/src/ffi.rs
+++ b/pegainfer-kernels/src/ffi.rs
@@ -483,6 +483,18 @@ unsafe extern "C" {
         stream: CUstream,
     ) -> CUresult;
 
+    #[cfg(feature = "deepseek-v4-cutedsl-diagnostic")]
+    pub fn deepseek_cutedsl_indexer_scores_exact_bf16_cuda(
+        q: *const Half,
+        kv: *const Half,
+        weights: *const Half,
+        scores: *mut f32,
+        seq_len: i32,
+        compressed_len: i32,
+        score_scale: f32,
+        stream: CUstream,
+    ) -> CUresult;
+
     pub fn deepseek_indexer_topk_prefill_cuda(
         scores: *const f32,
         topk_idxs: *mut i32,

--- a/pegainfer-kernels/tests/deepseek_cutedsl_indexer.rs
+++ b/pegainfer-kernels/tests/deepseek_cutedsl_indexer.rs
@@ -342,7 +342,7 @@ fn indexer_scores_prefill_cutedsl_aot_matches_reference() -> Result<()> {
 fn indexer_scores_prefill_cutedsl_exact_matches_serial_topk_shape() -> Result<()> {
     let seq_len = 512usize;
     let local_heads = 8usize;
-    let compressed_len = 128usize;
+    let compressed_len = 129usize;
     let topk = 32usize;
     let ratio = 4usize;
     let score_scale = 0.125f32;

--- a/pegainfer-kernels/tests/deepseek_cutedsl_indexer.rs
+++ b/pegainfer-kernels/tests/deepseek_cutedsl_indexer.rs
@@ -27,6 +27,17 @@ unsafe extern "C" {
         compressed_len: i32,
         stream: CUstream,
     ) -> CUresult;
+
+    fn deepseek_cutedsl_indexer_scores_exact_bf16_cuda(
+        q: *const ffi::Half,
+        kv: *const ffi::Half,
+        weights: *const ffi::Half,
+        scores: *mut f32,
+        seq_len: i32,
+        compressed_len: i32,
+        score_scale: f32,
+        stream: CUstream,
+    ) -> CUresult;
 }
 
 struct DeviceBuffer<T> {
@@ -216,6 +227,33 @@ fn cutedsl_scores(
     Ok(scores)
 }
 
+fn cutedsl_exact_scores(
+    q_d: &DeviceBuffer<ffi::Half>,
+    kv_d: &DeviceBuffer<ffi::Half>,
+    weights_d: &DeviceBuffer<ffi::Half>,
+    seq_len: usize,
+    compressed_len: usize,
+    score_scale: f32,
+    stream: CUstream,
+) -> Result<Vec<f32>> {
+    let mut scores_d = DeviceBuffer::from_host(&vec![0.0f32; seq_len * compressed_len])?;
+    let result = unsafe {
+        deepseek_cutedsl_indexer_scores_exact_bf16_cuda(
+            q_d.as_ptr(),
+            kv_d.as_ptr(),
+            weights_d.as_ptr(),
+            scores_d.as_mut_ptr(),
+            seq_len as i32,
+            compressed_len as i32,
+            score_scale,
+            stream,
+        )
+    };
+    assert_cuda_success(result);
+    cuda_check(unsafe { cudaDeviceSynchronize() })?;
+    scores_d.copy_to_host()
+}
+
 fn assert_close(got: &[f32], expected: &[f32]) {
     assert_eq!(got.len(), expected.len());
     for (idx, (&got, &expected)) in got.iter().zip(expected).enumerate() {
@@ -301,10 +339,9 @@ fn indexer_scores_prefill_cutedsl_aot_matches_reference() -> Result<()> {
 }
 
 #[test]
-#[ignore = "diagnostic documents current CuTeDSL score drift before runtime enablement"]
-fn indexer_scores_prefill_cutedsl_serial_topk_diagnostic() -> Result<()> {
+fn indexer_scores_prefill_cutedsl_exact_matches_serial_topk_shape() -> Result<()> {
     let seq_len = 512usize;
-    let local_heads = 64usize;
+    let local_heads = 8usize;
     let compressed_len = 128usize;
     let topk = 32usize;
     let ratio = 4usize;
@@ -321,12 +358,11 @@ fn indexer_scores_prefill_cutedsl_serial_topk_diagnostic() -> Result<()> {
     let mut serial_scores_d = DeviceBuffer::from_host(&vec![0.0f32; seq_len * compressed_len])?;
     let stream: CUstream = ptr::null_mut();
 
-    let cutedsl = cutedsl_scores(
+    let cutedsl = cutedsl_exact_scores(
         &q_d,
         &kv_d,
-        &weights,
+        &weights_d,
         seq_len,
-        local_heads,
         compressed_len,
         score_scale,
         stream,
@@ -376,12 +412,13 @@ fn indexer_scores_prefill_cutedsl_serial_topk_diagnostic() -> Result<()> {
         }
     }
 
-    println!(
-        "CuTeDSL diagnostic: first_topk_mismatches={mismatches:?}, max_abs={max_abs} at {max_abs_idx}, max_rel={max_rel}"
+    assert!(
+        mismatches.is_empty(),
+        "CuTeDSL exact score path changed top-k: first mismatches={mismatches:?}, max_abs={max_abs} at {max_abs_idx}, max_rel={max_rel}"
     );
     assert!(
-        !mismatches.is_empty(),
-        "diagnostic expected to expose current CuTeDSL score/top-k drift"
+        max_abs == 0.0,
+        "CuTeDSL exact score path changed scores: max_abs={max_abs} at {max_abs_idx}, max_rel={max_rel}"
     );
     Ok(())
 }

--- a/pegainfer-kernels/tools/cutedsl/deepseek_v4/generate.py
+++ b/pegainfer-kernels/tools/cutedsl/deepseek_v4/generate.py
@@ -296,6 +296,7 @@ def main() -> None:
     rows = cute.SymInt(divisibility=8)
     seq_len = cute.SymInt(divisibility=1)
     compressed_len = cute.SymInt(divisibility=8)
+    scores_compressed_len = cute.SymInt(divisibility=1)
     q = make_fake_compact_tensor(
         cutlass.BFloat16,
         (rows, 128, 1),
@@ -327,7 +328,7 @@ def main() -> None:
     )
     kv_scores = make_fake_compact_tensor(
         cutlass.BFloat16,
-        (compressed_len, HEAD_DIM),
+        (scores_compressed_len, HEAD_DIM),
         stride_order=(1, 0),
     )
     weights_scores = make_fake_compact_tensor(
@@ -337,7 +338,7 @@ def main() -> None:
     )
     scores = make_fake_compact_tensor(
         cutlass.Float32,
-        (seq_len, compressed_len),
+        (seq_len, scores_compressed_len),
         stride_order=(1, 0),
     )
     score_scale = cutlass.Float32(0.125)

--- a/pegainfer-kernels/tools/cutedsl/deepseek_v4/generate.py
+++ b/pegainfer-kernels/tools/cutedsl/deepseek_v4/generate.py
@@ -24,6 +24,9 @@ import cutlass
 import cutlass.cute as cute
 from cutlass.cute.runtime import make_fake_compact_tensor
 
+LOCAL_HEADS = 8
+HEAD_DIM = 128
+
 
 def load_sm120_gemm_class(cutlass_root: Path):
     gemm_path = find_sm120_dense_gemm_path(cutlass_root)
@@ -80,6 +83,7 @@ def write_wrapper(out_dir: Path) -> Path:
     wrapper.write_text(
         r'''
 #include "deepseek_indexer_dots_gemm.h"
+#include "deepseek_indexer_scores_exact.h"
 
 #include <cuda_bf16.h>
 #include <cuda_runtime.h>
@@ -97,12 +101,18 @@ struct IndexerDotsWarmupShape {
 };
 
 idx_gemm_Kernel_Module_t g_indexer_dots_module;
+idx_scores_Kernel_Module_t g_indexer_scores_module;
 std::once_flag g_indexer_dots_once;
+std::once_flag g_indexer_scores_once;
 std::mutex g_indexer_dots_launch_mutex;
 IndexerDotsWarmupShape g_indexer_dots_warmup_shapes[kMaxIndexerDotsWarmupShapes];
 
 void load_indexer_dots_module_once() {
   idx_gemm_Kernel_Module_Load(&g_indexer_dots_module);
+}
+
+void load_indexer_scores_module_once() {
+  idx_scores_Kernel_Module_Load(&g_indexer_scores_module);
 }
 
 bool mark_indexer_dots_shape_for_warmup(int rows, int compressed_len) {
@@ -176,9 +186,96 @@ extern "C" cudaError_t deepseek_cutedsl_indexer_dots_bf16_cuda(
   }
   return cudaGetLastError();
 }
+
+extern "C" cudaError_t deepseek_cutedsl_indexer_scores_exact_bf16_cuda(
+    const __nv_bfloat16 *q,
+    const __nv_bfloat16 *kv,
+    const __nv_bfloat16 *weights,
+    float *scores,
+    int seq_len,
+    int compressed_len,
+    float score_scale,
+    cudaStream_t stream) {
+  if (q == nullptr || kv == nullptr || weights == nullptr || scores == nullptr ||
+      seq_len <= 0 || compressed_len <= 0) {
+    return cudaErrorInvalidValue;
+  }
+
+  std::call_once(g_indexer_scores_once, load_indexer_scores_module_once);
+
+  idx_scores_Tensor_q_t q_arg{};
+  q_arg.data = const_cast<__nv_bfloat16 *>(q);
+  q_arg.dynamic_shapes[0] = seq_len;
+
+  idx_scores_Tensor_kv_t kv_arg{};
+  kv_arg.data = const_cast<__nv_bfloat16 *>(kv);
+  kv_arg.dynamic_shapes[0] = compressed_len;
+
+  idx_scores_Tensor_weights_t weights_arg{};
+  weights_arg.data = const_cast<__nv_bfloat16 *>(weights);
+  weights_arg.dynamic_shapes[0] = seq_len;
+
+  idx_scores_Tensor_scores_t scores_arg{};
+  scores_arg.data = scores;
+  scores_arg.dynamic_shapes[0] = seq_len;
+  scores_arg.dynamic_shapes[1] = compressed_len;
+  scores_arg.dynamic_strides[0] = compressed_len;
+
+  int32_t ret = cute_dsl_idx_scores_wrapper(
+      &g_indexer_scores_module, &q_arg, &kv_arg, &weights_arg, &scores_arg,
+      score_scale, stream);
+  if (ret != 0) {
+    return cudaErrorUnknown;
+  }
+  return cudaGetLastError();
+}
 '''.lstrip()
     )
     return wrapper
+
+
+@cute.kernel
+def indexer_scores_exact_kernel(
+    q: cute.Tensor,
+    kv: cute.Tensor,
+    weights: cute.Tensor,
+    scores: cute.Tensor,
+    score_scale: cutlass.Float32,
+):
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx, _, _ = cute.arch.block_idx()
+    compressed_len = scores.shape[1]
+    idx = bidx * 128 + tidx
+    total = scores.shape[0] * compressed_len
+    if idx < total:
+        token = idx // compressed_len
+        compressed = idx - token * compressed_len
+        acc = cutlass.Float32(0.0)
+        for head in cutlass.range(LOCAL_HEADS, unroll_full=True):
+            dot = cutlass.Float32(0.0)
+            for dim in cutlass.range(HEAD_DIM, unroll_full=True):
+                dot += cutlass.Float32(q[token, head, dim]) * cutlass.Float32(kv[compressed, dim])
+            if dot > cutlass.Float32(0.0):
+                acc += dot * cutlass.Float32(weights[token, head])
+        scores[token, compressed] = acc * score_scale
+
+
+@cute.jit
+def indexer_scores_exact(
+    q: cute.Tensor,
+    kv: cute.Tensor,
+    weights: cute.Tensor,
+    scores: cute.Tensor,
+    score_scale: cutlass.Float32,
+    stream: cuda.CUstream,
+):
+    total = scores.shape[0] * scores.shape[1]
+    blocks = (total + 127) // 128
+    indexer_scores_exact_kernel(q, kv, weights, scores, score_scale).launch(
+        grid=(blocks, 1, 1),
+        block=(128, 1, 1),
+        stream=stream,
+    )
 
 
 def main() -> None:
@@ -197,6 +294,7 @@ def main() -> None:
     Sm120GemmKernel = load_sm120_gemm_class(cutlass_root)
 
     rows = cute.SymInt(divisibility=8)
+    seq_len = cute.SymInt(divisibility=1)
     compressed_len = cute.SymInt(divisibility=8)
     q = make_fake_compact_tensor(
         cutlass.BFloat16,
@@ -222,11 +320,41 @@ def main() -> None:
         file_name="deepseek_indexer_dots_gemm",
         function_prefix="idx_gemm",
     )
+    q_scores = make_fake_compact_tensor(
+        cutlass.BFloat16,
+        (seq_len, LOCAL_HEADS, HEAD_DIM),
+        stride_order=(2, 1, 0),
+    )
+    kv_scores = make_fake_compact_tensor(
+        cutlass.BFloat16,
+        (compressed_len, HEAD_DIM),
+        stride_order=(1, 0),
+    )
+    weights_scores = make_fake_compact_tensor(
+        cutlass.BFloat16,
+        (seq_len, LOCAL_HEADS),
+        stride_order=(1, 0),
+    )
+    scores = make_fake_compact_tensor(
+        cutlass.Float32,
+        (seq_len, compressed_len),
+        stride_order=(1, 0),
+    )
+    score_scale = cutlass.Float32(0.125)
+    compiled_scores = cute.compile(
+        indexer_scores_exact, q_scores, kv_scores, weights_scores, scores, score_scale, stream
+    )
+    compiled_scores.export_to_c(
+        file_path=str(out_dir),
+        file_name="deepseek_indexer_scores_exact",
+        function_prefix="idx_scores",
+    )
     wrapper = write_wrapper(out_dir)
 
     runtime_libs = cute.runtime.find_runtime_libraries(enable_tvm_ffi=False)
     runtime_dirs = sorted({str(Path(path).resolve().parent) for path in runtime_libs})
     print(f"OBJ_PATH={out_dir / 'deepseek_indexer_dots_gemm.o'}")
+    print(f"OBJ_PATH={out_dir / 'deepseek_indexer_scores_exact.o'}")
     print(f"HEADER_DIR={out_dir}")
     print(f"WRAPPER_PATH={wrapper}")
     for runtime_dir in runtime_dirs:

--- a/pegainfer-server/Cargo.toml
+++ b/pegainfer-server/Cargo.toml
@@ -47,6 +47,10 @@ zeromq = { workspace = true }
 [features]
 default = []
 deepseek-v4 = ["dep:pegainfer-deepseek-v4", "pegainfer-deepseek-v4/deepseek-v4"]
+deepseek-v4-cutedsl-diagnostic = [
+    "deepseek-v4",
+    "pegainfer-deepseek-v4/deepseek-v4-cutedsl-diagnostic",
+]
 
 [dev-dependencies]
 criterion = { workspace = true }


### PR DESCRIPTION
## Summary

Adds a diagnostic CuTeDSL exact indexer-score path for DeepSeek V4 and turns the previous score/top-k drift repro into a passing numerical-equivalence gate.

The production DSV4 runtime remains on the existing serial CUDA score kernels. The CuTeDSL path is still only reachable through the explicit `deepseek-v4-cutedsl-diagnostic` feature.

## What changed

- Generates an additional CuTeDSL AOT score kernel that mirrors the serial GPU accumulation order for the TP8 rank-local DSV4 shape (`local_heads=8`, `head_dim=128`).
- Adds a diagnostic FFI entry point: `deepseek_cutedsl_indexer_scores_exact_bf16_cuda`.
- Wires `deepseek-v4-cutedsl-diagnostic` through `pegainfer-deepseek-v4` and `pegainfer-server` so the diagnostic server can exercise the CuTeDSL exact prefill score path.
- Adds a score/top-k regression: serial GPU scores vs CuTeDSL exact scores must have `max_abs=0` and no top-k split for the covered shape.
- Adds a runtime shape guard so the diagnostic path fails closed if the local-head/head-dim contract changes.

## Evidence

Local:

- `git diff --check` passed.
- `cargo fmt --check` passed.
- `pre-commit run --files ...` remains blocked by the repo's existing invalid `.pre-commit-config.yaml` (`repo='builtin'` missing `rev`); no hook was bypassed.

5090:

- `cargo test -r -p pegainfer-kernels --features deepseek-v4-cutedsl-diagnostic --test deepseek_cutedsl_indexer -- --nocapture` passed: 4 passed / 0 failed / 0 ignored.
- `cargo build -r -p pegainfer-server --features deepseek-v4-cutedsl-diagnostic --bin pegainfer` passed.
- Production feature check: `cargo check -p pegainfer-kernels --features deepseek-v4` passed and did not emit the CuTeDSL AOT artifact generation warning.
- HTTP token/hash gate with diagnostic feature, `/data/DeepSeek-V4-Flash`, prompt words 16, max tokens 16, warmup 2, 8 measured requests, repeats 3:

| concurrency | failed | timeout | combined hash | QPS range | TTFT avg range | TPOT avg range |
|---|---:|---:|---|---:|---:|---:|
| 1 | 0 | 0 | `22706877075acde0` | 1.705-1.722 | 156.7-159.9 ms | 28.25-28.43 ms |
| 2 | 0 | 0 | `22706877075acde0` | 1.719-1.723 | 664.9-666.4 ms | 28.24-28.29 ms |
| 4 | 0 | 0 | `22706877075acde0` | 1.720-1.721 | 1464.3-1467.1 ms | 28.27-28.27 ms |
| 8 | 0 | 0 | `22706877075acde0` | 1.720-1.721 | 2191.9-2193.4 ms | 28.27-28.30 ms |

The 5090 server was stopped after validation.

## Scope

This is an equivalence/diagnostic PR. It does not claim a performance win, does not replace the production runtime score path, and does not enable CuTeDSL outside the explicit diagnostic feature.
