### PR TITLE
test(deepseek-v2-lite): refresh EP2 HF oracle

### DIFF
--- a/docs/models/deepseek-v2-lite/decode-attribution-gate.md
+++ b/docs/models/deepseek-v2-lite/decode-attribution-gate.md
@@ -9,7 +9,7 @@
 This gate deliberately stays model-specific and shape-specific:
 
 - Model: DeepSeek-V2-Lite.
-- Shape: batch `1`, prompt `Hello`, output length `16`.
+- Shape: batch `1`, prompt `Hello`, prompt token ids `[17464]`, output length `16`.
 - Backends: default host-staged EP2 and `PEGAINFER_DSV2_LITE_EP_BACKEND=nccl`.
 - Accuracy oracle: the same generated token/text/hash gate used by `hf-accuracy-gate.md`.
 - Attribution source: `DeepSeekV2LiteEp2Generator::generate_greedy_with_attribution`.
@@ -100,15 +100,17 @@ NCCL WARN Cuda failure 1 'invalid argument'
 
 Use a newer NCCL runtime through the normal library path if the system runtime fails this way. The project code path should not change just to work around local NCCL installation age.
 
-The HF oracle needs a Python environment that can load DeepSeek-V2-Lite with `trust_remote_code=True`, including the model's `flash_attn` dependency. Keep that environment separate from the Rust runtime claim: it is only the truth-source generator for the comparison JSON.
+The HF oracle needs a Python environment that can load DeepSeek-V2-Lite with `trust_remote_code=True`. The helper script tolerates the model file's optional `flash_attn` import check when FlashAttention is not installed, but the HF environment remains separate from the Rust runtime claim: it is only the truth-source generator for the comparison JSON.
 
 ## Latest Validation
 
-The full gate was last rerun on 2026-05-24 with DeepSeek-V2-Lite, `prompt="Hello"`, `output_len=16`, and 2x RTX 5090. The NCCL path used a newer NCCL runtime than the system 2.25.1 package, because the older runtime failed the EP2 init smoke on this GPU generation.
+The full gate was last rerun on 2026-05-26 with DeepSeek-V2-Lite, `prompt="Hello"`, `output_len=16`, and 2x A800-SXM4-80GB. The refreshed token/text oracle is confirmed by a real HF `AutoModelForCausalLM.generate(..., do_sample=false, use_cache=true)` run on the same model snapshot as the Rust E2E gate.
+
+The earlier 2026-05-24 hash is superseded because that record did not preserve enough HF/runtime provenance to reproduce the truth-source environment. Treat only the hash below as the active oracle. This refresh does not claim a model-runtime improvement, a manual-loop root cause, or a transport issue.
 
 - HF / host-staged / NCCL comparison: `all_token_text_exact`.
-- Token SHA256: `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225`.
-- Text SHA256: `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347`.
+- Token SHA256: `d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8`.
+- Text SHA256: `4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6`.
 - Host-staged attribution: `dispatch_calls=416`, `combine_calls=416`, `dispatch_elements=5111808`, `combine_elements=5111808`, `local_route_count=1284`, `remote_route_count=1212`.
 - NCCL attribution: `nccl_exchange_calls=416`, `nccl_combine_calls=416`, `nccl_exchange_elements=851968`, `nccl_combine_elements=851968`, `local_route_count=1284`, `remote_route_count=1212`.
 - GPU event timing: selected GPU/NCCL attribution sections are reported separately from CPU-side section timing; host-staged emitted `gpu_timing.sample_count=5056`, NCCL emitted `gpu_timing.sample_count=5888`, and both reported `gpu_timing.failure_count=0`.

--- a/docs/models/deepseek-v2-lite/hf-accuracy-gate.md
+++ b/docs/models/deepseek-v2-lite/hf-accuracy-gate.md
@@ -1,15 +1,15 @@
 # DeepSeek-V2-Lite EP2 HF Accuracy Gate
 
