### PR TITLE
test(dsv4): cover real indexer topk shape

### DIFF
--- a/docs/models/deepseek-v4/http-serving-benchmark.md
+++ b/docs/models/deepseek-v4/http-serving-benchmark.md
@@ -330,17 +330,20 @@ The current code path is:
 - output indices are `offset + compressed_idx`, where the ratio-4 prefill path
   uses the raw window length as `offset`.
 
-For the 10k prefill workload from the P3 observation, this gives the concrete
-shape:
+For the 10k prefill workload from the P3 observation, the runtime shape source
+is the DSV4 model config (`index_topk=512`) combined with
+`indexer_topk_indices_prefill`, which passes
+`config.index_topk.min(compressed_len)` to
+`deepseek_indexer_topk_prefill_cuda`. That gives the concrete runtime shape:
 
 | Field | Value |
 | --- | --- |
 | `seq_len` | `10580` |
 | `compressed_len` | `2645` |
-| `topk` | `32` |
+| `topk` | `512` |
 | `ratio` | `4` |
 | `offset` | `10580` |
-| shared memory per block | `10580` bytes |
+| shared memory per block | `12628` bytes |
 
 P3 `nsys` attribution, still under the explicit CuTeDSL score feature, showed
 top-k as the largest remaining indexer-side bucket:
@@ -359,18 +362,20 @@ cargo test --release -p pegainfer-kernels \
   --test deepseek_indexer_topk -- --ignored --nocapture
 ```
 
-It covers two cases:
+It covers three cases:
 
-- odd compressed length with pseudo-random scores:
+- synthetic odd compressed length with pseudo-random scores:
   `seq_len=257`, `compressed_len=129`, `topk=32`, `ratio=4`, `offset=777`;
-- the 10k profile shape:
-  `seq_len=10580`, `compressed_len=2645`, `topk=32`, `ratio=4`,
+- the real 10k runtime top-k shape:
+  `seq_len=10580`, `compressed_len=2645`, `topk=512`, `ratio=4`,
   `offset=10580`.
+- synthetic tie-heavy rows:
+  `seq_len=17`, `compressed_len=33`, `topk=12`, `ratio=4`, `offset=4096`.
 
-The first case checks exact output indices against a CPU reference. The second
-case uses monotonic scores so the expected top-k sequence is fully derivable
-while still exercising the real 10k launch shape, valid-position mask, top-k
-width, and offset behavior.
+The synthetic cases check boundary and strict tie-order behavior. The 10k case
+uses monotonic scores so the expected top-k sequence is fully derivable while
+exercising the real runtime top-k width, valid-position mask, and offset
+behavior.
 
 Hash evidence remains the P3 gate because this PR does not change runtime code:
 direct 10k generated-token hash `39a863e299d2b187`, 10k HTTP output hash
@@ -393,15 +398,21 @@ strict `>` semantics by keeping the lower candidate index when scores tie.
 Score, overlap compressor, cache reuse, scheduler, HTTP behavior, and decode
 top-k are unchanged.
 
-The ignored GPU gate now covers three cases:
+The ignored GPU gate in that historical task covered three cases:
 
-- odd compressed length: `seq_len=257`, `compressed_len=129`, `topk=32`,
+- synthetic odd compressed length: `seq_len=257`, `compressed_len=129`, `topk=32`,
   `ratio=4`, `offset=777`;
-- 10k profile shape: `seq_len=10580`, `compressed_len=2645`, `topk=32`,
-  `ratio=4`, `offset=10580`;
-- tie-heavy rows: `seq_len=17`, `compressed_len=33`, `topk=12`, `ratio=4`,
-  `offset=4096`, with equal score groups verifying that candidate order is
-  preserved.
+- synthetic 10k-like task shape: `seq_len=10580`, `compressed_len=2645`,
+  `topk=32`, `ratio=4`, `offset=10580`;
+- synthetic tie-heavy rows: `seq_len=17`, `compressed_len=33`, `topk=12`,
+  `ratio=4`, `offset=4096`, with equal score groups verifying that candidate
+  order is preserved.
+
+Those `topk=32` numbers are historical task-gate evidence only. They are not a
+valid source for future DSV4 runtime performance gates. Runtime top-k work must
+use the real config-derived 10k shape from P4:
+`seq_len=10580`, `compressed_len=2645`, `topk=512`, `ratio=4`,
+`offset=10580`.
 
 Validation at this PR head:
 

--- a/pegainfer-kernels/tests/deepseek_indexer_topk.rs
+++ b/pegainfer-kernels/tests/deepseek_indexer_topk.rs
@@ -190,11 +190,11 @@ fn indexer_topk_prefill_matches_reference_odd_shape() -> Result<()> {
 }
 
 #[test]
-#[ignore = "requires CUDA GPU; covers the 10k prefill launch/shape from task #27"]
-fn indexer_topk_prefill_matches_reference_10k_profile_shape() -> Result<()> {
+#[ignore = "requires CUDA GPU; covers the real DSV4 10k prefill index_topk shape"]
+fn indexer_topk_prefill_matches_reference_10k_real_index_topk_shape() -> Result<()> {
     let seq_len = 10580;
     let compressed_len = 2645;
-    let topk = 32;
+    let topk = 512;
     let ratio = 4;
     let offset = seq_len;
     let mut scores = vec![0.0f32; seq_len * compressed_len];


### PR DESCRIPTION
## Summary

- update the ignored DSV4 prefill indexer top-k 10k gate to use the real runtime `index_topk=512`
- document the real 10k top-k shape source as DSV4 config plus `indexer_topk_indices_prefill` using `config.index_topk.min(compressed_len)`
- mark old topk32 odd / tie-heavy / 10k-like gates as synthetic or historical task-gate evidence, not future runtime perf-gate sources
- correct the 10k top-k shared-memory entry to the current launcher formula: `(compressed_len + 256) * sizeof(float) + 256 * sizeof(int) = 12628 bytes`

## Scope

- test + docs contract correction only
- no runtime kernel, Rust, FFI, launcher, HTTP, or profile changes

## Validation

- `cargo fmt --check`
- `git diff --check`
- `pre-commit run --files pegainfer-kernels/tests/deepseek_indexer_topk.rs docs/models/deepseek-v4/http-serving-benchmark.md`
- after the docs-only shared-memory fix: `pre-commit run --files docs/models/deepseek-v4/http-serving-benchmark.md`
- 5090: `cargo test -r -p pegainfer-kernels --features deepseek-v4 --test deepseek_indexer_topk -- --ignored --nocapture`
  - `indexer_topk_prefill_matches_reference_odd_shape` PASS
  - `indexer_topk_prefill_matches_reference_10k_real_index_topk_shape` PASS (`seq_len=10580, compressed_len=2645, topk=512, ratio=4, offset=10580`)
  - `indexer_topk_prefill_matches_reference_tie_heavy_rows` PASS