### PR TITLE
fix(deepseek-v2-lite): align ep2 accuracy gate with HF

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -53,6 +53,12 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 | `models/deepseek-v4/pplx-ep-integration.md` | DeepSeek V4 PPLX EP integration: pplx-garden decode MoE path, EP8 bootstrap, common NUMA rank-slice placement, and H200 steady TPOT p50 `66.65ms`. |
 | `models/deepseek-v4/kernel-paths.md` | DeepSeek V4 CUDA sources, TileLang generator path, and `pegainfer-kernels/KERNELS.md` routing index are organized. |
 
+## models / deepseek-v2-lite
+
+| Path | TL;DR |
+| --- | --- |
+| `models/deepseek-v2-lite/hf-accuracy-gate.md` | DeepSeek-V2-Lite EP2 HF accuracy gate after PR #149/#150: HF incremental greedy, host-staged EP2, and NCCL EP2 are token/text exact for `Hello`, output_len=16. |
+
 ## subsystems / runtime
 
 | Path | TL;DR |

--- a/docs/models/deepseek-v2-lite/hf-accuracy-gate.md
+++ b/docs/models/deepseek-v2-lite/hf-accuracy-gate.md
@@ -1,0 +1,101 @@
+# DeepSeek-V2-Lite EP2 HF Accuracy Gate
+
+> **TL;DR:** HF comparison gate for issue #135 after PR #149 and PR #150. The remaining correctness question was not NCCL performance; it was whether the existing DeepSeek-V2-Lite EP=2 baseline matches Hugging Face's real incremental greedy decode for `prompt="Hello"`, `batch=1`, `output_len=16`.
+>
+> **Status:** Passing for the covered shape. The latest run is token-exact and text-exact across HF incremental greedy, pegainfer host-staged EP2, and pegainfer NCCL EP2.
+
+## Scope
+
+In scope:
+
+- HF truth: `AutoTokenizer` and `AutoModelForCausalLM` with `trust_remote_code=True`, `torch_dtype=torch.bfloat16`, `model.eval()`, and `torch.no_grad()`.
+- Generation shape: batch `1`, prompt `Hello`, output length `16`, greedy argmax only.
+- Pegainfer paths: default host-staged EP2 backend and explicit `PEGAINFER_DSV2_LITE_EP_BACKEND=nccl`.
+- Result comparison: generated token ids, generated text, token sha256, text sha256, and first different generated-token index.
+
+Out of scope:
+
+- Performance claims.
+- Sparse dispatch or production EP backend work.
+- Generic EP topology, multi-node support, larger prompts, or batch > 1.
+- Any NCCL runtime-path change when host-staged and NCCL still match each other.
+
+## Issue #135 Coverage Map
+
+| Issue / maintainer requirement | Covered by | Evidence |
+| --- | --- | --- |
+| DeepSeek-V2-Lite config loads independently from DeepSeek V4 assumptions. | PR #149 | Dedicated `pegainfer-deepseek-v2-lite` config/weight/model crate. |
+| Single-node `ep_size=2` validates rank, expert ownership, and local expert count. | PR #149 | EP layout is fixed to rank 0 experts `0..31` and rank 1 experts `32..63`, with load-time validation. |
+| Each rank only loads its owned 32 routed experts. | PR #149 | Driver rank loads rank 0 experts; expert rank loads only rank 1 routed experts. |
+| Unsupported backend/topology reports explicit errors. | PR #149 / #150 | Unsupported device count, duplicate devices, cuda_graph, and backend names fail closed. |
+| Minimal dispatch/combine path exists for the first correctness gate. | PR #149 | Host-staged dispatch/combine path remains the default baseline. |
+| Maintainer-requested naive NCCL backend exists before pegainfer-comm/NVLink work. | PR #150 | `PEGAINFER_DSV2_LITE_EP_BACKEND=nccl` path passes the same EP2 greedy E2E as host-staged. |
+| HF ground-truth accuracy comparison exists. | This gate | HF incremental greedy, host-staged EP2, and NCCL EP2 are token/text exact for the covered shape. |
+
+Together with PR #149 and PR #150, this gate covers issue #135's correctness-first acceptance surface for the narrow EP=2 milestone. Follow-up work should be tracked separately for sparse/GPU dispatch, pegainfer-comm/NVLink integration, performance evidence, long context, and broader prompts/batches.
+
+## Commands
+
+Run all three outputs from the same model snapshot:
+
+```bash
+mkdir -p target/accuracy/dsv2-lite-ep2
+
+python tools/accuracy/hf_dump_dsv2_lite_ep2_greedy.py \
+  --model-path models/DeepSeek-V2-Lite \
+  --prompt Hello \
+  --output-len 16 \
+  --out target/accuracy/dsv2-lite-ep2/hf.json
+
+PEGAINFER_TEST_MODEL_PATH=models/DeepSeek-V2-Lite \
+PEGAINFER_DSV2_LITE_E2E_JSON_OUT=target/accuracy/dsv2-lite-ep2/host-staged.json \
+  cargo test --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite --test e2e_ep2 -- --nocapture
+
+PEGAINFER_TEST_MODEL_PATH=models/DeepSeek-V2-Lite \
+PEGAINFER_DSV2_LITE_EP_BACKEND=nccl \
+PEGAINFER_DSV2_LITE_E2E_JSON_OUT=target/accuracy/dsv2-lite-ep2/nccl.json \
+  cargo test --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite --test e2e_ep2 -- --nocapture
+
+python tools/accuracy/compare_dsv2_lite_ep2_outputs.py \
+  --hf target/accuracy/dsv2-lite-ep2/hf.json \
+  --host-staged target/accuracy/dsv2-lite-ep2/host-staged.json \
+  --nccl target/accuracy/dsv2-lite-ep2/nccl.json \
+  --out target/accuracy/dsv2-lite-ep2/comparison.json \
+  --require-all-exact
+```
+
+Omit `--require-all-exact` only when intentionally collecting mismatch diagnostics.
+
+On Blackwell-class GPUs, make sure the selected NCCL runtime supports the device. Older NCCL runtimes may fail communicator initialization before the model-level comparison runs.
+
+## Interpretation
+
+- `all_token_text_exact`: HF, host-staged, and NCCL agree on generated token ids and generated text.
+- `pegainfer_baseline_accuracy_gap`: host-staged and NCCL match each other, but both differ from HF. Treat this as a pegainfer baseline accuracy problem before touching NCCL transport.
+- `nccl_transport_regression`: host-staged and NCCL differ. Debug the NCCL path before drawing any HF parity conclusion.
+
+## Latest Evidence
+
+2026-05-21, single-node 2 GPU validation, same `models/DeepSeek-V2-Lite` snapshot:
+
+| Source | Backend | Tokens | Token SHA256 | Text SHA256 | Text |
+| --- | --- | ---: | --- | --- | --- |
+| HF | incremental `past_key_values` | 16 | `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225` | `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347` | `, I am a 19 year old girl from the UK. I am` |
+| pegainfer | host-staged | 16 | `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225` | `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347` | `, I am a 19 year old girl from the UK. I am` |
+| pegainfer | NCCL | 16 | `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225` | `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347` | `, I am a 19 year old girl from the UK. I am` |
+
+Classification: `all_token_text_exact`.
+
+- HF vs host-staged: token-exact and text-exact; no first different token.
+- HF vs NCCL: token-exact and text-exact; no first different token.
+- Host-staged vs NCCL: token-exact and text-exact; this run does not show an NCCL transport regression.
+
+Accuracy fixes covered by this gate:
+
+- DeepSeek-V2 RoPE host path now matches HF's pair permutation and bf16 multiply/add materialization.
+- YaRN inv-frequency and `mscale_all_dim` attention softmax scaling are applied in the host attention path.
+- Host attention now rounds attention scores/probabilities through bf16 at the HF materialization points.
+- DeepSeek-V2 RMSNorm now rounds the normalized hidden to bf16 before multiplying the bf16 norm weight, matching the HF module.
+- MoE gate logits now use the HF fp32 gate projection, and selected experts are accumulated in deterministic expert-id order after top-k selection.
+- MoE routed expert output is materialized before adding shared experts, matching HF's `moe_infer(...).to(bf16) + shared_experts(...)` structure.
+- Fused `silu_mul` now matches the existing non-fused `silu_mul` bf16 behavior by rounding `SiLU(gate)` before multiplying by `up`.

