### PR TITLE
feat(server): add --served-model-name to decouple public model id (#80)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5784,7 +5784,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vllm-chat"
 version = "0.1.0"
-source = "git+https://github.com/Inferact/vllm-frontend-rs.git?rev=eb2b54b1a0b3ef2904a25538bc0211f058f7e95f#eb2b54b1a0b3ef2904a25538bc0211f058f7e95f"
+source = "git+https://github.com/Inferact/vllm-frontend-rs.git?rev=b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9#b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
@@ -5814,7 +5814,7 @@ dependencies = [
 [[package]]
 name = "vllm-engine-core-client"
 version = "0.1.0"
-source = "git+https://github.com/Inferact/vllm-frontend-rs.git?rev=eb2b54b1a0b3ef2904a25538bc0211f058f7e95f#eb2b54b1a0b3ef2904a25538bc0211f058f7e95f"
+source = "git+https://github.com/Inferact/vllm-frontend-rs.git?rev=b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9#b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9"
 dependencies = [
  "arc-swap",
  "byteorder",
@@ -5845,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "vllm-llm"
 version = "0.1.0"
-source = "git+https://github.com/Inferact/vllm-frontend-rs.git?rev=eb2b54b1a0b3ef2904a25538bc0211f058f7e95f#eb2b54b1a0b3ef2904a25538bc0211f058f7e95f"
+source = "git+https://github.com/Inferact/vllm-frontend-rs.git?rev=b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9#b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9"
 dependencies = [
  "easy-ext",
  "enum-as-inner",
@@ -5864,7 +5864,7 @@ dependencies = [
 [[package]]
 name = "vllm-metrics"
 version = "0.1.0"
-source = "git+https://github.com/Inferact/vllm-frontend-rs.git?rev=eb2b54b1a0b3ef2904a25538bc0211f058f7e95f#eb2b54b1a0b3ef2904a25538bc0211f058f7e95f"
+source = "git+https://github.com/Inferact/vllm-frontend-rs.git?rev=b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9#b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9"
 dependencies = [
  "prometheus-client",
 ]
@@ -5872,7 +5872,7 @@ dependencies = [
 [[package]]
 name = "vllm-server"
 version = "0.1.0"
-source = "git+https://github.com/Inferact/vllm-frontend-rs.git?rev=eb2b54b1a0b3ef2904a25538bc0211f058f7e95f#eb2b54b1a0b3ef2904a25538bc0211f058f7e95f"
+source = "git+https://github.com/Inferact/vllm-frontend-rs.git?rev=b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9#b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
@@ -5911,7 +5911,7 @@ dependencies = [
 [[package]]
 name = "vllm-text"
 version = "0.1.0"
-source = "git+https://github.com/Inferact/vllm-frontend-rs.git?rev=eb2b54b1a0b3ef2904a25538bc0211f058f7e95f#eb2b54b1a0b3ef2904a25538bc0211f058f7e95f"
+source = "git+https://github.com/Inferact/vllm-frontend-rs.git?rev=b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9#b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,9 +51,9 @@ tokio = "1"
 tokio-util = "0.7"
 toml = "1.1"
 uuid = "1"
-vllm-engine-core-client = { git = "https://github.com/Inferact/vllm-frontend-rs.git", rev = "eb2b54b1a0b3ef2904a25538bc0211f058f7e95f" }
-vllm-server = { git = "https://github.com/Inferact/vllm-frontend-rs.git", rev = "eb2b54b1a0b3ef2904a25538bc0211f058f7e95f" }
-vllm-text = { git = "https://github.com/Inferact/vllm-frontend-rs.git", rev = "eb2b54b1a0b3ef2904a25538bc0211f058f7e95f" }
+vllm-engine-core-client = { git = "https://github.com/Inferact/vllm-frontend-rs.git", rev = "b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9" }
+vllm-server = { git = "https://github.com/Inferact/vllm-frontend-rs.git", rev = "b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9" }
+vllm-text = { git = "https://github.com/Inferact/vllm-frontend-rs.git", rev = "b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9" }
 zeromq = { git = "https://github.com/BugenZhao/zmq.rs", rev = "dde4ee5c48846b0cc22b1f4fad8c7514748180fe", default-features = false, features = [
     "tokio-runtime",
     "all-transport",

--- a/pegainfer-server/src/main.rs
+++ b/pegainfer-server/src/main.rs
@@ -16,6 +16,11 @@ struct Args {
     #[arg(long, default_value = DEFAULT_MODEL_PATH)]
     model_path: PathBuf,
 
+    /// Public model ID returned by the OpenAI API (/v1/models, completion `model`).
+    /// Defaults to the model path when omitted.
+    #[arg(long)]
+    served_model_name: Option<String>,
+
     /// Port to listen on
     #[arg(long, default_value_t = 8000)]
     port: u16,
@@ -113,6 +118,7 @@ async fn main() -> anyhow::Result<()> {
     pegainfer::vllm_frontend::serve(
         handle,
         &args.model_path,
+        args.served_model_name.as_deref(),
         args.port,
         pegainfer::vllm_frontend::shutdown_token_from_ctrl_c(),
     )

--- a/pegainfer-server/src/vllm_frontend.rs
+++ b/pegainfer-server/src/vllm_frontend.rs
@@ -216,6 +216,7 @@ impl LocalEngineBridge {
 pub async fn serve(
     handle: EngineHandle,
     model_path: &Path,
+    served_model_name: Option<&str>,
     port: u16,
     shutdown: CancellationToken,
 ) -> Result<()> {
@@ -246,6 +247,9 @@ pub async fn serve(
         },
         coordinator_mode: CoordinatorMode::None,
         model: model_path.to_string_lossy().into_owned(),
+        served_model_name: served_model_name
+            .map(|name| vec![name.to_string()])
+            .unwrap_or_default(),
         listener_mode: HttpListenerMode::BindTcp {
             host: "0.0.0.0".to_string(),
             port,


### PR DESCRIPTION

## Description

Issues #80 

vllm-frontend-rs already support the saperate between `served-model-name` and `model-path`

1. upgrade the dependancy for `vllm-frontend-rs` to `b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9`, where [[feat: implement --served-model-name CLI option by ericcurtin · Pull Request #158 · Inferact/vllm-frontend-rs · GitHub](https://github.com/Inferact/vllm-frontend-rs/pull/158)](https://github.com/Inferact/vllm-frontend-rs/pull/158) support  `--served-model-name` CLI argument
2. add `served_model_name` to vllm serve config
3. smoke test:

```shell
# serve model as different name
cargo run --release -- --model-path models/Qwen3-4B --served-model-name test-served-name --port 18080

# 1. /v1/models return test-served-name instead of path
curl -s localhost:18080/v1/models | grep -q '"id":"test-served-name"' && echo "models OK" || echo "models FAIL"

# 2. we can use test-served-name to post request to /v1/completions 
curl -s localhost:18080/v1/completions -H 'content-type: application/json' \
  -d '{"model":"test-served-name","prompt":"Hi","max_tokens":4}' | grep -q '"model":"test-served-name"' && echo "completion OK" || echo "completion FAIL"
```



## Type of Change

New feature (non-breaking change which adds functionality)



## Checklist

- [x] My code follows the style guidelines of this project (see `docs/areas/coding-style.md`).
- [x] I have performed a self-review of my own code.
- [x] I have formatted my commits according to Commitizen conventions.
- [x] I have run the local test suite and all tests pass (see `CLAUDE.md`).

