### PR TITLE
fix(qwen3): align bf16 greedy numerics

### DIFF
--- a/pegainfer-kernels/KERNELS.md
+++ b/pegainfer-kernels/KERNELS.md
@@ -22,7 +22,7 @@ Qwen3-4B uses bf16 dense full attention with `hidden_size=2560`, `num_attention_
 | `qwen3_4b.norm.fused_add_rms` | residual | `ops::fused_add_rms_norm_batch_into` | `fused_add_rms_norm_batched_cuda` | `csrc/flashinfer_norm.cu` | FlashInfer CUDA | residual add plus RMSNorm over batch |
 | `qwen3_4b.mlp.silu_mul_fused` | MLP | `ops::silu_mul_fused_batch_into` | `silu_mul_fused_cuda` | `csrc/fused_proj.cu` | CUDA | input `[2 * intermediate, batch]`, output `[intermediate, batch]` |
 | `qwen3_4b.elementwise.add` | residual/unified | `ops::add_batch_into` | `add_cuda` | `csrc/elementwise.cu` | CUDA | same-shape `HiddenStates` |
-| `qwen3_4b.sampling.greedy` | decode output | `ops::gpu_sample_into` | `flashinfer_top1_cuda` | `csrc/flashinfer_top1.cu` | FlashInfer CUDA | top-1 path, uses row-state scratch |
+| `qwen3_4b.sampling.greedy` | decode output | `ops::gpu_sample_into` | `argmax_cuda` | `csrc/argmax.cu` | CUDA | greedy top-1 path, preserves lower-token-id tie-break |
 | `qwen3_4b.sampling.random` | decode output | `ops::gpu_sample_into` | `gpu_sample_flashinfer_cuda` | `csrc/flashinfer_sampling.cu` | FlashInfer CUDA | temperature/top-k/top-p path |
 
 ## DeepSeek V4 MP8 Path

--- a/pegainfer-kernels/csrc/prefill_attention.cu
+++ b/pegainfer-kernels/csrc/prefill_attention.cu
@@ -74,14 +74,18 @@ __global__ void prefill_qk_norm_rope_kernel(
         float hi = __bfloat162float(smem[d + half]);
         float c = __bfloat162float(cos_cache[pos * head_dim + d]);
         float s = __bfloat162float(sin_cache[pos * head_dim + d]);
-        result = __float2bfloat16(lo * c - hi * s);
+        float lo_cos = __bfloat162float(__float2bfloat16(lo * c));
+        float hi_sin = __bfloat162float(__float2bfloat16(hi * s));
+        result = __float2bfloat16(lo_cos - hi_sin);
     } else {
         int pair_d = d - half;
         float lo = __bfloat162float(smem[pair_d]);
         float hi = __bfloat162float(smem[d]);
         float c = __bfloat162float(cos_cache[pos * head_dim + pair_d]);
         float s = __bfloat162float(sin_cache[pos * head_dim + pair_d]);
-        result = __float2bfloat16(lo * s + hi * c);
+        float lo_sin = __bfloat162float(__float2bfloat16(lo * s));
+        float hi_cos = __bfloat162float(__float2bfloat16(hi * c));
+        result = __float2bfloat16(lo_sin + hi_cos);
     }
 
     data[offset] = result;

--- a/pegainfer-kernels/src/ops/sampling.rs
+++ b/pegainfer-kernels/src/ops/sampling.rs
@@ -110,8 +110,8 @@ fn gpu_sample_core(
     ctx: &DeviceContext,
     logits: &DeviceVec,
     probs_scratch: &mut CudaSlice<f32>,
-    top1_value_scratch: &mut CudaSlice<half::bf16>,
-    row_states_scratch: &mut CudaSlice<u8>,
+    _top1_value_scratch: &mut CudaSlice<half::bf16>,
+    _row_states_scratch: &mut CudaSlice<u8>,
     valid_scratch: &mut CudaSlice<u8>,
     out: &mut CudaSlice<i32>,
     temperature: f32,
@@ -121,15 +121,11 @@ fn gpu_sample_core(
 ) -> Result<u32> {
     if (temperature <= 0.0 || top_k == 1) && top_p >= 1.0 {
         let (l_ptr, _gl) = logits.data.device_ptr(&ctx.stream);
-        let (v_ptr, _gv) = top1_value_scratch.device_ptr_mut(&ctx.stream);
-        let (r_ptr, _gr) = row_states_scratch.device_ptr_mut(&ctx.stream);
         let (o_ptr, _go) = out.device_ptr_mut(&ctx.stream);
 
         unsafe {
-            ffi::flashinfer_top1_cuda(
+            ffi::argmax_cuda(
                 l_ptr as *const ffi::Half,
-                v_ptr as *mut ffi::Half,
-                r_ptr as *mut u8,
                 o_ptr as *mut i32,
                 logits.len as i32,
                 ctx.stream.cu_stream(),

--- a/pegainfer-qwen3-4b/src/batch_decode.rs
+++ b/pegainfer-qwen3-4b/src/batch_decode.rs
@@ -154,7 +154,7 @@ impl Qwen3Model {
                 &bufs.mlp_out,
                 next_weight,
                 &mut bufs.normed,
-            );
+            )?;
         }
 
         // Output projection: logits [vocab_size, bs]
@@ -242,20 +242,27 @@ impl Qwen3Model {
             &bufs.attn_proj,
             &layer.post_attention_layernorm,
             &mut bufs.normed,
-        );
+        )?;
 
-        // MLP: fused gate+up GEMM → silu_mul_fused → down GEMM
-        dag.gate_up_proj(
-            dag_label!(format!("L{layer_idx}.mlp.gate_up_proj")),
+        // MLP: split gate/up GEMMs → silu_mul → down GEMM
+        dag.mlp_gate_proj(
+            dag_label!(format!("L{layer_idx}.mlp.gate_proj")),
             &layer.mlp.gate_up_proj,
             &bufs.normed,
-            &mut bufs.gate_up_out,
+            &mut bufs.gate_out,
         );
-        dag.silu_mul(
+        dag.mlp_up_proj(
+            dag_label!(format!("L{layer_idx}.mlp.up_proj")),
+            &layer.mlp.gate_up_proj,
+            &bufs.normed,
+            &mut bufs.up_out,
+        );
+        dag.silu_mul_split(
             dag_label!(format!("L{layer_idx}.mlp.silu_mul")),
-            &bufs.gate_up_out,
+            &bufs.gate_out,
+            &bufs.up_out,
             &mut bufs.mlp_act,
-        );
+        )?;
         dag.down_proj(
             dag_label!(format!("L{layer_idx}.mlp.down_proj")),
             &layer.mlp.down_proj,

--- a/pegainfer-qwen3-4b/src/batch_decode_buffers.rs
+++ b/pegainfer-qwen3-4b/src/batch_decode_buffers.rs
@@ -60,8 +60,10 @@ pub(crate) struct BatchDecodeBuffers {
     pub(crate) attn_proj: HiddenStates,
     /// Fused QKV projection output [q_dim + 2*kv_dim, bs]
     pub(crate) qkv_out: HiddenStates,
-    /// Fused gate+up projection output [2*intermediate_size, bs]
-    pub(crate) gate_up_out: HiddenStates,
+    /// Split MLP gate projection output [intermediate_size, bs].
+    pub(crate) gate_out: HiddenStates,
+    /// Split MLP up projection output [intermediate_size, bs].
+    pub(crate) up_out: HiddenStates,
     pub(crate) mlp_act: HiddenStates,
     pub(crate) mlp_out: HiddenStates,
     pub(crate) hidden: HiddenStates,
@@ -122,7 +124,8 @@ impl BatchDecodeBuffers {
             attn_out: HiddenStates::zeros(ctx, q_dim, bs)?,
             attn_proj: HiddenStates::zeros(ctx, hidden_dim, bs)?,
             qkv_out: HiddenStates::zeros(ctx, q_dim + 2 * kv_dim, bs)?,
-            gate_up_out: HiddenStates::zeros(ctx, 2 * intermediate_size, bs)?,
+            gate_out: HiddenStates::zeros(ctx, intermediate_size, bs)?,
+            up_out: HiddenStates::zeros(ctx, intermediate_size, bs)?,
             mlp_act: HiddenStates::zeros(ctx, intermediate_size, bs)?,
             mlp_out: HiddenStates::zeros(ctx, hidden_dim, bs)?,
             hidden: HiddenStates::zeros(ctx, hidden_dim, bs)?,
@@ -163,7 +166,8 @@ impl BatchDecodeBuffers {
         self.attn_out.seq_len = bs;
         self.attn_proj.seq_len = bs;
         self.qkv_out.seq_len = bs;
-        self.gate_up_out.seq_len = bs;
+        self.gate_out.seq_len = bs;
+        self.up_out.seq_len = bs;
         self.mlp_act.seq_len = bs;
         self.mlp_out.seq_len = bs;
         self.hidden.seq_len = bs;

--- a/pegainfer-qwen3-4b/src/batch_decode_dag.rs
+++ b/pegainfer-qwen3-4b/src/batch_decode_dag.rs
@@ -16,7 +16,7 @@ use pegainfer_core::ops::call_spec::{
 #[cfg(feature = "kernel-call-trace")]
 use pegainfer_core::ops::call_trace;
 use pegainfer_core::tensor::{DeviceMatrix, DeviceVec, HiddenStates};
-use pegainfer_kernels::tensor::{AxisTag, Hidden, InDim, Inter2, Intermediate, QDim, Vocab};
+use pegainfer_kernels::tensor::{AxisTag, Hidden, InDim, Intermediate, QDim, Vocab};
 
 use crate::batch_decode_buffers::{BatchDecodeBuffers, DecodeAttentionPath};
 use crate::weights::Qwen3Model;
@@ -103,7 +103,7 @@ impl<'a> BatchDecodeDag<'a> {
         residual: &HiddenStates,
         weight: &DeviceVec,
         out: &mut HiddenStates,
-    ) {
+    ) -> Result<()> {
         #[cfg(feature = "kernel-call-trace")]
         Self::record(fused_add_rms_norm_batch_call::<Hidden>(
             label,
@@ -111,14 +111,14 @@ impl<'a> BatchDecodeDag<'a> {
             hidden.seq_len,
             self.model.config.rms_norm_eps,
         ));
-        pegainfer_kernels::ops::fused_add_rms_norm_batch_into(
+        pegainfer_kernels::ops::fused_add_rms_norm_round_batch_into(
             &self.model.ctx,
             hidden,
             residual,
             weight,
             self.model.config.rms_norm_eps,
             out,
-        );
+        )
     }
 
     pub(crate) fn gemm_rows<Out: AxisTag>(
@@ -275,16 +275,6 @@ impl<'a> BatchDecodeDag<'a> {
         }
     }
 
-    pub(crate) fn silu_mul(&self, label: DagLabel, gate_up: &HiddenStates, out: &mut HiddenStates) {
-        #[cfg(feature = "kernel-call-trace")]
-        Self::record(silu_mul_fused_batch_call(
-            label,
-            out.hidden_dim,
-            gate_up.seq_len,
-        ));
-        pegainfer_kernels::ops::silu_mul_fused_batch_into(&self.model.ctx, gate_up, out);
-    }
-
     pub(crate) fn all_reduce_hidden(
         &self,
         label: DagLabel,
@@ -309,14 +299,40 @@ impl<'a> BatchDecodeDag<'a> {
         self.gemm::<Hidden, QDim>(label, weight, x, out);
     }
 
-    pub(crate) fn gate_up_proj(
+    pub(crate) fn mlp_gate_proj(
         &self,
         label: DagLabel,
         weight: &DeviceMatrix,
         x: &HiddenStates,
         out: &mut HiddenStates,
     ) {
-        self.gemm::<Inter2, Hidden>(label, weight, x, out);
+        self.gemm_rows::<Intermediate>(label, weight, 0, out.hidden_dim, x, out);
+    }
+
+    pub(crate) fn mlp_up_proj(
+        &self,
+        label: DagLabel,
+        weight: &DeviceMatrix,
+        x: &HiddenStates,
+        out: &mut HiddenStates,
+    ) {
+        self.gemm_rows::<Intermediate>(label, weight, out.hidden_dim, out.hidden_dim, x, out);
+    }
+
+    pub(crate) fn silu_mul_split(
+        &self,
+        label: DagLabel,
+        gate: &HiddenStates,
+        up: &HiddenStates,
+        out: &mut HiddenStates,
+    ) -> Result<()> {
+        #[cfg(feature = "kernel-call-trace")]
+        Self::record(silu_mul_fused_batch_call(
+            label,
+            gate.hidden_dim,
+            gate.seq_len,
+        ));
+        pegainfer_kernels::ops::silu_mul_batch_into(&self.model.ctx, gate, up, out)
     }
 
     pub(crate) fn down_proj(

--- a/pegainfer-qwen3-4b/src/prefill.rs
+++ b/pegainfer-qwen3-4b/src/prefill.rs
@@ -22,7 +22,8 @@ pub(super) struct PrefillBuffers {
     pub(super) k_batch: HiddenStates, // kv_dim × seq_len
     pub(super) v_batch: HiddenStates, // kv_dim × seq_len
     pub(super) o_buf: HiddenStates,  // hidden_dim × seq_len (reused for mlp_out)
-    pub(super) gate_up_out: HiddenStates, // 2*inter_dim × seq_len
+    pub(super) gate_out: HiddenStates, // inter_dim × seq_len
+    pub(super) up_out: HiddenStates, // inter_dim × seq_len
     pub(super) act_out: HiddenStates, // inter_dim × seq_len
     pub(super) attn_output: HiddenStates, // q_dim × seq_len
 }
@@ -43,7 +44,8 @@ impl PrefillBuffers {
             k_batch: HiddenStates::zeros(ctx, kv_dim, seq_len)?,
             v_batch: HiddenStates::zeros(ctx, kv_dim, seq_len)?,
             o_buf: HiddenStates::zeros(ctx, hidden_dim, seq_len)?,
-            gate_up_out: HiddenStates::zeros(ctx, 2 * inter_dim, seq_len)?,
+            gate_out: HiddenStates::zeros(ctx, inter_dim, seq_len)?,
+            up_out: HiddenStates::zeros(ctx, inter_dim, seq_len)?,
             act_out: HiddenStates::zeros(ctx, inter_dim, seq_len)?,
             attn_output: HiddenStates::zeros(ctx, q_dim, seq_len)?,
         })
@@ -154,23 +156,34 @@ impl Qwen3Model {
         self.all_reduce_hidden(&mut bufs.o_buf)?;
 
         // 5+6. Residual add + MLP RMSNorm (fused): hidden += o_buf; normed = rms_norm(hidden)
-        ops::fused_add_rms_norm_batch_into(
+        pegainfer_kernels::ops::fused_add_rms_norm_round_batch_into(
             &self.ctx,
             hidden,
             &bufs.o_buf,
             &layer.post_attention_layernorm,
             self.config.rms_norm_eps,
             &mut bufs.normed,
-        );
+        )?;
 
-        // 7. MLP: fused gate+up GEMM → silu_mul → down → bufs.o_buf
-        ops::gemm_into(
+        // 7. MLP: split gate/up GEMMs → silu_mul → down → bufs.o_buf
+        let inter_dim = self.local_intermediate_size();
+        ops::gemm_rows_into(
             &self.ctx,
             &layer.mlp.gate_up_proj,
+            0,
+            inter_dim,
             &bufs.normed,
-            &mut bufs.gate_up_out,
+            &mut bufs.gate_out,
         );
-        ops::silu_mul_fused_batch_into(&self.ctx, &bufs.gate_up_out, &mut bufs.act_out);
+        ops::gemm_rows_into(
+            &self.ctx,
+            &layer.mlp.gate_up_proj,
+            inter_dim,
+            inter_dim,
+            &bufs.normed,
+            &mut bufs.up_out,
+        );
+        ops::silu_mul_batch_into(&self.ctx, &bufs.gate_out, &bufs.up_out, &mut bufs.act_out)?;
         ops::gemm_into(
             &self.ctx,
             &layer.mlp.down_proj,

--- a/pegainfer-qwen3-4b/src/unified_forward.rs
+++ b/pegainfer-qwen3-4b/src/unified_forward.rs
@@ -535,22 +535,32 @@ impl Qwen3Model {
         self.all_reduce_hidden(&mut bufs.o_buf)?;
 
         // ── 7+8. Residual add + MLP RMSNorm (fused) ─────────────────
-        ops::fused_add_rms_norm_batch_into(
+        pegainfer_kernels::ops::fused_add_rms_norm_round_batch_into(
             &self.ctx,
             hidden,
             &bufs.o_buf,
             &layer.post_attention_layernorm,
             self.config.rms_norm_eps,
             &mut bufs.normed,
-        );
+        )?;
 
-        ops::gemm_into(
+        ops::gemm_rows_into(
             &self.ctx,
             &layer.mlp.gate_up_proj,
+            0,
+            self.local_intermediate_size(),
             &bufs.normed,
-            &mut bufs.gate_up_out,
+            &mut bufs.gate_out,
         );
-        ops::silu_mul_fused_batch_into(&self.ctx, &bufs.gate_up_out, &mut bufs.act_out);
+        ops::gemm_rows_into(
+            &self.ctx,
+            &layer.mlp.gate_up_proj,
+            self.local_intermediate_size(),
+            self.local_intermediate_size(),
+            &bufs.normed,
+            &mut bufs.up_out,
+        );
+        ops::silu_mul_batch_into(&self.ctx, &bufs.gate_out, &bufs.up_out, &mut bufs.act_out)?;
         ops::gemm_into(
             &self.ctx,
             &layer.mlp.down_proj,


### PR DESCRIPTION
## Summary

Fixes Qwen3-4B base greedy drift against HF GPU bf16 by matching the materialization boundaries that affect tie-sensitive logits.

This was discovered while working on Qwen3 LoRA support in #173, where base-model numerical drift had to be separated from LoRA-specific correctness issues. The root-cause issue is tracked in #174.

Changes:

- preserve bf16 residual-add materialization before RMSNorm in Qwen3 prefill/decode/unified paths
- use lower-token-id greedy tie-break for exact logit ties
- split Qwen3 MLP gate/up projections into separate row-sliced GEMMs
- match HF/PyTorch RoPE bf16 elementwise multiply materialization in fused q/k norm+RoPE

## Validation

Local:

```bash
cargo fmt --all --check
PEGAINFER_CUDA_SM=80 cargo check --release -p pegainfer-qwen3-4b
```

GPU worker evidence from the investigation:

- `Tell me a story`, Qwen3-4B, HF CUDA bf16 vs PegaInfer
- no first diff through 128 generated tokens
- no first diff through 256 generated tokens

## Notes

The existing Qwen3 e2e golden text appears to encode the old drift branch, so a follow-up should add or refresh a regression gate for this HF bf16 greedy trace.