-> **TL;DR:** HF comparison gate for issue #135 after PR #149 and PR #150. The remaining correctness question was not NCCL performance; it was whether the existing DeepSeek-V2-Lite EP=2 baseline matches Hugging Face's real incremental greedy decode for `prompt="Hello"`, `batch=1`, `output_len=16`.
+> **TL;DR:** HF comparison gate for issue #135 after PR #149 and PR #150. The remaining correctness question was not NCCL performance; it was whether the existing DeepSeek-V2-Lite EP=2 baseline matches Hugging Face `generate(use_cache=true)` greedy decode for `prompt="Hello"`, `batch=1`, `output_len=16`.
 >
-> **Status:** Passing for the covered shape. The latest run is token-exact and text-exact across HF incremental greedy, pegainfer host-staged EP2, and pegainfer NCCL EP2.
+> **Status:** Passing for the covered shape. The latest run is token-exact and text-exact across HF `generate(use_cache=true)` greedy, pegainfer host-staged EP2, and pegainfer NCCL EP2.
 
 ## Scope
 
 In scope:
 
 - HF truth: `AutoTokenizer` and `AutoModelForCausalLM` with `trust_remote_code=True`, `torch_dtype=torch.bfloat16`, `model.eval()`, and `torch.no_grad()`.
-- Generation shape: batch `1`, prompt `Hello`, output length `16`, greedy argmax only.
+- Generation shape: batch `1`, prompt `Hello`, prompt token ids `[17464]`, output length `16`, greedy argmax only.
 - Pegainfer paths: default host-staged EP2 backend and explicit `PEGAINFER_DSV2_LITE_EP_BACKEND=nccl`.
 - Result comparison: generated token ids, generated text, token sha256, text sha256, and first different generated-token index.
 
@@ -30,7 +30,7 @@ Out of scope:
 | Unsupported backend/topology reports explicit errors. | PR #149 / #150 | Unsupported device count, duplicate devices, cuda_graph, and backend names fail closed. |
 | Minimal dispatch/combine path exists for the first correctness gate. | PR #149 | Host-staged dispatch/combine path remains the default baseline. |
 | Maintainer-requested naive NCCL backend exists before pegainfer-comm/NVLink work. | PR #150 | `PEGAINFER_DSV2_LITE_EP_BACKEND=nccl` path passes the same EP2 greedy E2E as host-staged. |
-| HF ground-truth accuracy comparison exists. | This gate | HF incremental greedy, host-staged EP2, and NCCL EP2 are token/text exact for the covered shape. |
+| HF ground-truth accuracy comparison exists. | This gate | HF `generate(use_cache=true)` greedy, host-staged EP2, and NCCL EP2 are token/text exact for the covered shape. |
 
 Together with PR #149 and PR #150, this gate covers issue #135's correctness-first acceptance surface for the narrow EP=2 milestone. Follow-up work should be tracked separately for sparse/GPU dispatch, pegainfer-comm/NVLink integration, performance evidence, long context, and broader prompts/batches.
 
@@ -76,13 +76,15 @@ On Blackwell-class GPUs, make sure the selected NCCL runtime supports the device
 
 ## Latest Evidence
 
-2026-05-21, single-node 2 GPU validation, same `models/DeepSeek-V2-Lite` snapshot:
+2026-05-26, single-node 2 GPU validation with the same `models/DeepSeek-V2-Lite` snapshot for all three outputs. The HF truth source used `AutoModelForCausalLM.generate(..., do_sample=false, use_cache=true)` with `torch==2.11.0+cu130` and `transformers==4.40.2`:
+
+The earlier 2026-05-21 hash is superseded because that record did not preserve enough HF/runtime provenance to reproduce the truth-source environment. Treat only the hash below as the active oracle. This refresh does not claim a model-runtime improvement, a manual-loop root cause, or a transport issue.
 
 | Source | Backend | Tokens | Token SHA256 | Text SHA256 | Text |
 | --- | --- | ---: | --- | --- | --- |
