### PR TITLE
fix(dsv4): allow short overlap prefill prompts

### DIFF
--- a/docs/models/deepseek-v4/online-throughput.md
+++ b/docs/models/deepseek-v4/online-throughput.md
@@ -4,7 +4,7 @@ Last touched: 2026-05-18
 
 TL;DR: latest main has a clean default `deepseek-v4` quality gate on the 8x5090
 validation run, but online throughput is still service-time limited. HTTP c1-c8
-fixed-shape load stays around 11.4 req/s with stable hashes because the path is
+fixed-shape load stays around 1.3 req/s with stable hashes because the path is
 still a single-request scheduler turn; mixed online load reports separate input
 and output token rates. Decode has partial bs>1 primitives, prefill does not have
 a native multi-request stack, and DSV4 does not use CUDA Graph yet.
@@ -13,8 +13,8 @@ a native multi-request stack, and DSV4 does not use CUDA Graph yet.
 
 | Field | Value |
 | --- | --- |
-| Task | task #43 |
-| Code | latest main `e4896043` plus benchmark-script reporting changes |
+| Task | task #43, updated by task #47/#48 for HTTP error detection and short-prompt prefill |
+| Code | latest main `019de7f` plus task #48 overlap-compressor short-prompt fix |
 | Model | `DeepSeek-V4-Flash` |
 | Feature path | default `deepseek-v4`; no EP/PPLX |
 | Hardware class | internal 8x RTX 5090 validation host |
@@ -36,6 +36,11 @@ trace lines are unavailable, prompt tokens fall back to `prompt_words`, and
 `ignore_eos=true` output tokens fall back to requested `max_tokens` instead of
 stream chunk count.
 
+Task #47 also makes the harness fail a request when the SSE stream reports
+`error` / `finish_reason=error`, the server log reports a matched stream error,
+or a traced request has `completion_tokens=0` while output tokens were requested.
+The older task #43 HTTP table undercounted these server-side generation errors.
+
 ## Direct Baseline
 
 | Workload | TTFT / E2E | TPOT | Hash | Notes |
@@ -51,10 +56,10 @@ Workload: streaming `/v1/completions`, warmup `2`, requests `8`, prompt words
 
 | Concurrency | Correctness | QPS avg | TTFT avg | TPOT avg | Combined hash |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | failed `0`, timeout `0`, per-request hashes stable | `11.28` | `34.4ms` | `28.86ms` | `4ba75d576badca64` |
-| 2 | failed `0`, timeout `0`, per-request hashes stable | `11.45` | `47.1ms` | `28.22ms` | `4ba75d576badca64` |
-| 4 | failed `0`, timeout `0`, per-request hashes stable | `11.46` | `66.7ms` | `28.21ms` | `4ba75d576badca64` |
-| 8 | failed `0`, timeout `0`, per-request hashes stable | `11.45` | `108.1ms` | `28.22ms` | `4ba75d576badca64` |
+| 1 | failed `0`, timeout `0`, per-request hashes stable | `1.33` | `275.67ms` | `31.81ms` | `4c7d24746f19ff5b` |
+| 2 | failed `0`, timeout `0`, per-request hashes stable | `1.32` | `954.91ms` | `31.94ms` | `4c7d24746f19ff5b` |
+| 4 | failed `0`, timeout `0`, per-request hashes stable | `1.34` | `2049.55ms` | `31.33ms` | `4c7d24746f19ff5b` |
+| 8 | failed `0`, timeout `0`, per-request hashes stable | `1.34` | `3337.98ms` | `31.70ms` | `4c7d24746f19ff5b` |
 
 Interpretation: QPS and TPOT barely move from c2 to c8 because the current HTTP
 scheduler admits one request turn at a time. Concurrency mostly changes queue

--- a/pegainfer-kernels/csrc/deepseek_v4/deepseek_compressor.cu
+++ b/pegainfer-kernels/csrc/deepseek_v4/deepseek_compressor.cu
@@ -821,7 +821,7 @@ cudaError_t deepseek_compressor_overlap_prefill_cuda(
       norm == nullptr || weighted == nullptr || out == nullptr) {
     return cudaErrorInvalidValue;
   }
