### PR TITLE
ci: add minimal cpu checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cpu-checks:
+    name: CPU checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: nightly
+          components: rustfmt, clippy
+
+      - name: Check formatting
+        run: cargo fmt --all --check
+
+      - name: Check locked Cargo metadata
+        run: cargo metadata --locked --no-deps --format-version 1
+
+      - name: Check pegainfer-comm
+        run: cargo check --release -p pegainfer-comm --all-targets
+
+      - name: Clippy pegainfer-comm
+        run: cargo clippy --release -p pegainfer-comm --all-targets -- -D warnings
+
+      - name: Test pegainfer-comm
+        run: cargo test --release -p pegainfer-comm


### PR DESCRIPTION
## Summary

  - add the first GitHub Actions CI gate for hosted CPU runners
  - run Rust formatting, locked Cargo metadata, and `pegainfer-comm` default-feature check/clippy/lib tests
  - document the GPU/model/server coverage gap

  ## What CI covers

  ```bash
  cargo fmt --all --check
  cargo metadata --locked --no-deps --format-version 1
  cargo check --release -p pegainfer-comm --all-targets
  cargo clippy --release -p pegainfer-comm --all-targets -- -D warnings
  cargo test --release -p pegainfer-comm --lib
```

  ## Not covered

  GitHub-hosted runners do not have the CUDA/GPU environment needed by the main inference path. This PR does not cover:

  - pegainfer-server
  - pegainfer-core
  - pegainfer-kernels
  - pegainfer-qwen3-4b
  - pegainfer-qwen35-4b
  - pegainfer-deepseek-v4
  - CUDA/Triton kernel compilation
  - GPU e2e tests
  - model-weight regressions

  Follow-ups can evaluate a CPU-only kernel stub feature or a self-hosted GPU runner.

  ## Testing

  - [x] cargo fmt --all --check
  - [x] cargo metadata --locked --no-deps --format-version 1
  - [x] cargo check --release -p pegainfer-comm --all-targets
  - [x] cargo clippy --release -p pegainfer-comm --all-targets -- -D warnings
  - [x] cargo test --release -p pegainfer-comm --lib