### PR TITLE
feat(deepseek-v2-lite): add EP2 decode attribution gate

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 | Path | TL;DR |
 | --- | --- |
 | `models/deepseek-v2-lite/hf-accuracy-gate.md` | DeepSeek-V2-Lite EP2 HF accuracy gate after PR #149/#150: HF incremental greedy, host-staged EP2, and NCCL EP2 are token/text exact for `Hello`, output_len=16. |
+| `models/deepseek-v2-lite/decode-attribution-gate.md` | DeepSeek-V2-Lite EP2 decode attribution gate for the same `Hello`/16-token shape: structured JSON with accuracy hashes, CPU-side timing rollups, host-staged dispatch/combine counts, NCCL exchange/combine counts, and explicit no-throughput claim boundary. |
 
 ## subsystems / runtime
 

--- a/docs/models/deepseek-v2-lite/decode-attribution-gate.md
+++ b/docs/models/deepseek-v2-lite/decode-attribution-gate.md
@@ -1,0 +1,110 @@
+# DeepSeek-V2-Lite EP2 Decode Attribution Gate
+
+> **TL;DR:** DeepSeek-V2-Lite now has a narrow EP2 decode attribution report for the same correctness shape as the HF gate: `batch=1`, `prompt="Hello"`, `output_len=16`, host-staged backend, and NCCL backend. The report is CPU-side attribution plus route/transfer counts; it is evidence for the next bottleneck decision, not a throughput or production EP claim.
+>
+> **Status:** Passing for the covered EP2 `Hello` / 16-token host-staged and NCCL attribution gate.
+
+## Scope
+
+This gate deliberately stays model-specific and shape-specific:
+
+- Model: DeepSeek-V2-Lite.
+- Shape: batch `1`, prompt `Hello`, output length `16`.
+- Backends: default host-staged EP2 and `PEGAINFER_DSV2_LITE_EP_BACKEND=nccl`.
+- Accuracy oracle: the same generated token/text/hash gate used by `hf-accuracy-gate.md`.
+- Attribution source: `DeepSeekV2LiteEp2Generator::generate_greedy_with_attribution`.
+
+Out of scope:
+
+- sparse dispatch;
+- pegainfer-comm / NVLink backend;
+- multi-node or generic EP topology;
+- batch > 1 or broader prompts;
+- performance improvement or throughput claims.
+
+## Report Shape
+
+`dsv2_lite_ep2_decode_attribution` emits structured JSON:
+
+- `report_type`, `model`, `phase`, `backend`, and fixed-shape `config`;
+- nested `accuracy` with generated token ids, generated text, token sha256, and text sha256;
+- CPU-side `timing` with total generation, the prefill-produced first output token, `per_output_token_us`, the 15 true decode-token samples for `output_len=16`, and latency stats;
+- `by_section`, `by_op`, and `by_call_site` rollups in the same vocabulary family as the Qwen3 model report;
+- `coverage` rows that explicitly mark GPU event timing and throughput claims as not covered;
+- `ep` counters for host-staged dispatch/combine and NCCL dense exchange/combine plus local/remote route counts.
+
+Host-staged `dispatch_calls` / `combine_calls` count MoE layer invocations in the fixed greedy run. Host-staged `dispatch_elements` / `combine_elements` count selected routed hidden vectors, so the value is route count times hidden size. NCCL `exchange` and `combine` counters count the dense all-reduce calls and elements used by the current naive NCCL gate.
+
+## Commands
+
+Run the accuracy gate first, because attribution is not allowed to weaken the HF / host-staged / NCCL oracle:
+
+```bash
+mkdir -p target/accuracy/dsv2-lite-ep2
+
+python tools/accuracy/hf_dump_dsv2_lite_ep2_greedy.py \
+  --model-path models/DeepSeek-V2-Lite \
+  --prompt Hello \
+  --output-len 16 \
+  --out target/accuracy/dsv2-lite-ep2/hf.json
+
+PEGAINFER_TEST_MODEL_PATH=models/DeepSeek-V2-Lite \
+PEGAINFER_DSV2_LITE_E2E_JSON_OUT=target/accuracy/dsv2-lite-ep2/host-staged.json \
+  cargo test --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite --test e2e_ep2 -- --nocapture
+
+PEGAINFER_TEST_MODEL_PATH=models/DeepSeek-V2-Lite \
+PEGAINFER_DSV2_LITE_EP_BACKEND=nccl \
+PEGAINFER_DSV2_LITE_E2E_JSON_OUT=target/accuracy/dsv2-lite-ep2/nccl.json \
+  cargo test --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite --test e2e_ep2 -- --nocapture
+
+python tools/accuracy/compare_dsv2_lite_ep2_outputs.py \
+  --hf target/accuracy/dsv2-lite-ep2/hf.json \
+  --host-staged target/accuracy/dsv2-lite-ep2/host-staged.json \
+  --nccl target/accuracy/dsv2-lite-ep2/nccl.json \
+  --out target/accuracy/dsv2-lite-ep2/comparison.json \
+  --require-all-exact
+```
+
+Then collect attribution for the same two pegainfer backends:
+
+```bash
+cargo run --release -p pegainfer-deepseek-v2-lite \
+  --features deepseek-v2-lite \
+  --bin dsv2_lite_ep2_decode_attribution \
+  -- --model-path models/DeepSeek-V2-Lite \
+  --out target/accuracy/dsv2-lite-ep2/host-staged-attribution.json
+
+PEGAINFER_DSV2_LITE_EP_BACKEND=nccl \
+  cargo run --release -p pegainfer-deepseek-v2-lite \
+  --features deepseek-v2-lite \
+  --bin dsv2_lite_ep2_decode_attribution \
+  -- --model-path models/DeepSeek-V2-Lite \
+  --out target/accuracy/dsv2-lite-ep2/nccl-attribution.json
+```
+
+## Environment Notes
+
+The NCCL path depends on a runtime that supports the selected GPU. On newer GPUs, older NCCL runtimes may fail communicator initialization before the model-level comparison runs, for example with a shared-memory init error like:
+
+```text
+ncclMaxSharedMem 82240 exceeds device/fn maxSharedMem 79856
+NCCL WARN Cuda failure 1 'invalid argument'
+```
+
+Use a newer NCCL runtime through the normal library path if the system runtime fails this way. The project code path should not change just to work around local NCCL installation age.
+
+The HF oracle needs a Python environment that can load DeepSeek-V2-Lite with `trust_remote_code=True`, including the model's `flash_attn` dependency. Keep that environment separate from the Rust runtime claim: it is only the truth-source generator for the comparison JSON.
+
+## Latest Validation
+
+The full gate was last rerun on 2026-05-22 with `models/DeepSeek-V2-Lite`, `prompt="Hello"`, and `output_len=16`:
+
+- HF / host-staged / NCCL comparison: `all_token_text_exact`.
+- Token SHA256: `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225`.
+- Text SHA256: `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347`.
+- Host-staged attribution: `dispatch_calls=416`, `combine_calls=416`, `dispatch_elements=5111808`, `combine_elements=5111808`, `local_route_count=1284`, `remote_route_count=1212`.
+- NCCL attribution: `nccl_exchange_calls=416`, `nccl_combine_calls=416`, `nccl_exchange_elements=851968`, `nccl_combine_elements=851968`, `local_route_count=1284`, `remote_route_count=1212`.
+
+## Claim Boundary
+
+This report proves only that the covered DeepSeek-V2-Lite EP2 greedy path still produces the expected token/text hashes and that the current runtime observed the listed CPU-side sections, route counts, and dense collective counts. It does not prove GPU kernel event timing, serving throughput, sparse dispatch readiness, multi-node behavior, or production EP readiness.

--- a/docs/models/deepseek-v4/support.md
+++ b/docs/models/deepseek-v4/support.md
@@ -224,7 +224,7 @@ DeepSeek V4 is a workspace member, but its DeepSeek-specific bins, integration t
 Verified:
 
 - `PEGAINFER_NVCC_JOBS=8 cargo check --release --workspace` passed with DeepSeek TileLang disabled in `pegainfer-kernels`.
