### PR TITLE
test(frontend): reuse vLLM tokenizer resolver in benches and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3607,6 +3607,7 @@ dependencies = [
  "pegainfer-core",
  "pegainfer-cupti",
  "pegainfer-kernels",
+ "pegainfer-vllm-support",
  "rand 0.10.1",
  "serde",
  "serde_json",
@@ -3628,6 +3629,7 @@ dependencies = [
  "log",
  "pegainfer-core",
  "pegainfer-kernels",
+ "pegainfer-vllm-support",
  "rand 0.10.1",
  "safetensors",
  "serde",
@@ -3654,6 +3656,7 @@ dependencies = [
  "pegainfer-deepseek-v4",
  "pegainfer-qwen3-4b",
  "pegainfer-qwen35-4b",
+ "pegainfer-vllm-support",
  "rand 0.10.1",
  "rmp-serde",
  "rmpv",
@@ -3666,6 +3669,14 @@ dependencies = [
  "vllm-server",
  "vllm-text",
  "zeromq",
+]
+
+[[package]]
+name = "pegainfer-vllm-support"
+version = "0.1.0"
+dependencies = [
+ "tokio",
+ "vllm-text",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3675,6 +3675,7 @@ dependencies = [
 name = "pegainfer-vllm-support"
 version = "0.1.0"
 dependencies = [
+ "once_cell",
  "tokio",
  "vllm-text",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "3"
 default-members = ["pegainfer-server"]
 members = [
+    "pegainfer-vllm-support",
     "pegainfer-server",
     "pegainfer-core",
     "pegainfer-cupti",
@@ -68,6 +69,7 @@ pegainfer-deepseek-v4 = { path = "pegainfer-deepseek-v4" }
 pegainfer-kernels = { path = "pegainfer-kernels" }
 pegainfer-qwen3-4b = { path = "pegainfer-qwen3-4b" }
 pegainfer-qwen35-4b = { path = "pegainfer-qwen35-4b" }
+pegainfer-vllm-support = { path = "pegainfer-vllm-support" }
 pegainfer-comm = { path = "pegainfer-comm" }
 pkg-config = "0.3.32"
 postcard = { version = "1.1.3", features = ["alloc", "use-std"] }

--- a/pegainfer-qwen3-4b/Cargo.toml
+++ b/pegainfer-qwen3-4b/Cargo.toml
@@ -27,6 +27,7 @@ toml = { workspace = true, optional = true }
 kernel-report = ["dep:clap", "dep:hex", "dep:pegainfer-cupti", "dep:sha2", "dep:toml"]
 
 [dev-dependencies]
+pegainfer-vllm-support = { workspace = true }
 vllm-text = { workspace = true }
 
 [[bin]]

--- a/pegainfer-qwen3-4b/tests/common/mod.rs
+++ b/pegainfer-qwen3-4b/tests/common/mod.rs
@@ -1,12 +1,6 @@
-use std::path::Path;
-use std::sync::Arc;
-
-use vllm_text::tokenizer::{DynTokenizer, HuggingFaceTokenizer};
+use vllm_text::tokenizer::DynTokenizer;
 
 pub(crate) fn load_tokenizer(model_path: &str) -> DynTokenizer {
-    let tokenizer_path = Path::new(model_path).join("tokenizer.json");
-    Arc::new(
-        HuggingFaceTokenizer::new(&tokenizer_path)
-            .unwrap_or_else(|e| panic!("Failed to load {}: {e}", tokenizer_path.display())),
-    )
+    pegainfer_vllm_support::load_tokenizer(model_path)
+        .unwrap_or_else(|err| panic!("Failed to load tokenizer for {model_path}: {err}"))
 }

--- a/pegainfer-qwen35-4b/Cargo.toml
+++ b/pegainfer-qwen35-4b/Cargo.toml
@@ -20,6 +20,7 @@ tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
 criterion = { workspace = true }
+pegainfer-vllm-support = { workspace = true }
 vllm-text = { workspace = true }
 
 [lints]

--- a/pegainfer-qwen35-4b/tests/common/mod.rs
+++ b/pegainfer-qwen35-4b/tests/common/mod.rs
@@ -1,12 +1,6 @@
-use std::path::Path;
-use std::sync::Arc;
-
-use vllm_text::tokenizer::{DynTokenizer, HuggingFaceTokenizer};
+use vllm_text::tokenizer::DynTokenizer;
 
 pub(crate) fn load_tokenizer(model_path: &str) -> DynTokenizer {
-    let tokenizer_path = Path::new(model_path).join("tokenizer.json");
-    Arc::new(
-        HuggingFaceTokenizer::new(&tokenizer_path)
-            .unwrap_or_else(|e| panic!("Failed to load {}: {e}", tokenizer_path.display())),
-    )
+    pegainfer_vllm_support::load_tokenizer(model_path)
+        .unwrap_or_else(|err| panic!("Failed to load tokenizer for {model_path}: {err}"))
 }

--- a/pegainfer-server/Cargo.toml
+++ b/pegainfer-server/Cargo.toml
@@ -22,6 +22,7 @@ pegainfer-core = { workspace = true }
 pegainfer-deepseek-v4 = { workspace = true, optional = true }
 pegainfer-qwen3-4b = { workspace = true }
 pegainfer-qwen35-4b = { workspace = true }
+pegainfer-vllm-support = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
 colored = { workspace = true }

--- a/pegainfer-server/src/bin/bench_serving.rs
+++ b/pegainfer-server/src/bin/bench_serving.rs
@@ -13,7 +13,6 @@ use std::fmt::Write as _;
 use std::fs;
 use std::io::{IsTerminal, stdout};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, ensure};
@@ -27,11 +26,12 @@ use pegainfer::sampler::SamplingParams;
 use pegainfer::scheduler::{SchedulerHandle, SchedulerRequest, TokenEvent};
 use pegainfer::server_engine::{ModelType, detect_model_type};
 use pegainfer_core::engine::EngineLoadOptions;
+use pegainfer_vllm_support::load_tokenizer as load_vllm_tokenizer;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
-use vllm_text::tokenizer::{DynTokenizer, HuggingFaceTokenizer};
+use vllm_text::tokenizer::DynTokenizer;
 
 const SNAPSHOT_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../bench_snapshots");
 const SNAPSHOT_PREFILL_OUTPUT_LEN: usize = 1;
@@ -760,11 +760,6 @@ fn truncate_preview(text: &str, limit: usize) -> String {
 
 fn synthetic_prompt_tokens(len: usize) -> Vec<u32> {
     (0..len).map(|i| ((i % 1000) + 100) as u32).collect()
-}
-
-fn load_vllm_tokenizer(model_path: &str) -> Result<DynTokenizer> {
-    let tokenizer_path = Path::new(model_path).join("tokenizer.json");
-    Ok(Arc::new(HuggingFaceTokenizer::new(&tokenizer_path)?))
 }
 
 #[derive(Debug, Clone)]

--- a/pegainfer-server/tests/common/mod.rs
+++ b/pegainfer-server/tests/common/mod.rs
@@ -1,12 +1,6 @@
-use std::path::Path;
-use std::sync::Arc;
-
-use vllm_text::tokenizer::{DynTokenizer, HuggingFaceTokenizer};
+use vllm_text::tokenizer::DynTokenizer;
 
 pub(crate) fn load_tokenizer(model_path: &str) -> DynTokenizer {
-    let tokenizer_path = Path::new(model_path).join("tokenizer.json");
-    Arc::new(
-        HuggingFaceTokenizer::new(&tokenizer_path)
-            .unwrap_or_else(|e| panic!("Failed to load {}: {e}", tokenizer_path.display())),
-    )
+    pegainfer_vllm_support::load_tokenizer(model_path)
+        .unwrap_or_else(|err| panic!("Failed to load tokenizer for {model_path}: {err}"))
 }

--- a/pegainfer-vllm-support/Cargo.toml
+++ b/pegainfer-vllm-support/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "pegainfer-vllm-support"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tokio = { workspace = true, features = ["net", "rt", "time"] }
+vllm-text = { workspace = true }
+
+[lints]
+workspace = true

--- a/pegainfer-vllm-support/Cargo.toml
+++ b/pegainfer-vllm-support/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+once_cell = { workspace = true }
 tokio = { workspace = true, features = ["net", "rt", "time"] }
 vllm-text = { workspace = true }
 

--- a/pegainfer-vllm-support/src/lib.rs
+++ b/pegainfer-vllm-support/src/lib.rs
@@ -1,0 +1,33 @@
+use std::sync::Arc;
+
+use vllm_text::backend::hf::{ResolvedModelFiles, TokenizerSource};
+use vllm_text::tokenizer::{
+    DynTokenizer, HuggingFaceTokenizer, TekkenTokenizer, TiktokenTokenizer,
+};
+use vllm_text::{Error, Result};
+
+pub fn load_tokenizer(model_id: &str) -> Result<DynTokenizer> {
+    let files = resolve_model_files(model_id)?;
+    tokenizer_from_source(&files.tokenizer)
+}
+
+pub fn tokenizer_from_source(source: &TokenizerSource) -> Result<DynTokenizer> {
+    match source {
+        TokenizerSource::HuggingFace(path) => Ok(Arc::new(HuggingFaceTokenizer::new(path)?)),
+        TokenizerSource::Tiktoken(path) => Ok(Arc::new(TiktokenTokenizer::new(path)?)),
+        TokenizerSource::Tekken(path) => Ok(Arc::new(TekkenTokenizer::new(path)?)),
+    }
+}
+
+fn resolve_model_files(model_id: &str) -> Result<ResolvedModelFiles> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|err| {
+            Error::Tokenizer(format!(
+                "failed to create tokenizer resolver runtime: {err}"
+            ))
+        })?;
+
+    runtime.block_on(ResolvedModelFiles::new(model_id))
+}

--- a/pegainfer-vllm-support/src/lib.rs
+++ b/pegainfer-vllm-support/src/lib.rs
@@ -1,13 +1,30 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
+use once_cell::sync::OnceCell;
+use tokio::runtime::{Builder, Runtime};
 use vllm_text::backend::hf::{ResolvedModelFiles, TokenizerSource};
 use vllm_text::tokenizer::{
     DynTokenizer, HuggingFaceTokenizer, TekkenTokenizer, TiktokenTokenizer,
 };
 use vllm_text::{Error, Result};
 
+static TOKENIZER_RESOLVER_RUNTIME: OnceCell<Mutex<Runtime>> = OnceCell::new();
+
 pub fn load_tokenizer(model_id: &str) -> Result<DynTokenizer> {
+    if tokio::runtime::Handle::try_current().is_ok() {
+        return Err(Error::Tokenizer(
+            "pegainfer_vllm_support::load_tokenizer is synchronous and cannot be called from \
+             inside an active Tokio runtime; use load_tokenizer_async instead"
+                .to_string(),
+        ));
+    }
+
     let files = resolve_model_files(model_id)?;
+    tokenizer_from_source(&files.tokenizer)
+}
+
+pub async fn load_tokenizer_async(model_id: &str) -> Result<DynTokenizer> {
+    let files = ResolvedModelFiles::new(model_id).await?;
     tokenizer_from_source(&files.tokenizer)
 }
 
@@ -20,14 +37,45 @@ pub fn tokenizer_from_source(source: &TokenizerSource) -> Result<DynTokenizer> {
 }
 
 fn resolve_model_files(model_id: &str) -> Result<ResolvedModelFiles> {
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|err| {
-            Error::Tokenizer(format!(
-                "failed to create tokenizer resolver runtime: {err}"
-            ))
-        })?;
+    let runtime = TOKENIZER_RESOLVER_RUNTIME.get_or_try_init(|| {
+        Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map(Mutex::new)
+            .map_err(|err| {
+                Error::Tokenizer(format!(
+                    "failed to create tokenizer resolver runtime: {err}"
+                ))
+            })
+    })?;
+    let runtime = runtime
+        .lock()
+        .map_err(|_| Error::Tokenizer("tokenizer resolver runtime mutex poisoned".to_string()))?;
 
     runtime.block_on(ResolvedModelFiles::new(model_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sync_loader_rejects_active_tokio_runtime() {
+        let runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime should build");
+
+        let err = runtime.block_on(async {
+            match load_tokenizer("unused-model-id") {
+                Ok(_) => panic!("sync tokenizer loader should reject active Tokio runtime"),
+                Err(err) => err,
+            }
+        });
+
+        assert!(
+            err.to_string().contains("load_tokenizer_async"),
+            "unexpected error: {err}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Closes #82.

Bench/test tokenizer loading now goes through the same `vllm-text` model-file resolver used by the serving frontend. I added a small internal `pegainfer-vllm-support` helper that resolves `ResolvedModelFiles` and constructs the tokenizer from `TokenizerSource::{HuggingFace,Tiktoken,Tekken}`. The issue-listed bench/test helpers now call that shared helper instead of hardcoding `model_path/tokenizer.json`.

## Scope

In scope:
- Add `pegainfer-vllm-support::load_tokenizer`.
- Reuse `vllm_text::backend::hf::ResolvedModelFiles`.
- Dispatch resolved tokenizer sources to:
  - `HuggingFaceTokenizer::new`
  - `TiktokenTokenizer::new`
  - `TekkenTokenizer::new`
- Replace direct `tokenizer.json` loading in `bench_serving` and Qwen/server test helpers.

Out of scope:
- No new CLI tokenizer flag.
- No serving-path behavior change.
- No benchmark or performance claim.

## Evidence

Local:
- `cargo fmt --check` passed.
- `git diff --check` passed.
- `cargo test -p pegainfer-vllm-support` passed.

Remote RTX 5090 validation host:
- GPU: RTX 5090, driver `580.76.05`.
- CUDA toolkit: `/usr/local/cuda-13.0/bin/nvcc`, CUDA `13.0`, `V13.0.88`.
- Triton env: `/root/autodl-tmp/pegainfer-venv`, `triton 3.7.0`; `CompileArgs` and `compile_kernel` are available.
- Minimal `nvcc` probes passed for both `compute_120/sm_120` and `compute_120f/sm_120f`.
- `cargo test -p pegainfer-vllm-support` passed.
- `PEGAINFER_CUDA_SM=120 PEGAINFER_TRITON_PYTHON=/root/autodl-tmp/pegainfer-venv/bin/python CUDA_HOME=/usr/local/cuda-13.0 cargo check --release -p pegainfer-server --bin bench_serving` passed.

## Claim Boundary

This verifies the tokenizer-helper refactor and the affected `bench_serving` compile surface on SM120. I did not run Qwen model-weight E2E in this PR; this change is intended to align bench/test tokenizer file resolution with the existing vLLM frontend resolver, not to change model numerical output.