### PR TITLE
fix(kimi-k2): restore pplx feature build

### DIFF
--- a/pegainfer-kimi-k2/src/runner/moe_pplx.rs
+++ b/pegainfer-kimi-k2/src/runner/moe_pplx.rs
@@ -46,7 +46,6 @@ use crate::{
 
 use super::worker::{
     KimiMoeForwardCache, KimiWorkerDecodeScratch, MARLIN_W13_OUT_DIM, SHARED_ACTIVATED_DIM,
-    SHARED_GATE_UP_DIM,
 };
 
 pub(super) const PPLX_EXPERT_PADDING: usize = 8;

--- a/pegainfer-kimi-k2/src/runner/worker/forward.rs
+++ b/pegainfer-kimi-k2/src/runner/worker/forward.rs
@@ -58,7 +58,7 @@ pub(super) fn forward_decode_batch_next_token_kernels(
             KimiLayerForwardKindCache::Moe(moe) => {
                 #[cfg(feature = "pplx-ep")]
                 if let Some(pplx_ctx) = pplx.as_mut() {
-                    super::moe_pplx::forward_moe_layer_decode_pplx(
+                    crate::runner::moe_pplx::forward_moe_layer_decode_pplx(
                         device_ctx,
                         decode_aux_ctx,
                         comm,

--- a/pegainfer-kimi-k2/src/runner/worker/state.rs
+++ b/pegainfer-kimi-k2/src/runner/worker/state.rs
@@ -6,7 +6,7 @@ impl KimiRankThreadState {
         self.ctx.set_current()?;
         if self.moe_pplx_scratch.is_none() {
             self.moe_pplx_scratch = Some(
-                super::moe_pplx::KimiMoePplxScratch::new(
+                crate::runner::moe_pplx::KimiMoePplxScratch::new(
                     &self.ctx.as_device_context(),
                     KIMI_DECODE_MAX_BATCH,
                 )


### PR DESCRIPTION
## Summary
- fix PPLX EP references from worker submodules after the Kimi runner file split
- remove the stale PPLX-only unused import so the feature builds cleanly

## Validation
- cargo fmt --check
- git diff --check
- cargo check --release -p pegainfer-server --features kimi-k2-pplx-ep --bin bench_serving
- h20-100: cargo check --release -p pegainfer-server --features kimi-k2-pplx-ep --bin bench_serving

## Notes
- h20-100 was restored to clean origin/main after validation.