### PR TITLE
chore(frontend): repoint vllm-frontend deps to vllm-project/vllm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +180,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -459,6 +483,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +542,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -592,10 +644,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -745,6 +795,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,6 +833,12 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "cookie"
@@ -1211,27 +1276,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "unicode-xid",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,6 +1523,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast_image_resize"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12dd43e5011e8d8411a3215a0d57a2ec5c68282fb90eb5d7221fab0113442174"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "document-features",
+ "image",
+ "num-traits",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "fastant"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,8 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "fastokens"
-version = "0.1.0"
-source = "git+https://github.com/BugenZhao/fastokens.git?rev=12a865a1f13aaae8f7b14bab1f177bba30577ad7#12a865a1f13aaae8f7b14bab1f177bba30577ad7"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796a262ed47d1458a4b40d0ed831c927e6f54d5b9c1de2683bb4ac9b04f4c7cc"
 dependencies = [
  "daachorse",
  "fancy-regex 0.17.0",
@@ -1676,6 +1735,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1723,15 +1792,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getopts"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1816,6 +1876,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",
@@ -1844,9 +1905,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2372,18 +2430,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-macro"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d57a3e447e24c22647738e4607f1df1e0ec6f72e16182c4cd199f647cdfb0e4"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2399,15 +2445,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -2495,12 +2532,6 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 
 [[package]]
 name = "lazy_static"
@@ -2597,6 +2628,26 @@ name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "llm-multimodal"
+version = "1.5.0"
+source = "git+https://github.com/vllm-project/llm-multimodal?rev=5b558989844d1c7af3e43d0f604069ffd9c06320#5b558989844d1c7af3e43d0f604069ffd9c06320"
+dependencies = [
+ "base64 0.22.1",
+ "blake3",
+ "bytes",
+ "fast_image_resize",
+ "image",
+ "ndarray 0.17.2",
+ "once_cell",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "lock_api"
@@ -2725,64 +2776,6 @@ name = "macro_rules_attribute-proc_macro"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
-
-[[package]]
-name = "malachite"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbdf9cb251732db30a7200ebb6ae5d22fe8e11397364416617d2c2cf0c51cb5"
-dependencies = [
- "malachite-base",
- "malachite-nz",
- "malachite-q",
-]
-
-[[package]]
-name = "malachite-base"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea0ed76adf7defc1a92240b5c36d5368cfe9251640dcce5bd2d0b7c1fd87aeb"
-dependencies = [
- "hashbrown 0.14.5",
- "itertools 0.11.0",
- "libm",
- "ryu",
-]
-
-[[package]]
-name = "malachite-bigint"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d149aaa2965d70381709d9df4c7ee1fc0de1c614a4efc2ee356f5e43d68749f8"
-dependencies = [
- "derive_more",
- "malachite",
- "num-integer",
- "num-traits",
- "paste",
-]
-
-[[package]]
-name = "malachite-nz"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34a79feebb2bc9aa7762047c8e5495269a367da6b5a90a99882a0aeeac1841f7"
-dependencies = [
- "itertools 0.11.0",
- "libm",
- "malachite-base",
-]
-
-[[package]]
-name = "malachite-q"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f235d5747b1256b47620f5640c2a17a88c7569eebdf27cd9cb130e1a619191"
-dependencies = [
- "itertools 0.11.0",
- "malachite-base",
- "malachite-nz",
-]
 
 [[package]]
 name = "matchers"
@@ -3010,6 +3003,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3220,25 +3228,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "openai-protocol"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e085454d7136bcdfe5681e1469b0c585d7a9c5cfeed5c37ad3e958e1db3637"
-dependencies = [
- "bitflags",
- "chrono",
- "rand 0.9.4",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "serde_with",
- "tokio",
- "tracing",
- "url",
- "validator",
-]
-
-[[package]]
 name = "openssl"
 version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3296,6 +3285,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3737,6 +3732,7 @@ dependencies = [
  "once_cell",
  "tokio",
  "vllm-text",
+ "vllm-tokenizer",
 ]
 
 [[package]]
@@ -3763,44 +3759,6 @@ dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -3874,6 +3832,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4289,22 +4261,11 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -4321,31 +4282,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -4401,7 +4343,7 @@ dependencies = [
  "paste",
  "profiling",
  "rand 0.9.4",
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "simd_helpers",
  "thiserror 2.0.18",
  "v_frame",
@@ -4608,6 +4550,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "riptoken"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "196b37c4dd48f99b51e8aeaa3d0c343df62c7bb5b66cd6735aa072524fbe8665"
+dependencies = [
+ "fancy-regex 0.17.0",
+ "rayon",
+ "regex",
+ "regex-automata",
+ "rustc-hash 2.1.2",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4740,63 +4695,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustpython-ast"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cdaf8ee5c1473b993b398c174641d3aa9da847af36e8d5eb8291930b72f31a5"
-dependencies = [
- "is-macro",
- "malachite-bigint",
- "rustpython-parser-core",
- "static_assertions",
-]
-
-[[package]]
-name = "rustpython-parser"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868f724daac0caf9bd36d38caf45819905193a901e8f1c983345a68e18fb2abb"
-dependencies = [
- "anyhow",
- "is-macro",
- "itertools 0.11.0",
- "lalrpop-util",
- "log",
- "malachite-bigint",
- "num-traits",
- "phf",
- "phf_codegen",
- "rustc-hash 1.1.0",
- "rustpython-ast",
- "rustpython-parser-core",
- "tiny-keccak",
- "unic-emoji-char",
- "unic-ucd-ident",
- "unicode_names2",
-]
-
-[[package]]
-name = "rustpython-parser-core"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b6c12fa273825edc7bccd9a734f0ad5ba4b8a2f4da5ff7efe946f066d0f4ad"
-dependencies = [
- "is-macro",
- "memchr",
- "rustpython-parser-vendored",
-]
-
-[[package]]
-name = "rustpython-parser-vendored"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04fcea49a4630a3a5d940f4d514dc4f575ed63c14c3e3ed07146634aed7f67a6"
-dependencies = [
- "memchr",
- "once_cell",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4855,18 +4753,6 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "schemars_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
@@ -4887,18 +4773,6 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -5017,17 +4891,6 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5224,12 +5087,6 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
-
-[[package]]
-name = "siphasher"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -5545,7 +5402,7 @@ dependencies = [
  "env_logger",
  "hound",
  "log",
- "ndarray",
+ "ndarray 0.16.1",
  "regex",
  "rubato",
  "rustc-hash 1.1.0",
@@ -5728,15 +5585,6 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -6002,25 +5850,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tool-parser"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bdcf0aa96d42cfc2ecc8e7b3c10598b9c1a6052f996b5ab574dec72f483d87c"
-dependencies = [
- "async-trait",
- "num-traits",
- "openai-protocol",
- "parking_lot",
- "regex",
- "rustpython-parser",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6197,58 +6026,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
-name = "unic-char-property"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221"
-dependencies = [
- "unic-char-range",
-]
-
-[[package]]
-name = "unic-char-range"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc"
-
-[[package]]
-name = "unic-common"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
-
-[[package]]
-name = "unic-emoji-char"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b07221e68897210270a38bde4babb655869637af0f69407f96053a34f76494d"
-dependencies = [
- "unic-char-property",
- "unic-char-range",
- "unic-ucd-version",
-]
-
-[[package]]
-name = "unic-ucd-ident"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e230a37c0381caa9219d67cf063aa3a375ffed5bf541a452db16e744bdab6987"
-dependencies = [
- "unic-char-property",
- "unic-char-range",
- "unic-ucd-version",
-]
-
-[[package]]
-name = "unic-ucd-version"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
-dependencies = [
- "unic-common",
-]
-
-[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6292,28 +6069,6 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
-name = "unicode_names2"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1673eca9782c84de5f81b82e4109dcfb3611c8ba0d52930ec4a9478f547b2dd"
-dependencies = [
- "phf",
- "unicode_names2_generator",
-]
-
-[[package]]
-name = "unicode_names2_generator"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91e5b84611016120197efd7dc93ef76774f4e084cd73c9fb3ea4a86c570c56e"
-dependencies = [
- "getopts",
- "log",
- "phf_codegen",
- "rand 0.8.6",
-]
 
 [[package]]
 name = "unindent"
@@ -6546,16 +6301,19 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 [[package]]
 name = "vllm-chat"
 version = "0.1.0"
-source = "git+https://github.com/Inferact/vllm-frontend-rs.git?rev=b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9#b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9"
+source = "git+https://github.com/vllm-project/vllm.git?rev=65b7a812a2dabd212d78c7b5b8a320b4efb9750d#65b7a812a2dabd212d78c7b5b8a320b4efb9750d"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
  "easy-ext",
  "futures",
+ "half",
+ "itertools 0.14.0",
+ "llm-multimodal",
  "minijinja",
  "minijinja-contrib",
  "openai-harmony",
- "openai-protocol",
+ "reqwest",
  "serde",
  "serde-json-fmt",
  "serde_json",
@@ -6563,26 +6321,31 @@ dependencies = [
  "subenum",
  "thiserror 2.0.18",
  "thiserror-ext",
- "tool-parser",
+ "tokio",
  "tracing",
  "trait-set",
  "uuid",
  "vllm-engine-core-client",
  "vllm-llm",
+ "vllm-reasoning-parser",
  "vllm-text",
- "winnow",
+ "vllm-tokenizer",
+ "vllm-tool-parser",
 ]
 
 [[package]]
 name = "vllm-engine-core-client"
 version = "0.1.0"
-source = "git+https://github.com/Inferact/vllm-frontend-rs.git?rev=b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9#b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9"
+source = "git+https://github.com/vllm-project/vllm.git?rev=65b7a812a2dabd212d78c7b5b8a320b4efb9750d#65b7a812a2dabd212d78c7b5b8a320b4efb9750d"
 dependencies = [
  "arc-swap",
+ "bytemuck",
  "byteorder",
  "bytes",
+ "easy-ext",
  "enum-as-inner",
  "futures",
+ "half",
  "hex",
  "itertools 0.14.0",
  "parking_lot",
@@ -6607,7 +6370,7 @@ dependencies = [
 [[package]]
 name = "vllm-llm"
 version = "0.1.0"
-source = "git+https://github.com/Inferact/vllm-frontend-rs.git?rev=b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9#b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9"
+source = "git+https://github.com/vllm-project/vllm.git?rev=65b7a812a2dabd212d78c7b5b8a320b4efb9750d#65b7a812a2dabd212d78c7b5b8a320b4efb9750d"
 dependencies = [
  "easy-ext",
  "enum-as-inner",
@@ -6626,15 +6389,24 @@ dependencies = [
 [[package]]
 name = "vllm-metrics"
 version = "0.1.0"
-source = "git+https://github.com/Inferact/vllm-frontend-rs.git?rev=b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9#b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9"
+source = "git+https://github.com/vllm-project/vllm.git?rev=65b7a812a2dabd212d78c7b5b8a320b4efb9750d#65b7a812a2dabd212d78c7b5b8a320b4efb9750d"
 dependencies = [
  "prometheus-client",
 ]
 
 [[package]]
+name = "vllm-reasoning-parser"
+version = "0.1.0"
+source = "git+https://github.com/vllm-project/vllm.git?rev=65b7a812a2dabd212d78c7b5b8a320b4efb9750d#65b7a812a2dabd212d78c7b5b8a320b4efb9750d"
+dependencies = [
+ "thiserror 2.0.18",
+ "vllm-tokenizer",
+]
+
+[[package]]
 name = "vllm-server"
 version = "0.1.0"
-source = "git+https://github.com/Inferact/vllm-frontend-rs.git?rev=b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9#b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9"
+source = "git+https://github.com/vllm-project/vllm.git?rev=65b7a812a2dabd212d78c7b5b8a320b4efb9750d#65b7a812a2dabd212d78c7b5b8a320b4efb9750d"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
@@ -6643,6 +6415,7 @@ dependencies = [
  "http-body",
  "itertools 0.14.0",
  "libc",
+ "llm-multimodal",
  "prost",
  "prost-types",
  "rmpv",
@@ -6673,30 +6446,56 @@ dependencies = [
 [[package]]
 name = "vllm-text"
 version = "0.1.0"
-source = "git+https://github.com/Inferact/vllm-frontend-rs.git?rev=b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9#b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9"
+source = "git+https://github.com/vllm-project/vllm.git?rev=65b7a812a2dabd212d78c7b5b8a320b4efb9750d#65b7a812a2dabd212d78c7b5b8a320b4efb9750d"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
- "base64 0.22.1",
  "easy-ext",
  "enum-as-inner",
- "fastokens",
  "futures",
  "hf-hub 0.5.0",
  "itertools 0.14.0",
- "rustc-hash 1.1.0",
  "serde",
  "serde_json",
  "serde_with",
+ "thiserror 2.0.18",
+ "thiserror-ext",
+ "tracing",
+ "trait-set",
+ "vllm-engine-core-client",
+ "vllm-llm",
+ "vllm-tokenizer",
+]
+
+[[package]]
+name = "vllm-tokenizer"
+version = "0.1.0"
+source = "git+https://github.com/vllm-project/vllm.git?rev=65b7a812a2dabd212d78c7b5b8a320b4efb9750d#65b7a812a2dabd212d78c7b5b8a320b4efb9750d"
+dependencies = [
+ "base64 0.22.1",
+ "fastokens",
+ "riptoken",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
  "tekken-rs",
  "thiserror 2.0.18",
  "thiserror-ext",
  "tiktoken-rs 0.9.1",
  "tokenizers",
  "tracing",
- "trait-set",
- "vllm-engine-core-client",
- "vllm-llm",
+]
+
+[[package]]
+name = "vllm-tool-parser"
+version = "0.1.0"
+source = "git+https://github.com/vllm-project/vllm.git?rev=65b7a812a2dabd212d78c7b5b8a320b4efb9750d#65b7a812a2dabd212d78c7b5b8a320b4efb9750d"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "thiserror-ext",
+ "winnow",
 ]
 
 [[package]]
@@ -6896,6 +6695,17 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "win_uds"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd30a1a28a3799479cbf4e17284a220ea9ff6bad098a9d0224543a5d1efe1da"
+dependencies = [
+ "async-io",
+ "futures-io",
+ "socket2",
+]
 
 [[package]]
 name = "winapi"
@@ -7356,8 +7166,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zeromq"
-version = "0.6.0-pre.1"
-source = "git+https://github.com/BugenZhao/zmq.rs?rev=dde4ee5c48846b0cc22b1f4fad8c7514748180fe#dde4ee5c48846b0cc22b1f4fad8c7514748180fe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb2c254fd8f366755335c9e43b865f8484fe3bd717d65ffe7c3f28852863030"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -7375,6 +7186,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "uuid",
+ "win_uds",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,10 +98,11 @@ tokio = "1"
 tokio-util = "0.7"
 toml = "1.1"
 uuid = "1"
-vllm-engine-core-client = { git = "https://github.com/Inferact/vllm-frontend-rs.git", rev = "b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9" }
-vllm-server = { git = "https://github.com/Inferact/vllm-frontend-rs.git", rev = "b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9" }
-vllm-text = { git = "https://github.com/Inferact/vllm-frontend-rs.git", rev = "b7bc63d7e2a7a1cb3ca0e9dc02394756aedaa2f9" }
-zeromq = { git = "https://github.com/BugenZhao/zmq.rs", rev = "dde4ee5c48846b0cc22b1f4fad8c7514748180fe", default-features = false, features = [
+vllm-engine-core-client = { git = "https://github.com/vllm-project/vllm.git", rev = "65b7a812a2dabd212d78c7b5b8a320b4efb9750d" }
+vllm-server = { git = "https://github.com/vllm-project/vllm.git", rev = "65b7a812a2dabd212d78c7b5b8a320b4efb9750d" }
+vllm-text = { git = "https://github.com/vllm-project/vllm.git", rev = "65b7a812a2dabd212d78c7b5b8a320b4efb9750d" }
+vllm-tokenizer = { git = "https://github.com/vllm-project/vllm.git", rev = "65b7a812a2dabd212d78c7b5b8a320b4efb9750d" }
+zeromq = { version = "0.6.0", default-features = false, features = [
     "tokio-runtime",
     "all-transport",
 ] }

--- a/pegainfer-vllm-frontend/src/lib.rs
+++ b/pegainfer-vllm-frontend/src/lib.rs
@@ -9,11 +9,13 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use vllm_engine_core_client::protocol::handshake::EngineCoreReadyResponse;
+use vllm_engine_core_client::protocol::logprobs::{
+    Logprobs, MaybeWireLogprobs, PositionLogprobs, TokenLogprob as WireTokenLogprob,
+};
 use vllm_engine_core_client::protocol::{
     EngineCoreEvent, EngineCoreEventType, EngineCoreFinishReason, EngineCoreOutput,
     EngineCoreOutputs, EngineCoreRequest, EngineCoreRequestType, EngineCoreSamplingParams,
-    Logprobs, MaybeWireLogprobs, PositionLogprobs, StopReason, TokenLogprob as WireTokenLogprob,
-    UtilityOutput, UtilityResultEnvelope, encode_msgpack, stats::PrefillStats,
+    StopReason, UtilityOutput, UtilityResultEnvelope, encode_msgpack, stats::PrefillStats,
 };
 use vllm_engine_core_client::{EngineId, TransportMode};
 use vllm_server::{
@@ -72,6 +74,7 @@ impl LocalEngineBridge {
             max_model_len: self.max_model_len as u64,
             num_gpu_blocks: 0,
             dp_stats_address: None,
+            dtype: None,
         };
         input
             .send(ZmqMessage::from(encode_msgpack(&ready)?))

--- a/pegainfer-vllm-support/Cargo.toml
+++ b/pegainfer-vllm-support/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 once_cell = { workspace = true }
 tokio = { workspace = true, features = ["net", "rt", "time"] }
 vllm-text = { workspace = true }
+vllm-tokenizer = { workspace = true }
 
 [lints]
 workspace = true

--- a/pegainfer-vllm-support/src/lib.rs
+++ b/pegainfer-vllm-support/src/lib.rs
@@ -3,10 +3,8 @@ use std::sync::{Arc, Mutex};
 use once_cell::sync::OnceCell;
 use tokio::runtime::{Builder, Runtime};
 use vllm_text::backend::hf::{ResolvedModelFiles, TokenizerSource};
-use vllm_text::tokenizer::{
-    DynTokenizer, HuggingFaceTokenizer, TekkenTokenizer, TiktokenTokenizer,
-};
 use vllm_text::{Error, Result};
+use vllm_tokenizer::{DynTokenizer, HuggingFaceTokenizer, TekkenTokenizer, TiktokenTokenizer};
 
 static TOKENIZER_RESOLVER_RUNTIME: OnceCell<Mutex<Runtime>> = OnceCell::new();
 


### PR DESCRIPTION
## Summary

Upstream moved the Rust frontend from `Inferact/vllm-frontend-rs` into `vllm-project/vllm/rust/` (vllm commit `39910f2b`, 2026-05-22). The old repo is now historical reference; follow the move so we keep getting protocol/parser fixes from the main vllm tree.

- Switch `vllm-{server,engine-core-client,text}` git source from `Inferact/vllm-frontend-rs@b7bc63d7` to `vllm-project/vllm@65b7a812a`
- Add `vllm-tokenizer` workspace dep — tokenizer types (`DynTokenizer`, `HuggingFaceTokenizer`, …) were split out of `vllm-text` into a standalone crate
- Switch `zeromq` from `BugenZhao/zmq.rs` (0.6.0-pre.1) to crates.io `0.6.0` to align with vllm's own zeromq dep, avoiding two copies of `zeromq` in the dep graph
- `pegainfer-vllm-support`: rewire tokenizer imports through `vllm-tokenizer`
- `pegainfer-vllm-frontend`: rewire logprobs imports through `protocol::logprobs::*` (no longer re-exported at protocol root); add new `EngineCoreReadyResponse.dtype` field

## Test plan

- [x] `cargo build --release -p pegainfer-vllm-frontend -p pegainfer-vllm-support` — clean, 0 warnings
- [x] `cargo build --release -p pegainfer-server` — clean
- [x] `bench_serving request --prompt-len 512 --output-len 256` on Qwen3-4B / RTX 5070 Ti:
  - TTFT 48.6 ms · steady TPOT **11.77 ms** (p99 11.94) · 84 tok/s
  - CUDA Graph + Triton decode attention path healthy
- [ ] End-to-end HTTP `/v1/completions` smoke test deferred (the Qwen3-4B greedy e2e baseline drift on `main` is a known pre-existing issue, unrelated to this change — `qwen3-4b`/`kernels`/`core` are untouched here)

## Notes

- Cargo.lock churn is mostly transitive (vllm pulls in `llm-multimodal`, `blake3`, `fast_image_resize`, `async-io`, …)
- Cargo will fully clone `vllm-project/vllm` (~200 MB git db) on first build — one-time cost, shared via `~/.cargo/git/db/`. No shallow support on stable cargo
- Known duplicate transitive versions (`tiktoken-rs 0.7/0.9`, `hf-hub 0.4/0.5`, `ureq 2/3`, `syn 1/2`, `thiserror 1/2`) all come from vllm's own dep tree, not fixable from pegainfer

🤖 Generated with [Claude Code](https://claude.com/claude-code)