### PR TITLE
Add CONTRIBUTING.md and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## What does this PR do?
+
+Brief description of the change.
+
+## Type of Change
+
+- [ ] eat — New feature
+- [ ] ix — Bug fix
+- [ ] perf — Performance improvement
+- [ ] docs — Documentation only
+- [ ] chore — Maintenance / tooling
+
+## Checklist
+
+- [ ] Tests pass (cargo test --release --workspace --lib)
+- [ ] Commit messages follow Commitizen format (	ype(scope): description)
+- [ ] No debug prints or commented-out code
+- [ ] New public APIs have doc comments
+- [ ] If changing numerical output, updated baselines in 	est_data/
+
+## Related Issues
+
+Fixes #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to pegainfer
+
+Thanks for your interest in contributing! This guide will get you from "I want to help" to "my PR is in review."
+
+## Quick Links
+
+- **Build & Run** → [CLAUDE.md](CLAUDE.md#build--run)
+- **Onboarding** → [docs/resources/developer-onboarding.md](docs/resources/developer-onboarding.md)
+- **Coding Style** → [docs/areas/coding-style.md](docs/areas/coding-style.md)
+
+## Branch Naming
+
+Use a prefix that describes the change type:
+
+| Prefix | Example |
+|--------|---------|
+| eat/ | eat/add-llama-support |
+| ix/ | ix/softmax-overflow |
+| perf/ | perf/optimize-kv-cache |
+| docs/ | docs/add-benchmark-guide |
+| chore/ | chore/update-deps |
+
+## Commit Format
+
+We use [Commitizen](https://commitizen-tools.github.io/commitizen/) conventions:
+
+`
+type(scope): description
+
+feat(qwen3): add streaming support
+fix(scheduler): fix token event ordering
+perf(cuda): fuse attention kernels
+docs(api): add curl examples
+`
+
+## Running Tests
+
+`ash
+# Fast unit tests (~9s)
+cargo test --release --workspace --lib
+
+# E2E tests (requires GPU + model weights)
+PEGAINFER_TEST_MODEL_PATH=models/Qwen3-4B cargo test --release -p pegainfer-qwen3-4b --test e2e
+`
+
+**Always use --release** — debug builds are too slow for GPU/CUDA code.
+
+## PR Checklist
+
+Before opening a PR:
+
+- [ ] Tests pass (cargo test --release --workspace --lib)
+- [ ] Commit messages follow Commitizen format
+- [ ] No debug prints or commented-out code
+- [ ] New public APIs have doc comments
+- [ ] If changing numerical output, update test baselines in 	est_data/
+
+## Questions?
+
+Open an issue with the question label or start a Discussion.


### PR DESCRIPTION
## Changes

### CONTRIBUTING.md
Consolidates contributor-facing conventions into a single file:
- Branch naming conventions (`feat/`, `fix/`, `perf/`, `docs/`, `chore/`)
- Commit message format (Commitizen conventions with examples)
- Test commands (unit + E2E)
- PR checklist
- Quick links to existing docs (CLAUDE.md, onboarding, coding style)

### .github/PULL_REQUEST_TEMPLATE.md
- Structured PR template with type checklist and verification steps

As discussed in the issue: keeps the CONTRIBUTING.md short and scannable, linking out to full docs where appropriate.

Fixes #124

---
Wallet: zp6