### PR TITLE
feat(deepseek-v2-lite): add EP2 GPU attribution corroboration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3575,6 +3575,7 @@ dependencies = [
  "hex",
  "libloading 0.9.0",
  "memmap2",
+ "nvtx",
  "pegainfer-core",
  "pegainfer-engine",
  "safetensors",

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 | Path | TL;DR |
 | --- | --- |
 | `models/deepseek-v2-lite/hf-accuracy-gate.md` | DeepSeek-V2-Lite EP2 HF accuracy gate after PR #149/#150: HF incremental greedy, host-staged EP2, and NCCL EP2 are token/text exact for `Hello`, output_len=16. |
-| `models/deepseek-v2-lite/decode-attribution-gate.md` | DeepSeek-V2-Lite EP2 decode attribution gate for the same `Hello`/16-token shape: structured JSON with accuracy hashes, CPU-side timing rollups, host-staged dispatch/combine counts, NCCL exchange/combine counts, and explicit no-throughput claim boundary. |
+| `models/deepseek-v2-lite/decode-attribution-gate.md` | DeepSeek-V2-Lite EP2 decode attribution gate for the same `Hello`/16-token shape: structured JSON with accuracy hashes, CPU-side timing, selected CUDA event/NVTX attribution, host-staged/NCCL EP counts, and explicit no-throughput claim boundary. |
 
 ## models / kimi-k2
 

--- a/docs/models/deepseek-v2-lite/decode-attribution-gate.md
+++ b/docs/models/deepseek-v2-lite/decode-attribution-gate.md
@@ -1,6 +1,6 @@
 # DeepSeek-V2-Lite EP2 Decode Attribution Gate
 
-> **TL;DR:** DeepSeek-V2-Lite now has a narrow EP2 decode attribution report for the same correctness shape as the HF gate: `batch=1`, `prompt="Hello"`, `output_len=16`, host-staged backend, and NCCL backend. The report is CPU-side attribution plus route/transfer counts; it is evidence for the next bottleneck decision, not a throughput or production EP claim.
+> **TL;DR:** DeepSeek-V2-Lite now has a narrow EP2 decode attribution report for the same correctness shape as the HF gate: `batch=1`, `prompt="Hello"`, `output_len=16`, host-staged backend, and NCCL backend. The report combines CPU-side attribution, selected CUDA event timing, optional NVTX ranges, and route/transfer counts; it is evidence for the next bottleneck decision, not a throughput or production EP claim.
 >
 > **Status:** Passing for the covered EP2 `Hello` / 16-token host-staged and NCCL attribution gate.
 
@@ -13,6 +13,8 @@ This gate deliberately stays model-specific and shape-specific:
 - Backends: default host-staged EP2 and `PEGAINFER_DSV2_LITE_EP_BACKEND=nccl`.
 - Accuracy oracle: the same generated token/text/hash gate used by `hf-accuracy-gate.md`.
 - Attribution source: `DeepSeekV2LiteEp2Generator::generate_greedy_with_attribution`.
+- GPU attribution source: CUDA events around selected stream sections in the explicit attribution path.
+- NVTX source: set `PEGAINFER_DSV2_LITE_NVTX=1` to emit matching ranges for those selected sections during a profiler run.
 
 Out of scope:
 
@@ -29,11 +31,14 @@ Out of scope:
 - `report_type`, `model`, `phase`, `backend`, and fixed-shape `config`;
 - nested `accuracy` with generated token ids, generated text, token sha256, and text sha256;
 - CPU-side `timing` with total generation, the prefill-produced first output token, `per_output_token_us`, the 15 true decode-token samples for `output_len=16`, and latency stats;
+- `gpu_timing`, `by_gpu_section`, and `by_gpu_call_site` with CUDA event timing for selected GPU/NCCL stream sections, plus a `failure_count` for event-timing failures that did not replace the token/text hash oracle;
 - `by_section`, `by_op`, and `by_call_site` rollups in the same vocabulary family as the Qwen3 model report;
-- `coverage` rows that explicitly mark GPU event timing and throughput claims as not covered;
+- `coverage` rows that distinguish CPU section timing, selected GPU event timing, optional NVTX ranges, and unclaimed throughput;
 - `ep` counters for host-staged dispatch/combine and NCCL dense exchange/combine plus local/remote route counts.
 
 Host-staged `dispatch_calls` / `combine_calls` count MoE layer invocations in the fixed greedy run. Host-staged `dispatch_elements` / `combine_elements` count selected routed hidden vectors, so the value is route count times hidden size. NCCL `exchange` and `combine` counters count the dense all-reduce calls and elements used by the current naive NCCL gate.
+
+The GPU event rows are intentionally narrower than the CPU rows. They cover sections that enqueue device work or NCCL work on known streams, including projections, dense/shared/routed experts, host-to-device combine, NCCL dense exchange, and NCCL combine. They do not relabel pure host routing or host accumulation as GPU work, and the mixed `attention_host_path` stays CPU-side because it includes host attention assembly as well as internal GPU projections.
 
 ## Commands
 
@@ -82,6 +87,8 @@ PEGAINFER_DSV2_LITE_EP_BACKEND=nccl \
   --out target/accuracy/dsv2-lite-ep2/nccl-attribution.json
 ```
 
+For an Nsight Systems pass, run the same attribution command under the profiler and set `PEGAINFER_DSV2_LITE_NVTX=1`; the JSON `coverage` row then records `nvtx_ranges=emitted`. The NVTX labels are correlation markers for the selected GPU/NCCL sections, not timing evidence by themselves. Their wall-clock span can include CPU-side wrapper work, event setup, and synchronization around the section, so compare JSON `by_gpu_*` rows only with CUDA event timing, not with raw NVTX range duration.
+
 ## Environment Notes
 
 The NCCL path depends on a runtime that supports the selected GPU. On newer GPUs, older NCCL runtimes may fail communicator initialization before the model-level comparison runs, for example with a shared-memory init error like:
@@ -97,14 +104,16 @@ The HF oracle needs a Python environment that can load DeepSeek-V2-Lite with `tr
 
 ## Latest Validation
 
-The full gate was last rerun on 2026-05-22 with `models/DeepSeek-V2-Lite`, `prompt="Hello"`, and `output_len=16`:
+The full gate was last rerun on 2026-05-24 with DeepSeek-V2-Lite, `prompt="Hello"`, `output_len=16`, and 2x RTX 5090. The NCCL path used a newer NCCL runtime than the system 2.25.1 package, because the older runtime failed the EP2 init smoke on this GPU generation.
 
 - HF / host-staged / NCCL comparison: `all_token_text_exact`.
 - Token SHA256: `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225`.
 - Text SHA256: `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347`.
 - Host-staged attribution: `dispatch_calls=416`, `combine_calls=416`, `dispatch_elements=5111808`, `combine_elements=5111808`, `local_route_count=1284`, `remote_route_count=1212`.
 - NCCL attribution: `nccl_exchange_calls=416`, `nccl_combine_calls=416`, `nccl_exchange_elements=851968`, `nccl_combine_elements=851968`, `local_route_count=1284`, `remote_route_count=1212`.
+- GPU event timing: selected GPU/NCCL attribution sections are reported separately from CPU-side section timing; host-staged emitted `gpu_timing.sample_count=5056`, NCCL emitted `gpu_timing.sample_count=5888`, and both reported `gpu_timing.failure_count=0`.
+- NVTX smoke: with `PEGAINFER_DSV2_LITE_NVTX=1`, host-staged emitted `nvtx_range_count=5056` and `coverage.nvtx_ranges=emitted`.
 
 ## Claim Boundary
 
-This report proves only that the covered DeepSeek-V2-Lite EP2 greedy path still produces the expected token/text hashes and that the current runtime observed the listed CPU-side sections, route counts, and dense collective counts. It does not prove GPU kernel event timing, serving throughput, sparse dispatch readiness, multi-node behavior, or production EP readiness.
+This report proves only that the covered DeepSeek-V2-Lite EP2 greedy path still produces the expected token/text hashes and that the current runtime observed the listed CPU-side sections, selected CUDA event sections, NVTX markers when enabled, route counts, and dense collective counts. It does not prove serving throughput, sparse dispatch readiness, multi-node behavior, or production EP readiness.

--- a/pegainfer-deepseek-v2-lite/Cargo.toml
+++ b/pegainfer-deepseek-v2-lite/Cargo.toml
@@ -17,6 +17,7 @@ half = { workspace = true }
 hex = { workspace = true }
 libloading = "0.9"
 memmap2 = { workspace = true }
+nvtx = { workspace = true }
 pegainfer-core = { workspace = true }
 pegainfer-engine = { workspace = true }
 safetensors = { workspace = true }

--- a/pegainfer-deepseek-v2-lite/src/attribution.rs
+++ b/pegainfer-deepseek-v2-lite/src/attribution.rs
@@ -1,18 +1,25 @@
 use std::{
     collections::BTreeMap,
+    env,
     time::{Duration, Instant},
 };
 
 use anyhow::Result;
+use cudarc::driver::sys;
+use pegainfer_core::tensor::DeviceContext;
 use serde::Serialize;
 
 #[derive(Clone, Debug, Default)]
 pub struct DecodeAttributionProfile {
     enabled: bool,
+    nvtx_enabled: bool,
+    nvtx_range_count: usize,
     total_generation_us: u64,
     prefill_next_token_us: Option<u64>,
     per_token_decode_us: Vec<u64>,
     samples: Vec<SectionSample>,
+    gpu_samples: Vec<GpuSectionSample>,
+    gpu_timing_failures: usize,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -23,6 +30,17 @@ pub struct SectionSample {
     pub layer: Option<usize>,
     pub token_index: Option<usize>,
     pub elapsed_us: u64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct GpuSectionSample {
+    phase: &'static str,
+    section: &'static str,
+    call_site: String,
+    layer: Option<usize>,
+    token_index: Option<usize>,
+    device_ordinals: Vec<usize>,
+    elapsed_us: u64,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -62,6 +80,7 @@ impl DecodeAttributionProfile {
     pub(crate) fn enabled() -> Self {
         Self {
             enabled: true,
+            nvtx_enabled: nvtx_enabled_from_env(),
             ..Self::default()
         }
     }
@@ -113,6 +132,141 @@ impl DecodeAttributionProfile {
         result
     }
 
+    pub(crate) fn record_gpu_result<T, C, S>(
+        &mut self,
+        ctx: &DeviceContext,
+        phase: &'static str,
+        section: &'static str,
+        call_site: C,
+        layer: Option<usize>,
+        token_index: Option<usize>,
+        f: impl FnOnce() -> Result<T>,
+    ) -> Result<T>
+    where
+        C: FnOnce() -> S,
+        S: Into<String>,
+    {
+        self.record_gpu_contexts(&[ctx], phase, section, call_site, layer, token_index, f)
+    }
+
+    pub(crate) fn record_gpu_pair_result<T, C, S>(
+        &mut self,
+        rank0: &DeviceContext,
+        rank1: &DeviceContext,
+        phase: &'static str,
+        section: &'static str,
+        call_site: C,
+        layer: Option<usize>,
+        token_index: Option<usize>,
+        f: impl FnOnce() -> Result<T>,
+    ) -> Result<T>
+    where
+        C: FnOnce() -> S,
+        S: Into<String>,
+    {
+        self.record_gpu_contexts(
+            &[rank0, rank1],
+            phase,
+            section,
+            call_site,
+            layer,
+            token_index,
+            f,
+        )
+    }
+
+    fn record_gpu_contexts<T, C, S>(
+        &mut self,
+        contexts: &[&DeviceContext],
+        phase: &'static str,
+        section: &'static str,
+        call_site: C,
+        layer: Option<usize>,
+        token_index: Option<usize>,
+        f: impl FnOnce() -> Result<T>,
+    ) -> Result<T>
+    where
+        C: FnOnce() -> S,
+        S: Into<String>,
+    {
+        if !self.enabled {
+            return f();
+        }
+        assert!(
+            !contexts.is_empty(),
+            "GPU attribution requires at least one CUDA context"
+        );
+
+        let call_site = call_site().into();
+        let _nvtx_range = if self.nvtx_enabled {
+            let range = nvtx::range!("dsv2lite.ep2.{}", call_site);
+            self.nvtx_range_count += 1;
+            Some(range)
+        } else {
+            None
+        };
+
+        let timing_state = (|| -> Result<_> {
+            let mut start_events = Vec::with_capacity(contexts.len());
+            let mut end_events = Vec::with_capacity(contexts.len());
+            for ctx in contexts {
+                start_events.push(
+                    ctx.ctx
+                        .new_event(Some(sys::CUevent_flags::CU_EVENT_DEFAULT))?,
+                );
+                end_events.push(
+                    ctx.ctx
+                        .new_event(Some(sys::CUevent_flags::CU_EVENT_DEFAULT))?,
+                );
+            }
+            for (ctx, event) in contexts.iter().zip(&start_events) {
+                event.record(&ctx.stream)?;
+            }
+            Ok((start_events, end_events))
+        })();
+
+        let cpu_start = Instant::now();
+        let result = f();
+        let cpu_elapsed_us = micros(cpu_start.elapsed());
+        let timing_result = timing_state.and_then(|(start_events, end_events)| {
+            let mut elapsed_us = 0.0f64;
+            for (ctx, event) in contexts.iter().zip(&end_events) {
+                event.record(&ctx.stream)?;
+            }
+            for (start, end) in start_events.iter().zip(&end_events) {
+                elapsed_us = elapsed_us.max(f64::from(start.elapsed_ms(end)?) * 1_000.0);
+            }
+            Ok(elapsed_us.ceil().min(u64::MAX as f64) as u64)
+        });
+
+        match timing_result {
+            Ok(elapsed_us) => {
+                self.gpu_samples.push(GpuSectionSample {
+                    phase,
+                    section,
+                    call_site: call_site.clone(),
+                    layer,
+                    token_index,
+                    device_ordinals: contexts.iter().map(|ctx| ctx.device_ordinal).collect(),
+                    elapsed_us,
+                });
+            }
+            Err(_) => {
+                self.gpu_timing_failures += 1;
+            }
+        }
+        self.samples.push(SectionSample {
+            phase,
+            section,
+            call_site,
+            layer,
+            token_index,
+            elapsed_us: cpu_elapsed_us,
+        });
+
+        result
+    }
+
     pub fn total_generation_us(&self) -> u64 {
         self.total_generation_us
     }
@@ -125,79 +279,128 @@ impl DecodeAttributionProfile {
         &self.per_token_decode_us
     }
 
+    pub fn gpu_sample_count(&self) -> usize {
+        self.gpu_samples.len()
+    }
+
+    pub fn gpu_timing_failure_count(&self) -> usize {
+        self.gpu_timing_failures
+    }
+
+    pub fn nvtx_enabled(&self) -> bool {
+        self.nvtx_enabled
+    }
+
+    pub fn nvtx_range_count(&self) -> usize {
+        self.nvtx_range_count
+    }
+
     pub fn by_section(&self) -> Vec<SectionRollup> {
-        let total = self.samples.iter().map(|sample| sample.elapsed_us).sum();
-        let mut groups: BTreeMap<&str, Vec<u64>> = BTreeMap::new();
-        for sample in &self.samples {
-            groups
-                .entry(sample.section)
-                .or_default()
-                .push(sample.elapsed_us);
-        }
-        let mut rows: Vec<_> = groups
-            .into_iter()
-            .map(|(section, samples)| {
-                let stats = sample_stats(samples);
-                SectionRollup {
-                    section: section.to_string(),
-                    calls: stats.calls,
-                    total_us: stats.total_us,
-                    mean_us: stats.mean_us,
-                    min_us: stats.min_us,
-                    p50_us: stats.p50_us,
-                    p95_us: stats.p95_us,
-                    p99_us: stats.p99_us,
-                    max_us: stats.max_us,
-                    pct: pct(stats.total_us, total),
-                }
-            })
-            .collect();
-        rows.sort_by(|left, right| {
-            right
-                .total_us
-                .cmp(&left.total_us)
-                .then(left.section.cmp(&right.section))
-        });
-        rows
+        section_rollups(
+            self.samples
+                .iter()
+                .map(|sample| (sample.section, sample.elapsed_us)),
+        )
     }
 
     pub fn by_call_site(&self) -> Vec<CallSiteRollup> {
-        let total = self.samples.iter().map(|sample| sample.elapsed_us).sum();
-        let mut groups: BTreeMap<(&str, &str), Vec<u64>> = BTreeMap::new();
-        for sample in &self.samples {
-            groups
-                .entry((sample.call_site.as_str(), sample.section))
-                .or_default()
-                .push(sample.elapsed_us);
-        }
-        let mut rows: Vec<_> = groups
-            .into_iter()
-            .map(|((call_site, section), samples)| {
-                let stats = sample_stats(samples);
-                CallSiteRollup {
-                    call_site: call_site.to_string(),
-                    section: section.to_string(),
-                    calls: stats.calls,
-                    total_us: stats.total_us,
-                    mean_us: stats.mean_us,
-                    min_us: stats.min_us,
-                    p50_us: stats.p50_us,
-                    p95_us: stats.p95_us,
-                    p99_us: stats.p99_us,
-                    max_us: stats.max_us,
-                    pct: pct(stats.total_us, total),
-                }
-            })
-            .collect();
-        rows.sort_by(|left, right| {
-            right
-                .total_us
-                .cmp(&left.total_us)
-                .then(left.call_site.cmp(&right.call_site))
-                .then(left.section.cmp(&right.section))
-        });
-        rows
+        call_site_rollups(
+            self.samples
+                .iter()
+                .map(|sample| (sample.call_site.as_str(), sample.section, sample.elapsed_us)),
+        )
     }
+
+    pub fn by_gpu_section(&self) -> Vec<SectionRollup> {
+        section_rollups(
+            self.gpu_samples
+                .iter()
+                .map(|sample| (sample.section, sample.elapsed_us)),
+        )
+    }
+
+    pub fn by_gpu_call_site(&self) -> Vec<CallSiteRollup> {
+        call_site_rollups(
+            self.gpu_samples
+                .iter()
+                .map(|sample| (sample.call_site.as_str(), sample.section, sample.elapsed_us)),
+        )
+    }
+}
+
+fn section_rollups<'a>(samples: impl IntoIterator<Item = (&'a str, u64)>) -> Vec<SectionRollup> {
+    let mut total = 0u64;
+    let mut groups: BTreeMap<&str, Vec<u64>> = BTreeMap::new();
+    for (section, elapsed_us) in samples {
+        total += elapsed_us;
+        groups.entry(section).or_default().push(elapsed_us);
+    }
+    let mut rows: Vec<_> = groups
+        .into_iter()
+        .map(|(section, samples)| {
+            let stats = sample_stats(samples);
+            SectionRollup {
+                section: section.to_string(),
+                calls: stats.calls,
+                total_us: stats.total_us,
+                mean_us: stats.mean_us,
+                min_us: stats.min_us,
+                p50_us: stats.p50_us,
+                p95_us: stats.p95_us,
+                p99_us: stats.p99_us,
+                max_us: stats.max_us,
+                pct: pct(stats.total_us, total),
+            }
+        })
+        .collect();
+    rows.sort_by(|left, right| {
+        right
+            .total_us
+            .cmp(&left.total_us)
+            .then(left.section.cmp(&right.section))
+    });
+    rows
+}
+
+fn call_site_rollups<'a>(
+    samples: impl IntoIterator<Item = (&'a str, &'a str, u64)>,
+) -> Vec<CallSiteRollup> {
+    let mut total = 0u64;
+    let mut groups: BTreeMap<(&str, &str), Vec<u64>> = BTreeMap::new();
+    for (call_site, section, elapsed_us) in samples {
+        total += elapsed_us;
+        groups
+            .entry((call_site, section))
+            .or_default()
+            .push(elapsed_us);
+    }
+    let mut rows: Vec<_> = groups
+        .into_iter()
+        .map(|((call_site, section), samples)| {
+            let stats = sample_stats(samples);
+            CallSiteRollup {
+                call_site: call_site.to_string(),
+                section: section.to_string(),
+                calls: stats.calls,
+                total_us: stats.total_us,
+                mean_us: stats.mean_us,
+                min_us: stats.min_us,
+                p50_us: stats.p50_us,
+                p95_us: stats.p95_us,
+                p99_us: stats.p99_us,
+                max_us: stats.max_us,
+                pct: pct(stats.total_us, total),
+            }
+        })
+        .collect();
+    rows.sort_by(|left, right| {
+        right
+            .total_us
+            .cmp(&left.total_us)
+            .then(left.call_site.cmp(&right.call_site))
+            .then(left.section.cmp(&right.section))
+    });
+    rows
 }
 
 #[derive(Clone, Copy)]
@@ -245,6 +448,17 @@ fn micros(duration: Duration) -> u64 {
     duration.as_micros().min(u64::MAX as u128) as u64
 }
 
+fn nvtx_enabled_from_env() -> bool {
+    nvtx_enabled_value(env::var("PEGAINFER_DSV2_LITE_NVTX").ok().as_deref())
+}
+
+fn nvtx_enabled_value(value: Option<&str>) -> bool {
+    matches!(
+        value,
+        Some("1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON")
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -283,5 +497,63 @@ mod tests {
         assert_eq!(rows[0].calls, 2);
         assert_eq!(rows[0].total_us, 50);
         assert_eq!(rows[1].section, "short");
+    }
+
+    #[test]
+    fn gpu_rollups_sort_by_total_time() {
+        let mut profile = DecodeAttributionProfile::enabled();
+        profile.gpu_samples.push(GpuSectionSample {
+            phase: "decode",
+            section: "gpu_short",
+            call_site: "layer.0.gpu_short".to_string(),
+            layer: Some(0),
+            token_index: Some(0),
+            device_ordinals: vec![0],
+            elapsed_us: 7,
+        });
+        profile.gpu_samples.push(GpuSectionSample {
+            phase: "decode",
+            section: "gpu_long",
+            call_site: "layer.0.gpu_long".to_string(),
+            layer: Some(0),
+            token_index: Some(0),
+            device_ordinals: vec![0, 1],
+            elapsed_us: 11,
+        });
+        profile.gpu_samples.push(GpuSectionSample {
+            phase: "decode",
+            section: "gpu_long",
+            call_site: "layer.1.gpu_long".to_string(),
+            layer: Some(1),
+            token_index: Some(0),
+            device_ordinals: vec![1],
+            elapsed_us: 13,
+        });
+
+        let rows = profile.by_gpu_section();
+
+        assert_eq!(rows[0].section, "gpu_long");
+        assert_eq!(rows[0].calls, 2);
+        assert_eq!(rows[0].total_us, 24);
+        assert_eq!(rows[1].section, "gpu_short");
+    }
+
+    #[test]
+    fn gpu_rollups_are_empty_without_samples() {
+        let profile = DecodeAttributionProfile::enabled();
+
+        assert!(profile.by_gpu_section().is_empty());
+        assert!(profile.by_gpu_call_site().is_empty());
+    }
+
+    #[test]
+    fn nvtx_env_parser_accepts_only_enabled_values() {
+        for value in ["1", "true", "TRUE", "yes", "YES", "on", "ON"] {
+            assert!(nvtx_enabled_value(Some(value)), "{value}");
+        }
+        for value in ["", "0", "false", "False", "no", "off", "enabled"] {
+            assert!(!nvtx_enabled_value(Some(value)), "{value}");
+        }
+        assert!(!nvtx_enabled_value(None));
     }
 }

--- a/pegainfer-deepseek-v2-lite/src/bin/dsv2_lite_ep2_decode_attribution.rs
+++ b/pegainfer-deepseek-v2-lite/src/bin/dsv2_lite_ep2_decode_attribution.rs
@@ -73,6 +73,8 @@ fn main() -> Result<()> {
     );
 
     let by_section = attribution.by_section();
+    let by_gpu_section = attribution.by_gpu_section();
+    let by_gpu_call_site = attribution.by_gpu_call_site();
     let by_op: Vec<Value> = by_section
         .iter()
         .map(|row| {
@@ -129,14 +131,24 @@ fn main() -> Result<()> {
             "per_token_decode_us": attribution.per_token_decode_us(),
             "per_token_decode_stats": latency_stats(attribution.per_token_decode_us()),
         },
-        "attribution_source": "DeepSeekV2LiteEp2Generator::generate_greedy_with_attribution; GPU/NCCL work is timed from the host and synchronized only where the existing runtime already synchronizes.",
+        "attribution_source": "DeepSeekV2LiteEp2Generator::generate_greedy_with_attribution; CPU sections use host wall-clock timers, and selected GPU/NCCL sections also carry CUDA event timing plus optional NVTX ranges.",
+        "gpu_timing": {
+            "source": "CUDA event timing around selected DeepSeek-V2-Lite EP2 GPU/NCCL stream sections in the explicit attribution path",
+            "sample_count": attribution.gpu_sample_count(),
+            "failure_count": attribution.gpu_timing_failure_count(),
+            "nvtx_enabled": attribution.nvtx_enabled(),
+            "nvtx_range_count": attribution.nvtx_range_count(),
+            "scope": "selected GPU/NCCL sections only; host routing, host accumulation, and the mixed attention_host_path remain CPU-side attribution rows; GPU timing failures do not replace the token/text hash oracle; NVTX range wall time is only a profiler correlation marker and may include host/event overhead",
+        },
         "schedule_source": "fixed DeepSeek-V2-Lite EP2 greedy gate: prompt=Hello, output_len=16, cuda_graph=false, device_ordinals=[0,1]",
         "by_section": by_section,
         "by_op": by_op,
         "by_call_site": attribution.by_call_site(),
-        "coverage": coverage_rows(&result.stats.ep_backend),
+        "by_gpu_section": by_gpu_section,
+        "by_gpu_call_site": by_gpu_call_site,
+        "coverage": coverage_rows(&result.stats.ep_backend, &attribution),
         "ep": ep_report(&result.stats),
-        "claim_boundary": "Attribution only for the covered EP2 Hello/16 decode gate. CPU-side section timing and route/collective counts are not a throughput, GPU-kernel-event, sparse-dispatch, multi-node, or production EP readiness claim.",
+        "claim_boundary": "Attribution only for the covered EP2 Hello/16 decode gate. CPU-side section timing, selected CUDA event timing, NVTX ranges, and route/collective counts are not a throughput, sparse-dispatch, multi-node, or production EP readiness claim.",
     });
 
     let text = serde_json::to_string_pretty(&report)?;
@@ -214,7 +226,10 @@ fn ep_report(stats: &pegainfer_deepseek_v2_lite::GenerationStats) -> Value {
     })
 }
 
