### PR TITLE
feat(dsv4): enable CuTeDSL indexer score runtime

### DIFF
--- a/pegainfer-deepseek-v4/Cargo.toml
+++ b/pegainfer-deepseek-v4/Cargo.toml
@@ -13,6 +13,10 @@ deepseek-v4-cutedsl-diagnostic = [
     "deepseek-v4",
     "pegainfer-kernels/deepseek-v4-cutedsl-diagnostic",
 ]
+deepseek-v4-cutedsl-indexer-score = [
+    "deepseek-v4",
+    "pegainfer-kernels/deepseek-v4-cutedsl-indexer-score",
+]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/pegainfer-deepseek-v4/src/runtime/indexer.rs
+++ b/pegainfer-deepseek-v4/src/runtime/indexer.rs
@@ -126,14 +126,14 @@ pub fn indexer_scores_prefill_bf16_hidden(
         let (scores_ptr, _scores_guard) = scores.device_ptr_mut(&ctx.stream);
         let score_scale =
             1.0f32 / (config.index_head_dim as f32).sqrt() / (config.index_n_heads as f32).sqrt();
-        #[cfg(feature = "deepseek-v4-cutedsl-diagnostic")]
+        #[cfg(feature = "deepseek-v4-cutedsl-indexer-score")]
         ensure!(
             local_heads == 8 && config.index_head_dim == 128,
-            "CuTeDSL diagnostic indexer scores expect local_heads=8 and head_dim=128, got local_heads={} head_dim={}",
+            "CuTeDSL indexer score runtime expects local_heads=8 and head_dim=128, got local_heads={} head_dim={}",
             local_heads,
             config.index_head_dim
         );
-        #[cfg(feature = "deepseek-v4-cutedsl-diagnostic")]
+        #[cfg(feature = "deepseek-v4-cutedsl-indexer-score")]
         let result = unsafe {
             ffi::deepseek_cutedsl_indexer_scores_exact_bf16_cuda(
                 q_ptr as *const ffi::Half,
@@ -146,7 +146,7 @@ pub fn indexer_scores_prefill_bf16_hidden(
                 ctx.stream.cu_stream(),
             )
         };
-        #[cfg(not(feature = "deepseek-v4-cutedsl-diagnostic"))]
+        #[cfg(not(feature = "deepseek-v4-cutedsl-indexer-score"))]
         let result = unsafe {
             ffi::deepseek_indexer_scores_prefill_cuda(
                 q_ptr as *const ffi::Half,

--- a/pegainfer-kernels/Cargo.toml
+++ b/pegainfer-kernels/Cargo.toml
@@ -15,6 +15,7 @@ cc = { workspace = true }
 default = []
 deepseek-v4 = []
 deepseek-v4-cutedsl-diagnostic = ["deepseek-v4"]
+deepseek-v4-cutedsl-indexer-score = ["deepseek-v4"]
 
 [lints]
 workspace = true

--- a/pegainfer-kernels/build.rs
+++ b/pegainfer-kernels/build.rs
@@ -1002,13 +1002,16 @@ fn main() {
     let sm_targets = detect_sm_targets();
     let arch_args = nvcc_arch_args(&sm_targets);
     let deepseek_enabled = cfg!(feature = "deepseek-v4");
-    let cutedsl_diagnostic_enabled = cfg!(feature = "deepseek-v4-cutedsl-diagnostic");
+    let cutedsl_enabled = cfg!(any(
+        feature = "deepseek-v4-cutedsl-diagnostic",
+        feature = "deepseek-v4-cutedsl-indexer-score"
+    ));
     let tilelang_artifacts = if deepseek_enabled {
         Some(generate_deepseek_tilelang_artifacts(&out_dir))
     } else {
         None
     };
-    let cutedsl_artifacts = if cutedsl_diagnostic_enabled {
+    let cutedsl_artifacts = if cutedsl_enabled {
         Some(generate_deepseek_cutedsl_artifacts(&out_dir))
     } else {
         None

--- a/pegainfer-kernels/src/ffi.rs
+++ b/pegainfer-kernels/src/ffi.rs
@@ -483,7 +483,10 @@ unsafe extern "C" {
         stream: CUstream,
     ) -> CUresult;
 
-    #[cfg(feature = "deepseek-v4-cutedsl-diagnostic")]
+    #[cfg(any(
+        feature = "deepseek-v4-cutedsl-diagnostic",
+        feature = "deepseek-v4-cutedsl-indexer-score"
+    ))]
     pub fn deepseek_cutedsl_indexer_scores_exact_bf16_cuda(
         q: *const Half,
         kv: *const Half,

--- a/pegainfer-server/Cargo.toml
+++ b/pegainfer-server/Cargo.toml
@@ -51,6 +51,10 @@ deepseek-v4-cutedsl-diagnostic = [
     "deepseek-v4",
     "pegainfer-deepseek-v4/deepseek-v4-cutedsl-diagnostic",
 ]
+deepseek-v4-cutedsl-indexer-score = [
+    "deepseek-v4",
+    "pegainfer-deepseek-v4/deepseek-v4-cutedsl-indexer-score",
+]
 
 [dev-dependencies]
 criterion = { workspace = true }


### PR DESCRIPTION
## Summary

Enables the PR #114 CuTeDSL exact indexer-score path behind a new explicit runtime feature:

- `pegainfer-kernels/deepseek-v4-cutedsl-indexer-score`
- `pegainfer-deepseek-v4/deepseek-v4-cutedsl-indexer-score`
- `pegainfer-server/deepseek-v4-cutedsl-indexer-score`

Default `deepseek-v4` still uses the serial CUDA score kernels. The existing diagnostic feature remains a diagnostic/test entry; runtime replacement is only selected by the new experimental feature.

## What changed

- Builds CuTeDSL AOT artifacts when either the diagnostic feature or the experimental runtime feature is enabled.
- Exposes the exact CuTeDSL score FFI when either feature is enabled.
- Routes `indexer_scores_prefill_bf16_hidden` to CuTeDSL exact scores only under `deepseek-v4-cutedsl-indexer-score`.
- Leaves decode score path and all other ratio4 kernels unchanged.
- Keeps the rank-local shape guard (`local_heads=8`, `head_dim=128`) on the experimental runtime path.

## Evidence

Local:

- `git diff --check` passed.
- `cargo fmt --check` passed.
- `pre-commit run --files ...` remains blocked by the repo's existing invalid `.pre-commit-config.yaml` (`repo='builtin'` missing `rev`); no hook was bypassed.

5090:

- Default production feature boundary:
  - `cargo check -p pegainfer-kernels --features deepseek-v4` passed.
  - Build output did not contain the CuTeDSL AOT artifact warning.
- Diagnostic equivalence remains green:
  - `cargo test -r -p pegainfer-kernels --features deepseek-v4-cutedsl-diagnostic --test deepseek_cutedsl_indexer -- --nocapture` passed: 4 passed / 0 failed / 0 ignored.
- Experimental runtime build:
  - `cargo build -r -p pegainfer-server --features deepseek-v4-cutedsl-indexer-score --bin pegainfer --bin bench_serving` passed.
- Direct decode/hash gate with experimental feature:
  - `target/release/bench_serving --model-path /data/DeepSeek-V4-Flash --format json --out /tmp/dsv4_runtime_direct.json request --prompt-len 1 --output-len 160 --warmup 2 --iters 3 --seed 42`
  - generated-token hash: `6346f03343d75a65` for all 3 measured iterations.
  - The JSON report was written before the known NCCL abort-on-shutdown path printed during process teardown.
- HTTP token/hash gate with experimental feature, `/data/DeepSeek-V4-Flash`, prompt words 16, max tokens 16, warmup 2, 8 measured requests, repeats 3:

| concurrency | failed | timeout | combined hash | QPS range | TTFT avg range | TPOT avg range |
|---|---:|---:|---|---:|---:|---:|
| 1 | 0 | 0 | `22706877075acde0` | 1.687-1.695 | 151.0-154.0 ms | 29.24-29.29 ms |
| 2 | 0 | 0 | `22706877075acde0` | 1.692-1.696 | 667.7-668.9 ms | 29.22-29.29 ms |
| 4 | 0 | 0 | `22706877075acde0` | 1.680-1.696 | 1478.2-1490.8 ms | 29.25-29.51 ms |
| 8 | 0 | 0 | `22706877075acde0` | 1.690-1.696 | 2213.7-2222.4 ms | 29.26-29.36 ms |

The 5090 server was stopped after validation.

## Scope

This is runtime enablement for one already-equivalent indexer-score kernel path. It does not claim a performance win, does not touch scheduler/HTTP harness behavior, does not add cache reuse or duplicate-compute changes, and does not modify other ratio4 kernels.
