### PR TITLE
feat(qwen3): add runtime traced model report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3622,6 +3622,7 @@ dependencies = [
  "cc",
  "cudarc",
  "half",
+ "serde",
 ]
 
 [[package]]
@@ -3630,6 +3631,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "comfy-table",
  "crossbeam-channel",
  "cudarc",
  "fastrace",

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,7 +76,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 | Path | TL;DR |
 | --- | --- |
 | `subsystems/kernels/pegainfer-kernels-boundary.md` | Architecture decision: pegainfer should use reusable frontend/runtime/data-plane layers plus per-model engines; kernels become first-class assets through a ledger, simulator, and request tracing. |
-| `subsystems/kernels/kernel-op-reports.md` | Qwen3 kernel report moved to a feature-gated bin; full raw-CUPTI decode/prefill reports, split prefill stages, 10k attention-core comparisons, BF16-HMMA tensor metrics, FlashInfer FMHA v2/package measurements, and measured FA2 `CTA_TILE_Q=64` prefill default in place. |
+| `subsystems/kernels/kernel-op-reports.md` | Qwen3 kernel/report tooling is feature-gated: `qwen3_kernel_report` covers per-op kernel reports, and `qwen3_model_report` emits runtime-traced eager-DAG decode operator rollups with TensorSpec `KernelCall`s, latency stats, tables, and Graphviz DOT; measured FA2 `CTA_TILE_Q=64` prefill default in place. |
 
 ## playbooks
 

--- a/docs/subsystems/kernels/kernel-op-reports.md
+++ b/docs/subsystems/kernels/kernel-op-reports.md
@@ -1,8 +1,9 @@
 # Kernel Op Reports
 
 **Created**: 2026-05-04
+**Last touched**: 2026-05
 **Status**: active; prefill/report commit ready, decode tuning deferred
-**TL;DR**: `qwen3_kernel_snapshot` is no longer a Cargo bench. Qwen3 now has a feature-gated `qwen3_kernel_report` bin that reads `kernel_manifests/qwen3-4b.toml`, emits cold-L2 per-op reports for paged decode and paged prefill attention, stores raw CUPTI metric maps without runner-owned diagnosis labels, compares reports, and composes measured decode op reports into phase contribution reports. Prefill is split into QK+RoPE, KV scatter, and attention-core stage reports; at `seq_len=10000`, the attention core dominates and contiguous single-request FlashInfer is only `1.008x` faster than the paged path. FlashInfer FMHA v2 was measured and is slower on RTX 5090 for this shape, while the measured FA2 `CTA_TILE_Q=64` path wins the single-request prefill grid and is now the Qwen3 production prefill default.
+**TL;DR**: `qwen3_kernel_snapshot` is no longer a Cargo bench. Qwen3 has feature-gated `qwen3_kernel_report` per-op kernel tooling and `qwen3_model_report` model-level decode operator reporting. Decode now routes through an eager `BatchDecodeDag`, so the executable forward sequence is also the `KernelCall` contract source for runtime tracing; `qwen3_model_report` disables CUDA Graph, traces that DAG, then joins traced TensorSpecs against measured microbench results to emit by-op, by-call-site, coverage, schedule-preview, latency-stat, and Graphviz DOT reports. Prefill remains covered by `qwen3_kernel_report` stage reports; measured FA2 `CTA_TILE_Q=64` is the Qwen3 production prefill default on the RTX 5090 grid.
 
 ## Preparation
 
@@ -365,9 +366,83 @@
   - `PEGAINFER_CUDA_SM=120 PEGAINFER_TRITON_PYTHON=<python-venv>/bin/python cargo clippy --release -p pegainfer-qwen3-4b --features kernel-report --all-targets -- -D warnings`
   - `PEGAINFER_CUDA_SM=120 PEGAINFER_TRITON_PYTHON=<python-venv>/bin/python cargo clippy --release -p pegainfer --bin pegainfer -- -D warnings`
 
+### Step 21: Add runtime-traced Qwen3 model operator report
+- Added non-enum tensor metadata vocabulary under `pegainfer-kernels/src/tensor.rs`:
+  - marker traits for dtype, layout, and axis tags;
+  - erased `TensorSpec`, `TensorArg`, `AttrSpec`, and `KernelCall` for schedules, reports, and future instrumentation.
+- Added `pegainfer-core::ops::call_spec` builders so op TensorSpec construction lives next to op wrappers, not in the model-report CLI.
+- Added `pegainfer-core::ops::call_trace` and traced op wrappers behind the `kernel-call-trace` feature. Normal Qwen3 builds re-export the direct kernel ops and compile out trace labels/recording. The `pegainfer-qwen3-4b` `kernel-report` feature enables `kernel-call-trace`.
+- Wired Qwen3 batch decode labels into the actual `batch_decode` path through feature-gated macros, so label formatting and trace collection disappear when the feature is off. The trace path forces CUDA Graph off before recording.
+- Added `qwen3_model_report`, a feature-gated per-model CLI:
+  - `cargo run --release -p pegainfer-qwen3-4b --features kernel-report --bin qwen3_model_report -- decode --batch-size 16 --kv-len 2048 --format text`
+  - The CLI loads `models/Qwen3-4B` by default, creates KV state for the requested decode context, runs one real `batch_decode` trace, microbenches the traced KernelCalls, and emits JSON under `target/model_reports/qwen3-4b/`.
+  - Missing bench providers fail loudly with the missing `op`, `label`, and TensorSpec; no estimated or nearest-neighbor rows are used.
+- Validation:
+  - `cargo fmt --all --check` passed.
+  - `git diff --check` passed.
+  - `cargo check --release -p pegainfer-qwen3-4b --lib` passed, confirming trace wrappers are not required for the normal library path.
+  - `cargo check --release -p pegainfer-qwen3-4b --features kernel-report --bin qwen3_model_report` passed.
+  - `cargo run --release -p pegainfer-qwen3-4b --features kernel-report --bin qwen3_model_report -- decode --batch-size 16 --kv-len 2048 --format text` passed and wrote `target/model_reports/qwen3-4b/decode-bs16-kv2048.json`.
+  - JSON audit confirmed `model/phase/config/schedule/by_op/by_call_site/coverage` are present, `schedule_source` is `runtime trace: Qwen3Model::batch_decode with CUDA Graph disabled`, and paged KV is represented as `bf16[page, layer, kv, pos_in_page, kv_head, head_dim] layout=paged_kv_page_first`.
+  - `cargo test --release -p pegainfer-qwen3-4b --lib` passed: `7 passed`.
+
+### Step 22: Add latency stats, readable tables, and DOT output
+- `qwen3_model_report` now records latency samples per unique traced `KernelCall` instead of a single mean. JSON schema `2` includes `mean_us`, sample `stddev_us`, `min_us`, `p50_us`, `p95_us`, `p99_us`, and `max_us`.
+- Default report iterations increased from `8` to `32` so p99 has enough samples to be useful for quick operator diagnostics.
+- Text output now uses `comfy-table` for by-op, by-call-site, coverage, and compact schedule-preview sections. The detailed TensorSpec schedule stays in JSON.
+- Each run writes a sibling Graphviz DOT file next to the JSON, for example:
+  - `target/model_reports/qwen3-4b/decode-bs16-kv2048.json`
+  - `target/model_reports/qwen3-4b/decode-bs16-kv2048.dot`
+- Validation:
+  - `cargo check --release -p pegainfer-qwen3-4b --features kernel-report --bin qwen3_model_report` passed.
+  - `cargo run --release -p pegainfer-qwen3-4b --features kernel-report --bin qwen3_model_report -- decode --batch-size 16 --kv-len 2048 --format text` passed and wrote JSON plus DOT.
+  - `dot -Tsvg target/model_reports/qwen3-4b/decode-bs16-kv2048.dot -o /tmp/qwen3-model-report.svg` passed.
+  - JSON audit confirmed schema `2`, default `iters=32`, and `stddev_us` / `p99_us` fields in by-op rows.
+  - `cargo fmt --all --check`, `git diff --check`, and `cargo check --release -p pegainfer-qwen3-4b --lib` passed.
+
+### Step 23: Make decode tracing come from an eager DAG builder
+- Added `pegainfer-qwen3-4b/src/batch_decode_dag.rs`.
+- `BatchDecodeDag` is eager: each method records the op's `KernelCall` contract when `kernel-call-trace` is active and immediately launches the production kernel. The batch decode forward path now calls DAG methods instead of wrapping free-form op calls with ad hoc trace labels.
+- Normal builds still compile out label construction through `dag_label!`; the `kernel-report` feature enables labels and `KernelCall` recording.
+- `all_reduce_hidden` now has an untraced internal path so the DAG builder owns decode all-reduce trace records without double-counting.
+- Validation:
+  - `cargo check --release -p pegainfer-qwen3-4b --lib` passed.
+  - `cargo check --release -p pegainfer-qwen3-4b --features kernel-report --bin qwen3_model_report` passed.
+  - `cargo run --release -p pegainfer-qwen3-4b --features kernel-report --bin qwen3_model_report -- decode --batch-size 16 --kv-len 2048 --format text` passed; by-op counts remained `gemm=109`, `gemm_rows=108`, `paged_decode_attention=36`, `all_reduce_hidden=72`.
+
+### Step 24: Check eager-DAG decode runtime impact
+- Ran current worktree decode-heavy request benchmark:
+  - `cargo run --release --bin bench_serving -- --model-path models/Qwen3-4B request --prompt-len 1024 --output-len 256 --warmup 5 --iters 20`
+  - Result: `steady_tpot_ms p50=11.33`, `p95=11.35`, `p99=11.45`, samples `5080`.
+- Ran current worktree fixed-context decode probe:
+  - `target/release/qwen3_decode_context --model-path models/Qwen3-4B --contexts 1024 --iters 20`
+  - Result: `p50=11.3781ms`, `avg=11.6660ms`.
+- Built a detached baseline worktree at `HEAD=3ffe745` and ran the same fixed-context decode probe on the same GPU/model:
+  - `PEGAINFER_TRITON_PYTHON=/data/code/workspace-rustllm/pegainfer/.venv/bin/python cargo run --release -p pegainfer-qwen3-4b --bin qwen3_decode_context --manifest-path /tmp/pegainfer-bench-baseline/Cargo.toml -- --model-path /data/code/workspace-rustllm/pegainfer/models/Qwen3-4B --contexts 1024 --iters 20`
+  - Result: `p50=11.3610ms`, `avg=11.6449ms`.
+- Interpretation: eager DAG is not measurable as a decode overhead in this probe. Current worktree vs same-machine `HEAD` baseline is `+0.0171ms` p50 (`+0.15%`), well under the benchmark-regression `2%` TPOT threshold.
+- The standard `bench_serving snapshot --warmup 5 --iters 20` could not complete because `prefill-heavy (10000,1)` hit CUDA OOM on this run. The existing tracked `bench_snapshots/rtx-5090/qwen3-4b.json` was restored from backup after the failed snapshot attempt.
+- Existing snapshot data at `bench_snapshots/rtx-5090/qwen3-4b.json` still has `steady_tpot_ms p50=7.559606ms`, which is much faster than both current worktree and detached `HEAD` measurements on this machine. Since detached `HEAD` reproduces the same `~11.36ms` fixed-context number as the eager-DAG worktree, that older snapshot delta is not attributable to the eager DAG change.
+
+### Step 25: PR readiness cleanup
+- Cleaned release clippy findings surfaced by the model-report work:
+  - `pegainfer-kernels::tensor::KernelCall` builder methods are now `#[must_use]`, and attrs are explicitly string-valued at the erased report boundary.
+  - `pegainfer-kernels/build.rs` and `pegainfer-core/src/cpu_topology.rs` no longer trip release clippy on `map(...).unwrap_or_else(...)`, raw pointer borrows, or redundant closures.
+  - Qwen3 e2e/regen tests and `qwen3_model_report` text/DOT rendering now pass the all-targets clippy style gates.
+- Local checks passed:
+  - `cargo fmt --all --check`
+  - `git diff --check`
+  - `cargo clippy --release -p pegainfer-qwen3-4b --features kernel-report --all-targets -- -D warnings`
+  - `cargo test --release -p pegainfer-qwen3-4b --lib`
+  - `cargo run --release -p pegainfer-qwen3-4b --features kernel-report --bin qwen3_model_report -- decode --batch-size 16 --kv-len 2048 --format text`
+- Qwen3-4B e2e was run with an absolute model path:
+  - `PEGAINFER_TEST_MODEL_PATH=/data/code/workspace-rustllm/pegainfer/models/Qwen3-4B cargo test --release -p pegainfer-qwen3-4b --test e2e -- --nocapture`
+  - Current worktree produced greedy-output mismatches on repeated runs.
+  - A detached baseline worktree at `HEAD=3ffe745` reproduced the same Kanye prompt mismatch, so this e2e failure is not introduced by the eager-DAG/model-report changes.
+
 ## Debrief
 
-- **Outcome**: Replaced the Qwen3 kernel snapshot bench with a normal, feature-gated `qwen3_kernel_report` binary. The runner now covers paged decode attention, paged prefill attention, split prefill stages, and contiguous single-request prefill attention core with cold-L2 latency only. GPU manifest runs passed for decode/prefill, targeted 10k stage comparisons passed for paged `bs=1`, single contiguous `bs=1`, and paged `bs=2`, FlashInfer Python/package alternatives were measured for the same Qwen3 10k BF16 prefill attention-core shape, and Qwen3 production prefill now uses measured FA2 `CTA_TILE_Q=64`.
+- **Outcome**: Replaced the Qwen3 kernel snapshot bench with a normal, feature-gated `qwen3_kernel_report` binary and added `qwen3_model_report` for runtime-traced decode operator reports. The runner now covers paged decode attention, paged prefill attention, split prefill stages, and contiguous single-request prefill attention core with cold-L2 latency only. GPU manifest runs passed for decode/prefill, targeted 10k stage comparisons passed for paged `bs=1`, single contiguous `bs=1`, and paged `bs=2`, FlashInfer Python/package alternatives were measured for the same Qwen3 10k BF16 prefill attention-core shape, Qwen3 production prefill now uses measured FA2 `CTA_TILE_Q=64`, model-level decode reports now emit latency stats, readable tables, and Graphviz DOT, and decode tracing now comes from the same eager DAG builder that launches the kernels.
 - **Pitfalls encountered**:
   - `cargo bench` appends a trailing `--bench` argument to `harness=false` binaries. That made the new `clap` parser fail and confirmed this should be a real bin, not a bench target.
   - A normal `src/bin` target cannot use dev-dependencies. Making report-only dependencies ordinary non-optional dependencies would pull CUPTI into default Qwen3/server builds, so the bin now uses `required-features = ["kernel-report"]`.
@@ -376,6 +451,7 @@
   - FlashInfer's JIT environment treats `FLASHINFER_JIT_VERBOSE=1` as a debug build switch for backward compatibility. The first FMHA v2 cache contained `-O0 -G`; those results were discarded, and the release measurement used a separate cache directory with explicit debug flags disabled.
   - The official `flashinfer-python 0.6.6` package did not expose `trtllm_fmha_v2_prefill`. Its public `trtllm-gen` wrapper also has a plan-argument bug with explicit max lengths and then reports unsupported architecture on RTX 5090 once that is worked around.
   - The temporary validation worktree does not have model weights under the default model path, so model-loading tests fail with `No such file or directory`. For kernel-report work, keep using report binaries and release builds unless a model path is explicitly staged.
