### PR TITLE
feat(qwen3): centralize KV cache ownership

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -103,6 +103,12 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 | `subsystems/kernels/kernel-op-reports.md` | Qwen3 kernel/report tooling is feature-gated: `qwen3_kernel_report` covers per-op kernel reports, and `qwen3_model_report` emits runtime-traced eager-DAG decode operator rollups with TensorSpec `KernelCall`s, latency stats, tables, and Graphviz DOT; measured FA2 `CTA_TILE_Q=64` prefill default in place. |
 | `subsystems/kernels/typed-forward-pipeline.md` | Reusable typed tensor pipeline macro in `pegainfer-kernels` so model crates can express common `typed_ops` chains without model-specific wrapper macros. |
 
+## subsystems / kv-cache
+
+| Path | TL;DR |
+| --- | --- |
+| `subsystems/kv-cache/redesign.md` | Qwen3 KV boundary: scheduler speaks token lifecycle, executor-side `Qwen3KvCache` translates to TP physical KV and `KvExecView`, workers only execute, and commit happens after worker success. Release and serving smoke pass; c16 random is a forward workspace admission issue. |
+
 ## playbooks
 
 | Path | TL;DR |

--- a/docs/subsystems/kv-cache/redesign.md
+++ b/docs/subsystems/kv-cache/redesign.md
@@ -129,13 +129,12 @@ The code keeps `KvState` as the owner of page permits inside `Qwen3KvCache`, but
 
 - Ran a sub-agent review focused on KV ownership, error paths, rank consistency, and commit semantics.
 - Fixed the high-severity finding by moving logical `seq_len` advance out of worker forward paths and into `Qwen3KvCache` commit after rank success.
-- Removed the ownership lease from the worker protocol; worker responses now contain only execution results.
 - Removed the ownership lease from the worker protocol and kept TP physical allocation inside `Qwen3KvCache`; rank remains an implementation detail of KV storage, not a scheduling decision point.
 - Result: success.
 
 ### Step 6: Serve benchmark smoke
 
-- Started the OpenAI-compatible server with `uv run --with triton cargo run --release --bin pegainfer -- --model-path /data/models/Qwen3-4B --served-model-name Qwen3-4B --port 8000`.
+- Started the OpenAI-compatible server with `uv run --with triton cargo run --release --bin pegainfer -- --model-path <Qwen3-4B> --served-model-name Qwen3-4B --port 8000`.
 - Verified `/v1/completions` with `max_tokens=4` before load.
 - Ran `vllm bench serve` against the local server with random prompts across short decode, long decode, and long prefill shapes.
 - Saved raw result JSON under `target/profiling/kv-cache-redesign/`.

--- a/docs/subsystems/kv-cache/redesign.md
+++ b/docs/subsystems/kv-cache/redesign.md
@@ -1,0 +1,252 @@
+# KV Cache Redesign
+
+TL;DR: Qwen3 KV 边界已落地：scheduler 只提交 token 级请求生命周期决策，executor-side `Qwen3KvCache` 把这些决策翻译成 TP 物理 KV 状态和 `KvExecView`，worker 只执行、不分配、不释放、不持有、不 advance KV。Release checks 和 serving smoke 通过；c16 random 记录为 forward workspace admission 问题，不属于 KV ownership 边界。
+
+Last touched: 2026-05
+
+## 动机
+
+旧 paged KV 能跑，但状态所有权、资源分配、执行描述混在 worker 里，随着 p/d 分离和 offloading 的需求会持续放大维护成本。
+
+## 改造前架构
+
+```
+Scheduler (单线程)
+  ├─ admission control: 按 worst-case KV residency 预留
+  ├─ 只知道 page_size / available_pages / max_request_pages
+  └─ 不持有任何 KV 状态
+
+Executor (per-rank worker 线程)
+  ├─ RequestStateStore: HashMap<RequestId, KvState>
+  ├─ KvState 自己持有 OwnedPagePermit + KvPool Arc clone
+  ├─ ensure_capacity() 时自行去 pool 抢页
+  └─ forward 直接 mutate KvState 并 advance seq_len
+```
+
+## 问题
+
+### 1. 两次决策，语义不一致
+
+旧 scheduler 做 admission accounting，worker 做实际 `try_grow`。两层之间没有关联，worker 分配 KV 时没有一个统一资源边界。旧代码能 work 是因为 scheduler loop 单线程串行，但这个隐含假设一旦打破就出问题。
+
+### 2. KvState 持有 KvPool 的 Arc
+
+- 每个请求都持有池的引用，形成 "请求知道池" 的反向依赖
+- `ensure_capacity` 自己去 pool 抢页 — 这个行为应该由 KV cache 模块控制
+
+### 3. take/restore dance
+
+`RequestStateStore` 的 `take_batch` / `restore_batch`：每次 forward 前从 HashMap move out KvState，forward 后塞回。这是因为 KvState 是 `!Copy` 且需要 `&mut`。开销不大但：
+- 如果 forward panic，KvState 泄漏（页最终通过 permit drop 归还，但状态丢了）
+- KV 状态的所有权搅在 worker 里，scheduler 完全摸不到
+
+### 4. p/d 分离和 offloading 不友好
+
+系统需要能回答 "这个请求的 KV 在哪、多大、能不能 offload/迁移"。但旧 KV 状态被锁在各 rank worker 的 `RequestStateStore` 里，调度层只能通过间接接口感知。
+
+## 设计决策
+
+## Preparation
+
+- **Read**:
+  - `docs/index.md` — confirms this belongs under `subsystems/kv-cache`.
+  - `docs/subsystems/kv-cache/redesign.md` — current KV ownership problem and pending decisions.
+  - `pegainfer-core/src/kv_pool.rs` — current `KvPool` / `KvState` / `KvDesc` ownership and grow behavior.
+  - `pegainfer-core/src/page_pool.rs` — `OwnedPagePermit` grow and RAII release semantics.
+  - `pegainfer-qwen3-4b/src/executor.rs` — worker-local `RequestStateStore` and `take_batch` / `restore_batch`.
+  - `pegainfer-qwen3-4b/src/scheduler.rs` and `src/scheduler/*.rs` — scheduler admission, execution, failure, and release flow.
+  - `pegainfer-qwen3-4b/src/prefill.rs`, `batch_decode.rs`, `unified_forward.rs` — places where worker-side forward currently grows and advances KV.
+- **Relevant history**:
+  - No older KV redesign task doc exists; this document is the active record.
+- **Plan**:
+  1. Establish the responsibility contract in this doc: scheduler speaks request/token, KV cache translates to physical state, worker only executes.
+  2. Move Qwen3 per-request KV storage out of worker threads into an executor-side KV cache module, so workers no longer allocate, release, or privately store request KV state.
+  3. Make the executor-side KV cache pre-grow capacity for prefill/decode/unified steps and build `KvExecView` values for workers.
+  4. Change Qwen3 forward paths to consume `KvExecView` instead of mutating `KvState`.
+  5. Run focused checks for Qwen3 executor/core changes and record results.
+- **Risks / open questions**:
+  - TP 下一个 request 的逻辑 KV 状态会映射到多个物理 KV pool；KV cache 必须把同一个 token-level 决策一次性落到所有物理 pool 上。
+
+## Contract First
+
+Three roles own three different languages:
+
+- **Scheduler** owns request lifecycle decisions. It speaks in `RequestId`, prompt tokens, generated tokens, limits, admission, retirement, and cancellation. It should not know physical page IDs, buffer pointers, padding pages, or per-rank permits.
+- **KV cache module** owns resource translation. It answers whether token-level work can be admitted, prepares physical KV state for a forward step, and releases request KV state. Internally it may allocate pages, maintain per-rank state, handle padding pages, or later route to offload / p-d storage.
+- **Worker** owns forward execution. It receives a complete execution payload, launches kernels, samples results, and reports success or failure. It does not admit, allocate, grow, release, or privately store request KV state.
+
+The stable contract is:
+
+```text
+Scheduler -> KV cache:
+  admit_requests(active_token_states, pending_token_requests) -> admission decisions
+  prepare_prefill / prepare_decode / prepare_unified(appends) -> per-worker execution payloads
+  commit_prefill / commit_decode / commit_unified(appends)
+  release(request_id)
+
+KV cache -> Worker:
+  execution payload with buffer/page/layout/length metadata
+
+Worker -> Scheduler:
+  forward success/failure and generated tokens
+```
+
+The code keeps `KvState` as the owner of page permits inside `Qwen3KvCache`, but workers receive only `KvExecView`: a value-type execution descriptor with cloned buffer access, page IDs, committed length, and execution-visible length. That removes the worker-private `RequestStateStore` and puts allocate/grow/release/commit behind one translation module.
+
+## Execution Log
+
+### Step 1: Establish the contract
+
+- Added the contract-first section above: scheduler speaks request/token lifecycle, KV cache translates to resources, worker executes a complete payload.
+- Recorded the boundary: `KvState` owns pages inside the KV cache; `KvExecView` is the worker payload.
+- Result: success.
+
+### Step 2: Move request KV storage out of worker threads
+
+- Modified `pegainfer-qwen3-4b/src/executor.rs`.
+- Added executor-side `Qwen3KvCache` with internal `RankKvStateStore`s and moved `drop_request` plus token-level admission behind it.
+- `RankWorker` no longer owns a `RequestStateStore`; `StepCommand` carries the per-rank KV batch for that forward step.
+- Worker responses no longer carry KV state back; `Qwen3KvCache` remains the owner throughout execution.
+- Result: success.
+
+### Step 3: Move grow out of forward execution
+
+- Added `KvState::capacity_tokens` and `KvState::ensure_prepared_capacity` in `pegainfer-core/src/kv_pool.rs`.
+- `Qwen3KvCache` now maps each token append request onto every TP physical KV pool before sending work to workers for prefill, decode, and unified steps.
+- Updated Qwen3 `prefill`, `batch_decode`, and `unified_forward` paths to consume `KvExecView` and build paged metadata from execution-visible lengths instead of advancing `seq_len` during forward.
+- `Qwen3KvCache` commits `seq_len` only after all ranks return success and the primary worker returns the expected payload type.
+- `Qwen3KvCache` now treats physical state presence as an internal invariant and builds `KvExecView` only after the scheduler-thread token decision has been prepared in every TP KV pool.
+- Result: success.
+
+### Step 4: Cleanup
+
+- Removed dead `Qwen3Model::alloc_kv`.
+- Updated `batch_decode_trace` to build trace KV views through `Qwen3KvCache.prepare_*`.
+- Initialized `pegainfer-kernels/third_party/flashinfer` submodule so release checks can find FlashInfer headers.
+- Result: success.
+
+### Step 5: Review fixes
+
+- Ran a sub-agent review focused on KV ownership, error paths, rank consistency, and commit semantics.
+- Fixed the high-severity finding by moving logical `seq_len` advance out of worker forward paths and into `Qwen3KvCache` commit after rank success.
+- Removed the ownership lease from the worker protocol; worker responses now contain only execution results.
+- Removed the ownership lease from the worker protocol and kept TP physical allocation inside `Qwen3KvCache`; rank remains an implementation detail of KV storage, not a scheduling decision point.
+- Result: success.
+
+### Step 6: Serve benchmark smoke
+
+- Started the OpenAI-compatible server with `uv run --with triton cargo run --release --bin pegainfer -- --model-path /data/models/Qwen3-4B --served-model-name Qwen3-4B --port 8000`.
+- Verified `/v1/completions` with `max_tokens=4` before load.
+- Ran `vllm bench serve` against the local server with random prompts across short decode, long decode, and long prefill shapes.
+- Saved raw result JSON under `target/profiling/kv-cache-redesign/`.
+- Result: success, 140 completed / 0 failed.
+
+### Step 7: Code quality cleanup
+
+- Extracted executor-side KV ownership from `executor.rs` into `pegainfer-qwen3-4b/src/kv_cache.rs`.
+- Introduced `KvExecViewBatch` as the worker payload so `executor.rs` no longer depends on the internal `(RequestId, KvState)` storage shape.
+- Collapsed prefill/decode/unified KV grow, view construction, and commit logic around a shared `KvAppend` model, so the KV cache consumes only `RequestId + append_tokens` instead of executor step items.
+- `executor.rs` dropped below the 1k-line review threshold: `1278` lines before cleanup, `956` after cleanup.
+- Result: success.
+
+### Step 8: Sub-agent review fixes
+
+- Ran a `toxic-reviewer`-standard sub-agent review over the full local diff.
+- Closed the public `KvState::desc_with_seq_len` backdoor; callers now use committed `desc()` or checked `exec_view()`.
+- Moved `batch_decode_trace` off direct `KvState` allocation/grow/advance and onto `Qwen3KvCache.prepare_*`.
+- Changed `ModelExecutor::admit_requests` to return `Result<Vec<KvAdmission>>` and added release-path length validation so malformed admission batches error pending requests instead of dropping them through `zip`.
+- Changed rank-step execution to drain every dispatched worker response before returning errors, so `Qwen3KvCache` does not release pages while a worker may still hold a `KvExecView`.
+- Added regression tests for malformed admission batch length and all-physical-pool preflight without partial grow.
+- Result: success.
+
+### Verification
+
+- `cargo fmt --check` — passed.
+- `git diff --check` — passed.
+- `uv run --with triton cargo check --release -p pegainfer-qwen3-4b` — passed.
+- `uv run --with triton cargo check --release -p pegainfer-qwen3-4b --features kernel-call-trace` — passed.
+- `uv run --with triton cargo test --release -p pegainfer-qwen3-4b --lib` — passed: 9 tests.
+- `uv run --with triton cargo test --release -p pegainfer-core --lib` — passed: 12 tests.
+- `uv run --with triton cargo test --release --workspace --lib --exclude pegainfer-comm --exclude pegainfer-comm-a2a-kernels --exclude pegainfer-comm-cuda-lib --exclude pegainfer-comm-cuda-sys --exclude pegainfer-comm-cudart-sys --exclude pegainfer-comm-fabric-debug --exclude pegainfer-comm-fabric-lib --exclude pegainfer-comm-libibverbs-sys --exclude pegainfer-comm-logging-lib --exclude pegainfer-comm-p2p-all-to-all --exclude pegainfer-comm-proc-lib --exclude pegainfer-comm-python-ext --exclude pegainfer-comm-thread-lib --exclude pegainfer-comm-torch-lib -- --test-threads=1` — passed across non-comm workspace packages.
+- The same non-comm workspace command without `--test-threads=1` hit `pegainfer-server::ops::tests::test_rms_norm_batch_multi_tile` once with a FlashInfer launch error; that exact test passed when rerun alone, so the recorded workspace gate uses serial GPU tests.
+- `uv run --with triton cargo test --release --workspace --lib` — blocked in `pegainfer-comm-a2a-kernels` build because this shell cannot find `nvcc`.
+
+### Serve Benchmark
+
+Single RTX 5070 Ti, Qwen3-4B, `--backend openai`, random dataset, `--request-rate inf`, `--max-concurrency 1`, `--ignore-eos`, 20 prompts per shape. `requested out tok/s` is computed as `completed * requested_output_len / duration`; raw benchmark JSON is retained because the reported generated-token counts differ from requested lengths for some streamed responses.
+
+| input | output | ok/fail | duration s | req/s | requested out tok/s | TTFT med/p99 ms | TPOT med/p99 ms | ITL med/p99 ms |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 1 | 20/0 | 0.27 | 75.07 | 75.07 | 13.05/15.22 | 0.00/0.00 | 0.00/0.01 |
+| 1 | 64 | 20/0 | 14.06 | 1.42 | 91.05 | 14.10/30.11 | 10.91/10.92 | 10.91/11.16 |
+| 128 | 32 | 20/0 | 7.24 | 2.76 | 88.36 | 18.24/50.72 | 11.01/11.06 | 11.02/11.25 |
+| 512 | 64 | 20/0 | 14.97 | 1.34 | 85.48 | 51.62/52.23 | 11.65/11.67 | 11.63/11.89 |
+| 1024 | 128 | 20/0 | 29.35 | 0.68 | 87.22 | 99.34/100.06 | 11.34/11.38 | 11.33/11.60 |
+| 2048 | 32 | 20/0 | 10.77 | 1.86 | 59.42 | 200.11/201.66 | 11.46/11.48 | 11.44/11.81 |
+| 4096 | 64 | 20/0 | 22.56 | 0.89 | 56.74 | 420.27/429.66 | 11.80/11.84 | 11.79/12.07 |
+
+### Serve Benchmark: Random C16
+
+`vllm bench serve`, random dataset, `--request-rate inf`, `--max-concurrency 16`, `--num-prompts 1000`, `--ignore-eos`, `--temperature 0`. Raw artifacts live under `target/profiling/kv-cache-redesign-random-c16/`.
+
+| center input | center output | range ratio | sampled input | sampled output | ok/fail | duration s | req/s | output tok/s | TTFT med/p99 ms | TPOT med/p99 ms | ITL med/p99 ms | note |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 1024 | 128 | 0.5 | 512-1536 | 64-192 | 1000/0 | 10.14 | 98.63 | 95839.36 | 114.16/223.33 | -0.00/0.00 | 13.99/19.99 | Not a clean pass: server logs showed `CUDA_ERROR_OUT_OF_MEMORY` and streamed completions with `finish_reason="error"`; this vLLM bench run still counted them as completed. |
+| 1024 | 128 | 0.5 | 512-1536 | 64-192 | 64/0 | 0.75 | 85.33 | 84853.50 | 123.84/428.81 | -0.00/0.00 | 4.55/5.01 | Saved-log reproduction: first failure is activation allocation, `gate_up_out` shape `19456x15291`, after a unified c16 prefill batch with `15290` prompt tokens. |
+| 512 | 64 | 0.5 | 256-768 | 32-96 | 1000/0 | 114.05 | 8.77 | 614.46 | 98.72/839.06 | 26.97/32.03 | 14.20/125.35 | Completed without the inflated output-token accounting seen in the larger run. |
+
+The c16 OOM is not KV page exhaustion. The saved server log shows the chain:
+
+```text
+unified plan failed: prefill_requests=15, decode_requests=1, prefill_tokens_total=15290, prefill_tokens_min=528, prefill_tokens_max=1507
+primary unified worker rank 0 failed
+unified scratch allocation failed: total_tokens=15291, total_prefill=15290, decode_tokens=1
+alloc prefill gate_up_out failed: dims=19456x15291
+Alloc failed: DriverError(CUDA_ERROR_OUT_OF_MEMORY, "out of memory")
+```
+
+Startup sized KV at `2513` pages, about `5654 MB` or `85%` of the reported free GPU memory. That leaves too little activation/workspace headroom for c16 random prefill batches with roughly 13k-18k total prompt tokens. KV cache admission now exposes a token-level API, but it accounts for KV residency only; forward workspace remains a separate budget.
+
+## Debrief
+
+- **Outcome**: Qwen3 worker threads no longer privately own request KV storage or allocate/release/advance KV. The executor-side KV cache now owns TP physical request state in `kv_cache.rs`, accepts token-level admission inputs from scheduler, prepares all physical KV pools before execution through a shared append model, builds value-type `KvExecView` payloads for workers, and commits logical length after successful worker execution.
+- **Pitfalls encountered**:
+  - `cargo check` initially failed because the FlashInfer submodule was absent; initializing `pegainfer-kernels/third_party/flashinfer` fixed the header lookup.
+  - Build then required Triton for AOT generation; `uv run --with triton ...` provided the expected Python environment without adding project files.
+- **Lessons learned**:
+  - The useful boundary is ownership plus payload shape: `KvState` owns permits in the KV cache, while `KvExecView` is a disposable worker descriptor.
+  - Existing paged metadata can be built from execution-visible lengths without mutating `KvState`; that gives us commit-after-success while preserving current kernel interfaces.
+  - Tests should use `Qwen3KvCache.prepare_*` to produce `KvExecView`; hand-constructing `KvState` in model tests reintroduces the old boundary.
+  - Keep `Qwen3KvCache` on the token/resource boundary. Passing executor step items into it leaks sampling/logprob concerns into the KV layer.
+
+## Final Architecture
+
+```text
+Scheduler
+  speaks RequestId + token counts + lifecycle
+  calls ModelExecutor::admit_requests with token-level budget inputs
+  never reads page IDs, buffer pointers, or TP physical state
+
+Qwen3KvCache
+  owns Vec<KvPool> and one RankKvStateStore per TP physical KV pool
+  turns token append requests into physical capacity in every KV pool
+  builds per-worker KvExecViewBatch values
+  commits seq_len only after worker execution succeeds
+  releases all physical request state on finish / cancel / error
+
+Worker
+  receives KvExecViewBatch as a disposable execution descriptor
+  launches prefill/decode/unified kernels
+  returns sampled tokens or errors
+  never owns KvState and never mutates committed KV length
+```
+
+`RankKvStateStore` is deliberately private to `kv_cache.rs`. Its rank dimension is a storage implementation detail for tensor parallelism. The public boundary above it is token-level admission plus `RequestId + append_tokens`; the public boundary below it is `KvExecView`.
+
+## Invariants
+
+- Scheduler is the request/token lifecycle authority. It decides which requests are active, deferred, rejected, finished, or cancelled.
+- `Qwen3KvCache` is the KV resource authority. Scheduler does not compute physical KV capacity, and worker does not allocate KV.
+- Physical TP storage must be prepared as one transaction: every physical KV pool is checked before any grow is applied.
+- Commit is post-success. Failed forward leaves committed KV length unchanged.
+- Model tests that need KV descriptors should go through `Qwen3KvCache.prepare_*`, not direct `KvState` construction.

