### PR TITLE
feat(deepseek-v2-lite): add EP2 lockstep batch benchmark path

### DIFF
--- a/pegainfer-deepseek-v2-lite/src/lib.rs
+++ b/pegainfer-deepseek-v2-lite/src/lib.rs
@@ -18,7 +18,9 @@ pub use attribution::{CallSiteRollup, DecodeAttributionProfile, SectionRollup, S
 pub use config::Config;
 use config::SUPPORTED_HIDDEN_SIZE;
 use ep::SUPPORTED_ROUTED_EXPERTS;
-pub use runtime::{DeepSeekV2LiteEp2Generator, GenerationResult, GenerationStats};
+pub use runtime::{
+    BatchedGenerationResult, DeepSeekV2LiteEp2Generator, GenerationResult, GenerationStats,
+};
 
 pub fn probe_config_json(json: &serde_json::Value) -> Result<bool> {
     let Some(model_type) = json.get("model_type").and_then(serde_json::Value::as_str) else {

--- a/pegainfer-deepseek-v2-lite/src/runtime.rs
+++ b/pegainfer-deepseek-v2-lite/src/runtime.rs
@@ -1,7 +1,7 @@
 use std::{
     env,
     path::{Path, PathBuf},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use anyhow::{Context, Result, bail, ensure};
@@ -65,6 +65,14 @@ pub struct GenerationResult {
     pub tokens: Vec<u32>,
     pub finish_reason: FinishReason,
     pub stats: GenerationStats,
+}
+
+#[derive(Clone, Debug)]
+pub struct BatchedGenerationResult {
+    pub tokens: Vec<Vec<u32>>,
+    pub prefill_next_token_us: Vec<u64>,
+    pub per_token_decode_us: Vec<u64>,
+    pub total_generation_us: u64,
 }
 
 pub struct DeepSeekV2LiteEp2Generator {
@@ -233,6 +241,102 @@ impl DeepSeekV2LiteEp2Generator {
             &mut attribution,
         )?;
         Ok((result, attribution))
+    }
+
+    pub fn generate_greedy_batch_same_prompt_with_timings(
+        &mut self,
+        prompt_tokens: &[u32],
+        batch_size: usize,
+        max_new_tokens: usize,
+        ignore_eos: bool,
+    ) -> Result<BatchedGenerationResult> {
+        ensure!(!prompt_tokens.is_empty(), "prompt_tokens must not be empty");
+        ensure!(batch_size > 0, "batch_size must be positive");
+        ensure!(
+            batch_size <= 8,
+            "DeepSeek-V2-Lite batched decode benchmark supports batch_size <= 8, got {batch_size}"
+        );
+        ensure!(max_new_tokens > 0, "max_new_tokens must be positive");
+        ensure!(
+            ignore_eos,
+            "DeepSeek-V2-Lite batched decode benchmark requires ignore_eos=true so every row has the same output length"
+        );
+
+        let requested_context = prompt_tokens.len() + max_new_tokens;
+        let supported_context = self.config.supported_plain_rope_context();
+        ensure!(
+            requested_context <= supported_context,
+            "DeepSeek-V2-Lite EP=2 first gate supports plain RoPE context <= {supported_context} tokens; requested prompt_tokens={} max_new_tokens={} total={requested_context}. YaRN rope_scaling long context is not implemented yet.",
+            prompt_tokens.len(),
+            max_new_tokens
+        );
+
+        let generation_start = Instant::now();
+        let mut attribution = DecodeAttributionProfile::disabled();
+        let mut stats = GenerationStats {
+            model_path: self.model_path.clone(),
+            device_ordinals: self.device_ordinals.clone(),
+            ep_backend: self.backend.kind().as_str().to_string(),
+            ep_size: 2,
+            prompt_tokens: prompt_tokens.len() * batch_size,
+            ..GenerationStats::default()
+        };
+        let mut caches: Vec<_> = (0..batch_size)
+            .map(|_| DecodeCache::new(&self.config))
+            .collect();
+        let mut generated = vec![Vec::with_capacity(max_new_tokens); batch_size];
+        let mut prefill_next_token_us = Vec::with_capacity(batch_size);
+
+        for row in 0..batch_size {
+            let next = self.prefill_next_token(
+                prompt_tokens,
+                &mut caches[row],
+                &mut stats,
+                &mut attribution,
+            )?;
+            prefill_next_token_us.push(duration_micros(generation_start.elapsed()));
+            generated[row].push(next);
+        }
+
+        let mut per_token_decode_us = Vec::with_capacity(max_new_tokens.saturating_sub(1));
+        for token_index in 1..max_new_tokens {
+            let input_tokens: Vec<_> = generated
+                .iter()
+                .map(|tokens| {
+                    *tokens
+                        .last()
+                        .expect("batched decode rows are seeded by prefill")
+                })
+                .collect();
+            let position = prompt_tokens.len() + token_index - 1;
+            let decode_start = Instant::now();
+            // This is a correctness-first lockstep batch benchmark path. All
+            // rows advance under one batch decode step/timing sample, while the
+            // row forward reuses the already-gated single-row EP2 oracle until a
+            // fused batched DSV2-Lite forward has its own accuracy gate.
+            let mut next_tokens = Vec::with_capacity(batch_size);
+            for row in 0..batch_size {
+                next_tokens.push(self.decode_next_token(
+                    input_tokens[row],
+                    position,
+                    &mut caches[row],
+                    &mut stats,
+                    &mut attribution,
+                    token_index,
+                )?);
+            }
+            per_token_decode_us.push(duration_micros(decode_start.elapsed()));
+            for (row, token) in next_tokens.into_iter().enumerate() {
+                generated[row].push(token);
+            }
+        }
+
+        Ok(BatchedGenerationResult {
+            tokens: generated,
+            prefill_next_token_us,
+            per_token_decode_us,
+            total_generation_us: duration_micros(generation_start.elapsed()),
+        })
     }
 
     fn generate_greedy_inner(
@@ -968,6 +1072,10 @@ fn token_sha256(tokens: &[u32]) -> String {
         hasher.update(token.to_le_bytes());
     }
     hex::encode(hasher.finalize())
+}
+
+fn duration_micros(duration: Duration) -> u64 {
+    duration.as_micros().min(u128::from(u64::MAX)) as u64
 }
 
 fn append_generated_token(

--- a/pegainfer-server/src/bin/bench_serving.rs
+++ b/pegainfer-server/src/bin/bench_serving.rs
@@ -853,6 +853,8 @@ struct GenTimings {
     total: Duration,
     emitted_tokens: usize,
     generated_tokens: Vec<u32>,
+    decode_tokens_for_rate: usize,
+    decode_time_for_rate: Duration,
 }
 
 trait BenchModel {
@@ -910,12 +912,16 @@ where
 
     let total = start.elapsed();
     let ttft = first_at.map_or(total, |t| t - start);
+    let decode_tokens_for_rate = emitted_tokens.saturating_sub(1);
+    let decode_time_for_rate = tbt.iter().copied().sum();
     GenTimings {
         ttft,
         tbt,
         total,
         emitted_tokens,
         generated_tokens,
+        decode_tokens_for_rate,
+        decode_time_for_rate,
     }
 }
 
@@ -1050,9 +1056,8 @@ struct DeepSeekV2LiteBenchModel {
 impl BenchModel for DeepSeekV2LiteBenchModel {
     fn validate_concurrency(&self, concurrency: usize) -> Result<()> {
         ensure!(
-            concurrency == 1,
-            "DeepSeek-V2-Lite direct attribution benchmark supports --concurrency 1 only; \
-             the current EP2 first gate does not expose a true batched serving path"
+            concurrency > 0 && concurrency <= 8,
+            "DeepSeek-V2-Lite direct benchmark supports --concurrency 1..=8 through the narrow same-prompt lockstep batch path, got {concurrency}"
         );
         Ok(())
     }
@@ -1076,6 +1081,31 @@ impl BenchModel for DeepSeekV2LiteBenchModel {
             attribution.prefill_next_token_us(),
             attribution.per_token_decode_us(),
         )
+    }
+
+    fn timed_generation_batch(
+        &mut self,
+        prompt_tokens: &[u32],
+        max_new_tokens: usize,
+        sampling: &SamplingParams,
+        _rng: &mut StdRng,
+        concurrency: usize,
+    ) -> Vec<GenTimings> {
+        assert_dsv2_lite_sampling_contract(sampling);
+        if concurrency == 1 {
+            return vec![self.timed_generation(prompt_tokens, max_new_tokens, sampling, _rng)];
+        }
+
+        let result = self
+            .generator
+            .generate_greedy_batch_same_prompt_with_timings(
+                prompt_tokens,
+                concurrency,
+                max_new_tokens,
+                sampling.ignore_eos,
+            )
+            .expect("DeepSeek-V2-Lite batched generation failed");
+        timings_from_dsv2_lite_batched_generation(result, max_new_tokens)
     }
 }
 
@@ -1135,16 +1165,95 @@ fn timings_from_dsv2_lite_attribution(
             "DeepSeek-V2-Lite decode timing contains a zero-duration sample; refusing to report TPOT"
         );
     }
+    let tbt: Vec<_> = per_token_decode_us
+        .iter()
+        .map(|us| Duration::from_micros(*us))
+        .collect();
+    let decode_time_for_rate = tbt.iter().copied().sum();
     GenTimings {
         ttft: Duration::from_micros(prefill_next_token_us.unwrap_or(total_generation_us)),
-        tbt: per_token_decode_us
-            .iter()
-            .map(|us| Duration::from_micros(*us))
-            .collect(),
+        tbt,
         total: Duration::from_micros(total_generation_us),
         emitted_tokens,
         generated_tokens: generated_token_ids,
+        decode_tokens_for_rate: emitted_tokens.saturating_sub(1),
+        decode_time_for_rate,
     }
+}
+
+#[cfg(feature = "deepseek-v2-lite")]
+fn timings_from_dsv2_lite_batched_generation(
+    result: pegainfer_deepseek_v2_lite::BatchedGenerationResult,
+    expected_generated_tokens: usize,
+) -> Vec<GenTimings> {
+    let batch_size = result.tokens.len();
+    assert!(
+        batch_size > 0,
+        "DeepSeek-V2-Lite batch result must contain at least one row"
+    );
+    assert_eq!(
+        result.prefill_next_token_us.len(),
+        batch_size,
+        "DeepSeek-V2-Lite batch result TTFT count mismatch"
+    );
+    assert!(
+        result.total_generation_us > 0,
+        "DeepSeek-V2-Lite batch total generation timing is zero; refusing to report TPOT"
+    );
+    assert!(
+        result.prefill_next_token_us.iter().all(|us| *us > 0),
+        "DeepSeek-V2-Lite batch TTFT timing contains a zero-duration sample; refusing to report TPOT"
+    );
+    let expected_decode_steps = expected_generated_tokens.saturating_sub(1);
+    assert_eq!(
+        result.per_token_decode_us.len(),
+        expected_decode_steps,
+        "DeepSeek-V2-Lite batch timing count mismatch: got {} decode samples for {} generated tokens",
+        result.per_token_decode_us.len(),
+        expected_generated_tokens
+    );
+    if expected_decode_steps > 0 {
+        assert!(
+            result.per_token_decode_us.iter().all(|us| *us > 0),
+            "DeepSeek-V2-Lite batch decode timing contains a zero-duration sample; refusing to report TPOT"
+        );
+    }
+
+    let tbt: Vec<_> = result
+        .per_token_decode_us
+        .iter()
+        .map(|us| Duration::from_micros(*us))
+        .collect();
+    let decode_time_for_rate: Duration = tbt.iter().copied().sum();
+    let decode_tokens_for_rate = batch_size * expected_decode_steps;
+
+    result
+        .tokens
+        .into_iter()
+        .zip(result.prefill_next_token_us)
+        .enumerate()
+        .map(|(idx, (generated_token_ids, prefill_us))| {
+            let emitted_tokens = generated_token_ids.len();
+            assert_eq!(
+                emitted_tokens, expected_generated_tokens,
+                "DeepSeek-V2-Lite batch row {idx} generated token count mismatch: got {} tokens for requested output_len={}",
+                emitted_tokens, expected_generated_tokens
+            );
+            GenTimings {
+                ttft: Duration::from_micros(prefill_us),
+                tbt: tbt.clone(),
+                total: Duration::from_micros(result.total_generation_us),
+                emitted_tokens,
+                generated_tokens: generated_token_ids,
+                decode_tokens_for_rate: if idx == 0 { decode_tokens_for_rate } else { 0 },
+                decode_time_for_rate: if idx == 0 {
+                    decode_time_for_rate
+                } else {
+                    Duration::ZERO
+                },
+            }
+        })
+        .collect()
 }
 
 fn command_seed(cli: &Cli) -> u64 {
@@ -1243,11 +1352,8 @@ fn build_request_metrics(timings: &[GenTimings]) -> RequestMetrics {
 
     let total_emitted: usize = timings.iter().map(|t| t.emitted_tokens).sum();
     let total_request_time: Duration = timings.iter().map(|t| t.total).sum();
-    let total_decode_steps: usize = timings
-        .iter()
-        .map(|t| t.emitted_tokens.saturating_sub(1))
-        .sum();
-    let total_decode_time: Duration = timings.iter().flat_map(|t| t.tbt.iter()).copied().sum();
+    let total_decode_steps: usize = timings.iter().map(|t| t.decode_tokens_for_rate).sum();
+    let total_decode_time: Duration = timings.iter().map(|t| t.decode_time_for_rate).sum();
 
     RequestMetrics {
         ttft_ms: summarize_durations(&ttfts),
@@ -2112,6 +2218,37 @@ mod tests {
         assert_eq!(timings.total, Duration::from_micros(60_000));
         assert_eq!(timings.emitted_tokens, 3);
         assert_eq!(timings.generated_tokens, vec![11, 304, 608]);
+        assert_eq!(timings.decode_tokens_for_rate, 2);
+        assert_eq!(timings.decode_time_for_rate, Duration::from_micros(37_000));
+    }
+
+    #[test]
+    fn dsv2_lite_batched_timings_use_shared_decode_time_for_rate() {
+        let timings = timings_from_dsv2_lite_batched_generation(
+            pegainfer_deepseek_v2_lite::BatchedGenerationResult {
+                tokens: vec![vec![11, 304, 608], vec![11, 304, 608]],
+                prefill_next_token_us: vec![20_000, 21_000],
+                per_token_decode_us: vec![19_000, 18_000],
+                total_generation_us: 80_000,
+            },
+            3,
+        );
+
+        assert_eq!(timings.len(), 2);
+        assert_eq!(timings[0].decode_tokens_for_rate, 4);
+        assert_eq!(
+            timings[0].decode_time_for_rate,
+            Duration::from_micros(37_000)
+        );
+        assert_eq!(timings[1].decode_tokens_for_rate, 0);
+        assert_eq!(timings[1].decode_time_for_rate, Duration::ZERO);
+
+        let metrics = build_request_metrics(&timings);
+        assert_eq!(metrics.steady_tpot_ms.unwrap().p50_ms, 18.0);
+        assert!(
+            metrics.decode_tok_s.unwrap() > 100.0,
+            "batched decode tok/s should use one shared step duration instead of duplicating it per row"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

Refs #170.

This PR adds a narrow DeepSeek-V2-Lite EP2 benchmark path so `bench_serving request` can report non-bogus PegaInfer TPOT at `--concurrency 1`, `4`, and `8`.

The path is intentionally correctness-first and benchmark-only:

- same prompt for all rows;
- fixed output length via `ignore_eos=true`;
- independent per-row `DecodeCache`;
- prefill remains row-by-row;
- decode advances rows in lockstep, while each row still reuses the existing single-row EP2 greedy oracle;
- no runtime communication path change for either host-staged or NCCL EP2.

It also fixes aggregate decode-rate accounting for the batch path: one lockstep decode step produces `batch_size` decode tokens but only consumes one shared step duration.

## Scope

In scope:

- Add `generate_greedy_batch_same_prompt_with_timings` for DeepSeek-V2-Lite EP2.
- Allow DeepSeek-V2-Lite direct `bench_serving request --concurrency 1..=8`.
- Fail closed if batch timing/token counts are malformed.
- Preserve token-trace evidence in the benchmark output.
- Add unit coverage for shared decode-time rate accounting.

Out of scope:

- Fused batched forward.
- Continuous batching.
- Sparse dispatch.
- Runtime communication path changes.
- NCCL performance optimization.
- A production EP backend claim.

## Comparison Data

Measured on `2x NVIDIA A800-SXM4-80GB`, DeepSeek-V2-Lite, prompt `Hello`, input length `1`, output length `16`, greedy.

Notes:

- vLLM rows are reference measurements collected on the same machine and model snapshot for #170.
- PegaInfer rows were rerun after this PR's benchmark-path change.
- vLLM was measured with `vllm bench latency`; TPOT is reported as `latency / output_len` proxy.
- vLLM modes:
  - `tp2-ep2`: `tensor_parallel_size=2`, `enable_expert_parallel=true`
  - `tp2`: `tensor_parallel_size=2`, `enable_expert_parallel=false`
- PegaInfer was measured with this PR's `bench_serving request` path.
- vLLM output is treated as performance reference only; HF/PegaInfer token exactness remains covered by the existing HF oracle and EP2 E2E gate.

| engine | mode/backend | batch | TPOT p50 ms | TPOT avg ms | generated/decode tok/s | token trace | gap vs vLLM TP2+EP2 p50 | gap vs vLLM TP2 p50 |
| --- | --- | ---: | ---: | ---: | ---: | --- | ---: | ---: |
| vLLM | tp2-ep2 | 1 | 10.792 | 10.755 | 92.981 | n/a | 1.00x | - |
| vLLM | tp2 | 1 | 10.557 | 10.570 | 94.604 | n/a | - | 1.00x |
| PegaInfer | host-staged | 1 | 66.562 | 66.983 | 14.759 | exact `0c114cabaea56600` | 6.17x | 6.31x |
| PegaInfer | NCCL | 1 | 550.654 | 567.178 | 1.765 | exact `0c114cabaea56600` | 51.03x | 52.16x |
| vLLM | tp2-ep2 | 4 | 12.250 | 12.305 | 325.062 | n/a | 1.00x | - |
| vLLM | tp2 | 4 | 11.049 | 11.085 | 360.846 | n/a | - | 1.00x |
| PegaInfer | host-staged | 4 | 253.791 | 252.194 | 15.083 | exact `0c114cabaea56600` | 20.72x | 22.97x |
| PegaInfer | NCCL | 4 | 2230.098 | 2244.654 | 1.783 | exact `0c114cabaea56600` | 182.05x | 201.83x |
| vLLM | tp2-ep2 | 8 | 11.670 | 11.692 | 684.223 | n/a | 1.00x | - |
| vLLM | tp2 | 8 | 12.006 | 12.134 | 659.304 | n/a | - | 1.00x |
| PegaInfer | host-staged | 8 | 505.695 | 509.547 | 15.722 | exact `0c114cabaea56600` | 43.33x | 42.12x |
| PegaInfer | NCCL | 8 | 4284.003 | 4321.610 | 1.847 | exact `0c114cabaea56600` | 367.10x | 356.81x |

PegaInfer generated token prefix for all host-staged/NCCL rows:

```text
[11, 304, 608, 245, 207, 17, 15, 1012, 1712, 11691, 285, 304, 463, 803, 2497, 245]
```

## Evidence

Local:

- `cargo fmt --check` passed.
- `git diff --check` passed.

Remote 2-GPU validation:

- `cargo fmt --check` passed.
- `cargo check --release -p pegainfer-comm` passed.
- `cargo check --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite` passed.
- `cargo check --release -p pegainfer-server --features deepseek-v2-lite` passed.
- `cargo test --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite --lib -- --nocapture` passed: 20 tests.
- `cargo test --release -p pegainfer-server --features deepseek-v2-lite --bin bench_serving dsv2_lite -- --nocapture` passed: 11 tests.
- Host-staged EP2 E2E passed.
- NCCL EP2 E2E passed.

EP2 E2E token/text hashes:

- token sha256: `d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8`
- text sha256: `4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6`

## Claim Boundary

This PR makes the current PegaInfer DeepSeek-V2-Lite EP2 direct benchmark measurable at batch/concurrency `1`, `4`, and `8`, and reports the current gap against vLLM for the same small benchmark shape.

It does not claim a performance improvement, fused batching, continuous batching, or production EP readiness.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project (see `docs/areas/coding-style.md`).
- [x] I have performed a self-review of my own code.
- [x] I have formatted my commits according to Commitizen conventions.
- [x] I have run the local test suite and all tests pass (see `CLAUDE.md`).