--- a/pegainfer-deepseek-v2-lite/src/host_ops.rs
+++ b/pegainfer-deepseek-v2-lite/src/host_ops.rs
@@ -41,6 +41,8 @@ pub(crate) fn normalize_compressed_kv(
     norm_weight: &[f32],
     seq_len: usize,
 ) -> Vec<bf16> {
+    assert_eq!(kv_a_host.len(), config.kv_a_proj_rows() * seq_len);
+    assert_eq!(norm_weight.len(), config.kv_lora_rank);
     let mut out = vec![bf16::ZERO; config.kv_lora_rank * seq_len];
     for token in 0..seq_len {
         let src = &kv_a_host[token * config.kv_a_proj_rows()
@@ -51,12 +53,36 @@ pub(crate) fn normalize_compressed_kv(
     out
 }
 
-fn rms_norm_host(input: &[f32], weight: &[f32], eps: f32, out: &mut [bf16]) {
+pub(crate) fn rms_norm_host(input: &[f32], weight: &[f32], eps: f32, out: &mut [bf16]) {
+    assert_eq!(input.len(), weight.len());
+    assert_eq!(out.len(), input.len());
     let sum_sq = input.iter().map(|value| value * value).sum::<f32>();
     let inv_rms = (sum_sq / input.len() as f32 + eps).sqrt().recip();
     for ((dst, value), scale) in out.iter_mut().zip(input).zip(weight) {
-        *dst = bf16::from_f32(value * inv_rms * scale);
+        let normalized = bf16::from_f32(value * inv_rms).to_f32();
+        *dst = bf16::from_f32(normalized * scale);
     }
+}
+
+pub(crate) fn rms_norm_hidden_host(
+    config: &Config,
+    input: &[f32],
+    weight: &[f32],
+    seq_len: usize,
+) -> Vec<bf16> {
+    assert_eq!(input.len(), config.hidden_size * seq_len);
+    assert_eq!(weight.len(), config.hidden_size);
+    let mut out = vec![bf16::ZERO; config.hidden_size * seq_len];
+    for token in 0..seq_len {
+        let offset = token * config.hidden_size;
+        rms_norm_host(
+            &input[offset..offset + config.hidden_size],
+            weight,
+            config.rms_norm_eps,
+            &mut out[offset..offset + config.hidden_size],
+        );
+    }
+    out
 }
 
 pub(crate) fn append_kv_and_build_queries(
@@ -72,24 +98,33 @@ pub(crate) fn append_kv_and_build_queries(
     let num_heads = config.num_attention_heads;
     let q_head_dim = config.query_head_dim();
     let kv_b_stride = config.qk_nope_head_dim + config.v_head_dim;
+    assert_eq!(q_host.len(), config.q_proj_rows() * seq_len);
+    assert_eq!(kv_a_host.len(), config.kv_a_proj_rows() * seq_len);
+    assert_eq!(kv_b_host.len(), config.kv_b_proj_rows() * seq_len);
+    assert_eq!(queries.len(), num_heads * q_head_dim * seq_len);
     let mut key = vec![0.0f32; q_head_dim];
+    let rope_inv_freq: Vec<_> = (0..config.qk_rope_head_dim / 2)
+        .map(|pair| rope_inv_freq(config, pair))
+        .collect();
+    let rope_mscale = rope_cache_mscale(config);
 
     for token in 0..seq_len {
         let pos = start_pos + token;
         let k_pe_raw = &kv_a_host[token * config.kv_a_proj_rows() + config.kv_lora_rank
             ..token * config.kv_a_proj_rows() + config.kv_lora_rank + config.qk_rope_head_dim];
-        let k_pe = apply_rope(k_pe_raw, pos, config.qk_rope_head_dim, config.rope_theta);
+        let k_pe = apply_deepseek_v2_rope(k_pe_raw, pos, config, &rope_inv_freq, rope_mscale);
 
         for head in 0..num_heads {
             let q_base = token * config.q_proj_rows() + head * q_head_dim;
             let query_base = (token * num_heads + head) * q_head_dim;
             queries[query_base..query_base + config.qk_nope_head_dim]
                 .copy_from_slice(&q_host[q_base..q_base + config.qk_nope_head_dim]);
-            let q_pe = apply_rope(
+            let q_pe = apply_deepseek_v2_rope(
                 &q_host[q_base + config.qk_nope_head_dim..q_base + q_head_dim],
                 pos,
-                config.qk_rope_head_dim,
-                config.rope_theta,
+                config,
+                &rope_inv_freq,
+                rope_mscale,
             );
             queries[query_base + config.qk_nope_head_dim..query_base + q_head_dim]
                 .copy_from_slice(&q_pe);
@@ -107,20 +142,86 @@ pub(crate) fn append_kv_and_build_queries(
     }
 }
 
-fn apply_rope(input: &[f32], pos: usize, dim: usize, theta: f32) -> Vec<f32> {
+fn apply_deepseek_v2_rope(
+    input: &[f32],
+    pos: usize,
+    config: &Config,
+    inv_freq: &[f32],
+    mscale: f32,
+) -> Vec<f32> {
+    let dim = config.qk_rope_head_dim;
     let half = dim / 2;
     let mut out = vec![0.0f32; dim];
-    for i in 0..half {
-        let inv_freq = 1.0f32 / theta.powf((2 * i) as f32 / dim as f32);
-        let angle = pos as f32 * inv_freq;
-        let cos = angle.cos();
-        let sin = angle.sin();
-        let x1 = input[i];
-        let x2 = input[i + half];
-        out[i] = x1 * cos - x2 * sin;
-        out[i + half] = x2 * cos + x1 * sin;
+    assert_eq!(input.len(), dim);
+    assert_eq!(inv_freq.len(), half);
+    assert_eq!(dim % 2, 0);
+    for pair in 0..half {
+        let angle = pos as f32 * inv_freq[pair];
+        let cos = bf16::from_f32(angle.cos() * mscale).to_f32();
+        let sin = bf16::from_f32(angle.sin() * mscale).to_f32();
+        let x0 = input[2 * pair];
+        let x1 = input[2 * pair + 1];
+        let x0_cos = bf16::from_f32(x0 * cos).to_f32();
+        let neg_x1_sin = bf16::from_f32(-x1 * sin).to_f32();
+        let x1_cos = bf16::from_f32(x1 * cos).to_f32();
+        let x0_sin = bf16::from_f32(x0 * sin).to_f32();
+        out[pair] = bf16::from_f32(x0_cos + neg_x1_sin).to_f32();
+        out[pair + half] = bf16::from_f32(x1_cos + x0_sin).to_f32();
     }
     out
+}
+
+fn rope_cache_mscale(config: &Config) -> f32 {
+    let Some(rope_scaling) = &config.rope_scaling else {
+        return 1.0;
+    };
+    yarn_get_mscale(rope_scaling.factor, rope_scaling.mscale)
+        / yarn_get_mscale(rope_scaling.factor, rope_scaling.mscale_all_dim)
+}
+
+fn rope_inv_freq(config: &Config, pair: usize) -> f32 {
+    let dim = config.qk_rope_head_dim;
+    let base = config.rope_theta;
+    let freq_extra = 1.0 / base.powf((2 * pair) as f32 / dim as f32);
+    let Some(rope_scaling) = &config.rope_scaling else {
+        return freq_extra;
+    };
+
+    let freq_inter = freq_extra / rope_scaling.factor;
+    let low = yarn_find_correction_dim(rope_scaling.beta_fast as f32, dim, base, rope_scaling)
+        .floor()
+        .max(0.0);
+    let high = yarn_find_correction_dim(rope_scaling.beta_slow as f32, dim, base, rope_scaling)
+        .ceil()
+        .min((dim - 1) as f32);
+    let ramp = if (high - low).abs() < f32::EPSILON {
+        if (pair as f32) <= low { 0.0 } else { 1.0 }
+    } else {
+        ((pair as f32 - low) / (high - low)).clamp(0.0, 1.0)
+    };
+    let inv_freq_mask = 1.0 - ramp;
+    freq_inter * (1.0 - inv_freq_mask) + freq_extra * inv_freq_mask
+}
+
+fn yarn_find_correction_dim(
+    num_rotations: f32,
+    dim: usize,
+    base: f32,
+    rope_scaling: &crate::config::RopeScaling,
+) -> f32 {
+    dim as f32
+        * (rope_scaling.original_max_position_embeddings as f32
+            / (num_rotations * 2.0 * std::f32::consts::PI))
+            .ln()
+        / (2.0 * base.ln())
+}
+
+fn yarn_get_mscale(scale: f32, mscale: f32) -> f32 {
+    if scale <= 1.0 {
+        1.0
+    } else {
+        0.1 * mscale * scale.ln() + 1.0
+    }
 }
 
 pub(crate) fn compute_attention_host(
@@ -133,7 +234,8 @@ pub(crate) fn compute_attention_host(
     let num_heads = config.num_attention_heads;
     let q_head_dim = config.query_head_dim();
     let value_dim = config.v_head_dim;
-    let scale = (q_head_dim as f32).sqrt().recip();
+    let scale = attention_softmax_scale(config);
+    assert_eq!(queries.len(), seq_len * num_heads * q_head_dim);
     let mut out = vec![0.0f32; seq_len * config.o_proj_cols()];
 
     for token in 0..seq_len {
@@ -145,11 +247,13 @@ pub(crate) fn compute_attention_host(
             for (pos, score) in scores.iter_mut().enumerate() {
                 let k_base = (pos * num_heads + head) * q_head_dim;
                 let key = &cache.keys[k_base..k_base + q_head_dim];
-                *score = dot(query, key) * scale;
+                let raw_score = bf16::from_f32(dot(query, key)).to_f32();
+                *score = bf16::from_f32(raw_score * scale).to_f32();
             }
             let probs = softmax(&scores);
             let out_base = token * config.o_proj_cols() + head * value_dim;
             for (pos, prob) in probs.iter().enumerate() {
+                let prob = bf16::from_f32(*prob).to_f32();
                 let v_base = (pos * num_heads + head) * value_dim;
                 let value = &cache.values[v_base..v_base + value_dim];
                 for dim in 0..value_dim {
@@ -162,11 +266,23 @@ pub(crate) fn compute_attention_host(
     out
 }
 
+fn attention_softmax_scale(config: &Config) -> f32 {
+    let mut scale = (config.query_head_dim() as f32).sqrt().recip();
+    if let Some(rope_scaling) = &config.rope_scaling
+        && rope_scaling.mscale_all_dim > 0.0
+    {
+        let mscale = yarn_get_mscale(rope_scaling.factor, rope_scaling.mscale_all_dim);
+        scale *= mscale * mscale;
+    }
+    scale
+}
+
 pub(crate) fn topk_softmax_routes(
     config: &Config,
     logits: &[f32],
     seq_len: usize,
 ) -> Vec<Vec<(usize, f32)>> {
+    assert_eq!(logits.len(), seq_len * config.n_routed_experts);
     let mut routes = Vec::with_capacity(seq_len);
     for token in 0..seq_len {
         let scores =
@@ -179,9 +295,32 @@ pub(crate) fn topk_softmax_routes(
                 .then_with(|| lhs_idx.cmp(rhs_idx))
         });
         indexed.truncate(config.num_experts_per_token);
+        // Avoid adding an extra probability-sorted accumulation order on top of
+        // HF's unsorted top-k gate path.
+        indexed.sort_by_key(|(idx, _)| *idx);
         routes.push(indexed);
     }
     routes
+}
+
+pub(crate) fn gate_logits_host(config: &Config, input: &[bf16], gate_weight: &[f32]) -> Vec<f32> {
+    assert_eq!(input.len() % config.hidden_size, 0);
+    assert_eq!(
+        gate_weight.len(),
+        config.n_routed_experts * config.hidden_size
+    );
+    let mut logits = vec![0.0f32; (input.len() / config.hidden_size) * config.n_routed_experts];
+    for (token, token_input) in input.chunks_exact(config.hidden_size).enumerate() {
+        for expert in 0..config.n_routed_experts {
+            let weight_base = expert * config.hidden_size;
+            let mut acc = 0.0f32;
+            for dim in 0..config.hidden_size {
+                acc += token_input[dim].to_f32() * gate_weight[weight_base + dim];
+            }
+            logits[token * config.n_routed_experts + expert] = acc;
+        }
+    }
+    logits
 }
 
 fn softmax(scores: &[f32]) -> Vec<f32> {
@@ -245,4 +384,75 @@ pub(crate) fn hidden_from_f32_host(
 ) -> Result<HiddenStates> {
     let bf16_data: Vec<_> = data.iter().copied().map(bf16::from_f32).collect();
     hidden_from_bf16_host(ctx, &bf16_data, hidden_dim, seq_len)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::test_lite_config;
+
+    #[test]
+    fn deepseek_v2_rope_matches_hf_pair_permutation_at_position_zero() {
+        let config = test_lite_config();
+        let input: Vec<_> = (0..config.qk_rope_head_dim)
+            .map(|value| value as f32)
+            .collect();
+        let inv_freq: Vec<_> = (0..config.qk_rope_head_dim / 2)
+            .map(|pair| rope_inv_freq(&config, pair))
+            .collect();
+
+        let out = apply_deepseek_v2_rope(&input, 0, &config, &inv_freq, rope_cache_mscale(&config));
+
+        let half = config.qk_rope_head_dim / 2;
+        for pair in 0..half {
+            assert_eq!(out[pair], input[2 * pair]);
+            assert_eq!(out[pair + half], input[2 * pair + 1]);
+        }
+    }
+
+    #[test]
+    fn yarn_attention_scale_uses_mscale_all_dim() {
+        let config = test_lite_config();
+        let rope_scaling = config.rope_scaling.as_ref().unwrap();
+        let mscale = yarn_get_mscale(rope_scaling.factor, rope_scaling.mscale_all_dim);
+        let expected = (config.query_head_dim() as f32).sqrt().recip() * mscale * mscale;
+
+        assert_eq!(attention_softmax_scale(&config), expected);
+    }
+
+    #[test]
+    fn rms_norm_host_rounds_normalized_hidden_before_weight() {
+        let input = [3.0f32, 4.0];
+        let weight = [3.0f32, 0.5];
+        let eps = 0.0;
+        let mut out = [bf16::ZERO; 2];
+
+        rms_norm_host(&input, &weight, eps, &mut out);
+
+        let inv_rms = ((3.0f32 * 3.0 + 4.0 * 4.0) / 2.0).sqrt().recip();
+        let expected0 = bf16::from_f32(bf16::from_f32(3.0 * inv_rms).to_f32() * 3.0);
+        let expected1 = bf16::from_f32(bf16::from_f32(4.0 * inv_rms).to_f32() * 0.5);
+        assert_eq!(out, [expected0, expected1]);
+    }
+
+    #[test]
+    fn topk_softmax_routes_accumulates_selected_experts_by_id() {
+        let config = test_lite_config();
+        let mut logits = vec![-10.0f32; config.n_routed_experts];
+        for (expert, logit) in [
+            (20, 6.0),
+            (7, 5.0),
+            (10, 4.0),
+            (41, 3.0),
+            (54, 2.0),
+            (58, 1.0),
+        ] {
+            logits[expert] = logit;
+        }
+
+        let routes = topk_softmax_routes(&config, &logits, 1);
+        let experts: Vec<_> = routes[0].iter().map(|(expert, _)| *expert).collect();
+
+        assert_eq!(experts, vec![7, 10, 20, 41, 54, 58]);
+    }
 }

--- a/pegainfer-deepseek-v2-lite/src/model.rs
+++ b/pegainfer-deepseek-v2-lite/src/model.rs
@@ -1,13 +1,13 @@
 use std::{collections::HashMap, path::Path};
 
 use anyhow::{Result, bail, ensure};
+use half::bf16;
 use pegainfer_core::{
     ops,
-    tensor::{DeviceContext, DeviceMatrix, DeviceVec, HiddenStates},
-    weight_loader::{
-        deserialize_shards, load_shard_info, load_tensor_1d, load_tensor_2d, mmap_shards,
-    },
+    tensor::{DeviceContext, DeviceMatrix, HiddenStates},
+    weight_loader::{deserialize_shards, load_shard_info, load_tensor_2d, mmap_shards},
 };
+use safetensors::Dtype;
 
 use crate::{Config, device::activate, ep::ExpertParallelLayout};
 
@@ -16,7 +16,7 @@ pub(crate) struct DriverRankModel {
     pub(crate) layout: ExpertParallelLayout,
     pub(crate) embed_tokens: DeviceMatrix,
     pub(crate) lm_head: DeviceMatrix,
-    pub(crate) norm: DeviceVec,
+    pub(crate) norm_host: Vec<f32>,
     pub(crate) layers: Vec<LayerWeights>,
 }
 
@@ -27,8 +27,8 @@ pub(crate) struct ExpertRankModel {
 }
 
 pub(crate) struct LayerWeights {
-    pub(crate) input_layernorm: DeviceVec,
-    pub(crate) post_attention_layernorm: DeviceVec,
+    pub(crate) input_layernorm_host: Vec<f32>,
+    pub(crate) post_attention_layernorm_host: Vec<f32>,
     pub(crate) attention: AttentionWeights,
     pub(crate) mlp: MlpWeights,
 }
@@ -52,7 +52,7 @@ pub(crate) struct DenseMlp {
 }
 
 pub(crate) struct MoeMlp {
-    pub(crate) gate: DeviceMatrix,
+    pub(crate) gate_host: Vec<f32>,
     pub(crate) shared: DenseMlp,
     pub(crate) experts: Vec<ExpertMlp>,
 }
@@ -80,31 +80,27 @@ impl DriverRankModel {
                 "DeepSeek-V2-Lite first gate expects untied lm_head"
             );
             let lm_head = load_tensor_2d(&ctx, shards, weight_map, "lm_head.weight")?;
-            let norm = load_tensor_1d(&ctx, shards, weight_map, "model.norm.weight")?;
+            let norm_host = load_tensor_1d_host(shards, weight_map, "model.norm.weight")?;
 
             let mut layers = Vec::with_capacity(config.num_hidden_layers);
             for layer_idx in 0..config.num_hidden_layers {
                 let prefix = format!("model.layers.{layer_idx}");
-                let input_layernorm = load_tensor_1d(
-                    &ctx,
+                let input_layernorm_host = load_tensor_1d_host(
                     shards,
                     weight_map,
                     &format!("{prefix}.input_layernorm.weight"),
                 )?;
-                let post_attention_layernorm = load_tensor_1d(
-                    &ctx,
+                let post_attention_layernorm_host = load_tensor_1d_host(
                     shards,
                     weight_map,
                     &format!("{prefix}.post_attention_layernorm.weight"),
                 )?;
                 let attn = format!("{prefix}.self_attn");
-                let kv_a_norm = load_tensor_1d(
-                    &ctx,
+                let kv_a_norm_host = load_tensor_1d_host(
                     shards,
                     weight_map,
                     &format!("{attn}.kv_a_layernorm.weight"),
                 )?;
-                let kv_a_norm_host = kv_a_norm.to_host(&ctx)?;
                 let attention = AttentionWeights {
                     q_proj: load_tensor_2d(
                         &ctx,
@@ -146,8 +142,8 @@ impl DriverRankModel {
                     MlpWeights::Dense(load_dense_mlp(&ctx, shards, weight_map, &mlp_prefix)?)
                 };
                 layers.push(LayerWeights {
-                    input_layernorm,
-                    post_attention_layernorm,
+                    input_layernorm_host,
+                    post_attention_layernorm_host,
                     attention,
                     mlp,
                 });
@@ -158,7 +154,7 @@ impl DriverRankModel {
                 layout,
                 embed_tokens,
                 lm_head,
-                norm,
+                norm_host,
                 layers,
             })
         })
@@ -298,14 +294,82 @@ fn load_moe_mlp(
     layout: &ExpertParallelLayout,
     prefix: &str,
 ) -> Result<MoeMlp> {
-    let gate = load_tensor_2d(ctx, shards, weight_map, &format!("{prefix}.gate.weight"))?;
+    let gate_host = load_tensor_2d_host(shards, weight_map, &format!("{prefix}.gate.weight"))?;
     let shared = load_dense_mlp(ctx, shards, weight_map, &format!("{prefix}.shared_experts"))?;
     let experts = load_owned_experts(ctx, shards, weight_map, config, layout, prefix)?;
     Ok(MoeMlp {
-        gate,
+        gate_host,
         shared,
         experts,
     })
+}
+
+fn load_tensor_1d_host(
+    shards: &[safetensors::SafeTensors<'_>],
+    weight_map: &HashMap<String, usize>,
+    name: &str,
+) -> Result<Vec<f32>> {
+    load_bf16_tensor_host(shards, weight_map, name, 1)
+}
+
+fn load_tensor_2d_host(
+    shards: &[safetensors::SafeTensors<'_>],
+    weight_map: &HashMap<String, usize>,
+    name: &str,
+) -> Result<Vec<f32>> {
+    load_bf16_tensor_host(shards, weight_map, name, 2)
+}
+
+fn load_bf16_tensor_host(
+    shards: &[safetensors::SafeTensors<'_>],
+    weight_map: &HashMap<String, usize>,
+    name: &str,
+    expected_rank: usize,
+) -> Result<Vec<f32>> {
+    let tensor = find_tensor(shards, weight_map, name)?;
+    let shape = tensor.shape();
+    ensure!(
+        tensor.dtype() == Dtype::BF16,
+        "tensor {name} expected BF16, got {:?}",
+        tensor.dtype()
+    );
+    ensure!(
+        shape.len() == expected_rank,
+        "tensor {name} expected {expected_rank}D, got {shape:?}"
+    );
+    let elem_count = shape.iter().product::<usize>();
+    let expected_bytes = elem_count * std::mem::size_of::<bf16>();
+    ensure!(
+        tensor.data().len() == expected_bytes,
+        "tensor {name} expected {expected_bytes} bf16 bytes, got {}",
+        tensor.data().len()
+    );
+    Ok(tensor
+        .data()
+        .chunks_exact(std::mem::size_of::<bf16>())
+        .map(|bytes| {
+            let bits = u16::from_le_bytes([bytes[0], bytes[1]]);
+            bf16::from_bits(bits).to_f32()
+        })
+        .collect())
+}
+
+fn find_tensor<'a>(
+    shards: &'a [safetensors::SafeTensors<'a>],
+    weight_map: &HashMap<String, usize>,
+    name: &str,
+) -> Result<safetensors::tensor::TensorView<'a>> {
+    if let Some(&idx) = weight_map.get(name) {
+        return shards[idx]
+            .tensor(name)
+            .map_err(|err| anyhow::anyhow!("failed to load tensor {name}: {err}"));
+    }
+    for shard in shards {
+        if let Ok(tensor) = shard.tensor(name) {
+            return Ok(tensor);
+        }
+    }
+    bail!("tensor {name} not found in any shard")
 }
 
 fn load_owned_experts(

--- a/pegainfer-deepseek-v2-lite/src/runtime.rs
+++ b/pegainfer-deepseek-v2-lite/src/runtime.rs
@@ -5,7 +5,10 @@ use std::{
 
 use anyhow::{Context, Result, bail, ensure};
 use half::bf16;
-use pegainfer_core::{ops, tensor::HiddenStates};
+use pegainfer_core::{
+    ops,
+    tensor::{DeviceVec, HiddenStates},
+};
 use pegainfer_engine::engine::{EngineLoadOptions, FinishReason};
 use sha2::{Digest, Sha256};
 
@@ -15,8 +18,9 @@ use crate::{
     ep::ExpertParallelConfig,
     host_ops::{
         DecodeCache, LayerCache, append_kv_and_build_queries, compute_attention_host,
-        hidden_from_bf16_host, hidden_from_f32_host, hidden_to_bf16, hidden_to_f32,
-        normalize_compressed_kv, topk_softmax_routes,
+        gate_logits_host, hidden_from_bf16_host, hidden_from_f32_host, hidden_to_bf16,
+        hidden_to_f32, normalize_compressed_kv, rms_norm_hidden_host, rms_norm_host,
+        topk_softmax_routes,
     },
     model::{
         AttentionWeights, DriverRankModel, ExpertMlp, ExpertRankModel, MlpWeights, MoeMlp,
@@ -318,30 +322,14 @@ impl DeepSeekV2LiteEp2Generator {
         activate(&self.rank0.ctx)?;
 
         let layer = &self.rank0.layers[layer_idx];
-        let mut normed =
-            HiddenStates::zeros(&self.rank0.ctx, self.config.hidden_size, hidden.seq_len)?;
-        ops::rms_norm_batch_into(
-            &self.rank0.ctx,
-            hidden,
-            &layer.input_layernorm,
-            self.config.rms_norm_eps,
-            &mut normed,
-        );
+        let normed = self.rms_norm_hidden(hidden, &layer.input_layernorm_host)?;
 
         let attn = self.attention_forward(&normed, &layer.attention, start_pos, cache)?;
         activate(&self.rank0.ctx)?;
         let attn_projected = ops::gemm(&self.rank0.ctx, &layer.attention.o_proj, &attn)?;
         let after_attn = ops::add_batch(&self.rank0.ctx, hidden, &attn_projected)?;
 
-        let mut ffn_norm =
-            HiddenStates::zeros(&self.rank0.ctx, self.config.hidden_size, after_attn.seq_len)?;
-        ops::rms_norm_batch_into(
-            &self.rank0.ctx,
-            &after_attn,
-            &layer.post_attention_layernorm,
-            self.config.rms_norm_eps,
-            &mut ffn_norm,
-        );
+        let ffn_norm = self.rms_norm_hidden(&after_attn, &layer.post_attention_layernorm_host)?;
 
         let (ffn_out, local_routes, remote_routes) = match &layer.mlp {
             MlpWeights::Dense(dense) => {
@@ -439,13 +427,12 @@ impl DeepSeekV2LiteEp2Generator {
         moe: &MoeMlp,
     ) -> Result<(HiddenStates, usize, usize)> {
         activate(&self.rank0.ctx)?;
-        let route_logits = ops::gemm(&self.rank0.ctx, &moe.gate, input)?;
-        let route_logits_host = hidden_to_f32(&self.rank0.ctx, &route_logits)?;
+        let input_host = hidden_to_bf16(&self.rank0.ctx, input)?;
+        let route_logits_host = gate_logits_host(&self.config, &input_host, &moe.gate_host);
         let routes = topk_softmax_routes(&self.config, &route_logits_host, input.seq_len);
 
         let shared = dense_mlp_forward(&self.rank0.ctx, &moe.shared, input)?;
-        let mut accum = hidden_to_f32(&self.rank0.ctx, &shared)?;
-        let input_host = hidden_to_bf16(&self.rank0.ctx, input)?;
+        let mut routed_accum = vec![0.0f32; input.seq_len * self.config.hidden_size];
         let mut local_routes = 0usize;
         let mut remote_routes = 0usize;
 
@@ -461,7 +448,7 @@ impl DeepSeekV2LiteEp2Generator {
                     local_routes += 1;
                 }
                 let offset = token * self.config.hidden_size;
-                for (dst, value) in accum[offset..offset + self.config.hidden_size]
+                for (dst, value) in routed_accum[offset..offset + self.config.hidden_size]
                     .iter_mut()
                     .zip(out)
                 {
@@ -470,12 +457,14 @@ impl DeepSeekV2LiteEp2Generator {
             }
         }
 
-        let hidden = hidden_from_f32_host(
+        let routed = hidden_from_f32_host(
             &self.rank0.ctx,
-            &accum,
+            &routed_accum,
             self.config.hidden_size,
             input.seq_len,
         )?;
+        activate(&self.rank0.ctx)?;
+        let hidden = ops::add_batch(&self.rank0.ctx, &routed, &shared)?;
         Ok((hidden, local_routes, remote_routes))
     }
 
@@ -487,12 +476,12 @@ impl DeepSeekV2LiteEp2Generator {
         moe: &MoeMlp,
     ) -> Result<(HiddenStates, usize, usize)> {
         activate(&self.rank0.ctx)?;
-        let route_logits = ops::gemm(&self.rank0.ctx, &moe.gate, input)?;
-        let route_logits_host = hidden_to_f32(&self.rank0.ctx, &route_logits)?;
+        let input_host = hidden_to_bf16(&self.rank0.ctx, input)?;
+        let route_logits_host = gate_logits_host(&self.config, &input_host, &moe.gate_host);
         let routes = topk_softmax_routes(&self.config, &route_logits_host, input.seq_len);
 
         let shared = dense_mlp_forward(&self.rank0.ctx, &moe.shared, input)?;
-        let mut rank0_contrib = hidden_to_f32(&self.rank0.ctx, &shared)?;
+        let mut rank0_contrib = vec![0.0f32; input.seq_len * self.config.hidden_size];
         let mut rank1_contrib = vec![0.0f32; rank0_contrib.len()];
         // NCCL covers only the dense hidden exchange and final contribution
         // sum in this first gate. Route iteration and expert-output
@@ -542,12 +531,14 @@ impl DeepSeekV2LiteEp2Generator {
             &rank0_contrib,
             &rank1_contrib,
         )?;
-        let hidden = hidden_from_f32_host(
+        let routed = hidden_from_f32_host(
             &self.rank0.ctx,
             &combined,
             self.config.hidden_size,
             input.seq_len,
         )?;
+        activate(&self.rank0.ctx)?;
+        let hidden = ops::add_batch(&self.rank0.ctx, &routed, &shared)?;
         Ok((hidden, local_routes, remote_routes))
     }
 
@@ -578,14 +569,29 @@ impl DeepSeekV2LiteEp2Generator {
     fn sample_last_token(&self, hidden: &HiddenStates) -> Result<u32> {
         activate(&self.rank0.ctx)?;
         let last = ops::extract_vec(&self.rank0.ctx, hidden, hidden.seq_len - 1)?;
-        let normed = ops::rms_norm(
-            &self.rank0.ctx,
-            &last,
-            &self.rank0.norm,
-            self.config.rms_norm_eps,
-        )?;
+        let normed = self.rms_norm_vec(&last, &self.rank0.norm_host)?;
         let logits = ops::linear(&self.rank0.ctx, &normed, &self.rank0.lm_head)?;
         ops::argmax(&self.rank0.ctx, &logits)
+    }
+
+    fn rms_norm_hidden(&self, hidden: &HiddenStates, weight: &[f32]) -> Result<HiddenStates> {
+        activate(&self.rank0.ctx)?;
+        let input_host = hidden_to_f32(&self.rank0.ctx, hidden)?;
+        let out = rms_norm_hidden_host(&self.config, &input_host, weight, hidden.seq_len);
+        hidden_from_bf16_host(
+            &self.rank0.ctx,
+            &out,
+            self.config.hidden_size,
+            hidden.seq_len,
+        )
+    }
+
+    fn rms_norm_vec(&self, input: &DeviceVec, weight: &[f32]) -> Result<DeviceVec> {
+        activate(&self.rank0.ctx)?;
+        let input_host = input.to_host(&self.rank0.ctx)?;
+        let mut out = vec![bf16::ZERO; input.len];
+        rms_norm_host(&input_host, weight, self.config.rms_norm_eps, &mut out);
+        DeviceVec::from_host(&self.rank0.ctx, &out)
     }
 }
 

--- a/pegainfer-deepseek-v2-lite/tests/e2e_ep2.rs
+++ b/pegainfer-deepseek-v2-lite/tests/e2e_ep2.rs
@@ -1,5 +1,5 @@
 use std::{
-    env,
+    env, fs,
     path::{Path, PathBuf},
 };
 
@@ -11,18 +11,18 @@ use vllm_text::tokenizer::{HuggingFaceTokenizer, Tokenizer};
 
 const EXPECTED_GENERATED_TOKENS: usize = 16;
 const EXPECTED_OUTPUT_TOKEN_SHA256: &str =
-    "f39e57d9b3eb949057ada9b3bc92f7f7037dfd19658dbe3ce145d8fad03ded5e";
+    "4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225";
 const EXPECTED_OUTPUT_TEXT_SHA256: &str =
-    "a521f6dc9739b4506a46822da7c239ac558a879d571f54a064a4a2fbc3a097b7";
+    "0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347";
 const DSV2_LITE_HIDDEN_SIZE: usize = 2048;
 const DSV2_LITE_MOE_LAYERS: usize = 26;
+const E2E_JSON_OUT_ENV: &str = "PEGAINFER_DSV2_LITE_E2E_JSON_OUT";
 
 #[test]
 fn test_deepseek_v2_lite_ep2_rust_generation() -> Result<()> {
-    let model_path = PathBuf::from(
-        env::var("PEGAINFER_TEST_MODEL_PATH")
-            .context("PEGAINFER_TEST_MODEL_PATH must point to DeepSeek-V2-Lite weights")?,
-    );
+    let model_path_label = env::var("PEGAINFER_TEST_MODEL_PATH")
+        .context("PEGAINFER_TEST_MODEL_PATH must point to DeepSeek-V2-Lite weights")?;
+    let model_path = resolve_model_path(&model_path_label);
     ensure!(
         model_path.join("config.json").exists(),
         "missing config.json under {}",
@@ -45,10 +45,10 @@ fn test_deepseek_v2_lite_ep2_rust_generation() -> Result<()> {
         "duplicate CUDA ordinal error should mention distinct devices, got {duplicate_ordinal_err:#}"
     );
 
-    run_rust_generation(&model_path)
+    run_rust_generation(&model_path_label, &model_path)
 }
 
-fn run_rust_generation(model_path: &Path) -> Result<()> {
+fn run_rust_generation(model_path_label: &str, model_path: &Path) -> Result<()> {
     let tokenizer_path = model_path.join("tokenizer.json");
     let tokenizer = HuggingFaceTokenizer::new(&tokenizer_path).map_err(|err| {
         anyhow::anyhow!(
@@ -96,12 +96,6 @@ fn run_rust_generation(model_path: &Path) -> Result<()> {
         result.finish_reason == FinishReason::Length,
         "DeepSeek-V2-Lite E2E finish_reason drift: got {:?}, expected Length",
         result.finish_reason
-    );
-    ensure!(
-        result.stats.output_token_sha256 == EXPECTED_OUTPUT_TOKEN_SHA256,
-        "DeepSeek-V2-Lite E2E token hash drift: got {}, expected {}",
-        result.stats.output_token_sha256,
-        EXPECTED_OUTPUT_TOKEN_SHA256
     );
     ensure!(
         result.stats.ep_backend == current_backend(),
@@ -178,23 +172,23 @@ fn run_rust_generation(model_path: &Path) -> Result<()> {
     let mut hasher = Sha256::new();
     hasher.update(output_text.as_bytes());
     let output_text_sha256 = hex::encode(hasher.finalize());
-    ensure!(
-        output_text_sha256 == EXPECTED_OUTPUT_TEXT_SHA256,
-        "DeepSeek-V2-Lite E2E text hash drift: got {}, expected {}",
-        output_text_sha256,
-        EXPECTED_OUTPUT_TEXT_SHA256
-    );
     let payload = serde_json::json!({
-        "model_path": model_path,
+        "model_path": model_path_label,
         "gpu_count": 2,
         "ep_size": result.stats.ep_size,
         "ep_backend": result.stats.ep_backend,
-        "devices": result.stats.device_ordinals,
+        "devices": &result.stats.device_ordinals,
         "prompt": prompt,
         "prompt_tokens": result.stats.prompt_tokens,
+        "prompt_token_ids": &prompt_tokens,
+        "max_new_tokens": 16,
         "generated_tokens": result.stats.generated_tokens,
+        "generated_token_ids": &result.tokens,
+        "generated_text": &output_text,
         "output_token_sha256": result.stats.output_token_sha256,
         "output_text_sha256": output_text_sha256,
+        "token_sha256_algorithm": "sha256 over generated token ids encoded as little-endian u32",
+        "text_sha256_algorithm": "sha256 over UTF-8 generated text bytes",
         "host_dispatch_local_routes": result.stats.host_dispatch_local_routes,
         "host_dispatch_remote_routes": result.stats.host_dispatch_remote_routes,
         "nccl_dispatch_local_routes": result.stats.nccl_dispatch_local_routes,
@@ -204,12 +198,63 @@ fn run_rust_generation(model_path: &Path) -> Result<()> {
         "nccl_combine_calls": result.stats.nccl_combine_calls,
         "nccl_dense_exchange_elements": result.stats.nccl_dense_exchange_elements,
         "nccl_combine_elements": result.stats.nccl_combine_elements,
-        "output_text": output_text,
+        "output_text": &output_text,
     });
-    println!("{}", serde_json::to_string_pretty(&payload)?);
+    let payload_text = serde_json::to_string_pretty(&payload)?;
+    if let Ok(path) = env::var(E2E_JSON_OUT_ENV) {
+        if !path.is_empty() {
+            let path = PathBuf::from(path);
+            let path = resolve_workspace_path(path);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)
+                    .with_context(|| format!("create {}", parent.display()))?;
+            }
+            fs::write(&path, format!("{payload_text}\n"))
+                .with_context(|| format!("write {}", path.display()))?;
+        }
+    }
+    println!("{payload_text}");
+    ensure!(
+        result.stats.output_token_sha256 == EXPECTED_OUTPUT_TOKEN_SHA256,
+        "DeepSeek-V2-Lite E2E token hash drift: got {}, expected {}",
+        result.stats.output_token_sha256,
+        EXPECTED_OUTPUT_TOKEN_SHA256
+    );
+    ensure!(
+        output_text_sha256 == EXPECTED_OUTPUT_TEXT_SHA256,
+        "DeepSeek-V2-Lite E2E text hash drift: got {}, expected {}",
+        output_text_sha256,
+        EXPECTED_OUTPUT_TEXT_SHA256
+    );
     Ok(())
 }
 
 fn current_backend() -> String {
     env::var("PEGAINFER_DSV2_LITE_EP_BACKEND").unwrap_or_else(|_| "host-staged".to_string())
+}
+
+fn resolve_model_path(raw: &str) -> PathBuf {
+    let path = PathBuf::from(raw);
+    if path.join("config.json").exists() {
+        return path;
+    }
+    let workspace_path = resolve_workspace_path(path.clone());
+    if workspace_path.join("config.json").exists() {
+        return workspace_path;
+    }
+    path
+}
+
+fn resolve_workspace_path(path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        return path;
+    }
+    workspace_root().join(path)
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("model crate must live under the workspace root")
+        .to_path_buf()
 }

--- a/pegainfer-kernels/csrc/fused_proj.cu
+++ b/pegainfer-kernels/csrc/fused_proj.cu
@@ -38,7 +38,7 @@ __global__ void deinterleave_qkv_kernel(
 // Column-major: token j at offset j * 2*I.
 //   gate = combined[j * 2*I + i]     for i in [0, I)
 //   up   = combined[j * 2*I + I + i] for i in [0, I)
-//   out[j * I + i] = silu(gate) * up
+//   out[j * I + i] = bf16(silu(gate)) * up, rounded to bf16
 // ============================================================================
 
 __global__ void silu_mul_fused_kernel(
@@ -58,7 +58,8 @@ __global__ void silu_mul_fused_kernel(
     float u = __bfloat162float(gate_up[src_offset + intermediate_size + row]);
 
     float silu_g = g / (1.0f + expf(-g));
-    out[idx] = __float2bfloat16(silu_g * u);
+    float silu_bf16 = __bfloat162float(__float2bfloat16(silu_g));
+    out[idx] = __float2bfloat16(silu_bf16 * u);
   }
 }
 

--- a/pegainfer-kernels/src/ops/elementwise.rs
+++ b/pegainfer-kernels/src/ops/elementwise.rs
@@ -161,3 +161,75 @@ pub fn write_vec_into(
         .map_err(|e| anyhow!("Device copy failed: {}", e))?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use half::bf16;
+
+    fn hidden_from_host(
+        ctx: &DeviceContext,
+        data: &[bf16],
+        hidden_dim: usize,
+        seq_len: usize,
+    ) -> Result<HiddenStates> {
+        Ok(HiddenStates {
+            data: ctx.stream.clone_htod(data)?,
+            hidden_dim,
+            seq_len,
+        })
+    }
+
+    fn hidden_to_host(ctx: &DeviceContext, hidden: &HiddenStates) -> Result<Vec<bf16>> {
+        let host = ctx.stream.clone_dtoh(&hidden.data)?;
+        ctx.sync()?;
+        Ok(host)
+    }
+
+    #[test]
+    fn silu_mul_fused_matches_split_bf16_rounding() -> Result<()> {
+        let ctx = DeviceContext::new()?;
+        let hidden_dim = 4;
+        let seq_len = 3;
+        let gate: Vec<_> = [
+            -3.0, -1.5, 0.0, 2.0, 0.25, 1.0, 3.5, -0.75, 8.0, -8.0, 0.125, -0.5,
+        ]
+        .into_iter()
+        .map(bf16::from_f32)
+        .collect();
+        let up: Vec<_> = [
+            0.5, -2.0, 4.0, 1.25, -1.0, 0.75, 2.5, -3.0, 0.25, 1.5, -0.625, 5.0,
+        ]
+        .into_iter()
+        .map(bf16::from_f32)
+        .collect();
+        let mut gate_up = Vec::with_capacity(2 * hidden_dim * seq_len);
+        for token in 0..seq_len {
+            let offset = token * hidden_dim;
+            gate_up.extend_from_slice(&gate[offset..offset + hidden_dim]);
+            gate_up.extend_from_slice(&up[offset..offset + hidden_dim]);
+        }
+
+        let gate_hidden = hidden_from_host(&ctx, &gate, hidden_dim, seq_len)?;
+        let up_hidden = hidden_from_host(&ctx, &up, hidden_dim, seq_len)?;
+        let gate_up_hidden = hidden_from_host(&ctx, &gate_up, 2 * hidden_dim, seq_len)?;
+        let split = silu_mul_batch(&ctx, &gate_hidden, &up_hidden)?;
+        let mut fused = HiddenStates::zeros(&ctx, hidden_dim, seq_len)?;
+
+        silu_mul_fused_batch_into(&ctx, &gate_up_hidden, &mut fused);
+
+        let split_host = hidden_to_host(&ctx, &split)?;
+        let fused_host = hidden_to_host(&ctx, &fused)?;
+        assert_eq!(split_host.len(), fused_host.len());
+        for (idx, (split_value, fused_value)) in
+            split_host.iter().zip(fused_host.iter()).enumerate()
+        {
+            assert_eq!(
+                split_value.to_bits(),
+                fused_value.to_bits(),
+                "fused/split silu_mul mismatch at index {idx}"
+            );
+        }
+        Ok(())
+    }
+}

--- a/tools/accuracy/compare_dsv2_lite_ep2_outputs.py
+++ b/tools/accuracy/compare_dsv2_lite_ep2_outputs.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Compare HF, host-staged, and NCCL DeepSeek-V2-Lite EP=2 greedy outputs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+def sha256_u32_le(values: list[int]) -> str:
+    digest = hashlib.sha256()
+    for value in values:
+        digest.update(int(value).to_bytes(4, byteorder="little", signed=False))
+    return digest.hexdigest()
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def load_json_or_stdout(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        decoder = json.JSONDecoder()
+        for index, char in enumerate(text):
+            if char != "{":
+                continue
+            try:
+                obj, _ = decoder.raw_decode(text[index:])
+            except json.JSONDecodeError:
+                continue
+            if isinstance(obj, dict):
+                return obj
+        raise
+
+
+@dataclass
+class Output:
+    name: str
+    model_path: str | None
+    backend: str | None
+    prompt: str | None
+    prompt_token_ids: list[int]
+    generated_token_ids: list[int]
+    generated_text: str
+    reported_token_sha256: str | None
+    reported_text_sha256: str | None
+    token_sha256: str
+    text_sha256: str
+    raw: dict[str, Any]
+
+
+def normalize(name: str, payload: dict[str, Any]) -> Output:
+    token_ids = payload.get("generated_token_ids")
+    if token_ids is None:
+        token_ids = payload.get("output_tokens")
+    if token_ids is None:
+        token_ids = payload.get("tokens")
+    if token_ids is None:
+        token_ids = []
+
+    generated_text = payload.get("generated_text")
+    if generated_text is None:
+        generated_text = payload.get("output_text")
+    if generated_text is None:
+        generated_text = payload.get("output")
+    if generated_text is None:
+        generated_text = ""
+
+    reported_token_hash = payload.get("token_sha256")
+    if reported_token_hash is None:
+        reported_token_hash = payload.get("output_token_sha256")
+    reported_text_hash = payload.get("text_sha256")
+    if reported_text_hash is None:
+        reported_text_hash = payload.get("output_text_sha256")
+
+    prompt_token_ids = payload.get("prompt_token_ids") or []
+
+    return Output(
+        name=name,
+        model_path=payload.get("model_path"),
+        backend=payload.get("ep_backend") or payload.get("backend"),
+        prompt=payload.get("prompt"),
+        prompt_token_ids=[int(value) for value in prompt_token_ids],
+        generated_token_ids=[int(value) for value in token_ids],
+        generated_text=str(generated_text),
+        reported_token_sha256=reported_token_hash,
+        reported_text_sha256=reported_text_hash,
+        token_sha256=sha256_u32_le([int(value) for value in token_ids]),
+        text_sha256=sha256_text(str(generated_text)),
+        raw=payload,
+    )
+
+
+def first_token_diff(left: Output, right: Output) -> dict[str, Any] | None:
+    limit = min(len(left.generated_token_ids), len(right.generated_token_ids))
+    for index in range(limit):
+        left_token = left.generated_token_ids[index]
+        right_token = right.generated_token_ids[index]
+        if left_token != right_token:
+            return {
+                "index": index,
+                left.name: left_token,
+                right.name: right_token,
+                "reason": "token_mismatch",
+            }
+    if len(left.generated_token_ids) != len(right.generated_token_ids):
+        return {
+            "index": limit,
+            left.name: left.generated_token_ids[limit]
+            if len(left.generated_token_ids) > limit
+            else None,
+            right.name: right.generated_token_ids[limit]
+            if len(right.generated_token_ids) > limit
+            else None,
+            "reason": "length_mismatch",
+        }
+    return None
+
+
+def pair_summary(left: Output, right: Output) -> dict[str, Any]:
+    token_exact = left.generated_token_ids == right.generated_token_ids
+    text_exact = left.generated_text == right.generated_text
+    return {
+        "token_exact": token_exact,
+        "text_exact": text_exact,
+        "first_different_token": None if token_exact else first_token_diff(left, right),
+    }
+
+
+def classify(pairs: dict[str, dict[str, Any]]) -> str:
+    host_nccl_exact = pairs["host_staged_vs_nccl"]["token_exact"] and pairs[
+        "host_staged_vs_nccl"
+    ]["text_exact"]
+    hf_host_exact = pairs["hf_vs_host_staged"]["token_exact"] and pairs[
+        "hf_vs_host_staged"
+    ]["text_exact"]
+    hf_nccl_exact = pairs["hf_vs_nccl"]["token_exact"] and pairs["hf_vs_nccl"][
+        "text_exact"
+    ]
+    if host_nccl_exact and hf_host_exact and hf_nccl_exact:
+        return "all_token_text_exact"
+    if not host_nccl_exact:
+        return "nccl_transport_regression"
+    return "pegainfer_baseline_accuracy_gap"
+
+
+def short(text: str, width: int = 72) -> str:
+    one_line = text.replace("\n", "\\n")
+    if len(one_line) <= width:
+        return one_line
+    return one_line[: width - 3] + "..."
+
+
+def table(outputs: list[Output]) -> str:
+    rows = [
+        "| Source | Backend | Tokens | Token SHA256 | Text SHA256 | Text |",
+        "| --- | --- | ---: | --- | --- | --- |",
+    ]
+    for output in outputs:
+        rows.append(
+            "| {name} | {backend} | {tokens} | `{token_hash}` | `{text_hash}` | `{text}` |".format(
+                name=output.name,
+                backend=output.backend or "-",
+                tokens=len(output.generated_token_ids),
+                token_hash=output.token_sha256,
+                text_hash=output.text_sha256,
+                text=short(output.generated_text),
+            )
+        )
+    return "\n".join(rows)
+
+
+def hash_warnings(outputs: list[Output]) -> list[str]:
+    warnings = []
+    for output in outputs:
+        if (
+            output.reported_token_sha256
+            and output.reported_token_sha256 != output.token_sha256
+        ):
+            warnings.append(
+                f"{output.name}: reported token hash {output.reported_token_sha256} "
+                f"does not match recomputed {output.token_sha256}"
+            )
+        if output.reported_text_sha256 and output.reported_text_sha256 != output.text_sha256:
+            warnings.append(
+                f"{output.name}: reported text hash {output.reported_text_sha256} "
+                f"does not match recomputed {output.text_sha256}"
+            )
+    return warnings
+
+
+def context_warnings(hf: Output, host: Output, nccl: Output) -> list[str]:
+    warnings = []
+    outputs = [hf, host, nccl]
+
+    prompts = {output.prompt for output in outputs if output.prompt is not None}
+    if len(prompts) > 1:
+        warnings.append(f"prompt mismatch across outputs: {sorted(prompts)!r}")
+
+    prompt_token_ids = {
+        tuple(output.prompt_token_ids)
+        for output in outputs
+        if output.prompt_token_ids
+    }
+    if len(prompt_token_ids) > 1:
+        warnings.append("prompt_token_ids mismatch across outputs")
+
+    model_paths = {output.model_path for output in outputs if output.model_path is not None}
+    if len(model_paths) > 1:
+        warnings.append(
+            "model_path labels differ; verify all outputs use the same snapshot: "
+            f"{sorted(model_paths)!r}"
+        )
+
+    hf_output_len = hf.raw.get("output_len")
+    peg_output_lens = {
+        output.raw.get("max_new_tokens")
+        for output in [host, nccl]
+        if output.raw.get("max_new_tokens") is not None
+    }
+    output_lens = set()
+    if hf_output_len is not None:
+        output_lens.add(hf_output_len)
+    output_lens.update(peg_output_lens)
+    if len(output_lens) > 1:
+        warnings.append(f"output length labels differ across outputs: {sorted(output_lens)!r}")
+
+    if hf.raw.get("generation_mode") not in (None, "incremental_past_key_values"):
+        warnings.append(
+            "HF output generation_mode is not incremental_past_key_values: "
+            f"{hf.raw.get('generation_mode')}"
+        )
+    if host.backend not in (None, "host-staged"):
+        warnings.append(f"host-staged file reports backend {host.backend!r}")
+    if nccl.backend not in (None, "nccl"):
+        warnings.append(f"NCCL file reports backend {nccl.backend!r}")
+
+    return warnings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hf", required=True, help="HF JSON output")
+    parser.add_argument("--host-staged", required=True, help="host-staged pegainfer JSON output")
+    parser.add_argument("--nccl", required=True, help="NCCL pegainfer JSON output")
+    parser.add_argument("--out", help="Optional path for structured comparison JSON")
+    parser.add_argument(
+        "--require-all-exact",
+        action="store_true",
+        help="Exit nonzero unless HF, host-staged, and NCCL are token/text exact",
+    )
+    args = parser.parse_args()
+
+    hf = normalize("hf", load_json_or_stdout(Path(args.hf)))
+    host = normalize("host_staged", load_json_or_stdout(Path(args.host_staged)))
+    nccl = normalize("nccl", load_json_or_stdout(Path(args.nccl)))
+    outputs = [hf, host, nccl]
+
+    pairs = {
+        "hf_vs_host_staged": pair_summary(hf, host),
+        "hf_vs_nccl": pair_summary(hf, nccl),
+        "host_staged_vs_nccl": pair_summary(host, nccl),
+    }
+    classification = classify(pairs)
+    warnings = hash_warnings(outputs) + context_warnings(hf, host, nccl)
+    result = {
+        "classification": classification,
+        "outputs": {
+            output.name: {
+                "model_path": output.model_path,
+                "backend": output.backend,
+                "prompt": output.prompt,
+                "prompt_token_ids": output.prompt_token_ids,
+                "generated_token_ids": output.generated_token_ids,
+                "generated_text": output.generated_text,
+                "token_sha256": output.token_sha256,
+                "text_sha256": output.text_sha256,
+                "reported_token_sha256": output.reported_token_sha256,
+                "reported_text_sha256": output.reported_text_sha256,
+            }
+            for output in outputs
+        },
+        "pairs": pairs,
+        "warnings": warnings,
+    }
+
+    print(table(outputs))
+    print()
+    print(f"Classification: {classification}")
+    print(json.dumps({"pairs": pairs, "warnings": warnings}, indent=2, ensure_ascii=False))
+
+    if args.out:
+        out_path = Path(args.out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(result, indent=2, ensure_ascii=False) + "\n")
+        print(f"wrote {out_path}")
+
+    if args.require_all_exact and classification != "all_token_text_exact":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/accuracy/hf_dump_dsv2_lite_ep2_greedy.py
+++ b/tools/accuracy/hf_dump_dsv2_lite_ep2_greedy.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Dump Hugging Face greedy incremental generation for DeepSeek-V2-Lite EP=2 comparisons."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+def sha256_u32_le(values: list[int]) -> str:
+    digest = hashlib.sha256()
+    for value in values:
+        digest.update(int(value).to_bytes(4, byteorder="little", signed=False))
+    return digest.hexdigest()
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def load_model(model_path: str, device_map: str, device: str):
+    kwargs = {
+        "trust_remote_code": True,
+        "torch_dtype": torch.bfloat16,
+    }
+    if device_map == "none":
+        model = AutoModelForCausalLM.from_pretrained(model_path, **kwargs)
+        model = model.to(device)
+    else:
+        model = AutoModelForCausalLM.from_pretrained(
+            model_path,
+            device_map=device_map,
+            **kwargs,
+        )
+    model.eval()
+    return model
+
+
+def generate_incremental(
+    model,
+    tokenizer,
+    prompt: str,
+    output_len: int,
+    device: str,
+    ignore_eos: bool,
+):
+    prompt_token_ids = tokenizer.encode(prompt, add_special_tokens=False)
+    if not prompt_token_ids:
+        raise RuntimeError("tokenizer returned empty prompt")
+
+    input_device = device
+    if device == "cuda" and hasattr(model, "device"):
+        input_device = str(model.device)
+    elif device == "cuda":
+        input_device = str(next(model.parameters()).device)
+
+    input_ids = torch.tensor([prompt_token_ids], dtype=torch.long, device=input_device)
+    attention_mask = torch.ones_like(input_ids)
+
+    generated_token_ids: list[int] = []
+    eos_token_id = tokenizer.eos_token_id
+    finish_reason = "length"
+
+    with torch.no_grad():
+        outputs = model(input_ids=input_ids, attention_mask=attention_mask, use_cache=True)
+        past_key_values = outputs.past_key_values
+        next_token = torch.argmax(outputs.logits[:, -1, :], dim=-1)
+
+        for _ in range(output_len):
+            token_id = int(next_token.item())
+            generated_token_ids.append(token_id)
+            if not ignore_eos and eos_token_id is not None and token_id == eos_token_id:
+                finish_reason = "eos"
+                break
+            if len(generated_token_ids) >= output_len:
+                break
+
+            token_input = next_token.view(1, 1).to(input_device)
+            attention_mask = torch.cat(
+                [
+                    attention_mask,
+                    torch.ones((1, 1), dtype=attention_mask.dtype, device=input_device),
+                ],
+                dim=-1,
+            )
+            model_inputs = model.prepare_inputs_for_generation(
+                token_input,
+                past_key_values=past_key_values,
+                attention_mask=attention_mask,
+                use_cache=True,
+            )
+            outputs = model(**model_inputs)
+            past_key_values = outputs.past_key_values
+            next_token = torch.argmax(outputs.logits[:, -1, :], dim=-1)
+
+    generated_text = tokenizer.decode(
+        generated_token_ids,
+        skip_special_tokens=False,
+        clean_up_tokenization_spaces=False,
+    )
+    return {
+        "prompt_token_ids": prompt_token_ids,
+        "generated_token_ids": generated_token_ids,
+        "generated_text": generated_text,
+        "token_sha256": sha256_u32_le(generated_token_ids),
+        "text_sha256": sha256_text(generated_text),
+        "finish_reason": finish_reason,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--model-path", required=True, help="HF model path or id")
+    parser.add_argument("--prompt", default="Hello", help="Prompt text")
+    parser.add_argument("--output-len", type=int, default=16, help="Greedy output length")
+    parser.add_argument(
+        "--device-map",
+        default="auto",
+        help="HF device_map value; use 'none' for a single-device local load",
+    )
+    parser.add_argument(
+        "--device",
+        default="cuda",
+        help="Device used when device_map=none",
+    )
+    parser.add_argument(
+        "--ignore-eos",
+        action="store_true",
+        help="Keep generating even if the model emits eos",
+    )
+    parser.add_argument("--out", default="-", help="Write JSON to file; '-' prints to stdout")
+    args = parser.parse_args()
+
+    model_path = Path(args.model_path)
+    if model_path.exists() and not model_path.is_dir():
+        print(f"error: model path {model_path} is not a directory", file=sys.stderr)
+        return 1
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        args.model_path,
+        trust_remote_code=True,
+    )
+    model = load_model(args.model_path, args.device_map, args.device)
+    result = generate_incremental(
+        model,
+        tokenizer,
+        args.prompt,
+        args.output_len,
+        args.device,
+        args.ignore_eos,
+    )
+
+    payload = {
+        "model_path": args.model_path,
+        "model_type": getattr(getattr(model, "config", None), "model_type", None),
+        "torch_version": torch.__version__,
+        "transformers_version": __import__("transformers").__version__,
+        "device_map": args.device_map,
+        "device": args.device,
+        "dtype": "torch.bfloat16",
+        "prompt": args.prompt,
+        "output_len": args.output_len,
+        "prompt_token_ids": result["prompt_token_ids"],
+        "generated_token_ids": result["generated_token_ids"],
+        "generated_text": result["generated_text"],
+        "token_sha256": result["token_sha256"],
+        "text_sha256": result["text_sha256"],
+        "finish_reason": result["finish_reason"],
+        "generation_mode": "incremental_past_key_values",
+    }
+    text = json.dumps(payload, indent=2, ensure_ascii=False)
+
+    if args.out == "-":
+        print(text)
+    else:
+        out_path = Path(args.out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(text + "\n", encoding="utf-8")
+        print(f"wrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Add a narrow HF ground-truth gate for DeepSeek-V2-Lite EP2. The new comparison path uses real incremental HF greedy decode (`past_key_values`) and compares HF vs pegainfer host-staged vs pegainfer NCCL on `batch=1`, `prompt="Hello"`, `output_len=16`. It records token ids, generated text, and hashes, and keeps the host-staged/NCCL hash oracle intact.

## Scope
In scope:
- HF oracle script with `AutoTokenizer` / `AutoModelForCausalLM`, `trust_remote_code=True`, `torch_dtype=torch.bfloat16`, `model.eval()`, `torch.no_grad()`
- comparison script for HF / host-staged / NCCL outputs
- structured E2E JSON output and docs for rerunning the gate
- small host-side parity fixes for RoPE, YaRN scaling, RMSNorm, MoE gate logits, and fused `silu_mul` rounding

Out of scope:
- performance claims
- sparse dispatch / pegainfer-comm / NVLink follow-up work
- generic EP, multi-node, larger prompts, or batch > 1

## Evidence
- `cargo fmt --check`
- `git diff --check`
- `cargo check --release -p pegainfer-comm`
- `cargo check --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite`
- `cargo check --release -p pegainfer-server --features deepseek-v2-lite`
- `cargo test --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite --lib -- --nocapture`
- HF dump, host-staged E2E, NCCL E2E, and comparison gate all passed on the same `models/DeepSeek-V2-Lite` snapshot
- Classification: `all_token_text_exact`

## Claim Boundary
This closes #135 as the correctness-first DeepSeek-V2-Lite EP=2 milestone. It does not claim production EP readiness, sparse/GPU dispatch, NVLink performance, multi-node support, or broader prompt/batch coverage.

Fixes #135