### PR TITLE
bench(dsv4): fail HTTP benchmark on generation errors

### DIFF
--- a/scripts/bench_http_serving.py
+++ b/scripts/bench_http_serving.py
@@ -152,6 +152,26 @@ def parse_sse_text(payload: dict[str, Any]) -> str:
     return delta.get("content") or ""
 
 
+def parse_sse_finish_reason(payload: dict[str, Any]) -> str | None:
+    choices = payload.get("choices") or []
+    if not choices:
+        return None
+    finish_reason = choices[0].get("finish_reason")
+    return finish_reason if isinstance(finish_reason, str) else None
+
+
+def parse_sse_error(payload: dict[str, Any]) -> str | None:
+    error = payload.get("error")
+    if isinstance(error, str):
+        return error
+    if isinstance(error, dict):
+        message = error.get("message")
+        if isinstance(message, str):
+            return message
+        return json.dumps(error, sort_keys=True)
+    return None
+
+
 def request_once(
     index: int,
     request_id: str,
@@ -210,6 +230,12 @@ def request_once(
             if data == "[DONE]":
                 break
             payload = json.loads(data)
+            stream_error = parse_sse_error(payload)
+            if stream_error is not None:
+                raise RuntimeError(f"SSE error: {stream_error}")
+            finish_reason = parse_sse_finish_reason(payload)
+            if finish_reason == "error":
+                raise RuntimeError("SSE finish_reason=error")
             text = parse_sse_text(payload)
             if not text:
                 continue
@@ -327,6 +353,7 @@ def failed_result(
 
 
 TRACE_RE = re.compile(r"pegainfer_http_trace\s+(\{.*\})")
+STREAM_ERROR_RE = re.compile(r'request failed .*self\.request_id="([^"]+)"')
 
 
 def load_server_traces(path: Path | None) -> dict[str, dict[str, Any]]:
@@ -334,6 +361,11 @@ def load_server_traces(path: Path | None) -> dict[str, dict[str, Any]]:
         return {}
     traces: dict[str, dict[str, Any]] = {}
     for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        stream_error_match = STREAM_ERROR_RE.search(line)
+        if stream_error_match:
+            request_id = stream_error_match.group(1)
+            traces.setdefault(request_id, {"request_id": request_id})["server_error"] = line.strip()
+            continue
         match = TRACE_RE.search(line)
         if not match:
             continue
@@ -363,6 +395,26 @@ def attach_server_traces(results: list[RequestResult], traces: dict[str, dict[st
             scheduled_at = trace.get("scheduled_at_unix_s")
             if isinstance(queued_at, (int, float)) and isinstance(scheduled_at, (int, float)):
                 trace["admission_queue_ms"] = max(0.0, (float(scheduled_at) - float(queued_at)) * 1000.0)
+        apply_server_error_gate(result)
+
+
+def apply_server_error_gate(result: RequestResult) -> None:
+    if not result.ok or result.server_trace is None:
+        return
+    server_error = result.server_trace.get("server_error")
+    if isinstance(server_error, str):
+        result.ok = False
+        result.error = f"server generation error: {server_error}"
+        return
+    finish_reason = result.server_trace.get("finish_reason")
+    if finish_reason == "error":
+        result.ok = False
+        result.error = "server generation error: finish_reason=error"
+        return
+    completion_tokens = result.server_trace.get("completion_tokens")
+    if result.max_tokens > 0 and completion_tokens == 0:
+        result.ok = False
+        result.error = "server generation error: completion_tokens=0"
 
 
 def find_server_trace(

--- a/tests/test_bench_http_serving.py
+++ b/tests/test_bench_http_serving.py
@@ -22,11 +22,13 @@ SPEC.loader.exec_module(bench_http_serving)
 
 
 class DoneOnlyHandler(BaseHTTPRequestHandler):
+    response_body = b"data: [DONE]\n\n"
+
     def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API.
         self.send_response(200)
         self.send_header("Content-Type", "text/event-stream")
         self.end_headers()
-        self.wfile.write(b"data: [DONE]\n\n")
+        self.wfile.write(self.response_body)
 
     def log_message(self, format: str, *args: object) -> None:
         return
@@ -34,6 +36,7 @@ class DoneOnlyHandler(BaseHTTPRequestHandler):
 
 class BenchHttpServingTests(unittest.TestCase):
     def setUp(self) -> None:
+        DoneOnlyHandler.response_body = b"data: [DONE]\n\n"
         self.server = ThreadingHTTPServer(("127.0.0.1", 0), DoneOnlyHandler)
         self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
         self.thread.start()
@@ -63,6 +66,53 @@ class BenchHttpServingTests(unittest.TestCase):
         self.assertEqual(result.status, 200)
         self.assertIn("without streamed text chunks", result.error or "")
         self.assertEqual(result.output_chunks, 0)
+
+    def test_finish_reason_error_stream_fails_even_after_text_chunk(self) -> None:
+        DoneOnlyHandler.response_body = (
+            b'data: {"choices":[{"text":"partial","finish_reason":null}]}\n\n'
+            b'data: {"choices":[{"text":"","finish_reason":"error"}]}\n\n'
+            b"data: [DONE]\n\n"
+        )
+
+        result = bench_http_serving.request_once(
+            index=0,
+            request_id="req-finish-error",
+            url=self.url,
+            model="fake-model",
+            prompt_words=1,
+            prompt="hello",
+            max_tokens=1,
+            temperature=0.0,
+            timeout=5,
+            ignore_eos=True,
+        )
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.status, 200)
+        self.assertIn("finish_reason=error", result.error or "")
+
+    def test_error_payload_stream_fails(self) -> None:
+        DoneOnlyHandler.response_body = (
+            b'data: {"error":{"message":"generation failed"}}\n\n'
+            b"data: [DONE]\n\n"
+        )
+
+        result = bench_http_serving.request_once(
+            index=0,
+            request_id="req-payload-error",
+            url=self.url,
+            model="fake-model",
+            prompt_words=1,
+            prompt="hello",
+            max_tokens=1,
+            temperature=0.0,
+            timeout=5,
+            ignore_eos=True,
+        )
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.status, 200)
+        self.assertIn("SSE error: generation failed", result.error or "")
 
     def test_server_trace_log_is_attached_by_vllm_completion_id_prefix(self) -> None:
         result = bench_http_serving.RequestResult(
@@ -106,6 +156,83 @@ class BenchHttpServingTests(unittest.TestCase):
         self.assertAlmostEqual(result.server_trace["admission_queue_ms"], 20.0, places=3)
         self.assertAlmostEqual(result.server_trace["stream_flush_ms"], 50.0, places=3)
         self.assertAlmostEqual(result.server_trace["frontend_to_queue_ms"], 10.0, places=3)
+
+    def test_server_stream_error_log_marks_request_failed(self) -> None:
+        result = bench_http_serving.RequestResult(
+            index=0,
+            request_id="bench-0",
+            prompt_words=16,
+            max_tokens=16,
+            ok=True,
+            status=200,
+            error=None,
+            timed_out=False,
+            start_s=1.0,
+            start_wall_s=100.0,
+            first_token_s=1.2,
+            first_token_wall_s=100.25,
+            end_s=1.4,
+            end_wall_s=100.4,
+            latency_ms=400.0,
+            ttft_ms=200.0,
+            tpot_ms=None,
+            itl_ms=[],
+            output_chunks=1,
+            output_chars=80,
+            output_hash="abcd",
+            text_prefix="text",
+        )
+        line = (
+            'ERROR vllm_engine_core_client::client::stream: stream.rs:90 '
+            'request failed with an internal error during generation '
+            'self.request_id="cmpl-bench-0-generated"\\n'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "server.log"
+            path.write_text(line, encoding="utf-8")
+            traces = bench_http_serving.load_server_traces(path)
+            bench_http_serving.attach_server_traces([result], traces)
+
+        self.assertFalse(result.ok)
+        self.assertIn("server generation error", result.error or "")
+
+    def test_server_trace_zero_completion_tokens_marks_request_failed(self) -> None:
+        result = bench_http_serving.RequestResult(
+            index=0,
+            request_id="bench-0",
+            prompt_words=16,
+            max_tokens=16,
+            ok=True,
+            status=200,
+            error=None,
+            timed_out=False,
+            start_s=1.0,
+            start_wall_s=100.0,
+            first_token_s=1.2,
+            first_token_wall_s=100.25,
+            end_s=1.4,
+            end_wall_s=100.4,
+            latency_ms=400.0,
+            ttft_ms=200.0,
+            tpot_ms=None,
+            itl_ms=[],
+            output_chunks=1,
+            output_chars=80,
+            output_hash="abcd",
+            text_prefix="text",
+        )
+        line = (
+            'INFO pegainfer_http_trace {"request_id":"cmpl-bench-0-generated",'
+            '"completion_tokens":0}\\n'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "server.log"
+            path.write_text(line, encoding="utf-8")
+            traces = bench_http_serving.load_server_traces(path)
+            bench_http_serving.attach_server_traces([result], traces)
+
+        self.assertFalse(result.ok)
+        self.assertIn("completion_tokens=0", result.error or "")
 
     def test_mixed_workload_report_records_input_and_output_tokens(self) -> None:
         results = [


### PR DESCRIPTION
## Summary

- Treat streaming `error` payloads and `finish_reason=error` as failed HTTP benchmark requests.
- Attach server-side stream error log lines to the matching benchmark request and mark them failed.
- Treat traced `completion_tokens=0` / `finish_reason=error` as generation failures when output was requested.

## Validation

Local:
- `python3 -m py_compile scripts/bench_http_serving.py scripts/bench_http_sweep.py`
- `python3 -m unittest tests/test_bench_http_serving.py`
- `git diff --check`
- `cargo fmt --check`
- `pre-commit run --files scripts/bench_http_serving.py tests/test_bench_http_serving.py`

5090 baseline rerun with the updated harness against main `5bf9996`:
- c1: harness exit `1`, `failed=1`, first error `SSE error: Internal server error`
- c2: harness exit `1`, `failed=4`, first error `SSE error: Internal server error`
- c4: harness exit `1`, `failed=4`, first error `SSE error: Internal server error`
- c8: harness exit `1`, `failed=4`, first error `SSE error: Internal server error`

This means the previous HTTP benchmark path was counting server-side generation errors as successful HTTP 200 streams. The active-set/CUDA Graph work should stay paused until the short-prompt prefill failure is fixed or a new clean baseline is established.