-fn coverage_rows(backend: &str) -> Vec<Value> {
+fn coverage_rows(
+    backend: &str,
+    attribution: &pegainfer_deepseek_v2_lite::DecodeAttributionProfile,
+) -> Vec<Value> {
     vec![
         json!({
             "item": "accuracy.token_text_hash",
@@ -233,8 +248,13 @@ fn coverage_rows(backend: &str) -> Vec<Value> {
         }),
         json!({
             "item": "gpu_event_timing",
-            "status": "not_covered",
-            "source": "first gate intentionally avoids intrusive CUDA event timing in the DeepSeek runtime",
+            "status": gpu_timing_status(attribution),
+            "source": "CUDA event timing around selected GPU/NCCL stream sections; pure host sections and mixed attention_host_path are not represented as GPU event rows; failures are counted separately from the accuracy oracle",
+        }),
+        json!({
+            "item": "nvtx_ranges",
+            "status": if attribution.nvtx_enabled() { "emitted" } else { "available_when_enabled" },
+            "source": "set PEGAINFER_DSV2_LITE_NVTX=1 to emit NVTX ranges for the same selected GPU/NCCL attribution sections",
         }),
         json!({
             "item": "throughput_or_production_ep_readiness",
@@ -242,6 +262,18 @@ fn coverage_rows(backend: &str) -> Vec<Value> {
             "source": "single batch=1 prompt=Hello output_len=16 diagnostic gate only",
         }),
     ]
+}
+
+fn gpu_timing_status(attribution: &pegainfer_deepseek_v2_lite::DecodeAttributionProfile) -> &str {
+    match (
+        attribution.gpu_sample_count(),
+        attribution.gpu_timing_failure_count(),
+    ) {
+        (0, 0) => "not_covered",
+        (0, _) => "timing_failed",
+        (_, 0) => "measured",
+        (_, _) => "measured_with_failures",
+    }
 }
 
 fn latency_stats(samples: &[u64]) -> Value {

--- a/pegainfer-deepseek-v2-lite/src/runtime.rs
+++ b/pegainfer-deepseek-v2-lite/src/runtime.rs
@@ -444,7 +444,8 @@ impl DeepSeekV2LiteEp2Generator {
             || self.attention_forward(&normed, &layer.attention, start_pos, cache),
         )?;
         activate(&self.rank0.ctx)?;
-        let attn_projected = attribution.record_result(
+        let attn_projected = attribution.record_gpu_result(
+            &self.rank0.ctx,
             phase,
             "gpu_o_proj_enqueue",
             || format!("layer.{layer_idx}.attention_o_proj"),
@@ -452,7 +453,8 @@ impl DeepSeekV2LiteEp2Generator {
             token_index,
             || ops::gemm(&self.rank0.ctx, &layer.attention.o_proj, &attn),
         )?;
-        let after_attn = attribution.record_result(
+        let after_attn = attribution.record_gpu_result(
+            &self.rank0.ctx,
             phase,
             "gpu_residual_add_enqueue",
             || format!("layer.{layer_idx}.attention_residual_add"),
@@ -472,7 +474,8 @@ impl DeepSeekV2LiteEp2Generator {
 
         let (ffn_out, local_routes, remote_routes) = match &layer.mlp {
             MlpWeights::Dense(dense) => (
-                attribution.record_result(
+                attribution.record_gpu_result(
+                    &self.rank0.ctx,
                     phase,
                     "dense_mlp_enqueue",
                     || format!("layer.{layer_idx}.dense_mlp"),
@@ -501,7 +504,8 @@ impl DeepSeekV2LiteEp2Generator {
             }
         };
         stats.record_routes(self.backend.kind(), local_routes, remote_routes);
-        attribution.record_result(
+        attribution.record_gpu_result(
+            &self.rank0.ctx,
             phase,
             "gpu_residual_add_enqueue",
             || format!("layer.{layer_idx}.ffn_residual_add"),
@@ -615,7 +619,8 @@ impl DeepSeekV2LiteEp2Generator {
             },
         )?;
 
-        let shared = attribution.record_result(
+        let shared = attribution.record_gpu_result(
+            &self.rank0.ctx,
             phase,
             "shared_expert_enqueue",
             || format!("layer.{layer_idx}.shared_expert"),
@@ -637,7 +642,13 @@ impl DeepSeekV2LiteEp2Generator {
                 } else {
                     "host_staged_remote_dispatch"
                 };
-                let (out, is_remote) = attribution.record_result(
+                let expert_ctx = if owner_rank == 0 {
+                    &self.rank0.ctx
+                } else {
+                    &self.rank1.ctx
+                };
+                let (out, is_remote) = attribution.record_gpu_result(
+                    expert_ctx,
                     phase,
                     section,
                     || format!("layer.{layer_idx}.{section}"),
@@ -670,7 +681,8 @@ impl DeepSeekV2LiteEp2Generator {
             }
         }
 
-        let routed = attribution.record_result(
+        let routed = attribution.record_gpu_result(
+            &self.rank0.ctx,
             phase,
             "host_staged_combine_to_device",
             || format!("layer.{layer_idx}.host_staged.combine_to_device"),
@@ -686,7 +698,8 @@ impl DeepSeekV2LiteEp2Generator {
             },
         )?;
         activate(&self.rank0.ctx)?;
-        let hidden = attribution.record_result(
+        let hidden = attribution.record_gpu_result(
+            &self.rank0.ctx,
             phase,
             "shared_plus_routed_enqueue",
             || format!("layer.{layer_idx}.shared_plus_routed"),
@@ -725,7 +738,8 @@ impl DeepSeekV2LiteEp2Generator {
             },
         )?;
 
-        let shared = attribution.record_result(
+        let shared = attribution.record_gpu_result(
+            &self.rank0.ctx,
             phase,
             "shared_expert_enqueue",
             || format!("layer.{layer_idx}.shared_expert"),
@@ -738,7 +752,9 @@ impl DeepSeekV2LiteEp2Generator {
         // NCCL covers only the dense hidden exchange and final contribution
         // sum in this first gate. Route iteration and expert-output
         // accumulation stay host-side so host-staged remains a simple oracle.
-        let rank1_input = attribution.record_result(
+        let rank1_input = attribution.record_gpu_pair_result(
+            &self.rank0.ctx,
+            &self.rank1.ctx,
             phase,
             "nccl_dense_exchange",
             || format!("layer.{layer_idx}.nccl.dense_exchange"),
@@ -757,7 +773,8 @@ impl DeepSeekV2LiteEp2Generator {
                         local_routes += 1;
                         let expert = self.rank0.routed_expert(layer_idx, global_expert)?;
                         (
-                            attribution.record_result(
+                            attribution.record_gpu_result(
+                                &self.rank0.ctx,
                                 phase,
                                 "nccl_local_expert",
                                 || format!("layer.{layer_idx}.nccl.local_expert"),
@@ -772,7 +789,8 @@ impl DeepSeekV2LiteEp2Generator {
                         remote_routes += 1;
                         let expert = self.rank1.routed_expert(layer_idx, global_expert)?;
                         (
-                            attribution.record_result(
+                            attribution.record_gpu_result(
+                                &self.rank1.ctx,
                                 phase,
                                 "nccl_remote_expert",
                                 || format!("layer.{layer_idx}.nccl.remote_expert"),
@@ -814,7 +832,9 @@ impl DeepSeekV2LiteEp2Generator {
             }
         }
 
-        let combined = attribution.record_result(
+        let combined = attribution.record_gpu_pair_result(
+            &self.rank0.ctx,
+            &self.rank1.ctx,
             phase,
             "nccl_combine",
             || format!("layer.{layer_idx}.nccl.combine"),
@@ -829,7 +849,8 @@ impl DeepSeekV2LiteEp2Generator {
                 )
             },
         )?;
-        let routed = attribution.record_result(
+        let routed = attribution.record_gpu_result(
+            &self.rank0.ctx,
             phase,
             "nccl_combine_to_device",
             || format!("layer.{layer_idx}.nccl.combine_to_device"),
@@ -845,7 +866,8 @@ impl DeepSeekV2LiteEp2Generator {
             },
         )?;
         activate(&self.rank0.ctx)?;
-        let hidden = attribution.record_result(
+        let hidden = attribution.record_gpu_result(
+            &self.rank0.ctx,
             phase,
             "shared_plus_routed_enqueue",
             || format!("layer.{layer_idx}.shared_plus_routed"),


### PR DESCRIPTION
## Summary

Adds selected CUDA event timing and optional NVTX correlation markers to the existing DeepSeek-V2-Lite EP2 decode attribution gate. The report keeps the fixed `batch=1`, `prompt="Hello"`, `output_len=16` shape and preserves the HF / host-staged / NCCL token/text/hash oracle.

Refs #155.

## Scope

In scope:
- Add selected GPU/NCCL timing rollups to `dsv2_lite_ep2_decode_attribution` via `gpu_timing`, `by_gpu_section`, and `by_gpu_call_site`.
- Keep CPU-side section rollups and EP route/transfer counters in the existing structured report.
- Emit optional NVTX ranges with `PEGAINFER_DSV2_LITE_NVTX=1`.
- Count GPU timing failures separately so event-timing issues do not replace the token/text hash oracle.

Out of scope:
- Sparse dispatch.
- pegainfer-comm / NVLink backend.
- Multi-node or generic EP topology.
- Batch > 1 or broader prompt coverage.
- Throughput or production EP readiness claims.

## Evidence

Local:
- `cargo fmt --all --check`
- `git diff --check`
- changed-file scan for private host/path/token strings

2x RTX 5090 validation:
- `cargo check --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite --all-targets`
- `cargo test --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite --lib -- --nocapture` (20 tests)
- `dsv2_lite_ep2_decode_attribution` host-staged: token/text hash exact, `gpu_timing.sample_count=5056`, `gpu_timing.failure_count=0`
- `dsv2_lite_ep2_decode_attribution` NCCL: token/text hash exact, `gpu_timing.sample_count=5888`, `gpu_timing.failure_count=0`
- `PEGAINFER_DSV2_LITE_NVTX=1` host-staged smoke: `nvtx_range_count=5056`, `coverage.nvtx_ranges=emitted`
- HF / host-staged / NCCL comparison: `Classification: all_token_text_exact`, warnings `[]`

Hashes:
- token SHA256: `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225`
- text SHA256: `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347`

## Claim Boundary

This is a diagnostic attribution gate for the covered DeepSeek-V2-Lite EP2 `Hello` / 16-token decode shape only. CUDA event timing is collected on the explicit attribution path and may introduce synchronization overhead there; it is not a serving throughput, sparse-dispatch, multi-node, or production EP readiness claim. NVTX ranges are profiler correlation markers, not the timing source.