-  if (seq_len < 4 || (seq_len & 3) != 0 || hidden_dim <= 0 || head_dim <= 0) {
+  if (seq_len < 4 || hidden_dim <= 0 || head_dim <= 0) {
     return cudaErrorInvalidValue;
   }
   const int compressed_len = seq_len / 4;

--- a/pegainfer-kernels/tests/deepseek_compressor_overlap.rs
+++ b/pegainfer-kernels/tests/deepseek_compressor_overlap.rs
@@ -259,7 +259,6 @@ fn assert_close(name: &str, got: &[f32], expected: &[f32], max_abs_limit: f32) -
 // reference uses; the 3x bf16-noise FlashAttention-style envelope is well
 // inside what the downstream RMSNorm BF16 store quantises away anyway.
 fn check_case(name: &str, seq_len: usize, hidden_dim: usize, head_dim: usize) -> Result<()> {
-    ensure!(seq_len % 4 == 0, "seq_len must be ratio4 aligned");
     let eps = 1.0e-6;
     let case = make_case(seq_len, hidden_dim, head_dim);
     let (expected_weighted, expected_out) = reference_overlap(&case, eps);
@@ -286,6 +285,7 @@ fn overlap_prefill_matches_reference_small_main_and_indexer_shapes() -> Result<(
 #[test]
 #[ignore = "requires CUDA GPU; covers odd/boundary compressed and head shapes"]
 fn overlap_prefill_matches_reference_odd_boundary_shape() -> Result<()> {
+    check_case("short-http", 21, 64, 32)?;
     check_case("odd-boundary", 68, 40, 33)
 }
 


### PR DESCRIPTION
## Summary
- allow the DSV4 overlap prefill compressor to accept short prompts whose `seq_len` is not a multiple of ratio4
- add a CUDA ignored test case for the 21-token short HTTP prompt shape
- update the DSV4 online-throughput doc with the #142 error-aware fixed-shape HTTP rerun

## Root cause
The short HTTP benchmark uses a 16-word prompt that tokenizes to `seq_len=21`. At layer 2 the model takes the ratio4 overlap-compressor prefill path, but the PR #140 GEMM route added a `(seq_len & 3) == 0` launch guard in `deepseek_compressor_overlap_prefill_cuda`. That guard rejected the real HTTP prompt before launch with `CUDA_ERROR_INVALID_VALUE`.

The kernel already derives `compressed_len = seq_len / 4` and only consumes complete ratio4 compressed rows, so non-4-aligned prompt tails are legal and match the reference path.

## Validation
Local:
- `python3 -m py_compile scripts/bench_http_serving.py scripts/bench_http_sweep.py`
- `python3 -m unittest tests/test_bench_http_serving.py`
- `git diff --check`
- `cargo fmt --check`
- `pre-commit run --files pegainfer-kernels/csrc/deepseek_v4/deepseek_compressor.cu pegainfer-kernels/tests/deepseek_compressor_overlap.rs docs/models/deepseek-v4/online-throughput.md` reached repo config parsing and is blocked by the existing `.pre-commit-config.yaml` `repo='builtin'` / missing `rev` issue; no hook was bypassed

5090:
- `cargo test -r -p pegainfer-kernels --features deepseek-v4 --test deepseek_compressor_overlap -- --ignored --nocapture` (`3 passed`)
- `cargo build -r -p pegainfer-server --features deepseek-v4 --bin pegainfer --bin bench_serving`
- fixed-shape HTTP, #142 harness, prompt words 16, max tokens 16, 8 measured requests each:

| concurrency | failed | timeout | qps | ttft avg | tpot avg | combined hash |
| ---: | ---: | ---: | ---: | ---: | ---: | --- |
| 1 | 0 | 0 | 1.33 | 275.67ms | 31.81ms | `4c7d24746f19ff5b` |
| 2 | 0 | 0 | 1.32 | 954.91ms | 31.94ms | `4c7d24746f19ff5b` |
| 4 | 0 | 0 | 1.34 | 2049.55ms | 31.33ms | `4c7d24746f19ff5b` |
| 8 | 0 | 0 | 1.34 | 3337.98ms | 31.70ms | `4c7d24746f19ff5b` |

5090 server and benchmark processes were cleaned after validation.