-| HF | incremental `past_key_values` | 16 | `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225` | `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347` | `, I am a 19 year old girl from the UK. I am` |
-| pegainfer | host-staged | 16 | `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225` | `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347` | `, I am a 19 year old girl from the UK. I am` |
-| pegainfer | NCCL | 16 | `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225` | `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347` | `, I am a 19 year old girl from the UK. I am` |
+| HF | `generate(use_cache=true)` | 16 | `d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8` | `4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6` | `, I am a 20 year old female and I have been having a` |
+| pegainfer | host-staged | 16 | `d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8` | `4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6` | `, I am a 20 year old female and I have been having a` |
+| pegainfer | NCCL | 16 | `d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8` | `4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6` | `, I am a 20 year old female and I have been having a` |
 
 Classification: `all_token_text_exact`.
 

--- a/pegainfer-deepseek-v2-lite/src/bin/dsv2_lite_ep2_decode_attribution.rs
+++ b/pegainfer-deepseek-v2-lite/src/bin/dsv2_lite_ep2_decode_attribution.rs
@@ -13,9 +13,9 @@ use vllm_text::tokenizer::{HuggingFaceTokenizer, Tokenizer};
 const PROMPT: &str = "Hello";
 const OUTPUT_LEN: usize = 16;
 const EXPECTED_OUTPUT_TOKEN_SHA256: &str =
-    "4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225";
+    "d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8";
 const EXPECTED_OUTPUT_TEXT_SHA256: &str =
