### PR TITLE
feat(deepseek-v2-lite): add naive NCCL EP2 backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3573,6 +3573,7 @@ dependencies = [
  "cudarc",
  "half",
  "hex",
+ "libloading 0.9.0",
  "memmap2",
  "pegainfer-core",
  "pegainfer-engine",

--- a/pegainfer-deepseek-v2-lite/Cargo.toml
+++ b/pegainfer-deepseek-v2-lite/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = { workspace = true }
 cudarc = { workspace = true }
 half = { workspace = true }
 hex = { workspace = true }
+libloading = "0.9"
 memmap2 = { workspace = true }
 pegainfer-core = { workspace = true }
 pegainfer-engine = { workspace = true }

--- a/pegainfer-deepseek-v2-lite/src/engine.rs
+++ b/pegainfer-deepseek-v2-lite/src/engine.rs
@@ -16,7 +16,7 @@ pub(crate) fn start_engine(model_path: &Path, options: EngineLoadOptions) -> Res
     let mut generator = DeepSeekV2LiteEp2Generator::load(model_path, options)?;
     let (submit_tx, mut submit_rx) = mpsc::unbounded_channel();
 
-    std::thread::Builder::new()
+    let join_handle = std::thread::Builder::new()
         .name("deepseek-v2-lite-ep2".to_string())
         .spawn(move || {
             while let Some(req) = submit_rx.blocking_recv() {
@@ -25,7 +25,7 @@ pub(crate) fn start_engine(model_path: &Path, options: EngineLoadOptions) -> Res
         })
         .context("spawn DeepSeek-V2-Lite EP=2 engine thread")?;
 
-    Ok(EngineHandle::new(submit_tx))
+    Ok(EngineHandle::new_with_join_handle(submit_tx, join_handle))
 }
 
 fn handle_request(generator: &mut DeepSeekV2LiteEp2Generator, req: &GenerateRequest) {

--- a/pegainfer-deepseek-v2-lite/src/lib.rs
+++ b/pegainfer-deepseek-v2-lite/src/lib.rs
@@ -4,6 +4,7 @@ mod engine;
 mod ep;
 mod host_ops;
 mod model;
+mod nccl_backend;
 mod runtime;
 mod weights;
 

--- a/pegainfer-deepseek-v2-lite/src/nccl_backend.rs
+++ b/pegainfer-deepseek-v2-lite/src/nccl_backend.rs
@@ -1,5 +1,5 @@
 use std::{
-    ffi::{CStr, c_char, c_void},
+    ffi::{CStr, c_char, c_int, c_void},
     ptr,
     sync::Arc,
 };
@@ -15,11 +15,10 @@ use pegainfer_core::tensor::{DeviceContext, HiddenStates};
 
 use crate::device::activate;
 
-type NcclCommInitAll = unsafe extern "C" fn(
-    *mut ncclComm_t,
-    ::core::ffi::c_int,
-    *const ::core::ffi::c_int,
-) -> ncclResult_t;
+type NcclCommInitAll = unsafe extern "C" fn(*mut ncclComm_t, c_int, *const c_int) -> ncclResult_t;
+type NcclCommCount = unsafe extern "C" fn(ncclComm_t, *mut c_int) -> ncclResult_t;
+type NcclCommCuDevice = unsafe extern "C" fn(ncclComm_t, *mut c_int) -> ncclResult_t;
+type NcclCommDestroy = unsafe extern "C" fn(ncclComm_t) -> ncclResult_t;
 type NcclCommAbort = unsafe extern "C" fn(ncclComm_t) -> ncclResult_t;
 type NcclGroupStart = unsafe extern "C" fn() -> ncclResult_t;
 type NcclGroupEnd = unsafe extern "C" fn() -> ncclResult_t;
@@ -42,6 +41,9 @@ pub(crate) struct NaiveNcclEp2Backend {
 struct RawNcclLib {
     _library: Library,
     comm_init_all: NcclCommInitAll,
+    comm_count: NcclCommCount,
+    comm_cu_device: NcclCommCuDevice,
+    comm_destroy: NcclCommDestroy,
     comm_abort: NcclCommAbort,
     group_start: NcclGroupStart,
     group_end: NcclGroupEnd,
@@ -72,10 +74,13 @@ impl NaiveNcclEp2Backend {
             comms.iter().all(|comm| !comm.is_null()),
             "DeepSeek-V2-Lite NCCL EP=2 communicator initialization returned a null communicator"
         );
-        Ok(Self { lib, comms })
+        let backend = Self { lib, comms };
+        backend.validate_communicators(&ordinals)?;
+        backend.smoke_all_reduce_f32(rank0, rank1)?;
+        Ok(backend)
     }
 
-    pub(crate) fn dispatch_rank0_hidden_to_rank1(
+    pub(crate) fn dense_all_reduce_rank0_hidden_to_rank1(
         &self,
         rank0: &DeviceContext,
         rank1: &DeviceContext,
@@ -83,7 +88,7 @@ impl NaiveNcclEp2Backend {
     ) -> Result<HiddenStates> {
         ensure!(
             input.hidden_dim > 0 && input.seq_len > 0,
-            "DeepSeek-V2-Lite NCCL dispatch requires non-empty hidden states"
+            "DeepSeek-V2-Lite NCCL dense hidden exchange requires non-empty hidden states"
         );
         activate(rank0)?;
         let mut rank0_recv = HiddenStates::zeros(rank0, input.hidden_dim, input.seq_len)?;
@@ -91,8 +96,11 @@ impl NaiveNcclEp2Backend {
         let rank1_send = HiddenStates::zeros(rank1, input.hidden_dim, input.seq_len)?;
         let mut rank1_recv = HiddenStates::zeros(rank1, input.hidden_dim, input.seq_len)?;
 
+        // Correctness-first dense exchange: rank0 contributes the hidden state
+        // and rank1 contributes zeros. This makes rank0 hidden visible on rank1
+        // without pretending to be sparse routed dispatch.
         let count = input.hidden_dim * input.seq_len;
-        self.grouped("DeepSeek-V2-Lite NCCL dispatch all-reduce", || {
+        self.grouped("DeepSeek-V2-Lite NCCL dense hidden all-reduce", || {
             activate(rank0)?;
             self.all_reduce_bf16(
                 0,
@@ -100,7 +108,7 @@ impl NaiveNcclEp2Backend {
                 &mut rank0_recv.data,
                 count,
                 rank0.stream.cu_stream(),
-                "DeepSeek-V2-Lite NCCL dispatch rank0 all-reduce",
+                "DeepSeek-V2-Lite NCCL dense hidden rank0 all-reduce",
             )?;
             activate(rank1)?;
             self.all_reduce_bf16(
@@ -109,7 +117,7 @@ impl NaiveNcclEp2Backend {
                 &mut rank1_recv.data,
                 count,
                 rank1.stream.cu_stream(),
-                "DeepSeek-V2-Lite NCCL dispatch rank1 all-reduce",
+                "DeepSeek-V2-Lite NCCL dense hidden rank1 all-reduce",
             )?;
             Ok(())
         })?;
@@ -169,6 +177,75 @@ impl NaiveNcclEp2Backend {
         let combined = rank0.stream.clone_dtoh(&rank0_recv)?;
         rank0.sync()?;
         Ok(combined)
+    }
+
+    fn smoke_all_reduce_f32(&self, rank0: &DeviceContext, rank1: &DeviceContext) -> Result<()> {
+        activate(rank0)?;
+        let rank0_send = rank0.stream.clone_htod(&[1.0f32])?;
+        let mut rank0_recv = rank0.stream.alloc_zeros::<f32>(1)?;
+        activate(rank1)?;
+        let rank1_send = rank1.stream.clone_htod(&[2.0f32])?;
+        let mut rank1_recv = rank1.stream.alloc_zeros::<f32>(1)?;
+
+        self.grouped("DeepSeek-V2-Lite NCCL EP=2 init smoke all-reduce", || {
+            activate(rank0)?;
+            self.all_reduce_f32(
+                0,
+                &rank0_send,
+                &mut rank0_recv,
+                1,
+                rank0.stream.cu_stream(),
+                "DeepSeek-V2-Lite NCCL init smoke rank0 all-reduce",
+            )?;
+            activate(rank1)?;
+            self.all_reduce_f32(
+                1,
+                &rank1_send,
+                &mut rank1_recv,
+                1,
+                rank1.stream.cu_stream(),
+                "DeepSeek-V2-Lite NCCL init smoke rank1 all-reduce",
+            )?;
+            Ok(())
+        })?;
+        rank0.sync()?;
+        rank1.sync()?;
+
+        activate(rank0)?;
+        let rank0_value = rank0.stream.clone_dtoh(&rank0_recv)?;
+        rank0.sync()?;
+        activate(rank1)?;
+        let rank1_value = rank1.stream.clone_dtoh(&rank1_recv)?;
+        rank1.sync()?;
+        ensure!(
+            rank0_value == [3.0] && rank1_value == [3.0],
+            "DeepSeek-V2-Lite NCCL EP=2 init smoke all-reduce returned rank0={rank0_value:?}, rank1={rank1_value:?}, expected [3.0]"
+        );
+        Ok(())
+    }
+
+    fn validate_communicators(&self, expected_ordinals: &[c_int; 2]) -> Result<()> {
+        for (rank, expected_ordinal) in expected_ordinals.iter().copied().enumerate() {
+            let comm = self.comm(rank)?;
+            let count = self.lib.query_comm_count(
+                comm,
+                &format!("DeepSeek-V2-Lite NCCL communicator rank {rank} world-size query"),
+            )?;
+            ensure!(
+                count == self.comms.len() as c_int,
+                "DeepSeek-V2-Lite NCCL communicator rank {rank} world size mismatch: got {count}, expected {}",
+                self.comms.len()
+            );
+            let device = self.lib.query_comm_cu_device(
+                comm,
+                &format!("DeepSeek-V2-Lite NCCL communicator rank {rank} device query"),
+            )?;
+            ensure!(
+                device == expected_ordinal,
+                "DeepSeek-V2-Lite NCCL communicator rank {rank} CUDA device mismatch: got {device}, expected {expected_ordinal}"
+            );
+        }
+        Ok(())
     }
 
     fn all_reduce_bf16(
@@ -276,11 +353,18 @@ impl Drop for NaiveNcclEp2Backend {
     fn drop(&mut self) {
         for comm in &mut self.comms {
             if !comm.is_null() {
-                let _ = unsafe {
-                    // SAFETY: Best-effort teardown for communicator handles
-                    // returned by `ncclCommInitAll`.
-                    (self.lib.comm_abort)(*comm)
+                let destroy_status = unsafe {
+                    // SAFETY: Best-effort clean teardown for communicator
+                    // handles returned by `ncclCommInitAll`.
+                    (self.lib.comm_destroy)(*comm)
                 };
+                if destroy_status != ncclResult_t::ncclSuccess {
+                    let _ = unsafe {
+                        // SAFETY: Abort is the fallback when clean destroy
+                        // reports an error during best-effort Drop.
+                        (self.lib.comm_abort)(*comm)
+                    };
+                }
                 *comm = ptr::null_mut();
             }
         }
@@ -316,6 +400,9 @@ impl RawNcclLib {
     unsafe fn from_library(library: Library) -> Result<Self> {
         Ok(Self {
             comm_init_all: unsafe { load_symbol(&library, b"ncclCommInitAll\0")? },
+            comm_count: unsafe { load_symbol(&library, b"ncclCommCount\0")? },
+            comm_cu_device: unsafe { load_symbol(&library, b"ncclCommCuDevice\0")? },
+            comm_destroy: unsafe { load_symbol(&library, b"ncclCommDestroy\0")? },
             comm_abort: unsafe { load_symbol(&library, b"ncclCommAbort\0")? },
             group_start: unsafe { load_symbol(&library, b"ncclGroupStart\0")? },
             group_end: unsafe { load_symbol(&library, b"ncclGroupEnd\0")? },
@@ -340,6 +427,28 @@ impl RawNcclLib {
             }
         };
         bail!("{context} failed: {message} ({status:?})")
+    }
+
+    fn query_comm_count(&self, comm: ncclComm_t, context: &str) -> Result<c_int> {
+        let mut count = 0;
+        let status = unsafe {
+            // SAFETY: `count` is a valid out pointer and `comm` was validated
+            // by the caller as a non-null communicator handle.
+            (self.comm_count)(comm, &mut count)
+        };
+        self.check(status, context)?;
+        Ok(count)
+    }
+
+    fn query_comm_cu_device(&self, comm: ncclComm_t, context: &str) -> Result<c_int> {
+        let mut device = -1;
+        let status = unsafe {
+            // SAFETY: `device` is a valid out pointer and `comm` was validated
+            // by the caller as a non-null communicator handle.
+            (self.comm_cu_device)(comm, &mut device)
+        };
+        self.check(status, context)?;
+        Ok(device)
     }
 }
 

--- a/pegainfer-deepseek-v2-lite/src/nccl_backend.rs
+++ b/pegainfer-deepseek-v2-lite/src/nccl_backend.rs
@@ -1,0 +1,355 @@
+use std::{
+    ffi::{CStr, c_char, c_void},
+    ptr,
+    sync::Arc,
+};
+
+use anyhow::{Context, Result, bail, ensure};
+use cudarc::{
+    driver::{CudaSlice, DevicePtr, DevicePtrMut, sys::CUstream},
+    nccl::sys::{ncclComm_t, ncclDataType_t, ncclRedOp_t, ncclResult_t},
+};
+use half::bf16;
+use libloading::Library;
+use pegainfer_core::tensor::{DeviceContext, HiddenStates};
+
+use crate::device::activate;
+
+type NcclCommInitAll = unsafe extern "C" fn(
+    *mut ncclComm_t,
+    ::core::ffi::c_int,
+    *const ::core::ffi::c_int,
+) -> ncclResult_t;
+type NcclCommAbort = unsafe extern "C" fn(ncclComm_t) -> ncclResult_t;
+type NcclGroupStart = unsafe extern "C" fn() -> ncclResult_t;
+type NcclGroupEnd = unsafe extern "C" fn() -> ncclResult_t;
+type NcclAllReduce = unsafe extern "C" fn(
+    *const c_void,
+    *mut c_void,
+    usize,
+    ncclDataType_t,
+    ncclRedOp_t,
+    ncclComm_t,
+    CUstream,
+) -> ncclResult_t;
+type NcclGetErrorString = unsafe extern "C" fn(ncclResult_t) -> *const c_char;
+
+pub(crate) struct NaiveNcclEp2Backend {
+    lib: Arc<RawNcclLib>,
+    comms: Vec<ncclComm_t>,
+}
+
+struct RawNcclLib {
+    _library: Library,
+    comm_init_all: NcclCommInitAll,
+    comm_abort: NcclCommAbort,
+    group_start: NcclGroupStart,
+    group_end: NcclGroupEnd,
+    all_reduce: NcclAllReduce,
+    get_error_string: NcclGetErrorString,
+}
+
+impl NaiveNcclEp2Backend {
+    pub(crate) fn new(rank0: &DeviceContext, rank1: &DeviceContext) -> Result<Self> {
+        ensure!(
+            rank0.device_ordinal != rank1.device_ordinal,
+            "DeepSeek-V2-Lite NCCL EP=2 requires distinct CUDA devices, got {:?}",
+            [rank0.device_ordinal, rank1.device_ordinal]
+        );
+        let lib = Arc::new(RawNcclLib::load()?);
+        let ordinals = [rank0.device_ordinal as i32, rank1.device_ordinal as i32];
+        let mut comms = vec![ptr::null_mut(); 2];
+        let status = unsafe {
+            // SAFETY: `comms` has space for two communicator handles and
+            // `ordinals` names the two distinct CUDA devices validated above.
+            (lib.comm_init_all)(comms.as_mut_ptr(), comms.len() as i32, ordinals.as_ptr())
+        };
+        lib.check(
+            status,
+            "DeepSeek-V2-Lite NCCL EP=2 communicator initialization",
+        )?;
+        ensure!(
+            comms.iter().all(|comm| !comm.is_null()),
+            "DeepSeek-V2-Lite NCCL EP=2 communicator initialization returned a null communicator"
+        );
+        Ok(Self { lib, comms })
+    }
+
+    pub(crate) fn dispatch_rank0_hidden_to_rank1(
+        &self,
+        rank0: &DeviceContext,
+        rank1: &DeviceContext,
+        input: &HiddenStates,
+    ) -> Result<HiddenStates> {
+        ensure!(
+            input.hidden_dim > 0 && input.seq_len > 0,
+            "DeepSeek-V2-Lite NCCL dispatch requires non-empty hidden states"
+        );
+        activate(rank0)?;
+        let mut rank0_recv = HiddenStates::zeros(rank0, input.hidden_dim, input.seq_len)?;
+        activate(rank1)?;
+        let rank1_send = HiddenStates::zeros(rank1, input.hidden_dim, input.seq_len)?;
+        let mut rank1_recv = HiddenStates::zeros(rank1, input.hidden_dim, input.seq_len)?;
+
+        let count = input.hidden_dim * input.seq_len;
+        self.grouped("DeepSeek-V2-Lite NCCL dispatch all-reduce", || {
+            activate(rank0)?;
+            self.all_reduce_bf16(
+                0,
+                &input.data,
+                &mut rank0_recv.data,
+                count,
+                rank0.stream.cu_stream(),
+                "DeepSeek-V2-Lite NCCL dispatch rank0 all-reduce",
+            )?;
+            activate(rank1)?;
+            self.all_reduce_bf16(
+                1,
+                &rank1_send.data,
+                &mut rank1_recv.data,
+                count,
+                rank1.stream.cu_stream(),
+                "DeepSeek-V2-Lite NCCL dispatch rank1 all-reduce",
+            )?;
+            Ok(())
+        })?;
+        rank0.sync()?;
+        rank1.sync()?;
+        Ok(rank1_recv)
+    }
+
+    pub(crate) fn combine_f32_contributions_to_rank0(
+        &self,
+        rank0: &DeviceContext,
+        rank1: &DeviceContext,
+        rank0_contrib: &[f32],
+        rank1_contrib: &[f32],
+    ) -> Result<Vec<f32>> {
+        ensure!(
+            !rank0_contrib.is_empty(),
+            "DeepSeek-V2-Lite NCCL combine requires non-empty rank0 contribution"
+        );
+        ensure!(
+            rank0_contrib.len() == rank1_contrib.len(),
+            "DeepSeek-V2-Lite NCCL combine contribution length mismatch: rank0={}, rank1={}",
+            rank0_contrib.len(),
+            rank1_contrib.len()
+        );
+        activate(rank0)?;
+        let rank0_send = rank0.stream.clone_htod(rank0_contrib)?;
+        let mut rank0_recv = rank0.stream.alloc_zeros::<f32>(rank0_contrib.len())?;
+        activate(rank1)?;
+        let rank1_send = rank1.stream.clone_htod(rank1_contrib)?;
+        let mut rank1_recv = rank1.stream.alloc_zeros::<f32>(rank1_contrib.len())?;
+
+        self.grouped("DeepSeek-V2-Lite NCCL combine all-reduce", || {
+            activate(rank0)?;
+            self.all_reduce_f32(
+                0,
+                &rank0_send,
+                &mut rank0_recv,
+                rank0_contrib.len(),
+                rank0.stream.cu_stream(),
+                "DeepSeek-V2-Lite NCCL combine rank0 all-reduce",
+            )?;
+            activate(rank1)?;
+            self.all_reduce_f32(
+                1,
+                &rank1_send,
+                &mut rank1_recv,
+                rank1_contrib.len(),
+                rank1.stream.cu_stream(),
+                "DeepSeek-V2-Lite NCCL combine rank1 all-reduce",
+            )?;
+            Ok(())
+        })?;
+        rank0.sync()?;
+        rank1.sync()?;
+
+        let combined = rank0.stream.clone_dtoh(&rank0_recv)?;
+        rank0.sync()?;
+        Ok(combined)
+    }
+
+    fn all_reduce_bf16(
+        &self,
+        rank: usize,
+        send: &CudaSlice<bf16>,
+        recv: &mut CudaSlice<bf16>,
+        count: usize,
+        stream: CUstream,
+        context: &str,
+    ) -> Result<()> {
+        ensure!(
+            recv.len() >= count,
+            "{context}: recv buffer too small: recv={}, required={count}",
+            recv.len()
+        );
+        ensure!(
+            send.len() >= count,
+            "{context}: send buffer too small: send={}, required={count}",
+            send.len()
+        );
+        let stream_ref = recv.stream().clone();
+        let (send_ptr, _send_guard) = send.device_ptr(&stream_ref);
+        let (recv_ptr, _recv_guard) = recv.device_ptr_mut(&stream_ref);
+        let status = unsafe {
+            // SAFETY: Device pointers come from cudarc allocations on the
+            // active CUDA devices, and `count` was checked against both buffers.
+            (self.lib.all_reduce)(
+                send_ptr as *const c_void,
+                recv_ptr as *mut c_void,
+                count,
+                ncclDataType_t::ncclBfloat16,
+                ncclRedOp_t::ncclSum,
+                self.comm(rank)?,
+                stream,
+            )
+        };
+        self.lib.check(status, context)
+    }
+
+    fn all_reduce_f32(
+        &self,
+        rank: usize,
+        send: &CudaSlice<f32>,
+        recv: &mut CudaSlice<f32>,
+        count: usize,
+        stream: CUstream,
+        context: &str,
+    ) -> Result<()> {
+        ensure!(
+            send.len() >= count && recv.len() >= count,
+            "{context}: contribution buffer too small: send={}, recv={}, required={count}",
+            send.len(),
+            recv.len()
+        );
+        let stream_ref = recv.stream().clone();
+        let (send_ptr, _send_guard) = send.device_ptr(&stream_ref);
+        let (recv_ptr, _recv_guard) = recv.device_ptr_mut(&stream_ref);
+        let status = unsafe {
+            // SAFETY: Device pointers come from cudarc allocations and `count`
+            // was checked against both buffers before enqueueing the collective.
+            (self.lib.all_reduce)(
+                send_ptr as *const c_void,
+                recv_ptr as *mut c_void,
+                count,
+                ncclDataType_t::ncclFloat32,
+                ncclRedOp_t::ncclSum,
+                self.comm(rank)?,
+                stream,
+            )
+        };
+        self.lib.check(status, context)
+    }
+
+    fn comm(&self, rank: usize) -> Result<ncclComm_t> {
+        let comm = *self.comms.get(rank).ok_or_else(|| {
+            anyhow::anyhow!("DeepSeek-V2-Lite NCCL communicator rank {rank} is missing")
+        })?;
+        ensure!(
+            !comm.is_null(),
+            "DeepSeek-V2-Lite NCCL communicator rank {rank} is null"
+        );
+        Ok(comm)
+    }
+
+    fn grouped(&self, context: &str, f: impl FnOnce() -> Result<()>) -> Result<()> {
+        let start = unsafe {
+            // SAFETY: NCCL group state is process-global and entered/exited on
+            // this single host thread for the paired rank0/rank1 calls.
+            (self.lib.group_start)()
+        };
+        self.lib.check(start, &format!("{context}: group_start"))?;
+        let op_result = f();
+        let end = unsafe {
+            // SAFETY: Matches the successful `group_start` above.
+            (self.lib.group_end)()
+        };
+        let end_result = self.lib.check(end, &format!("{context}: group_end"));
+        op_result?;
+        end_result
+    }
+}
+
+impl Drop for NaiveNcclEp2Backend {
+    fn drop(&mut self) {
+        for comm in &mut self.comms {
+            if !comm.is_null() {
+                let _ = unsafe {
+                    // SAFETY: Best-effort teardown for communicator handles
+                    // returned by `ncclCommInitAll`.
+                    (self.lib.comm_abort)(*comm)
+                };
+                *comm = ptr::null_mut();
+            }
+        }
+    }
+}
+
+impl RawNcclLib {
+    fn load() -> Result<Self> {
+        let mut tried = Vec::new();
+        for candidate in ["libnccl.so.2", "libnccl.so"] {
+            tried.push(candidate);
+            let library = match unsafe {
+                // SAFETY: Loading NCCL is required to create the selected
+                // runtime backend. All symbols are validated immediately below.
+                Library::new(candidate)
+            } {
+                Ok(library) => library,
+                Err(_) => continue,
+            };
+            return unsafe {
+                // SAFETY: The library is kept alive inside `RawNcclLib`; copied
+                // function pointers do not outlive it.
+                Self::from_library(library)
+            }
+            .with_context(|| format!("load DeepSeek-V2-Lite NCCL backend from {candidate}"));
+        }
+        bail!(
+            "DeepSeek-V2-Lite NCCL backend could not load libnccl; tried {}",
+            tried.join(", ")
+        )
+    }
+
+    unsafe fn from_library(library: Library) -> Result<Self> {
+        Ok(Self {
+            comm_init_all: unsafe { load_symbol(&library, b"ncclCommInitAll\0")? },
+            comm_abort: unsafe { load_symbol(&library, b"ncclCommAbort\0")? },
+            group_start: unsafe { load_symbol(&library, b"ncclGroupStart\0")? },
+            group_end: unsafe { load_symbol(&library, b"ncclGroupEnd\0")? },
+            all_reduce: unsafe { load_symbol(&library, b"ncclAllReduce\0")? },
+            get_error_string: unsafe { load_symbol(&library, b"ncclGetErrorString\0")? },
+            _library: library,
+        })
+    }
+
+    fn check(&self, status: ncclResult_t, context: &str) -> Result<()> {
+        if status == ncclResult_t::ncclSuccess {
+            return Ok(());
+        }
+        let message = unsafe {
+            // SAFETY: NCCL returns a static null-terminated string for known
+            // result codes; null is handled defensively.
+            let ptr = (self.get_error_string)(status);
+            if ptr.is_null() {
+                format!("{status:?}")
+            } else {
+                CStr::from_ptr(ptr).to_string_lossy().into_owned()
+            }
+        };
+        bail!("{context} failed: {message} ({status:?})")
+    }
+}
+
+unsafe fn load_symbol<T: Copy>(library: &Library, symbol: &'static [u8]) -> Result<T> {
+    unsafe { library.get::<T>(symbol) }
+        .map(|symbol| *symbol)
+        .with_context(|| {
+            format!(
+                "DeepSeek-V2-Lite NCCL backend missing required symbol {}",
+                String::from_utf8_lossy(symbol).trim_end_matches('\0')
+            )
+        })
+}

--- a/pegainfer-deepseek-v2-lite/src/nccl_backend.rs
+++ b/pegainfer-deepseek-v2-lite/src/nccl_backend.rs
@@ -18,7 +18,6 @@ use crate::device::activate;
 type NcclCommInitAll = unsafe extern "C" fn(*mut ncclComm_t, c_int, *const c_int) -> ncclResult_t;
 type NcclCommCount = unsafe extern "C" fn(ncclComm_t, *mut c_int) -> ncclResult_t;
 type NcclCommCuDevice = unsafe extern "C" fn(ncclComm_t, *mut c_int) -> ncclResult_t;
-type NcclCommDestroy = unsafe extern "C" fn(ncclComm_t) -> ncclResult_t;
 type NcclCommAbort = unsafe extern "C" fn(ncclComm_t) -> ncclResult_t;
 type NcclGroupStart = unsafe extern "C" fn() -> ncclResult_t;
 type NcclGroupEnd = unsafe extern "C" fn() -> ncclResult_t;
@@ -43,7 +42,6 @@ struct RawNcclLib {
     comm_init_all: NcclCommInitAll,
     comm_count: NcclCommCount,
     comm_cu_device: NcclCommCuDevice,
-    comm_destroy: NcclCommDestroy,
     comm_abort: NcclCommAbort,
     group_start: NcclGroupStart,
     group_end: NcclGroupEnd,
@@ -353,18 +351,11 @@ impl Drop for NaiveNcclEp2Backend {
     fn drop(&mut self) {
         for comm in &mut self.comms {
             if !comm.is_null() {
-                let destroy_status = unsafe {
-                    // SAFETY: Best-effort clean teardown for communicator
-                    // handles returned by `ncclCommInitAll`.
-                    (self.lib.comm_destroy)(*comm)
+                let _ = unsafe {
+                    // SAFETY: Abort is non-collective and safe for
+                    // best-effort teardown in Drop.
+                    (self.lib.comm_abort)(*comm)
                 };
-                if destroy_status != ncclResult_t::ncclSuccess {
-                    let _ = unsafe {
-                        // SAFETY: Abort is the fallback when clean destroy
-                        // reports an error during best-effort Drop.
-                        (self.lib.comm_abort)(*comm)
-                    };
-                }
                 *comm = ptr::null_mut();
             }
         }
@@ -402,7 +393,6 @@ impl RawNcclLib {
             comm_init_all: unsafe { load_symbol(&library, b"ncclCommInitAll\0")? },
             comm_count: unsafe { load_symbol(&library, b"ncclCommCount\0")? },
             comm_cu_device: unsafe { load_symbol(&library, b"ncclCommCuDevice\0")? },
-            comm_destroy: unsafe { load_symbol(&library, b"ncclCommDestroy\0")? },
             comm_abort: unsafe { load_symbol(&library, b"ncclCommAbort\0")? },
             group_start: unsafe { load_symbol(&library, b"ncclGroupStart\0")? },
             group_end: unsafe { load_symbol(&library, b"ncclGroupEnd\0")? },

--- a/pegainfer-deepseek-v2-lite/src/runtime.rs
+++ b/pegainfer-deepseek-v2-lite/src/runtime.rs
@@ -43,6 +43,10 @@ pub struct GenerationStats {
     pub nccl_dispatch_local_routes: usize,
     pub nccl_dispatch_remote_routes: usize,
     pub nccl_combine_routes: usize,
+    pub nccl_dense_exchange_calls: usize,
+    pub nccl_combine_calls: usize,
+    pub nccl_dense_exchange_elements: usize,
+    pub nccl_combine_elements: usize,
     pub output_token_sha256: String,
 }
 
@@ -135,6 +139,14 @@ impl GenerationStats {
                 self.nccl_combine_routes += local_routes + remote_routes;
             }
         }
+    }
+
+    fn record_nccl_moe_collectives(&mut self, hidden_dim: usize, seq_len: usize) {
+        let elements = hidden_dim * seq_len;
+        self.nccl_dense_exchange_calls += 1;
+        self.nccl_combine_calls += 1;
+        self.nccl_dense_exchange_elements += elements;
+        self.nccl_combine_elements += elements;
     }
 }
 
@@ -335,7 +347,13 @@ impl DeepSeekV2LiteEp2Generator {
             MlpWeights::Dense(dense) => {
                 (dense_mlp_forward(&self.rank0.ctx, dense, &ffn_norm)?, 0, 0)
             }
-            MlpWeights::Moe(moe) => self.moe_forward(layer_idx, &ffn_norm, moe)?,
+            MlpWeights::Moe(moe) => {
+                let out = self.moe_forward(layer_idx, &ffn_norm, moe)?;
+                if self.backend.kind() == EpBackendKind::Nccl {
+                    stats.record_nccl_moe_collectives(ffn_norm.hidden_dim, ffn_norm.seq_len);
+                }
+                out
+            }
         };
         stats.record_routes(self.backend.kind(), local_routes, remote_routes);
         ops::add_batch(&self.rank0.ctx, &after_attn, &ffn_out)
@@ -476,8 +494,11 @@ impl DeepSeekV2LiteEp2Generator {
         let shared = dense_mlp_forward(&self.rank0.ctx, &moe.shared, input)?;
         let mut rank0_contrib = hidden_to_f32(&self.rank0.ctx, &shared)?;
         let mut rank1_contrib = vec![0.0f32; rank0_contrib.len()];
+        // NCCL covers only the dense hidden exchange and final contribution
+        // sum in this first gate. Route iteration and expert-output
+        // accumulation stay host-side so host-staged remains a simple oracle.
         let rank1_input =
-            nccl.dispatch_rank0_hidden_to_rank1(&self.rank0.ctx, &self.rank1.ctx, input)?;
+            nccl.dense_all_reduce_rank0_hidden_to_rank1(&self.rank0.ctx, &self.rank1.ctx, input)?;
         let mut local_routes = 0usize;
         let mut remote_routes = 0usize;
 

--- a/pegainfer-deepseek-v2-lite/src/runtime.rs
+++ b/pegainfer-deepseek-v2-lite/src/runtime.rs
@@ -19,23 +19,30 @@ use crate::{
         normalize_compressed_kv, topk_softmax_routes,
     },
     model::{
-        AttentionWeights, DriverRankModel, ExpertRankModel, MlpWeights, MoeMlp, dense_mlp_forward,
+        AttentionWeights, DriverRankModel, ExpertMlp, ExpertRankModel, MlpWeights, MoeMlp,
+        dense_mlp_forward,
     },
+    nccl_backend::NaiveNcclEp2Backend,
     weights::{ModelManifest, RankLoadPlan},
 };
 
 const EP_BACKEND_ENV: &str = "PEGAINFER_DSV2_LITE_EP_BACKEND";
 const HOST_STAGED_BACKEND: &str = "host-staged";
+const NCCL_BACKEND: &str = "nccl";
 
 #[derive(Clone, Debug, Default)]
 pub struct GenerationStats {
     pub model_path: PathBuf,
     pub device_ordinals: Vec<usize>,
+    pub ep_backend: String,
     pub ep_size: usize,
     pub prompt_tokens: usize,
     pub generated_tokens: usize,
     pub host_dispatch_local_routes: usize,
     pub host_dispatch_remote_routes: usize,
+    pub nccl_dispatch_local_routes: usize,
+    pub nccl_dispatch_remote_routes: usize,
+    pub nccl_combine_routes: usize,
     pub output_token_sha256: String,
 }
 
@@ -52,12 +59,84 @@ pub struct DeepSeekV2LiteEp2Generator {
     config: Config,
     rank0: DriverRankModel,
     rank1: ExpertRankModel,
+    backend: EpBackendRuntime,
 }
 
 // SAFETY: The generator is driven by exactly one worker thread after load. It
 // switches CUDA devices explicitly before every rank-local op and recreates the
 // thread-local cuBLAS handle when the active device changes.
 unsafe impl Send for DeepSeekV2LiteEp2Generator {}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum EpBackendKind {
+    HostStaged,
+    Nccl,
+}
+
+impl EpBackendKind {
+    fn from_env() -> Result<Self> {
+        let raw = env::var(EP_BACKEND_ENV).ok();
+        parse_backend(raw.as_deref())
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::HostStaged => HOST_STAGED_BACKEND,
+            Self::Nccl => NCCL_BACKEND,
+        }
+    }
+}
+
+enum EpBackendRuntime {
+    HostStaged,
+    Nccl(NaiveNcclEp2Backend),
+}
+
+impl EpBackendRuntime {
+    fn new(
+        kind: EpBackendKind,
+        rank0: &pegainfer_core::tensor::DeviceContext,
+        rank1: &pegainfer_core::tensor::DeviceContext,
+    ) -> Result<Self> {
+        match kind {
+            EpBackendKind::HostStaged => Ok(Self::HostStaged),
+            EpBackendKind::Nccl => Ok(Self::Nccl(NaiveNcclEp2Backend::new(rank0, rank1)?)),
+        }
+    }
+
+    fn kind(&self) -> EpBackendKind {
+        match self {
+            Self::HostStaged => EpBackendKind::HostStaged,
+            Self::Nccl(_) => EpBackendKind::Nccl,
+        }
+    }
+}
+
+fn parse_backend(raw: Option<&str>) -> Result<EpBackendKind> {
+    match raw.unwrap_or(HOST_STAGED_BACKEND) {
+        HOST_STAGED_BACKEND => Ok(EpBackendKind::HostStaged),
+        NCCL_BACKEND => Ok(EpBackendKind::Nccl),
+        other => bail!(
+            "DeepSeek-V2-Lite EP=2 backend '{other}' is not supported; supported backends: {HOST_STAGED_BACKEND}, {NCCL_BACKEND}"
+        ),
+    }
+}
+
+impl GenerationStats {
+    fn record_routes(&mut self, backend: EpBackendKind, local_routes: usize, remote_routes: usize) {
+        match backend {
+            EpBackendKind::HostStaged => {
+                self.host_dispatch_local_routes += local_routes;
+                self.host_dispatch_remote_routes += remote_routes;
+            }
+            EpBackendKind::Nccl => {
+                self.nccl_dispatch_local_routes += local_routes;
+                self.nccl_dispatch_remote_routes += remote_routes;
+                self.nccl_combine_routes += local_routes + remote_routes;
+            }
+        }
+    }
+}
 
 impl DeepSeekV2LiteEp2Generator {
     pub fn load(model_path: &Path, options: EngineLoadOptions) -> Result<Self> {
@@ -66,7 +145,7 @@ impl DeepSeekV2LiteEp2Generator {
             !options.enable_cuda_graph,
             "DeepSeek-V2-Lite EP=2 first gate requires cuda_graph disabled"
         );
-        validate_backend_and_devices(&options.device_ordinals)?;
+        let backend_kind = validate_backend_and_devices(&options.device_ordinals)?;
 
         let rank0_layout = ExpertParallelConfig::ep2(0).validate_for(&config)?;
         let rank1_layout = ExpertParallelConfig::ep2(1).validate_for(&config)?;
@@ -88,6 +167,7 @@ impl DeepSeekV2LiteEp2Generator {
             options.device_ordinals[1],
         )
         .context("load DeepSeek-V2-Lite EP rank 1")?;
+        let backend = EpBackendRuntime::new(backend_kind, &rank0.ctx, &rank1.ctx)?;
 
         Ok(Self {
             model_path: model_path.to_path_buf(),
@@ -95,6 +175,7 @@ impl DeepSeekV2LiteEp2Generator {
             config,
             rank0,
             rank1,
+            backend,
         })
     }
 
@@ -118,6 +199,7 @@ impl DeepSeekV2LiteEp2Generator {
         let mut stats = GenerationStats {
             model_path: self.model_path.clone(),
             device_ordinals: self.device_ordinals.clone(),
+            ep_backend: self.backend.kind().as_str().to_string(),
             ep_size: 2,
             prompt_tokens: prompt_tokens.len(),
             ..GenerationStats::default()
@@ -255,8 +337,7 @@ impl DeepSeekV2LiteEp2Generator {
             }
             MlpWeights::Moe(moe) => self.moe_forward(layer_idx, &ffn_norm, moe)?,
         };
-        stats.host_dispatch_local_routes += local_routes;
-        stats.host_dispatch_remote_routes += remote_routes;
+        stats.record_routes(self.backend.kind(), local_routes, remote_routes);
         ops::add_batch(&self.rank0.ctx, &after_attn, &ffn_out)
     }
 
@@ -327,6 +408,18 @@ impl DeepSeekV2LiteEp2Generator {
         input: &HiddenStates,
         moe: &MoeMlp,
     ) -> Result<(HiddenStates, usize, usize)> {
+        match &self.backend {
+            EpBackendRuntime::HostStaged => self.moe_forward_host_staged(layer_idx, input, moe),
+            EpBackendRuntime::Nccl(nccl) => self.moe_forward_nccl(nccl, layer_idx, input, moe),
+        }
+    }
+
+    fn moe_forward_host_staged(
+        &self,
+        layer_idx: usize,
+        input: &HiddenStates,
+        moe: &MoeMlp,
+    ) -> Result<(HiddenStates, usize, usize)> {
         activate(&self.rank0.ctx)?;
         let route_logits = ops::gemm(&self.rank0.ctx, &moe.gate, input)?;
         let route_logits_host = hidden_to_f32(&self.rank0.ctx, &route_logits)?;
@@ -362,6 +455,75 @@ impl DeepSeekV2LiteEp2Generator {
         let hidden = hidden_from_f32_host(
             &self.rank0.ctx,
             &accum,
+            self.config.hidden_size,
+            input.seq_len,
+        )?;
+        Ok((hidden, local_routes, remote_routes))
+    }
+
+    fn moe_forward_nccl(
+        &self,
+        nccl: &NaiveNcclEp2Backend,
+        layer_idx: usize,
+        input: &HiddenStates,
+        moe: &MoeMlp,
+    ) -> Result<(HiddenStates, usize, usize)> {
+        activate(&self.rank0.ctx)?;
+        let route_logits = ops::gemm(&self.rank0.ctx, &moe.gate, input)?;
+        let route_logits_host = hidden_to_f32(&self.rank0.ctx, &route_logits)?;
+        let routes = topk_softmax_routes(&self.config, &route_logits_host, input.seq_len);
+
+        let shared = dense_mlp_forward(&self.rank0.ctx, &moe.shared, input)?;
+        let mut rank0_contrib = hidden_to_f32(&self.rank0.ctx, &shared)?;
+        let mut rank1_contrib = vec![0.0f32; rank0_contrib.len()];
+        let rank1_input =
+            nccl.dispatch_rank0_hidden_to_rank1(&self.rank0.ctx, &self.rank1.ctx, input)?;
+        let mut local_routes = 0usize;
+        let mut remote_routes = 0usize;
+
+        for (token, token_routes) in routes.iter().enumerate() {
+            for &(global_expert, weight) in token_routes {
+                let owner_rank = self.rank0.layout.owner_rank(global_expert)?;
+                let (out, dst) = match owner_rank {
+                    0 => {
+                        local_routes += 1;
+                        let expert = self.rank0.routed_expert(layer_idx, global_expert)?;
+                        (
+                            expert_forward_device(&self.rank0.ctx, expert, input, token)?,
+                            &mut rank0_contrib,
+                        )
+                    }
+                    1 => {
+                        remote_routes += 1;
+                        let expert = self.rank1.routed_expert(layer_idx, global_expert)?;
+                        (
+                            expert_forward_device(&self.rank1.ctx, expert, &rank1_input, token)?,
+                            &mut rank1_contrib,
+                        )
+                    }
+                    other => {
+                        bail!("routed expert {global_expert} maps to unsupported EP rank {other}")
+                    }
+                };
+                let offset = token * self.config.hidden_size;
+                for (dst, value) in dst[offset..offset + self.config.hidden_size]
+                    .iter_mut()
+                    .zip(out)
+                {
+                    *dst += weight * value;
+                }
+            }
+        }
+
+        let combined = nccl.combine_f32_contributions_to_rank0(
+            &self.rank0.ctx,
+            &self.rank1.ctx,
+            &rank0_contrib,
+            &rank1_contrib,
+        )?;
+        let hidden = hidden_from_f32_host(
+            &self.rank0.ctx,
+            &combined,
             self.config.hidden_size,
             input.seq_len,
         )?;
@@ -406,7 +568,24 @@ impl DeepSeekV2LiteEp2Generator {
     }
 }
 
-fn validate_backend_and_devices(device_ordinals: &[usize]) -> Result<()> {
+fn expert_forward_device(
+    ctx: &pegainfer_core::tensor::DeviceContext,
+    expert: &ExpertMlp,
+    input: &HiddenStates,
+    token_idx: usize,
+) -> Result<Vec<f32>> {
+    activate(ctx)?;
+    let token = ops::extract_vec(ctx, input, token_idx)?;
+    let token_hidden = HiddenStates {
+        hidden_dim: token.len,
+        seq_len: 1,
+        data: token.data,
+    };
+    let out = dense_mlp_forward(ctx, &expert.dense, &token_hidden)?;
+    hidden_to_f32(ctx, &out)
+}
+
+fn validate_backend_and_devices(device_ordinals: &[usize]) -> Result<EpBackendKind> {
     ensure!(
         device_ordinals.len() == 2,
         "DeepSeek-V2-Lite first EP gate supports exactly 2 CUDA devices for ep_size=2, got {}",
@@ -417,12 +596,7 @@ fn validate_backend_and_devices(device_ordinals: &[usize]) -> Result<()> {
         "DeepSeek-V2-Lite EP=2 requires two distinct CUDA device ordinals, got {:?}",
         device_ordinals
     );
-    let backend = env::var(EP_BACKEND_ENV).unwrap_or_else(|_| HOST_STAGED_BACKEND.to_string());
-    ensure!(
-        backend == HOST_STAGED_BACKEND,
-        "DeepSeek-V2-Lite EP=2 backend '{backend}' is not supported by the first gate; supported backend: {HOST_STAGED_BACKEND}"
-    );
-    Ok(())
+    EpBackendKind::from_env()
 }
 
 fn token_sha256(tokens: &[u32]) -> String {
@@ -477,6 +651,27 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("two distinct CUDA device ordinals"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn ep_backend_defaults_to_host_staged() {
+        assert_eq!(parse_backend(None).unwrap(), EpBackendKind::HostStaged);
+    }
+
+    #[test]
+    fn ep_backend_accepts_nccl() {
+        assert_eq!(parse_backend(Some("nccl")).unwrap(), EpBackendKind::Nccl);
+    }
+
+    #[test]
+    fn ep_backend_rejects_unknown_backend() {
+        let err = parse_backend(Some("pplx")).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("supported backends: host-staged, nccl"),
             "unexpected error: {err:#}"
         );
     }

--- a/pegainfer-deepseek-v2-lite/tests/e2e_ep2.rs
+++ b/pegainfer-deepseek-v2-lite/tests/e2e_ep2.rs
@@ -14,6 +14,8 @@ const EXPECTED_OUTPUT_TOKEN_SHA256: &str =
     "f39e57d9b3eb949057ada9b3bc92f7f7037dfd19658dbe3ce145d8fad03ded5e";
 const EXPECTED_OUTPUT_TEXT_SHA256: &str =
     "a521f6dc9739b4506a46822da7c239ac558a879d571f54a064a4a2fbc3a097b7";
+const DSV2_LITE_HIDDEN_SIZE: usize = 2048;
+const DSV2_LITE_MOE_LAYERS: usize = 26;
 
 #[test]
 fn test_deepseek_v2_lite_ep2_rust_generation() -> Result<()> {
@@ -117,6 +119,13 @@ fn run_rust_generation(model_path: &Path) -> Result<()> {
                 result.stats.host_dispatch_local_routes > 0,
                 "host-staged EP gate did not exercise any local routed expert"
             );
+            ensure!(
+                result.stats.nccl_dense_exchange_calls == 0
+                    && result.stats.nccl_combine_calls == 0
+                    && result.stats.nccl_dense_exchange_elements == 0
+                    && result.stats.nccl_combine_elements == 0,
+                "host-staged EP gate unexpectedly recorded NCCL collectives"
+            );
         }
         "nccl" => {
             ensure!(
@@ -132,6 +141,32 @@ fn run_rust_generation(model_path: &Path) -> Result<()> {
                     == result.stats.nccl_dispatch_local_routes
                         + result.stats.nccl_dispatch_remote_routes,
                 "NCCL combine route accounting drift"
+            );
+            let expected_moe_calls = result.stats.generated_tokens * DSV2_LITE_MOE_LAYERS;
+            let expected_collective_elements = expected_moe_calls * DSV2_LITE_HIDDEN_SIZE;
+            ensure!(
+                result.stats.nccl_dense_exchange_calls == expected_moe_calls,
+                "NCCL dense hidden exchange call count drift: got {}, expected {}",
+                result.stats.nccl_dense_exchange_calls,
+                expected_moe_calls
+            );
+            ensure!(
+                result.stats.nccl_combine_calls == expected_moe_calls,
+                "NCCL combine call count drift: got {}, expected {}",
+                result.stats.nccl_combine_calls,
+                expected_moe_calls
+            );
+            ensure!(
+                result.stats.nccl_dense_exchange_elements == expected_collective_elements,
+                "NCCL dense hidden exchange element count drift: got {}, expected {}",
+                result.stats.nccl_dense_exchange_elements,
+                expected_collective_elements
+            );
+            ensure!(
+                result.stats.nccl_combine_elements == expected_collective_elements,
+                "NCCL combine element count drift: got {}, expected {}",
+                result.stats.nccl_combine_elements,
+                expected_collective_elements
             );
         }
         other => anyhow::bail!("unexpected DeepSeek-V2-Lite EP backend in E2E: {other}"),
@@ -165,6 +200,10 @@ fn run_rust_generation(model_path: &Path) -> Result<()> {
         "nccl_dispatch_local_routes": result.stats.nccl_dispatch_local_routes,
         "nccl_dispatch_remote_routes": result.stats.nccl_dispatch_remote_routes,
         "nccl_combine_routes": result.stats.nccl_combine_routes,
+        "nccl_dense_exchange_calls": result.stats.nccl_dense_exchange_calls,
+        "nccl_combine_calls": result.stats.nccl_combine_calls,
+        "nccl_dense_exchange_elements": result.stats.nccl_dense_exchange_elements,
+        "nccl_combine_elements": result.stats.nccl_combine_elements,
         "output_text": output_text,
     });
     println!("{}", serde_json::to_string_pretty(&payload)?);

--- a/pegainfer-deepseek-v2-lite/tests/e2e_ep2.rs
+++ b/pegainfer-deepseek-v2-lite/tests/e2e_ep2.rs
@@ -102,13 +102,40 @@ fn run_rust_generation(model_path: &Path) -> Result<()> {
         EXPECTED_OUTPUT_TOKEN_SHA256
     );
     ensure!(
-        result.stats.host_dispatch_remote_routes > 0,
-        "real EP gate did not exercise any remote routed expert"
+        result.stats.ep_backend == current_backend(),
+        "DeepSeek-V2-Lite E2E backend mismatch: got {}, expected {}",
+        result.stats.ep_backend,
+        current_backend()
     );
-    ensure!(
-        result.stats.host_dispatch_local_routes > 0,
-        "real EP gate did not exercise any local routed expert"
-    );
+    match result.stats.ep_backend.as_str() {
+        "host-staged" => {
+            ensure!(
+                result.stats.host_dispatch_remote_routes > 0,
+                "host-staged EP gate did not exercise any remote routed expert"
+            );
+            ensure!(
+                result.stats.host_dispatch_local_routes > 0,
+                "host-staged EP gate did not exercise any local routed expert"
+            );
+        }
+        "nccl" => {
+            ensure!(
+                result.stats.nccl_dispatch_remote_routes > 0,
+                "NCCL EP gate did not exercise any remote routed expert"
+            );
+            ensure!(
+                result.stats.nccl_dispatch_local_routes > 0,
+                "NCCL EP gate did not exercise any local routed expert"
+            );
+            ensure!(
+                result.stats.nccl_combine_routes
+                    == result.stats.nccl_dispatch_local_routes
+                        + result.stats.nccl_dispatch_remote_routes,
+                "NCCL combine route accounting drift"
+            );
+        }
+        other => anyhow::bail!("unexpected DeepSeek-V2-Lite EP backend in E2E: {other}"),
+    }
 
     let output_text = tokenizer
         .decode(&result.tokens, false)
@@ -126,6 +153,7 @@ fn run_rust_generation(model_path: &Path) -> Result<()> {
         "model_path": model_path,
         "gpu_count": 2,
         "ep_size": result.stats.ep_size,
+        "ep_backend": result.stats.ep_backend,
         "devices": result.stats.device_ordinals,
         "prompt": prompt,
         "prompt_tokens": result.stats.prompt_tokens,
@@ -134,8 +162,15 @@ fn run_rust_generation(model_path: &Path) -> Result<()> {
         "output_text_sha256": output_text_sha256,
         "host_dispatch_local_routes": result.stats.host_dispatch_local_routes,
         "host_dispatch_remote_routes": result.stats.host_dispatch_remote_routes,
+        "nccl_dispatch_local_routes": result.stats.nccl_dispatch_local_routes,
+        "nccl_dispatch_remote_routes": result.stats.nccl_dispatch_remote_routes,
+        "nccl_combine_routes": result.stats.nccl_combine_routes,
         "output_text": output_text,
     });
     println!("{}", serde_json::to_string_pretty(&payload)?);
     Ok(())
+}
+
+fn current_backend() -> String {
+    env::var("PEGAINFER_DSV2_LITE_EP_BACKEND").unwrap_or_else(|_| "host-staged".to_string())
 }

--- a/pegainfer-engine/src/engine.rs
+++ b/pegainfer-engine/src/engine.rs
@@ -1,4 +1,8 @@
-use std::path::PathBuf;
+use std::{
+    path::PathBuf,
+    sync::Arc,
+    thread::{self, JoinHandle},
+};
 
 use tokio::sync::mpsc;
 
@@ -88,18 +92,90 @@ pub enum TokenEvent {
 
 #[derive(Clone)]
 pub struct EngineHandle {
-    submit_tx: mpsc::UnboundedSender<GenerateRequest>,
+    inner: Arc<EngineInner>,
+}
+
+struct EngineInner {
+    submit_tx: Option<mpsc::UnboundedSender<GenerateRequest>>,
+    join_handle: Option<JoinHandle<()>>,
 }
 
 impl EngineHandle {
     pub fn new(submit_tx: mpsc::UnboundedSender<GenerateRequest>) -> Self {
-        Self { submit_tx }
+        Self::from_parts(submit_tx, None)
+    }
+
+    /// Construct a handle that owns the engine thread shutdown.
+    ///
+    /// Dropping the last handle clone closes the submit channel and then waits
+    /// for the thread to return. That final drop may block until in-flight
+    /// generation and backend teardown finish.
+    pub fn new_with_join_handle(
+        submit_tx: mpsc::UnboundedSender<GenerateRequest>,
+        join_handle: JoinHandle<()>,
+    ) -> Self {
+        Self::from_parts(submit_tx, Some(join_handle))
+    }
+
+    fn from_parts(
+        submit_tx: mpsc::UnboundedSender<GenerateRequest>,
+        join_handle: Option<JoinHandle<()>>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(EngineInner {
+                submit_tx: Some(submit_tx),
+                join_handle,
+            }),
+        }
     }
 
     pub fn submit(
         &self,
         req: GenerateRequest,
     ) -> std::result::Result<(), mpsc::error::SendError<GenerateRequest>> {
-        self.submit_tx.send(req)
+        match self.inner.submit_tx.as_ref() {
+            Some(submit_tx) => submit_tx.send(req),
+            None => Err(mpsc::error::SendError(req)),
+        }
+    }
+}
+
+impl Drop for EngineInner {
+    fn drop(&mut self) {
+        let _ = self.submit_tx.take();
+        if let Some(join_handle) = self.join_handle.take() {
+            if join_handle.thread().id() != thread::current().id() {
+                let _ = join_handle.join();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+
+    use super::*;
+
+    #[test]
+    fn joins_owned_thread_after_last_handle_drop() {
+        let (submit_tx, mut submit_rx) = mpsc::unbounded_channel::<GenerateRequest>();
+        let exited = Arc::new(AtomicBool::new(false));
+        let thread_exited = Arc::clone(&exited);
+        let join_handle = thread::spawn(move || {
+            while submit_rx.blocking_recv().is_some() {}
+            thread_exited.store(true, Ordering::SeqCst);
+        });
+        let handle = EngineHandle::new_with_join_handle(submit_tx, join_handle);
+        let clone = handle.clone();
+
+        drop(handle);
+        assert!(!exited.load(Ordering::SeqCst));
+
+        drop(clone);
+        assert!(exited.load(Ordering::SeqCst));
     }
 }


### PR DESCRIPTION
## Summary

Part of #135. Follow-up to #149.

This adds a correctness-first naive NCCL backend for DeepSeek-V2-Lite EP=2. The existing host-staged path remains the default baseline / fallback, and the NCCL path is enabled explicitly with:

```bash
PEGAINFER_DSV2_LITE_EP_BACKEND=nccl
```
The EP layout stays fixed to:
- rank 0: routed experts 0..31
- rank 1: routed experts 32..63

The NCCL path is intentionally a dense correctness exchange, not sparse routed dispatch: rank0 contributes hidden states, rank1 contributes zeros, then both ranks all-reduce; final rank0/rank1 f32 contributions are combined with another all-reduce.
## Evidence
Static / build checks:
```
cargo fmt --check
git diff --check
cargo check --release -p pegainfer-comm
cargo check --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite
cargo check --release -p pegainfer-server --features deepseek-v2-lite
cargo test --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite --lib -- --nocapture
cargo test --release -p pegainfer-engine --lib
```
2GPU E2E:
- host-staged backend: passed, generated 16 tokens
- NCCL backend: passed, generated 16 tokens
- token hash matched:
    f39e57d9b3eb949057ada9b3bc92f7f7037dfd19658dbe3ce145d8fad03ded5e
- text hash matched:
    a521f6dc9739b4506a46822da7c239ac558a879d571f54a064a4a2fbc3a097b7
- NCCL collective coverage:
  - dense exchange calls: 416
  - combine calls: 416
  - dense exchange elements: 851968
  - combine elements: 851968

Benchmark smoke:
- host-staged: generated all requested tokens and exited successfully
- NCCL: generated all requested tokens and exited successfully
Smoke only; no throughput or production-performance claim. 
## Claim Boundary
This PR proves the naive NCCL EP2 path matches the existing host-staged baseline for the covered single-node 2GPU greedy E2E case.
It does not claim production EP readiness, NVLink performance, throughput improvement, general EP topology support, or HF accuracy parity.
## Follow-up
Next step is a narrow HF ground-truth comparison for the same DSV2-Lite EP2 greedy case: batch=1, prompt Hello, output_len=16.

If HF and pegainfer align, that can become the first accuracy gate. If not, the NCCL result remains transport-equivalence evidence, and the baseline accuracy gap should be debugged separately before changing the NCCL path.