--- a/pegainfer-core/src/kv_pool.rs
+++ b/pegainfer-core/src/kv_pool.rs
@@ -161,11 +161,19 @@ impl KvState {
         self.permit.pages().len()
     }
 
+    pub fn capacity_tokens(&self) -> usize {
+        self.permit.len() * self.pool.inner.layout.page_size
+    }
+
     pub fn last_page_len(&self) -> usize {
-        if self.seq_len == 0 {
+        self.last_page_len_for(self.seq_len)
+    }
+
+    fn last_page_len_for(&self, seq_len: usize) -> usize {
+        if seq_len == 0 {
             0
         } else {
-            let rem = self.seq_len % self.pool.inner.layout.page_size;
+            let rem = seq_len % self.pool.inner.layout.page_size;
             if rem == 0 {
                 self.pool.inner.layout.page_size
             } else {
@@ -208,6 +216,18 @@ impl KvState {
         Ok(())
     }
 
+    /// Validate that an owner outside the forward path already prepared enough
+    /// physical KV capacity for `token_count` tokens.
+    pub fn ensure_prepared_capacity(&self, token_count: usize) -> Result<()> {
+        if token_count > self.capacity_tokens() {
+            bail!(
+                "KvState: capacity was not prepared (need {token_count} tokens, have {})",
+                self.capacity_tokens()
+            );
+        }
+        Ok(())
+    }
+
     /// Advance sequence length after writing tokens.
     pub fn advance(&mut self, count: usize) {
         self.seq_len += count;
@@ -215,13 +235,29 @@ impl KvState {
 
     /// Build kernel-facing metadata for this request's KV.
     pub fn desc(&self) -> KvDesc<'_> {
+        self.desc_with_seq_len(self.seq_len)
+    }
+
+    fn desc_with_seq_len(&self, seq_len: usize) -> KvDesc<'_> {
         KvDesc {
             layout: self.pool.inner.layout,
             buffer: &self.pool.inner.buffer,
             pages: self.permit.pages(),
-            seq_len: self.seq_len,
-            last_page_len: self.last_page_len(),
+            seq_len,
+            last_page_len: self.last_page_len_for(seq_len),
         }
+    }
+
+    pub fn exec_view(&self, append_tokens: usize) -> Result<KvExecView> {
+        let seq_len = self.seq_len + append_tokens;
+        self.ensure_prepared_capacity(seq_len)?;
+        Ok(KvExecView {
+            pool: self.pool.clone(),
+            pages: self.permit.pages().to_vec(),
+            committed_len: self.seq_len,
+            seq_len,
+            last_page_len: self.last_page_len_for(seq_len),
+        })
     }
 
     /// Reset for a new request: return all pages, zero seq_len.
@@ -233,6 +269,58 @@ impl KvState {
             .try_acquire_many(0)
             .expect("zero acquire");
         self.seq_len = 0;
+    }
+}
+
+/// Value-type execution descriptor for one prepared KV request.
+///
+/// It carries only kernel-facing metadata and cloned access to the backing
+/// buffer. Page ownership stays with the `KvState` that produced the view.
+pub struct KvExecView {
+    pool: KvPool,
+    pages: Vec<PageId>,
+    committed_len: usize,
+    seq_len: usize,
+    last_page_len: usize,
+}
+
+impl KvExecView {
+    pub fn committed_len(&self) -> usize {
+        self.committed_len
+    }
+
+    pub fn seq_len(&self) -> usize {
+        self.seq_len
+    }
+
+    pub fn last_page_len(&self) -> usize {
+        self.last_page_len
+    }
+
+    pub fn num_pages(&self) -> usize {
+        self.pages.len()
+    }
+
+    pub fn page_indices_i32(&self) -> Vec<i32> {
+        self.pages.iter().map(|p| p.index() as i32).collect()
+    }
+
+    pub fn buffer(&self) -> &CudaSlice<bf16> {
+        &self.pool.inner.buffer
+    }
+
+    pub fn layout(&self) -> &KvLayout {
+        &self.pool.inner.layout
+    }
+
+    pub fn desc(&self) -> KvDesc<'_> {
+        KvDesc {
+            layout: self.pool.inner.layout,
+            buffer: &self.pool.inner.buffer,
+            pages: &self.pages,
+            seq_len: self.seq_len,
+            last_page_len: self.last_page_len,
+        }
     }
 }
 

--- a/pegainfer-qwen3-4b/src/batch_decode.rs
+++ b/pegainfer-qwen3-4b/src/batch_decode.rs
@@ -7,7 +7,7 @@ use super::batch_decode_buffers::{
 };
 use super::batch_decode_dag::BatchDecodeDag;
 use super::weights::{Qwen3Model, TransformerBlock};
-use pegainfer_core::kv_pool::{KvLayout, KvState};
+use pegainfer_core::kv_pool::{KvExecView, KvLayout};
 #[cfg(feature = "kernel-call-trace")]
 use pegainfer_core::ops;
 use pegainfer_kernels::tensor::{KvDim, QDim};
@@ -46,19 +46,16 @@ impl Qwen3Model {
     pub(crate) fn batch_decode(
         &self,
         token_ids: &[u32],
-        kv_states: &mut [&mut KvState],
+        kv_views: &[KvExecView],
         bufs: &mut BatchDecodeBuffers,
     ) -> Result<()> {
         let bs = token_ids.len();
-        assert_eq!(bs, kv_states.len());
+        assert_eq!(bs, kv_views.len());
         assert!(bs > 0);
 
-        // Grow pages and advance seq_len for each request
         let mut positions = Vec::with_capacity(bs);
-        for kv in kv_states.iter_mut() {
-            let pos = kv.seq_len();
-            kv.ensure_capacity(pos + 1)?;
-            kv.advance(1);
+        for kv in kv_views {
+            let pos = kv.committed_len();
             positions.push(pos as i32);
         }
 
@@ -84,15 +81,14 @@ impl Qwen3Model {
             .stream
             .memcpy_htod(&positions, &mut bufs.positions_d)?;
 
-        let kv_refs: Vec<&KvState> = kv_states.iter().map(|s| &**s).collect();
-        bufs.sync_paged_meta(&self.ctx, &kv_refs, padded_bs)?;
+        bufs.sync_paged_meta(&self.ctx, kv_views, padded_bs)?;
         let attention_path = bufs.attention_path(padded_bs);
         #[cfg(feature = "kernel-call-trace")]
-        let trace_kv_len = kv_refs.iter().map(|kv| kv.seq_len()).max().unwrap_or(0);
+        let trace_kv_len = kv_views.iter().map(KvExecView::seq_len).max().unwrap_or(0);
 
         // Forward pass — with or without CUDA Graph
-        let kv_buffer = kv_states[0].buffer();
-        let layout = *kv_states[0].layout();
+        let kv_buffer = kv_views[0].buffer();
+        let layout = *kv_views[0].layout();
         if self.enable_cuda_graph {
             let bucket_idx = BATCH_BUCKETS.iter().position(|&b| b == padded_bs).unwrap();
             let graph_idx = BatchDecodeBuffers::graph_index(bucket_idx, attention_path);
@@ -275,6 +271,8 @@ impl Qwen3Model {
 mod tests {
     use super::*;
     use crate::batch_decode_buffers::BatchDecodeBuffers;
+    use crate::kv_cache::{KvAppend, Qwen3KvCache};
+    use crate::request::RequestId;
     use crate::weights::ModelRuntimeConfig;
     use pegainfer_core::ops;
     use pegainfer_core::sampler::SamplingParams;
@@ -379,13 +377,18 @@ mod tests {
         prompt_tokens: &[u32],
         params: &SamplingParams,
         rng: &mut StdRng,
-    ) -> (KvState, u32) {
-        let mut kv_state = model.kv_pool.alloc();
+    ) -> (Qwen3KvCache, RequestId, u32) {
+        let mut kv_cache = Qwen3KvCache::new(vec![model.kv_pool().clone()]);
+        let request_id = RequestId::new(0);
+        let appends = vec![KvAppend::prefill(request_id, prompt_tokens.len())];
         let prompts: Vec<&[u32]> = vec![prompt_tokens];
-        let mut kv_refs: Vec<&mut KvState> = vec![&mut kv_state];
-        let (logits_vec, _) = model.batch_prefill(&prompts, &mut kv_refs, false).unwrap();
+        let rank_views = kv_cache.prepare_prefill(&appends).unwrap();
+        let (logits_vec, _) = model
+            .batch_prefill(&prompts, rank_views[0].views(), false)
+            .unwrap();
+        kv_cache.commit_prefill(&appends).unwrap();
         let first_token = sample_logits(model, &logits_vec[0], params, rng);
-        (kv_state, first_token)
+        (kv_cache, request_id, first_token)
     }
 
     /// Run single-request decode via batch_decode(bs=1) for a prompt, return generated token IDs.
@@ -402,7 +405,8 @@ mod tests {
         let params = SamplingParams::default(); // greedy
         let mut rng = StdRng::seed_from_u64(seed);
 
-        let (mut kv_state, first_token) = prefill_one(model, prompt_tokens, &params, &mut rng);
+        let (mut kv_cache, request_id, first_token) =
+            prefill_one(model, prompt_tokens, &params, &mut rng);
         let mut bufs = BatchDecodeBuffers::new(
             &model.ctx,
             model.config.hidden_size,
@@ -420,10 +424,12 @@ mod tests {
         let mut tokens = vec![first_token];
         for _ in 1..num_decode_steps {
             let token_ids = [*tokens.last().unwrap()];
-            let mut kv_refs: Vec<&mut KvState> = vec![&mut kv_state];
+            let appends = vec![KvAppend::decode(request_id)];
+            let rank_views = kv_cache.prepare_decode(&appends).unwrap();
             model
-                .batch_decode(&token_ids, &mut kv_refs, &mut bufs)
+                .batch_decode(&token_ids, rank_views[0].views(), &mut bufs)
                 .unwrap();
+            kv_cache.commit_decode(&appends).unwrap();
             let params_refs: Vec<&SamplingParams> = vec![&params];
             let batch_tokens = sample_batch_tokens(model, &bufs, &params_refs, &mut rng);
             tokens.push(batch_tokens[0]);
@@ -442,9 +448,18 @@ mod tests {
         let params = SamplingParams::default();
         let mut rng = StdRng::seed_from_u64(seed);
 
-        let mut kv_states: Vec<KvState> = (0..bs).map(|_| model.kv_pool.alloc()).collect();
-        let mut kv_refs: Vec<&mut KvState> = kv_states.iter_mut().collect();
-        let (logits_vec, _) = model.batch_prefill(prompts, &mut kv_refs, false).unwrap();
+        let mut kv_cache = Qwen3KvCache::new(vec![model.kv_pool().clone()]);
+        let request_ids: Vec<RequestId> = (0..bs as u64).map(RequestId::new).collect();
+        let prefill_appends: Vec<KvAppend> = request_ids
+            .iter()
+            .zip(prompts)
+            .map(|(&request_id, prompt)| KvAppend::prefill(request_id, prompt.len()))
+            .collect();
+        let rank_views = kv_cache.prepare_prefill(&prefill_appends).unwrap();
+        let (logits_vec, _) = model
+            .batch_prefill(prompts, rank_views[0].views(), false)
+            .unwrap();
+        kv_cache.commit_prefill(&prefill_appends).unwrap();
         let first_tokens: Vec<u32> = logits_vec
             .iter()
             .map(|logits| sample_logits(model, logits, &params, &mut rng))
@@ -474,10 +489,13 @@ mod tests {
 
         for _ in 1..num_decode_steps {
             let token_ids: Vec<u32> = all_tokens.iter().map(|t| *t.last().unwrap()).collect();
-            let mut kv_refs: Vec<&mut KvState> = kv_states.iter_mut().collect();
+            let decode_appends: Vec<KvAppend> =
+                request_ids.iter().copied().map(KvAppend::decode).collect();
+            let rank_views = kv_cache.prepare_decode(&decode_appends).unwrap();
             model
-                .batch_decode(&token_ids, &mut kv_refs, &mut bufs)
+                .batch_decode(&token_ids, rank_views[0].views(), &mut bufs)
                 .unwrap();
+            kv_cache.commit_decode(&decode_appends).unwrap();
             let params_refs: Vec<&SamplingParams> = (0..bs).map(|_| &params).collect();
             let tokens = sample_batch_tokens(model, &bufs, &params_refs, &mut rng);
             for (i, &tok) in tokens.iter().enumerate() {
@@ -522,14 +540,24 @@ mod tests {
             let mut seq_first_tokens = Vec::new();
             for prompt in [&prefill_a, &prefill_b, &prefill_c] {
                 let mut rng = StdRng::seed_from_u64(seed);
-                let (_kv_state, token) = prefill_one(&model, prompt.as_slice(), &params, &mut rng);
+                let (_kv_cache, _request_id, token) =
+                    prefill_one(&model, prompt.as_slice(), &params, &mut rng);
                 seq_first_tokens.push(token);
             }
 
             let prompts: Vec<&[u32]> = vec![&prefill_a, &prefill_b, &prefill_c];
-            let mut kv_states: Vec<KvState> = (0..3).map(|_| model.kv_pool.alloc()).collect();
-            let mut kv_refs: Vec<&mut KvState> = kv_states.iter_mut().collect();
-            let (logits_vec, _) = model.batch_prefill(&prompts, &mut kv_refs, false).unwrap();
+            let mut kv_cache = Qwen3KvCache::new(vec![model.kv_pool().clone()]);
+            let request_ids: Vec<RequestId> = (0..3).map(RequestId::new).collect();
+            let appends: Vec<KvAppend> = request_ids
+                .iter()
+                .zip(&prompts)
+                .map(|(&request_id, prompt)| KvAppend::prefill(request_id, prompt.len()))
+                .collect();
+            let rank_views = kv_cache.prepare_prefill(&appends).unwrap();
+            let (logits_vec, _) = model
+                .batch_prefill(&prompts, rank_views[0].views(), false)
+                .unwrap();
+            kv_cache.commit_prefill(&appends).unwrap();
 
             let mut batch_first_tokens = Vec::new();
             for logits in &logits_vec {

--- a/pegainfer-qwen3-4b/src/batch_decode_buffers.rs
+++ b/pegainfer-qwen3-4b/src/batch_decode_buffers.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use cudarc::driver::CudaSlice;
 
 use pegainfer_core::cuda_graph::CudaGraphState;
-use pegainfer_core::kv_pool::KvState;
+use pegainfer_core::kv_pool::KvExecView;
 use pegainfer_core::tensor::{DeviceContext, HiddenStates};
 
 /// Bucket sizes for CUDA Graph capture. Actual batch is padded to the nearest bucket.
@@ -170,17 +170,17 @@ impl BatchDecodeBuffers {
         self.logits.seq_len = bs;
     }
 
-    /// Sync paged attention metadata from multiple KvStates to GPU buffers.
+    /// Sync paged attention metadata from multiple prepared KV views to GPU buffers.
     ///
-    /// `padded_bs` >= `kv_states.len()`: padding slots (if any) point to the
+    /// `padded_bs` >= `kv_views.len()`: padding slots (if any) point to the
     /// reserved padding page with seq_len=1 so FlashInfer accesses valid memory.
     pub(crate) fn sync_paged_meta(
         &mut self,
         ctx: &DeviceContext,
-        kv_states: &[&KvState],
+        kv_views: &[KvExecView],
         padded_bs: usize,
     ) -> Result<()> {
-        let real_bs = kv_states.len();
+        let real_bs = kv_views.len();
         debug_assert!(padded_bs >= real_bs);
 
         // Build concatenated page_indices and CSR indptr
@@ -190,7 +190,7 @@ impl BatchDecodeBuffers {
         let mut chunk_sizes = Vec::with_capacity(padded_bs);
         self.max_seq_len = 0;
 
-        for kv in kv_states {
+        for kv in kv_views {
             let pages = kv.page_indices_i32();
             all_page_indices.extend_from_slice(&pages);
             indptr.push(all_page_indices.len() as i32);
@@ -221,7 +221,7 @@ impl BatchDecodeBuffers {
             .memcpy_htod(&request_indices, &mut self.request_indices_d)?;
         ctx.stream
             .memcpy_htod(&kv_tile_indices, &mut self.kv_tile_indices_d)?;
-        self.sync_split_kv_meta(ctx, kv_states, padded_bs)?;
+        self.sync_split_kv_meta(ctx, kv_views, padded_bs)?;
 
         Ok(())
     }
@@ -229,7 +229,7 @@ impl BatchDecodeBuffers {
     fn sync_split_kv_meta(
         &mut self,
         ctx: &DeviceContext,
-        kv_states: &[&KvState],
+        kv_views: &[KvExecView],
         padded_bs: usize,
     ) -> Result<()> {
         let split_chunk_size =
@@ -241,8 +241,9 @@ impl BatchDecodeBuffers {
         let mut split_block_valid_mask = Vec::with_capacity(split_padded_slots);
         split_o_indptr.push(0);
 
-        for (request_idx, kv) in kv_states.iter().enumerate() {
-            let chunks = kv.seq_len().div_ceil(split_chunk_size).max(1);
+        for (request_idx, kv) in kv_views.iter().enumerate() {
+            let seq_len = kv.seq_len();
+            let chunks = seq_len.div_ceil(split_chunk_size).max(1);
             debug_assert!(chunks <= SPLIT_KV_MAX_CHUNKS_PER_REQUEST);
             for chunk_idx in 0..chunks {
                 split_request_indices.push(request_idx as i32);
@@ -252,7 +253,7 @@ impl BatchDecodeBuffers {
             split_o_indptr.push(split_request_indices.len() as i32);
         }
 
-        for _ in kv_states.len()..padded_bs {
+        for _ in kv_views.len()..padded_bs {
             split_o_indptr.push(split_request_indices.len() as i32);
         }
 

--- a/pegainfer-qwen3-4b/src/batch_decode_trace.rs
+++ b/pegainfer-qwen3-4b/src/batch_decode_trace.rs
@@ -8,6 +8,10 @@ use pegainfer_kernels::tensor::KernelCall;
 #[cfg(feature = "kernel-call-trace")]
 use crate::batch_decode_buffers::BatchDecodeBuffers;
 #[cfg(feature = "kernel-call-trace")]
+use crate::kv_cache::{KvAppend, Qwen3KvCache};
+#[cfg(feature = "kernel-call-trace")]
+use crate::request::RequestId;
+#[cfg(feature = "kernel-call-trace")]
 use crate::weights::{ModelRuntimeConfig, Qwen3Model};
 
 pub const MODEL: &str = "qwen3-4b";
@@ -38,16 +42,20 @@ pub fn trace_decode_kernel_calls(
             device_ordinal: 0,
         },
     )?;
-    let mut kv_states = (0..batch_size)
-        .map(|_| {
-            let mut kv = model.alloc_kv();
-            if kv_len > 1 {
-                kv.ensure_capacity(kv_len - 1)?;
-                kv.advance(kv_len - 1);
-            }
-            Ok(kv)
-        })
-        .collect::<Result<Vec<_>>>()?;
+    let mut kv_cache = Qwen3KvCache::new(vec![model.kv_pool().clone()]);
+    let request_ids: Vec<_> = (0..batch_size)
+        .map(|index| RequestId::new(index as u64))
+        .collect();
+    let prefill_appends: Vec<_> = request_ids
+        .iter()
+        .map(|&request_id| KvAppend::prefill(request_id, kv_len.saturating_sub(1)))
+        .collect();
+    let decode_appends: Vec<_> = request_ids
+        .iter()
+        .map(|&request_id| KvAppend::decode(request_id))
+        .collect();
+    kv_cache.prepare_prefill(&prefill_appends)?;
+    kv_cache.commit_prefill(&prefill_appends)?;
 
     let mut bufs = BatchDecodeBuffers::new(
         model.device_ctx(),
@@ -63,8 +71,8 @@ pub fn trace_decode_kernel_calls(
     )?;
     let token_ids = vec![0_u32; batch_size];
     let ((), calls) = call_trace::collect_result(|| {
-        let mut kv_refs = kv_states.iter_mut().collect::<Vec<_>>();
-        model.batch_decode(&token_ids, &mut kv_refs, &mut bufs)
+        let rank_views = kv_cache.prepare_decode(&decode_appends)?;
+        model.batch_decode(&token_ids, rank_views[0].views(), &mut bufs)
     })?;
     Ok(calls)
 }

--- a/pegainfer-qwen3-4b/src/executor.rs
+++ b/pegainfer-qwen3-4b/src/executor.rs
@@ -548,16 +548,19 @@ impl Qwen3Executor {
         let primary = self
             .primary
             .run_step(steps.next().expect("primary step checked above"), true)?;
-        let mut send_error = None;
+        let mut errors = Vec::new();
         let mut pending = Vec::with_capacity(self.workers.len());
         for (rank, (worker, step)) in self.workers.iter().zip(steps).enumerate() {
             match worker.run_step(step, false) {
                 Ok(recv) => pending.push((rank + 1, recv)),
                 Err(error) => {
-                    send_error = Some(error.context(format!(
-                        "tensor-parallel {op_name} worker rank {} send failed",
-                        rank + 1
-                    )));
+                    errors.push(format!(
+                        "{:#}",
+                        error.context(format!(
+                            "tensor-parallel {op_name} worker rank {} send failed",
+                            rank + 1
+                        ))
+                    ));
                     break;
                 }
             }
@@ -568,7 +571,6 @@ impl Qwen3Executor {
             Err(_) => Err(anyhow::anyhow!("primary worker dropped step response")),
         };
 
-        let mut ack_result = Ok(());
         for (rank, recv) in pending {
             let result = match recv.recv() {
                 Ok(response) => response.result,
@@ -579,26 +581,41 @@ impl Qwen3Executor {
             match result {
                 Ok(WorkerStepOutcome::Ack) => {}
                 Ok(other) => {
-                    ack_result = Err(anyhow::anyhow!(
-                        "tensor-parallel {op_name} worker returned unexpected payload: {}",
+                    errors.push(format!(
+                        "tensor-parallel {op_name} worker rank {rank} returned unexpected payload: {}",
                         other.kind()
                     ));
                 }
                 Err(error) => {
-                    ack_result = Err(error.context(format!(
-                        "tensor-parallel {op_name} worker rank {rank} failed",
-                    )));
+                    errors.push(format!(
+                        "{:#}",
+                        error.context(format!(
+                            "tensor-parallel {op_name} worker rank {rank} failed",
+                        ))
+                    ));
                 }
             }
         }
 
-        if let Some(error) = send_error {
-            return Err(error);
+        let primary_result = match primary_result {
+            Ok(outcome) => Some(outcome),
+            Err(error) => {
+                errors.push(format!(
+                    "{:#}",
+                    error.context(format!("primary {op_name} worker rank 0 failed"))
+                ));
+                None
+            }
+        };
+
+        if !errors.is_empty() {
+            anyhow::bail!(
+                "tensor-parallel {op_name} step failed with {} error(s):\n{}",
+                errors.len(),
+                errors.join("\n")
+            );
         }
-        let primary_result =
-            primary_result.with_context(|| format!("primary {op_name} worker rank 0 failed"))?;
-        ack_result?;
-        Ok(primary_result)
+        Ok(primary_result.expect("primary result exists when no rank errors were collected"))
     }
 }
 
@@ -608,7 +625,7 @@ impl ModelExecutor for Qwen3Executor {
         active: &[KvBudgetState],
         pending: &[KvBudgetRequest],
     ) -> Result<Vec<KvAdmission>> {
-        Ok(self.kv_cache.admit_requests(active, pending))
+        self.kv_cache.admit_requests(active, pending)
     }
 
     fn is_stop_token(&self, token_id: u32) -> bool {

--- a/pegainfer-qwen3-4b/src/executor.rs
+++ b/pegainfer-qwen3-4b/src/executor.rs
@@ -1,3 +1,4 @@
+use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 
 use anyhow::{Context, Result};
@@ -545,13 +546,16 @@ impl Qwen3Executor {
         );
         let op_name = steps[0].kind();
         let mut steps = steps.into_iter();
-        let primary = self
-            .primary
-            .run_step(steps.next().expect("primary step checked above"), true)?;
+        let start_gate = Arc::new(StepStartGate::new());
+        let primary = self.primary.run_step(
+            steps.next().expect("primary step checked above"),
+            true,
+            Arc::clone(&start_gate),
+        )?;
         let mut errors = Vec::new();
         let mut pending = Vec::with_capacity(self.workers.len());
         for (rank, (worker, step)) in self.workers.iter().zip(steps).enumerate() {
-            match worker.run_step(step, false) {
+            match worker.run_step(step, false, Arc::clone(&start_gate)) {
                 Ok(recv) => pending.push((rank + 1, recv)),
                 Err(error) => {
                     errors.push(format!(
@@ -565,6 +569,18 @@ impl Qwen3Executor {
                 }
             }
         }
+
+        if !errors.is_empty() {
+            start_gate.cancel()?;
+            drain_cancelled_rank_steps(primary, pending);
+            anyhow::bail!(
+                "tensor-parallel {op_name} step failed before start with {} error(s):\n{}",
+                errors.len(),
+                errors.join("\n")
+            );
+        }
+
+        start_gate.start()?;
 
         let primary_result = match primary.recv() {
             Ok(response) => response.result,
@@ -616,6 +632,16 @@ impl Qwen3Executor {
             );
         }
         Ok(primary_result.expect("primary result exists when no rank errors were collected"))
+    }
+}
+
+fn drain_cancelled_rank_steps(
+    primary: channel::Receiver<WorkerStepResponse>,
+    pending: Vec<(usize, channel::Receiver<WorkerStepResponse>)>,
+) {
+    let _ = primary.recv();
+    for (_, recv) in pending {
+        let _ = recv.recv();
     }
 }
 
@@ -879,9 +905,68 @@ enum WorkerCommand {
     RunStep {
         step: StepCommand,
         collect_result: bool,
+        start_gate: Arc<StepStartGate>,
         resp: channel::Sender<WorkerStepResponse>,
     },
     Shutdown,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum StepStartState {
+    Waiting,
+    Start,
+    Cancel,
+}
+
+struct StepStartGate {
+    state: Mutex<StepStartState>,
+    ready: Condvar,
+}
+
+impl StepStartGate {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(StepStartState::Waiting),
+            ready: Condvar::new(),
+        }
+    }
+
+    fn start(&self) -> Result<()> {
+        self.set_state(StepStartState::Start)
+    }
+
+    fn cancel(&self) -> Result<()> {
+        self.set_state(StepStartState::Cancel)
+    }
+
+    fn set_state(&self, next: StepStartState) -> Result<()> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| anyhow::anyhow!("step start gate poisoned"))?;
+        *state = next;
+        self.ready.notify_all();
+        Ok(())
+    }
+
+    fn wait(&self) -> Result<()> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| anyhow::anyhow!("step start gate poisoned"))?;
+        loop {
+            match *state {
+                StepStartState::Waiting => {
+                    state = self
+                        .ready
+                        .wait(state)
+                        .map_err(|_| anyhow::anyhow!("step start gate poisoned"))?;
+                }
+                StepStartState::Start => return Ok(()),
+                StepStartState::Cancel => anyhow::bail!("rank step cancelled before start"),
+            }
+        }
+    }
 }
 
 enum WorkerStepOutcome {
@@ -923,10 +1008,15 @@ impl RankWorker {
                                 WorkerCommand::RunStep {
                                     step,
                                     collect_result,
+                                    start_gate,
                                     resp,
                                 } => {
-                                    let result =
-                                        execute_step_on_lane(&mut lane, step, collect_result);
+                                    let result = match start_gate.wait() {
+                                        Ok(()) => {
+                                            execute_step_on_lane(&mut lane, step, collect_result)
+                                        }
+                                        Err(error) => WorkerStepResponse { result: Err(error) },
+                                    };
                                     let _ = resp.send(result);
                                 }
                                 WorkerCommand::Shutdown => break,
@@ -952,12 +1042,14 @@ impl RankWorker {
         &self,
         step: StepCommand,
         collect_result: bool,
+        start_gate: Arc<StepStartGate>,
     ) -> Result<channel::Receiver<WorkerStepResponse>> {
         let (resp_tx, resp_rx) = channel::bounded(1);
         self.tx
             .send(WorkerCommand::RunStep {
                 step,
                 collect_result,
+                start_gate,
                 resp: resp_tx,
             })
             .map_err(|_| anyhow::anyhow!("tensor-parallel worker step channel closed"))?;
@@ -969,5 +1061,28 @@ impl RankWorker {
         if let Some(handle) = self.handle.take() {
             let _ = handle.join();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn step_start_gate_cancel_wakes_waiter() {
+        let gate = Arc::new(StepStartGate::new());
+        let waiter_gate = Arc::clone(&gate);
+        let waiter = thread::spawn(move || waiter_gate.wait());
+
+        gate.cancel().expect("cancel start gate");
+        let err = waiter
+            .join()
+            .expect("waiter thread must not panic")
+            .expect_err("cancelled gate must not start worker execution");
+
+        assert!(
+            err.to_string().contains("cancelled before start"),
+            "unexpected error: {err:#}"
+        );
     }
 }

--- a/pegainfer-qwen3-4b/src/executor.rs
+++ b/pegainfer-qwen3-4b/src/executor.rs
@@ -1,30 +1,20 @@
-use std::collections::HashMap;
 use std::thread;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use crossbeam_channel as channel;
 
 use crate::batch_decode_buffers::{BATCH_BUCKETS, BatchDecodeBuffers};
 use crate::config::TensorParallelConfig;
+use crate::kv_cache::{
+    KvAdmission, KvAppend, KvBudgetRequest, KvBudgetState, KvExecViewBatch, Qwen3KvCache,
+};
+use crate::request::RequestId;
 use crate::weights::{ModelRuntimeConfig, Qwen3Model};
 use pegainfer_core::engine::TokenLogprob;
-use pegainfer_core::kv_pool::{KvPool, KvState};
+use pegainfer_core::kv_pool::KvExecView;
 use pegainfer_core::ops;
 use pegainfer_core::sampler::SamplingParams;
 use pegainfer_core::tensor::{DeviceContext, DeviceVec, HiddenStates};
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub struct RequestId(pub(crate) u64);
-
-impl RequestId {
-    pub fn new(value: u64) -> Self {
-        Self(value)
-    }
-
-    pub fn get(self) -> u64 {
-        self.0
-    }
-}
 
 #[derive(Clone)]
 pub struct PrefillStepItem {
@@ -87,125 +77,43 @@ impl DecodeStepItem {
     }
 }
 
-type RequestStateBatch = Vec<(RequestId, KvState)>;
-
-struct RequestStateStore {
-    states: HashMap<RequestId, KvState>,
-}
-
-impl RequestStateStore {
-    fn new() -> Self {
-        Self {
-            states: HashMap::new(),
-        }
-    }
-
-    fn ensure_with<F>(&mut self, request_ids: &[RequestId], mut alloc: F)
-    where
-        F: FnMut() -> KvState,
-    {
-        for &request_id in request_ids {
-            self.states.entry(request_id).or_insert_with(&mut alloc);
-        }
-    }
-
-    fn drop_request(&mut self, request_id: RequestId) {
-        self.states.remove(&request_id);
-    }
-
-    fn take_batch(
-        &mut self,
-        request_ids: &[RequestId],
-        missing_context: &'static str,
-    ) -> Result<RequestStateBatch> {
-        request_ids
-            .iter()
-            .map(|request_id| {
-                self.states
-                    .remove(request_id)
-                    .ok_or_else(|| anyhow::anyhow!("{missing_context} for {:?}", request_id))
-                    .map(|kv| (*request_id, kv))
-            })
-            .collect()
-    }
-
-    fn restore_batch(&mut self, batch: RequestStateBatch) {
-        for (request_id, kv_state) in batch {
-            let replaced = self.states.insert(request_id, kv_state);
-            debug_assert!(replaced.is_none(), "request state restored twice");
-        }
-    }
-}
-
-fn kv_state_refs(batch: &mut RequestStateBatch) -> Vec<&mut KvState> {
-    batch.iter_mut().map(|(_, kv_state)| kv_state).collect()
-}
-
 fn execute_prefill_on_lane(
     lane: &mut LocalQwen3Lane,
-    request_states: &mut RequestStateStore,
     requests: &[PrefillStepItem],
+    kv_views: &KvExecViewBatch,
     echo: bool,
-    missing_context: &'static str,
 ) -> Result<(Vec<DeviceVec>, Option<HiddenStates>)> {
-    let request_ids: Vec<RequestId> = requests.iter().map(|req| req.request_id).collect();
-    request_states.ensure_with(&request_ids, || lane.alloc_kv());
     let prompts: Vec<&[u32]> = requests.iter().map(PrefillStepItem::as_slice).collect();
-    let mut request_state_batch = request_states.take_batch(&request_ids, missing_context)?;
-    let mut kv_states = kv_state_refs(&mut request_state_batch);
-    let result = lane.execute_prefill(&prompts, &mut kv_states, echo);
-    request_states.restore_batch(request_state_batch);
-    result
+    lane.execute_prefill(&prompts, kv_views.views(), echo)
 }
 
 fn execute_decode_on_lane(
     lane: &mut LocalQwen3Lane,
-    request_states: &mut RequestStateStore,
     requests: &[DecodeStepItem],
-    missing_context: &'static str,
+    kv_views: &KvExecViewBatch,
 ) -> Result<()> {
-    let request_ids: Vec<RequestId> = requests.iter().map(|req| req.request_id).collect();
     let token_ids: Vec<u32> = requests.iter().map(|req| req.token_id).collect();
-    let mut request_state_batch = request_states.take_batch(&request_ids, missing_context)?;
-    let mut kv_states = kv_state_refs(&mut request_state_batch);
-    let result = lane.execute_decode(&token_ids, &mut kv_states);
-    request_states.restore_batch(request_state_batch);
-    result
+    lane.execute_decode(&token_ids, kv_views.views())
 }
 
 fn execute_unified_on_lane(
     lane: &mut LocalQwen3Lane,
-    request_states: &mut RequestStateStore,
     prefill_requests: &[PrefillStepItem],
+    prefill_kv_views: &KvExecViewBatch,
     decode_requests: &[DecodeStepItem],
-    prefill_missing_context: &'static str,
-    decode_missing_context: &'static str,
+    decode_kv_views: &KvExecViewBatch,
 ) -> Result<(Vec<DeviceVec>, Vec<DeviceVec>)> {
-    let prefill_request_ids: Vec<RequestId> =
-        prefill_requests.iter().map(|req| req.request_id).collect();
-    let decode_request_ids: Vec<RequestId> =
-        decode_requests.iter().map(|req| req.request_id).collect();
-    request_states.ensure_with(&prefill_request_ids, || lane.alloc_kv());
     let prefill_prompts: Vec<&[u32]> = prefill_requests
         .iter()
         .map(PrefillStepItem::as_slice)
         .collect();
     let decode_tokens: Vec<u32> = decode_requests.iter().map(|req| req.token_id).collect();
-    let mut prefill_request_state_batch =
-        request_states.take_batch(&prefill_request_ids, prefill_missing_context)?;
-    let mut decode_request_state_batch =
-        request_states.take_batch(&decode_request_ids, decode_missing_context)?;
-    let mut prefill_kv_states = kv_state_refs(&mut prefill_request_state_batch);
-    let mut decode_kv_states = kv_state_refs(&mut decode_request_state_batch);
-    let result = lane.execute_unified(
+    lane.execute_unified(
         &prefill_prompts,
-        &mut prefill_kv_states,
+        prefill_kv_views.views(),
         &decode_tokens,
-        &mut decode_kv_states,
-    );
-    request_states.restore_batch(prefill_request_state_batch);
-    request_states.restore_batch(decode_request_state_batch);
-    result
+        decode_kv_views.views(),
+    )
 }
 
 fn build_prefill_request_results(
@@ -286,81 +194,83 @@ fn build_decode_request_results(
 
 fn execute_step_on_lane(
     lane: &mut LocalQwen3Lane,
-    request_states: &mut RequestStateStore,
-    step: &StepCommand,
+    step: StepCommand,
     collect_result: bool,
-) -> Result<WorkerStepOutcome> {
+) -> WorkerStepResponse {
     match step {
-        StepCommand::Prefill { requests, echo } => {
-            let (logits, all_position_logits) = execute_prefill_on_lane(
-                lane,
-                request_states,
-                requests,
-                *echo,
-                "missing local request state",
-            )?;
-            if collect_result {
-                Ok(WorkerStepOutcome::Prefill(PrefillResult {
-                    requests: build_prefill_request_results(
-                        lane,
-                        requests,
-                        &logits,
-                        all_position_logits.as_ref(),
-                        *echo,
-                    )?,
-                }))
-            } else {
-                Ok(WorkerStepOutcome::Ack)
-            }
+        StepCommand::Prefill {
+            requests,
+            echo,
+            kv_views,
+        } => {
+            let result = execute_prefill_on_lane(lane, &requests, &kv_views, echo).and_then(
+                |(logits, all_position_logits)| {
+                    if collect_result {
+                        Ok(WorkerStepOutcome::Prefill(PrefillResult {
+                            requests: build_prefill_request_results(
+                                lane,
+                                &requests,
+                                &logits,
+                                all_position_logits.as_ref(),
+                                echo,
+                            )?,
+                        }))
+                    } else {
+                        Ok(WorkerStepOutcome::Ack)
+                    }
+                },
+            );
+            WorkerStepResponse { result }
         }
-        StepCommand::Decode { requests } => {
-            execute_decode_on_lane(
-                lane,
-                request_states,
-                requests,
-                "missing local decode request state",
-            )?;
-            if collect_result {
-                let logits: Vec<DeviceVec> = (0..requests.len())
-                    .map(|i| ops::extract_vec(lane.model.device_ctx(), &lane.bufs.logits, i))
-                    .collect::<Result<Vec<_>>>()?;
-                Ok(WorkerStepOutcome::Decode(DecodeResult {
-                    requests: build_decode_request_results(lane, requests, &logits)?,
-                }))
-            } else {
-                Ok(WorkerStepOutcome::Ack)
-            }
+        StepCommand::Decode { requests, kv_views } => {
+            let result = execute_decode_on_lane(lane, &requests, &kv_views).and_then(|()| {
+                if collect_result {
+                    let logits: Vec<DeviceVec> = (0..requests.len())
+                        .map(|i| ops::extract_vec(lane.model.device_ctx(), &lane.bufs.logits, i))
+                        .collect::<Result<Vec<_>>>()?;
+                    Ok(WorkerStepOutcome::Decode(DecodeResult {
+                        requests: build_decode_request_results(lane, &requests, &logits)?,
+                    }))
+                } else {
+                    Ok(WorkerStepOutcome::Ack)
+                }
+            });
+            WorkerStepResponse { result }
         }
         StepCommand::Unified {
             prefill_requests,
+            prefill_kv_views,
             decode_requests,
+            decode_kv_views,
         } => {
-            let (prefill_logits, decode_logits) = execute_unified_on_lane(
+            let result = execute_unified_on_lane(
                 lane,
-                request_states,
-                prefill_requests,
-                decode_requests,
-                "missing local unified prefill request state",
-                "missing local unified decode request state",
-            )?;
-            if collect_result {
-                Ok(WorkerStepOutcome::Unified(UnifiedResult {
-                    prefill_requests: build_prefill_request_results(
-                        lane,
-                        prefill_requests,
-                        &prefill_logits,
-                        None,
-                        false,
-                    )?,
-                    decode_requests: build_decode_request_results(
-                        lane,
-                        decode_requests,
-                        &decode_logits,
-                    )?,
-                }))
-            } else {
-                Ok(WorkerStepOutcome::Ack)
-            }
+                &prefill_requests,
+                &prefill_kv_views,
+                &decode_requests,
+                &decode_kv_views,
+            )
+            .and_then(|(prefill_logits, decode_logits)| {
+                if collect_result {
+                    Ok(WorkerStepOutcome::Unified(UnifiedResult {
+                        prefill_requests: build_prefill_request_results(
+                            lane,
+                            &prefill_requests,
+                            &prefill_logits,
+                            None,
+                            false,
+                        )?,
+                        decode_requests: build_decode_request_results(
+                            lane,
+                            &decode_requests,
+                            &decode_logits,
+                        )?,
+                    }))
+                } else {
+                    Ok(WorkerStepOutcome::Ack)
+                }
+            });
+            WorkerStepResponse { result }
         }
     }
 }
@@ -500,9 +410,11 @@ pub struct UnifiedResult {
 }
 
 pub(crate) trait ModelExecutor: Send {
-    fn page_size(&self) -> usize;
-    fn max_request_pages(&self) -> usize;
-    fn available_pages(&self) -> usize;
+    fn admit_requests(
+        &self,
+        active: &[KvBudgetState],
+        pending: &[KvBudgetRequest],
+    ) -> Result<Vec<KvAdmission>>;
     fn is_stop_token(&self, token_id: u32) -> bool;
     fn drop_request(&mut self, request_id: RequestId) -> Result<()>;
 
@@ -512,13 +424,12 @@ pub(crate) trait ModelExecutor: Send {
 }
 
 struct Qwen3ExecutorMetadata {
-    page_size: usize,
     stop_token_ids: Vec<u32>,
 }
 
 pub struct Qwen3Executor {
     metadata: Qwen3ExecutorMetadata,
-    kv_pools: Vec<KvPool>,
+    kv_cache: Qwen3KvCache,
     primary: RankWorker,
     workers: Vec<RankWorker>,
 }
@@ -526,13 +437,12 @@ pub struct Qwen3Executor {
 impl Qwen3Executor {
     pub(crate) fn single(model: Qwen3Model) -> Result<Self> {
         let metadata = Qwen3ExecutorMetadata {
-            page_size: model.kv_pool().layout().page_size,
             stop_token_ids: model.config().stop_token_ids.clone(),
         };
         let kv_pool = model.kv_pool().clone();
         Ok(Self {
             metadata,
-            kv_pools: vec![kv_pool],
+            kv_cache: Qwen3KvCache::new(vec![kv_pool]),
             primary: RankWorker::spawn(0, LocalQwen3Lane::new(model)?)?,
             workers: Vec::new(),
         })
@@ -573,7 +483,6 @@ impl Qwen3Executor {
         }
 
         let metadata = Qwen3ExecutorMetadata {
-            page_size: models[0].kv_pool().layout().page_size,
             stop_token_ids: models[0].config().stop_token_ids.clone(),
         };
 
@@ -601,22 +510,10 @@ impl Qwen3Executor {
 
         Ok(Self {
             metadata,
-            kv_pools,
+            kv_cache: Qwen3KvCache::new(kv_pools),
             primary,
             workers,
         })
-    }
-
-    pub fn page_size(&self) -> usize {
-        <Self as ModelExecutor>::page_size(self)
-    }
-
-    pub fn max_request_pages(&self) -> usize {
-        <Self as ModelExecutor>::max_request_pages(self)
-    }
-
-    pub fn available_pages(&self) -> usize {
-        <Self as ModelExecutor>::available_pages(self)
     }
 
     pub fn is_stop_token(&self, token_id: u32) -> bool {
@@ -639,60 +536,79 @@ impl Qwen3Executor {
         <Self as ModelExecutor>::execute_unified(self, plan)
     }
 
-    fn wait_for_step_ack(
-        pending: Vec<channel::Receiver<Result<WorkerStepOutcome>>>,
-        op_name: &'static str,
-    ) -> Result<()> {
-        for recv in pending {
-            match recv
-                .recv()
-                .map_err(|_| anyhow::anyhow!("tensor-parallel {op_name} worker dropped"))??
-            {
-                WorkerStepOutcome::Ack => {}
-                other => {
-                    return Err(anyhow::anyhow!(
+    fn run_rank_steps(&mut self, steps: Vec<StepCommand>) -> Result<WorkerStepOutcome> {
+        anyhow::ensure!(
+            steps.len() == self.workers.len() + 1,
+            "rank step count {} does not match worker count {}",
+            steps.len(),
+            self.workers.len() + 1
+        );
+        let op_name = steps[0].kind();
+        let mut steps = steps.into_iter();
+        let primary = self
+            .primary
+            .run_step(steps.next().expect("primary step checked above"), true)?;
+        let mut send_error = None;
+        let mut pending = Vec::with_capacity(self.workers.len());
+        for (rank, (worker, step)) in self.workers.iter().zip(steps).enumerate() {
+            match worker.run_step(step, false) {
+                Ok(recv) => pending.push((rank + 1, recv)),
+                Err(error) => {
+                    send_error = Some(error.context(format!(
+                        "tensor-parallel {op_name} worker rank {} send failed",
+                        rank + 1
+                    )));
+                    break;
+                }
+            }
+        }
+
+        let primary_result = match primary.recv() {
+            Ok(response) => response.result,
+            Err(_) => Err(anyhow::anyhow!("primary worker dropped step response")),
+        };
+
+        let mut ack_result = Ok(());
+        for (rank, recv) in pending {
+            let result = match recv.recv() {
+                Ok(response) => response.result,
+                Err(_) => Err(anyhow::anyhow!(
+                    "tensor-parallel {op_name} worker rank {rank} dropped"
+                )),
+            };
+            match result {
+                Ok(WorkerStepOutcome::Ack) => {}
+                Ok(other) => {
+                    ack_result = Err(anyhow::anyhow!(
                         "tensor-parallel {op_name} worker returned unexpected payload: {}",
                         other.kind()
                     ));
                 }
+                Err(error) => {
+                    ack_result = Err(error.context(format!(
+                        "tensor-parallel {op_name} worker rank {rank} failed",
+                    )));
+                }
             }
         }
-        Ok(())
-    }
 
-    fn run_step(&self, step: &StepCommand) -> Result<WorkerStepOutcome> {
-        let primary = self.primary.run_step(step.clone(), true)?;
-        let mut pending = Vec::with_capacity(self.workers.len());
-        for worker in &self.workers {
-            pending.push(worker.run_step(step.clone(), false)?);
+        if let Some(error) = send_error {
+            return Err(error);
         }
-        let primary_result = primary
-            .recv()
-            .map_err(|_| anyhow::anyhow!("primary worker dropped step response"))??;
-        Self::wait_for_step_ack(pending, step.kind())?;
+        let primary_result =
+            primary_result.with_context(|| format!("primary {op_name} worker rank 0 failed"))?;
+        ack_result?;
         Ok(primary_result)
     }
 }
 
 impl ModelExecutor for Qwen3Executor {
-    fn page_size(&self) -> usize {
-        self.metadata.page_size
-    }
-
-    fn max_request_pages(&self) -> usize {
-        self.kv_pools
-            .iter()
-            .map(|pool| pool.capacity_pages().saturating_sub(1))
-            .min()
-            .unwrap_or(0)
-    }
-
-    fn available_pages(&self) -> usize {
-        self.kv_pools
-            .iter()
-            .map(KvPool::available_pages)
-            .min()
-            .unwrap_or(0)
+    fn admit_requests(
+        &self,
+        active: &[KvBudgetState],
+        pending: &[KvBudgetRequest],
+    ) -> Result<Vec<KvAdmission>> {
+        Ok(self.kv_cache.admit_requests(active, pending))
     }
 
     fn is_stop_token(&self, token_id: u32) -> bool {
@@ -700,20 +616,30 @@ impl ModelExecutor for Qwen3Executor {
     }
 
     fn drop_request(&mut self, request_id: RequestId) -> Result<()> {
-        self.primary.drop_request(request_id)?;
-        for worker in &self.workers {
-            worker.drop_request(request_id)?;
-        }
+        self.kv_cache.drop_request(request_id);
         Ok(())
     }
 
     fn execute_prefill(&mut self, plan: PrefillPlan<'_>) -> Result<PrefillResult> {
-        let step = StepCommand::Prefill {
-            requests: plan.requests.to_vec(),
-            echo: plan.echo,
-        };
-        match self.run_step(&step)? {
-            WorkerStepOutcome::Prefill(result) => Ok(result),
+        let appends: Vec<KvAppend> = plan
+            .requests
+            .iter()
+            .map(|req| KvAppend::prefill(req.request_id, req.prompt_tokens.len()))
+            .collect();
+        let rank_batches = self.kv_cache.prepare_prefill(&appends)?;
+        let steps = rank_batches
+            .into_iter()
+            .map(|kv_views| StepCommand::Prefill {
+                requests: plan.requests.to_vec(),
+                echo: plan.echo,
+                kv_views,
+            })
+            .collect();
+        match self.run_rank_steps(steps)? {
+            WorkerStepOutcome::Prefill(result) => {
+                self.kv_cache.commit_prefill(&appends)?;
+                Ok(result)
+            }
             other => Err(anyhow::anyhow!(
                 "prefill step returned unexpected payload: {}",
                 other.kind()
@@ -722,11 +648,24 @@ impl ModelExecutor for Qwen3Executor {
     }
 
     fn execute_decode(&mut self, plan: DecodePlan<'_>) -> Result<DecodeResult> {
-        let step = StepCommand::Decode {
-            requests: plan.requests.to_vec(),
-        };
-        match self.run_step(&step)? {
-            WorkerStepOutcome::Decode(result) => Ok(result),
+        let appends: Vec<KvAppend> = plan
+            .requests
+            .iter()
+            .map(|req| KvAppend::decode(req.request_id))
+            .collect();
+        let rank_batches = self.kv_cache.prepare_decode(&appends)?;
+        let steps = rank_batches
+            .into_iter()
+            .map(|kv_views| StepCommand::Decode {
+                requests: plan.requests.to_vec(),
+                kv_views,
+            })
+            .collect();
+        match self.run_rank_steps(steps)? {
+            WorkerStepOutcome::Decode(result) => {
+                self.kv_cache.commit_decode(&appends)?;
+                Ok(result)
+            }
             other => Err(anyhow::anyhow!(
                 "decode step returned unexpected payload: {}",
                 other.kind()
@@ -735,12 +674,34 @@ impl ModelExecutor for Qwen3Executor {
     }
 
     fn execute_unified(&mut self, plan: UnifiedPlan<'_>) -> Result<UnifiedResult> {
-        let step = StepCommand::Unified {
-            prefill_requests: plan.prefill_requests.to_vec(),
-            decode_requests: plan.decode_requests.to_vec(),
-        };
-        match self.run_step(&step)? {
-            WorkerStepOutcome::Unified(result) => Ok(result),
+        let prefill_appends: Vec<KvAppend> = plan
+            .prefill_requests
+            .iter()
+            .map(|req| KvAppend::prefill(req.request_id, req.prompt_tokens.len()))
+            .collect();
+        let decode_appends: Vec<KvAppend> = plan
+            .decode_requests
+            .iter()
+            .map(|req| KvAppend::decode(req.request_id))
+            .collect();
+        let rank_batches = self
+            .kv_cache
+            .prepare_unified(&prefill_appends, &decode_appends)?;
+        let steps = rank_batches
+            .into_iter()
+            .map(|states| StepCommand::Unified {
+                prefill_requests: plan.prefill_requests.to_vec(),
+                prefill_kv_views: states.prefill,
+                decode_requests: plan.decode_requests.to_vec(),
+                decode_kv_views: states.decode,
+            })
+            .collect();
+        match self.run_rank_steps(steps)? {
+            WorkerStepOutcome::Unified(result) => {
+                self.kv_cache
+                    .commit_unified(&prefill_appends, &decode_appends)?;
+                Ok(result)
+            }
             other => Err(anyhow::anyhow!(
                 "unified step returned unexpected payload: {}",
                 other.kind()
@@ -767,8 +728,18 @@ struct LocalQwen3Lane {
 impl LocalQwen3Lane {
     fn new(model: Qwen3Model) -> Result<Self> {
         let max_bucket = *BATCH_BUCKETS.last().unwrap();
-        let bufs = model.create_batch_decode_bufs(max_bucket)?;
-        let sample_scratch = SamplingScratch::new(model.device_ctx(), model.config().vocab_size)?;
+        let bufs = model
+            .create_batch_decode_bufs(max_bucket)
+            .with_context(|| {
+                format!("create batch decode buffers failed: max_bucket={max_bucket}")
+            })?;
+        let sample_scratch = SamplingScratch::new(model.device_ctx(), model.config().vocab_size)
+            .with_context(|| {
+                format!(
+                    "create sampling scratch failed: vocab_size={}",
+                    model.config().vocab_size
+                )
+            })?;
         Ok(Self {
             model,
             bufs,
@@ -779,10 +750,6 @@ impl LocalQwen3Lane {
     fn bind(&self) -> Result<CublasThreadGuard> {
         bind_model_thread(&self.model)?;
         Ok(CublasThreadGuard)
-    }
-
-    fn alloc_kv(&self) -> KvState {
-        self.model.alloc_kv()
     }
 
     fn sample_from_logits(
@@ -833,45 +800,47 @@ impl LocalQwen3Lane {
     fn execute_prefill(
         &mut self,
         prompts: &[&[u32]],
-        kv_states: &mut [&mut KvState],
+        kv_views: &[KvExecView],
         echo: bool,
     ) -> Result<(Vec<DeviceVec>, Option<HiddenStates>)> {
-        self.model.batch_prefill(prompts, kv_states, echo)
+        self.model.batch_prefill(prompts, kv_views, echo)
     }
 
-    fn execute_decode(&mut self, token_ids: &[u32], kv_states: &mut [&mut KvState]) -> Result<()> {
-        self.model
-            .batch_decode(token_ids, kv_states, &mut self.bufs)
+    fn execute_decode(&mut self, token_ids: &[u32], kv_views: &[KvExecView]) -> Result<()> {
+        self.model.batch_decode(token_ids, kv_views, &mut self.bufs)
     }
 
     fn execute_unified(
         &mut self,
         prefill_prompts: &[&[u32]],
-        prefill_kv_states: &mut [&mut KvState],
+        prefill_kv_views: &[KvExecView],
         decode_tokens: &[u32],
-        decode_kv_states: &mut [&mut KvState],
+        decode_kv_views: &[KvExecView],
     ) -> Result<(Vec<DeviceVec>, Vec<DeviceVec>)> {
         self.model.unified_step(
             prefill_prompts,
-            prefill_kv_states,
+            prefill_kv_views,
             decode_tokens,
-            decode_kv_states,
+            decode_kv_views,
         )
     }
 }
 
-#[derive(Clone)]
 enum StepCommand {
     Prefill {
         requests: Vec<PrefillStepItem>,
         echo: bool,
+        kv_views: KvExecViewBatch,
     },
     Decode {
         requests: Vec<DecodeStepItem>,
+        kv_views: KvExecViewBatch,
     },
     Unified {
         prefill_requests: Vec<PrefillStepItem>,
+        prefill_kv_views: KvExecViewBatch,
         decode_requests: Vec<DecodeStepItem>,
+        decode_kv_views: KvExecViewBatch,
     },
 }
 
@@ -885,15 +854,15 @@ impl StepCommand {
     }
 }
 
+struct WorkerStepResponse {
+    result: Result<WorkerStepOutcome>,
+}
+
 enum WorkerCommand {
     RunStep {
         step: StepCommand,
         collect_result: bool,
-        resp: channel::Sender<Result<WorkerStepOutcome>>,
-    },
-    DropRequest {
-        request_id: RequestId,
-        resp: channel::Sender<Result<()>>,
+        resp: channel::Sender<WorkerStepResponse>,
     },
     Shutdown,
 }
@@ -928,7 +897,6 @@ impl RankWorker {
         let handle = thread::Builder::new()
             .name(format!("qwen3-tp-rank-{rank}"))
             .spawn(move || {
-                let mut request_states = RequestStateStore::new();
                 let startup = lane.bind();
                 match startup {
                     Ok(_guard) => {
@@ -940,17 +908,9 @@ impl RankWorker {
                                     collect_result,
                                     resp,
                                 } => {
-                                    let result = execute_step_on_lane(
-                                        &mut lane,
-                                        &mut request_states,
-                                        &step,
-                                        collect_result,
-                                    );
+                                    let result =
+                                        execute_step_on_lane(&mut lane, step, collect_result);
                                     let _ = resp.send(result);
-                                }
-                                WorkerCommand::DropRequest { request_id, resp } => {
-                                    request_states.drop_request(request_id);
-                                    let _ = resp.send(Ok(()));
                                 }
                                 WorkerCommand::Shutdown => break,
                             }
@@ -975,7 +935,7 @@ impl RankWorker {
         &self,
         step: StepCommand,
         collect_result: bool,
-    ) -> Result<channel::Receiver<Result<WorkerStepOutcome>>> {
+    ) -> Result<channel::Receiver<WorkerStepResponse>> {
         let (resp_tx, resp_rx) = channel::bounded(1);
         self.tx
             .send(WorkerCommand::RunStep {
@@ -985,21 +945,6 @@ impl RankWorker {
             })
             .map_err(|_| anyhow::anyhow!("tensor-parallel worker step channel closed"))?;
         Ok(resp_rx)
-    }
-
-    fn drop_request(&self, request_id: RequestId) -> Result<()> {
-        let (resp_tx, resp_rx) = channel::bounded(1);
-        self.tx
-            .send(WorkerCommand::DropRequest {
-                request_id,
-                resp: resp_tx,
-            })
-            .map_err(|_| {
-                anyhow::anyhow!("tensor-parallel worker channel closed on drop_request")
-            })?;
-        resp_rx
-            .recv()
-            .map_err(|_| anyhow::anyhow!("tensor-parallel worker dropped drop_request response"))?
     }
 
     fn shutdown(&mut self) {

--- a/pegainfer-qwen3-4b/src/kv_cache.rs
+++ b/pegainfer-qwen3-4b/src/kv_cache.rs
@@ -238,12 +238,11 @@ impl Qwen3KvCache {
         &self,
         active: &[KvBudgetState],
         pending: &[KvBudgetRequest],
-    ) -> Vec<KvAdmission> {
-        let page_size = self
-            .pools
-            .first()
-            .map(|pool| pool.layout().page_size)
-            .unwrap_or(1);
+    ) -> Result<Vec<KvAdmission>> {
+        let Some(first_pool) = self.pools.first() else {
+            anyhow::bail!("Qwen3KvCache has no physical KV pools");
+        };
+        let page_size = first_pool.layout().page_size;
         let active_future_physical_pages: usize = active
             .iter()
             .map(|req| {
@@ -256,7 +255,7 @@ impl Qwen3KvCache {
             .saturating_sub(active_future_physical_pages);
         let max_request_physical_pages = self.max_request_physical_pages();
 
-        pending
+        Ok(pending
             .iter()
             .map(|req| {
                 debug_assert!(req.prompt_tokens <= req.max_tokens);
@@ -270,7 +269,7 @@ impl Qwen3KvCache {
                     KvAdmission::Defer
                 }
             })
-            .collect()
+            .collect())
     }
 
     pub(crate) fn drop_request(&mut self, request_id: RequestId) {
@@ -409,6 +408,25 @@ mod tests {
 
     fn test_pool(ctx: &DeviceContext, available_request_pages: usize) -> KvPool {
         KvPool::new(ctx, 1, 1, 1, 16, available_request_pages + 1).expect("test KvPool allocation")
+    }
+
+    #[test]
+    fn admit_requests_errors_without_physical_pools() {
+        let cache = Qwen3KvCache::new(Vec::new());
+        let err = cache
+            .admit_requests(
+                &[],
+                &[KvBudgetRequest {
+                    prompt_tokens: 1,
+                    max_tokens: 1,
+                }],
+            )
+            .expect_err("empty physical KV pool set must be explicit");
+
+        assert!(
+            err.to_string().contains("no physical KV pools"),
+            "unexpected error: {err:#}"
+        );
     }
 
     #[test]

--- a/pegainfer-qwen3-4b/src/kv_cache.rs
+++ b/pegainfer-qwen3-4b/src/kv_cache.rs
@@ -1,0 +1,441 @@
+use std::collections::HashMap;
+
+use anyhow::{Context, Result};
+use pegainfer_core::kv_pool::{KvExecView, KvPool, KvState};
+
+use crate::request::RequestId;
+
+pub(crate) struct KvBudgetState {
+    pub(crate) current_tokens: usize,
+    pub(crate) max_tokens: usize,
+}
+
+pub(crate) struct KvBudgetRequest {
+    pub(crate) prompt_tokens: usize,
+    pub(crate) max_tokens: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum KvAdmission {
+    Admit,
+    Defer,
+    Reject,
+}
+
+pub(crate) struct KvExecViewBatch(Vec<KvExecView>);
+
+impl KvExecViewBatch {
+    pub(crate) fn views(&self) -> &[KvExecView] {
+        &self.0
+    }
+}
+
+pub(crate) struct UnifiedKvExecViews {
+    pub(crate) prefill: KvExecViewBatch,
+    pub(crate) decode: KvExecViewBatch,
+}
+
+impl UnifiedKvExecViews {
+    fn new(prefill: KvExecViewBatch, decode: KvExecViewBatch) -> Self {
+        Self { prefill, decode }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct KvAppend {
+    request_id: RequestId,
+    append_tokens: usize,
+    source: &'static str,
+}
+
+impl KvAppend {
+    pub(crate) fn prefill(request_id: RequestId, append_tokens: usize) -> Self {
+        Self {
+            request_id,
+            append_tokens,
+            source: "prefill",
+        }
+    }
+
+    pub(crate) fn decode(request_id: RequestId) -> Self {
+        Self {
+            request_id,
+            append_tokens: 1,
+            source: "decode",
+        }
+    }
+}
+
+fn append_request_ids(appends: &[KvAppend]) -> Vec<RequestId> {
+    appends.iter().map(|append| append.request_id).collect()
+}
+
+fn pages_needed(token_count: usize, page_size: usize) -> usize {
+    token_count.div_ceil(page_size)
+}
+
+struct PlannedGrow {
+    request_id: RequestId,
+    target_tokens: usize,
+    source: &'static str,
+}
+
+struct RankPreparePlan {
+    rank: usize,
+    grows: Vec<PlannedGrow>,
+}
+
+struct RankKvStateStore {
+    states: HashMap<RequestId, KvState>,
+}
+
+impl RankKvStateStore {
+    fn new() -> Self {
+        Self {
+            states: HashMap::new(),
+        }
+    }
+
+    fn ensure_with<F>(&mut self, request_ids: &[RequestId], mut alloc: F)
+    where
+        F: FnMut() -> KvState,
+    {
+        for &request_id in request_ids {
+            self.states.entry(request_id).or_insert_with(&mut alloc);
+        }
+    }
+
+    fn drop_request(&mut self, request_id: RequestId) {
+        self.states.remove(&request_id);
+    }
+
+    fn plan_appends(
+        &self,
+        rank: usize,
+        pool: &KvPool,
+        appends: &[KvAppend],
+    ) -> Result<RankPreparePlan> {
+        let page_size = pool.layout().page_size;
+        let mut total_grow_pages = 0usize;
+        let mut grows = Vec::new();
+
+        for append in appends {
+            let state = self
+                .states
+                .get(&append.request_id)
+                .ok_or_else(|| anyhow::anyhow!("missing {} KV state", append.source))?;
+            let seq_len = state.seq_len();
+            let held_pages = state.num_pages();
+            let target_tokens = seq_len + append.append_tokens;
+            let available_pages = pool.available_pages();
+            let needed_pages = pages_needed(target_tokens, page_size);
+            let grow_pages = needed_pages.saturating_sub(held_pages);
+            total_grow_pages += grow_pages;
+
+            if grow_pages > 0 {
+                grows.push(PlannedGrow {
+                    request_id: append.request_id,
+                    target_tokens,
+                    source: append.source,
+                });
+            }
+
+            if total_grow_pages > available_pages {
+                anyhow::bail!(
+                    "rank {rank} prepare {} KV failed: request_id={}, seq_len={}, append_tokens={}, target_tokens={}, held_pages={}, grow_pages={}, total_grow_pages={}, available_pages={}",
+                    append.source,
+                    append.request_id.get(),
+                    seq_len,
+                    append.append_tokens,
+                    target_tokens,
+                    held_pages,
+                    grow_pages,
+                    total_grow_pages,
+                    available_pages
+                );
+            }
+        }
+
+        Ok(RankPreparePlan { rank, grows })
+    }
+
+    fn apply_plan(&mut self, plan: RankPreparePlan) -> Result<()> {
+        for grow in plan.grows {
+            self.states
+                .get_mut(&grow.request_id)
+                .ok_or_else(|| anyhow::anyhow!("missing {} KV state", grow.source))?
+                .ensure_capacity(grow.target_tokens)
+                .with_context(|| {
+                    format!(
+                        "rank {} apply {} KV grow failed: request_id={}, target_tokens={}",
+                        plan.rank,
+                        grow.source,
+                        grow.request_id.get(),
+                        grow.target_tokens
+                    )
+                })?;
+        }
+        Ok(())
+    }
+
+    fn build_views(
+        &self,
+        appends: &[KvAppend],
+        missing_context: &'static str,
+    ) -> Result<KvExecViewBatch> {
+        Ok(KvExecViewBatch(
+            appends
+                .iter()
+                .map(|append| {
+                    self.states
+                        .get(&append.request_id)
+                        .ok_or_else(|| {
+                            anyhow::anyhow!("{missing_context} for {:?}", append.request_id)
+                        })?
+                        .exec_view(append.append_tokens)
+                        .with_context(|| {
+                            format!(
+                                "build {} KV exec view failed: request_id={}, append_tokens={}",
+                                append.source,
+                                append.request_id.get(),
+                                append.append_tokens
+                            )
+                        })
+                })
+                .collect::<Result<Vec<_>>>()?,
+        ))
+    }
+}
+
+pub(crate) struct Qwen3KvCache {
+    pools: Vec<KvPool>,
+    rank_states: Vec<RankKvStateStore>,
+}
+
+impl Qwen3KvCache {
+    pub(crate) fn new(pools: Vec<KvPool>) -> Self {
+        let rank_states = pools.iter().map(|_| RankKvStateStore::new()).collect();
+        Self { pools, rank_states }
+    }
+
+    fn max_request_physical_pages(&self) -> usize {
+        self.pools
+            .iter()
+            .map(|pool| pool.capacity_pages().saturating_sub(1))
+            .min()
+            .unwrap_or(0)
+    }
+
+    fn available_physical_pages(&self) -> usize {
+        self.pools
+            .iter()
+            .map(KvPool::available_pages)
+            .min()
+            .unwrap_or(0)
+    }
+
+    pub(crate) fn admit_requests(
+        &self,
+        active: &[KvBudgetState],
+        pending: &[KvBudgetRequest],
+    ) -> Vec<KvAdmission> {
+        let page_size = self
+            .pools
+            .first()
+            .map(|pool| pool.layout().page_size)
+            .unwrap_or(1);
+        let active_future_physical_pages: usize = active
+            .iter()
+            .map(|req| {
+                pages_needed(req.max_tokens, page_size)
+                    .saturating_sub(pages_needed(req.current_tokens, page_size))
+            })
+            .sum();
+        let mut budget = self
+            .available_physical_pages()
+            .saturating_sub(active_future_physical_pages);
+        let max_request_physical_pages = self.max_request_physical_pages();
+
+        pending
+            .iter()
+            .map(|req| {
+                debug_assert!(req.prompt_tokens <= req.max_tokens);
+                let max_needed = pages_needed(req.max_tokens, page_size);
+                if max_needed > max_request_physical_pages {
+                    KvAdmission::Reject
+                } else if max_needed <= budget {
+                    budget -= max_needed;
+                    KvAdmission::Admit
+                } else {
+                    KvAdmission::Defer
+                }
+            })
+            .collect()
+    }
+
+    pub(crate) fn drop_request(&mut self, request_id: RequestId) {
+        for store in &mut self.rank_states {
+            store.drop_request(request_id);
+        }
+    }
+
+    pub(crate) fn commit_prefill(&mut self, appends: &[KvAppend]) -> Result<()> {
+        self.commit_appends(appends)
+    }
+
+    pub(crate) fn commit_decode(&mut self, appends: &[KvAppend]) -> Result<()> {
+        self.commit_appends(appends)
+    }
+
+    pub(crate) fn commit_unified(
+        &mut self,
+        prefill_appends: &[KvAppend],
+        decode_appends: &[KvAppend],
+    ) -> Result<()> {
+        let mut appends = Vec::with_capacity(prefill_appends.len() + decode_appends.len());
+        appends.extend_from_slice(prefill_appends);
+        appends.extend_from_slice(decode_appends);
+        self.commit_appends(&appends)
+    }
+
+    pub(crate) fn prepare_prefill(&mut self, appends: &[KvAppend]) -> Result<Vec<KvExecViewBatch>> {
+        let request_ids = append_request_ids(appends);
+        for (rank, store) in self.rank_states.iter_mut().enumerate() {
+            let pool = self.pools[rank].clone();
+            store.ensure_with(&request_ids, || pool.alloc());
+        }
+        self.prepare_all_ranks(appends)?;
+        self.build_rank_views(appends, "missing local prefill request state")
+    }
+
+    pub(crate) fn prepare_decode(&mut self, appends: &[KvAppend]) -> Result<Vec<KvExecViewBatch>> {
+        self.prepare_all_ranks(appends)?;
+        self.build_rank_views(appends, "missing local decode request state")
+    }
+
+    pub(crate) fn prepare_unified(
+        &mut self,
+        prefill_appends: &[KvAppend],
+        decode_appends: &[KvAppend],
+    ) -> Result<Vec<UnifiedKvExecViews>> {
+        let mut all_appends = Vec::with_capacity(prefill_appends.len() + decode_appends.len());
+        all_appends.extend_from_slice(prefill_appends);
+        all_appends.extend_from_slice(decode_appends);
+        let prefill_ids = append_request_ids(prefill_appends);
+
+        for (rank, store) in self.rank_states.iter_mut().enumerate() {
+            let pool = self.pools[rank].clone();
+            store.ensure_with(&prefill_ids, || pool.alloc());
+        }
+        self.prepare_all_ranks(&all_appends)?;
+        self.build_unified_rank_views(prefill_appends, decode_appends)
+    }
+
+    fn prepare_all_ranks(&mut self, appends: &[KvAppend]) -> Result<()> {
+        let plans = self
+            .rank_states
+            .iter()
+            .enumerate()
+            .map(|(rank, store)| store.plan_appends(rank, &self.pools[rank], appends))
+            .collect::<Result<Vec<_>>>()?;
+
+        for (store, plan) in self.rank_states.iter_mut().zip(plans) {
+            store.apply_plan(plan)?;
+        }
+        Ok(())
+    }
+
+    fn build_rank_views(
+        &self,
+        appends: &[KvAppend],
+        missing_context: &'static str,
+    ) -> Result<Vec<KvExecViewBatch>> {
+        self.rank_states
+            .iter()
+            .map(|store| store.build_views(appends, missing_context))
+            .collect()
+    }
+
+    fn build_unified_rank_views(
+        &self,
+        prefill_appends: &[KvAppend],
+        decode_appends: &[KvAppend],
+    ) -> Result<Vec<UnifiedKvExecViews>> {
+        self.rank_states
+            .iter()
+            .map(|store| {
+                let prefill = store.build_views(
+                    prefill_appends,
+                    "missing local unified prefill request state",
+                )?;
+                let decode = store
+                    .build_views(decode_appends, "missing local unified decode request state")?;
+                Ok(UnifiedKvExecViews::new(prefill, decode))
+            })
+            .collect()
+    }
+
+    fn commit_appends(&mut self, appends: &[KvAppend]) -> Result<()> {
+        for (rank, store) in self.rank_states.iter().enumerate() {
+            for append in appends {
+                store.states.get(&append.request_id).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "missing {} KV state at commit for rank {}",
+                        append.source,
+                        rank
+                    )
+                })?;
+            }
+        }
+
+        for store in &mut self.rank_states {
+            for append in appends {
+                store
+                    .states
+                    .get_mut(&append.request_id)
+                    .expect("commit state presence checked above")
+                    .advance(append.append_tokens);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pegainfer_core::tensor::DeviceContext;
+
+    use super::*;
+
+    fn test_pool(ctx: &DeviceContext, available_request_pages: usize) -> KvPool {
+        KvPool::new(ctx, 1, 1, 1, 16, available_request_pages + 1).expect("test KvPool allocation")
+    }
+
+    #[test]
+    fn prepare_prefill_does_not_partially_grow_physical_pools() {
+        let ctx = DeviceContext::new().expect("GPU required for KV cache tests");
+        let rank0_pool = test_pool(&ctx, 2);
+        let rank1_pool = test_pool(&ctx, 1);
+        let mut cache = Qwen3KvCache::new(vec![rank0_pool.clone(), rank1_pool.clone()]);
+
+        let err = match cache.prepare_prefill(&[KvAppend::prefill(RequestId::new(7), 32)]) {
+            Ok(_) => panic!("rank1 should not have enough physical KV pages"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.to_string().contains("rank 1 prepare prefill KV failed"),
+            "unexpected error: {err:#}"
+        );
+        assert_eq!(
+            rank0_pool.available_pages(),
+            2,
+            "rank0 must not grow before rank1 preflight succeeds"
+        );
+        assert_eq!(
+            rank1_pool.available_pages(),
+            1,
+            "failing rank must not change physical page ownership"
+        );
+    }
+}

--- a/pegainfer-qwen3-4b/src/lib.rs
+++ b/pegainfer-qwen3-4b/src/lib.rs
@@ -7,7 +7,9 @@ pub mod batch_decode_trace;
 mod config;
 mod executor;
 pub mod kernel_bench;
+mod kv_cache;
 mod prefill;
+mod request;
 mod scheduler;
 mod unified_forward;
 mod weights;
@@ -26,9 +28,10 @@ pub use kernel_plan::kernel_plan;
 pub mod runtime {
     pub use crate::executor::{
         DecodePlan, DecodeRequestResult, DecodeResult, DecodeStepItem, PrefillPlan,
-        PrefillRequestResult, PrefillResult, PrefillStepItem, Qwen3Executor, RequestId,
-        UnifiedPlan, UnifiedResult,
+        PrefillRequestResult, PrefillResult, PrefillStepItem, Qwen3Executor, UnifiedPlan,
+        UnifiedResult,
     };
+    pub use crate::request::RequestId;
 }
 
 pub fn probe_model(model_path: &Path) -> Result<Option<ModelInfo>> {

--- a/pegainfer-qwen3-4b/src/prefill.rs
+++ b/pegainfer-qwen3-4b/src/prefill.rs
@@ -1,8 +1,8 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use super::config::PREFILL_ATTENTION_CTA_TILE_Q;
 use super::weights::{Qwen3Model, TransformerBlock};
-use pegainfer_core::kv_pool::{KvLayout, KvState};
+use pegainfer_core::kv_pool::{KvExecView, KvLayout};
 use pegainfer_core::ops;
 use pegainfer_core::ops::PrefillPagedPlan;
 use pegainfer_core::tensor::{DeviceContext, DeviceVec, HiddenStates};
@@ -37,15 +37,36 @@ impl PrefillBuffers {
         seq_len: usize,
     ) -> Result<Self> {
         Ok(Self {
-            hidden_out: HiddenStates::zeros(ctx, hidden_dim, seq_len)?,
-            normed: HiddenStates::zeros(ctx, hidden_dim, seq_len)?,
-            q_batch: HiddenStates::zeros(ctx, q_dim, seq_len)?,
-            k_batch: HiddenStates::zeros(ctx, kv_dim, seq_len)?,
-            v_batch: HiddenStates::zeros(ctx, kv_dim, seq_len)?,
-            o_buf: HiddenStates::zeros(ctx, hidden_dim, seq_len)?,
-            gate_up_out: HiddenStates::zeros(ctx, 2 * inter_dim, seq_len)?,
-            act_out: HiddenStates::zeros(ctx, inter_dim, seq_len)?,
-            attn_output: HiddenStates::zeros(ctx, q_dim, seq_len)?,
+            hidden_out: HiddenStates::zeros(ctx, hidden_dim, seq_len).with_context(|| {
+                format!("alloc prefill hidden_out failed: dims={hidden_dim}x{seq_len}")
+            })?,
+            normed: HiddenStates::zeros(ctx, hidden_dim, seq_len).with_context(|| {
+                format!("alloc prefill normed failed: dims={hidden_dim}x{seq_len}")
+            })?,
+            q_batch: HiddenStates::zeros(ctx, q_dim, seq_len)
+                .with_context(|| format!("alloc prefill q_batch failed: dims={q_dim}x{seq_len}"))?,
+            k_batch: HiddenStates::zeros(ctx, kv_dim, seq_len).with_context(|| {
+                format!("alloc prefill k_batch failed: dims={kv_dim}x{seq_len}")
+            })?,
+            v_batch: HiddenStates::zeros(ctx, kv_dim, seq_len).with_context(|| {
+                format!("alloc prefill v_batch failed: dims={kv_dim}x{seq_len}")
+            })?,
+            o_buf: HiddenStates::zeros(ctx, hidden_dim, seq_len).with_context(|| {
+                format!("alloc prefill o_buf failed: dims={hidden_dim}x{seq_len}")
+            })?,
+            gate_up_out: HiddenStates::zeros(ctx, 2 * inter_dim, seq_len).with_context(|| {
+                format!(
+                    "alloc prefill gate_up_out failed: dims={}x{}",
+                    2 * inter_dim,
+                    seq_len
+                )
+            })?,
+            act_out: HiddenStates::zeros(ctx, inter_dim, seq_len).with_context(|| {
+                format!("alloc prefill act_out failed: dims={inter_dim}x{seq_len}")
+            })?,
+            attn_output: HiddenStates::zeros(ctx, q_dim, seq_len).with_context(|| {
+                format!("alloc prefill attn_output failed: dims={q_dim}x{seq_len}")
+            })?,
         })
     }
 }
@@ -220,27 +241,26 @@ impl Qwen3Model {
     pub(crate) fn batch_prefill(
         &self,
         prompts: &[&[u32]],
-        kv_states: &mut [&mut KvState],
+        kv_views: &[KvExecView],
         echo: bool,
     ) -> Result<(Vec<DeviceVec>, Option<HiddenStates>)> {
         let batch_size = prompts.len();
-        assert_eq!(batch_size, kv_states.len());
+        assert_eq!(batch_size, kv_views.len());
 
         let seq_lens: Vec<usize> = prompts.iter().map(|p| p.len()).collect();
-        let start_positions: Vec<usize> = kv_states.iter().map(|kv| kv.seq_len()).collect();
+        let start_positions: Vec<usize> = kv_views.iter().map(KvExecView::committed_len).collect();
 
         // Concatenate all tokens
         let all_tokens: Vec<u32> = prompts.iter().flat_map(|p| p.iter().copied()).collect();
-        let hidden = self.get_embeddings_batch(&all_tokens)?;
+        let hidden = self.get_embeddings_batch(&all_tokens).with_context(|| {
+            format!(
+                "batch prefill embedding failed: requests={}, total_tokens={}",
+                batch_size,
+                all_tokens.len()
+            )
+        })?;
 
-        // Allocate pages and advance for each request
-        for (i, kv) in kv_states.iter_mut().enumerate() {
-            kv.ensure_capacity(start_positions[i] + seq_lens[i])?;
-            kv.advance(seq_lens[i]);
-        }
-
-        // Build batch plan (all descs must reflect post-advance state)
-        let descs: Vec<_> = kv_states.iter().map(|kv| kv.desc()).collect();
+        let descs: Vec<_> = kv_views.iter().map(KvExecView::desc).collect();
         let plan = PrefillPagedPlan::new_batch_with_cta_tile_q(
             &self.ctx,
             &descs,
@@ -253,8 +273,8 @@ impl Qwen3Model {
         )?;
 
         // Forward through all layers
-        let kv_buffer = kv_states[0].buffer();
-        let layout = *kv_states[0].layout();
+        let kv_buffer = kv_views[0].buffer();
+        let layout = *kv_views[0].layout();
         let hidden = self.process_all_layers_batch_multi(hidden, &layout, kv_buffer, &plan)?;
 
         // All-position logits for echo (before we extract last-token logits)
@@ -303,7 +323,10 @@ impl Qwen3Model {
             kv_dim,
             inter_dim,
             total_tokens,
-        )?;
+        )
+        .with_context(|| {
+            format!("batch prefill scratch allocation failed: total_tokens={total_tokens}")
+        })?;
 
         for (layer_idx, layer) in self.layers.iter().enumerate() {
             self.forward_layer_batch_paged(

--- a/pegainfer-qwen3-4b/src/request.rs
+++ b/pegainfer-qwen3-4b/src/request.rs
@@ -1,0 +1,12 @@
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct RequestId(pub(crate) u64);
+
+impl RequestId {
+    pub fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub fn get(self) -> u64 {
+        self.0
+    }
+}

--- a/pegainfer-qwen3-4b/src/scheduler.rs
+++ b/pegainfer-qwen3-4b/src/scheduler.rs
@@ -17,7 +17,9 @@ use rand::SeedableRng;
 use rand::rngs::StdRng;
 use tokio::sync::mpsc;
 
-use crate::executor::{ModelExecutor, Qwen3Executor, RequestId};
+use crate::executor::{ModelExecutor, Qwen3Executor};
+use crate::kv_cache::{KvAdmission, KvBudgetRequest, KvBudgetState};
+use crate::request::RequestId;
 use pegainfer_core::engine::{EngineHandle, GenerateRequest, TokenEvent};
 use pegainfer_core::sampler::SamplingParams;
 
@@ -141,13 +143,22 @@ fn scheduler_loop<E>(
             }
         }
 
-        let admission = admit_deferred_requests(
-            deferred,
-            &active,
-            executor.page_size(),
-            executor.available_pages(),
-            executor.max_request_pages(),
-        );
+        let admission = match admit_deferred_requests(deferred, &active, &executor) {
+            Ok(admission) => admission,
+            Err((still_deferred, error)) => {
+                let message = format!("KV admission failed: {error:#}");
+                warn!("{message}");
+                for req in still_deferred {
+                    let _ = req.token_tx.send(TokenEvent::Error {
+                        message: message.clone(),
+                        prompt_tokens: req.prompt_tokens.len(),
+                        completion_tokens: 0,
+                    });
+                }
+                deferred = Vec::new();
+                continue;
+            }
+        };
         for rejected in &admission.rejected {
             send_rejection(rejected);
         }
@@ -161,8 +172,9 @@ fn scheduler_loop<E>(
         let artifacts = match execute_plan(&mut executor, &mut active, plan, &mut rng) {
             Ok(v) => v,
             Err(e) => {
-                warn!("Execution step failed: {e}");
-                fail_touched_requests(&mut executor, &mut active, failure_targets, &e.to_string());
+                let message = format!("{e:#}");
+                warn!("Execution step failed: {message}");
+                fail_touched_requests(&mut executor, &mut active, failure_targets, &message);
                 continue;
             }
         };
@@ -185,10 +197,6 @@ struct AdmissionOutcome {
     rejected: Vec<PendingRequest>,
 }
 
-fn pages_needed(token_count: usize, page_size: usize) -> usize {
-    token_count.div_ceil(page_size)
-}
-
 // Prefill samples the first output token but does not append it to KV. A
 // generated token occupies KV only when it is fed as the next decode input.
 // Therefore N returned completion tokens occupy at most N - 1 generated-token
@@ -209,55 +217,62 @@ fn current_active_tokens(req: &ActiveRequestState) -> usize {
         .saturating_add(req.generated_count.saturating_sub(1))
 }
 
-fn active_future_pages(active: &[ActiveRequestState], page_size: usize) -> usize {
-    active
-        .iter()
-        .map(|req| {
-            pages_needed(max_active_tokens(req), page_size)
-                .saturating_sub(pages_needed(current_active_tokens(req), page_size))
-        })
-        .sum()
-}
-
 fn admit_deferred_requests(
     deferred: Vec<PendingRequest>,
     active: &[ActiveRequestState],
-    page_size: usize,
-    available_pages: usize,
-    max_request_pages: usize,
-) -> AdmissionOutcome {
-    let mut budget = available_pages.saturating_sub(active_future_pages(active, page_size));
+    executor: &impl ModelExecutor,
+) -> std::result::Result<AdmissionOutcome, (Vec<PendingRequest>, anyhow::Error)> {
+    let active_budget: Vec<KvBudgetState> = active
+        .iter()
+        .map(|req| KvBudgetState {
+            current_tokens: current_active_tokens(req),
+            max_tokens: max_active_tokens(req),
+        })
+        .collect();
+    let pending_budget: Vec<KvBudgetRequest> = deferred
+        .iter()
+        .map(|req| KvBudgetRequest {
+            prompt_tokens: req.prompt_tokens.len(),
+            max_tokens: max_request_tokens(req),
+        })
+        .collect();
+    let decisions = match executor.admit_requests(&active_budget, &pending_budget) {
+        Ok(decisions) => decisions,
+        Err(error) => return Err((deferred, error)),
+    };
+    if decisions.len() != deferred.len() {
+        let error = anyhow::anyhow!(
+            "KV admission returned {} decisions for {} pending requests",
+            decisions.len(),
+            deferred.len()
+        );
+        return Err((deferred, error));
+    }
+
     let mut pending = Vec::new();
     let mut still_deferred = Vec::new();
     let mut rejected = Vec::new();
 
-    for req in deferred {
-        let max_needed = pages_needed(max_request_tokens(&req), page_size);
-        if max_needed > max_request_pages {
-            rejected.push(req);
-            continue;
-        }
-
-        if max_needed <= budget {
-            budget -= max_needed;
-            pending.push(req);
-        } else {
-            still_deferred.push(req);
+    for (req, decision) in deferred.into_iter().zip(decisions) {
+        match decision {
+            KvAdmission::Admit => pending.push(req),
+            KvAdmission::Defer => still_deferred.push(req),
+            KvAdmission::Reject => rejected.push(req),
         }
     }
 
-    AdmissionOutcome {
+    Ok(AdmissionOutcome {
         pending,
         deferred: still_deferred,
         rejected,
-    }
+    })
 }
 
 fn send_rejection(req: &PendingRequest) {
     let max_tokens = max_request_tokens(req);
     let _ = req.token_tx.send(TokenEvent::Rejected {
         message: format!(
-            "request requires more KV pages than this model instance can provide: prompt_tokens={}, max_context_tokens={}",
+            "request requires more KV cache than this model instance can provide: prompt_tokens={}, max_context_tokens={}",
             req.prompt_tokens.len(),
             max_tokens
         ),
@@ -341,22 +356,22 @@ mod tests {
     };
 
     struct FakeExecutor {
-        page_size: usize,
-        max_request_pages: usize,
-        available_pages: usize,
+        max_request_tokens: usize,
+        available_tokens: usize,
         held_tokens: HashMap<RequestId, usize>,
         fail_decode_once: bool,
+        truncate_admission: bool,
         dropped: Arc<Mutex<Vec<u64>>>,
     }
 
     impl FakeExecutor {
-        fn new(max_request_pages: usize, dropped: Arc<Mutex<Vec<u64>>>) -> Self {
+        fn new(max_request_tokens: usize, dropped: Arc<Mutex<Vec<u64>>>) -> Self {
             Self {
-                page_size: 16,
-                max_request_pages,
-                available_pages: max_request_pages,
+                max_request_tokens,
+                available_tokens: max_request_tokens,
                 held_tokens: HashMap::new(),
                 fail_decode_once: false,
+                truncate_admission: false,
                 dropped,
             }
         }
@@ -366,35 +381,57 @@ mod tests {
             self
         }
 
+        fn with_truncated_admission(mut self) -> Self {
+            self.truncate_admission = true;
+            self
+        }
+
         fn ensure_request_tokens(
             &mut self,
             request_id: RequestId,
             token_count: usize,
         ) -> Result<()> {
             let current_tokens = self.held_tokens.get(&request_id).copied().unwrap_or(0);
-            let current_pages = pages_needed(current_tokens, self.page_size);
-            let needed_pages = pages_needed(token_count, self.page_size);
-            let grow = needed_pages.saturating_sub(current_pages);
-            if grow > self.available_pages {
+            let grow_tokens = token_count.saturating_sub(current_tokens);
+            if grow_tokens > self.available_tokens {
                 anyhow::bail!("fake KV capacity exhausted");
             }
-            self.available_pages -= grow;
+            self.available_tokens -= grow_tokens;
             self.held_tokens.insert(request_id, token_count);
             Ok(())
         }
     }
 
     impl ModelExecutor for FakeExecutor {
-        fn page_size(&self) -> usize {
-            self.page_size
-        }
+        fn admit_requests(
+            &self,
+            active: &[KvBudgetState],
+            pending: &[KvBudgetRequest],
+        ) -> Result<Vec<KvAdmission>> {
+            let active_future_tokens: usize = active
+                .iter()
+                .map(|req| req.max_tokens.saturating_sub(req.current_tokens))
+                .sum();
+            let mut budget = self.available_tokens.saturating_sub(active_future_tokens);
 
-        fn max_request_pages(&self) -> usize {
-            self.max_request_pages
-        }
-
-        fn available_pages(&self) -> usize {
-            self.available_pages
+            let mut decisions: Vec<_> = pending
+                .iter()
+                .map(|req| {
+                    debug_assert!(req.prompt_tokens <= req.max_tokens);
+                    if req.max_tokens > self.max_request_tokens {
+                        KvAdmission::Reject
+                    } else if req.max_tokens <= budget {
+                        budget -= req.max_tokens;
+                        KvAdmission::Admit
+                    } else {
+                        KvAdmission::Defer
+                    }
+                })
+                .collect();
+            if self.truncate_admission {
+                decisions.pop();
+            }
+            Ok(decisions)
         }
 
         fn is_stop_token(&self, _token_id: u32) -> bool {
@@ -403,7 +440,7 @@ mod tests {
 
         fn drop_request(&mut self, request_id: RequestId) -> Result<()> {
             if let Some(tokens) = self.held_tokens.remove(&request_id) {
-                self.available_pages += pages_needed(tokens, self.page_size);
+                self.available_tokens += tokens;
             }
             self.dropped.lock().unwrap().push(request_id.get());
             Ok(())
@@ -500,7 +537,6 @@ mod tests {
         let (pending_req, _pending_rx) = request(16, 1);
         let pending = PendingRequest::from_scheduler_request(RequestId(7), pending_req);
         assert_eq!(max_request_tokens(&pending), 16);
-        assert_eq!(pages_needed(max_request_tokens(&pending), 16), 1);
 
         let (token_tx, _token_rx) = mpsc::unbounded_channel();
         let after_prefill = ActiveRequestState {
@@ -532,9 +568,9 @@ mod tests {
     }
 
     #[test]
-    fn one_token_completion_on_page_boundary_fits_one_page() {
+    fn one_token_completion_needs_only_prompt_tokens() {
         let dropped = Arc::new(Mutex::new(Vec::new()));
-        let executor = FakeExecutor::new(1, Arc::clone(&dropped));
+        let executor = FakeExecutor::new(16, Arc::clone(&dropped));
         let handle = start_with_executor(executor, 42);
 
         let (fits_exactly, mut rx) = request(16, 1);
@@ -549,14 +585,14 @@ mod tests {
         );
         assert!(
             dropped.lock().unwrap().contains(&0),
-            "finished request should release its one prompt page"
+            "finished request should release its prompt KV allocation"
         );
     }
 
     #[test]
     fn request_waits_for_full_kv_budget_before_prefill() {
         let dropped = Arc::new(Mutex::new(Vec::new()));
-        let executor = FakeExecutor::new(4, Arc::clone(&dropped));
+        let executor = FakeExecutor::new(34, Arc::clone(&dropped));
         let handle = start_with_executor(executor, 42);
 
         let (long_running, mut long_rx) = request(16, 18);
@@ -623,7 +659,7 @@ mod tests {
     #[test]
     fn impossible_request_is_rejected_without_blocking_later_work() {
         let dropped = Arc::new(Mutex::new(Vec::new()));
-        let executor = FakeExecutor::new(2, Arc::clone(&dropped));
+        let executor = FakeExecutor::new(32, Arc::clone(&dropped));
         let handle = start_with_executor(executor, 42);
 
         let (too_large, mut too_large_rx) = request(16, 34);
@@ -636,7 +672,7 @@ mod tests {
             }) => {
                 assert_eq!(prompt_tokens, 16);
                 assert_eq!(completion_tokens, 0);
-                assert!(message.contains("requires more KV pages"));
+                assert!(message.contains("requires more KV cache"));
             }
             _ => panic!("oversized request should be rejected"),
         }
@@ -654,9 +690,37 @@ mod tests {
     }
 
     #[test]
+    fn malformed_admission_batch_errors_pending_requests() {
+        let dropped = Arc::new(Mutex::new(Vec::new()));
+        let executor = FakeExecutor::new(64, Arc::clone(&dropped)).with_truncated_admission();
+        let handle = start_with_executor(executor, 42);
+
+        let (first, mut first_rx) = request(16, 1);
+        let (second, mut second_rx) = request(16, 1);
+        handle.submit(first).expect("submit first");
+        handle.submit(second).expect("submit second");
+
+        for rx in [&mut first_rx, &mut second_rx] {
+            match rx.blocking_recv() {
+                Some(TokenEvent::Error { message, .. }) => {
+                    assert!(
+                        message
+                            .contains("KV admission returned 1 decisions for 2 pending requests")
+                    );
+                }
+                _ => panic!("malformed admission should error pending request"),
+            }
+        }
+        assert!(
+            dropped.lock().unwrap().is_empty(),
+            "admission failed before request KV state was allocated"
+        );
+    }
+
+    #[test]
     fn decode_error_drops_request_state_and_scheduler_recovers() {
         let dropped = Arc::new(Mutex::new(Vec::new()));
-        let executor = FakeExecutor::new(4, Arc::clone(&dropped)).with_decode_failure();
+        let executor = FakeExecutor::new(64, Arc::clone(&dropped)).with_decode_failure();
         let handle = start_with_executor(executor, 42);
 
         let (will_fail, mut fail_rx) = request(16, 2);
@@ -706,7 +770,7 @@ mod tests {
     #[test]
     fn active_receiver_drop_releases_request_state() {
         let dropped = Arc::new(Mutex::new(Vec::new()));
-        let executor = FakeExecutor::new(4, Arc::clone(&dropped));
+        let executor = FakeExecutor::new(64, Arc::clone(&dropped));
         let handle = start_with_executor(executor, 42);
 
         let (will_disconnect, mut token_rx) = request(16, 3);

--- a/pegainfer-qwen3-4b/src/scheduler/effects.rs
+++ b/pegainfer-qwen3-4b/src/scheduler/effects.rs
@@ -1,6 +1,6 @@
 use tokio::sync::mpsc;
 
-use crate::executor::RequestId;
+use crate::request::RequestId;
 use pegainfer_core::engine::{FinishReason, TokenLogprob};
 
 use super::{ActiveRequestState, TokenEvent};

--- a/pegainfer-qwen3-4b/src/scheduler/plan.rs
+++ b/pegainfer-qwen3-4b/src/scheduler/plan.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use rand::rngs::StdRng;
 
 use crate::executor::{
@@ -26,6 +26,24 @@ pub(super) enum ExecutionArtifacts {
         pending: Vec<PendingRequest>,
         result: UnifiedResult,
     },
+}
+
+fn len_summary(values: impl Iterator<Item = usize>) -> (usize, usize, usize) {
+    let mut count = 0;
+    let mut total = 0;
+    let mut min = usize::MAX;
+    let mut max = 0;
+    for value in values {
+        count += 1;
+        total += value;
+        min = min.min(value);
+        max = max.max(value);
+    }
+    if count == 0 {
+        (0, 0, 0)
+    } else {
+        (total, min, max)
+    }
 }
 
 pub(super) fn build_next_plan(
@@ -63,10 +81,22 @@ pub(super) fn execute_plan(
                 })
                 .collect();
             let any_echo = pending.iter().any(|r| r.echo);
-            let result = executor.execute_prefill(PrefillPlan {
-                requests: &requests,
-                echo: any_echo,
-            })?;
+            let (prompt_total, prompt_min, prompt_max) =
+                len_summary(requests.iter().map(|r| r.prompt_tokens.len()));
+            let result = executor
+                .execute_prefill(PrefillPlan {
+                    requests: &requests,
+                    echo: any_echo,
+                })
+                .with_context(|| {
+                    format!(
+                        "prefill plan failed: requests={}, prompt_tokens_total={}, prompt_tokens_min={}, prompt_tokens_max={}, echo={any_echo}",
+                        requests.len(),
+                        prompt_total,
+                        prompt_min,
+                        prompt_max
+                    )
+                })?;
             Ok(ExecutionArtifacts::Prefill { pending, result })
         }
         ExecutionPlan::Decode => {
@@ -80,9 +110,11 @@ pub(super) fn execute_plan(
                     random_val: rand::RngExt::random(rng),
                 })
                 .collect();
-            let result = executor.execute_decode(DecodePlan {
-                requests: &requests,
-            })?;
+            let result = executor
+                .execute_decode(DecodePlan {
+                    requests: &requests,
+                })
+                .with_context(|| format!("decode plan failed: requests={}", requests.len()))?;
             Ok(ExecutionArtifacts::Decode { result })
         }
         ExecutionPlan::Unified { pending } => {
@@ -107,10 +139,23 @@ pub(super) fn execute_plan(
                     random_val: rand::RngExt::random(rng),
                 })
                 .collect();
-            let result = executor.execute_unified(UnifiedPlan {
-                prefill_requests: &prefill_requests,
-                decode_requests: &decode_requests,
-            })?;
+            let (prompt_total, prompt_min, prompt_max) =
+                len_summary(prefill_requests.iter().map(|r| r.prompt_tokens.len()));
+            let result = executor
+                .execute_unified(UnifiedPlan {
+                    prefill_requests: &prefill_requests,
+                    decode_requests: &decode_requests,
+                })
+                .with_context(|| {
+                    format!(
+                        "unified plan failed: prefill_requests={}, decode_requests={}, prefill_tokens_total={}, prefill_tokens_min={}, prefill_tokens_max={}",
+                        prefill_requests.len(),
+                        decode_requests.len(),
+                        prompt_total,
+                        prompt_min,
+                        prompt_max
+                    )
+                })?;
             Ok(ExecutionArtifacts::Unified { pending, result })
         }
     }

--- a/pegainfer-qwen3-4b/src/unified_forward.rs
+++ b/pegainfer-qwen3-4b/src/unified_forward.rs
@@ -4,7 +4,7 @@
 //! Attention splits: prefill tokens use FlashInfer BatchPrefill, decode tokens
 //! use FlashInfer BatchDecode, outputs are concatenated.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use cudarc::driver::{CudaSlice, DevicePtr, DevicePtrMut};
 use half::bf16;
 
@@ -12,7 +12,7 @@ use super::config::PREFILL_ATTENTION_CTA_TILE_Q;
 use super::prefill::PrefillBuffers;
 use super::weights::{Qwen3Model, TransformerBlock};
 use pegainfer_core::ffi;
-use pegainfer_core::kv_pool::{KvLayout, KvState};
+use pegainfer_core::kv_pool::{KvExecView, KvLayout};
 use pegainfer_core::ops;
 use pegainfer_core::ops::PrefillPagedPlan;
 use pegainfer_core::tensor::{DeviceContext, DeviceVec, HiddenStates};
@@ -32,17 +32,17 @@ struct DecodeAttentionMeta {
 impl DecodeAttentionMeta {
     fn build(
         ctx: &DeviceContext,
-        kv_states: &[&mut KvState],
+        kv_views: &[KvExecView],
         decode_positions: &[usize],
     ) -> Result<Self> {
-        let num_decode = kv_states.len();
+        let num_decode = kv_views.len();
 
         let mut all_page_indices = Vec::new();
         let mut indptr = vec![0i32];
         let mut last_page_lens = Vec::with_capacity(num_decode);
         let mut chunk_sizes = Vec::with_capacity(num_decode);
 
-        for kv in kv_states {
+        for kv in kv_views {
             let pages = kv.page_indices_i32();
             all_page_indices.extend_from_slice(&pages);
             indptr.push(all_page_indices.len() as i32);
@@ -78,14 +78,14 @@ impl Qwen3Model {
     pub(crate) fn unified_step(
         &self,
         prefill_prompts: &[&[u32]],
-        prefill_kv_states: &mut [&mut KvState],
+        prefill_kv_views: &[KvExecView],
         decode_tokens: &[u32],
-        decode_kv_states: &mut [&mut KvState],
+        decode_kv_views: &[KvExecView],
     ) -> Result<(Vec<DeviceVec>, Vec<DeviceVec>)> {
         let num_prefill_reqs = prefill_prompts.len();
         let num_decode_reqs = decode_tokens.len();
-        assert_eq!(num_prefill_reqs, prefill_kv_states.len());
-        assert_eq!(num_decode_reqs, decode_kv_states.len());
+        assert_eq!(num_prefill_reqs, prefill_kv_views.len());
+        assert_eq!(num_decode_reqs, decode_kv_views.len());
         assert!(num_prefill_reqs > 0 && num_decode_reqs > 0);
 
         let prefill_seq_lens: Vec<usize> = prefill_prompts.iter().map(|p| p.len()).collect();
@@ -98,22 +98,25 @@ impl Qwen3Model {
             all_tokens.extend_from_slice(prompt);
         }
         all_tokens.extend_from_slice(decode_tokens);
-        let hidden = self.get_embeddings_batch(&all_tokens)?;
+        let hidden = self.get_embeddings_batch(&all_tokens).with_context(|| {
+            format!(
+                "unified embedding failed: prefill_requests={}, decode_requests={}, total_prefill_tokens={}, total_tokens={}",
+                num_prefill_reqs,
+                num_decode_reqs,
+                total_prefill,
+                total_tokens
+            )
+        })?;
 
         // ── 2. Prepare KV states ──────────────────────────────────────
-        let prefill_start_positions: Vec<usize> =
-            prefill_kv_states.iter().map(|kv| kv.seq_len()).collect();
-        for (i, kv) in prefill_kv_states.iter_mut().enumerate() {
-            kv.ensure_capacity(prefill_start_positions[i] + prefill_seq_lens[i])?;
-            kv.advance(prefill_seq_lens[i]);
-        }
+        let prefill_start_positions: Vec<usize> = prefill_kv_views
+            .iter()
+            .map(KvExecView::committed_len)
+            .collect();
 
         let mut decode_positions = Vec::with_capacity(num_decode_reqs);
-        for kv in decode_kv_states.iter_mut() {
-            let pos = kv.seq_len();
-            kv.ensure_capacity(pos + 1)?;
-            kv.advance(1);
-            decode_positions.push(pos);
+        for kv in decode_kv_views {
+            decode_positions.push(kv.committed_len());
         }
 
         // ── 3. Build metadata ─────────────────────────────────────────
@@ -130,7 +133,7 @@ impl Qwen3Model {
         let positions_d = self.ctx.stream.clone_htod(&positions)?;
 
         // Prefill plan (for prefill attention + KV scatter)
-        let prefill_descs: Vec<_> = prefill_kv_states.iter().map(|kv| kv.desc()).collect();
+        let prefill_descs: Vec<_> = prefill_kv_views.iter().map(KvExecView::desc).collect();
         let prefill_plan = PrefillPagedPlan::new_batch_with_cta_tile_q(
             &self.ctx,
             &prefill_descs,
@@ -142,13 +145,12 @@ impl Qwen3Model {
             PREFILL_ATTENTION_CTA_TILE_Q,
         )?;
 
-        // Decode attention metadata (built AFTER advance so seq_lens reflect new state)
         let decode_meta =
-            DecodeAttentionMeta::build(&self.ctx, decode_kv_states, &decode_positions)?;
+            DecodeAttentionMeta::build(&self.ctx, decode_kv_views, &decode_positions)?;
 
         // ── 4. Process layers ─────────────────────────────────────────
-        let kv_buffer = prefill_kv_states[0].buffer();
-        let layout = *prefill_kv_states[0].layout();
+        let kv_buffer = prefill_kv_views[0].buffer();
+        let layout = *prefill_kv_views[0].layout();
 
         let hidden = self.unified_layers(
             hidden,
@@ -220,7 +222,13 @@ impl Qwen3Model {
             kv_dim,
             inter_dim,
             total_tokens,
-        )?;
+        )
+        .with_context(|| {
+            format!(
+                "unified scratch allocation failed: total_tokens={}, total_prefill={}, decode_tokens={}",
+                total_tokens, total_prefill, num_decode
+            )
+        })?;
 
         for (layer_idx, layer) in self.layers.iter().enumerate() {
             self.unified_forward_layer(

--- a/pegainfer-qwen3-4b/src/weights.rs
+++ b/pegainfer-qwen3-4b/src/weights.rs
@@ -422,11 +422,6 @@ impl Qwen3Model {
         Ok(())
     }
 
-    /// Allocate a fresh (empty) per-request KV state from the shared pool.
-    pub(crate) fn alloc_kv(&self) -> pegainfer_core::kv_pool::KvState {
-        self.kv_pool.alloc()
-    }
-
     pub(crate) fn kv_pool(&self) -> &pegainfer_core::kv_pool::KvPool {
         &self.kv_pool
     }

--- a/test_data/Qwen3-4B.json
+++ b/test_data/Qwen3-4B.json
@@ -3,13 +3,13 @@
     {
       "max_new_tokens": 50,
       "name": "tell_story",
-      "output": " about a young girl who is a talented artist, but she is not allowed to paint because of her gender. What happens next? Please write in a way that is suitable for children, with a happy ending. \n\nOkay, so I need to create",
+      "output": " about a young girl named Lila who is a talented painter and her journey to become a successful artist. Include the following elements: a mentor, a challenge, and a turning point. Also, include a scene where she paints a self-portrait and",
       "prompt": "Tell me a story"
     },
     {
       "max_new_tokens": 50,
       "name": "my_name",
-      "output": " Xiaoyu, and I am a student at the University of Science and Technology of China. I am currently working on a research project about the application of machine learning in the field of materials science. My research is focused on the prediction of material properties",
+      "output": " Xiaoyu, and I am a student at the University of Science and Technology of China. I am currently working on a research project about the application of AI in the field of education. I am interested in exploring how AI can be used to improve",
       "prompt": "My name is"
     },
     {
@@ -21,13 +21,13 @@
     {
       "max_new_tokens": 50,
       "name": "chinese_weather",
-      "output": "，阳光明媚，适合户外活动。我决定去公园散步。公园里有各种各样的花，有玫瑰、郁金香、菊花，还有各种各样的树木，比如松树、梧桐树、银杏树。我",
+      "output": "，阳光明媚，适合出去玩。我决定去公园散步。公园里有各种各样的花，有玫瑰、郁金香、菊花，还有各种各样的树木，比如松树、梧桐树、银杏树。我",
       "prompt": "今天天气真好"
     },
     {
       "max_new_tokens": 50,
       "name": "chinese_capital",
-      "output": "北京的地理位置和历史背景。\n\n北京，作为中国的首都，位于中国北部，是中华人民共和国的首都，也是中国的政治、文化和国际交往中心。北京的地理位置非常优越，地处华北平原的北部边缘，东临渤海，西",
+      "output": "北京的地理位置和历史背景。\n\n北京，作为中国的首都，位于中国北部，是中华人民共和国的首都，也是中国的政治、文化和国际交往中心。北京地处华北平原北部，东临渤海，西接内蒙古高原，南邻天津",
       "prompt": "请介绍一下中国的首都"
     },
     {
@@ -39,13 +39,13 @@
     {
       "max_new_tokens": 50,
       "name": "kanye_album",
-      "output": "《Yeezus》，因为它的音乐风格非常独特，融合了多种元素，比如电子、嘻哈、摇滚和实验音乐。此外，Yeezus 的制作人是 Kanye 本人，这使得专辑在制作上更加",
+      "output": "《Yeezus》，因为它的音乐风格非常独特，融合了多种元素，比如电子、嘻哈、摇滚和实验音乐。此外，专辑中的歌曲如《Power》和《Ultralight Beam》展现了 Kanye 的音乐",
       "prompt": "我最喜欢的 Kanye West 的专辑是"
     },
     {
       "max_new_tokens": 50,
       "name": "coldplay_ghost",
-      "output": "让人难以置信，我听了一次就爱上了。这首歌的旋律和歌词真的太棒了，我感觉它能触动每个人的心弦。不过，我有点担心，如果我听太多次，会不会变得麻木？毕竟，",
+      "output": "让人难以置信，我听了一次就爱上了。这首歌的旋律和歌词真的太棒了，我感觉它能触动每个人的心弦。不过，我有点担心，如果我只听一次，会不会错过一些重要的东西？",
       "prompt": "Coldplay 的《Ghost story》专辑真是"
     },
     {


### PR DESCRIPTION
## Summary

- centralize Qwen3 request KV ownership in executor-side `Qwen3KvCache`
- send workers value-type `KvExecViewBatch` payloads instead of worker-owned `KvState`
- prepare physical KV across all TP pools before execution and commit logical KV length only after worker success
- update scheduler admission/error handling around token-level KV budgets
- add a KV cache redesign record and docs index entry

## Notes

- The c16 random serving note remains documented as a forward workspace admission issue, not KV page exhaustion.
- This PR keeps the worker boundary execution-only: no worker-side KV allocate, release, or committed length mutation.

## Validation

- pre-commit hooks via `git commit`
- `git diff --check origin/main...HEAD`
- `cargo fmt --check`
- `uv run --with triton cargo check --release -p pegainfer-qwen3-4b`
- `uv run --with triton cargo check --release -p pegainfer-qwen3-4b --features kernel-call-trace`
- `uv run --with triton cargo test --release -p pegainfer-core --lib`
- `uv run --with triton cargo test --release -p pegainfer-qwen3-4b --lib`