-    "0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347";
+    "4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6";
 
 struct Cli {
     model_path: String,

--- a/pegainfer-deepseek-v2-lite/tests/e2e_ep2.rs
+++ b/pegainfer-deepseek-v2-lite/tests/e2e_ep2.rs
@@ -11,9 +11,9 @@ use vllm_text::tokenizer::{HuggingFaceTokenizer, Tokenizer};
 
 const EXPECTED_GENERATED_TOKENS: usize = 16;
 const EXPECTED_OUTPUT_TOKEN_SHA256: &str =
-    "4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225";
+    "d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8";
 const EXPECTED_OUTPUT_TEXT_SHA256: &str =
-    "0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347";
+    "4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6";
 const DSV2_LITE_HIDDEN_SIZE: usize = 2048;
 const DSV2_LITE_MOE_LAYERS: usize = 26;
 const E2E_JSON_OUT_ENV: &str = "PEGAINFER_DSV2_LITE_E2E_JSON_OUT";

--- a/tools/accuracy/compare_dsv2_lite_ep2_outputs.py
+++ b/tools/accuracy/compare_dsv2_lite_ep2_outputs.py
@@ -232,10 +232,15 @@ def context_warnings(hf: Output, host: Output, nccl: Output) -> list[str]:
     if len(output_lens) > 1:
         warnings.append(f"output length labels differ across outputs: {sorted(output_lens)!r}")
 
-    if hf.raw.get("generation_mode") not in (None, "incremental_past_key_values"):
+    hf_generation_mode = hf.raw.get("generation_mode")
+    if hf_generation_mode not in (
+        None,
+        "incremental_past_key_values",
+        "transformers_generate_use_cache",
+    ):
         warnings.append(
-            "HF output generation_mode is not incremental_past_key_values: "
-            f"{hf.raw.get('generation_mode')}"
+            "HF output generation_mode is not a recognized HF generation mode: "
+            f"{hf_generation_mode}"
         )
     if host.backend not in (None, "host-staged"):
         warnings.append(f"host-staged file reports backend {host.backend!r}")

--- a/tools/accuracy/hf_dump_dsv2_lite_ep2_greedy.py
+++ b/tools/accuracy/hf_dump_dsv2_lite_ep2_greedy.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Dump Hugging Face greedy incremental generation for DeepSeek-V2-Lite EP=2 comparisons."""
+"""Dump Hugging Face greedy generation for DeepSeek-V2-Lite EP=2 comparisons."""
 
 from __future__ import annotations
 
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 
 import torch
+import transformers.dynamic_module_utils as dynamic_module_utils
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 
@@ -22,6 +23,25 @@ def sha256_u32_le(values: list[int]) -> str:
 
 def sha256_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def allow_missing_optional_flash_attn() -> None:
+    # This is a standalone oracle-dump script; the process exits after loading the
+    # model, so keeping the compatibility patch installed is intentional.
+    original_check_imports = dynamic_module_utils.check_imports
+
+    def check_imports(filename: str, *args, **kwargs):
+        try:
+            return original_check_imports(filename, *args, **kwargs)
+        except ImportError as exc:
+            message = str(exc)
+            if getattr(exc, "name", None) == "flash_attn" or (
+                "requires the following packages" in message and "flash_attn" in message
+            ):
+                return dynamic_module_utils.get_relative_imports(filename)
+            raise
+
+    dynamic_module_utils.check_imports = check_imports
 
 
 def load_model(model_path: str, device_map: str, device: str):
@@ -42,7 +62,16 @@ def load_model(model_path: str, device_map: str, device: str):
     return model
 
 
-def generate_incremental(
+def first_parameter_device(model, fallback: str) -> str:
+    if hasattr(model, "device"):
+        return str(model.device)
+    try:
+        return str(next(model.parameters()).device)
+    except StopIteration:
+        return fallback
+
+
+def generate_with_transformers(
     model,
     tokenizer,
     prompt: str,
@@ -54,51 +83,23 @@ def generate_incremental(
     if not prompt_token_ids:
         raise RuntimeError("tokenizer returned empty prompt")
 
-    input_device = device
-    if device == "cuda" and hasattr(model, "device"):
-        input_device = str(model.device)
-    elif device == "cuda":
-        input_device = str(next(model.parameters()).device)
-
-    input_ids = torch.tensor([prompt_token_ids], dtype=torch.long, device=input_device)
-    attention_mask = torch.ones_like(input_ids)
-
-    generated_token_ids: list[int] = []
-    eos_token_id = tokenizer.eos_token_id
-    finish_reason = "length"
+    input_device = first_parameter_device(model, device) if device == "cuda" else device
+    inputs = tokenizer(prompt, return_tensors="pt", add_special_tokens=False).to(input_device)
+    generation_kwargs = {
+        "max_new_tokens": output_len,
+        "do_sample": False,
+        "use_cache": True,
+        "pad_token_id": tokenizer.eos_token_id,
+    }
+    if ignore_eos:
+        generation_kwargs["eos_token_id"] = None
 
     with torch.no_grad():
-        outputs = model(input_ids=input_ids, attention_mask=attention_mask, use_cache=True)
-        past_key_values = outputs.past_key_values
-        next_token = torch.argmax(outputs.logits[:, -1, :], dim=-1)
+        output_ids = model.generate(**inputs, **generation_kwargs)
 
-        for _ in range(output_len):
-            token_id = int(next_token.item())
-            generated_token_ids.append(token_id)
-            if not ignore_eos and eos_token_id is not None and token_id == eos_token_id:
-                finish_reason = "eos"
-                break
-            if len(generated_token_ids) >= output_len:
-                break
-
-            token_input = next_token.view(1, 1).to(input_device)
-            attention_mask = torch.cat(
-                [
-                    attention_mask,
-                    torch.ones((1, 1), dtype=attention_mask.dtype, device=input_device),
-                ],
-                dim=-1,
-            )
-            model_inputs = model.prepare_inputs_for_generation(
-                token_input,
-                past_key_values=past_key_values,
-                attention_mask=attention_mask,
-                use_cache=True,
-            )
-            outputs = model(**model_inputs)
-            past_key_values = outputs.past_key_values
-            next_token = torch.argmax(outputs.logits[:, -1, :], dim=-1)
-
+    input_len = inputs["input_ids"].shape[1]
+    generated_token_ids = output_ids[0, input_len:].tolist()
+    finish_reason = "length" if len(generated_token_ids) >= output_len else "eos"
     generated_text = tokenizer.decode(
         generated_token_ids,
         skip_special_tokens=False,
@@ -144,12 +145,13 @@ def main() -> int:
         print(f"error: model path {model_path} is not a directory", file=sys.stderr)
         return 1
 
+    allow_missing_optional_flash_attn()
     tokenizer = AutoTokenizer.from_pretrained(
         args.model_path,
         trust_remote_code=True,
     )
     model = load_model(args.model_path, args.device_map, args.device)
-    result = generate_incremental(
+    result = generate_with_transformers(
         model,
         tokenizer,
         args.prompt,
@@ -163,6 +165,9 @@ def main() -> int:
         "model_type": getattr(getattr(model, "config", None), "model_type", None),
         "torch_version": torch.__version__,
         "transformers_version": __import__("transformers").__version__,
+        "compat_patches": [
+            "dynamic_module_utils.check_imports ignores missing optional flash_attn import"
+        ],
         "device_map": args.device_map,
         "device": args.device,
         "dtype": "torch.bfloat16",
@@ -174,7 +179,13 @@ def main() -> int:
         "token_sha256": result["token_sha256"],
         "text_sha256": result["text_sha256"],
         "finish_reason": result["finish_reason"],
-        "generation_mode": "incremental_past_key_values",
+        "generation_mode": "transformers_generate_use_cache",
+        "generation": {
+            "do_sample": False,
+            "max_new_tokens": args.output_len,
+            "use_cache": True,
+            "ignore_eos": args.ignore_eos,
+        },
     }
     text = json.dumps(payload, indent=2, ensure_ascii=False)
 


### PR DESCRIPTION
## Summary

Refreshes the DeepSeek-V2-Lite EP2 accuracy oracle to a reproducible Hugging Face `AutoModelForCausalLM.generate(..., do_sample=false, use_cache=true)` greedy run. The covered shape stays fixed at `batch=1`, `prompt="Hello"`, prompt token ids `[17464]`, and `output_len=16`.

Refs #135.

## Scope

In scope:
- Use the official Transformers `generate(use_cache=true)` path for the HF oracle dump.
- Refresh the DeepSeek-V2-Lite EP2 E2E expected token/text hashes.
- Keep the decode attribution binary on the same token/text hash oracle.
- Let the comparison script recognize `generation_mode=transformers_generate_use_cache`.
- Update the HF accuracy and decode attribution docs to point at the active oracle.

Out of scope:
- Runtime communication changes.
- NCCL transport changes.
- Host-side combine changes.
- Performance optimization.
- Sparse dispatch.
- Real batching.
- Multi-node support.
- Broader prompt or batch coverage.

## Evidence

Local:
- `git diff --check`
- `cargo fmt --check`
- `python3 -m py_compile tools/accuracy/hf_dump_dsv2_lite_ep2_greedy.py tools/accuracy/compare_dsv2_lite_ep2_outputs.py`

2 GPU validation:
- HF / host-staged / NCCL comparison: `all_token_text_exact`
- comparison warnings: `[]`
- host-staged E2E: passed
- NCCL E2E: passed
- host-staged decode attribution: passed
- NCCL decode attribution: passed
- `cargo check --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite --all-targets`: passed
- `cargo test --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite --lib -- --nocapture`: passed

Refreshed oracle:
- generated token ids: `[11,304,608,245,207,17,15,1012,1712,11691,285,304,463,803,2497,245]`
- generated text: `", I am a 20 year old female and I have been having a"`
- token SHA256: `d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8`
- text SHA256: `4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6`

## Claim Boundary

This PR only refreshes and re-anchors the narrow DeepSeek-V2-Lite EP2 correctness oracle for the covered `Hello` / 16-token greedy shape. It does not claim better performance, lower TPOT, batching support, sparse dispatch, multi-node support, or production EP readiness.