+  - The local Qwen3-4B e2e greedy baseline can fail on `HEAD=3ffe745` with the same Kanye prompt mismatch seen in this worktree. Treat that as a separate baseline/test-data issue, not as evidence against the eager-DAG/model-report PR.
 - **Lessons learned**:
   - Kernel reporting should be treated as tooling, not benchmarking harness plumbing. Cargo bench's hidden behavior is a poor fit for a manifest-driven CLI.
   - Report tooling that needs profiler libraries should be feature-gated from the production model crate dependency graph.

--- a/pegainfer-core/Cargo.toml
+++ b/pegainfer-core/Cargo.toml
@@ -19,5 +19,9 @@ safetensors = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 
+[features]
+default = []
+kernel-call-trace = []
+
 [lints]
 workspace = true

--- a/pegainfer-core/src/cpu_topology.rs
+++ b/pegainfer-core/src/cpu_topology.rs
@@ -112,7 +112,7 @@ pub fn current_allowed_cpus() -> Result<Vec<CpuId>> {
     unsafe {
         let mut allowed: libc::cpu_set_t = std::mem::zeroed();
         let set_size = std::mem::size_of::<libc::cpu_set_t>();
-        let ret = libc::sched_getaffinity(0, set_size, &mut allowed);
+        let ret = libc::sched_getaffinity(0, set_size, std::ptr::addr_of_mut!(allowed));
         ensure!(ret == 0, "sched_getaffinity failed with errno {}", errno());
 
         let mut cpus = Vec::new();
@@ -132,7 +132,11 @@ pub fn pin_current_thread_to_cpu(cpu: CpuId) -> Result<()> {
         libc::CPU_ZERO(&mut target);
         libc::CPU_SET(cpu.as_usize(), &mut target);
         let set_size = std::mem::size_of::<libc::cpu_set_t>();
-        let ret = libc::pthread_setaffinity_np(libc::pthread_self(), set_size, &target);
+        let ret = libc::pthread_setaffinity_np(
+            libc::pthread_self(),
+            set_size,
+            std::ptr::addr_of!(target),
+        );
         ensure!(
             ret == 0,
             "pthread_setaffinity_np failed for CPU {cpu} with errno {ret}"
@@ -152,7 +156,7 @@ pub fn cuda_device_pci_bus_id(device_ordinal: usize) -> Result<String> {
             .map_err(|err| anyhow::anyhow!("{err:?}"))?;
         CStr::from_ptr(buf.as_ptr())
             .to_str()
-            .map(|bus_id| bus_id.to_ascii_lowercase())
+            .map(str::to_ascii_lowercase)
             .map_err(anyhow::Error::msg)
     }
 }

--- a/pegainfer-core/src/ops.rs
+++ b/pegainfer-core/src/ops.rs
@@ -1,8 +1,13 @@
 //! Shared GPU operation wrappers and kernel-crate re-exports.
 
 mod attention;
+pub mod call_spec;
+#[cfg(feature = "kernel-call-trace")]
+pub mod call_trace;
 mod paged_plan;
 mod sampling;
+#[cfg(feature = "kernel-call-trace")]
+mod traced;
 
 pub use attention::{
     paged_attention_batch_decode_hd256_into, paged_attention_batch_decode_into,
@@ -10,11 +15,19 @@ pub use attention::{
 };
 pub use paged_plan::PrefillPagedPlan;
 pub use pegainfer_kernels::ops::{
-    add_batch, add_batch_into, embedding_batch, embedding_decode_into, extract_vec,
-    extract_vec_into, fused_add_rms_norm_batch_into, fused_add_rms_norm_into, gemm, gemm_into,
-    gemm_rows_into, gemv, linear, qk_norm_partial_rope_batched_decode_hd256_into,
-    qk_norm_rope_batch_decode_into, rms_norm, rms_norm_batch_into, rms_norm_batch_offset_into,
-    rms_norm_gated_batch_into, rms_norm_into, rms_norm_offset_into, silu_mul_batch,
-    silu_mul_batch_into, silu_mul_fused_batch_into, write_vec_into,
+    add_batch, add_batch_into, embedding_decode_into, extract_vec, extract_vec_into,
+    fused_add_rms_norm_into, gemm, gemv, linear, qk_norm_partial_rope_batched_decode_hd256_into,
+    rms_norm, rms_norm_batch_offset_into, rms_norm_gated_batch_into, rms_norm_into,
+    rms_norm_offset_into, silu_mul_batch, silu_mul_batch_into, write_vec_into,
+};
+#[cfg(not(feature = "kernel-call-trace"))]
+pub use pegainfer_kernels::ops::{
+    embedding_batch, fused_add_rms_norm_batch_into, gemm_into, gemm_rows_into,
+    qk_norm_rope_batch_decode_into, rms_norm_batch_into, silu_mul_fused_batch_into,
 };
 pub use sampling::{argmax, flashinfer_topk_row_states_bytes, gpu_sample, gpu_sample_into};
+#[cfg(feature = "kernel-call-trace")]
+pub use traced::{
+    embedding_batch, fused_add_rms_norm_batch_into, gemm_into, gemm_rows_into,
+    qk_norm_rope_batch_decode_into, rms_norm_batch_into, silu_mul_fused_batch_into,
+};

--- a/pegainfer-core/src/ops/attention.rs
+++ b/pegainfer-core/src/ops/attention.rs
@@ -3,6 +3,10 @@ use cudarc::driver::CudaSlice;
 use half::bf16;
 
 use super::PrefillPagedPlan;
+#[cfg(feature = "kernel-call-trace")]
+use super::call_trace;
+#[cfg(feature = "kernel-call-trace")]
+use super::traced;
 use crate::kv_pool::KvLayout;
 use crate::tensor::{DeviceContext, DeviceVec, HiddenStates};
 
@@ -69,6 +73,20 @@ pub fn paged_attention_batch_decode_into(
     num_qo_heads: usize,
     batch_size: usize,
 ) -> Result<()> {
+    #[cfg(feature = "kernel-call-trace")]
+    if call_trace::is_enabled() {
+        let label = call_trace::current_label("paged_decode_attention");
+        call_trace::record_call(traced::paged_decode_call_spec(
+            label,
+            q,
+            k,
+            kv_buffer.len(),
+            layout,
+            num_qo_heads,
+            batch_size,
+            "non_partition",
+        ));
+    }
     pegainfer_kernels::ops::paged_attention_batch_decode_into(
         ctx,
         q,
@@ -116,6 +134,20 @@ pub fn paged_attention_batch_decode_split_kv_into(
     num_qo_heads: usize,
     batch_size: usize,
 ) -> Result<()> {
+    #[cfg(feature = "kernel-call-trace")]
+    if call_trace::is_enabled() {
+        let label = call_trace::current_label("paged_decode_attention");
+        call_trace::record_call(traced::paged_decode_call_spec(
+            label,
+            q,
+            k,
+            kv_buffer.len(),
+            layout,
+            num_qo_heads,
+            batch_size,
+            "split_kv_256x64",
+        ));
+    }
     pegainfer_kernels::ops::paged_attention_batch_decode_split_kv_into(
         ctx,
         q,

--- a/pegainfer-core/src/ops/call_spec.rs
+++ b/pegainfer-core/src/ops/call_spec.rs
@@ -1,0 +1,251 @@
+use pegainfer_kernels::tensor::{
+    AxisSpec, AxisTag, Batch, BatchPlusOne, Bf16, Contiguous1D, F32, HeadDim, Hidden,
+    HiddenStatesLayout, I32, InDim, Inter2, Intermediate, KernelCall, Kv, KvDim, KvHead, Layer,
+    OutDim, OutTotal, Page, PageSlot, PagedKvPageFirst, PosInPage, QDim, RopeDim, RowMajor2D, Seq,
+    TensorSpec, Tile, Token, U32, Vocab,
+};
+
+#[derive(Clone, Copy, Debug)]
+pub struct PagedDecodeCallSpec {
+    pub batch_size: usize,
+    pub total_pages: usize,
+    pub num_layers: usize,
+    pub page_size: usize,
+    pub q_dim: usize,
+    pub kv_dim: usize,
+    pub num_q_heads: usize,
+    pub num_kv_heads: usize,
+    pub head_dim: usize,
+    pub kv_len: usize,
+    pub variant: &'static str,
+}
+
+pub fn embedding_batch_call(
+    label: impl Into<String>,
+    vocab: usize,
+    hidden: usize,
+    batch: usize,
+) -> KernelCall {
+    KernelCall::new("embedding_batch", label)
+        .input("weight", embed_table(vocab, hidden))
+        .input("token_ids", token_ids(batch))
+        .output("out", hidden_batch::<Hidden>(hidden, batch))
+}
+
+pub fn rms_norm_batch_call<A: AxisTag>(
+    label: impl Into<String>,
+    dim: usize,
+    batch: usize,
+    eps: f32,
+) -> KernelCall {
+    KernelCall::new("rms_norm_batch", label)
+        .input("x", hidden_batch::<A>(dim, batch))
+        .input("weight", vector::<A, Bf16>(dim))
+        .output("out", hidden_batch::<A>(dim, batch))
+        .attr("eps", eps.to_string())
+}
+
+pub fn fused_add_rms_norm_batch_call<A: AxisTag>(
+    label: impl Into<String>,
+    dim: usize,
+    batch: usize,
+    eps: f32,
+) -> KernelCall {
+    KernelCall::new("fused_add_rms_norm_batch", label)
+        .input("hidden", hidden_batch::<A>(dim, batch))
+        .input("residual", hidden_batch::<A>(dim, batch))
+        .input("weight", vector::<A, Bf16>(dim))
+        .output("out", hidden_batch::<A>(dim, batch))
+        .attr("eps", eps.to_string())
+}
+
+pub fn gemm_rows_call<Out: AxisTag>(
+    label: impl Into<String>,
+    weight_out_total: usize,
+    in_dim: usize,
+    rows: usize,
+    row_offset: usize,
+    batch: usize,
+) -> KernelCall {
+    KernelCall::new("gemm_rows", label)
+        .input("weight", weight_matrix_total(weight_out_total, in_dim))
+        .input("x", hidden_batch::<Hidden>(in_dim, batch))
+        .output("out", hidden_batch::<Out>(rows, batch))
+        .attr("row_offset", row_offset.to_string())
+        .attr("rows", rows.to_string())
+}
+
+pub fn gemm_call<Out: AxisTag, In: AxisTag>(
+    label: impl Into<String>,
+    out_dim: usize,
+    in_dim: usize,
+    batch: usize,
+) -> KernelCall {
+    KernelCall::new("gemm", label)
+        .input("weight", weight_matrix(out_dim, in_dim))
+        .input("x", hidden_batch::<In>(in_dim, batch))
+        .output("out", hidden_batch::<Out>(out_dim, batch))
+}
+
+pub fn qk_norm_rope_batch_decode_call(
+    label: impl Into<String>,
+    q_dim: usize,
+    kv_dim: usize,
+    batch: usize,
+    rope_seq: usize,
+    num_q_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    eps: f32,
+) -> KernelCall {
+    KernelCall::new("qk_norm_rope_batch_decode", label)
+        .input("q", hidden_batch::<QDim>(q_dim, batch))
+        .input("k", hidden_batch::<KvDim>(kv_dim, batch))
+        .input("q_norm", vector::<HeadDim, Bf16>(head_dim))
+        .input("k_norm", vector::<HeadDim, Bf16>(head_dim))
+        .input("cos_cache", rope_cache(rope_seq, head_dim))
+        .input("sin_cache", rope_cache(rope_seq, head_dim))
+        .input("positions", meta_i32::<Batch>(batch))
+        .output("q", hidden_batch::<QDim>(q_dim, batch))
+        .output("k", hidden_batch::<KvDim>(kv_dim, batch))
+        .attr("num_q_heads", num_q_heads.to_string())
+        .attr("num_kv_heads", num_kv_heads.to_string())
+        .attr("head_dim", head_dim.to_string())
+        .attr("eps", eps.to_string())
+}
+
+pub fn paged_decode_attention_call(
+    label: impl Into<String>,
+    spec: PagedDecodeCallSpec,
+) -> KernelCall {
+    let mut call = KernelCall::new("paged_decode_attention", label)
+        .input("q", hidden_batch::<QDim>(spec.q_dim, spec.batch_size))
+        .input("k", hidden_batch::<KvDim>(spec.kv_dim, spec.batch_size))
+        .input("v", hidden_batch::<KvDim>(spec.kv_dim, spec.batch_size))
+        .input("kv_buffer", paged_kv(spec))
+        .input("page_indices", meta_i32::<PageSlot>(spec.total_pages))
+        .input("page_indptr", meta_i32::<BatchPlusOne>(spec.batch_size + 1))
+        .input("last_page_len", meta_i32::<Batch>(spec.batch_size))
+        .input("positions", meta_i32::<Batch>(spec.batch_size))
+        .input("request_indices", meta_i32::<Batch>(spec.batch_size))
+        .output("out", hidden_batch::<QDim>(spec.q_dim, spec.batch_size))
+        .attr("num_q_heads", spec.num_q_heads.to_string())
+        .attr("num_kv_heads", spec.num_kv_heads.to_string())
+        .attr("head_dim", spec.head_dim.to_string())
+        .attr("page_size", spec.page_size.to_string())
+        .attr("kv_len", spec.kv_len.to_string())
+        .attr("variant", spec.variant.to_string());
+
+    if spec.variant == "split_kv_256x64" {
+        let padded_slots = spec.batch_size * 64;
+        call = call
+            .input("split_request_indices", meta_i32::<PageSlot>(padded_slots))
+            .input("split_kv_tile_indices", meta_i32::<PageSlot>(padded_slots))
+            .input("split_kv_chunk_size", meta_i32::<Tile>(1))
+            .input(
+                "split_o_indptr",
+                meta_i32::<BatchPlusOne>(spec.batch_size + 1),
+            )
+            .input("split_block_valid_mask", meta_u8::<PageSlot>(padded_slots))
+            .input(
+                "split_tmp_v",
+                TensorSpec::new::<Bf16, Contiguous1D>([
+                    AxisSpec::new::<PageSlot>(padded_slots),
+                    AxisSpec::new::<QDim>(spec.q_dim),
+                ]),
+            )
+            .input(
+                "split_tmp_s",
+                TensorSpec::new::<F32, Contiguous1D>([
+                    AxisSpec::new::<PageSlot>(padded_slots),
+                    AxisSpec::new::<HeadDim>(spec.num_q_heads),
+                ]),
+            );
+    } else {
+        call = call
+            .input("kv_tile_indices", meta_i32::<Tile>(spec.batch_size))
+            .input("kv_chunk_size", meta_i32::<Batch>(spec.batch_size));
+    }
+
+    call
+}
+
+pub fn silu_mul_fused_batch_call(
+    label: impl Into<String>,
+    inter: usize,
+    batch: usize,
+) -> KernelCall {
+    KernelCall::new("silu_mul_fused_batch", label)
+        .input("gate_up", hidden_batch::<Inter2>(2 * inter, batch))
+        .output("out", hidden_batch::<Intermediate>(inter, batch))
+}
+
+pub fn all_reduce_hidden_call(label: impl Into<String>, hidden: usize, batch: usize) -> KernelCall {
+    KernelCall::new("all_reduce_hidden", label)
+        .input("x", hidden_batch::<Hidden>(hidden, batch))
+        .output("out", hidden_batch::<Hidden>(hidden, batch))
+        .attr("tp_world_size", 1.to_string())
+        .attr("no_op", true.to_string())
+}
+
+pub fn hidden_batch<A: AxisTag>(dim: usize, batch: usize) -> TensorSpec {
+    TensorSpec::new::<Bf16, HiddenStatesLayout>([
+        AxisSpec::new::<A>(dim),
+        AxisSpec::new::<Batch>(batch),
+    ])
+}
+
+pub fn weight_matrix(out: usize, in_dim: usize) -> TensorSpec {
+    TensorSpec::new::<Bf16, RowMajor2D>([
+        AxisSpec::new::<OutDim>(out),
+        AxisSpec::new::<InDim>(in_dim),
+    ])
+}
+
+pub fn weight_matrix_total(out_total: usize, in_dim: usize) -> TensorSpec {
+    TensorSpec::new::<Bf16, RowMajor2D>([
+        AxisSpec::new::<OutTotal>(out_total),
+        AxisSpec::new::<InDim>(in_dim),
+    ])
+}
+
+pub fn vector<A: AxisTag, D: pegainfer_kernels::tensor::DTypeTag>(dim: usize) -> TensorSpec {
+    TensorSpec::new::<D, Contiguous1D>([AxisSpec::new::<A>(dim)])
+}
+
+pub fn embed_table(vocab: usize, hidden: usize) -> TensorSpec {
+    TensorSpec::new::<Bf16, RowMajor2D>([
+        AxisSpec::new::<Vocab>(vocab),
+        AxisSpec::new::<Hidden>(hidden),
+    ])
+}
+
+pub fn token_ids(batch: usize) -> TensorSpec {
+    TensorSpec::new::<U32, Contiguous1D>([AxisSpec::new::<Token>(batch)])
+}
+
+pub fn rope_cache(seq: usize, head_dim: usize) -> TensorSpec {
+    TensorSpec::new::<Bf16, Contiguous1D>([
+        AxisSpec::new::<Seq>(seq),
+        AxisSpec::new::<RopeDim>(head_dim),
+    ])
+}
+
+pub fn paged_kv(spec: PagedDecodeCallSpec) -> TensorSpec {
+    TensorSpec::new::<Bf16, PagedKvPageFirst>([
+        AxisSpec::new::<Page>(spec.total_pages),
+        AxisSpec::new::<Layer>(spec.num_layers),
+        AxisSpec::new::<Kv>(2),
+        AxisSpec::new::<PosInPage>(spec.page_size),
+        AxisSpec::new::<KvHead>(spec.num_kv_heads),
+        AxisSpec::new::<HeadDim>(spec.head_dim),
+    ])
+}
+
+pub fn meta_i32<A: AxisTag>(size: usize) -> TensorSpec {
+    TensorSpec::new::<I32, Contiguous1D>([AxisSpec::new::<A>(size)])
+}
+
+pub fn meta_u8<A: AxisTag>(size: usize) -> TensorSpec {
+    TensorSpec::new::<pegainfer_kernels::tensor::U8, Contiguous1D>([AxisSpec::new::<A>(size)])
+}

--- a/pegainfer-core/src/ops/call_trace.rs
+++ b/pegainfer-core/src/ops/call_trace.rs
@@ -1,0 +1,68 @@
+use std::cell::{Cell, RefCell};
+
+use anyhow::Result;
+use pegainfer_kernels::tensor::KernelCall;
+
+thread_local! {
+    static TRACE: RefCell<Option<Vec<KernelCall>>> = const { RefCell::new(None) };
+    static LABEL_STACK: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+    static DECODE_KV_LEN: Cell<Option<usize>> = const { Cell::new(None) };
+}
+
+pub fn collect_result<T>(f: impl FnOnce() -> Result<T>) -> Result<(T, Vec<KernelCall>)> {
+    TRACE.with(|trace| {
+        let previous = trace.replace(Some(Vec::new()));
+        assert!(
+            previous.is_none(),
+            "nested kernel call trace collection is not supported"
+        );
+    });
+
+    let result = f();
+    let calls = TRACE.with(|trace| trace.replace(None).unwrap_or_default());
+    result.map(|value| (value, calls))
+}
+
+pub fn is_enabled() -> bool {
+    TRACE.with(|trace| trace.borrow().is_some())
+}
+
+pub fn record_call(call: KernelCall) {
+    TRACE.with(|trace| {
+        if let Some(calls) = trace.borrow_mut().as_mut() {
+            calls.push(call);
+        }
+    });
+}
+
+pub fn with_label<T>(label: impl Into<String>, f: impl FnOnce() -> T) -> T {
+    LABEL_STACK.with(|stack| stack.borrow_mut().push(label.into()));
+    let result = f();
+    LABEL_STACK.with(|stack| {
+        stack.borrow_mut().pop();
+    });
+    result
+}
+
+pub fn current_label(default_op: &str) -> String {
+    LABEL_STACK.with(|stack| {
+        stack
+            .borrow()
+            .last()
+            .cloned()
+            .unwrap_or_else(|| default_op.to_string())
+    })
+}
+
+pub fn with_decode_kv_len<T>(kv_len: usize, f: impl FnOnce() -> T) -> T {
+    DECODE_KV_LEN.with(|cell| {
+        let previous = cell.replace(Some(kv_len));
+        let result = f();
+        cell.set(previous);
+        result
+    })
+}
+
+pub fn decode_kv_len() -> Option<usize> {
+    DECODE_KV_LEN.with(Cell::get)
+}

--- a/pegainfer-core/src/ops/traced.rs
+++ b/pegainfer-core/src/ops/traced.rs
@@ -1,0 +1,196 @@
+use anyhow::Result;
+use cudarc::driver::CudaSlice;
+
+use crate::ops::call_spec::{
+    self, PagedDecodeCallSpec, embedding_batch_call, fused_add_rms_norm_batch_call, gemm_call,
+    gemm_rows_call, qk_norm_rope_batch_decode_call, rms_norm_batch_call, silu_mul_fused_batch_call,
+};
+use crate::ops::call_trace;
+use crate::tensor::{DeviceContext, DeviceMatrix, DeviceVec, HiddenStates};
+use pegainfer_kernels::tensor::{Hidden, InDim, OutDim};
+
+pub fn embedding_batch(
+    ctx: &DeviceContext,
+    embed: &DeviceMatrix,
+    token_ids_gpu: &CudaSlice<u32>,
+    out: &mut HiddenStates,
+) -> Result<()> {
+    if call_trace::is_enabled() {
+        let label = call_trace::current_label("embedding_batch");
+        call_trace::record_call(embedding_batch_call(
+            label,
+            embed.rows,
+            embed.cols,
+            out.seq_len,
+        ));
+    }
+    pegainfer_kernels::ops::embedding_batch(ctx, embed, token_ids_gpu, out)
+}
+
+pub fn rms_norm_batch_into(
+    ctx: &DeviceContext,
+    x: &HiddenStates,
+    weight: &DeviceVec,
+    eps: f32,
+    out: &mut HiddenStates,
+) {
+    if call_trace::is_enabled() {
+        let label = call_trace::current_label("rms_norm_batch");
+        call_trace::record_call(rms_norm_batch_call::<Hidden>(
+            label,
+            x.hidden_dim,
+            x.seq_len,
+            eps,
+        ));
+    }
+    pegainfer_kernels::ops::rms_norm_batch_into(ctx, x, weight, eps, out);
+}
+
+pub fn gemm_rows_into(
+    ctx: &DeviceContext,
+    weight: &DeviceMatrix,
+    row_offset: usize,
+    num_rows: usize,
+    x: &HiddenStates,
+    out: &mut HiddenStates,
+) {
+    if call_trace::is_enabled() {
+        let label = call_trace::current_label("gemm_rows");
+        call_trace::record_call(gemm_rows_call::<OutDim>(
+            label,
+            weight.rows,
+            weight.cols,
+            num_rows,
+            row_offset,
+            x.seq_len,
+        ));
+    }
+    pegainfer_kernels::ops::gemm_rows_into(ctx, weight, row_offset, num_rows, x, out);
+}
+
+pub fn gemm_into(
+    ctx: &DeviceContext,
+    weight: &DeviceMatrix,
+    x: &HiddenStates,
+    out: &mut HiddenStates,
+) {
+    if call_trace::is_enabled() {
+        let label = call_trace::current_label("gemm");
+        call_trace::record_call(gemm_call::<OutDim, InDim>(
+            label,
+            weight.rows,
+            weight.cols,
+            x.seq_len,
+        ));
+    }
+    pegainfer_kernels::ops::gemm_into(ctx, weight, x, out);
+}
+
+pub fn qk_norm_rope_batch_decode_into(
+    ctx: &DeviceContext,
+    q: &mut HiddenStates,
+    k: &mut HiddenStates,
+    q_norm_weight: &DeviceVec,
+    k_norm_weight: &DeviceVec,
+    cos_cache: &DeviceVec,
+    sin_cache: &DeviceVec,
+    positions_d: &CudaSlice<i32>,
+    num_q_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    rms_eps: f32,
+) {
+    if call_trace::is_enabled() {
+        let label = call_trace::current_label("qk_norm_rope_batch_decode");
+        let rope_seq = cos_cache.len / head_dim;
+        call_trace::record_call(qk_norm_rope_batch_decode_call(
+            label,
+            q.hidden_dim,
+            k.hidden_dim,
+            q.seq_len,
+            rope_seq,
+            num_q_heads,
+            num_kv_heads,
+            head_dim,
+            rms_eps,
+        ));
+    }
+    pegainfer_kernels::ops::qk_norm_rope_batch_decode_into(
+        ctx,
+        q,
+        k,
+        q_norm_weight,
+        k_norm_weight,
+        cos_cache,
+        sin_cache,
+        positions_d,
+        num_q_heads,
+        num_kv_heads,
+        head_dim,
+        rms_eps,
+    );
+}
+
+pub fn fused_add_rms_norm_batch_into(
+    ctx: &DeviceContext,
+    hidden: &mut HiddenStates,
+    residual: &HiddenStates,
+    weight: &DeviceVec,
+    eps: f32,
+    out: &mut HiddenStates,
+) {
+    if call_trace::is_enabled() {
+        let label = call_trace::current_label("fused_add_rms_norm_batch");
+        call_trace::record_call(fused_add_rms_norm_batch_call::<Hidden>(
+            label,
+            hidden.hidden_dim,
+            hidden.seq_len,
+            eps,
+        ));
+    }
+    pegainfer_kernels::ops::fused_add_rms_norm_batch_into(ctx, hidden, residual, weight, eps, out);
+}
+
+pub fn silu_mul_fused_batch_into(
+    ctx: &DeviceContext,
+    gate_up: &HiddenStates,
+    out: &mut HiddenStates,
+) {
+    if call_trace::is_enabled() {
+        let label = call_trace::current_label("silu_mul_fused_batch");
+        call_trace::record_call(silu_mul_fused_batch_call(
+            label,
+            out.hidden_dim,
+            gate_up.seq_len,
+        ));
+    }
+    pegainfer_kernels::ops::silu_mul_fused_batch_into(ctx, gate_up, out);
+}
+
+pub(crate) fn paged_decode_call_spec(
+    label: String,
+    q: &HiddenStates,
+    k: &HiddenStates,
+    kv_buffer_len: usize,
+    layout: &crate::kv_pool::KvLayout,
+    num_q_heads: usize,
+    batch_size: usize,
+    variant: &'static str,
+) -> pegainfer_kernels::tensor::KernelCall {
+    call_spec::paged_decode_attention_call(
+        label,
+        PagedDecodeCallSpec {
+            batch_size,
+            total_pages: kv_buffer_len / layout.page_stride,
+            num_layers: layout.num_layers,
+            page_size: layout.page_size,
+            q_dim: q.hidden_dim,
+            kv_dim: k.hidden_dim,
+            num_q_heads,
+            num_kv_heads: layout.num_kv_heads,
+            head_dim: layout.head_dim,
+            kv_len: call_trace::decode_kv_len().unwrap_or(0),
+            variant,
+        },
+    )
+}

--- a/pegainfer-kernels/Cargo.toml
+++ b/pegainfer-kernels/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 anyhow = { workspace = true }
 cudarc = { workspace = true }
 half = { workspace = true }
+serde = { workspace = true }
 
 [build-dependencies]
 cc = { workspace = true }

--- a/pegainfer-kernels/build.rs
+++ b/pegainfer-kernels/build.rs
@@ -167,9 +167,7 @@ fn normalize_nvcc_sm(sm: &str, supported_arches: Option<&BTreeSet<String>>) -> S
         if supported_arches.is_some_and(|arches| arches.contains(&format!("compute_{preferred}"))) {
             return preferred.to_string();
         }
-        let raw = sm_numeric_prefix(sm)
-            .map(|sm| sm.to_string())
-            .unwrap_or_else(|| sm.to_string());
+        let raw = sm_numeric_prefix(sm).map_or_else(|| sm.to_string(), |sm| sm.to_string());
         println!(
             "cargo:warning=nvcc does not list compute_{preferred}; compiling CUDA kernels for raw sm_{raw}"
         );

--- a/pegainfer-kernels/src/tensor.rs
+++ b/pegainfer-kernels/src/tensor.rs
@@ -3,9 +3,211 @@
 use anyhow::{Result, anyhow};
 use cudarc::driver::{CudaContext, CudaSlice, CudaStream};
 use half::bf16;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::ffi;
+
+/// Marker trait for tensor metadata tags.
+pub trait NamedTag {
+    const NAME: &'static str;
+}
+
+/// Marker trait for tensor element type vocabulary.
+pub trait DTypeTag: NamedTag {}
+
+/// Marker trait for tensor layout vocabulary.
+pub trait LayoutTag: NamedTag {}
+
+/// Marker trait for tensor axis vocabulary.
+pub trait AxisTag: NamedTag {}
+
+macro_rules! named_tag {
+    ($name:ident, $value:literal, $trait_name:ident) => {
+        #[derive(Clone, Copy, Debug, Default)]
+        pub struct $name;
+
+        impl NamedTag for $name {
+            const NAME: &'static str = $value;
+        }
+
+        impl $trait_name for $name {}
+    };
+}
+
+named_tag!(Bf16, "bf16", DTypeTag);
+named_tag!(F32, "f32", DTypeTag);
+named_tag!(I32, "i32", DTypeTag);
+named_tag!(U32, "u32", DTypeTag);
+named_tag!(U8, "u8", DTypeTag);
+
+named_tag!(Contiguous1D, "contiguous_1d", LayoutTag);
+named_tag!(RowMajor2D, "row_major_2d", LayoutTag);
+named_tag!(HiddenStatesLayout, "hidden_states", LayoutTag);
+named_tag!(PagedKvPageFirst, "paged_kv_page_first", LayoutTag);
+
+named_tag!(Batch, "batch", AxisTag);
+named_tag!(BatchPlusOne, "batch_plus_1", AxisTag);
+named_tag!(HeadDim, "head_dim", AxisTag);
+named_tag!(Hidden, "hidden", AxisTag);
+named_tag!(InDim, "in", AxisTag);
+named_tag!(Intermediate, "intermediate", AxisTag);
+named_tag!(Inter2, "inter2", AxisTag);
+named_tag!(Kv, "kv", AxisTag);
+named_tag!(KvDim, "kv_dim", AxisTag);
+named_tag!(KvHead, "kv_head", AxisTag);
+named_tag!(Layer, "layer", AxisTag);
+named_tag!(OutDim, "out", AxisTag);
+named_tag!(OutTotal, "out_total", AxisTag);
+named_tag!(Page, "page", AxisTag);
+named_tag!(PageSlot, "page_slot", AxisTag);
+named_tag!(PosInPage, "pos_in_page", AxisTag);
+named_tag!(QDim, "q_dim", AxisTag);
+named_tag!(RopeDim, "rope_dim", AxisTag);
+named_tag!(Seq, "seq", AxisTag);
+named_tag!(Tile, "tile", AxisTag);
+named_tag!(Token, "token", AxisTag);
+named_tag!(Vocab, "vocab", AxisTag);
+
+/// One named axis in an erased tensor metadata description.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct AxisSpec {
+    pub name: String,
+    pub size: usize,
+}
+
+impl AxisSpec {
+    pub fn new<A: AxisTag>(size: usize) -> Self {
+        Self {
+            name: A::NAME.to_string(),
+            size,
+        }
+    }
+
+    pub fn named(name: impl Into<String>, size: usize) -> Self {
+        Self {
+            name: name.into(),
+            size,
+        }
+    }
+}
+
+/// Erased tensor metadata for schedules, reports, and future instrumentation.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct TensorSpec {
+    pub dtype: String,
+    pub layout: String,
+    pub axes: Vec<AxisSpec>,
+}
+
+impl TensorSpec {
+    pub fn new<D: DTypeTag, L: LayoutTag>(axes: impl IntoIterator<Item = AxisSpec>) -> Self {
+        Self {
+            dtype: D::NAME.to_string(),
+            layout: L::NAME.to_string(),
+            axes: axes.into_iter().collect(),
+        }
+    }
+
+    pub fn named(
+        dtype: impl Into<String>,
+        layout: impl Into<String>,
+        axes: impl IntoIterator<Item = AxisSpec>,
+    ) -> Self {
+        Self {
+            dtype: dtype.into(),
+            layout: layout.into(),
+            axes: axes.into_iter().collect(),
+        }
+    }
+
+    pub fn compact(&self) -> String {
+        let axes = self
+            .axes
+            .iter()
+            .map(|axis| format!("{}={}", axis.name, axis.size))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("{}[{}] layout={}", self.dtype, axes, self.layout)
+    }
+}
+
+/// A named kernel argument carrying an erased tensor description.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct TensorArg {
+    pub name: String,
+    pub spec: TensorSpec,
+}
+
+impl TensorArg {
+    pub fn new(name: impl Into<String>, spec: TensorSpec) -> Self {
+        Self {
+            name: name.into(),
+            spec,
+        }
+    }
+
+    pub fn compact(&self) -> String {
+        format!("{}: {}", self.name, self.spec.compact())
+    }
+}
+
+/// String-valued non-tensor kernel metadata.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct AttrSpec {
+    pub name: String,
+    pub value: String,
+}
+
+impl AttrSpec {
+    pub fn new(name: impl Into<String>, value: String) -> Self {
+        Self {
+            name: name.into(),
+            value,
+        }
+    }
+}
+
+/// Erased logical kernel call IR shared by static schedules and future traces.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct KernelCall {
+    pub op: String,
+    pub label: String,
+    pub inputs: Vec<TensorArg>,
+    pub outputs: Vec<TensorArg>,
+    pub attrs: Vec<AttrSpec>,
+}
+
+impl KernelCall {
+    #[must_use]
+    pub fn new(op: impl Into<String>, label: impl Into<String>) -> Self {
+        Self {
+            op: op.into(),
+            label: label.into(),
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            attrs: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn input(mut self, name: impl Into<String>, spec: TensorSpec) -> Self {
+        self.inputs.push(TensorArg::new(name, spec));
+        self
+    }
+
+    #[must_use]
+    pub fn output(mut self, name: impl Into<String>, spec: TensorSpec) -> Self {
+        self.outputs.push(TensorArg::new(name, spec));
+        self
+    }
+
+    #[must_use]
+    pub fn attr(mut self, name: impl Into<String>, value: String) -> Self {
+        self.attrs.push(AttrSpec::new(name, value));
+        self
+    }
+}
 
 /// CUDA device context holding context and stream.
 #[derive(Clone)]

--- a/pegainfer-qwen3-4b/Cargo.toml
+++ b/pegainfer-qwen3-4b/Cargo.toml
@@ -10,6 +10,7 @@ pegainfer-cupti = { workspace = true, optional = true }
 pegainfer-kernels = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true, optional = true }
+comfy-table = { workspace = true, optional = true }
 crossbeam-channel = { workspace = true }
 cudarc = { workspace = true }
 fastrace = { workspace = true }
@@ -24,7 +25,16 @@ tokio = { workspace = true, features = ["sync"] }
 toml = { workspace = true, optional = true }
 
 [features]
-kernel-report = ["dep:clap", "dep:hex", "dep:pegainfer-cupti", "dep:sha2", "dep:toml"]
+kernel-call-trace = ["pegainfer-core/kernel-call-trace"]
+kernel-report = [
+    "dep:clap",
+    "dep:comfy-table",
+    "dep:hex",
+    "dep:pegainfer-cupti",
+    "dep:sha2",
+    "dep:toml",
+    "kernel-call-trace",
+]
 
 [dev-dependencies]
 pegainfer-vllm-support = { workspace = true }
@@ -33,6 +43,11 @@ vllm-text = { workspace = true }
 [[bin]]
 name = "qwen3_kernel_report"
 path = "src/bin/qwen3_kernel_report.rs"
+required-features = ["kernel-report"]
+
+[[bin]]
+name = "qwen3_model_report"
+path = "src/bin/qwen3_model_report.rs"
 required-features = ["kernel-report"]
 
 [lints]

--- a/pegainfer-qwen3-4b/src/batch_decode.rs
+++ b/pegainfer-qwen3-4b/src/batch_decode.rs
@@ -5,9 +5,38 @@ use anyhow::Result;
 use super::batch_decode_buffers::{
     BATCH_BUCKETS, BatchDecodeBuffers, DecodeAttentionPath, bucket_for,
 };
+use super::batch_decode_dag::BatchDecodeDag;
 use super::weights::{Qwen3Model, TransformerBlock};
 use pegainfer_core::kv_pool::{KvLayout, KvState};
+#[cfg(feature = "kernel-call-trace")]
 use pegainfer_core::ops;
+use pegainfer_kernels::tensor::{KvDim, QDim};
+
+#[cfg(feature = "kernel-call-trace")]
+macro_rules! dag_label {
+    ($label:expr) => {
+        $label.to_string()
+    };
+}
+
+#[cfg(not(feature = "kernel-call-trace"))]
+macro_rules! dag_label {
+    ($label:expr) => {
+        ()
+    };
+}
+
+#[cfg(feature = "kernel-call-trace")]
+macro_rules! trace_decode_kv_len {
+    ($kv_len:expr, $body:block) => {
+        ops::call_trace::with_decode_kv_len($kv_len, || $body)
+    };
+}
+
+#[cfg(not(feature = "kernel-call-trace"))]
+macro_rules! trace_decode_kv_len {
+    ($kv_len:expr, $body:block) => {{ $body }};
+}
 
 impl Qwen3Model {
     /// Batch decode step: N requests, 1 new token each, one forward pass.
@@ -58,6 +87,8 @@ impl Qwen3Model {
         let kv_refs: Vec<&KvState> = kv_states.iter().map(|s| &**s).collect();
         bufs.sync_paged_meta(&self.ctx, &kv_refs, padded_bs)?;
         let attention_path = bufs.attention_path(padded_bs);
+        #[cfg(feature = "kernel-call-trace")]
+        let trace_kv_len = kv_refs.iter().map(|kv| kv.seq_len()).max().unwrap_or(0);
 
         // Forward pass — with or without CUDA Graph
         let kv_buffer = kv_states[0].buffer();
@@ -68,12 +99,16 @@ impl Qwen3Model {
             // Take graphs out of bufs to avoid split-borrow conflict with closure
             let mut graphs = std::mem::take(&mut bufs.graphs);
             let result = graphs[graph_idx].run_or_capture(&self.ctx, || {
-                self.batch_decode_kernels(kv_buffer, &layout, padded_bs, attention_path, bufs)
+                trace_decode_kv_len!(trace_kv_len, {
+                    self.batch_decode_kernels(kv_buffer, &layout, padded_bs, attention_path, bufs)
+                })
             });
             bufs.graphs = graphs;
             result?;
         } else {
-            self.batch_decode_kernels(kv_buffer, &layout, padded_bs, attention_path, bufs)?;
+            trace_decode_kv_len!(trace_kv_len, {
+                self.batch_decode_kernels(kv_buffer, &layout, padded_bs, attention_path, bufs)
+            })?;
         }
 
         Ok(())
@@ -87,55 +122,44 @@ impl Qwen3Model {
         attention_path: DecodeAttentionPath,
         bufs: &mut BatchDecodeBuffers,
     ) -> Result<()> {
-        let eps = self.config.rms_norm_eps;
         let num_layers = self.layers.len();
+        let dag = BatchDecodeDag::new(self, kv_buffer, layout, bs, attention_path);
 
         // Embedding: N token_ids → hidden [hidden_dim, bs]
-        ops::embedding_batch(
-            &self.ctx,
-            &self.embed_tokens,
-            &bufs.token_ids_d,
-            &mut bufs.hidden,
-        )?;
+        dag.embedding(dag_label!("embedding"), &bufs.token_ids_d, &mut bufs.hidden)?;
 
         // First layer norm
-        ops::rms_norm_batch_into(
-            &self.ctx,
+        dag.rms_norm(
+            dag_label!("input.rms_norm"),
             &bufs.hidden,
             &self.layers[0].input_layernorm,
-            eps,
             &mut bufs.normed,
         );
 
         for (layer_idx, layer) in self.layers.iter().enumerate() {
-            self.batch_decode_layer(
-                layer_idx,
-                layer,
-                kv_buffer,
-                layout,
-                bs,
-                attention_path,
-                bufs,
-            )?;
+            Self::batch_decode_layer(layer_idx, layer, &dag, bufs)?;
 
             let next_weight = if layer_idx + 1 < num_layers {
                 &self.layers[layer_idx + 1].input_layernorm
             } else {
                 &self.norm
             };
-            ops::fused_add_rms_norm_batch_into(
-                &self.ctx,
+            dag.fused_add_rms_norm(
+                if layer_idx + 1 < num_layers {
+                    dag_label!(format!("L{layer_idx}.mlp.fused_add_rms_norm"))
+                } else {
+                    dag_label!("final.rms_norm")
+                },
                 &mut bufs.hidden,
                 &bufs.mlp_out,
                 next_weight,
-                eps,
                 &mut bufs.normed,
             );
         }
 
         // Output projection: logits [vocab_size, bs]
-        ops::gemm_into(
-            &self.ctx,
+        dag.lm_head(
+            dag_label!("lm_head"),
             self.output_projection(),
             &bufs.normed,
             &mut bufs.logits,
@@ -146,41 +170,35 @@ impl Qwen3Model {
 
     #[allow(clippy::too_many_arguments)]
     fn batch_decode_layer(
-        &self,
         layer_idx: usize,
         layer: &TransformerBlock,
-        kv_buffer: &cudarc::driver::CudaSlice<half::bf16>,
-        layout: &KvLayout,
-        bs: usize,
-        attention_path: DecodeAttentionPath,
+        dag: &BatchDecodeDag<'_>,
         bufs: &mut BatchDecodeBuffers,
     ) -> Result<()> {
-        let eps = self.config.rms_norm_eps;
-
         // Match prefill numerics: compute Q/K/V via row-sliced GEMMs instead of
         // fused qkv GEMM + deinterleave. The fused path is mathematically
         // equivalent but diverges enough under shard-local TP to flip greedy
         // decode in parity tests.
         let q_dim = layer.attention.q_dim;
         let kv_dim = layer.attention.kv_dim;
-        ops::gemm_rows_into(
-            &self.ctx,
+        dag.gemm_rows::<QDim>(
+            dag_label!(format!("L{layer_idx}.attn.q_proj")),
             &layer.attention.qkv_proj,
             0,
             q_dim,
             &bufs.normed,
             &mut bufs.q,
         );
-        ops::gemm_rows_into(
-            &self.ctx,
+        dag.gemm_rows::<KvDim>(
+            dag_label!(format!("L{layer_idx}.attn.k_proj")),
             &layer.attention.qkv_proj,
             q_dim,
             kv_dim,
             &bufs.normed,
             &mut bufs.k,
         );
-        ops::gemm_rows_into(
-            &self.ctx,
+        dag.gemm_rows::<KvDim>(
+            dag_label!(format!("L{layer_idx}.attn.v_proj")),
             &layer.attention.qkv_proj,
             q_dim + kv_dim,
             kv_dim,
@@ -189,107 +207,65 @@ impl Qwen3Model {
         );
 
         // QK norm + RoPE (batched, per-request positions)
-        ops::qk_norm_rope_batch_decode_into(
-            &self.ctx,
+        dag.qk_norm_rope(
+            dag_label!(format!("L{layer_idx}.attn.qk_norm_rope")),
             &mut bufs.q,
             &mut bufs.k,
             &layer.attention.q_norm,
             &layer.attention.k_norm,
-            &self.cos_cache,
-            &self.sin_cache,
             &bufs.positions_d,
-            self.local_num_attention_heads(),
-            self.local_num_key_value_heads(),
-            self.config.head_dim,
-            eps,
         );
 
         // KV append + paged attention decode (FlashInfer, batched)
-        match attention_path {
-            DecodeAttentionPath::NonPartition => {
-                ops::paged_attention_batch_decode_into(
-                    &self.ctx,
-                    &bufs.q,
-                    &bufs.k,
-                    &bufs.v,
-                    kv_buffer,
-                    layout,
-                    layer_idx,
-                    &bufs.page_indices_d,
-                    &bufs.page_indptr_d,
-                    &bufs.last_page_len_d,
-                    &bufs.positions_d,
-                    &bufs.request_indices_d,
-                    &bufs.kv_tile_indices_d,
-                    &bufs.kv_chunk_size_d,
-                    &mut bufs.attn_out,
-                    self.local_num_attention_heads(),
-                    bs,
-                )?;
-            }
-            DecodeAttentionPath::SplitKv => {
-                ops::paged_attention_batch_decode_split_kv_into(
-                    &self.ctx,
-                    &bufs.q,
-                    &bufs.k,
-                    &bufs.v,
-                    kv_buffer,
-                    layout,
-                    layer_idx,
-                    &bufs.page_indices_d,
-                    &bufs.page_indptr_d,
-                    &bufs.last_page_len_d,
-                    &bufs.positions_d,
-                    &bufs.request_indices_d,
-                    &bufs.split_request_indices_d,
-                    &bufs.split_kv_tile_indices_d,
-                    &bufs.split_kv_chunk_size_d,
-                    &bufs.split_o_indptr_d,
-                    &bufs.split_block_valid_mask_d,
-                    &mut bufs.split_tmp_v,
-                    &mut bufs.split_tmp_s,
-                    bufs.split_padded_slots,
-                    &mut bufs.attn_out,
-                    self.local_num_attention_heads(),
-                    bs,
-                )?;
-            }
-        }
+        dag.paged_decode_attention(
+            dag_label!(format!("L{layer_idx}.attn.paged_decode")),
+            layer_idx,
+            bufs,
+        )?;
 
         // O projection (GEMM)
-        ops::gemm_into(
-            &self.ctx,
+        dag.o_proj(
+            dag_label!(format!("L{layer_idx}.attn.o_proj")),
             &layer.attention.o_proj,
             &bufs.attn_out,
             &mut bufs.attn_proj,
         );
-        self.all_reduce_hidden(&mut bufs.attn_proj)?;
+        dag.all_reduce_hidden(
+            dag_label!(format!("L{layer_idx}.attn.all_reduce")),
+            &mut bufs.attn_proj,
+        )?;
 
         // Residual + LayerNorm
-        ops::fused_add_rms_norm_batch_into(
-            &self.ctx,
+        dag.fused_add_rms_norm(
+            dag_label!(format!("L{layer_idx}.attn.fused_add_rms_norm")),
             &mut bufs.hidden,
             &bufs.attn_proj,
             &layer.post_attention_layernorm,
-            eps,
             &mut bufs.normed,
         );
 
         // MLP: fused gate+up GEMM → silu_mul_fused → down GEMM
-        ops::gemm_into(
-            &self.ctx,
+        dag.gate_up_proj(
+            dag_label!(format!("L{layer_idx}.mlp.gate_up_proj")),
             &layer.mlp.gate_up_proj,
             &bufs.normed,
             &mut bufs.gate_up_out,
         );
-        ops::silu_mul_fused_batch_into(&self.ctx, &bufs.gate_up_out, &mut bufs.mlp_act);
-        ops::gemm_into(
-            &self.ctx,
+        dag.silu_mul(
+            dag_label!(format!("L{layer_idx}.mlp.silu_mul")),
+            &bufs.gate_up_out,
+            &mut bufs.mlp_act,
+        );
+        dag.down_proj(
+            dag_label!(format!("L{layer_idx}.mlp.down_proj")),
             &layer.mlp.down_proj,
             &bufs.mlp_act,
             &mut bufs.mlp_out,
         );
-        self.all_reduce_hidden(&mut bufs.mlp_out)?;
+        dag.all_reduce_hidden(
+            dag_label!(format!("L{layer_idx}.mlp.all_reduce")),
+            &mut bufs.mlp_out,
+        )?;
 
         Ok(())
     }
@@ -300,6 +276,7 @@ mod tests {
     use super::*;
     use crate::batch_decode_buffers::BatchDecodeBuffers;
     use crate::weights::ModelRuntimeConfig;
+    use pegainfer_core::ops;
     use pegainfer_core::sampler::SamplingParams;
     use pegainfer_core::tensor::DeviceVec;
     use rand::SeedableRng;

--- a/pegainfer-qwen3-4b/src/batch_decode_dag.rs
+++ b/pegainfer-qwen3-4b/src/batch_decode_dag.rs
@@ -1,0 +1,348 @@
+//! Eager decode DAG builder.
+//!
+//! Each method is both the model's executable forward step and the metadata
+//! contract used by `qwen3_model_report`. The model-level report therefore
+//! observes the same op sequence that decode executes.
+
+use anyhow::Result;
+use cudarc::driver::CudaSlice;
+use half::bf16;
+use pegainfer_core::kv_pool::KvLayout;
+#[cfg(feature = "kernel-call-trace")]
+use pegainfer_core::ops::call_spec::{
+    self, PagedDecodeCallSpec, embedding_batch_call, fused_add_rms_norm_batch_call, gemm_call,
+    gemm_rows_call, qk_norm_rope_batch_decode_call, rms_norm_batch_call, silu_mul_fused_batch_call,
+};
+#[cfg(feature = "kernel-call-trace")]
+use pegainfer_core::ops::call_trace;
+use pegainfer_core::tensor::{DeviceMatrix, DeviceVec, HiddenStates};
+use pegainfer_kernels::tensor::{AxisTag, Hidden, InDim, Inter2, Intermediate, QDim, Vocab};
+
+use crate::batch_decode_buffers::{BatchDecodeBuffers, DecodeAttentionPath};
+use crate::weights::Qwen3Model;
+
+#[cfg(feature = "kernel-call-trace")]
+pub(crate) type DagLabel = String;
+#[cfg(not(feature = "kernel-call-trace"))]
+pub(crate) type DagLabel = ();
+
+pub(crate) struct BatchDecodeDag<'a> {
+    model: &'a Qwen3Model,
+    kv_buffer: &'a CudaSlice<bf16>,
+    layout: &'a KvLayout,
+    batch_size: usize,
+    attention_path: DecodeAttentionPath,
+}
+
+#[cfg_attr(not(feature = "kernel-call-trace"), allow(unused_variables))]
+impl<'a> BatchDecodeDag<'a> {
+    pub(crate) fn new(
+        model: &'a Qwen3Model,
+        kv_buffer: &'a CudaSlice<bf16>,
+        layout: &'a KvLayout,
+        batch_size: usize,
+        attention_path: DecodeAttentionPath,
+    ) -> Self {
+        Self {
+            model,
+            kv_buffer,
+            layout,
+            batch_size,
+            attention_path,
+        }
+    }
+
+    pub(crate) fn embedding(
+        &self,
+        label: DagLabel,
+        token_ids: &CudaSlice<u32>,
+        out: &mut HiddenStates,
+    ) -> Result<()> {
+        #[cfg(feature = "kernel-call-trace")]
+        Self::record(embedding_batch_call(
+            label,
+            self.model.embed_tokens.rows,
+            self.model.embed_tokens.cols,
+            out.seq_len,
+        ));
+        pegainfer_kernels::ops::embedding_batch(
+            &self.model.ctx,
+            &self.model.embed_tokens,
+            token_ids,
+            out,
+        )
+    }
+
+    pub(crate) fn rms_norm(
+        &self,
+        label: DagLabel,
+        x: &HiddenStates,
+        weight: &DeviceVec,
+        out: &mut HiddenStates,
+    ) {
+        #[cfg(feature = "kernel-call-trace")]
+        Self::record(rms_norm_batch_call::<Hidden>(
+            label,
+            x.hidden_dim,
+            x.seq_len,
+            self.model.config.rms_norm_eps,
+        ));
+        pegainfer_kernels::ops::rms_norm_batch_into(
+            &self.model.ctx,
+            x,
+            weight,
+            self.model.config.rms_norm_eps,
+            out,
+        );
+    }
+
+    pub(crate) fn fused_add_rms_norm(
+        &self,
+        label: DagLabel,
+        hidden: &mut HiddenStates,
+        residual: &HiddenStates,
+        weight: &DeviceVec,
+        out: &mut HiddenStates,
+    ) {
+        #[cfg(feature = "kernel-call-trace")]
+        Self::record(fused_add_rms_norm_batch_call::<Hidden>(
+            label,
+            hidden.hidden_dim,
+            hidden.seq_len,
+            self.model.config.rms_norm_eps,
+        ));
+        pegainfer_kernels::ops::fused_add_rms_norm_batch_into(
+            &self.model.ctx,
+            hidden,
+            residual,
+            weight,
+            self.model.config.rms_norm_eps,
+            out,
+        );
+    }
+
+    pub(crate) fn gemm_rows<Out: AxisTag>(
+        &self,
+        label: DagLabel,
+        weight: &DeviceMatrix,
+        row_offset: usize,
+        rows: usize,
+        x: &HiddenStates,
+        out: &mut HiddenStates,
+    ) {
+        #[cfg(feature = "kernel-call-trace")]
+        Self::record(gemm_rows_call::<Out>(
+            label,
+            weight.rows,
+            weight.cols,
+            rows,
+            row_offset,
+            x.seq_len,
+        ));
+        pegainfer_kernels::ops::gemm_rows_into(&self.model.ctx, weight, row_offset, rows, x, out);
+    }
+
+    pub(crate) fn gemm<Out: AxisTag, In: AxisTag>(
+        &self,
+        label: DagLabel,
+        weight: &DeviceMatrix,
+        x: &HiddenStates,
+        out: &mut HiddenStates,
+    ) {
+        #[cfg(feature = "kernel-call-trace")]
+        Self::record(gemm_call::<Out, In>(
+            label,
+            weight.rows,
+            weight.cols,
+            x.seq_len,
+        ));
+        pegainfer_kernels::ops::gemm_into(&self.model.ctx, weight, x, out);
+    }
+
+    pub(crate) fn qk_norm_rope(
+        &self,
+        label: DagLabel,
+        q: &mut HiddenStates,
+        k: &mut HiddenStates,
+        q_norm: &DeviceVec,
+        k_norm: &DeviceVec,
+        positions: &CudaSlice<i32>,
+    ) {
+        #[cfg(feature = "kernel-call-trace")]
+        Self::record(qk_norm_rope_batch_decode_call(
+            label,
+            q.hidden_dim,
+            k.hidden_dim,
+            q.seq_len,
+            self.model.cos_cache.len / self.model.config.head_dim,
+            self.model.local_num_attention_heads(),
+            self.model.local_num_key_value_heads(),
+            self.model.config.head_dim,
+            self.model.config.rms_norm_eps,
+        ));
+        pegainfer_kernels::ops::qk_norm_rope_batch_decode_into(
+            &self.model.ctx,
+            q,
+            k,
+            q_norm,
+            k_norm,
+            &self.model.cos_cache,
+            &self.model.sin_cache,
+            positions,
+            self.model.local_num_attention_heads(),
+            self.model.local_num_key_value_heads(),
+            self.model.config.head_dim,
+            self.model.config.rms_norm_eps,
+        );
+    }
+
+    pub(crate) fn paged_decode_attention(
+        &self,
+        label: DagLabel,
+        layer_idx: usize,
+        bufs: &mut BatchDecodeBuffers,
+    ) -> Result<()> {
+        #[cfg(feature = "kernel-call-trace")]
+        Self::record(call_spec::paged_decode_attention_call(
+            label,
+            PagedDecodeCallSpec {
+                batch_size: self.batch_size,
+                total_pages: self.kv_buffer.len() / self.layout.page_stride,
+                num_layers: self.layout.num_layers,
+                page_size: self.layout.page_size,
+                q_dim: bufs.q.hidden_dim,
+                kv_dim: bufs.k.hidden_dim,
+                num_q_heads: self.model.local_num_attention_heads(),
+                num_kv_heads: self.layout.num_kv_heads,
+                head_dim: self.layout.head_dim,
+                kv_len: call_trace::decode_kv_len().unwrap_or(0),
+                variant: match self.attention_path {
+                    DecodeAttentionPath::NonPartition => "non_partition",
+                    DecodeAttentionPath::SplitKv => "split_kv_256x64",
+                },
+            },
+        ));
+
+        match self.attention_path {
+            DecodeAttentionPath::NonPartition => {
+                pegainfer_kernels::ops::paged_attention_batch_decode_into(
+                    &self.model.ctx,
+                    &bufs.q,
+                    &bufs.k,
+                    &bufs.v,
+                    self.kv_buffer,
+                    &self.layout.kernel_layout(),
+                    layer_idx,
+                    &bufs.page_indices_d,
+                    &bufs.page_indptr_d,
+                    &bufs.last_page_len_d,
+                    &bufs.positions_d,
+                    &bufs.request_indices_d,
+                    &bufs.kv_tile_indices_d,
+                    &bufs.kv_chunk_size_d,
+                    &mut bufs.attn_out,
+                    self.model.local_num_attention_heads(),
+                    self.batch_size,
+                )
+            }
+            DecodeAttentionPath::SplitKv => {
+                pegainfer_kernels::ops::paged_attention_batch_decode_split_kv_into(
+                    &self.model.ctx,
+                    &bufs.q,
+                    &bufs.k,
+                    &bufs.v,
+                    self.kv_buffer,
+                    &self.layout.kernel_layout(),
+                    layer_idx,
+                    &bufs.page_indices_d,
+                    &bufs.page_indptr_d,
+                    &bufs.last_page_len_d,
+                    &bufs.positions_d,
+                    &bufs.request_indices_d,
+                    &bufs.split_request_indices_d,
+                    &bufs.split_kv_tile_indices_d,
+                    &bufs.split_kv_chunk_size_d,
+                    &bufs.split_o_indptr_d,
+                    &bufs.split_block_valid_mask_d,
+                    &mut bufs.split_tmp_v,
+                    &mut bufs.split_tmp_s,
+                    bufs.split_padded_slots,
+                    &mut bufs.attn_out,
+                    self.model.local_num_attention_heads(),
+                    self.batch_size,
+                )
+            }
+        }
+    }
+
+    pub(crate) fn silu_mul(&self, label: DagLabel, gate_up: &HiddenStates, out: &mut HiddenStates) {
+        #[cfg(feature = "kernel-call-trace")]
+        Self::record(silu_mul_fused_batch_call(
+            label,
+            out.hidden_dim,
+            gate_up.seq_len,
+        ));
+        pegainfer_kernels::ops::silu_mul_fused_batch_into(&self.model.ctx, gate_up, out);
+    }
+
+    pub(crate) fn all_reduce_hidden(
+        &self,
+        label: DagLabel,
+        hidden: &mut HiddenStates,
+    ) -> Result<()> {
+        #[cfg(feature = "kernel-call-trace")]
+        Self::record(call_spec::all_reduce_hidden_call(
+            label,
+            hidden.hidden_dim,
+            hidden.seq_len,
+        ));
+        self.model.all_reduce_hidden_untraced(hidden)
+    }
+
+    pub(crate) fn o_proj(
+        &self,
+        label: DagLabel,
+        weight: &DeviceMatrix,
+        x: &HiddenStates,
+        out: &mut HiddenStates,
+    ) {
+        self.gemm::<Hidden, QDim>(label, weight, x, out);
+    }
+
+    pub(crate) fn gate_up_proj(
+        &self,
+        label: DagLabel,
+        weight: &DeviceMatrix,
+        x: &HiddenStates,
+        out: &mut HiddenStates,
+    ) {
+        self.gemm::<Inter2, Hidden>(label, weight, x, out);
+    }
+
+    pub(crate) fn down_proj(
+        &self,
+        label: DagLabel,
+        weight: &DeviceMatrix,
+        x: &HiddenStates,
+        out: &mut HiddenStates,
+    ) {
+        self.gemm::<Hidden, Intermediate>(label, weight, x, out);
+    }
+
+    pub(crate) fn lm_head(
+        &self,
+        label: DagLabel,
+        weight: &DeviceMatrix,
+        x: &HiddenStates,
+        out: &mut HiddenStates,
+    ) {
+        self.gemm::<Vocab, InDim>(label, weight, x, out);
+    }
+
+    #[cfg(feature = "kernel-call-trace")]
+    fn record(call: pegainfer_kernels::tensor::KernelCall) {
+        if call_trace::is_enabled() {
+            call_trace::record_call(call);
+        }
+    }
+}

--- a/pegainfer-qwen3-4b/src/batch_decode_trace.rs
+++ b/pegainfer-qwen3-4b/src/batch_decode_trace.rs
@@ -1,0 +1,85 @@
+#[cfg(feature = "kernel-call-trace")]
+use anyhow::Result;
+#[cfg(feature = "kernel-call-trace")]
+use pegainfer_core::ops::call_trace;
+#[cfg(feature = "kernel-call-trace")]
+use pegainfer_kernels::tensor::KernelCall;
+
+#[cfg(feature = "kernel-call-trace")]
+use crate::batch_decode_buffers::BatchDecodeBuffers;
+#[cfg(feature = "kernel-call-trace")]
+use crate::weights::{ModelRuntimeConfig, Qwen3Model};
+
+pub const MODEL: &str = "qwen3-4b";
+pub const PHASE_DECODE: &str = "decode";
+pub const HIDDEN_SIZE: usize = 2560;
+pub const INTERMEDIATE_SIZE: usize = 9728;
+pub const NUM_LAYERS: usize = 36;
+pub const NUM_Q_HEADS: usize = 32;
+pub const NUM_KV_HEADS: usize = 8;
+pub const HEAD_DIM_VALUE: usize = 128;
+pub const KV_DIM_VALUE: usize = NUM_KV_HEADS * HEAD_DIM_VALUE;
+pub const RMS_NORM_EPS: f32 = 1.0e-6;
+
+#[cfg(feature = "kernel-call-trace")]
+pub fn trace_decode_kernel_calls(
+    model_path: &str,
+    batch_size: usize,
+    kv_len: usize,
+) -> Result<Vec<KernelCall>> {
+    anyhow::ensure!(batch_size > 0, "batch_size must be greater than zero");
+    anyhow::ensure!(kv_len > 0, "kv_len must be greater than zero");
+
+    let model = Qwen3Model::from_safetensors_with_runtime(
+        model_path,
+        ModelRuntimeConfig {
+            enable_cuda_graph: false,
+            tensor_parallel: None,
+            device_ordinal: 0,
+        },
+    )?;
+    let mut kv_states = (0..batch_size)
+        .map(|_| {
+            let mut kv = model.alloc_kv();
+            if kv_len > 1 {
+                kv.ensure_capacity(kv_len - 1)?;
+                kv.advance(kv_len - 1);
+            }
+            Ok(kv)
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut bufs = BatchDecodeBuffers::new(
+        model.device_ctx(),
+        model.config().hidden_size,
+        model.local_q_dim(),
+        model.local_kv_dim(),
+        model.local_intermediate_size(),
+        model.config().vocab_size,
+        batch_size,
+        model.kv_pool.capacity_pages(),
+        model.kv_pool.padding_page_id(),
+        model.local_num_attention_heads(),
+    )?;
+    let token_ids = vec![0_u32; batch_size];
+    let ((), calls) = call_trace::collect_result(|| {
+        let mut kv_refs = kv_states.iter_mut().collect::<Vec<_>>();
+        model.batch_decode(&token_ids, &mut kv_refs, &mut bufs)
+    })?;
+    Ok(calls)
+}
+
+pub fn normalize_call_site(label: &str) -> String {
+    let Some(rest) = label.strip_prefix('L') else {
+        return label.to_string();
+    };
+    let digit_count = rest
+        .as_bytes()
+        .iter()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    if digit_count == 0 || rest.as_bytes().get(digit_count) != Some(&b'.') {
+        return label.to_string();
+    }
+    format!("layer.*{}", &rest[digit_count..])
+}

--- a/pegainfer-qwen3-4b/src/bin/qwen3_model_report.rs
+++ b/pegainfer-qwen3-4b/src/bin/qwen3_model_report.rs
@@ -1,0 +1,1079 @@
+use std::collections::{BTreeMap, HashMap};
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow, bail};
+use clap::Parser;
+use comfy_table::{Cell, Color, ContentArrangement, Table, presets::UTF8_FULL};
+use cudarc::driver::{CudaSlice, sys};
+use half::bf16;
+use pegainfer_core::kv_pool::KvLayout;
+use pegainfer_core::ops;
+use pegainfer_kernels::tensor::{
+    DeviceContext, DeviceMatrix, DeviceVec, HiddenStates, KernelCall, TensorSpec,
+};
+use pegainfer_qwen3_4b::batch_decode_trace::{
+    HEAD_DIM_VALUE, KV_DIM_VALUE, MODEL, NUM_KV_HEADS, NUM_LAYERS, NUM_Q_HEADS, PHASE_DECODE,
+    RMS_NORM_EPS, normalize_call_site, trace_decode_kernel_calls,
+};
+use pegainfer_qwen3_4b::kernel_bench::{L2CacheClear, SplitKvConfig};
+use serde::Serialize;
+
+const DEFAULT_ITERS: u64 = 32;
+const DEFAULT_SPLIT_KV: SplitKvConfig = SplitKvConfig::new(256, 64);
+
+#[derive(Parser)]
+#[command(about = "Qwen3-4B model-level operator report")]
+struct Cli {
+    /// Only `decode` is implemented in the MVP.
+    command: String,
+    #[arg(long = "batch-size")]
+    batch_size: usize,
+    #[arg(long = "kv-len")]
+    kv_len: usize,
+    #[arg(long, default_value = "text")]
+    format: String,
+    #[arg(long)]
+    out: Option<PathBuf>,
+    #[arg(long, default_value_t = DEFAULT_ITERS)]
+    iters: u64,
+    #[arg(long, default_value = "models/Qwen3-4B")]
+    model_path: String,
+}
+
+#[derive(Clone, Serialize)]
+struct ModelReport {
+    schema: u32,
+    report_type: String,
+    model: String,
+    phase: String,
+    config: ReportConfig,
+    schedule_source: String,
+    total_measured_us: f64,
+    total_p99_us: f64,
+    schedule: Vec<KernelCall>,
+    by_op: Vec<RollupRow>,
+    by_call_site: Vec<CallSiteRow>,
+    coverage: Vec<CoverageRow>,
+}
+
+#[derive(Clone, Serialize)]
+struct ReportConfig {
+    batch_size: usize,
+    kv_len: usize,
+    layers: usize,
+    tp_world_size: usize,
+    iters: u64,
+}
+
+#[derive(Clone, Serialize)]
+struct RollupRow {
+    op: String,
+    calls: usize,
+    total_us: f64,
+    total_p99_us: f64,
+    per_call_us: f64,
+    stddev_us: f64,
+    p99_us: f64,
+    pct: f64,
+}
+
+#[derive(Clone, Serialize)]
+struct CallSiteRow {
+    call_site: String,
+    op: String,
+    calls: usize,
+    per_call_us: f64,
+    stddev_us: f64,
+    p99_us: f64,
+    total_us: f64,
+    total_p99_us: f64,
+    pct: f64,
+}
+
+#[derive(Clone, Serialize)]
+struct CoverageRow {
+    call_site: String,
+    op: String,
+    status: String,
+    calls: usize,
+    latency: Option<LatencyStats>,
+    key: Option<String>,
+}
+
+#[derive(Clone, Serialize)]
+struct LatencyStats {
+    iters: u64,
+    mean_us: f64,
+    stddev_us: f64,
+    min_us: f64,
+    p50_us: f64,
+    p95_us: f64,
+    p99_us: f64,
+    max_us: f64,
+}
+
+#[derive(Clone)]
+struct BenchEntry {
+    key: String,
+    stats: LatencyStats,
+}
+
+struct OpAccum {
+    calls: usize,
+    total_us: f64,
+    total_p99_us: f64,
+    sum_stddev_us: f64,
+    sum_p99_us: f64,
+}
+
+struct SiteAccum {
+    op: String,
+    calls: usize,
+    total_us: f64,
+    total_p99_us: f64,
+    sum_stddev_us: f64,
+    sum_p99_us: f64,
+}
+
+impl LatencyStats {
+    fn zero(iters: u64) -> Self {
+        Self {
+            iters,
+            mean_us: 0.0,
+            stddev_us: 0.0,
+            min_us: 0.0,
+            p50_us: 0.0,
+            p95_us: 0.0,
+            p99_us: 0.0,
+            max_us: 0.0,
+        }
+    }
+
+    fn from_samples(iters: u64, mut samples: Vec<f64>) -> Result<Self> {
+        anyhow::ensure!(!samples.is_empty(), "latency sample set is empty");
+        samples.sort_by(f64::total_cmp);
+        let mean_us = samples.iter().sum::<f64>() / samples.len() as f64;
+        let stddev_us = if samples.len() > 1 {
+            let variance = samples
+                .iter()
+                .map(|sample| {
+                    let delta = sample - mean_us;
+                    delta * delta
+                })
+                .sum::<f64>()
+                / (samples.len() - 1) as f64;
+            variance.sqrt()
+        } else {
+            0.0
+        };
+        Ok(Self {
+            iters,
+            mean_us,
+            stddev_us,
+            min_us: samples[0],
+            p50_us: percentile(&samples, 0.50),
+            p95_us: percentile(&samples, 0.95),
+            p99_us: percentile(&samples, 0.99),
+            max_us: samples[samples.len() - 1],
+        })
+    }
+}
+
+fn percentile(sorted: &[f64], quantile: f64) -> f64 {
+    let idx = ((sorted.len() as f64 - 1.0) * quantile).ceil() as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    if cli.command != PHASE_DECODE {
+        bail!("only `decode` is implemented; got `{}`", cli.command);
+    }
+    if cli.batch_size == 0 {
+        bail!("--batch-size must be greater than zero");
+    }
+    if cli.kv_len == 0 {
+        bail!("--kv-len must be greater than zero");
+    }
+    if cli.iters == 0 {
+        bail!("--iters must be greater than zero");
+    }
+    if cli.format != "text" && cli.format != "json" {
+        bail!("--format must be `text` or `json`");
+    }
+
+    let schedule = trace_decode_kernel_calls(&cli.model_path, cli.batch_size, cli.kv_len)?;
+    let catalog = measure_catalog(&schedule, cli.iters)
+        .with_context(|| "failed to build strict measured catalog")?;
+    let report = compose_report(cli.batch_size, cli.kv_len, cli.iters, schedule, &catalog)?;
+    let out = cli.out.unwrap_or_else(|| {
+        PathBuf::from(format!(
+            "target/model_reports/{MODEL}/decode-bs{}-kv{}.json",
+            cli.batch_size, cli.kv_len
+        ))
+    });
+    write_json_report(&out, &report)?;
+    let dot_out = out.with_extension("dot");
+    write_dot_report(&dot_out, &report)?;
+
+    match cli.format.as_str() {
+        "text" => print_text_report(&report, &out, &dot_out),
+        "json" => {
+            println!("{}", serde_json::to_string_pretty(&report)?);
+            eprintln!("wrote {}", out.display());
+            eprintln!("wrote {}", dot_out.display());
+        }
+        _ => unreachable!("format validated above"),
+    }
+
+    Ok(())
+}
+
+fn write_json_report(path: &Path, report: &ModelReport) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let json = serde_json::to_string_pretty(report)?;
+    fs::write(path, json).with_context(|| format!("failed to write {}", path.display()))
+}
+
+fn write_dot_report(path: &Path, report: &ModelReport) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let mut site_order = Vec::new();
+    for call in &report.schedule {
+        let site = normalize_call_site(&call.label);
+        if !site_order.contains(&site) {
+            site_order.push(site);
+        }
+    }
+    let rows = report
+        .by_call_site
+        .iter()
+        .map(|row| (row.call_site.as_str(), row))
+        .collect::<HashMap<_, _>>();
+    let mut dot = String::new();
+    dot.push_str("digraph qwen3_decode_operator_report {\n");
+    dot.push_str("  rankdir=LR;\n");
+    dot.push_str("  graph [fontname=\"Helvetica\"];\n");
+    dot.push_str("  node [shape=box, style=\"rounded,filled\", fontname=\"Helvetica\", fillcolor=\"#f8fafc\", color=\"#94a3b8\"];\n");
+    dot.push_str("  edge [color=\"#94a3b8\"];\n");
+    for site in &site_order {
+        let Some(row) = rows.get(site.as_str()) else {
+            continue;
+        };
+        let fill = if row.pct >= 25.0 {
+            "#fee2e2"
+        } else if row.pct >= 10.0 {
+            "#ffedd5"
+        } else if row.pct >= 2.0 {
+            "#fef9c3"
+        } else {
+            "#f8fafc"
+        };
+        writeln!(
+            dot,
+            "  \"{}\" [fillcolor=\"{}\", label=\"{}\\n{}\\nmean {} · p99/call {} · {:.1}%\"];",
+            dot_escape(site),
+            fill,
+            dot_escape(site),
+            dot_escape(&row.op),
+            format_us(row.total_us),
+            format_us(row.p99_us),
+            row.pct
+        )?;
+    }
+    for window in site_order.windows(2) {
+        writeln!(
+            dot,
+            "  \"{}\" -> \"{}\";",
+            dot_escape(&window[0]),
+            dot_escape(&window[1])
+        )?;
+    }
+    dot.push_str("}\n");
+    fs::write(path, dot).with_context(|| format!("failed to write {}", path.display()))
+}
+
+fn compose_report(
+    batch_size: usize,
+    kv_len: usize,
+    iters: u64,
+    schedule: Vec<KernelCall>,
+    catalog: &HashMap<String, BenchEntry>,
+) -> Result<ModelReport> {
+    let mut op_rows: BTreeMap<String, OpAccum> = BTreeMap::new();
+    let mut site_rows: BTreeMap<String, SiteAccum> = BTreeMap::new();
+    let mut coverage_rows: BTreeMap<(String, String), CoverageRow> = BTreeMap::new();
+    let mut total = 0.0;
+    let mut total_p99 = 0.0;
+    let mut missing = Vec::new();
+
+    for call in &schedule {
+        let site = normalize_call_site(&call.label);
+        if is_noop_all_reduce(call) {
+            let op_entry = op_rows.entry(call.op.clone()).or_insert_with(|| OpAccum {
+                calls: 0,
+                total_us: 0.0,
+                total_p99_us: 0.0,
+                sum_stddev_us: 0.0,
+                sum_p99_us: 0.0,
+            });
+            op_entry.calls += 1;
+            let site_entry = site_rows.entry(site.clone()).or_insert_with(|| SiteAccum {
+                op: call.op.clone(),
+                calls: 0,
+                total_us: 0.0,
+                total_p99_us: 0.0,
+                sum_stddev_us: 0.0,
+                sum_p99_us: 0.0,
+            });
+            site_entry.calls += 1;
+            coverage_rows
+                .entry((site.clone(), call.op.clone()))
+                .and_modify(|row| row.calls += 1)
+                .or_insert(CoverageRow {
+                    call_site: site,
+                    op: call.op.clone(),
+                    status: "no_op".to_string(),
+                    calls: 1,
+                    latency: Some(LatencyStats::zero(iters)),
+                    key: None,
+                });
+            continue;
+        }
+
+        let key = bench_key(call)?;
+        let Some(entry) = catalog.get(&key) else {
+            missing.push(format!(
+                "op={} label={} key={key}\n{}",
+                call.op,
+                call.label,
+                describe_call(call)
+            ));
+            continue;
+        };
+
+        total += entry.stats.mean_us;
+        total_p99 += entry.stats.p99_us;
+        let op_entry = op_rows.entry(call.op.clone()).or_insert_with(|| OpAccum {
+            calls: 0,
+            total_us: 0.0,
+            total_p99_us: 0.0,
+            sum_stddev_us: 0.0,
+            sum_p99_us: 0.0,
+        });
+        op_entry.calls += 1;
+        op_entry.total_us += entry.stats.mean_us;
+        op_entry.total_p99_us += entry.stats.p99_us;
+        op_entry.sum_stddev_us += entry.stats.stddev_us;
+        op_entry.sum_p99_us += entry.stats.p99_us;
+
+        let site_entry = site_rows.entry(site.clone()).or_insert_with(|| SiteAccum {
+            op: call.op.clone(),
+            calls: 0,
+            total_us: 0.0,
+            total_p99_us: 0.0,
+            sum_stddev_us: 0.0,
+            sum_p99_us: 0.0,
+        });
+        site_entry.calls += 1;
+        site_entry.total_us += entry.stats.mean_us;
+        site_entry.total_p99_us += entry.stats.p99_us;
+        site_entry.sum_stddev_us += entry.stats.stddev_us;
+        site_entry.sum_p99_us += entry.stats.p99_us;
+
+        coverage_rows
+            .entry((site.clone(), call.op.clone()))
+            .and_modify(|row| row.calls += 1)
+            .or_insert(CoverageRow {
+                call_site: site,
+                op: call.op.clone(),
+                status: "measured".to_string(),
+                calls: 1,
+                latency: Some(entry.stats.clone()),
+                key: Some(entry.key.clone()),
+            });
+    }
+
+    if !missing.is_empty() {
+        bail!("missing bench result:\n{}", missing.join("\n\n"));
+    }
+
+    let mut by_op: Vec<_> = op_rows
+        .into_iter()
+        .map(|(op, row)| {
+            let calls = row.calls.max(1) as f64;
+            RollupRow {
+                op,
+                calls: row.calls,
+                total_us: row.total_us,
+                total_p99_us: row.total_p99_us,
+                per_call_us: row.total_us / calls,
+                stddev_us: row.sum_stddev_us / calls,
+                p99_us: row.sum_p99_us / calls,
+                pct: pct(row.total_us, total),
+            }
+        })
+        .collect();
+    by_op.sort_by(|a, b| b.total_us.total_cmp(&a.total_us).then(a.op.cmp(&b.op)));
+
+    let mut by_call_site: Vec<_> = site_rows
+        .into_iter()
+        .map(|(call_site, row)| {
+            let calls = row.calls.max(1) as f64;
+            CallSiteRow {
+                call_site,
+                op: row.op,
+                calls: row.calls,
+                per_call_us: row.total_us / calls,
+                stddev_us: row.sum_stddev_us / calls,
+                p99_us: row.sum_p99_us / calls,
+                total_us: row.total_us,
+                total_p99_us: row.total_p99_us,
+                pct: pct(row.total_us, total),
+            }
+        })
+        .collect();
+    by_call_site.sort_by(|a, b| {
+        b.total_us
+            .total_cmp(&a.total_us)
+            .then(a.call_site.cmp(&b.call_site))
+    });
+
+    Ok(ModelReport {
+        schema: 2,
+        report_type: "model_operator_report".to_string(),
+        model: MODEL.to_string(),
+        phase: PHASE_DECODE.to_string(),
+        config: ReportConfig {
+            batch_size,
+            kv_len,
+            layers: NUM_LAYERS,
+            tp_world_size: 1,
+            iters,
+        },
+        schedule_source:
+            "runtime trace: Qwen3Model::batch_decode eager DAG with CUDA Graph disabled".to_string(),
+        total_measured_us: total,
+        total_p99_us: total_p99,
+        schedule,
+        by_op,
+        by_call_site,
+        coverage: coverage_rows.into_values().collect(),
+    })
+}
+
+fn pct(value: f64, total: f64) -> f64 {
+    if total == 0.0 {
+        0.0
+    } else {
+        value / total * 100.0
+    }
+}
+
+fn measure_catalog(calls: &[KernelCall], iters: u64) -> Result<HashMap<String, BenchEntry>> {
+    let mut catalog = HashMap::new();
+    for call in calls {
+        if is_noop_all_reduce(call) {
+            continue;
+        }
+        let key = bench_key(call)?;
+        if catalog.contains_key(&key) {
+            continue;
+        }
+        let stats = measure_call(call, iters).with_context(|| {
+            format!("failed to measure {}\n{}", call.label, describe_call(call))
+        })?;
+        catalog.insert(key.clone(), BenchEntry { key, stats });
+    }
+    Ok(catalog)
+}
+
+fn measure_call(call: &KernelCall, iters: u64) -> Result<LatencyStats> {
+    match call.op.as_str() {
+        "embedding_batch" => measure_embedding(call, iters),
+        "rms_norm_batch" => measure_rms_norm_batch(call, iters),
+        "gemm_rows" => measure_gemm_rows(call, iters),
+        "qk_norm_rope_batch_decode" => measure_qk_norm_rope(call, iters),
+        "paged_decode_attention" => measure_paged_decode_attention(call, iters),
+        "gemm" => measure_gemm(call, iters),
+        "fused_add_rms_norm_batch" => measure_fused_add_rms_norm(call, iters),
+        "silu_mul_fused_batch" => measure_silu_mul_fused(call, iters),
+        other => bail!("no benchmark provider for op `{other}`"),
+    }
+}
+
+fn measure_embedding(call: &KernelCall, iters: u64) -> Result<LatencyStats> {
+    let weight = input(call, "weight")?;
+    let out = output(call, "out")?;
+    let vocab = axis(weight, "vocab")?;
+    let hidden = axis(weight, "hidden")?;
+    let batch = axis(out, "batch")?;
+    let ctx = DeviceContext::new()?;
+    let embed = zero_matrix(&ctx, vocab, hidden)?;
+    let token_ids: CudaSlice<u32> = ctx.stream.alloc_zeros(batch)?;
+    let mut out = HiddenStates::zeros(&ctx, hidden, batch)?;
+    measure_loop(&ctx, iters, || {
+        ops::embedding_batch(&ctx, &embed, &token_ids, &mut out)?;
+        Ok(())
+    })
+}
+
+fn measure_rms_norm_batch(call: &KernelCall, iters: u64) -> Result<LatencyStats> {
+    let x = input(call, "x")?;
+    let hidden = axis(x, "hidden")?;
+    let batch = axis(x, "batch")?;
+    let ctx = DeviceContext::new()?;
+    let x = HiddenStates::zeros(&ctx, hidden, batch)?;
+    let weight = DeviceVec::zeros(&ctx, hidden)?;
+    let mut out = HiddenStates::zeros(&ctx, hidden, batch)?;
+    measure_loop(&ctx, iters, || {
+        ops::rms_norm_batch_into(&ctx, &x, &weight, RMS_NORM_EPS, &mut out);
+        Ok(())
+    })
+}
+
+fn measure_gemm_rows(call: &KernelCall, iters: u64) -> Result<LatencyStats> {
+    let weight = input(call, "weight")?;
+    let x = input(call, "x")?;
+    let out = output(call, "out")?;
+    let out_total = axis(weight, "out_total")?;
+    let in_dim = axis(weight, "in")?;
+    let rows = attr_usize(call, "rows")?;
+    let row_offset = attr_usize(call, "row_offset")?;
+    let batch = axis(x, "batch")?;
+    let out_dim = first_axis_size(out)?;
+    anyhow::ensure!(out_dim == rows, "gemm_rows output dim must match rows");
+    let ctx = DeviceContext::new()?;
+    let weight = zero_matrix(&ctx, out_total, in_dim)?;
+    let x = HiddenStates::zeros(&ctx, in_dim, batch)?;
+    let mut out = HiddenStates::zeros(&ctx, rows, batch)?;
+    measure_loop(&ctx, iters, || {
+        ops::gemm_rows_into(&ctx, &weight, row_offset, rows, &x, &mut out);
+        Ok(())
+    })
+}
+
+fn measure_gemm(call: &KernelCall, iters: u64) -> Result<LatencyStats> {
+    let weight = input(call, "weight")?;
+    let x = input(call, "x")?;
+    let out_dim = axis(weight, "out")?;
+    let in_dim = axis(weight, "in")?;
+    let batch = axis(x, "batch")?;
+    let ctx = DeviceContext::new()?;
+    let weight = zero_matrix(&ctx, out_dim, in_dim)?;
+    let x = HiddenStates::zeros(&ctx, in_dim, batch)?;
+    let mut out = HiddenStates::zeros(&ctx, out_dim, batch)?;
+    measure_loop(&ctx, iters, || {
+        ops::gemm_into(&ctx, &weight, &x, &mut out);
+        Ok(())
+    })
+}
+
+fn measure_fused_add_rms_norm(call: &KernelCall, iters: u64) -> Result<LatencyStats> {
+    let hidden_spec = input(call, "hidden")?;
+    let hidden_dim = axis(hidden_spec, "hidden")?;
+    let batch = axis(hidden_spec, "batch")?;
+    let ctx = DeviceContext::new()?;
+    let mut hidden = HiddenStates::zeros(&ctx, hidden_dim, batch)?;
+    let residual = HiddenStates::zeros(&ctx, hidden_dim, batch)?;
+    let weight = DeviceVec::zeros(&ctx, hidden_dim)?;
+    let mut out = HiddenStates::zeros(&ctx, hidden_dim, batch)?;
+    measure_loop(&ctx, iters, || {
+        ops::fused_add_rms_norm_batch_into(
+            &ctx,
+            &mut hidden,
+            &residual,
+            &weight,
+            RMS_NORM_EPS,
+            &mut out,
+        );
+        Ok(())
+    })
+}
+
+fn measure_silu_mul_fused(call: &KernelCall, iters: u64) -> Result<LatencyStats> {
+    let gate_up = input(call, "gate_up")?;
+    let out = output(call, "out")?;
+    let inter2 = axis(gate_up, "inter2")?;
+    let inter = axis(out, "intermediate")?;
+    let batch = axis(gate_up, "batch")?;
+    anyhow::ensure!(inter2 == 2 * inter, "gate_up axis must be 2 * intermediate");
+    let ctx = DeviceContext::new()?;
+    let gate_up = HiddenStates::zeros(&ctx, inter2, batch)?;
+    let mut out = HiddenStates::zeros(&ctx, inter, batch)?;
+    measure_loop(&ctx, iters, || {
+        ops::silu_mul_fused_batch_into(&ctx, &gate_up, &mut out);
+        Ok(())
+    })
+}
+
+fn measure_qk_norm_rope(call: &KernelCall, iters: u64) -> Result<LatencyStats> {
+    let q = input(call, "q")?;
+    let k = input(call, "k")?;
+    let q_dim = axis(q, "q_dim")?;
+    let kv_dim = axis(k, "kv_dim")?;
+    let batch = axis(q, "batch")?;
+    let seq = axis(input(call, "cos_cache")?, "seq")?;
+    let ctx = DeviceContext::new()?;
+    let mut q = HiddenStates::zeros(&ctx, q_dim, batch)?;
+    let mut k = HiddenStates::zeros(&ctx, kv_dim, batch)?;
+    let q_norm = DeviceVec::zeros(&ctx, HEAD_DIM_VALUE)?;
+    let k_norm = DeviceVec::zeros(&ctx, HEAD_DIM_VALUE)?;
+    let cos_cache = DeviceVec::zeros(&ctx, seq * HEAD_DIM_VALUE)?;
+    let sin_cache = DeviceVec::zeros(&ctx, seq * HEAD_DIM_VALUE)?;
+    let positions_host = vec![seq.saturating_sub(1) as i32; batch];
+    let positions = ctx.stream.clone_htod(&positions_host)?;
+    measure_loop(&ctx, iters, || {
+        ops::qk_norm_rope_batch_decode_into(
+            &ctx,
+            &mut q,
+            &mut k,
+            &q_norm,
+            &k_norm,
+            &cos_cache,
+            &sin_cache,
+            &positions,
+            NUM_Q_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM_VALUE,
+            RMS_NORM_EPS,
+        );
+        Ok(())
+    })
+}
+
+fn measure_paged_decode_attention(call: &KernelCall, iters: u64) -> Result<LatencyStats> {
+    let q = input(call, "q")?;
+    let kv = input(call, "kv_buffer")?;
+    let batch = axis(q, "batch")?;
+    let q_dim = axis(q, "q_dim")?;
+    let total_pages = axis(kv, "page")?;
+    let num_layers = axis(kv, "layer")?;
+    let kv_heads = axis(kv, "kv_head")?;
+    let head_dim = axis(kv, "head_dim")?;
+    let page_size = axis(kv, "pos_in_page")?;
+    let kv_len = attr_usize(call, "kv_len")?;
+    let pages_per_request = kv_len.div_ceil(page_size);
+    let layout = KvLayout::new(num_layers, kv_heads, head_dim, page_size);
+    let ctx = DeviceContext::new()?;
+    let q = HiddenStates::zeros(&ctx, q_dim, batch)?;
+    let k = HiddenStates::zeros(&ctx, KV_DIM_VALUE, batch)?;
+    let v = HiddenStates::zeros(&ctx, KV_DIM_VALUE, batch)?;
+    let mut out = HiddenStates::zeros(&ctx, q_dim, batch)?;
+    let kv_buffer: CudaSlice<bf16> = ctx.stream.alloc_zeros(total_pages * layout.page_stride)?;
+    let (page_indices, page_indptr) = page_tables(batch, pages_per_request);
+    let last_page_len_value = match kv_len % page_size {
+        0 => page_size,
+        rem => rem,
+    };
+    let last_page_len = vec![last_page_len_value as i32; batch];
+    let positions = vec![kv_len.saturating_sub(1) as i32; batch];
+    let request_indices: Vec<i32> = (0..batch as i32).collect();
+    let page_indices_d = ctx.stream.clone_htod(&page_indices)?;
+    let page_indptr_d = ctx.stream.clone_htod(&page_indptr)?;
+    let last_page_len_d = ctx.stream.clone_htod(&last_page_len)?;
+    let positions_d = ctx.stream.clone_htod(&positions)?;
+    let request_indices_d = ctx.stream.clone_htod(&request_indices)?;
+    let variant = attr_string(call, "variant")?;
+
+    if variant == "split_kv_256x64" {
+        let split_chunk_size = DEFAULT_SPLIT_KV.actual_chunk_size(kv_len);
+        let chunks_per_request = DEFAULT_SPLIT_KV.active_chunks(kv_len);
+        let padded_slots = batch * DEFAULT_SPLIT_KV.max_chunks_per_request;
+        let mut split_request_indices = Vec::with_capacity(padded_slots);
+        let mut split_kv_tile_indices = Vec::with_capacity(padded_slots);
+        let mut split_o_indptr = Vec::with_capacity(batch + 1);
+        let mut split_block_valid_mask = Vec::with_capacity(padded_slots);
+        split_o_indptr.push(0);
+        for request_idx in 0..batch {
+            for chunk_idx in 0..chunks_per_request {
+                split_request_indices.push(request_idx as i32);
+                split_kv_tile_indices.push(chunk_idx as i32);
+                split_block_valid_mask.push(1_u8);
+            }
+            split_o_indptr.push(split_request_indices.len() as i32);
+        }
+        while split_request_indices.len() < padded_slots {
+            split_request_indices.push(0);
+            split_kv_tile_indices.push(0);
+            split_block_valid_mask.push(0);
+        }
+        let split_kv_chunk_size = [split_chunk_size as i32];
+        let split_request_indices_d = ctx.stream.clone_htod(&split_request_indices)?;
+        let split_kv_tile_indices_d = ctx.stream.clone_htod(&split_kv_tile_indices)?;
+        let split_kv_chunk_size_d = ctx.stream.clone_htod(&split_kv_chunk_size)?;
+        let split_o_indptr_d = ctx.stream.clone_htod(&split_o_indptr)?;
+        let split_block_valid_mask_d = ctx.stream.clone_htod(&split_block_valid_mask)?;
+        let mut split_tmp_v = ctx.stream.alloc_zeros(padded_slots * q_dim)?;
+        let mut split_tmp_s = ctx.stream.alloc_zeros(padded_slots * NUM_Q_HEADS)?;
+        measure_loop(&ctx, iters, || {
+            ops::paged_attention_batch_decode_split_kv_into(
+                &ctx,
+                &q,
+                &k,
+                &v,
+                &kv_buffer,
+                &layout,
+                0,
+                &page_indices_d,
+                &page_indptr_d,
+                &last_page_len_d,
+                &positions_d,
+                &request_indices_d,
+                &split_request_indices_d,
+                &split_kv_tile_indices_d,
+                &split_kv_chunk_size_d,
+                &split_o_indptr_d,
+                &split_block_valid_mask_d,
+                &mut split_tmp_v,
+                &mut split_tmp_s,
+                padded_slots,
+                &mut out,
+                NUM_Q_HEADS,
+                batch,
+            )
+        })
+    } else if variant == "non_partition" {
+        let kv_tile_indices = vec![0_i32; batch];
+        let kv_chunk_size = vec![kv_len as i32; batch];
+        let kv_tile_indices_d = ctx.stream.clone_htod(&kv_tile_indices)?;
+        let kv_chunk_size_d = ctx.stream.clone_htod(&kv_chunk_size)?;
+        measure_loop(&ctx, iters, || {
+            ops::paged_attention_batch_decode_into(
+                &ctx,
+                &q,
+                &k,
+                &v,
+                &kv_buffer,
+                &layout,
+                0,
+                &page_indices_d,
+                &page_indptr_d,
+                &last_page_len_d,
+                &positions_d,
+                &request_indices_d,
+                &kv_tile_indices_d,
+                &kv_chunk_size_d,
+                &mut out,
+                NUM_Q_HEADS,
+                batch,
+            )
+        })
+    } else {
+        bail!("unsupported decode attention variant `{variant}`")
+    }
+}
+
+fn page_tables(batch: usize, pages_per_request: usize) -> (Vec<i32>, Vec<i32>) {
+    let mut page_indices = Vec::with_capacity(batch * pages_per_request);
+    let mut page_indptr = Vec::with_capacity(batch + 1);
+    page_indptr.push(0);
+    for request_idx in 0..batch {
+        for page_offset in 0..pages_per_request {
+            page_indices.push((request_idx * pages_per_request + page_offset) as i32);
+        }
+        page_indptr.push(page_indices.len() as i32);
+    }
+    (page_indices, page_indptr)
+}
+
+fn measure_loop(
+    ctx: &DeviceContext,
+    iters: u64,
+    mut launch: impl FnMut() -> Result<()>,
+) -> Result<LatencyStats> {
+    let mut cache_clear = L2CacheClear::new(ctx)?;
+    let start = ctx
+        .ctx
+        .new_event(Some(sys::CUevent_flags::CU_EVENT_DEFAULT))?;
+    let end = ctx
+        .ctx
+        .new_event(Some(sys::CUevent_flags::CU_EVENT_DEFAULT))?;
+    launch()?;
+    ctx.sync()?;
+    let mut samples = Vec::with_capacity(iters as usize);
+    for _ in 0..iters {
+        cache_clear.clear(ctx)?;
+        start.record(&ctx.stream)?;
+        launch()?;
+        end.record(&ctx.stream)?;
+        samples.push(f64::from(start.elapsed_ms(&end)?) * 1.0e3);
+    }
+    LatencyStats::from_samples(iters, samples)
+}
+
+fn zero_matrix(ctx: &DeviceContext, rows: usize, cols: usize) -> Result<DeviceMatrix> {
+    Ok(DeviceMatrix {
+        data: ctx.stream.alloc_zeros(rows * cols)?,
+        rows,
+        cols,
+    })
+}
+
+fn input<'a>(call: &'a KernelCall, name: &str) -> Result<&'a TensorSpec> {
+    call.inputs
+        .iter()
+        .find(|arg| arg.name == name)
+        .map(|arg| &arg.spec)
+        .ok_or_else(|| anyhow!("call `{}` missing input `{name}`", call.label))
+}
+
+fn output<'a>(call: &'a KernelCall, name: &str) -> Result<&'a TensorSpec> {
+    call.outputs
+        .iter()
+        .find(|arg| arg.name == name)
+        .map(|arg| &arg.spec)
+        .ok_or_else(|| anyhow!("call `{}` missing output `{name}`", call.label))
+}
+
+fn axis(spec: &TensorSpec, name: &str) -> Result<usize> {
+    spec.axes
+        .iter()
+        .find(|axis| axis.name == name)
+        .map(|axis| axis.size)
+        .ok_or_else(|| anyhow!("{} missing axis `{name}`", spec.compact()))
+}
+
+fn first_axis_size(spec: &TensorSpec) -> Result<usize> {
+    spec.axes
+        .first()
+        .map(|axis| axis.size)
+        .ok_or_else(|| anyhow!("{} has no axes", spec.compact()))
+}
+
+fn attr_string(call: &KernelCall, name: &str) -> Result<String> {
+    call.attrs
+        .iter()
+        .find(|attr| attr.name == name)
+        .map(|attr| attr.value.clone())
+        .ok_or_else(|| anyhow!("call `{}` missing attr `{name}`", call.label))
+}
+
+fn attr_usize(call: &KernelCall, name: &str) -> Result<usize> {
+    attr_string(call, name)?
+        .parse::<usize>()
+        .with_context(|| format!("call `{}` attr `{name}` is not usize", call.label))
+}
+
+fn is_noop_all_reduce(call: &KernelCall) -> bool {
+    call.op == "all_reduce_hidden"
+        && call
+            .attrs
+            .iter()
+            .any(|attr| attr.name == "no_op" && attr.value == "true")
+}
+
+fn bench_key(call: &KernelCall) -> Result<String> {
+    #[derive(Serialize)]
+    struct Key<'a> {
+        op: &'a str,
+        inputs: &'a [pegainfer_kernels::tensor::TensorArg],
+        outputs: &'a [pegainfer_kernels::tensor::TensorArg],
+        attrs: BTreeMap<&'a str, &'a str>,
+    }
+
+    let attrs = call
+        .attrs
+        .iter()
+        .filter(|attr| attr.name != "no_op" && attr.name != "tp_world_size")
+        .map(|attr| (attr.name.as_str(), attr.value.as_str()))
+        .collect();
+    serde_json::to_string(&Key {
+        op: &call.op,
+        inputs: &call.inputs,
+        outputs: &call.outputs,
+        attrs,
+    })
+    .with_context(|| format!("failed to serialize bench key for {}", call.label))
+}
+
+fn describe_call(call: &KernelCall) -> String {
+    let inputs = call
+        .inputs
+        .iter()
+        .map(|arg| format!("  in  {}", arg.compact()))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let outputs = call
+        .outputs
+        .iter()
+        .map(|arg| format!("  out {}", arg.compact()))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!("{inputs}\n{outputs}")
+}
+
+fn print_text_report(report: &ModelReport, out: &Path, dot_out: &Path) {
+    println!("{MODEL} decode operator report");
+    println!(
+        "config: bs={} kv_len={} layers={} tp={} iters={}",
+        report.config.batch_size,
+        report.config.kv_len,
+        report.config.layers,
+        report.config.tp_world_size,
+        report.config.iters
+    );
+    println!("json: {}", out.display());
+    println!("dot:  {}", dot_out.display());
+    println!("source: {}", report.schedule_source);
+    println!();
+
+    println!("By op");
+    let mut by_op = table();
+    by_op.set_header(vec![
+        "op",
+        "calls",
+        "mean total",
+        "%tot",
+        "avg mean",
+        "avg std",
+        "avg p99",
+    ]);
+    for row in &report.by_op {
+        by_op.add_row(vec![
+            Cell::new(&row.op).fg(op_color(row.pct)),
+            Cell::new(row.calls),
+            Cell::new(format_us(row.total_us)),
+            Cell::new(format_pct(row.pct)),
+            Cell::new(format_us(row.per_call_us)),
+            Cell::new(format_us(row.stddev_us)),
+            Cell::new(format_us(row.p99_us)),
+        ]);
+    }
+    println!("{by_op}");
+
+    println!("By call site");
+    let mut by_site = table();
+    by_site.set_header(vec![
+        "call site",
+        "op",
+        "calls",
+        "mean/call",
+        "std",
+        "p99/call",
+        "mean total",
+        "%tot",
+    ]);
+    for row in report.by_call_site.iter().take(16) {
+        by_site.add_row(vec![
+            Cell::new(&row.call_site).fg(op_color(row.pct)),
+            Cell::new(&row.op),
+            Cell::new(row.calls),
+            Cell::new(format_us(row.per_call_us)),
+            Cell::new(format_us(row.stddev_us)),
+            Cell::new(format_us(row.p99_us)),
+            Cell::new(format_us(row.total_us)),
+            Cell::new(format_pct(row.pct)),
+        ]);
+    }
+    println!("{by_site}");
+
+    println!("Coverage");
+    let mut coverage = table();
+    coverage.set_header(vec!["call site", "op", "status", "calls", "mean", "p99"]);
+    for row in &report.coverage {
+        let mean = row
+            .latency
+            .as_ref()
+            .map_or_else(|| "-".to_string(), |value| format_us(value.mean_us));
+        let p99 = row
+            .latency
+            .as_ref()
+            .map_or_else(|| "-".to_string(), |value| format_us(value.p99_us));
+        coverage.add_row(vec![
+            Cell::new(&row.call_site),
+            Cell::new(&row.op),
+            Cell::new(&row.status).fg(status_color(&row.status)),
+            Cell::new(row.calls),
+            Cell::new(mean),
+            Cell::new(p99),
+        ]);
+    }
+    println!("{coverage}");
+
+    println!("Schedule preview");
+    let mut preview = table();
+    preview.set_header(vec!["label", "op", "args", "first input"]);
+    for call in report.schedule.iter().take(14) {
+        let first_input = call
+            .inputs
+            .first()
+            .map(pegainfer_core::tensor::TensorArg::compact)
+            .map_or_else(|| "-".to_string(), |input| truncate(&input, 86));
+        preview.add_row(vec![
+            Cell::new(&call.label),
+            Cell::new(&call.op),
+            Cell::new(format!(
+                "{} in / {} out",
+                call.inputs.len(),
+                call.outputs.len()
+            )),
+            Cell::new(first_input),
+        ]);
+    }
+    println!("{preview}");
+}
+
+fn table() -> Table {
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .set_content_arrangement(ContentArrangement::Dynamic);
+    table
+}
+
+fn op_color(pct: f64) -> Color {
+    if pct >= 25.0 {
+        Color::Red
+    } else if pct >= 10.0 {
+        Color::Yellow
+    } else {
+        Color::White
+    }
+}
+
+fn status_color(status: &str) -> Color {
+    match status {
+        "measured" => Color::Green,
+        "no_op" => Color::DarkGrey,
+        _ => Color::Yellow,
+    }
+}
+
+fn format_us(value: f64) -> String {
+    if value >= 1_000.0 {
+        format!("{:.3} ms", value / 1_000.0)
+    } else {
+        format!("{value:.3} us")
+    }
+}
+
+fn format_pct(value: f64) -> String {
+    format!("{value:.1}%")
+}
+
+fn truncate(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    let mut truncated = value
+        .chars()
+        .take(max_chars.saturating_sub(3))
+        .collect::<String>();
+    truncated.push_str("...");
+    truncated
+}
+
+fn dot_escape(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+}

--- a/pegainfer-qwen3-4b/src/lib.rs
+++ b/pegainfer-qwen3-4b/src/lib.rs
@@ -2,6 +2,8 @@ pub mod kernel_plan;
 
 mod batch_decode;
 mod batch_decode_buffers;
+mod batch_decode_dag;
+pub mod batch_decode_trace;
 mod config;
 mod executor;
 pub mod kernel_bench;

--- a/pegainfer-qwen3-4b/src/weights.rs
+++ b/pegainfer-qwen3-4b/src/weights.rs
@@ -397,6 +397,24 @@ impl Qwen3Model {
         &self,
         hidden: &mut pegainfer_core::tensor::HiddenStates,
     ) -> Result<()> {
+        #[cfg(feature = "kernel-call-trace")]
+        if pegainfer_core::ops::call_trace::is_enabled() {
+            let label = pegainfer_core::ops::call_trace::current_label("all_reduce_hidden");
+            pegainfer_core::ops::call_trace::record_call(
+                pegainfer_core::ops::call_spec::all_reduce_hidden_call(
+                    label,
+                    hidden.hidden_dim,
+                    hidden.seq_len,
+                ),
+            );
+        }
+        self.all_reduce_hidden_untraced(hidden)
+    }
+
+    pub(crate) fn all_reduce_hidden_untraced(
+        &self,
+        hidden: &mut pegainfer_core::tensor::HiddenStates,
+    ) -> Result<()> {
         if let Some(comm) = &self.tp_comm {
             comm.all_reduce_in_place(&mut hidden.data, &ReduceOp::Sum)
                 .map_err(|e| anyhow::anyhow!("nccl all-reduce failed: {e:?}"))?;

--- a/pegainfer-qwen3-4b/tests/e2e.rs
+++ b/pegainfer-qwen3-4b/tests/e2e.rs
@@ -91,8 +91,7 @@ fn generate_tokens(
     loop {
         match token_rx.blocking_recv() {
             Some(TokenEvent::Token { id, .. }) => tokens.push(id),
-            Some(TokenEvent::PromptTokens { .. }) => {}
-            Some(TokenEvent::Scheduled { .. }) => {}
+            Some(TokenEvent::PromptTokens { .. } | TokenEvent::Scheduled { .. }) => {}
             Some(TokenEvent::Finished { finish_reason, .. }) => {
                 return (tokens, finish_reason);
             }

--- a/pegainfer-qwen3-4b/tests/regen_test_data.rs
+++ b/pegainfer-qwen3-4b/tests/regen_test_data.rs
@@ -109,8 +109,7 @@ fn generate_text_scheduler(
     loop {
         match token_rx.blocking_recv() {
             Some(TokenEvent::Token { id, .. }) => tokens.push(id),
-            Some(TokenEvent::PromptTokens { .. }) => {}
-            Some(TokenEvent::Scheduled { .. }) => {}
+            Some(TokenEvent::PromptTokens { .. } | TokenEvent::Scheduled { .. }) => {}
             Some(TokenEvent::Finished { .. }) => break,
             Some(TokenEvent::Error { message, .. }) => panic!("generation failed: {message}"),
             Some(TokenEvent::Rejected { message, .. }) => panic!("generation rejected: {message}"),


### PR DESCRIPTION
## Summary
- add erased TensorSpec / KernelCall metadata vocabulary for runtime operator traces
- add feature-gated kernel-call tracing wrappers in pegainfer-core ops
- route Qwen3-4B decode through an eager BatchDecodeDag so the executed forward path is also the traced model report source
- add qwen3_model_report CLI with by-op, by-call-site, coverage, schedule preview, JSON, and Graphviz DOT output

## Validation
- cargo fmt --all --check
- git diff --check
- cargo clippy --release -p pegainfer-qwen3-4b --features kernel-report --all-targets -- -D warnings
- cargo test --release -p pegainfer-qwen3-4b --lib
- cargo run --release -p pegainfer-qwen3-4b --features kernel-report --bin qwen3_model_report -- decode --batch-size 16 --kv-len 2048 --format text
- PEGAINFER_TEST_MODEL_PATH=/data/code/workspace-rustllm/pegainfer/models/Qwen3-4B cargo test --release -p pegainfer-qwen3-4b --test e2e -- --nocapture

## E2E note
Qwen3-4B e2e currently reports greedy-output mismatches. I reproduced the same Kanye prompt mismatch from a detached baseline worktree at HEAD=3ffe745, so this is not introduced by the eager-DAG/model-report changes.
