### PR TITLE
feat(deepseek-v2-lite): add correctness-first EP2 bring-up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3566,6 +3566,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pegainfer-deepseek-v2-lite"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "cudarc",
+ "half",
+ "hex",
+ "memmap2",
+ "pegainfer-core",
+ "pegainfer-engine",
+ "safetensors",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tokio",
+ "vllm-text",
+]
+
+[[package]]
 name = "pegainfer-deepseek-v4"
 version = "0.1.0"
 dependencies = [
@@ -3665,6 +3684,7 @@ dependencies = [
  "log",
  "logforth",
  "pegainfer-core",
+ "pegainfer-deepseek-v2-lite",
  "pegainfer-deepseek-v4",
  "pegainfer-qwen3-4b",
  "pegainfer-qwen35-4b",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "pegainfer-cupti",
     "pegainfer-kernels",
     "pegainfer-deepseek-v4",
+    "pegainfer-deepseek-v2-lite",
     "pegainfer-qwen3-4b",
     "pegainfer-qwen35-4b",
     # ---- pegainfer-comm (EP all-to-all skeleton, hardware-free default) ----
@@ -72,6 +73,7 @@ pegainfer-engine = { path = "pegainfer-engine" }
 pegainfer-kernels = { path = "pegainfer-kernels" }
 pegainfer-qwen3-4b = { path = "pegainfer-qwen3-4b" }
 pegainfer-qwen35-4b = { path = "pegainfer-qwen35-4b" }
+pegainfer-deepseek-v2-lite = { path = "pegainfer-deepseek-v2-lite" }
 pegainfer-vllm-frontend = { path = "pegainfer-vllm-frontend" }
 pegainfer-vllm-support = { path = "pegainfer-vllm-support" }
 pegainfer-comm = { path = "pegainfer-comm" }

--- a/pegainfer-deepseek-v2-lite/Cargo.toml
+++ b/pegainfer-deepseek-v2-lite/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "pegainfer-deepseek-v2-lite"
+version = "0.1.0"
+edition = "2024"
+autobenches = false
+autobins = false
+autotests = false
+
+[features]
+default = []
+deepseek-v2-lite = []
+
+[dependencies]
+anyhow = { workspace = true }
+cudarc = { workspace = true }
+half = { workspace = true }
+hex = { workspace = true }
+memmap2 = { workspace = true }
+pegainfer-core = { workspace = true }
+pegainfer-engine = { workspace = true }
+safetensors = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+vllm-text = { workspace = true }
+
+[lints]
+workspace = true
+
+[[test]]
+name = "e2e_ep2"
+path = "tests/e2e_ep2.rs"
+required-features = ["deepseek-v2-lite"]

--- a/pegainfer-deepseek-v2-lite/src/config.rs
+++ b/pegainfer-deepseek-v2-lite/src/config.rs
@@ -1,0 +1,285 @@
+use std::{fs, path::Path};
+
+use anyhow::{Result, ensure};
+use serde::Deserialize;
+
+use crate::ep::SUPPORTED_ROUTED_EXPERTS;
+
+pub(crate) const SUPPORTED_HIDDEN_SIZE: usize = 2048;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RopeScaling {
+    pub beta_fast: usize,
+    pub beta_slow: usize,
+    pub factor: f32,
+    pub mscale: f32,
+    pub mscale_all_dim: f32,
+    pub original_max_position_embeddings: usize,
+    #[serde(rename = "type")]
+    pub kind: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Config {
+    pub model_type: String,
+    pub bos_token_id: u32,
+    pub eos_token_id: u32,
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub moe_intermediate_size: usize,
+    pub num_hidden_layers: usize,
+    pub first_k_dense_replace: usize,
+    pub moe_layer_freq: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    pub q_lora_rank: Option<usize>,
+    pub kv_lora_rank: usize,
+    pub qk_nope_head_dim: usize,
+    pub qk_rope_head_dim: usize,
+    pub v_head_dim: usize,
+    pub n_routed_experts: usize,
+    pub n_shared_experts: usize,
+    #[serde(rename = "num_experts_per_tok")]
+    pub num_experts_per_token: usize,
+    pub routed_scaling_factor: f32,
+    pub scoring_func: String,
+    pub topk_method: String,
+    pub n_group: usize,
+    pub topk_group: usize,
+    pub norm_topk_prob: bool,
+    pub rms_norm_eps: f32,
+    pub rope_theta: f32,
+    pub rope_scaling: Option<RopeScaling>,
+    pub max_position_embeddings: usize,
+    pub tie_word_embeddings: bool,
+}
+
+impl Config {
+    pub fn from_model_dir(model_path: impl AsRef<Path>) -> Result<Self> {
+        let config_path = model_path.as_ref().join("config.json");
+        let content = fs::read_to_string(&config_path)?;
+        let config: Self = serde_json::from_str(&content)?;
+        config.validate_lite()?;
+        Ok(config)
+    }
+
+    pub fn validate_lite(&self) -> Result<()> {
+        ensure!(
+            self.model_type == "deepseek_v2",
+            "DeepSeek-V2-Lite expects model_type=deepseek_v2, got {}",
+            self.model_type
+        );
+        ensure!(
+            self.hidden_size == SUPPORTED_HIDDEN_SIZE,
+            "DeepSeek-V2-Lite expects hidden_size={}, got {}",
+            SUPPORTED_HIDDEN_SIZE,
+            self.hidden_size
+        );
+        ensure!(
+            self.num_hidden_layers == 27,
+            "DeepSeek-V2-Lite expects num_hidden_layers=27, got {}",
+            self.num_hidden_layers
+        );
+        ensure!(
+            self.num_attention_heads == 16,
+            "DeepSeek-V2-Lite expects num_attention_heads=16, got {}",
+            self.num_attention_heads
+        );
+        ensure!(
+            self.num_key_value_heads == 16,
+            "DeepSeek-V2-Lite expects num_key_value_heads=16, got {}",
+            self.num_key_value_heads
+        );
+        ensure!(
+            self.q_lora_rank.is_none(),
+            "DeepSeek-V2-Lite first gate expects q_lora_rank=null, got {:?}",
+            self.q_lora_rank
+        );
+        ensure!(
+            self.kv_lora_rank == 512,
+            "DeepSeek-V2-Lite expects kv_lora_rank=512, got {}",
+            self.kv_lora_rank
+        );
+        ensure!(
+            self.qk_nope_head_dim == 128 && self.qk_rope_head_dim == 64 && self.v_head_dim == 128,
+            "DeepSeek-V2-Lite expects qk_nope_head_dim=128, qk_rope_head_dim=64, v_head_dim=128; got {}/{}/{}",
+            self.qk_nope_head_dim,
+            self.qk_rope_head_dim,
+            self.v_head_dim
+        );
+        ensure!(
+            self.n_routed_experts == SUPPORTED_ROUTED_EXPERTS,
+            "DeepSeek-V2-Lite expects n_routed_experts={}, got {}",
+            SUPPORTED_ROUTED_EXPERTS,
+            self.n_routed_experts
+        );
+        ensure!(
+            self.n_shared_experts == 2,
+            "DeepSeek-V2-Lite expects n_shared_experts=2, got {}",
+            self.n_shared_experts
+        );
+        ensure!(
+            self.num_experts_per_token == 6,
+            "DeepSeek-V2-Lite expects num_experts_per_tok=6, got {}",
+            self.num_experts_per_token
+        );
+        ensure!(
+            self.first_k_dense_replace == 1,
+            "DeepSeek-V2-Lite expects first_k_dense_replace=1, got {}",
+            self.first_k_dense_replace
+        );
+        ensure!(
+            self.moe_layer_freq == 1,
+            "DeepSeek-V2-Lite expects moe_layer_freq=1, got {}",
+            self.moe_layer_freq
+        );
+        ensure!(
+            self.intermediate_size > 0 && self.moe_intermediate_size > 0,
+            "DeepSeek-V2-Lite intermediate sizes must be positive"
+        );
+        ensure!(
+            self.scoring_func == "softmax",
+            "DeepSeek-V2-Lite first gate expects scoring_func=softmax, got {}",
+            self.scoring_func
+        );
+        ensure!(
+            self.topk_method == "greedy",
+            "DeepSeek-V2-Lite first gate expects topk_method=greedy, got {}",
+            self.topk_method
+        );
+        ensure!(
+            self.n_group == 1 && self.topk_group == 1,
+            "DeepSeek-V2-Lite greedy routing expects n_group=1 and topk_group=1, got {}/{}",
+            self.n_group,
+            self.topk_group
+        );
+        ensure!(
+            !self.norm_topk_prob,
+            "DeepSeek-V2-Lite first gate expects norm_topk_prob=false"
+        );
+        ensure!(
+            (self.routed_scaling_factor - 1.0).abs() < f32::EPSILON,
+            "DeepSeek-V2-Lite first gate expects routed_scaling_factor=1.0, got {}",
+            self.routed_scaling_factor
+        );
+        if let Some(rope_scaling) = &self.rope_scaling {
+            ensure!(
+                rope_scaling.kind == "yarn",
+                "DeepSeek-V2-Lite first gate expects rope_scaling.type=yarn, got {}",
+                rope_scaling.kind
+            );
+            ensure!(
+                rope_scaling.original_max_position_embeddings > 0
+                    && rope_scaling.original_max_position_embeddings
+                        <= self.max_position_embeddings,
+                "DeepSeek-V2-Lite rope_scaling original_max_position_embeddings={} must be in 1..={}",
+                rope_scaling.original_max_position_embeddings,
+                self.max_position_embeddings
+            );
+            ensure!(
+                rope_scaling.factor >= 1.0
+                    && rope_scaling.beta_fast > 0
+                    && rope_scaling.beta_slow > 0
+                    && rope_scaling.mscale > 0.0
+                    && rope_scaling.mscale_all_dim > 0.0,
+                "DeepSeek-V2-Lite rope_scaling values must be positive"
+            );
+        }
+        Ok(())
+    }
+
+    pub fn is_moe_layer(&self, layer: usize) -> bool {
+        layer >= self.first_k_dense_replace
+            && (layer - self.first_k_dense_replace).is_multiple_of(self.moe_layer_freq)
+    }
+
+    pub fn query_head_dim(&self) -> usize {
+        self.qk_nope_head_dim + self.qk_rope_head_dim
+    }
+
+    pub fn q_proj_rows(&self) -> usize {
+        self.num_attention_heads * self.query_head_dim()
+    }
+
+    pub fn kv_a_proj_rows(&self) -> usize {
+        self.kv_lora_rank + self.qk_rope_head_dim
+    }
+
+    pub fn kv_b_proj_rows(&self) -> usize {
+        self.num_attention_heads * (self.qk_nope_head_dim + self.v_head_dim)
+    }
+
+    pub fn o_proj_cols(&self) -> usize {
+        self.num_attention_heads * self.v_head_dim
+    }
+
+    pub fn shared_moe_intermediate(&self) -> usize {
+        self.n_shared_experts * self.moe_intermediate_size
+    }
+
+    pub fn supported_plain_rope_context(&self) -> usize {
+        self.rope_scaling
+            .as_ref()
+            .map_or(self.max_position_embeddings, |rope_scaling| {
+                rope_scaling.original_max_position_embeddings
+            })
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn test_lite_config() -> Config {
+    Config {
+        model_type: "deepseek_v2".to_string(),
+        bos_token_id: 100_000,
+        eos_token_id: 100_001,
+        vocab_size: 102_400,
+        hidden_size: 2048,
+        intermediate_size: 10944,
+        moe_intermediate_size: 1408,
+        num_hidden_layers: 27,
+        first_k_dense_replace: 1,
+        moe_layer_freq: 1,
+        num_attention_heads: 16,
+        num_key_value_heads: 16,
+        q_lora_rank: None,
+        kv_lora_rank: 512,
+        qk_nope_head_dim: 128,
+        qk_rope_head_dim: 64,
+        v_head_dim: 128,
+        n_routed_experts: 64,
+        n_shared_experts: 2,
+        num_experts_per_token: 6,
+        routed_scaling_factor: 1.0,
+        scoring_func: "softmax".to_string(),
+        topk_method: "greedy".to_string(),
+        n_group: 1,
+        topk_group: 1,
+        norm_topk_prob: false,
+        rms_norm_eps: 0.000_001,
+        rope_theta: 10000.0,
+        rope_scaling: Some(RopeScaling {
+            beta_fast: 32,
+            beta_slow: 1,
+            factor: 40.0,
+            mscale: 0.707,
+            mscale_all_dim: 0.707,
+            original_max_position_embeddings: 4096,
+            kind: "yarn".to_string(),
+        }),
+        max_position_embeddings: 163_840,
+        tie_word_embeddings: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn yarn_config_limits_first_gate_to_original_context() {
+        let config = test_lite_config();
+
+        assert_eq!(config.supported_plain_rope_context(), 4096);
+    }
+}

--- a/pegainfer-deepseek-v2-lite/src/device.rs
+++ b/pegainfer-deepseek-v2-lite/src/device.rs
@@ -1,0 +1,28 @@
+use std::cell::Cell;
+
+use anyhow::{Result, ensure};
+use pegainfer_core::{ffi, tensor::DeviceContext};
+
+thread_local! {
+    static ACTIVE_DEVICE: Cell<Option<usize>> = const { Cell::new(None) };
+}
+
+pub(crate) fn activate(ctx: &DeviceContext) -> Result<()> {
+    ACTIVE_DEVICE.with(|active| {
+        if active.get() == Some(ctx.device_ordinal) {
+            return Ok(());
+        }
+        unsafe {
+            ffi::cublas_destroy();
+            let err = ffi::cuda_set_device(ctx.device_ordinal as i32);
+            ensure!(
+                err == 0,
+                "failed to activate CUDA device {}: cudaError={err}",
+                ctx.device_ordinal
+            );
+            ffi::cublas_init();
+        }
+        active.set(Some(ctx.device_ordinal));
+        Ok(())
+    })
+}

--- a/pegainfer-deepseek-v2-lite/src/engine.rs
+++ b/pegainfer-deepseek-v2-lite/src/engine.rs
@@ -1,0 +1,165 @@
+use std::{
+    path::Path,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{Context, Result};
+use pegainfer_engine::{
+    engine::{EngineHandle, EngineLoadOptions, FinishReason, GenerateRequest, TokenEvent},
+    sampler::SamplingParams,
+};
+use tokio::sync::mpsc;
+
+use crate::runtime::{DeepSeekV2LiteEp2Generator, GenerationResult};
+
+pub(crate) fn start_engine(model_path: &Path, options: EngineLoadOptions) -> Result<EngineHandle> {
+    let mut generator = DeepSeekV2LiteEp2Generator::load(model_path, options)?;
+    let (submit_tx, mut submit_rx) = mpsc::unbounded_channel();
+
+    std::thread::Builder::new()
+        .name("deepseek-v2-lite-ep2".to_string())
+        .spawn(move || {
+            while let Some(req) = submit_rx.blocking_recv() {
+                handle_request(&mut generator, &req);
+            }
+        })
+        .context("spawn DeepSeek-V2-Lite EP=2 engine thread")?;
+
+    Ok(EngineHandle::new(submit_tx))
+}
+
+fn handle_request(generator: &mut DeepSeekV2LiteEp2Generator, req: &GenerateRequest) {
+    let prompt_tokens = req.prompt_tokens.len();
+    let now = unix_time_secs();
+    let _ = req.token_tx.send(TokenEvent::Scheduled {
+        queued_at_unix_s: req.queued_at_unix_s.unwrap_or(now),
+        scheduled_at_unix_s: now,
+        prompt_tokens,
+    });
+    if req.echo {
+        let _ = req.token_tx.send(TokenEvent::PromptTokens {
+            ids: req.prompt_tokens.clone(),
+            logprobs: vec![None; prompt_tokens],
+        });
+    }
+    if !is_greedy(req.params) {
+        reject_request(
+            req,
+            prompt_tokens,
+            format!(
+                "DeepSeek-V2-Lite EP=2 first gate serves greedy decoding only; requested temperature={}, top_k={}, top_p={}",
+                req.params.temperature, req.params.top_k, req.params.top_p
+            ),
+        );
+        return;
+    }
+    if req.logprobs > 0 {
+        reject_request(
+            req,
+            prompt_tokens,
+            "DeepSeek-V2-Lite EP=2 first gate does not return logprobs yet".to_string(),
+        );
+        return;
+    }
+    if req.max_tokens == 0 {
+        let _ = req.token_tx.send(TokenEvent::Finished {
+            finish_reason: FinishReason::Length,
+            prompt_tokens,
+            completion_tokens: 0,
+        });
+        return;
+    }
+
+    match generator.generate_greedy(&req.prompt_tokens, req.max_tokens, req.params.ignore_eos) {
+        Ok(result) => {
+            emit_generation_result(&req.token_tx, prompt_tokens, &result);
+        }
+        Err(err) => {
+            let _ = req.token_tx.send(TokenEvent::Error {
+                message: err.to_string(),
+                prompt_tokens,
+                completion_tokens: 0,
+            });
+        }
+    }
+}
+
+fn reject_request(req: &GenerateRequest, prompt_tokens: usize, message: String) {
+    let _ = req.token_tx.send(TokenEvent::Rejected {
+        message,
+        prompt_tokens,
+        completion_tokens: 0,
+    });
+}
+
+fn emit_generation_result(
+    token_tx: &mpsc::UnboundedSender<TokenEvent>,
+    prompt_tokens: usize,
+    result: &GenerationResult,
+) {
+    for token in &result.tokens {
+        let _ = token_tx.send(TokenEvent::Token {
+            id: *token,
+            logprob: None,
+        });
+    }
+    let _ = token_tx.send(TokenEvent::Finished {
+        finish_reason: result.finish_reason,
+        prompt_tokens,
+        completion_tokens: result.tokens.len(),
+    });
+}
+
+fn is_greedy(params: SamplingParams) -> bool {
+    (params.temperature <= 0.0 || params.top_k == 1) && params.top_p >= 1.0
+}
+
+fn unix_time_secs() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0.0, |duration| duration.as_secs_f64())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::GenerationStats;
+
+    #[test]
+    fn stop_generation_streams_tokens_and_stop_finish() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        emit_generation_result(
+            &tx,
+            3,
+            &GenerationResult {
+                tokens: vec![10, 11],
+                finish_reason: FinishReason::Stop,
+                stats: GenerationStats::default(),
+            },
+        );
+        drop(tx);
+
+        match rx.try_recv().expect("expected first token") {
+            TokenEvent::Token { id, .. } => assert_eq!(id, 10),
+            _ => panic!("expected first token event"),
+        }
+        match rx.try_recv().expect("expected second token") {
+            TokenEvent::Token { id, .. } => assert_eq!(id, 11),
+            _ => panic!("expected second token event"),
+        }
+        match rx.try_recv().expect("expected finished event") {
+            TokenEvent::Finished {
+                finish_reason,
+                prompt_tokens,
+                completion_tokens,
+            } => {
+                assert_eq!(finish_reason, FinishReason::Stop);
+                assert_eq!(prompt_tokens, 3);
+                assert_eq!(completion_tokens, 2);
+            }
+            _ => panic!("expected finished event"),
+        }
+        assert!(rx.try_recv().is_err());
+    }
+}

--- a/pegainfer-deepseek-v2-lite/src/ep.rs
+++ b/pegainfer-deepseek-v2-lite/src/ep.rs
@@ -1,0 +1,131 @@
+use std::ops::Range;
+
+use anyhow::{Result, ensure};
+
+use crate::Config;
+
+const SUPPORTED_EP_SIZE: usize = 2;
+pub(crate) const SUPPORTED_ROUTED_EXPERTS: usize = 64;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ExpertParallelConfig {
+    rank: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ExpertParallelLayout {
+    rank: usize,
+    ep_size: usize,
+    experts_per_rank: usize,
+    owned: Range<usize>,
+}
+
+impl ExpertParallelConfig {
+    pub(crate) fn ep2(rank: usize) -> Self {
+        Self { rank }
+    }
+
+    pub(crate) fn validate_for(self, config: &Config) -> Result<ExpertParallelLayout> {
+        ensure!(
+            self.rank < SUPPORTED_EP_SIZE,
+            "DeepSeek-V2-Lite EP rank {} must be < ep_size {}",
+            self.rank,
+            SUPPORTED_EP_SIZE
+        );
+        ensure!(
+            config.n_routed_experts == SUPPORTED_ROUTED_EXPERTS,
+            "DeepSeek-V2-Lite EP gate expects 64 routed experts, got {}",
+            config.n_routed_experts
+        );
+        ensure!(
+            config.n_routed_experts.is_multiple_of(SUPPORTED_EP_SIZE),
+            "n_routed_experts={} must divide evenly by ep_size={}",
+            config.n_routed_experts,
+            SUPPORTED_EP_SIZE
+        );
+        let experts_per_rank = config.n_routed_experts / SUPPORTED_EP_SIZE;
+        ensure!(
+            experts_per_rank == 32,
+            "DeepSeek-V2-Lite EP=2 expects 32 local routed experts, got {}",
+            experts_per_rank
+        );
+        let start = self.rank * experts_per_rank;
+        Ok(ExpertParallelLayout {
+            rank: self.rank,
+            ep_size: SUPPORTED_EP_SIZE,
+            experts_per_rank,
+            owned: start..start + experts_per_rank,
+        })
+    }
+}
+
+impl ExpertParallelLayout {
+    pub(crate) fn rank(&self) -> usize {
+        self.rank
+    }
+
+    pub(crate) fn ep_size(&self) -> usize {
+        self.ep_size
+    }
+
+    pub(crate) fn experts_per_rank(&self) -> usize {
+        self.experts_per_rank
+    }
+
+    pub(crate) fn owned_experts(&self) -> Range<usize> {
+        self.owned.clone()
+    }
+
+    fn owns(&self, expert: usize) -> bool {
+        self.owned.contains(&expert)
+    }
+
+    pub(crate) fn owner_rank(&self, expert: usize) -> Result<usize> {
+        ensure!(
+            expert < SUPPORTED_ROUTED_EXPERTS,
+            "routed expert {expert} out of range 0..{}",
+            SUPPORTED_ROUTED_EXPERTS
+        );
+        Ok(expert / self.experts_per_rank)
+    }
+
+    pub(crate) fn local_expert(&self, expert: usize) -> Result<usize> {
+        ensure!(
+            self.owns(expert),
+            "routed expert {expert} is owned by rank {}, not local rank {}",
+            self.owner_rank(expert)?,
+            self.rank
+        );
+        Ok(expert - self.owned.start)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::test_lite_config;
+
+    #[test]
+    fn ep2_expert_ranges_are_fixed() {
+        let config = test_lite_config();
+        config.validate_lite().unwrap();
+        let rank0 = ExpertParallelConfig::ep2(0).validate_for(&config).unwrap();
+        let rank1 = ExpertParallelConfig::ep2(1).validate_for(&config).unwrap();
+        assert_eq!(rank0.owned_experts(), 0..32);
+        assert_eq!(rank1.owned_experts(), 32..64);
+        assert_eq!(rank0.local_expert(31).unwrap(), 31);
+        assert_eq!(rank1.local_expert(32).unwrap(), 0);
+        assert!(rank0.local_expert(32).is_err());
+    }
+
+    #[test]
+    fn owner_rank_rejects_out_of_range_experts() {
+        let config = test_lite_config();
+        let rank0 = ExpertParallelConfig::ep2(0).validate_for(&config).unwrap();
+        assert_eq!(rank0.owner_rank(0).unwrap(), 0);
+        assert_eq!(rank0.owner_rank(31).unwrap(), 0);
+        assert_eq!(rank0.owner_rank(32).unwrap(), 1);
+        assert_eq!(rank0.owner_rank(63).unwrap(), 1);
+        assert!(rank0.owner_rank(64).is_err());
+    }
+}

--- a/pegainfer-deepseek-v2-lite/src/host_ops.rs
+++ b/pegainfer-deepseek-v2-lite/src/host_ops.rs
@@ -1,0 +1,248 @@
+use anyhow::{Result, ensure};
+use half::bf16;
+use pegainfer_core::tensor::{DeviceContext, HiddenStates};
+
+use crate::{Config, device::activate};
+
+#[derive(Default)]
+pub(crate) struct DecodeCache {
+    pub(crate) layers: Vec<LayerCache>,
+}
+
+#[derive(Default)]
+pub(crate) struct LayerCache {
+    keys: Vec<f32>,
+    values: Vec<f32>,
+}
+
+impl LayerCache {
+    pub(crate) fn len(&self, config: &Config) -> usize {
+        let per_token = config.num_attention_heads * config.query_head_dim();
+        if per_token == 0 {
+            return 0;
+        }
+        self.keys.len() / per_token
+    }
+}
+
+impl DecodeCache {
+    pub(crate) fn new(config: &Config) -> Self {
+        Self {
+            layers: (0..config.num_hidden_layers)
+                .map(|_| LayerCache::default())
+                .collect(),
+        }
+    }
+}
+
+pub(crate) fn normalize_compressed_kv(
+    config: &Config,
+    kv_a_host: &[f32],
+    norm_weight: &[f32],
+    seq_len: usize,
+) -> Vec<bf16> {
+    let mut out = vec![bf16::ZERO; config.kv_lora_rank * seq_len];
+    for token in 0..seq_len {
+        let src = &kv_a_host[token * config.kv_a_proj_rows()
+            ..token * config.kv_a_proj_rows() + config.kv_lora_rank];
+        let dst = &mut out[token * config.kv_lora_rank..(token + 1) * config.kv_lora_rank];
+        rms_norm_host(src, norm_weight, config.rms_norm_eps, dst);
+    }
+    out
+}
+
+fn rms_norm_host(input: &[f32], weight: &[f32], eps: f32, out: &mut [bf16]) {
+    let sum_sq = input.iter().map(|value| value * value).sum::<f32>();
+    let inv_rms = (sum_sq / input.len() as f32 + eps).sqrt().recip();
+    for ((dst, value), scale) in out.iter_mut().zip(input).zip(weight) {
+        *dst = bf16::from_f32(value * inv_rms * scale);
+    }
+}
+
+pub(crate) fn append_kv_and_build_queries(
+    config: &Config,
+    q_host: &[f32],
+    kv_a_host: &[f32],
+    kv_b_host: &[f32],
+    start_pos: usize,
+    seq_len: usize,
+    queries: &mut [f32],
+    cache: &mut LayerCache,
+) {
+    let num_heads = config.num_attention_heads;
+    let q_head_dim = config.query_head_dim();
+    let kv_b_stride = config.qk_nope_head_dim + config.v_head_dim;
+    let mut key = vec![0.0f32; q_head_dim];
+
+    for token in 0..seq_len {
+        let pos = start_pos + token;
+        let k_pe_raw = &kv_a_host[token * config.kv_a_proj_rows() + config.kv_lora_rank
+            ..token * config.kv_a_proj_rows() + config.kv_lora_rank + config.qk_rope_head_dim];
+        let k_pe = apply_rope(k_pe_raw, pos, config.qk_rope_head_dim, config.rope_theta);
+
+        for head in 0..num_heads {
+            let q_base = token * config.q_proj_rows() + head * q_head_dim;
+            let query_base = (token * num_heads + head) * q_head_dim;
+            queries[query_base..query_base + config.qk_nope_head_dim]
+                .copy_from_slice(&q_host[q_base..q_base + config.qk_nope_head_dim]);
+            let q_pe = apply_rope(
+                &q_host[q_base + config.qk_nope_head_dim..q_base + q_head_dim],
+                pos,
+                config.qk_rope_head_dim,
+                config.rope_theta,
+            );
+            queries[query_base + config.qk_nope_head_dim..query_base + q_head_dim]
+                .copy_from_slice(&q_pe);
+
+            let kv_b_base = token * config.kv_b_proj_rows() + head * kv_b_stride;
+            key[..config.qk_nope_head_dim]
+                .copy_from_slice(&kv_b_host[kv_b_base..kv_b_base + config.qk_nope_head_dim]);
+            key[config.qk_nope_head_dim..q_head_dim].copy_from_slice(&k_pe);
+            cache.keys.extend_from_slice(&key);
+            cache.values.extend_from_slice(
+                &kv_b_host[kv_b_base + config.qk_nope_head_dim
+                    ..kv_b_base + config.qk_nope_head_dim + config.v_head_dim],
+            );
+        }
+    }
+}
+
+fn apply_rope(input: &[f32], pos: usize, dim: usize, theta: f32) -> Vec<f32> {
+    let half = dim / 2;
+    let mut out = vec![0.0f32; dim];
+    for i in 0..half {
+        let inv_freq = 1.0f32 / theta.powf((2 * i) as f32 / dim as f32);
+        let angle = pos as f32 * inv_freq;
+        let cos = angle.cos();
+        let sin = angle.sin();
+        let x1 = input[i];
+        let x2 = input[i + half];
+        out[i] = x1 * cos - x2 * sin;
+        out[i + half] = x2 * cos + x1 * sin;
+    }
+    out
+}
+
+pub(crate) fn compute_attention_host(
+    config: &Config,
+    queries: &[f32],
+    cache: &LayerCache,
+    start_pos: usize,
+    seq_len: usize,
+) -> Vec<f32> {
+    let num_heads = config.num_attention_heads;
+    let q_head_dim = config.query_head_dim();
+    let value_dim = config.v_head_dim;
+    let scale = (q_head_dim as f32).sqrt().recip();
+    let mut out = vec![0.0f32; seq_len * config.o_proj_cols()];
+
+    for token in 0..seq_len {
+        let kv_len = start_pos + token + 1;
+        for head in 0..num_heads {
+            let q_base = (token * num_heads + head) * q_head_dim;
+            let query = &queries[q_base..q_base + q_head_dim];
+            let mut scores = vec![0.0f32; kv_len];
+            for (pos, score) in scores.iter_mut().enumerate() {
+                let k_base = (pos * num_heads + head) * q_head_dim;
+                let key = &cache.keys[k_base..k_base + q_head_dim];
+                *score = dot(query, key) * scale;
+            }
+            let probs = softmax(&scores);
+            let out_base = token * config.o_proj_cols() + head * value_dim;
+            for (pos, prob) in probs.iter().enumerate() {
+                let v_base = (pos * num_heads + head) * value_dim;
+                let value = &cache.values[v_base..v_base + value_dim];
+                for dim in 0..value_dim {
+                    out[out_base + dim] += prob * value[dim];
+                }
+            }
+        }
+    }
+
+    out
+}
+
+pub(crate) fn topk_softmax_routes(
+    config: &Config,
+    logits: &[f32],
+    seq_len: usize,
+) -> Vec<Vec<(usize, f32)>> {
+    let mut routes = Vec::with_capacity(seq_len);
+    for token in 0..seq_len {
+        let scores =
+            &logits[token * config.n_routed_experts..(token + 1) * config.n_routed_experts];
+        let probs = softmax(scores);
+        let mut indexed: Vec<_> = probs.into_iter().enumerate().collect();
+        indexed.sort_by(|(lhs_idx, lhs), (rhs_idx, rhs)| {
+            rhs.partial_cmp(lhs)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| lhs_idx.cmp(rhs_idx))
+        });
+        indexed.truncate(config.num_experts_per_token);
+        routes.push(indexed);
+    }
+    routes
+}
+
+fn softmax(scores: &[f32]) -> Vec<f32> {
+    let max = scores.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let mut exp = Vec::with_capacity(scores.len());
+    let mut sum = 0.0f32;
+    for score in scores {
+        let value = (score - max).exp();
+        exp.push(value);
+        sum += value;
+    }
+    if sum == 0.0 {
+        return vec![0.0; scores.len()];
+    }
+    exp.into_iter().map(|value| value / sum).collect()
+}
+
+fn dot(lhs: &[f32], rhs: &[f32]) -> f32 {
+    lhs.iter().zip(rhs).map(|(a, b)| a * b).sum()
+}
+
+pub(crate) fn hidden_to_bf16(ctx: &DeviceContext, hidden: &HiddenStates) -> Result<Vec<bf16>> {
+    activate(ctx)?;
+    let host = ctx.stream.clone_dtoh(&hidden.data)?;
+    ctx.sync()?;
+    Ok(host)
+}
+
+pub(crate) fn hidden_to_f32(ctx: &DeviceContext, hidden: &HiddenStates) -> Result<Vec<f32>> {
+    Ok(hidden_to_bf16(ctx, hidden)?
+        .iter()
+        .map(|value| value.to_f32())
+        .collect())
+}
+
+pub(crate) fn hidden_from_bf16_host(
+    ctx: &DeviceContext,
+    data: &[bf16],
+    hidden_dim: usize,
+    seq_len: usize,
+) -> Result<HiddenStates> {
+    activate(ctx)?;
+    ensure!(
+        data.len() == hidden_dim * seq_len,
+        "hidden host data len mismatch: got {}, expected {}",
+        data.len(),
+        hidden_dim * seq_len
+    );
+    Ok(HiddenStates {
+        data: ctx.stream.clone_htod(data)?,
+        hidden_dim,
+        seq_len,
+    })
+}
+
+pub(crate) fn hidden_from_f32_host(
+    ctx: &DeviceContext,
+    data: &[f32],
+    hidden_dim: usize,
+    seq_len: usize,
+) -> Result<HiddenStates> {
+    let bf16_data: Vec<_> = data.iter().copied().map(bf16::from_f32).collect();
+    hidden_from_bf16_host(ctx, &bf16_data, hidden_dim, seq_len)
+}

--- a/pegainfer-deepseek-v2-lite/src/lib.rs
+++ b/pegainfer-deepseek-v2-lite/src/lib.rs
@@ -1,0 +1,47 @@
+mod config;
+mod device;
+mod engine;
+mod ep;
+mod host_ops;
+mod model;
+mod runtime;
+mod weights;
+
+use std::path::Path;
+
+use anyhow::Result;
+use pegainfer_engine::engine::{EngineHandle, EngineLoadOptions};
+
+pub use config::Config;
+use config::SUPPORTED_HIDDEN_SIZE;
+use ep::SUPPORTED_ROUTED_EXPERTS;
+pub use runtime::{DeepSeekV2LiteEp2Generator, GenerationResult, GenerationStats};
+
+pub fn probe_config_json(json: &serde_json::Value) -> Result<bool> {
+    let Some(model_type) = json.get("model_type").and_then(serde_json::Value::as_str) else {
+        return Ok(false);
+    };
+    if model_type != "deepseek_v2" {
+        return Ok(false);
+    }
+    let n_routed_experts = json
+        .get("n_routed_experts")
+        .and_then(serde_json::Value::as_u64);
+    let hidden_size = json.get("hidden_size").and_then(serde_json::Value::as_u64);
+    let is_lite = n_routed_experts.is_some_and(|value| value == SUPPORTED_ROUTED_EXPERTS as u64)
+        && hidden_size.is_some_and(|value| value == SUPPORTED_HIDDEN_SIZE as u64);
+    if !is_lite {
+        anyhow::bail!(
+            "unsupported DeepSeek-V2 config: DeepSeek-V2-Lite first gate expects hidden_size={} and n_routed_experts={}, got hidden_size={:?}, n_routed_experts={:?}",
+            SUPPORTED_HIDDEN_SIZE,
+            SUPPORTED_ROUTED_EXPERTS,
+            hidden_size,
+            n_routed_experts
+        );
+    }
+    Ok(true)
+}
+
+pub fn start_engine(model_path: &Path, options: EngineLoadOptions) -> Result<EngineHandle> {
+    engine::start_engine(model_path, options)
+}

--- a/pegainfer-deepseek-v2-lite/src/model.rs
+++ b/pegainfer-deepseek-v2-lite/src/model.rs
@@ -1,0 +1,352 @@
+use std::{collections::HashMap, path::Path};
+
+use anyhow::{Result, bail, ensure};
+use pegainfer_core::{
+    ops,
+    tensor::{DeviceContext, DeviceMatrix, DeviceVec, HiddenStates},
+    weight_loader::{
+        deserialize_shards, load_shard_info, load_tensor_1d, load_tensor_2d, mmap_shards,
+    },
+};
+
+use crate::{Config, device::activate, ep::ExpertParallelLayout};
+
+pub(crate) struct DriverRankModel {
+    pub(crate) ctx: DeviceContext,
+    pub(crate) layout: ExpertParallelLayout,
+    pub(crate) embed_tokens: DeviceMatrix,
+    pub(crate) lm_head: DeviceMatrix,
+    pub(crate) norm: DeviceVec,
+    pub(crate) layers: Vec<LayerWeights>,
+}
+
+pub(crate) struct ExpertRankModel {
+    pub(crate) ctx: DeviceContext,
+    pub(crate) layout: ExpertParallelLayout,
+    layers: Vec<Option<Vec<ExpertMlp>>>,
+}
+
+pub(crate) struct LayerWeights {
+    pub(crate) input_layernorm: DeviceVec,
+    pub(crate) post_attention_layernorm: DeviceVec,
+    pub(crate) attention: AttentionWeights,
+    pub(crate) mlp: MlpWeights,
+}
+
+pub(crate) struct AttentionWeights {
+    pub(crate) q_proj: DeviceMatrix,
+    pub(crate) kv_a_proj: DeviceMatrix,
+    pub(crate) kv_a_norm_host: Vec<f32>,
+    pub(crate) kv_b_proj: DeviceMatrix,
+    pub(crate) o_proj: DeviceMatrix,
+}
+
+pub(crate) enum MlpWeights {
+    Dense(DenseMlp),
+    Moe(MoeMlp),
+}
+
+pub(crate) struct DenseMlp {
+    gate_up_proj: DeviceMatrix,
+    down_proj: DeviceMatrix,
+}
+
+pub(crate) struct MoeMlp {
+    pub(crate) gate: DeviceMatrix,
+    pub(crate) shared: DenseMlp,
+    pub(crate) experts: Vec<ExpertMlp>,
+}
+
+pub(crate) struct ExpertMlp {
+    pub(crate) global_expert: usize,
+    pub(crate) dense: DenseMlp,
+}
+
+impl DriverRankModel {
+    pub(crate) fn load(
+        model_path: &Path,
+        config: &Config,
+        layout: ExpertParallelLayout,
+        device_ordinal: usize,
+    ) -> Result<Self> {
+        let ctx = DeviceContext::new_with_device(device_ordinal)?;
+        activate(&ctx)?;
+
+        with_weight_shards(model_path, |shards, weight_map| {
+            let embed_tokens =
+                load_tensor_2d(&ctx, shards, weight_map, "model.embed_tokens.weight")?;
+            ensure!(
+                !config.tie_word_embeddings,
+                "DeepSeek-V2-Lite first gate expects untied lm_head"
+            );
+            let lm_head = load_tensor_2d(&ctx, shards, weight_map, "lm_head.weight")?;
+            let norm = load_tensor_1d(&ctx, shards, weight_map, "model.norm.weight")?;
+
+            let mut layers = Vec::with_capacity(config.num_hidden_layers);
+            for layer_idx in 0..config.num_hidden_layers {
+                let prefix = format!("model.layers.{layer_idx}");
+                let input_layernorm = load_tensor_1d(
+                    &ctx,
+                    shards,
+                    weight_map,
+                    &format!("{prefix}.input_layernorm.weight"),
+                )?;
+                let post_attention_layernorm = load_tensor_1d(
+                    &ctx,
+                    shards,
+                    weight_map,
+                    &format!("{prefix}.post_attention_layernorm.weight"),
+                )?;
+                let attn = format!("{prefix}.self_attn");
+                let kv_a_norm = load_tensor_1d(
+                    &ctx,
+                    shards,
+                    weight_map,
+                    &format!("{attn}.kv_a_layernorm.weight"),
+                )?;
+                let kv_a_norm_host = kv_a_norm.to_host(&ctx)?;
+                let attention = AttentionWeights {
+                    q_proj: load_tensor_2d(
+                        &ctx,
+                        shards,
+                        weight_map,
+                        &format!("{attn}.q_proj.weight"),
+                    )?,
+                    kv_a_proj: load_tensor_2d(
+                        &ctx,
+                        shards,
+                        weight_map,
+                        &format!("{attn}.kv_a_proj_with_mqa.weight"),
+                    )?,
+                    kv_a_norm_host,
+                    kv_b_proj: load_tensor_2d(
+                        &ctx,
+                        shards,
+                        weight_map,
+                        &format!("{attn}.kv_b_proj.weight"),
+                    )?,
+                    o_proj: load_tensor_2d(
+                        &ctx,
+                        shards,
+                        weight_map,
+                        &format!("{attn}.o_proj.weight"),
+                    )?,
+                };
+                let mlp_prefix = format!("{prefix}.mlp");
+                let mlp = if config.is_moe_layer(layer_idx) {
+                    MlpWeights::Moe(load_moe_mlp(
+                        &ctx,
+                        shards,
+                        weight_map,
+                        config,
+                        &layout,
+                        &mlp_prefix,
+                    )?)
+                } else {
+                    MlpWeights::Dense(load_dense_mlp(&ctx, shards, weight_map, &mlp_prefix)?)
+                };
+                layers.push(LayerWeights {
+                    input_layernorm,
+                    post_attention_layernorm,
+                    attention,
+                    mlp,
+                });
+            }
+
+            Ok(Self {
+                ctx,
+                layout,
+                embed_tokens,
+                lm_head,
+                norm,
+                layers,
+            })
+        })
+    }
+
+    pub(crate) fn routed_expert(
+        &self,
+        layer_idx: usize,
+        global_expert: usize,
+    ) -> Result<&ExpertMlp> {
+        let layer = self
+            .layers
+            .get(layer_idx)
+            .ok_or_else(|| anyhow::anyhow!("layer {layer_idx} out of range"))?;
+        let MlpWeights::Moe(moe) = &layer.mlp else {
+            bail!("layer {layer_idx} is not a MoE layer");
+        };
+        routed_expert_from_slice(&self.layout, &moe.experts, global_expert)
+    }
+}
+
+impl ExpertRankModel {
+    pub(crate) fn load(
+        model_path: &Path,
+        config: &Config,
+        layout: ExpertParallelLayout,
+        device_ordinal: usize,
+    ) -> Result<Self> {
+        let ctx = DeviceContext::new_with_device(device_ordinal)?;
+        activate(&ctx)?;
+
+        with_weight_shards(model_path, |shards, weight_map| {
+            let mut layers = Vec::with_capacity(config.num_hidden_layers);
+            for layer_idx in 0..config.num_hidden_layers {
+                if config.is_moe_layer(layer_idx) {
+                    let prefix = format!("model.layers.{layer_idx}.mlp");
+                    layers.push(Some(load_owned_experts(
+                        &ctx, shards, weight_map, config, &layout, &prefix,
+                    )?));
+                } else {
+                    layers.push(None);
+                }
+            }
+
+            Ok(Self {
+                ctx,
+                layout,
+                layers,
+            })
+        })
+    }
+
+    pub(crate) fn routed_expert(
+        &self,
+        layer_idx: usize,
+        global_expert: usize,
+    ) -> Result<&ExpertMlp> {
+        let experts = self
+            .layers
+            .get(layer_idx)
+            .ok_or_else(|| anyhow::anyhow!("layer {layer_idx} out of range"))?
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("layer {layer_idx} is not a MoE layer"))?;
+        routed_expert_from_slice(&self.layout, experts, global_expert)
+    }
+}
+
+fn with_weight_shards<T>(
+    model_path: &Path,
+    load: impl FnOnce(&[safetensors::SafeTensors<'_>], &HashMap<String, usize>) -> Result<T>,
+) -> Result<T> {
+    let model_path_str = model_path
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("model path must be valid UTF-8"))?;
+    let (shard_paths, weight_map) = load_shard_info(model_path_str)?;
+    let mmaps = mmap_shards(&shard_paths)?;
+    let shards = deserialize_shards(&mmaps)?;
+    load(&shards, &weight_map)
+}
+
+fn routed_expert_from_slice<'a>(
+    layout: &ExpertParallelLayout,
+    experts: &'a [ExpertMlp],
+    global_expert: usize,
+) -> Result<&'a ExpertMlp> {
+    let local_expert = layout.local_expert(global_expert)?;
+    let expert = experts.get(local_expert).ok_or_else(|| {
+        anyhow::anyhow!(
+            "rank {} local expert {} missing for global expert {}",
+            layout.rank(),
+            local_expert,
+            global_expert
+        )
+    })?;
+    ensure!(
+        expert.global_expert == global_expert,
+        "rank {} local expert {} expected global {}, got {}",
+        layout.rank(),
+        local_expert,
+        global_expert,
+        expert.global_expert
+    );
+    Ok(expert)
+}
+
+fn load_dense_mlp(
+    ctx: &DeviceContext,
+    shards: &[safetensors::SafeTensors<'_>],
+    weight_map: &HashMap<String, usize>,
+    prefix: &str,
+) -> Result<DenseMlp> {
+    let gate_proj = load_tensor_2d(
+        ctx,
+        shards,
+        weight_map,
+        &format!("{prefix}.gate_proj.weight"),
+    )?;
+    let up_proj = load_tensor_2d(ctx, shards, weight_map, &format!("{prefix}.up_proj.weight"))?;
+    let gate_up_proj = DeviceMatrix::vstack(ctx, &[&gate_proj, &up_proj])?;
+    let down_proj = load_tensor_2d(
+        ctx,
+        shards,
+        weight_map,
+        &format!("{prefix}.down_proj.weight"),
+    )?;
+    Ok(DenseMlp {
+        gate_up_proj,
+        down_proj,
+    })
+}
+
+fn load_moe_mlp(
+    ctx: &DeviceContext,
+    shards: &[safetensors::SafeTensors<'_>],
+    weight_map: &HashMap<String, usize>,
+    config: &Config,
+    layout: &ExpertParallelLayout,
+    prefix: &str,
+) -> Result<MoeMlp> {
+    let gate = load_tensor_2d(ctx, shards, weight_map, &format!("{prefix}.gate.weight"))?;
+    let shared = load_dense_mlp(ctx, shards, weight_map, &format!("{prefix}.shared_experts"))?;
+    let experts = load_owned_experts(ctx, shards, weight_map, config, layout, prefix)?;
+    Ok(MoeMlp {
+        gate,
+        shared,
+        experts,
+    })
+}
+
+fn load_owned_experts(
+    ctx: &DeviceContext,
+    shards: &[safetensors::SafeTensors<'_>],
+    weight_map: &HashMap<String, usize>,
+    config: &Config,
+    layout: &ExpertParallelLayout,
+    prefix: &str,
+) -> Result<Vec<ExpertMlp>> {
+    let mut experts = Vec::with_capacity(layout.experts_per_rank());
+    for global_expert in layout.owned_experts() {
+        let dense = load_dense_mlp(
+            ctx,
+            shards,
+            weight_map,
+            &format!("{prefix}.experts.{global_expert}"),
+        )?;
+        experts.push(ExpertMlp {
+            global_expert,
+            dense,
+        });
+    }
+    ensure!(
+        experts.len() == config.n_routed_experts / layout.ep_size(),
+        "rank {} loaded {} routed experts, expected {}",
+        layout.rank(),
+        experts.len(),
+        config.n_routed_experts / layout.ep_size()
+    );
+    Ok(experts)
+}
+
+pub(crate) fn dense_mlp_forward(
+    ctx: &DeviceContext,
+    mlp: &DenseMlp,
+    input: &HiddenStates,
+) -> Result<HiddenStates> {
+    activate(ctx)?;
+    let gate_up = ops::gemm(ctx, &mlp.gate_up_proj, input)?;
+    let mut act = HiddenStates::zeros(ctx, gate_up.hidden_dim / 2, input.seq_len)?;
+    ops::silu_mul_fused_batch_into(ctx, &gate_up, &mut act);
+    ops::gemm(ctx, &mlp.down_proj, &act)
+}

--- a/pegainfer-deepseek-v2-lite/src/runtime.rs
+++ b/pegainfer-deepseek-v2-lite/src/runtime.rs
@@ -1,0 +1,483 @@
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, bail, ensure};
+use half::bf16;
+use pegainfer_core::{ops, tensor::HiddenStates};
+use pegainfer_engine::engine::{EngineLoadOptions, FinishReason};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    Config,
+    device::activate,
+    ep::ExpertParallelConfig,
+    host_ops::{
+        DecodeCache, LayerCache, append_kv_and_build_queries, compute_attention_host,
+        hidden_from_bf16_host, hidden_from_f32_host, hidden_to_bf16, hidden_to_f32,
+        normalize_compressed_kv, topk_softmax_routes,
+    },
+    model::{
+        AttentionWeights, DriverRankModel, ExpertRankModel, MlpWeights, MoeMlp, dense_mlp_forward,
+    },
+    weights::{ModelManifest, RankLoadPlan},
+};
+
+const EP_BACKEND_ENV: &str = "PEGAINFER_DSV2_LITE_EP_BACKEND";
+const HOST_STAGED_BACKEND: &str = "host-staged";
+
+#[derive(Clone, Debug, Default)]
+pub struct GenerationStats {
+    pub model_path: PathBuf,
+    pub device_ordinals: Vec<usize>,
+    pub ep_size: usize,
+    pub prompt_tokens: usize,
+    pub generated_tokens: usize,
+    pub host_dispatch_local_routes: usize,
+    pub host_dispatch_remote_routes: usize,
+    pub output_token_sha256: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct GenerationResult {
+    pub tokens: Vec<u32>,
+    pub finish_reason: FinishReason,
+    pub stats: GenerationStats,
+}
+
+pub struct DeepSeekV2LiteEp2Generator {
+    model_path: PathBuf,
+    device_ordinals: Vec<usize>,
+    config: Config,
+    rank0: DriverRankModel,
+    rank1: ExpertRankModel,
+}
+
+// SAFETY: The generator is driven by exactly one worker thread after load. It
+// switches CUDA devices explicitly before every rank-local op and recreates the
+// thread-local cuBLAS handle when the active device changes.
+unsafe impl Send for DeepSeekV2LiteEp2Generator {}
+
+impl DeepSeekV2LiteEp2Generator {
+    pub fn load(model_path: &Path, options: EngineLoadOptions) -> Result<Self> {
+        let config = Config::from_model_dir(model_path)?;
+        ensure!(
+            !options.enable_cuda_graph,
+            "DeepSeek-V2-Lite EP=2 first gate requires cuda_graph disabled"
+        );
+        validate_backend_and_devices(&options.device_ordinals)?;
+
+        let rank0_layout = ExpertParallelConfig::ep2(0).validate_for(&config)?;
+        let rank1_layout = ExpertParallelConfig::ep2(1).validate_for(&config)?;
+        let manifest = ModelManifest::from_model_dir(model_path)?;
+        manifest.validate_rank_plan(&RankLoadPlan::for_driver_rank(&config, &rank0_layout))?;
+        manifest.validate_rank_plan(&RankLoadPlan::for_expert_rank(&config, &rank1_layout))?;
+
+        let rank0 = DriverRankModel::load(
+            model_path,
+            &config,
+            rank0_layout,
+            options.device_ordinals[0],
+        )
+        .context("load DeepSeek-V2-Lite EP rank 0")?;
+        let rank1 = ExpertRankModel::load(
+            model_path,
+            &config,
+            rank1_layout,
+            options.device_ordinals[1],
+        )
+        .context("load DeepSeek-V2-Lite EP rank 1")?;
+
+        Ok(Self {
+            model_path: model_path.to_path_buf(),
+            device_ordinals: options.device_ordinals,
+            config,
+            rank0,
+            rank1,
+        })
+    }
+
+    pub fn generate_greedy(
+        &mut self,
+        prompt_tokens: &[u32],
+        max_new_tokens: usize,
+        ignore_eos: bool,
+    ) -> Result<GenerationResult> {
+        ensure!(!prompt_tokens.is_empty(), "prompt_tokens must not be empty");
+        ensure!(max_new_tokens > 0, "max_new_tokens must be positive");
+        let requested_context = prompt_tokens.len() + max_new_tokens;
+        let supported_context = self.config.supported_plain_rope_context();
+        ensure!(
+            requested_context <= supported_context,
+            "DeepSeek-V2-Lite EP=2 first gate supports plain RoPE context <= {supported_context} tokens; requested prompt_tokens={} max_new_tokens={} total={requested_context}. YaRN rope_scaling long context is not implemented yet.",
+            prompt_tokens.len(),
+            max_new_tokens
+        );
+
+        let mut stats = GenerationStats {
+            model_path: self.model_path.clone(),
+            device_ordinals: self.device_ordinals.clone(),
+            ep_size: 2,
+            prompt_tokens: prompt_tokens.len(),
+            ..GenerationStats::default()
+        };
+
+        let mut cache = DecodeCache::new(&self.config);
+        let mut generated = Vec::with_capacity(max_new_tokens);
+        let mut next = self.prefill_next_token(prompt_tokens, &mut cache, &mut stats)?;
+        let mut finish_reason = FinishReason::Length;
+
+        for step in 0..max_new_tokens {
+            if let Some(reason) =
+                append_generated_token(&mut generated, next, self.config.eos_token_id, ignore_eos)
+            {
+                finish_reason = reason;
+                break;
+            }
+            if step + 1 == max_new_tokens {
+                break;
+            }
+            let position = prompt_tokens.len() + generated.len() - 1;
+            next = self.decode_next_token(next, position, &mut cache, &mut stats)?;
+        }
+
+        stats.generated_tokens = generated.len();
+        stats.output_token_sha256 = token_sha256(&generated);
+        Ok(GenerationResult {
+            tokens: generated,
+            finish_reason,
+            stats,
+        })
+    }
+
+    fn prefill_next_token(
+        &mut self,
+        prompt_tokens: &[u32],
+        cache: &mut DecodeCache,
+        stats: &mut GenerationStats,
+    ) -> Result<u32> {
+        let mut hidden = self.embed_tokens(prompt_tokens)?;
+        hidden = self.forward_layers(hidden, 0, cache, stats)?;
+        self.sample_last_token(&hidden)
+    }
+
+    fn decode_next_token(
+        &mut self,
+        token: u32,
+        position: usize,
+        cache: &mut DecodeCache,
+        stats: &mut GenerationStats,
+    ) -> Result<u32> {
+        let mut hidden = self.embed_tokens(&[token])?;
+        hidden = self.forward_layers(hidden, position, cache, stats)?;
+        self.sample_last_token(&hidden)
+    }
+
+    fn embed_tokens(&self, token_ids: &[u32]) -> Result<HiddenStates> {
+        activate(&self.rank0.ctx)?;
+        let token_ids_gpu = self.rank0.ctx.stream.clone_htod(token_ids)?;
+        let mut out =
+            HiddenStates::zeros(&self.rank0.ctx, self.config.hidden_size, token_ids.len())?;
+        ops::embedding_batch(
+            &self.rank0.ctx,
+            &self.rank0.embed_tokens,
+            &token_ids_gpu,
+            &mut out,
+        )?;
+        Ok(out)
+    }
+
+    fn forward_layers(
+        &mut self,
+        mut hidden: HiddenStates,
+        start_pos: usize,
+        cache: &mut DecodeCache,
+        stats: &mut GenerationStats,
+    ) -> Result<HiddenStates> {
+        ensure!(
+            cache.layers.len() == self.rank0.layers.len(),
+            "decode cache layer count mismatch"
+        );
+        for layer_idx in 0..self.rank0.layers.len() {
+            hidden = self
+                .forward_layer(
+                    layer_idx,
+                    &hidden,
+                    start_pos,
+                    &mut cache.layers[layer_idx],
+                    stats,
+                )
+                .with_context(|| format!("DeepSeek-V2-Lite layer {layer_idx}"))?;
+        }
+        Ok(hidden)
+    }
+
+    fn forward_layer(
+        &mut self,
+        layer_idx: usize,
+        hidden: &HiddenStates,
+        start_pos: usize,
+        cache: &mut LayerCache,
+        stats: &mut GenerationStats,
+    ) -> Result<HiddenStates> {
+        activate(&self.rank0.ctx)?;
+
+        let layer = &self.rank0.layers[layer_idx];
+        let mut normed =
+            HiddenStates::zeros(&self.rank0.ctx, self.config.hidden_size, hidden.seq_len)?;
+        ops::rms_norm_batch_into(
+            &self.rank0.ctx,
+            hidden,
+            &layer.input_layernorm,
+            self.config.rms_norm_eps,
+            &mut normed,
+        );
+
+        let attn = self.attention_forward(&normed, &layer.attention, start_pos, cache)?;
+        activate(&self.rank0.ctx)?;
+        let attn_projected = ops::gemm(&self.rank0.ctx, &layer.attention.o_proj, &attn)?;
+        let after_attn = ops::add_batch(&self.rank0.ctx, hidden, &attn_projected)?;
+
+        let mut ffn_norm =
+            HiddenStates::zeros(&self.rank0.ctx, self.config.hidden_size, after_attn.seq_len)?;
+        ops::rms_norm_batch_into(
+            &self.rank0.ctx,
+            &after_attn,
+            &layer.post_attention_layernorm,
+            self.config.rms_norm_eps,
+            &mut ffn_norm,
+        );
+
+        let (ffn_out, local_routes, remote_routes) = match &layer.mlp {
+            MlpWeights::Dense(dense) => {
+                (dense_mlp_forward(&self.rank0.ctx, dense, &ffn_norm)?, 0, 0)
+            }
+            MlpWeights::Moe(moe) => self.moe_forward(layer_idx, &ffn_norm, moe)?,
+        };
+        stats.host_dispatch_local_routes += local_routes;
+        stats.host_dispatch_remote_routes += remote_routes;
+        ops::add_batch(&self.rank0.ctx, &after_attn, &ffn_out)
+    }
+
+    fn attention_forward(
+        &self,
+        input: &HiddenStates,
+        attn: &AttentionWeights,
+        start_pos: usize,
+        cache: &mut LayerCache,
+    ) -> Result<HiddenStates> {
+        activate(&self.rank0.ctx)?;
+        ensure!(
+            cache.len(&self.config) == start_pos,
+            "attention cache position mismatch: cache_len={}, start_pos={start_pos}",
+            cache.len(&self.config)
+        );
+
+        let q = ops::gemm(&self.rank0.ctx, &attn.q_proj, input)?;
+        let kv_a = ops::gemm(&self.rank0.ctx, &attn.kv_a_proj, input)?;
+        let q_host = hidden_to_f32(&self.rank0.ctx, &q)?;
+        let kv_a_host = hidden_to_f32(&self.rank0.ctx, &kv_a)?;
+
+        let compressed_norm = normalize_compressed_kv(
+            &self.config,
+            &kv_a_host,
+            &attn.kv_a_norm_host,
+            input.seq_len,
+        );
+        let compressed = hidden_from_bf16_host(
+            &self.rank0.ctx,
+            &compressed_norm,
+            self.config.kv_lora_rank,
+            input.seq_len,
+        )?;
+        activate(&self.rank0.ctx)?;
+        let kv_b = ops::gemm(&self.rank0.ctx, &attn.kv_b_proj, &compressed)?;
+        let kv_b_host = hidden_to_f32(&self.rank0.ctx, &kv_b)?;
+
+        let mut queries =
+            vec![
+                0.0f32;
+                input.seq_len * self.config.num_attention_heads * self.config.query_head_dim()
+            ];
+        append_kv_and_build_queries(
+            &self.config,
+            &q_host,
+            &kv_a_host,
+            &kv_b_host,
+            start_pos,
+            input.seq_len,
+            &mut queries,
+            cache,
+        );
+
+        let out_host =
+            compute_attention_host(&self.config, &queries, cache, start_pos, input.seq_len);
+        hidden_from_f32_host(
+            &self.rank0.ctx,
+            &out_host,
+            self.config.o_proj_cols(),
+            input.seq_len,
+        )
+    }
+
+    fn moe_forward(
+        &self,
+        layer_idx: usize,
+        input: &HiddenStates,
+        moe: &MoeMlp,
+    ) -> Result<(HiddenStates, usize, usize)> {
+        activate(&self.rank0.ctx)?;
+        let route_logits = ops::gemm(&self.rank0.ctx, &moe.gate, input)?;
+        let route_logits_host = hidden_to_f32(&self.rank0.ctx, &route_logits)?;
+        let routes = topk_softmax_routes(&self.config, &route_logits_host, input.seq_len);
+
+        let shared = dense_mlp_forward(&self.rank0.ctx, &moe.shared, input)?;
+        let mut accum = hidden_to_f32(&self.rank0.ctx, &shared)?;
+        let input_host = hidden_to_bf16(&self.rank0.ctx, input)?;
+        let mut local_routes = 0usize;
+        let mut remote_routes = 0usize;
+
+        for (token, token_routes) in routes.iter().enumerate() {
+            let token_input =
+                &input_host[token * self.config.hidden_size..(token + 1) * self.config.hidden_size];
+            for &(global_expert, weight) in token_routes {
+                let (out, is_remote) =
+                    self.expert_forward_host(layer_idx, global_expert, token_input)?;
+                if is_remote {
+                    remote_routes += 1;
+                } else {
+                    local_routes += 1;
+                }
+                let offset = token * self.config.hidden_size;
+                for (dst, value) in accum[offset..offset + self.config.hidden_size]
+                    .iter_mut()
+                    .zip(out)
+                {
+                    *dst += weight * value;
+                }
+            }
+        }
+
+        let hidden = hidden_from_f32_host(
+            &self.rank0.ctx,
+            &accum,
+            self.config.hidden_size,
+            input.seq_len,
+        )?;
+        Ok((hidden, local_routes, remote_routes))
+    }
+
+    fn expert_forward_host(
+        &self,
+        layer_idx: usize,
+        global_expert: usize,
+        token_input: &[bf16],
+    ) -> Result<(Vec<f32>, bool)> {
+        let owner_rank = self.rank0.layout.owner_rank(global_expert)?;
+        let (ctx, expert) = match owner_rank {
+            0 => (
+                &self.rank0.ctx,
+                self.rank0.routed_expert(layer_idx, global_expert)?,
+            ),
+            1 => (
+                &self.rank1.ctx,
+                self.rank1.routed_expert(layer_idx, global_expert)?,
+            ),
+            other => bail!("routed expert {global_expert} maps to unsupported EP rank {other}"),
+        };
+
+        let input = hidden_from_bf16_host(ctx, token_input, self.config.hidden_size, 1)?;
+        let out = dense_mlp_forward(ctx, &expert.dense, &input)?;
+        Ok((hidden_to_f32(ctx, &out)?, owner_rank != 0))
+    }
+
+    fn sample_last_token(&self, hidden: &HiddenStates) -> Result<u32> {
+        activate(&self.rank0.ctx)?;
+        let last = ops::extract_vec(&self.rank0.ctx, hidden, hidden.seq_len - 1)?;
+        let normed = ops::rms_norm(
+            &self.rank0.ctx,
+            &last,
+            &self.rank0.norm,
+            self.config.rms_norm_eps,
+        )?;
+        let logits = ops::linear(&self.rank0.ctx, &normed, &self.rank0.lm_head)?;
+        ops::argmax(&self.rank0.ctx, &logits)
+    }
+}
+
+fn validate_backend_and_devices(device_ordinals: &[usize]) -> Result<()> {
+    ensure!(
+        device_ordinals.len() == 2,
+        "DeepSeek-V2-Lite first EP gate supports exactly 2 CUDA devices for ep_size=2, got {}",
+        device_ordinals.len()
+    );
+    ensure!(
+        device_ordinals[0] != device_ordinals[1],
+        "DeepSeek-V2-Lite EP=2 requires two distinct CUDA device ordinals, got {:?}",
+        device_ordinals
+    );
+    let backend = env::var(EP_BACKEND_ENV).unwrap_or_else(|_| HOST_STAGED_BACKEND.to_string());
+    ensure!(
+        backend == HOST_STAGED_BACKEND,
+        "DeepSeek-V2-Lite EP=2 backend '{backend}' is not supported by the first gate; supported backend: {HOST_STAGED_BACKEND}"
+    );
+    Ok(())
+}
+
+fn token_sha256(tokens: &[u32]) -> String {
+    let mut hasher = Sha256::new();
+    for token in tokens {
+        hasher.update(token.to_le_bytes());
+    }
+    hex::encode(hasher.finalize())
+}
+
+fn append_generated_token(
+    generated: &mut Vec<u32>,
+    token: u32,
+    eos_token_id: u32,
+    ignore_eos: bool,
+) -> Option<FinishReason> {
+    if !ignore_eos && token == eos_token_id {
+        return Some(FinishReason::Stop);
+    }
+    generated.push(token);
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stop_token_is_not_appended_when_eos_is_enabled() {
+        let mut generated = vec![10, 11];
+
+        let finish_reason = append_generated_token(&mut generated, 100_001, 100_001, false);
+
+        assert_eq!(finish_reason, Some(FinishReason::Stop));
+        assert_eq!(generated, vec![10, 11]);
+    }
+
+    #[test]
+    fn stop_token_is_appended_when_eos_is_ignored() {
+        let mut generated = vec![10, 11];
+
+        let finish_reason = append_generated_token(&mut generated, 100_001, 100_001, true);
+
+        assert_eq!(finish_reason, None);
+        assert_eq!(generated, vec![10, 11, 100_001]);
+    }
+
+    #[test]
+    fn duplicate_device_ordinals_are_rejected() {
+        let err = validate_backend_and_devices(&[0, 0]).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("two distinct CUDA device ordinals"),
+            "unexpected error: {err:#}"
+        );
+    }
+}

--- a/pegainfer-deepseek-v2-lite/src/weights.rs
+++ b/pegainfer-deepseek-v2-lite/src/weights.rs
@@ -1,0 +1,398 @@
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, ensure};
+use memmap2::Mmap;
+use safetensors::{Dtype, SafeTensors};
+use serde::Deserialize;
+
+use crate::{Config, ep::ExpertParallelLayout};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TensorInfo {
+    dtype: Dtype,
+    shape: Vec<usize>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ModelManifest {
+    tensors: BTreeMap<String, TensorInfo>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TensorRequirement {
+    name: String,
+    dtype: Dtype,
+    shape: Vec<usize>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct RankLoadPlan {
+    tensors: Vec<TensorRequirement>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SafetensorsIndex {
+    weight_map: HashMap<String, String>,
+}
+
+impl ModelManifest {
+    pub(crate) fn from_model_dir(model_path: impl AsRef<Path>) -> Result<Self> {
+        let model_path = model_path.as_ref();
+        let shard_paths = shard_paths(model_path)?;
+        let index = read_index(model_path)?;
+        let mut tensors = BTreeMap::new();
+
+        for shard_path in shard_paths {
+            let mmap = mmap_file(&shard_path)?;
+            let safetensors = SafeTensors::deserialize(&mmap)
+                .with_context(|| format!("deserialize {}", shard_path.display()))?;
+            for name in safetensors.names() {
+                let view = safetensors
+                    .tensor(name)
+                    .with_context(|| format!("read tensor metadata {name}"))?;
+                let indexed_shard = index.as_ref().and_then(|weight_map| weight_map.get(name));
+                if let Some(indexed_shard) = indexed_shard {
+                    let actual = shard_path
+                        .file_name()
+                        .and_then(|value| value.to_str())
+                        .unwrap_or_default();
+                    ensure!(
+                        indexed_shard == actual,
+                        "tensor {name} expected in shard {indexed_shard}, found in {actual}"
+                    );
+                }
+                tensors.insert(
+                    name.to_string(),
+                    TensorInfo {
+                        dtype: view.dtype(),
+                        shape: view.shape().to_vec(),
+                    },
+                );
+            }
+        }
+
+        Ok(Self { tensors })
+    }
+
+    fn get(&self, name: &str) -> Option<&TensorInfo> {
+        self.tensors.get(name)
+    }
+
+    pub(crate) fn validate_rank_plan(&self, plan: &RankLoadPlan) -> Result<()> {
+        for req in &plan.tensors {
+            let info = self
+                .get(&req.name)
+                .ok_or_else(|| anyhow::anyhow!("missing tensor {}", req.name))?;
+            ensure!(
+                info.dtype == req.dtype,
+                "tensor {} dtype mismatch: expected {:?}, got {:?}",
+                req.name,
+                req.dtype,
+                info.dtype
+            );
+            ensure!(
+                info.shape == req.shape,
+                "tensor {} shape mismatch: expected {:?}, got {:?}",
+                req.name,
+                req.shape,
+                info.shape
+            );
+        }
+        Ok(())
+    }
+}
+
+impl RankLoadPlan {
+    pub(crate) fn for_driver_rank(config: &Config, layout: &ExpertParallelLayout) -> Self {
+        let mut tensors = Vec::new();
+        push_top_level(config, &mut tensors);
+        for layer in 0..config.num_hidden_layers {
+            push_attention_layer(config, layer, &mut tensors);
+            if config.is_moe_layer(layer) {
+                push_moe_layer(config, layout, layer, &mut tensors);
+            } else {
+                push_dense_layer(config, layer, &mut tensors);
+            }
+        }
+
+        Self { tensors }
+    }
+
+    pub(crate) fn for_expert_rank(config: &Config, layout: &ExpertParallelLayout) -> Self {
+        let mut tensors = Vec::new();
+        for layer in 0..config.num_hidden_layers {
+            if config.is_moe_layer(layer) {
+                push_owned_experts(config, layout, layer, &mut tensors);
+            }
+        }
+
+        Self { tensors }
+    }
+}
+
+fn push_req(
+    tensors: &mut Vec<TensorRequirement>,
+    name: impl Into<String>,
+    dtype: Dtype,
+    shape: impl Into<Vec<usize>>,
+) {
+    tensors.push(TensorRequirement {
+        name: name.into(),
+        dtype,
+        shape: shape.into(),
+    });
+}
+
+fn push_top_level(config: &Config, tensors: &mut Vec<TensorRequirement>) {
+    push_req(
+        tensors,
+        "model.embed_tokens.weight",
+        Dtype::BF16,
+        [config.vocab_size, config.hidden_size],
+    );
+    if !config.tie_word_embeddings {
+        push_req(
+            tensors,
+            "lm_head.weight",
+            Dtype::BF16,
+            [config.vocab_size, config.hidden_size],
+        );
+    }
+    push_req(
+        tensors,
+        "model.norm.weight",
+        Dtype::BF16,
+        [config.hidden_size],
+    );
+}
+
+fn push_attention_layer(config: &Config, layer: usize, tensors: &mut Vec<TensorRequirement>) {
+    let prefix = format!("model.layers.{layer}");
+    push_req(
+        tensors,
+        format!("{prefix}.input_layernorm.weight"),
+        Dtype::BF16,
+        [config.hidden_size],
+    );
+    push_req(
+        tensors,
+        format!("{prefix}.post_attention_layernorm.weight"),
+        Dtype::BF16,
+        [config.hidden_size],
+    );
+    let attn = format!("{prefix}.self_attn");
+    push_req(
+        tensors,
+        format!("{attn}.q_proj.weight"),
+        Dtype::BF16,
+        [config.q_proj_rows(), config.hidden_size],
+    );
+    push_req(
+        tensors,
+        format!("{attn}.kv_a_proj_with_mqa.weight"),
+        Dtype::BF16,
+        [config.kv_a_proj_rows(), config.hidden_size],
+    );
+    push_req(
+        tensors,
+        format!("{attn}.kv_a_layernorm.weight"),
+        Dtype::BF16,
+        [config.kv_lora_rank],
+    );
+    push_req(
+        tensors,
+        format!("{attn}.kv_b_proj.weight"),
+        Dtype::BF16,
+        [config.kv_b_proj_rows(), config.kv_lora_rank],
+    );
+    push_req(
+        tensors,
+        format!("{attn}.o_proj.weight"),
+        Dtype::BF16,
+        [config.hidden_size, config.o_proj_cols()],
+    );
+}
+
+fn push_dense_layer(config: &Config, layer: usize, tensors: &mut Vec<TensorRequirement>) {
+    let prefix = format!("model.layers.{layer}.mlp");
+    push_req(
+        tensors,
+        format!("{prefix}.gate_proj.weight"),
+        Dtype::BF16,
+        [config.intermediate_size, config.hidden_size],
+    );
+    push_req(
+        tensors,
+        format!("{prefix}.up_proj.weight"),
+        Dtype::BF16,
+        [config.intermediate_size, config.hidden_size],
+    );
+    push_req(
+        tensors,
+        format!("{prefix}.down_proj.weight"),
+        Dtype::BF16,
+        [config.hidden_size, config.intermediate_size],
+    );
+}
+
+fn push_moe_layer(
+    config: &Config,
+    layout: &ExpertParallelLayout,
+    layer: usize,
+    tensors: &mut Vec<TensorRequirement>,
+) {
+    let prefix = format!("model.layers.{layer}.mlp");
+    push_req(
+        tensors,
+        format!("{prefix}.gate.weight"),
+        Dtype::BF16,
+        [config.n_routed_experts, config.hidden_size],
+    );
+    let shared = format!("{prefix}.shared_experts");
+    push_req(
+        tensors,
+        format!("{shared}.gate_proj.weight"),
+        Dtype::BF16,
+        [config.shared_moe_intermediate(), config.hidden_size],
+    );
+    push_req(
+        tensors,
+        format!("{shared}.up_proj.weight"),
+        Dtype::BF16,
+        [config.shared_moe_intermediate(), config.hidden_size],
+    );
+    push_req(
+        tensors,
+        format!("{shared}.down_proj.weight"),
+        Dtype::BF16,
+        [config.hidden_size, config.shared_moe_intermediate()],
+    );
+    push_owned_experts(config, layout, layer, tensors);
+}
+
+fn push_owned_experts(
+    config: &Config,
+    layout: &ExpertParallelLayout,
+    layer: usize,
+    tensors: &mut Vec<TensorRequirement>,
+) {
+    let prefix = format!("model.layers.{layer}.mlp");
+    for global_expert in layout.owned_experts() {
+        let expert = format!("{prefix}.experts.{global_expert}");
+        push_req(
+            tensors,
+            format!("{expert}.gate_proj.weight"),
+            Dtype::BF16,
+            [config.moe_intermediate_size, config.hidden_size],
+        );
+        push_req(
+            tensors,
+            format!("{expert}.up_proj.weight"),
+            Dtype::BF16,
+            [config.moe_intermediate_size, config.hidden_size],
+        );
+        push_req(
+            tensors,
+            format!("{expert}.down_proj.weight"),
+            Dtype::BF16,
+            [config.hidden_size, config.moe_intermediate_size],
+        );
+    }
+}
+
+fn shard_paths(model_path: &Path) -> Result<Vec<PathBuf>> {
+    let single = model_path.join("model.safetensors");
+    if single.exists() {
+        return Ok(vec![single]);
+    }
+    let index_path = model_path.join("model.safetensors.index.json");
+    let index = read_index(model_path)?
+        .ok_or_else(|| anyhow::anyhow!("missing {}", index_path.display()))?;
+    let unique: BTreeSet<_> = index.into_values().collect();
+    Ok(unique
+        .into_iter()
+        .map(|shard| model_path.join(shard))
+        .collect())
+}
+
+fn read_index(model_path: &Path) -> Result<Option<HashMap<String, String>>> {
+    let index_path = model_path.join("model.safetensors.index.json");
+    match fs::read_to_string(&index_path) {
+        Ok(content) => {
+            let index: SafetensorsIndex = serde_json::from_str(&content)
+                .with_context(|| format!("parse {}", index_path.display()))?;
+            Ok(Some(index.weight_map))
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn mmap_file(path: &Path) -> Result<Mmap> {
+    let file = fs::File::open(path).with_context(|| format!("open {}", path.display()))?;
+    // SAFETY: The safetensors shard is opened read-only and only read for
+    // metadata while the mmap is alive.
+    unsafe { Mmap::map(&file) }.with_context(|| format!("mmap {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::*;
+    use crate::{config::test_lite_config, ep::ExpertParallelConfig};
+
+    #[test]
+    fn driver_rank0_load_plan_keeps_routed_experts_rank_local() {
+        let config = test_lite_config();
+        let rank0 = ExpertParallelConfig::ep2(0).validate_for(&config).unwrap();
+        let rank0_plan = RankLoadPlan::for_driver_rank(&config, &rank0);
+        let expected_routed_tensors =
+            (config.num_hidden_layers - config.first_k_dense_replace) * 32 * 3;
+
+        assert_eq!(
+            routed_expert_tensor_count(&rank0_plan),
+            expected_routed_tensors
+        );
+        assert_eq!(routed_experts(&rank0_plan), (0..32).collect());
+    }
+
+    #[test]
+    fn expert_rank_load_plan_only_requires_owned_routed_experts() {
+        let config = test_lite_config();
+        let rank1 = ExpertParallelConfig::ep2(1).validate_for(&config).unwrap();
+        let plan = RankLoadPlan::for_expert_rank(&config, &rank1);
+        let expected_routed_tensors =
+            (config.num_hidden_layers - config.first_k_dense_replace) * 32 * 3;
+
+        assert_eq!(plan.tensors.len(), expected_routed_tensors);
+        assert_eq!(routed_expert_tensor_count(&plan), expected_routed_tensors);
+        assert!(
+            plan.tensors
+                .iter()
+                .all(|req| req.name.contains(".experts."))
+        );
+        assert_eq!(routed_experts(&plan), (32..64).collect());
+    }
+
+    fn routed_expert_tensor_count(plan: &RankLoadPlan) -> usize {
+        plan.tensors
+            .iter()
+            .filter(|req| req.name.contains(".experts."))
+            .count()
+    }
+
+    fn routed_experts(plan: &RankLoadPlan) -> BTreeSet<usize> {
+        plan.tensors
+            .iter()
+            .filter_map(|req| {
+                let (_, suffix) = req.name.split_once(".experts.")?;
+                suffix.split('.').next()?.parse().ok()
+            })
+            .collect()
+    }
+}

--- a/pegainfer-deepseek-v2-lite/tests/e2e_ep2.rs
+++ b/pegainfer-deepseek-v2-lite/tests/e2e_ep2.rs
@@ -1,0 +1,141 @@
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, ensure};
+use pegainfer_deepseek_v2_lite::DeepSeekV2LiteEp2Generator;
+use pegainfer_engine::engine::{EngineLoadOptions, FinishReason};
+use sha2::{Digest, Sha256};
+use vllm_text::tokenizer::{HuggingFaceTokenizer, Tokenizer};
+
+const EXPECTED_GENERATED_TOKENS: usize = 16;
+const EXPECTED_OUTPUT_TOKEN_SHA256: &str =
+    "f39e57d9b3eb949057ada9b3bc92f7f7037dfd19658dbe3ce145d8fad03ded5e";
+const EXPECTED_OUTPUT_TEXT_SHA256: &str =
+    "a521f6dc9739b4506a46822da7c239ac558a879d571f54a064a4a2fbc3a097b7";
+
+#[test]
+fn test_deepseek_v2_lite_ep2_rust_generation() -> Result<()> {
+    let model_path = PathBuf::from(
+        env::var("PEGAINFER_TEST_MODEL_PATH")
+            .context("PEGAINFER_TEST_MODEL_PATH must point to DeepSeek-V2-Lite weights")?,
+    );
+    ensure!(
+        model_path.join("config.json").exists(),
+        "missing config.json under {}",
+        model_path.display()
+    );
+
+    let duplicate_ordinal_err = DeepSeekV2LiteEp2Generator::load(
+        &model_path,
+        EngineLoadOptions {
+            enable_cuda_graph: false,
+            enable_prefill_profile: false,
+            device_ordinals: vec![0, 0],
+            seed: 42,
+        },
+    )
+    .err()
+    .context("duplicate CUDA device ordinals unexpectedly loaded")?;
+    ensure!(
+        format!("{duplicate_ordinal_err:#}").contains("two distinct CUDA device ordinals"),
+        "duplicate CUDA ordinal error should mention distinct devices, got {duplicate_ordinal_err:#}"
+    );
+
+    run_rust_generation(&model_path)
+}
+
+fn run_rust_generation(model_path: &Path) -> Result<()> {
+    let tokenizer_path = model_path.join("tokenizer.json");
+    let tokenizer = HuggingFaceTokenizer::new(&tokenizer_path).map_err(|err| {
+        anyhow::anyhow!(
+            "failed to load tokenizer {}: {err:?}",
+            tokenizer_path.display()
+        )
+    })?;
+    let prompt = "Hello";
+    let prompt_tokens = tokenizer
+        .encode(prompt, false)
+        .map_err(|err| anyhow::anyhow!("encode prompt failed: {err:?}"))?;
+    ensure!(!prompt_tokens.is_empty(), "tokenizer returned empty prompt");
+
+    let mut generator = DeepSeekV2LiteEp2Generator::load(
+        model_path,
+        EngineLoadOptions {
+            enable_cuda_graph: false,
+            enable_prefill_profile: false,
+            device_ordinals: vec![0, 1],
+            seed: 42,
+        },
+    )?;
+    let result = generator.generate_greedy(&prompt_tokens, 16, false)?;
+    ensure!(
+        !result.tokens.is_empty(),
+        "DeepSeek-V2-Lite Rust generation produced no tokens"
+    );
+    ensure!(
+        result.stats.ep_size == 2,
+        "DeepSeek-V2-Lite E2E expected ep_size=2, got {}",
+        result.stats.ep_size
+    );
+    ensure!(
+        result.stats.device_ordinals == vec![0, 1],
+        "DeepSeek-V2-Lite E2E expected devices [0, 1], got {:?}",
+        result.stats.device_ordinals
+    );
+    ensure!(
+        result.stats.generated_tokens == EXPECTED_GENERATED_TOKENS,
+        "DeepSeek-V2-Lite E2E generated {} tokens, expected {}",
+        result.stats.generated_tokens,
+        EXPECTED_GENERATED_TOKENS
+    );
+    ensure!(
+        result.finish_reason == FinishReason::Length,
+        "DeepSeek-V2-Lite E2E finish_reason drift: got {:?}, expected Length",
+        result.finish_reason
+    );
+    ensure!(
+        result.stats.output_token_sha256 == EXPECTED_OUTPUT_TOKEN_SHA256,
+        "DeepSeek-V2-Lite E2E token hash drift: got {}, expected {}",
+        result.stats.output_token_sha256,
+        EXPECTED_OUTPUT_TOKEN_SHA256
+    );
+    ensure!(
+        result.stats.host_dispatch_remote_routes > 0,
+        "real EP gate did not exercise any remote routed expert"
+    );
+    ensure!(
+        result.stats.host_dispatch_local_routes > 0,
+        "real EP gate did not exercise any local routed expert"
+    );
+
+    let output_text = tokenizer
+        .decode(&result.tokens, false)
+        .map_err(|err| anyhow::anyhow!("decode output failed: {err:?}"))?;
+    let mut hasher = Sha256::new();
+    hasher.update(output_text.as_bytes());
+    let output_text_sha256 = hex::encode(hasher.finalize());
+    ensure!(
+        output_text_sha256 == EXPECTED_OUTPUT_TEXT_SHA256,
+        "DeepSeek-V2-Lite E2E text hash drift: got {}, expected {}",
+        output_text_sha256,
+        EXPECTED_OUTPUT_TEXT_SHA256
+    );
+    let payload = serde_json::json!({
+        "model_path": model_path,
+        "gpu_count": 2,
+        "ep_size": result.stats.ep_size,
+        "devices": result.stats.device_ordinals,
+        "prompt": prompt,
+        "prompt_tokens": result.stats.prompt_tokens,
+        "generated_tokens": result.stats.generated_tokens,
+        "output_token_sha256": result.stats.output_token_sha256,
+        "output_text_sha256": output_text_sha256,
+        "host_dispatch_local_routes": result.stats.host_dispatch_local_routes,
+        "host_dispatch_remote_routes": result.stats.host_dispatch_remote_routes,
+        "output_text": output_text,
+    });
+    println!("{}", serde_json::to_string_pretty(&payload)?);
+    Ok(())
+}

--- a/pegainfer-kernels/build.rs
+++ b/pegainfer-kernels/build.rs
@@ -141,15 +141,49 @@ fn parse_sm_token(raw: &str) -> Option<String> {
     None
 }
 
-fn normalize_flashinfer_sm(sm: &str) -> String {
-    match sm {
-        // FlashInfer normalizes RTX 50 / SM120 to the family-specific `f`
-        // target when CUDA >= 12.9. Plain sm_120 builds compile but trip
-        // CUTLASS conditional MMA runtime asserts in SM120 groupwise GEMM.
-        "120" => "120f".to_string(),
-        "121" => "121a".to_string(),
-        _ => sm.to_string(),
+fn nvcc_supported_arches(nvcc: &str) -> Option<BTreeSet<String>> {
+    let output = Command::new(nvcc).arg("--list-gpu-arch").output().ok()?;
+    if !output.status.success() {
+        return None;
     }
+
+    Some(
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(str::trim)
+            .filter(|line| line.starts_with("compute_"))
+            .map(str::to_string)
+            .collect(),
+    )
+}
+
+fn normalize_nvcc_sm(sm: &str, supported_arches: Option<&BTreeSet<String>>) -> String {
+    let preferred = match sm {
+        "120" | "120f" => Some("120f"),
+        "121" | "121a" => Some("121a"),
+        _ => None,
+    };
+    if let Some(preferred) = preferred {
+        if supported_arches.is_some_and(|arches| arches.contains(&format!("compute_{preferred}"))) {
+            return preferred.to_string();
+        }
+        let raw = sm_numeric_prefix(sm)
+            .map(|sm| sm.to_string())
+            .unwrap_or_else(|| sm.to_string());
+        println!(
+            "cargo:warning=nvcc does not list compute_{preferred}; compiling CUDA kernels for raw sm_{raw}"
+        );
+        return raw;
+    }
+    sm.to_string()
+}
+
+fn normalize_nvcc_sms(sm_targets: &[String], nvcc: &str) -> Vec<String> {
+    let supported_arches = nvcc_supported_arches(nvcc);
+    sm_targets
+        .iter()
+        .map(|sm| normalize_nvcc_sm(sm, supported_arches.as_ref()))
+        .collect()
 }
 
 fn sm_targets_from_nvidia_smi() -> Option<Vec<String>> {
@@ -209,24 +243,16 @@ fn detect_sm_targets() -> Vec<String> {
     panic!("GPU detection failed");
 }
 
-fn nvcc_arch_args(sm_targets: &[String]) -> Vec<String> {
+fn nvcc_arch_args(normalized_sms: &[String]) -> Vec<String> {
     let mut args = Vec::new();
-    for sm in sm_targets {
-        let sm = normalize_flashinfer_sm(sm);
+    for sm in normalized_sms {
         args.push("-gencode".to_string());
         args.push(format!("arch=compute_{sm},code=sm_{sm}"));
     }
 
-    if let Some(max_sm) = sm_targets
+    if let Some(max_sm) = normalized_sms
         .iter()
-        .map(|sm| normalize_flashinfer_sm(sm))
-        .max_by_key(|sm| {
-            sm.chars()
-                .take_while(char::is_ascii_digit)
-                .collect::<String>()
-                .parse::<u32>()
-                .unwrap_or(0)
-        })
+        .max_by_key(|sm| sm_numeric_prefix(sm).unwrap_or(0))
     {
         args.push("-gencode".to_string());
         args.push(format!("arch=compute_{max_sm},code=compute_{max_sm}"));
@@ -669,7 +695,7 @@ fn flashinfer_includes_from_include(include: PathBuf) -> FlashInferIncludes {
 fn triton_target(sm_targets: &[String]) -> String {
     let max_sm = sm_targets
         .iter()
-        .filter_map(|sm| sm.parse::<u32>().ok())
+        .filter_map(|sm| sm_numeric_prefix(sm))
         .max()
         .expect("expected at least one CUDA SM target for Triton AOT");
 
@@ -680,6 +706,18 @@ fn triton_target(sm_targets: &[String]) -> String {
     }
 
     format!("cuda:{max_sm}:32")
+}
+
+fn sm_numeric_prefix(sm: &str) -> Option<u32> {
+    let digits = sm
+        .chars()
+        .take_while(char::is_ascii_digit)
+        .collect::<String>();
+    if digits.is_empty() {
+        None
+    } else {
+        digits.parse::<u32>().ok()
+    }
 }
 
 fn generate_triton_artifacts(
@@ -1000,7 +1038,8 @@ fn main() {
     let cuda_include = Path::new(&cuda_path).join("include");
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
     let sm_targets = detect_sm_targets();
-    let arch_args = nvcc_arch_args(&sm_targets);
+    let nvcc_sm_targets = normalize_nvcc_sms(&sm_targets, &nvcc);
+    let arch_args = nvcc_arch_args(&nvcc_sm_targets);
     let deepseek_enabled = cfg!(feature = "deepseek-v4");
     let cutedsl_enabled = cfg!(feature = "deepseek-v4");
     let tilelang_artifacts = if deepseek_enabled {
@@ -1014,8 +1053,16 @@ fn main() {
         None
     };
     println!(
-        "cargo:warning=Compiling CUDA kernels for targets: {}",
+        "cargo:warning=Detected CUDA SM targets: {}",
         sm_targets
+            .iter()
+            .map(|sm| format!("sm_{sm}"))
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+    println!(
+        "cargo:warning=Compiling CUDA kernels for nvcc targets: {}",
+        nvcc_sm_targets
             .iter()
             .map(|sm| format!("sm_{sm}"))
             .collect::<Vec<_>>()

--- a/pegainfer-kernels/tools/triton/gen_triton_aot.py
+++ b/pegainfer-kernels/tools/triton/gen_triton_aot.py
@@ -1,10 +1,18 @@
 import argparse
+import re
+import runpy
+import sys
 from pathlib import Path
 
 import triton
 from triton.backends.compiler import GPUTarget
 from triton.backends.nvidia.driver import ty_to_cpp
-from triton.tools.compile import CompileArgs, compile_kernel
+
+try:
+    from triton.tools.compile import CompileArgs, compile_kernel
+except ImportError:
+    CompileArgs = None
+    compile_kernel = None
 
 
 class OfflineCudaDriver:
@@ -31,6 +39,59 @@ def activate_target_driver(target: str | None) -> None:
     )
 
 
+def compile_kernel_compat(args: argparse.Namespace):
+    if compile_kernel is not None:
+        func_name, output_files = compile_kernel(
+            CompileArgs(
+                path=args.kernel_path,
+                kernel_name=args.kernel_name,
+                signature=args.signature,
+                grid=args.grid,
+                num_warps=args.num_warps,
+                num_stages=args.num_stages,
+                out_name=args.out_name,
+                out_path=Path(args.out_dir) / args.out_name,
+            )
+        )
+        c_path = next(path for path in output_files if path.suffix == ".c")
+        return func_name, c_path
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    old_argv = sys.argv[:]
+    try:
+        sys.argv = [
+            "triton.tools.compile",
+            args.kernel_path,
+            "--kernel-name",
+            args.kernel_name,
+            "--num-warps",
+            str(args.num_warps),
+            "--num-stages",
+            str(args.num_stages),
+            "--out-name",
+            args.out_name,
+            "--out-path",
+            str(out_dir / args.out_name),
+            "--signature",
+            args.signature,
+            "--grid",
+            args.grid,
+        ]
+        runpy.run_module("triton.tools.compile", run_name="__main__")
+    finally:
+        sys.argv = old_argv
+
+    candidates = sorted(out_dir.glob(f"{args.out_name}.*.c"))
+    if not candidates:
+        raise RuntimeError(f"failed to find generated Triton C stub in {out_dir}")
+    c_path = max(candidates, key=lambda path: path.stat().st_mtime)
+    match = re.search(r"CUresult\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(", c_path.read_text())
+    if match is None:
+        raise RuntimeError(f"failed to parse Triton function name from {c_path}")
+    return match.group(1), c_path
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--kernel-path", required=True)
@@ -48,20 +109,7 @@ def main() -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     activate_target_driver(args.target)
 
-    func_name, output_files = compile_kernel(
-        CompileArgs(
-            path=args.kernel_path,
-            kernel_name=args.kernel_name,
-            signature=args.signature,
-            grid=args.grid,
-            num_warps=args.num_warps,
-            num_stages=args.num_stages,
-            out_name=args.out_name,
-            out_path=out_dir / args.out_name,
-        )
-    )
-
-    c_path = next(path for path in output_files if path.suffix == ".c")
+    func_name, c_path = compile_kernel_compat(args)
 
     print(f"FUNC_NAME={func_name}")
     print(f"C_PATH={c_path}")

--- a/pegainfer-server/Cargo.toml
+++ b/pegainfer-server/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/bin/bench_serving.rs"
 
 [dependencies]
 pegainfer-core = { workspace = true }
+pegainfer-deepseek-v2-lite = { workspace = true, optional = true }
 pegainfer-deepseek-v4 = { workspace = true, optional = true }
 pegainfer-qwen3-4b = { workspace = true }
 pegainfer-qwen35-4b = { workspace = true }
@@ -42,6 +43,7 @@ vllm-text = { workspace = true }
 [features]
 default = []
 deepseek-v4 = ["dep:pegainfer-deepseek-v4", "pegainfer-deepseek-v4/deepseek-v4"]
+deepseek-v2-lite = ["dep:pegainfer-deepseek-v2-lite", "pegainfer-deepseek-v2-lite/deepseek-v2-lite"]
 pplx-ep = ["deepseek-v4", "pegainfer-deepseek-v4/pplx-ep"]
 deepseek-v4-cutedsl-diagnostic = [
     "deepseek-v4",

--- a/pegainfer-server/src/bin/bench_serving.rs
+++ b/pegainfer-server/src/bin/bench_serving.rs
@@ -441,11 +441,11 @@ fn aggregate_tok_s(tokens: usize, total: Duration) -> Option<f64> {
 }
 
 fn generated_token_hash(tokens: &[u32]) -> String {
-    let mut hash = 0xcbf29ce484222325u64;
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
     for token in tokens {
         for byte in token.to_le_bytes() {
             hash ^= u64::from(byte);
-            hash = hash.wrapping_mul(0x100000001b3);
+            hash = hash.wrapping_mul(0x0100_0000_01b3);
         }
     }
     format!("{hash:016x}")
@@ -928,8 +928,7 @@ impl BenchModel for SchedulerBenchModel {
                             break;
                         }
                     }
-                    Some(TokenEvent::PromptTokens { .. }) => {}
-                    Some(TokenEvent::Scheduled { .. }) => {}
+                    Some(TokenEvent::PromptTokens { .. } | TokenEvent::Scheduled { .. }) => {}
                     Some(TokenEvent::Finished { .. }) => break,
                     Some(TokenEvent::Error { message, .. }) => {
                         anyhow::bail!("scheduler request failed: {message}");
@@ -1052,12 +1051,18 @@ fn build_request_iterations(timings: &[GenTimings]) -> Vec<RequestIterationTimin
         .collect()
 }
 
-fn run_info(cli: &Cli, command: &'static str, model_type: ModelType, load_ms: f64) -> RunInfo {
+fn run_info(
+    cli: &Cli,
+    command: &'static str,
+    model_type: ModelType,
+    load_ms: f64,
+    cuda_graph: bool,
+) -> RunInfo {
     RunInfo {
         command,
         model_path: cli.model_path.clone(),
         model_type: format!("{model_type:?}"),
-        cuda_graph: cli.cuda_graph,
+        cuda_graph,
         load_ms,
         label: cli.label.clone(),
     }
@@ -1069,6 +1074,7 @@ fn bench_request(
     cli: &Cli,
     model_type: ModelType,
     load_ms: f64,
+    cuda_graph: bool,
     args: &RequestArgs,
 ) -> Result<BenchReport> {
     let prompt = resolve_prompt_input(
@@ -1087,7 +1093,7 @@ fn bench_request(
     );
     let timings = measure_timings(model, &prompt.tokens, args.output_len, &args.run)?;
     Ok(BenchReport::Request(Box::new(RequestReport {
-        run: run_info(cli, "request", model_type, load_ms),
+        run: run_info(cli, "request", model_type, load_ms, cuda_graph),
         workload: RequestWorkload {
             prompt: prompt.descriptor,
             output_len: args.output_len,
@@ -1105,6 +1111,7 @@ fn bench_matrix(
     cli: &Cli,
     model_type: ModelType,
     load_ms: f64,
+    cuda_graph: bool,
     args: &MatrixArgs,
 ) -> Result<BenchReport> {
     validate_run_args(&args.run)?;
@@ -1140,7 +1147,7 @@ fn bench_matrix(
     }
 
     Ok(BenchReport::Matrix(MatrixReport {
-        run: run_info(cli, "matrix", model_type, load_ms),
+        run: run_info(cli, "matrix", model_type, load_ms, cuda_graph),
         workload: MatrixWorkload {
             prompt_lens,
             output_lens,
@@ -1159,6 +1166,7 @@ fn bench_curve(
     cli: &Cli,
     model_type: ModelType,
     load_ms: f64,
+    cuda_graph: bool,
     args: &CurveArgs,
 ) -> Result<BenchReport> {
     ensure!(args.window > 0, "--window must be > 0");
@@ -1212,7 +1220,7 @@ fn bench_curve(
     }
 
     Ok(BenchReport::Curve(CurveReport {
-        run: run_info(cli, "curve", model_type, load_ms),
+        run: run_info(cli, "curve", model_type, load_ms, cuda_graph),
         workload: CurveWorkload {
             prompt: prompt.descriptor,
             output_len: args.output_len,
@@ -1297,13 +1305,18 @@ fn run_command(
     cli: &Cli,
     model_type: ModelType,
     load_ms: f64,
+    cuda_graph: bool,
     model: &mut dyn BenchModel,
     tokenizer: &DynTokenizer,
 ) -> Result<BenchReport> {
     match &cli.command {
-        Command::Request(args) => bench_request(model, tokenizer, cli, model_type, load_ms, args),
-        Command::Matrix(args) => bench_matrix(model, cli, model_type, load_ms, args),
-        Command::Curve(args) => bench_curve(model, tokenizer, cli, model_type, load_ms, args),
+        Command::Request(args) => {
+            bench_request(model, tokenizer, cli, model_type, load_ms, cuda_graph, args)
+        }
+        Command::Matrix(args) => bench_matrix(model, cli, model_type, load_ms, cuda_graph, args),
+        Command::Curve(args) => {
+            bench_curve(model, tokenizer, cli, model_type, load_ms, cuda_graph, args)
+        }
         Command::Snapshot(_) | Command::Compare(_) => unreachable!(),
     }
 }
@@ -1524,7 +1537,6 @@ fn run_compare(args: &CompareArgs) -> Result<()> {
         baseline.decode_heavy.prompt_len,
         baseline.decode_heavy.output_len,
     );
-
     println!("{}", render_comparison(&current, &baseline, &args.baseline));
     Ok(())
 }
@@ -1640,13 +1652,14 @@ fn dispatch(
     cli: &Cli,
     model_type: ModelType,
     load_ms: f64,
+    cuda_graph: bool,
     model: &mut dyn BenchModel,
     tokenizer: &DynTokenizer,
 ) -> Result<()> {
     if let Command::Snapshot(args) = &cli.command {
         run_snapshot(model, cli, model_type, args)
     } else {
-        let report = run_command(cli, model_type, load_ms, model, tokenizer)?;
+        let report = run_command(cli, model_type, load_ms, cuda_graph, model, tokenizer)?;
         emit_report(cli, &report)
     }
 }
@@ -1674,11 +1687,28 @@ fn main() -> Result<()> {
         cli.cuda_graph,
         cli.format
     );
-    let model_type = detect_model_type(&cli.model_path)?;
+    let model_type = detect_model_type(&cli.model_path)
+        .with_context(|| format!("failed to detect model type from {}", cli.model_path))?;
     debug!("Detected model type: {:?}", model_type);
     let load_start = Instant::now();
 
     match model_type {
+        #[cfg(feature = "deepseek-v2-lite")]
+        ModelType::DeepSeekV2Lite => {
+            let handle = pegainfer_deepseek_v2_lite::start_engine(
+                Path::new(&cli.model_path),
+                EngineLoadOptions {
+                    enable_cuda_graph: false,
+                    enable_prefill_profile: false,
+                    device_ordinals: vec![0, 1],
+                    seed: command_seed(&cli),
+                },
+            )?;
+            let tokenizer = load_vllm_tokenizer(&cli.model_path)?;
+            let load_ms = dur_ms(load_start.elapsed());
+            let mut bench = SchedulerBenchModel { handle };
+            dispatch(&cli, model_type, load_ms, false, &mut bench, &tokenizer)
+        }
         #[cfg(feature = "deepseek-v4")]
         ModelType::DeepSeekV4 => {
             let handle = pegainfer_deepseek_v4::start_engine(
@@ -1693,7 +1723,7 @@ fn main() -> Result<()> {
             let tokenizer = load_vllm_tokenizer(&cli.model_path)?;
             let load_ms = dur_ms(load_start.elapsed());
             let mut bench = SchedulerBenchModel { handle };
-            dispatch(&cli, model_type, load_ms, &mut bench, &tokenizer)
+            dispatch(&cli, model_type, load_ms, false, &mut bench, &tokenizer)
         }
         ModelType::Qwen3 => {
             let handle = pegainfer_qwen3_4b::start_engine(
@@ -1708,7 +1738,14 @@ fn main() -> Result<()> {
             let tokenizer = load_vllm_tokenizer(&cli.model_path)?;
             let load_ms = dur_ms(load_start.elapsed());
             let mut bench = SchedulerBenchModel { handle };
-            dispatch(&cli, model_type, load_ms, &mut bench, &tokenizer)
+            dispatch(
+                &cli,
+                model_type,
+                load_ms,
+                cli.cuda_graph,
+                &mut bench,
+                &tokenizer,
+            )
         }
         ModelType::Qwen35 => {
             let handle = pegainfer_qwen35_4b::start_engine_with_capacity(
@@ -1724,7 +1761,14 @@ fn main() -> Result<()> {
             let tokenizer = load_vllm_tokenizer(&cli.model_path)?;
             let load_ms = dur_ms(load_start.elapsed());
             let mut bench = SchedulerBenchModel { handle };
-            dispatch(&cli, model_type, load_ms, &mut bench, &tokenizer)
+            dispatch(
+                &cli,
+                model_type,
+                load_ms,
+                cli.cuda_graph,
+                &mut bench,
+                &tokenizer,
+            )
         }
     }
 }

--- a/pegainfer-server/src/main.rs
+++ b/pegainfer-server/src/main.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use std::time::Instant;
 
+use anyhow::Context;
 use clap::Parser;
 use log::info;
 use pegainfer::logging;
@@ -43,19 +44,28 @@ async fn main() -> anyhow::Result<()> {
 
     let args = Args::parse();
 
-    let model_path = args
-        .model_path
-        .to_str()
-        .expect("Model path must be valid UTF-8");
-    let model_type = detect_model_type(model_path).expect("Failed to detect model type");
+    let model_type = detect_model_type(&args.model_path).with_context(|| {
+        format!(
+            "failed to detect model type from {}",
+            args.model_path.display()
+        )
+    })?;
+    let effective_cuda_graph = match model_type {
+        #[cfg(feature = "deepseek-v2-lite")]
+        ModelType::DeepSeekV2Lite => false,
+        #[cfg(feature = "deepseek-v4")]
+        ModelType::DeepSeekV4 => false,
+        ModelType::Qwen3 | ModelType::Qwen35 => args.cuda_graph,
+    };
 
     info!("=== Rust LLM Server - {} (GPU) ===", model_type);
     info!("Loading engine...");
     let start = Instant::now();
     info!(
-        "Runtime options: model_path={}, cuda_graph={}, device_ordinal={}, tp_size={}",
+        "Runtime options: model_path={}, requested_cuda_graph={}, effective_cuda_graph={}, device_ordinal={}, tp_size={}",
         args.model_path.display(),
         args.cuda_graph,
+        effective_cuda_graph,
         args.device_ordinal,
         args.tp_size
     );
@@ -72,7 +82,23 @@ async fn main() -> anyhow::Result<()> {
                     seed: 42,
                 },
             )
-            .expect("Failed to start DeepSeek V4 engine");
+            .context("failed to start DeepSeek V4 engine")?;
+
+            info!("Engine loaded: elapsed_ms={}", start.elapsed().as_millis());
+
+            handle
+        }
+        #[cfg(feature = "deepseek-v2-lite")]
+        ModelType::DeepSeekV2Lite => {
+            let handle = pegainfer_deepseek_v2_lite::start_engine(
+                &args.model_path,
+                EngineLoadOptions {
+                    enable_cuda_graph: false,
+                    enable_prefill_profile: false,
+                    device_ordinals: vec![0, 1],
+                    seed: 42,
+                },
+            )?;
 
             info!("Engine loaded: elapsed_ms={}", start.elapsed().as_millis());
 
@@ -93,7 +119,7 @@ async fn main() -> anyhow::Result<()> {
                     seed: 42,
                 },
             )
-            .expect("Failed to start Qwen3 engine");
+            .context("failed to start Qwen3 engine")?;
 
             info!("Engine loaded: elapsed_ms={}", start.elapsed().as_millis());
 
@@ -109,7 +135,7 @@ async fn main() -> anyhow::Result<()> {
                     seed: 42,
                 },
             )
-            .expect("Failed to start Qwen3.5 engine");
+            .context("failed to start Qwen3.5 engine")?;
 
             info!("Engine loaded: elapsed_ms={}", start.elapsed().as_millis());
 
@@ -124,7 +150,7 @@ async fn main() -> anyhow::Result<()> {
         pegainfer::vllm_frontend::shutdown_token_from_ctrl_c(),
     )
     .await
-    .expect("vLLM frontend server failed");
+    .context("vLLM frontend server failed")?;
 
     Ok(())
 }

--- a/pegainfer-server/src/server_engine.rs
+++ b/pegainfer-server/src/server_engine.rs
@@ -1,6 +1,6 @@
-use std::fmt;
+use std::{fmt, path::Path};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 pub use pegainfer_core::engine::{FinishReason, TokenLogprob};
 
@@ -8,6 +8,8 @@ pub use pegainfer_core::engine::{FinishReason, TokenLogprob};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ModelType {
+    #[cfg(feature = "deepseek-v2-lite")]
+    DeepSeekV2Lite,
     #[cfg(feature = "deepseek-v4")]
     DeepSeekV4,
     Qwen3,
@@ -17,6 +19,8 @@ pub enum ModelType {
 impl fmt::Display for ModelType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            #[cfg(feature = "deepseek-v2-lite")]
+            Self::DeepSeekV2Lite => write!(f, "DeepSeek-V2-Lite"),
             #[cfg(feature = "deepseek-v4")]
             Self::DeepSeekV4 => write!(f, "DeepSeek V4"),
             Self::Qwen3 => write!(f, "Qwen3"),
@@ -26,10 +30,30 @@ impl fmt::Display for ModelType {
 }
 
 /// Detect model type from config.json.
-pub fn detect_model_type(model_path: &str) -> Result<ModelType> {
-    let config_path = format!("{}/config.json", model_path);
-    let content = std::fs::read_to_string(&config_path)?;
-    let json: serde_json::Value = serde_json::from_str(&content)?;
+pub fn detect_model_type(model_path: impl AsRef<Path>) -> Result<ModelType> {
+    let config_path = model_path.as_ref().join("config.json");
+    let content = std::fs::read_to_string(&config_path)
+        .with_context(|| format!("failed to read {}", config_path.display()))?;
+    let json: serde_json::Value = serde_json::from_str(&content)
+        .with_context(|| format!("failed to parse {}", config_path.display()))?;
+
+    if json
+        .get("model_type")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|model_type| model_type == "deepseek_v2")
+    {
+        #[cfg(feature = "deepseek-v2-lite")]
+        {
+            pegainfer_deepseek_v2_lite::probe_config_json(&json)?;
+            return Ok(ModelType::DeepSeekV2Lite);
+        }
+        #[cfg(not(feature = "deepseek-v2-lite"))]
+        {
+            anyhow::bail!(
+                "DeepSeek-V2-Lite support is feature-gated; rebuild pegainfer-server with --features deepseek-v2-lite"
+            );
+        }
+    }
 
     if json
         .get("model_type")


### PR DESCRIPTION
## Summary
Part of #135 
Adds a correctness-first DeepSeek-V2-Lite EP=2 bring-up behind the `deepseek-v2-lite` feature.

The first gate supports a single-node two-GPU layout with routed experts split as:
- rank 0: experts `0..31`
- rank 1: experts `32..63`

## Scope

In scope:
- Add a `pegainfer-deepseek-v2-lite` model crate.
- Load DeepSeek-V2-Lite config and weights without reusing DeepSeek V4 shape assumptions.
- Keep rank 0 as the driver/full-forward rank.
- Keep rank 1 expert-only, loading only owned routed experts.
- Add minimal host-staged dispatch/combine for the first correctness gate.
- Return explicit errors for unsupported backend/topology/cuda_graph paths.
- Wire server and `bench_serving` feature support.

Out of scope:
- Performance or throughput claims.
- Production EP backend.
- CUDA Graph support for this path.
- Long-context YaRN support beyond the plain RoPE first gate.
- General EP topology support beyond `ep_size=2`.

## Evidence

Static checks:
- `cargo fmt --check`
- `git diff --check upstream/main..HEAD`

Build / lint:
- `cargo check --release -p pegainfer-comm`
- `cargo check --release -p pegainfer-server --features deepseek-v2-lite`
- `cargo test --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite --lib -- --nocapture`
- `cargo clippy --release --no-deps -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite --lib --tests -- -D warnings`
- `cargo clippy --release --no-deps -p pegainfer-server --features deepseek-v2-lite --bin bench_serving --bin pegainfer -- -D warnings`

Real DeepSeek-V2-Lite EP2 E2E:
- devices: `[0, 1]`
- ep_size: `2`
- prompt: `Hello`
- prompt_tokens: `1`
- generated_tokens: `16`
- host_dispatch_local_routes: `1214`
- host_dispatch_remote_routes: `1282`
- output_token_sha256: `f39e57d9b3eb949057ada9b3bc92f7f7037dfd19658dbe3ce145d8fad03ded5e`
- output_text_sha256: `a521f6dc9739b4506a46822da7c239ac558a879d571f54a064a4a2fbc3a097b7`

Benchmark smoke:
- `bench_serving request --prompt Hello --output-len 16 --warmup 1 --iters 2`
- Smoke only; not used as a performance claim.

## Claim Boundary

This PR proves a small greedy correctness gate for DeepSeek-V2-Lite EP=2 on two local GPUs. It does not claim production readiness, NVLink performance, throughput improvement, or general EP topology support.