-- `PEGAINFER_NVCC_JOBS=8 cargo test --release --workspace --lib` reached existing Qwen3 lib tests and failed because the default local `models/Qwen3-4B` path is absent; it did not trigger DeepSeek TileLang generation.
+- `cargo test --release --workspace --lib` passed with DeepSeek TileLang disabled in `pegainfer-kernels`. Qwen model-loading lib tests now skip only when `PEGAINFER_TEST_MODEL_PATH` is unset and the default local model directory is absent; explicitly provided model paths still run normally and fail normally if invalid.
 
 ## Known Follow-ups
 

--- a/pegainfer-deepseek-v2-lite/Cargo.toml
+++ b/pegainfer-deepseek-v2-lite/Cargo.toml
@@ -33,3 +33,8 @@ workspace = true
 name = "e2e_ep2"
 path = "tests/e2e_ep2.rs"
 required-features = ["deepseek-v2-lite"]
+
+[[bin]]
+name = "dsv2_lite_ep2_decode_attribution"
+path = "src/bin/dsv2_lite_ep2_decode_attribution.rs"
+required-features = ["deepseek-v2-lite"]

--- a/pegainfer-deepseek-v2-lite/src/attribution.rs
+++ b/pegainfer-deepseek-v2-lite/src/attribution.rs
@@ -1,0 +1,287 @@
+use std::{
+    collections::BTreeMap,
+    time::{Duration, Instant},
+};
+
+use anyhow::Result;
+use serde::Serialize;
+
+#[derive(Clone, Debug, Default)]
+pub struct DecodeAttributionProfile {
+    enabled: bool,
+    total_generation_us: u64,
+    prefill_next_token_us: Option<u64>,
+    per_token_decode_us: Vec<u64>,
+    samples: Vec<SectionSample>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct SectionSample {
+    pub phase: &'static str,
+    pub section: &'static str,
+    pub call_site: String,
+    pub layer: Option<usize>,
+    pub token_index: Option<usize>,
+    pub elapsed_us: u64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct SectionRollup {
+    pub section: String,
+    pub calls: usize,
+    pub total_us: u64,
+    pub mean_us: f64,
+    pub min_us: u64,
+    pub p50_us: u64,
+    pub p95_us: u64,
+    pub p99_us: u64,
+    pub max_us: u64,
+    pub pct: f64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct CallSiteRollup {
+    pub call_site: String,
+    pub section: String,
+    pub calls: usize,
+    pub total_us: u64,
+    pub mean_us: f64,
+    pub min_us: u64,
+    pub p50_us: u64,
+    pub p95_us: u64,
+    pub p99_us: u64,
+    pub max_us: u64,
+    pub pct: f64,
+}
+
+impl DecodeAttributionProfile {
+    pub(crate) fn disabled() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn enabled() -> Self {
+        Self {
+            enabled: true,
+            ..Self::default()
+        }
+    }
+
+    pub(crate) fn set_total_generation(&mut self, elapsed: Duration) {
+        if self.enabled {
+            self.total_generation_us = micros(elapsed);
+        }
+    }
+
+    pub(crate) fn set_prefill_next_token(&mut self, elapsed: Duration) {
+        if self.enabled {
+            self.prefill_next_token_us = Some(micros(elapsed));
+        }
+    }
+
+    pub(crate) fn push_decode_token(&mut self, elapsed: Duration) {
+        if self.enabled {
+            self.per_token_decode_us.push(micros(elapsed));
+        }
+    }
+
+    pub(crate) fn record_result<T, C, S>(
+        &mut self,
+        phase: &'static str,
+        section: &'static str,
+        call_site: C,
+        layer: Option<usize>,
+        token_index: Option<usize>,
+        f: impl FnOnce() -> Result<T>,
+    ) -> Result<T>
+    where
+        C: FnOnce() -> S,
+        S: Into<String>,
+    {
+        if !self.enabled {
+            return f();
+        }
+        let start = Instant::now();
+        let result = f();
+        self.samples.push(SectionSample {
+            phase,
+            section,
+            call_site: call_site().into(),
+            layer,
+            token_index,
+            elapsed_us: micros(start.elapsed()),
+        });
+        result
+    }
+
+    pub fn total_generation_us(&self) -> u64 {
+        self.total_generation_us
+    }
+
+    pub fn prefill_next_token_us(&self) -> Option<u64> {
+        self.prefill_next_token_us
+    }
+
+    pub fn per_token_decode_us(&self) -> &[u64] {
+        &self.per_token_decode_us
+    }
+
+    pub fn by_section(&self) -> Vec<SectionRollup> {
+        let total = self.samples.iter().map(|sample| sample.elapsed_us).sum();
+        let mut groups: BTreeMap<&str, Vec<u64>> = BTreeMap::new();
+        for sample in &self.samples {
+            groups
+                .entry(sample.section)
+                .or_default()
+                .push(sample.elapsed_us);
+        }
+        let mut rows: Vec<_> = groups
+            .into_iter()
+            .map(|(section, samples)| {
+                let stats = sample_stats(samples);
+                SectionRollup {
+                    section: section.to_string(),
+                    calls: stats.calls,
+                    total_us: stats.total_us,
+                    mean_us: stats.mean_us,
+                    min_us: stats.min_us,
+                    p50_us: stats.p50_us,
+                    p95_us: stats.p95_us,
+                    p99_us: stats.p99_us,
+                    max_us: stats.max_us,
+                    pct: pct(stats.total_us, total),
+                }
+            })
+            .collect();
+        rows.sort_by(|left, right| {
+            right
+                .total_us
+                .cmp(&left.total_us)
+                .then(left.section.cmp(&right.section))
+        });
+        rows
+    }
+
+    pub fn by_call_site(&self) -> Vec<CallSiteRollup> {
+        let total = self.samples.iter().map(|sample| sample.elapsed_us).sum();
+        let mut groups: BTreeMap<(&str, &str), Vec<u64>> = BTreeMap::new();
+        for sample in &self.samples {
+            groups
+                .entry((sample.call_site.as_str(), sample.section))
+                .or_default()
+                .push(sample.elapsed_us);
+        }
+        let mut rows: Vec<_> = groups
+            .into_iter()
+            .map(|((call_site, section), samples)| {
+                let stats = sample_stats(samples);
+                CallSiteRollup {
+                    call_site: call_site.to_string(),
+                    section: section.to_string(),
+                    calls: stats.calls,
+                    total_us: stats.total_us,
+                    mean_us: stats.mean_us,
+                    min_us: stats.min_us,
+                    p50_us: stats.p50_us,
+                    p95_us: stats.p95_us,
+                    p99_us: stats.p99_us,
+                    max_us: stats.max_us,
+                    pct: pct(stats.total_us, total),
+                }
+            })
+            .collect();
+        rows.sort_by(|left, right| {
+            right
+                .total_us
+                .cmp(&left.total_us)
+                .then(left.call_site.cmp(&right.call_site))
+                .then(left.section.cmp(&right.section))
+        });
+        rows
+    }
+}
+
+#[derive(Clone, Copy)]
+struct SampleStats {
+    calls: usize,
+    total_us: u64,
+    mean_us: f64,
+    min_us: u64,
+    p50_us: u64,
+    p95_us: u64,
+    p99_us: u64,
+    max_us: u64,
+}
+
+fn sample_stats(mut samples: Vec<u64>) -> SampleStats {
+    debug_assert!(!samples.is_empty());
+    samples.sort_unstable();
+    let total_us = samples.iter().sum();
+    SampleStats {
+        calls: samples.len(),
+        total_us,
+        mean_us: total_us as f64 / samples.len() as f64,
+        min_us: samples[0],
+        p50_us: percentile(&samples, 0.50),
+        p95_us: percentile(&samples, 0.95),
+        p99_us: percentile(&samples, 0.99),
+        max_us: samples[samples.len() - 1],
+    }
+}
+
+fn percentile(sorted: &[u64], quantile: f64) -> u64 {
+    let idx = ((sorted.len() as f64 - 1.0) * quantile).ceil() as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+fn pct(value: u64, total: u64) -> f64 {
+    if total == 0 {
+        0.0
+    } else {
+        value as f64 / total as f64 * 100.0
+    }
+}
+
+fn micros(duration: Duration) -> u64 {
+    duration.as_micros().min(u64::MAX as u128) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rollups_sort_by_total_time() {
+        let mut profile = DecodeAttributionProfile::enabled();
+        profile.samples.push(SectionSample {
+            phase: "decode",
+            section: "short",
+            call_site: "layer.0.short".to_string(),
+            layer: Some(0),
+            token_index: Some(0),
+            elapsed_us: 10,
+        });
+        profile.samples.push(SectionSample {
+            phase: "decode",
+            section: "long",
+            call_site: "layer.0.long".to_string(),
+            layer: Some(0),
+            token_index: Some(0),
+            elapsed_us: 30,
+        });
+        profile.samples.push(SectionSample {
+            phase: "decode",
+            section: "long",
+            call_site: "layer.1.long".to_string(),
+            layer: Some(1),
+            token_index: Some(0),
+            elapsed_us: 20,
+        });
+
+        let rows = profile.by_section();
+
+        assert_eq!(rows[0].section, "long");
+        assert_eq!(rows[0].calls, 2);
+        assert_eq!(rows[0].total_us, 50);
+        assert_eq!(rows[1].section, "short");
+    }
+}

--- a/pegainfer-deepseek-v2-lite/src/bin/dsv2_lite_ep2_decode_attribution.rs
+++ b/pegainfer-deepseek-v2-lite/src/bin/dsv2_lite_ep2_decode_attribution.rs
@@ -1,0 +1,310 @@
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, bail, ensure};
+use pegainfer_deepseek_v2_lite::DeepSeekV2LiteEp2Generator;
+use pegainfer_engine::engine::EngineLoadOptions;
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use vllm_text::tokenizer::{HuggingFaceTokenizer, Tokenizer};
+
+const PROMPT: &str = "Hello";
+const OUTPUT_LEN: usize = 16;
+const EXPECTED_OUTPUT_TOKEN_SHA256: &str =
+    "4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225";
+const EXPECTED_OUTPUT_TEXT_SHA256: &str =
+    "0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347";
+
+struct Cli {
+    model_path: String,
+    out: Option<PathBuf>,
+}
+
+fn main() -> Result<()> {
+    let cli = parse_cli()?;
+    let model_path = resolve_model_path(&cli.model_path);
+    ensure!(
+        model_path.join("config.json").exists(),
+        "missing config.json under {}",
+        model_path.display()
+    );
+
+    let tokenizer_path = model_path.join("tokenizer.json");
+    let tokenizer = HuggingFaceTokenizer::new(&tokenizer_path).map_err(|err| {
+        anyhow::anyhow!(
+            "failed to load tokenizer {}: {err:?}",
+            tokenizer_path.display()
+        )
+    })?;
+    let prompt_tokens = tokenizer
+        .encode(PROMPT, false)
+        .map_err(|err| anyhow::anyhow!("encode prompt failed: {err:?}"))?;
+    ensure!(!prompt_tokens.is_empty(), "tokenizer returned empty prompt");
+
+    let mut generator = DeepSeekV2LiteEp2Generator::load(
+        &model_path,
+        EngineLoadOptions {
+            enable_cuda_graph: false,
+            enable_prefill_profile: false,
+            device_ordinals: vec![0, 1],
+            seed: 42,
+        },
+    )?;
+    let (result, attribution) =
+        generator.generate_greedy_with_attribution(&prompt_tokens, OUTPUT_LEN, false)?;
+    let generated_text = tokenizer
+        .decode(&result.tokens, false)
+        .map_err(|err| anyhow::anyhow!("decode output failed: {err:?}"))?;
+    let text_sha256 = sha256_text(&generated_text);
+
+    ensure!(
+        result.stats.output_token_sha256 == EXPECTED_OUTPUT_TOKEN_SHA256,
+        "DeepSeek-V2-Lite attribution token hash drift: got {}, expected {}",
+        result.stats.output_token_sha256,
+        EXPECTED_OUTPUT_TOKEN_SHA256
+    );
+    ensure!(
+        text_sha256 == EXPECTED_OUTPUT_TEXT_SHA256,
+        "DeepSeek-V2-Lite attribution text hash drift: got {}, expected {}",
+        text_sha256,
+        EXPECTED_OUTPUT_TEXT_SHA256
+    );
+
+    let by_section = attribution.by_section();
+    let by_op: Vec<Value> = by_section
+        .iter()
+        .map(|row| {
+            json!({
+                "op": row.section,
+                "calls": row.calls,
+                "total_us": row.total_us,
+                "mean_us": row.mean_us,
+                "min_us": row.min_us,
+                "p50_us": row.p50_us,
+                "p95_us": row.p95_us,
+                "p99_us": row.p99_us,
+                "max_us": row.max_us,
+                "pct": row.pct,
+            })
+        })
+        .collect();
+    let mut per_output_token_us = Vec::with_capacity(OUTPUT_LEN);
+    if let Some(prefill_next_token_us) = attribution.prefill_next_token_us() {
+        per_output_token_us.push(prefill_next_token_us);
+    }
+    per_output_token_us.extend_from_slice(attribution.per_token_decode_us());
+
+    let report = json!({
+        "schema": 1,
+        "report_type": "deepseek-v2-lite-ep2-decode-attribution",
+        "model": "DeepSeek-V2-Lite",
+        "phase": "decode",
+        "backend": &result.stats.ep_backend,
+        "config": {
+            "batch_size": 1,
+            "prompt": PROMPT,
+            "prompt_token_ids": &prompt_tokens,
+            "output_len": OUTPUT_LEN,
+            "ep_size": result.stats.ep_size,
+            "device_ordinals": &result.stats.device_ordinals,
+        },
+        "accuracy": {
+            "generated_token_ids": &result.tokens,
+            "generated_text": &generated_text,
+            "token_sha256": &result.stats.output_token_sha256,
+            "text_sha256": &text_sha256,
+            "expected_token_sha256": EXPECTED_OUTPUT_TOKEN_SHA256,
+            "expected_text_sha256": EXPECTED_OUTPUT_TEXT_SHA256,
+            "token_hash_exact": true,
+            "text_hash_exact": true,
+        },
+        "timing": {
+            "source": "CPU-side wall-clock sections around the existing DeepSeek-V2-Lite EP2 greedy path",
+            "total_generation_us": attribution.total_generation_us(),
+            "prefill_next_token_us": attribution.prefill_next_token_us(),
+            "per_output_token_us": per_output_token_us,
+            "decode_token_count": attribution.per_token_decode_us().len(),
+            "per_token_decode_us": attribution.per_token_decode_us(),
+            "per_token_decode_stats": latency_stats(attribution.per_token_decode_us()),
+        },
+        "attribution_source": "DeepSeekV2LiteEp2Generator::generate_greedy_with_attribution; GPU/NCCL work is timed from the host and synchronized only where the existing runtime already synchronizes.",
+        "schedule_source": "fixed DeepSeek-V2-Lite EP2 greedy gate: prompt=Hello, output_len=16, cuda_graph=false, device_ordinals=[0,1]",
+        "by_section": by_section,
+        "by_op": by_op,
+        "by_call_site": attribution.by_call_site(),
+        "coverage": coverage_rows(&result.stats.ep_backend),
+        "ep": ep_report(&result.stats),
+        "claim_boundary": "Attribution only for the covered EP2 Hello/16 decode gate. CPU-side section timing and route/collective counts are not a throughput, GPU-kernel-event, sparse-dispatch, multi-node, or production EP readiness claim.",
+    });
+
+    let text = serde_json::to_string_pretty(&report)?;
+    if let Some(out) = cli.out {
+        let path = resolve_workspace_path(out);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+        }
+        fs::write(&path, format!("{text}\n"))
+            .with_context(|| format!("write {}", path.display()))?;
+        eprintln!("wrote {}", path.display());
+    }
+    println!("{text}");
+    Ok(())
+}
+
+fn parse_cli() -> Result<Cli> {
+    let mut model_path = "models/DeepSeek-V2-Lite".to_string();
+    let mut out = None;
+    let mut args = env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--model-path" => {
+                model_path = args
+                    .next()
+                    .context("--model-path requires a path argument")?;
+            }
+            "--out" => {
+                out = Some(PathBuf::from(
+                    args.next().context("--out requires a path argument")?,
+                ));
+            }
+            "-h" | "--help" => {
+                println!(
+                    "DeepSeek-V2-Lite EP2 decode attribution gate\n\nUSAGE:\n  dsv2_lite_ep2_decode_attribution [--model-path PATH] [--out PATH]\n\nThe gate is intentionally fixed to batch=1, prompt=Hello, output_len=16. Select NCCL with PEGAINFER_DSV2_LITE_EP_BACKEND=nccl."
+                );
+                std::process::exit(0);
+            }
+            other => bail!(
+                "unsupported argument `{other}`; supported flags: --model-path PATH, --out PATH"
+            ),
+        }
+    }
+    Ok(Cli { model_path, out })
+}
+
+fn ep_report(stats: &pegainfer_deepseek_v2_lite::GenerationStats) -> Value {
+    let (local_route_count, remote_route_count) = match stats.ep_backend.as_str() {
+        "host-staged" => (
+            stats.host_dispatch_local_routes,
+            stats.host_dispatch_remote_routes,
+        ),
+        "nccl" => (
+            stats.nccl_dispatch_local_routes,
+            stats.nccl_dispatch_remote_routes,
+        ),
+        _ => (0, 0),
+    };
+    json!({
+        "dispatch_calls": stats.host_dispatch_calls,
+        "dispatch_elements": stats.host_dispatch_elements,
+        "combine_calls": stats.host_combine_calls,
+        "combine_elements": stats.host_combine_elements,
+        "nccl_exchange_calls": stats.nccl_dense_exchange_calls,
+        "nccl_exchange_elements": stats.nccl_dense_exchange_elements,
+        "nccl_combine_calls": stats.nccl_combine_calls,
+        "nccl_combine_elements": stats.nccl_combine_elements,
+        "local_route_count": local_route_count,
+        "remote_route_count": remote_route_count,
+        "host_dispatch_local_routes": stats.host_dispatch_local_routes,
+        "host_dispatch_remote_routes": stats.host_dispatch_remote_routes,
+        "nccl_dispatch_local_routes": stats.nccl_dispatch_local_routes,
+        "nccl_dispatch_remote_routes": stats.nccl_dispatch_remote_routes,
+        "nccl_combine_routes": stats.nccl_combine_routes,
+    })
+}
+
+fn coverage_rows(backend: &str) -> Vec<Value> {
+    vec![
+        json!({
+            "item": "accuracy.token_text_hash",
+            "status": "passed",
+            "source": "same token/text hash oracle as the DeepSeek-V2-Lite EP2 HF accuracy gate",
+        }),
+        json!({
+            "item": "cpu_side_sections",
+            "status": "measured",
+            "source": "Instant-based host-side section timers in the explicit attribution path",
+        }),
+        json!({
+            "item": "ep_route_and_transfer_counts",
+            "status": "measured",
+            "source": format!("{backend} EP counters recorded by the DeepSeek-V2-Lite EP2 runtime"),
+        }),
+        json!({
+            "item": "gpu_event_timing",
+            "status": "not_covered",
+            "source": "first gate intentionally avoids intrusive CUDA event timing in the DeepSeek runtime",
+        }),
+        json!({
+            "item": "throughput_or_production_ep_readiness",
+            "status": "not_claimed",
+            "source": "single batch=1 prompt=Hello output_len=16 diagnostic gate only",
+        }),
+    ]
+}
+
+fn latency_stats(samples: &[u64]) -> Value {
+    if samples.is_empty() {
+        return json!({
+            "count": 0,
+            "total_us": 0,
+            "mean_us": 0.0,
+            "min_us": 0,
+            "p50_us": 0,
+            "p95_us": 0,
+            "p99_us": 0,
+            "max_us": 0,
+        });
+    }
+    let mut sorted = samples.to_vec();
+    sorted.sort_unstable();
+    let total_us: u64 = sorted.iter().sum();
+    json!({
+        "count": sorted.len(),
+        "total_us": total_us,
+        "mean_us": total_us as f64 / sorted.len() as f64,
+        "min_us": sorted[0],
+        "p50_us": percentile(&sorted, 0.50),
+        "p95_us": percentile(&sorted, 0.95),
+        "p99_us": percentile(&sorted, 0.99),
+        "max_us": sorted[sorted.len() - 1],
+    })
+}
+
+fn percentile(sorted: &[u64], quantile: f64) -> u64 {
+    let idx = ((sorted.len() as f64 - 1.0) * quantile).ceil() as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+fn sha256_text(text: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(text.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+fn resolve_model_path(raw: &str) -> PathBuf {
+    let path = PathBuf::from(raw);
+    if path.join("config.json").exists() {
+        return path;
+    }
+    let workspace_path = resolve_workspace_path(path.clone());
+    if workspace_path.join("config.json").exists() {
+        return workspace_path;
+    }
+    path
+}
+
+fn resolve_workspace_path(path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        return path;
+    }
+    workspace_root().join(path)
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("model crate must live under the workspace root")
+        .to_path_buf()
+}

--- a/pegainfer-deepseek-v2-lite/src/lib.rs
+++ b/pegainfer-deepseek-v2-lite/src/lib.rs
@@ -1,3 +1,4 @@
+mod attribution;
 mod config;
 mod device;
 mod engine;
@@ -13,6 +14,7 @@ use std::path::Path;
 use anyhow::Result;
 use pegainfer_engine::engine::{EngineHandle, EngineLoadOptions};
 
+pub use attribution::{CallSiteRollup, DecodeAttributionProfile, SectionRollup, SectionSample};
 pub use config::Config;
 use config::SUPPORTED_HIDDEN_SIZE;
 use ep::SUPPORTED_ROUTED_EXPERTS;

--- a/pegainfer-deepseek-v2-lite/src/runtime.rs
+++ b/pegainfer-deepseek-v2-lite/src/runtime.rs
@@ -1,6 +1,7 @@
 use std::{
     env,
     path::{Path, PathBuf},
+    time::Instant,
 };
 
 use anyhow::{Context, Result, bail, ensure};
@@ -14,6 +15,7 @@ use sha2::{Digest, Sha256};
 
 use crate::{
     Config,
+    attribution::DecodeAttributionProfile,
     device::activate,
     ep::ExpertParallelConfig,
     host_ops::{
@@ -42,6 +44,10 @@ pub struct GenerationStats {
     pub ep_size: usize,
     pub prompt_tokens: usize,
     pub generated_tokens: usize,
+    pub host_dispatch_calls: usize,
+    pub host_dispatch_elements: usize,
+    pub host_combine_calls: usize,
+    pub host_combine_elements: usize,
     pub host_dispatch_local_routes: usize,
     pub host_dispatch_remote_routes: usize,
     pub nccl_dispatch_local_routes: usize,
@@ -145,6 +151,14 @@ impl GenerationStats {
         }
     }
 
+    fn record_host_staged_moe(&mut self, hidden_dim: usize, route_count: usize) {
+        let elements = hidden_dim * route_count;
+        self.host_dispatch_calls += 1;
+        self.host_combine_calls += 1;
+        self.host_dispatch_elements += elements;
+        self.host_combine_elements += elements;
+    }
+
     fn record_nccl_moe_collectives(&mut self, hidden_dim: usize, seq_len: usize) {
         let elements = hidden_dim * seq_len;
         self.nccl_dense_exchange_calls += 1;
@@ -201,8 +215,36 @@ impl DeepSeekV2LiteEp2Generator {
         max_new_tokens: usize,
         ignore_eos: bool,
     ) -> Result<GenerationResult> {
+        let mut attribution = DecodeAttributionProfile::disabled();
+        self.generate_greedy_inner(prompt_tokens, max_new_tokens, ignore_eos, &mut attribution)
+    }
+
+    pub fn generate_greedy_with_attribution(
+        &mut self,
+        prompt_tokens: &[u32],
+        max_new_tokens: usize,
+        ignore_eos: bool,
+    ) -> Result<(GenerationResult, DecodeAttributionProfile)> {
+        let mut attribution = DecodeAttributionProfile::enabled();
+        let result = self.generate_greedy_inner(
+            prompt_tokens,
+            max_new_tokens,
+            ignore_eos,
+            &mut attribution,
+        )?;
+        Ok((result, attribution))
+    }
+
+    fn generate_greedy_inner(
+        &mut self,
+        prompt_tokens: &[u32],
+        max_new_tokens: usize,
+        ignore_eos: bool,
+        attribution: &mut DecodeAttributionProfile,
+    ) -> Result<GenerationResult> {
         ensure!(!prompt_tokens.is_empty(), "prompt_tokens must not be empty");
         ensure!(max_new_tokens > 0, "max_new_tokens must be positive");
+        let generation_start = Instant::now();
         let requested_context = prompt_tokens.len() + max_new_tokens;
         let supported_context = self.config.supported_plain_rope_context();
         ensure!(
@@ -223,7 +265,10 @@ impl DeepSeekV2LiteEp2Generator {
 
         let mut cache = DecodeCache::new(&self.config);
         let mut generated = Vec::with_capacity(max_new_tokens);
-        let mut next = self.prefill_next_token(prompt_tokens, &mut cache, &mut stats)?;
+        let prefill_start = Instant::now();
+        let mut next =
+            self.prefill_next_token(prompt_tokens, &mut cache, &mut stats, attribution)?;
+        attribution.set_prefill_next_token(prefill_start.elapsed());
         let mut finish_reason = FinishReason::Length;
 
         for step in 0..max_new_tokens {
@@ -237,11 +282,22 @@ impl DeepSeekV2LiteEp2Generator {
                 break;
             }
             let position = prompt_tokens.len() + generated.len() - 1;
-            next = self.decode_next_token(next, position, &mut cache, &mut stats)?;
+            let token_index = generated.len();
+            let decode_start = Instant::now();
+            next = self.decode_next_token(
+                next,
+                position,
+                &mut cache,
+                &mut stats,
+                attribution,
+                token_index,
+            )?;
+            attribution.push_decode_token(decode_start.elapsed());
         }
 
         stats.generated_tokens = generated.len();
         stats.output_token_sha256 = token_sha256(&generated);
+        attribution.set_total_generation(generation_start.elapsed());
         Ok(GenerationResult {
             tokens: generated,
             finish_reason,
@@ -254,10 +310,25 @@ impl DeepSeekV2LiteEp2Generator {
         prompt_tokens: &[u32],
         cache: &mut DecodeCache,
         stats: &mut GenerationStats,
+        attribution: &mut DecodeAttributionProfile,
     ) -> Result<u32> {
-        let mut hidden = self.embed_tokens(prompt_tokens)?;
-        hidden = self.forward_layers(hidden, 0, cache, stats)?;
-        self.sample_last_token(&hidden)
+        let mut hidden = attribution.record_result(
+            "prefill",
+            "embedding",
+            || "prefill.embedding",
+            None,
+            None,
+            || self.embed_tokens(prompt_tokens),
+        )?;
+        hidden = self.forward_layers(hidden, 0, cache, stats, attribution, "prefill", Some(0))?;
+        attribution.record_result(
+            "prefill",
+            "sample_last_token",
+            || "prefill.sample_last_token",
+            None,
+            Some(0),
+            || self.sample_last_token(&hidden),
+        )
     }
 
     fn decode_next_token(
@@ -266,10 +337,34 @@ impl DeepSeekV2LiteEp2Generator {
         position: usize,
         cache: &mut DecodeCache,
         stats: &mut GenerationStats,
+        attribution: &mut DecodeAttributionProfile,
+        token_index: usize,
     ) -> Result<u32> {
-        let mut hidden = self.embed_tokens(&[token])?;
-        hidden = self.forward_layers(hidden, position, cache, stats)?;
-        self.sample_last_token(&hidden)
+        let mut hidden = attribution.record_result(
+            "decode",
+            "embedding",
+            || "decode.embedding",
+            None,
+            Some(token_index),
+            || self.embed_tokens(&[token]),
+        )?;
+        hidden = self.forward_layers(
+            hidden,
+            position,
+            cache,
+            stats,
+            attribution,
+            "decode",
+            Some(token_index),
+        )?;
+        attribution.record_result(
+            "decode",
+            "sample_last_token",
+            || "decode.sample_last_token",
+            None,
+            Some(token_index),
+            || self.sample_last_token(&hidden),
+        )
     }
 
     fn embed_tokens(&self, token_ids: &[u32]) -> Result<HiddenStates> {
@@ -292,6 +387,9 @@ impl DeepSeekV2LiteEp2Generator {
         start_pos: usize,
         cache: &mut DecodeCache,
         stats: &mut GenerationStats,
+        attribution: &mut DecodeAttributionProfile,
+        phase: &'static str,
+        token_index: Option<usize>,
     ) -> Result<HiddenStates> {
         ensure!(
             cache.layers.len() == self.rank0.layers.len(),
@@ -305,6 +403,9 @@ impl DeepSeekV2LiteEp2Generator {
                     start_pos,
                     &mut cache.layers[layer_idx],
                     stats,
+                    attribution,
+                    phase,
+                    token_index,
                 )
                 .with_context(|| format!("DeepSeek-V2-Lite layer {layer_idx}"))?;
         }
@@ -318,33 +419,96 @@ impl DeepSeekV2LiteEp2Generator {
         start_pos: usize,
         cache: &mut LayerCache,
         stats: &mut GenerationStats,
+        attribution: &mut DecodeAttributionProfile,
+        phase: &'static str,
+        token_index: Option<usize>,
     ) -> Result<HiddenStates> {
         activate(&self.rank0.ctx)?;
 
         let layer = &self.rank0.layers[layer_idx];
-        let normed = self.rms_norm_hidden(hidden, &layer.input_layernorm_host)?;
+        let normed = attribution.record_result(
+            phase,
+            "host_rms_norm",
+            || format!("layer.{layer_idx}.input_rms_norm"),
+            Some(layer_idx),
+            token_index,
+            || self.rms_norm_hidden(hidden, &layer.input_layernorm_host),
+        )?;
 
-        let attn = self.attention_forward(&normed, &layer.attention, start_pos, cache)?;
+        let attn = attribution.record_result(
+            phase,
+            "attention_host_path",
+            || format!("layer.{layer_idx}.attention_host_path"),
+            Some(layer_idx),
+            token_index,
+            || self.attention_forward(&normed, &layer.attention, start_pos, cache),
+        )?;
         activate(&self.rank0.ctx)?;
-        let attn_projected = ops::gemm(&self.rank0.ctx, &layer.attention.o_proj, &attn)?;
-        let after_attn = ops::add_batch(&self.rank0.ctx, hidden, &attn_projected)?;
+        let attn_projected = attribution.record_result(
+            phase,
+            "gpu_o_proj_enqueue",
+            || format!("layer.{layer_idx}.attention_o_proj"),
+            Some(layer_idx),
+            token_index,
+            || ops::gemm(&self.rank0.ctx, &layer.attention.o_proj, &attn),
+        )?;
+        let after_attn = attribution.record_result(
+            phase,
+            "gpu_residual_add_enqueue",
+            || format!("layer.{layer_idx}.attention_residual_add"),
+            Some(layer_idx),
+            token_index,
+            || ops::add_batch(&self.rank0.ctx, hidden, &attn_projected),
+        )?;
 
-        let ffn_norm = self.rms_norm_hidden(&after_attn, &layer.post_attention_layernorm_host)?;
+        let ffn_norm = attribution.record_result(
+            phase,
+            "host_rms_norm",
+            || format!("layer.{layer_idx}.post_attention_rms_norm"),
+            Some(layer_idx),
+            token_index,
+            || self.rms_norm_hidden(&after_attn, &layer.post_attention_layernorm_host),
+        )?;
 
         let (ffn_out, local_routes, remote_routes) = match &layer.mlp {
-            MlpWeights::Dense(dense) => {
-                (dense_mlp_forward(&self.rank0.ctx, dense, &ffn_norm)?, 0, 0)
-            }
+            MlpWeights::Dense(dense) => (
+                attribution.record_result(
+                    phase,
+                    "dense_mlp_enqueue",
+                    || format!("layer.{layer_idx}.dense_mlp"),
+                    Some(layer_idx),
+                    token_index,
+                    || dense_mlp_forward(&self.rank0.ctx, dense, &ffn_norm),
+                )?,
+                0,
+                0,
+            ),
             MlpWeights::Moe(moe) => {
-                let out = self.moe_forward(layer_idx, &ffn_norm, moe)?;
-                if self.backend.kind() == EpBackendKind::Nccl {
-                    stats.record_nccl_moe_collectives(ffn_norm.hidden_dim, ffn_norm.seq_len);
+                let (ffn_out, local_routes, remote_routes) =
+                    self.moe_forward(layer_idx, &ffn_norm, moe, attribution, phase, token_index)?;
+                match self.backend.kind() {
+                    EpBackendKind::HostStaged => {
+                        stats.record_host_staged_moe(
+                            ffn_norm.hidden_dim,
+                            local_routes + remote_routes,
+                        );
+                    }
+                    EpBackendKind::Nccl => {
+                        stats.record_nccl_moe_collectives(ffn_norm.hidden_dim, ffn_norm.seq_len);
+                    }
                 }
-                out
+                (ffn_out, local_routes, remote_routes)
             }
         };
         stats.record_routes(self.backend.kind(), local_routes, remote_routes);
-        ops::add_batch(&self.rank0.ctx, &after_attn, &ffn_out)
+        attribution.record_result(
+            phase,
+            "gpu_residual_add_enqueue",
+            || format!("layer.{layer_idx}.ffn_residual_add"),
+            Some(layer_idx),
+            token_index,
+            || ops::add_batch(&self.rank0.ctx, &after_attn, &ffn_out),
+        )
     }
 
     fn attention_forward(
@@ -413,10 +577,17 @@ impl DeepSeekV2LiteEp2Generator {
         layer_idx: usize,
         input: &HiddenStates,
         moe: &MoeMlp,
+        attribution: &mut DecodeAttributionProfile,
+        phase: &'static str,
+        token_index: Option<usize>,
     ) -> Result<(HiddenStates, usize, usize)> {
         match &self.backend {
-            EpBackendRuntime::HostStaged => self.moe_forward_host_staged(layer_idx, input, moe),
-            EpBackendRuntime::Nccl(nccl) => self.moe_forward_nccl(nccl, layer_idx, input, moe),
+            EpBackendRuntime::HostStaged => {
+                self.moe_forward_host_staged(layer_idx, input, moe, attribution, phase, token_index)
+            }
+            EpBackendRuntime::Nccl(nccl) => {
+                self.moe_forward_nccl(nccl, layer_idx, input, moe, attribution, phase, token_index)
+            }
         }
     }
 
@@ -425,13 +596,33 @@ impl DeepSeekV2LiteEp2Generator {
         layer_idx: usize,
         input: &HiddenStates,
         moe: &MoeMlp,
+        attribution: &mut DecodeAttributionProfile,
+        phase: &'static str,
+        token_index: Option<usize>,
     ) -> Result<(HiddenStates, usize, usize)> {
         activate(&self.rank0.ctx)?;
-        let input_host = hidden_to_bf16(&self.rank0.ctx, input)?;
-        let route_logits_host = gate_logits_host(&self.config, &input_host, &moe.gate_host);
-        let routes = topk_softmax_routes(&self.config, &route_logits_host, input.seq_len);
+        let (input_host, routes) = attribution.record_result(
+            phase,
+            "ep_route_host",
+            || format!("layer.{layer_idx}.host_staged.route"),
+            Some(layer_idx),
+            token_index,
+            || {
+                let input_host = hidden_to_bf16(&self.rank0.ctx, input)?;
+                let route_logits_host = gate_logits_host(&self.config, &input_host, &moe.gate_host);
+                let routes = topk_softmax_routes(&self.config, &route_logits_host, input.seq_len);
+                Ok((input_host, routes))
+            },
+        )?;
 
-        let shared = dense_mlp_forward(&self.rank0.ctx, &moe.shared, input)?;
+        let shared = attribution.record_result(
+            phase,
+            "shared_expert_enqueue",
+            || format!("layer.{layer_idx}.shared_expert"),
+            Some(layer_idx),
+            token_index,
+            || dense_mlp_forward(&self.rank0.ctx, &moe.shared, input),
+        )?;
         let mut routed_accum = vec![0.0f32; input.seq_len * self.config.hidden_size];
         let mut local_routes = 0usize;
         let mut remote_routes = 0usize;
@@ -440,31 +631,69 @@ impl DeepSeekV2LiteEp2Generator {
             let token_input =
                 &input_host[token * self.config.hidden_size..(token + 1) * self.config.hidden_size];
             for &(global_expert, weight) in token_routes {
-                let (out, is_remote) =
-                    self.expert_forward_host(layer_idx, global_expert, token_input)?;
+                let owner_rank = self.rank0.layout.owner_rank(global_expert)?;
+                let section = if owner_rank == 0 {
+                    "host_staged_local_expert"
+                } else {
+                    "host_staged_remote_dispatch"
+                };
+                let (out, is_remote) = attribution.record_result(
+                    phase,
+                    section,
+                    || format!("layer.{layer_idx}.{section}"),
+                    Some(layer_idx),
+                    token_index,
+                    || self.expert_forward_host(layer_idx, global_expert, token_input),
+                )?;
                 if is_remote {
                     remote_routes += 1;
                 } else {
                     local_routes += 1;
                 }
                 let offset = token * self.config.hidden_size;
-                for (dst, value) in routed_accum[offset..offset + self.config.hidden_size]
-                    .iter_mut()
-                    .zip(out)
-                {
-                    *dst += weight * value;
-                }
+                attribution.record_result(
+                    phase,
+                    "host_staged_combine_accumulate",
+                    || format!("layer.{layer_idx}.host_staged.combine_accumulate"),
+                    Some(layer_idx),
+                    token_index,
+                    || {
+                        for (dst, value) in routed_accum[offset..offset + self.config.hidden_size]
+                            .iter_mut()
+                            .zip(out)
+                        {
+                            *dst += weight * value;
+                        }
+                        Ok(())
+                    },
+                )?;
             }
         }
 
-        let routed = hidden_from_f32_host(
-            &self.rank0.ctx,
-            &routed_accum,
-            self.config.hidden_size,
-            input.seq_len,
+        let routed = attribution.record_result(
+            phase,
+            "host_staged_combine_to_device",
+            || format!("layer.{layer_idx}.host_staged.combine_to_device"),
+            Some(layer_idx),
+            token_index,
+            || {
+                hidden_from_f32_host(
+                    &self.rank0.ctx,
+                    &routed_accum,
+                    self.config.hidden_size,
+                    input.seq_len,
+                )
+            },
         )?;
         activate(&self.rank0.ctx)?;
-        let hidden = ops::add_batch(&self.rank0.ctx, &routed, &shared)?;
+        let hidden = attribution.record_result(
+            phase,
+            "shared_plus_routed_enqueue",
+            || format!("layer.{layer_idx}.shared_plus_routed"),
+            Some(layer_idx),
+            token_index,
+            || ops::add_batch(&self.rank0.ctx, &routed, &shared),
+        )?;
         Ok((hidden, local_routes, remote_routes))
     }
 
@@ -474,20 +703,49 @@ impl DeepSeekV2LiteEp2Generator {
         layer_idx: usize,
         input: &HiddenStates,
         moe: &MoeMlp,
+        attribution: &mut DecodeAttributionProfile,
+        phase: &'static str,
+        token_index: Option<usize>,
     ) -> Result<(HiddenStates, usize, usize)> {
         activate(&self.rank0.ctx)?;
-        let input_host = hidden_to_bf16(&self.rank0.ctx, input)?;
-        let route_logits_host = gate_logits_host(&self.config, &input_host, &moe.gate_host);
-        let routes = topk_softmax_routes(&self.config, &route_logits_host, input.seq_len);
+        let routes = attribution.record_result(
+            phase,
+            "ep_route_host",
+            || format!("layer.{layer_idx}.nccl.route"),
+            Some(layer_idx),
+            token_index,
+            || {
+                let input_host = hidden_to_bf16(&self.rank0.ctx, input)?;
+                let route_logits_host = gate_logits_host(&self.config, &input_host, &moe.gate_host);
+                Ok(topk_softmax_routes(
+                    &self.config,
+                    &route_logits_host,
+                    input.seq_len,
+                ))
+            },
+        )?;
 
-        let shared = dense_mlp_forward(&self.rank0.ctx, &moe.shared, input)?;
+        let shared = attribution.record_result(
+            phase,
+            "shared_expert_enqueue",
+            || format!("layer.{layer_idx}.shared_expert"),
+            Some(layer_idx),
+            token_index,
+            || dense_mlp_forward(&self.rank0.ctx, &moe.shared, input),
+        )?;
         let mut rank0_contrib = vec![0.0f32; input.seq_len * self.config.hidden_size];
         let mut rank1_contrib = vec![0.0f32; rank0_contrib.len()];
         // NCCL covers only the dense hidden exchange and final contribution
         // sum in this first gate. Route iteration and expert-output
         // accumulation stay host-side so host-staged remains a simple oracle.
-        let rank1_input =
-            nccl.dense_all_reduce_rank0_hidden_to_rank1(&self.rank0.ctx, &self.rank1.ctx, input)?;
+        let rank1_input = attribution.record_result(
+            phase,
+            "nccl_dense_exchange",
+            || format!("layer.{layer_idx}.nccl.dense_exchange"),
+            Some(layer_idx),
+            token_index,
+            || nccl.dense_all_reduce_rank0_hidden_to_rank1(&self.rank0.ctx, &self.rank1.ctx, input),
+        )?;
         let mut local_routes = 0usize;
         let mut remote_routes = 0usize;
 
@@ -499,7 +757,14 @@ impl DeepSeekV2LiteEp2Generator {
                         local_routes += 1;
                         let expert = self.rank0.routed_expert(layer_idx, global_expert)?;
                         (
-                            expert_forward_device(&self.rank0.ctx, expert, input, token)?,
+                            attribution.record_result(
+                                phase,
+                                "nccl_local_expert",
+                                || format!("layer.{layer_idx}.nccl.local_expert"),
+                                Some(layer_idx),
+                                token_index,
+                                || expert_forward_device(&self.rank0.ctx, expert, input, token),
+                            )?,
                             &mut rank0_contrib,
                         )
                     }
@@ -507,7 +772,21 @@ impl DeepSeekV2LiteEp2Generator {
                         remote_routes += 1;
                         let expert = self.rank1.routed_expert(layer_idx, global_expert)?;
                         (
-                            expert_forward_device(&self.rank1.ctx, expert, &rank1_input, token)?,
+                            attribution.record_result(
+                                phase,
+                                "nccl_remote_expert",
+                                || format!("layer.{layer_idx}.nccl.remote_expert"),
+                                Some(layer_idx),
+                                token_index,
+                                || {
+                                    expert_forward_device(
+                                        &self.rank1.ctx,
+                                        expert,
+                                        &rank1_input,
+                                        token,
+                                    )
+                                },
+                            )?,
                             &mut rank1_contrib,
                         )
                     }
@@ -516,29 +795,64 @@ impl DeepSeekV2LiteEp2Generator {
                     }
                 };
                 let offset = token * self.config.hidden_size;
-                for (dst, value) in dst[offset..offset + self.config.hidden_size]
-                    .iter_mut()
-                    .zip(out)
-                {
-                    *dst += weight * value;
-                }
+                attribution.record_result(
+                    phase,
+                    "nccl_contribution_accumulate",
+                    || format!("layer.{layer_idx}.nccl.contribution_accumulate"),
+                    Some(layer_idx),
+                    token_index,
+                    || {
+                        for (dst, value) in dst[offset..offset + self.config.hidden_size]
+                            .iter_mut()
+                            .zip(out)
+                        {
+                            *dst += weight * value;
+                        }
+                        Ok(())
+                    },
+                )?;
             }
         }
 
-        let combined = nccl.combine_f32_contributions_to_rank0(
-            &self.rank0.ctx,
-            &self.rank1.ctx,
-            &rank0_contrib,
-            &rank1_contrib,
+        let combined = attribution.record_result(
+            phase,
+            "nccl_combine",
+            || format!("layer.{layer_idx}.nccl.combine"),
+            Some(layer_idx),
+            token_index,
+            || {
+                nccl.combine_f32_contributions_to_rank0(
+                    &self.rank0.ctx,
+                    &self.rank1.ctx,
+                    &rank0_contrib,
+                    &rank1_contrib,
+                )
+            },
         )?;
-        let routed = hidden_from_f32_host(
-            &self.rank0.ctx,
-            &combined,
-            self.config.hidden_size,
-            input.seq_len,
+        let routed = attribution.record_result(
+            phase,
+            "nccl_combine_to_device",
+            || format!("layer.{layer_idx}.nccl.combine_to_device"),
+            Some(layer_idx),
+            token_index,
+            || {
+                hidden_from_f32_host(
+                    &self.rank0.ctx,
+                    &combined,
+                    self.config.hidden_size,
+                    input.seq_len,
+                )
+            },
         )?;
         activate(&self.rank0.ctx)?;
-        let hidden = ops::add_batch(&self.rank0.ctx, &routed, &shared)?;
+        let hidden = attribution.record_result(
+            phase,
+            "shared_plus_routed_enqueue",
+            || format!("layer.{layer_idx}.shared_plus_routed"),
+            Some(layer_idx),
+            token_index,
+            || ops::add_batch(&self.rank0.ctx, &routed, &shared),
+        )?;
         Ok((hidden, local_routes, remote_routes))
     }
 

--- a/pegainfer-deepseek-v2-lite/tests/e2e_ep2.rs
+++ b/pegainfer-deepseek-v2-lite/tests/e2e_ep2.rs
@@ -106,6 +106,13 @@ fn run_rust_generation(model_path_label: &str, model_path: &Path) -> Result<()> 
     match result.stats.ep_backend.as_str() {
         "host-staged" => {
             ensure!(
+                result.stats.host_dispatch_calls > 0
+                    && result.stats.host_combine_calls == result.stats.host_dispatch_calls
+                    && result.stats.host_dispatch_elements > 0
+                    && result.stats.host_combine_elements == result.stats.host_dispatch_elements,
+                "host-staged EP gate did not record dispatch/combine counts"
+            );
+            ensure!(
                 result.stats.host_dispatch_remote_routes > 0,
                 "host-staged EP gate did not exercise any remote routed expert"
             );
@@ -189,6 +196,10 @@ fn run_rust_generation(model_path_label: &str, model_path: &Path) -> Result<()> 
         "output_text_sha256": output_text_sha256,
         "token_sha256_algorithm": "sha256 over generated token ids encoded as little-endian u32",
         "text_sha256_algorithm": "sha256 over UTF-8 generated text bytes",
+        "host_dispatch_calls": result.stats.host_dispatch_calls,
+        "host_dispatch_elements": result.stats.host_dispatch_elements,
+        "host_combine_calls": result.stats.host_combine_calls,
+        "host_combine_elements": result.stats.host_combine_elements,
         "host_dispatch_local_routes": result.stats.host_dispatch_local_routes,
         "host_dispatch_remote_routes": result.stats.host_dispatch_remote_routes,
         "nccl_dispatch_local_routes": result.stats.nccl_dispatch_local_routes,

--- a/pegainfer-deepseek-v4/src/lib.rs
+++ b/pegainfer-deepseek-v4/src/lib.rs
@@ -1,11 +1,17 @@
 mod config;
+#[cfg(feature = "deepseek-v4")]
 mod direct;
+#[cfg(feature = "deepseek-v4")]
 pub mod e2e_runner;
+#[cfg(feature = "deepseek-v4")]
 mod model;
+#[cfg(feature = "deepseek-v4")]
 mod runtime;
+#[cfg(feature = "deepseek-v4")]
 mod weights;
 
 pub use config::{Config, RopeScaling, TensorParallelConfig};
+#[cfg(feature = "deepseek-v4")]
 pub use direct::{
     DeepSeekV4DirectGenerator, DeepSeekV4RequestState, DirectDecodeStep, DirectGeneration,
     DirectKvCacheActiveSnapshot, DirectKvCacheLease, DirectKvCacheReject,
@@ -14,12 +20,14 @@ pub use direct::{
 #[cfg(feature = "pplx-ep")]
 #[doc(hidden)]
 pub use direct::{PplxBootstrapParams, build_intra_node_backends_for_devices};
+#[cfg(feature = "deepseek-v4")]
 pub use model::{
     AttentionWeightNames, AttentionWeights, BlockWeightNames, BlockWeights, CompressorWeightNames,
     CompressorWeights, DeepSeekRankModel, ExpertWeightNames, ExpertWeights, FfnWeightNames,
     FfnWeights, IndexerWeightNames, IndexerWeights, QuantLinearNames, QuantLinearRef,
     RankWeightView, TensorRef, TopLevelWeightNames,
 };
+#[cfg(feature = "deepseek-v4")]
 pub use runtime::{
     AttentionProjections, Bf16Cache, Bf16HiddenStates, CompressorDecodeState, DeepSeekRopeCache,
     F32HiddenStates, F32Logits, HcHiddenStates, HcPreState, LayerDecodeCache, MoeFusedRoutePlan,
@@ -52,6 +60,7 @@ pub use runtime::{
     sparse_attention_prefill_bf16_hidden, window_and_compress_topk_indices, window_topk_indices,
     window_topk_indices_decode,
 };
+#[cfg(feature = "deepseek-v4")]
 pub use weights::{
     GpuRawTensor, RankGpuContext, RankManifest, RankWeights, TensorInfo, load_rank_manifest,
     load_rank_subset_to_gpu, load_rank_to_gpu, mp_rank_path,

--- a/pegainfer-qwen3-4b/src/batch_decode.rs
+++ b/pegainfer-qwen3-4b/src/batch_decode.rs
@@ -281,11 +281,23 @@ mod tests {
     use pegainfer_core::tensor::DeviceVec;
     use rand::SeedableRng;
     use rand::rngs::StdRng;
+    use std::path::Path;
 
     const MODEL_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../models/Qwen3-4B");
 
-    fn get_model_path() -> String {
-        std::env::var("PEGAINFER_TEST_MODEL_PATH").unwrap_or_else(|_| MODEL_PATH.to_string())
+    fn get_model_path_or_skip() -> Option<String> {
+        match std::env::var("PEGAINFER_TEST_MODEL_PATH") {
+            Ok(path) => Some(path),
+            Err(_) if Path::new(MODEL_PATH).join("config.json").exists() => {
+                Some(MODEL_PATH.to_string())
+            }
+            Err(_) => {
+                eprintln!(
+                    "skipping Qwen3 batch decode model test because {MODEL_PATH}/config.json is missing; set PEGAINFER_TEST_MODEL_PATH to run it"
+                );
+                None
+            }
+        }
     }
 
     fn sample_batch_tokens(
@@ -481,7 +493,9 @@ mod tests {
     /// OOM-ing on a single GPU.
     #[test]
     fn batch_matches_sequential() {
-        let model_path = get_model_path();
+        let Some(model_path) = get_model_path_or_skip() else {
+            return;
+        };
         let prompt_a: Vec<u32> = vec![9707]; // "Hello"
         let prompt_b: Vec<u32> = vec![3838, 374, 220, 17, 10, 17]; // "What is 2+2"
         let num_steps = 10;

--- a/pegainfer-qwen35-4b/src/unified_forward.rs
+++ b/pegainfer-qwen35-4b/src/unified_forward.rs
@@ -110,14 +110,26 @@ impl Qwen35Model {
 mod tests {
     use rand::SeedableRng;
     use rand::rngs::StdRng;
+    use std::path::Path;
 
     use super::*;
     use pegainfer_core::kv_pool::KvState;
 
     const MODEL_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../models/Qwen3.5-4B");
 
-    fn get_model_path() -> String {
-        std::env::var("PEGAINFER_TEST_MODEL_PATH").unwrap_or_else(|_| MODEL_PATH.to_string())
+    fn get_model_path_or_skip() -> Option<String> {
+        match std::env::var("PEGAINFER_TEST_MODEL_PATH") {
+            Ok(path) => Some(path),
+            Err(_) if Path::new(MODEL_PATH).join("config.json").exists() => {
+                Some(MODEL_PATH.to_string())
+            }
+            Err(_) => {
+                eprintln!(
+                    "skipping Qwen3.5 unified forward model test because {MODEL_PATH}/config.json is missing; set PEGAINFER_TEST_MODEL_PATH to run it"
+                );
+                None
+            }
+        }
     }
 
     /// Sample a token from a DeviceVec logits using greedy (argmax).
@@ -154,7 +166,9 @@ mod tests {
     /// Verify that unified_step decode output matches batch_decode_graph standalone.
     #[test]
     fn unified_step_decode_matches_graph_decode() {
-        let model_path = get_model_path();
+        let Some(model_path) = get_model_path_or_skip() else {
+            return;
+        };
         let model = Qwen35Model::from_safetensors_with_options(&model_path, true).unwrap();
 
         let prompt_a: Vec<u32> = vec![9707];


### PR DESCRIPTION
## Summary

Adds a narrow DeepSeek-V2-Lite EP=2 decode attribution gate for issue #155. The gate keeps the same correctness shape as the existing HF parity check: `batch=1`, prompt `Hello`, `output_len=16`, host-staged EP2, and NCCL EP2.

The new report path emits structured JSON with accuracy hashes, CPU-side timing rollups, by-section/by-op/by-call-site attribution, coverage rows, and EP-specific route/dispatch/combine counters. It is model-specific and intentionally does not introduce a generic profiler framework.

## Scope

In scope:
- Add `dsv2_lite_ep2_decode_attribution` for DeepSeek-V2-Lite EP2.
- Preserve the PR #154 HF / host-staged / NCCL token/text/hash oracle.
- Add host-staged dispatch/combine call and element counts to the existing e2e JSON.
- Report NCCL exchange/combine calls and elements, local/remote route counts, timing rollups, and explicit coverage boundaries.
- Keep DeepSeek-V4 default workspace builds feature-isolated from DeepSeek-V4 TileLang/FFI paths.
- Let Qwen model-loading lib tests skip only when the default local model path is absent and `PEGAINFER_TEST_MODEL_PATH` is unset.

Out of scope:
- Sparse dispatch.
- pegainfer-comm / NVLink backend.
- Multi-node EP.
- Generic EP topology.
- Batch > 1 or broader prompt coverage.
- Performance optimization or throughput claims.

## Evidence

Local:
- `cargo fmt --all --check` passed.
- `git diff --check` passed.

GPU validation:
- `cargo test --release --workspace --lib` passed.
- `cargo check --release --workspace` passed.
- `cargo check --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite --all-targets` passed.
- `cargo test --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite --lib -- --nocapture` passed: 17 tests.

DeepSeek-V2-Lite EP2 accuracy gate:
- HF / host-staged / NCCL comparison: `all_token_text_exact`.
- Token SHA256: `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225`.
- Text SHA256: `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347`.

Attribution samples:
- Host-staged: `dispatch_calls=416`, `combine_calls=416`, `dispatch_elements=5111808`, `combine_elements=5111808`, `local_route_count=1284`, `remote_route_count=1212`.
- NCCL: `nccl_exchange_calls=416`, `nccl_combine_calls=416`, `nccl_exchange_elements=851968`, `nccl_combine_elements=851968`, `local_route_count=1284`, `remote_route_count=1212`.

Additional guard:
- Explicitly invalid `PEGAINFER_TEST_MODEL_PATH` still fails Qwen model-loading tests, so the new skip only covers the default missing-local-model case.

## Claim Boundary

This is a diagnostic attribution gate for the covered DeepSeek-V2-Lite EP2 `Hello` / 16-token decode path. CPU-side timing and route/collective counts are not a GPU event timing result, serving throughput claim, sparse-dispatch readiness claim, multi-node claim, or production EP readiness claim.

Refs #155