### PR TITLE
feat(qwen3): add single-adapter LoRA inference mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3665,6 +3665,7 @@ dependencies = [
  "pegainfer-kernels",
  "pegainfer-vllm-support",
  "rand 0.10.1",
+ "safetensors",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3740,6 +3740,7 @@ name = "pegainfer-vllm-frontend"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "axum",
  "log",
  "pegainfer-engine",
  "rmp-serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3744,6 +3744,7 @@ dependencies = [
  "axum",
  "log",
  "pegainfer-engine",
+ "reqwest",
  "rmp-serde",
  "rmpv",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "json"] }
 rmp-serde = "1.3"
 rmpv = "1.3"
+reqwest = { version = "0.12", default-features = false, features = ["stream"] }
 safetensors = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.149"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
 
 [workspace.dependencies]
 anyhow = "1.0"
+axum = "0.8"
 bincode = "2.0.1"
 bindgen = "0.72.1"
 bytes = { version = "1.10.1", features = ["serde"] }

--- a/pegainfer-core/src/ops.rs
+++ b/pegainfer-core/src/ops.rs
@@ -18,7 +18,8 @@ pub use pegainfer_kernels::ops::{
     add_batch, add_batch_into, embedding_decode_into, extract_vec, extract_vec_into,
     fused_add_rms_norm_into, gemm, gemv, linear, qk_norm_partial_rope_batched_decode_hd256_into,
     rms_norm, rms_norm_batch_offset_into, rms_norm_gated_batch_into, rms_norm_into,
-    rms_norm_offset_into, silu_mul_batch, silu_mul_batch_into, write_vec_into,
+    rms_norm_offset_into, scaled_add_batch_into, scaled_add_rows_into, silu_mul_batch,
+    silu_mul_batch_into, write_vec_into,
 };
 #[cfg(not(feature = "kernel-call-trace"))]
 pub use pegainfer_kernels::ops::{

--- a/pegainfer-engine/Cargo.toml
+++ b/pegainfer-engine/Cargo.toml
@@ -6,5 +6,8 @@ edition = "2024"
 [dependencies]
 tokio = { workspace = true, features = ["sync"] }
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }
+
 [lints]
 workspace = true

--- a/pegainfer-engine/src/engine.rs
+++ b/pegainfer-engine/src/engine.rs
@@ -1,10 +1,12 @@
 use std::{
+    error::Error,
+    fmt,
     path::PathBuf,
     sync::Arc,
     thread::{self, JoinHandle},
 };
 
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::sampler::SamplingParams;
 
@@ -59,6 +61,47 @@ pub struct GenerateRequest {
     pub echo: bool,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LoadLoraAdapterRequest {
+    pub lora_name: String,
+    pub lora_path: PathBuf,
+}
+
+pub enum EngineControlRequest {
+    LoadLoraAdapter {
+        request: LoadLoraAdapterRequest,
+        response_tx: oneshot::Sender<std::result::Result<(), String>>,
+    },
+}
+
+pub enum EngineCommand {
+    Generate(GenerateRequest),
+    Control(EngineControlRequest),
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum EngineControlError {
+    Unsupported(&'static str),
+    ChannelClosed,
+    OperationFailed(String),
+}
+
+impl fmt::Display for EngineControlError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unsupported(message) => f.write_str(message),
+            Self::ChannelClosed => f.write_str("engine control channel closed"),
+            Self::OperationFailed(message) => {
+                write!(f, "engine control operation failed: {message}")
+            }
+        }
+    }
+}
+
+impl Error for EngineControlError {}
+
+pub type EngineControlResult<T> = std::result::Result<T, EngineControlError>;
+
 pub enum TokenEvent {
     Scheduled {
         queued_at_unix_s: f64,
@@ -97,12 +140,24 @@ pub struct EngineHandle {
 
 struct EngineInner {
     submit_tx: Option<mpsc::UnboundedSender<GenerateRequest>>,
+    command_tx: Option<mpsc::UnboundedSender<EngineCommand>>,
     join_handle: Option<JoinHandle<()>>,
 }
 
 impl EngineHandle {
     pub fn new(submit_tx: mpsc::UnboundedSender<GenerateRequest>) -> Self {
-        Self::from_parts(submit_tx, None)
+        Self::from_parts(Some(submit_tx), None, None)
+    }
+
+    pub fn new_with_command_channel(command_tx: mpsc::UnboundedSender<EngineCommand>) -> Self {
+        Self::from_parts(None, Some(command_tx), None)
+    }
+
+    pub fn new_with_command_channel_and_join_handle(
+        command_tx: mpsc::UnboundedSender<EngineCommand>,
+        join_handle: JoinHandle<()>,
+    ) -> Self {
+        Self::from_parts(None, Some(command_tx), Some(join_handle))
     }
 
     /// Construct a handle that owns the engine thread shutdown.
@@ -114,16 +169,18 @@ impl EngineHandle {
         submit_tx: mpsc::UnboundedSender<GenerateRequest>,
         join_handle: JoinHandle<()>,
     ) -> Self {
-        Self::from_parts(submit_tx, Some(join_handle))
+        Self::from_parts(Some(submit_tx), None, Some(join_handle))
     }
 
     fn from_parts(
-        submit_tx: mpsc::UnboundedSender<GenerateRequest>,
+        submit_tx: Option<mpsc::UnboundedSender<GenerateRequest>>,
+        command_tx: Option<mpsc::UnboundedSender<EngineCommand>>,
         join_handle: Option<JoinHandle<()>>,
     ) -> Self {
         Self {
             inner: Arc::new(EngineInner {
-                submit_tx: Some(submit_tx),
+                submit_tx,
+                command_tx,
                 join_handle,
             }),
         }
@@ -135,7 +192,46 @@ impl EngineHandle {
     ) -> std::result::Result<(), mpsc::error::SendError<GenerateRequest>> {
         match self.inner.submit_tx.as_ref() {
             Some(submit_tx) => submit_tx.send(req),
-            None => Err(mpsc::error::SendError(req)),
+            None => match self.inner.command_tx.as_ref() {
+                Some(command_tx) => command_tx
+                    .send(EngineCommand::Generate(req))
+                    .map_err(|err| match err.0 {
+                        EngineCommand::Generate(req) => mpsc::error::SendError(req),
+                        EngineCommand::Control(_) => unreachable!("submitted generate command"),
+                    }),
+                None => Err(mpsc::error::SendError(req)),
+            },
+        }
+    }
+
+    pub fn supports_lora_control(&self) -> bool {
+        self.inner.command_tx.is_some()
+    }
+
+    pub async fn load_lora_adapter(
+        &self,
+        request: LoadLoraAdapterRequest,
+    ) -> EngineControlResult<()> {
+        match self.inner.command_tx.as_ref() {
+            Some(command_tx) => {
+                let (response_tx, response_rx) = oneshot::channel();
+                command_tx
+                    .send(EngineCommand::Control(
+                        EngineControlRequest::LoadLoraAdapter {
+                            request,
+                            response_tx,
+                        },
+                    ))
+                    .map_err(|_| EngineControlError::ChannelClosed)?;
+
+                response_rx
+                    .await
+                    .map_err(|_| EngineControlError::ChannelClosed)?
+                    .map_err(EngineControlError::OperationFailed)
+            }
+            None => Err(EngineControlError::Unsupported(
+                "engine does not support dynamic LoRA adapter loading",
+            )),
         }
     }
 }
@@ -143,6 +239,7 @@ impl EngineHandle {
 impl Drop for EngineInner {
     fn drop(&mut self) {
         let _ = self.submit_tx.take();
+        let _ = self.command_tx.take();
         if let Some(join_handle) = self.join_handle.take() {
             if join_handle.thread().id() != thread::current().id() {
                 let _ = join_handle.join();
@@ -177,5 +274,63 @@ mod tests {
 
         drop(clone);
         assert!(exited.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn lora_control_support_is_opt_in() {
+        let (submit_tx, _submit_rx) = mpsc::unbounded_channel::<GenerateRequest>();
+        let handle = EngineHandle::new(submit_tx);
+        assert!(!handle.supports_lora_control());
+
+        let (command_tx, _command_rx) = mpsc::unbounded_channel::<EngineCommand>();
+        let handle = EngineHandle::new_with_command_channel(command_tx);
+        assert!(handle.supports_lora_control());
+    }
+
+    #[tokio::test]
+    async fn load_lora_adapter_sends_control_command() {
+        let (command_tx, mut command_rx) = mpsc::unbounded_channel::<EngineCommand>();
+        let handle = EngineHandle::new_with_command_channel(command_tx);
+
+        let request = LoadLoraAdapterRequest {
+            lora_name: "adapter-a".to_string(),
+            lora_path: PathBuf::from("/tmp/adapter-a"),
+        };
+        let load = tokio::spawn({
+            let handle = handle.clone();
+            let request = request.clone();
+            async move { handle.load_lora_adapter(request).await }
+        });
+
+        let command = command_rx.recv().await.expect("control command");
+        match command {
+            EngineCommand::Control(EngineControlRequest::LoadLoraAdapter {
+                request: actual,
+                response_tx,
+            }) => {
+                assert_eq!(actual, request);
+                response_tx.send(Ok(())).expect("send load result");
+            }
+            EngineCommand::Generate(_) => panic!("expected LoRA control command"),
+        }
+
+        load.await.expect("join load task").expect("load succeeded");
+    }
+
+    #[tokio::test]
+    async fn load_lora_adapter_reports_unsupported_without_control() {
+        let (submit_tx, _submit_rx) = mpsc::unbounded_channel::<GenerateRequest>();
+        let handle = EngineHandle::new(submit_tx);
+        let error = handle
+            .load_lora_adapter(LoadLoraAdapterRequest {
+                lora_name: "adapter-a".to_string(),
+                lora_path: PathBuf::from("/tmp/adapter-a"),
+            })
+            .await
+            .expect_err("control should be unsupported");
+        assert_eq!(
+            error,
+            EngineControlError::Unsupported("engine does not support dynamic LoRA adapter loading")
+        );
     }
 }

--- a/pegainfer-kernels/csrc/elementwise.cu
+++ b/pegainfer-kernels/csrc/elementwise.cu
@@ -27,16 +27,18 @@ __global__ void scaled_add_rows_kernel(
     int row_offset,
     int rows,
     int seq_len) {
-  int total = rows * seq_len;
-  for (int idx = blockIdx.x * blockDim.x + threadIdx.x;
-       idx < total;
-       idx += gridDim.x * blockDim.x) {
-    int token = idx / rows;
-    int row = idx - token * rows;
-    int out_idx = token * out_hidden_dim + row_offset + row;
-    float base = __bfloat162float(out[out_idx]);
-    float add = __bfloat162float(delta[idx]) * scale;
-    out[out_idx] = __float2bfloat16(base + add);
+  for (int token = blockIdx.y * blockDim.y + threadIdx.y;
+       token < seq_len;
+       token += gridDim.y * blockDim.y) {
+    for (int row = blockIdx.x * blockDim.x + threadIdx.x;
+         row < rows;
+         row += gridDim.x * blockDim.x) {
+      int delta_idx = token * rows + row;
+      int out_idx = token * out_hidden_dim + row_offset + row;
+      float base = __bfloat162float(out[out_idx]);
+      float add = __bfloat162float(delta[delta_idx]) * scale;
+      out[out_idx] = __float2bfloat16(base + add);
+    }
   }
 }
 
@@ -204,9 +206,12 @@ CUresult scaled_add_rows_cuda(
       row_offset + rows > out_hidden_dim) {
     return CUDA_ERROR_INVALID_VALUE;
   }
-  int total = rows * seq_len;
-  int block = 256;
-  int grid = (total + block - 1) / block;
+  dim3 block(32, 8);
+  int grid_x = (rows + block.x - 1) / block.x;
+  int grid_y = (seq_len + block.y - 1) / block.y;
+  grid_x = grid_x > 65535 ? 65535 : grid_x;
+  grid_y = grid_y > 65535 ? 65535 : grid_y;
+  dim3 grid(grid_x, grid_y);
   scaled_add_rows_kernel<<<grid, block, 0, stream>>>(
       delta, scale, out, out_hidden_dim, row_offset, rows, seq_len);
   return (CUresult)cudaGetLastError();

--- a/pegainfer-kernels/csrc/elementwise.cu
+++ b/pegainfer-kernels/csrc/elementwise.cu
@@ -19,6 +19,27 @@ __global__ void add_kernel(
   }
 }
 
+__global__ void scaled_add_rows_kernel(
+    const __nv_bfloat16 *__restrict__ delta,
+    float scale,
+    __nv_bfloat16 *__restrict__ out,
+    int out_hidden_dim,
+    int row_offset,
+    int rows,
+    int seq_len) {
+  int total = rows * seq_len;
+  for (int idx = blockIdx.x * blockDim.x + threadIdx.x;
+       idx < total;
+       idx += gridDim.x * blockDim.x) {
+    int token = idx / rows;
+    int row = idx - token * rows;
+    int out_idx = token * out_hidden_dim + row_offset + row;
+    float base = __bfloat162float(out[out_idx]);
+    float add = __bfloat162float(delta[idx]) * scale;
+    out[out_idx] = __float2bfloat16(base + add);
+  }
+}
+
 // ============================================================================
 // Type conversion helpers for deterministic decode collectives.
 // ============================================================================
@@ -166,6 +187,28 @@ CUresult add_cuda(
   int block = 256;
   int grid = (n + block - 1) / block;
   add_kernel<<<grid, block, 0, stream>>>(a, b, out, n);
+  return (CUresult)cudaGetLastError();
+}
+
+CUresult scaled_add_rows_cuda(
+    const __nv_bfloat16 *delta,
+    float scale,
+    __nv_bfloat16 *out,
+    int out_hidden_dim,
+    int row_offset,
+    int rows,
+    int seq_len,
+    cudaStream_t stream) {
+  if (delta == nullptr || out == nullptr || out_hidden_dim <= 0 ||
+      row_offset < 0 || rows <= 0 || seq_len <= 0 ||
+      row_offset + rows > out_hidden_dim) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  int total = rows * seq_len;
+  int block = 256;
+  int grid = (total + block - 1) / block;
+  scaled_add_rows_kernel<<<grid, block, 0, stream>>>(
+      delta, scale, out, out_hidden_dim, row_offset, rows, seq_len);
   return (CUresult)cudaGetLastError();
 }
 

--- a/pegainfer-kernels/src/ffi.rs
+++ b/pegainfer-kernels/src/ffi.rs
@@ -46,6 +46,17 @@ unsafe extern "C" {
         stream: CUstream,
     ) -> CUresult;
 
+    pub fn scaled_add_rows_cuda(
+        delta: *const Half,
+        scale: f32,
+        out: *mut Half,
+        out_hidden_dim: i32,
+        row_offset: i32,
+        rows: i32,
+        seq_len: i32,
+        stream: CUstream,
+    ) -> CUresult;
+
     pub fn bf16_to_f32_cuda(
         input: *const Half,
         output: *mut f32,

--- a/pegainfer-kernels/src/ops.rs
+++ b/pegainfer-kernels/src/ops.rs
@@ -17,7 +17,8 @@ pub use attention::{
 pub use elementwise::{
     add_batch, add_batch_into, bf16_hidden_to_f32_into, extract_vec, extract_vec_into,
     f32_to_bf16_hidden_into, repeat_f32_for_reduce_scatter_into, scale_f32_in_place,
-    silu_mul_batch, silu_mul_batch_into, silu_mul_fused_batch_into, write_vec_into,
+    scaled_add_batch_into, scaled_add_rows_into, silu_mul_batch, silu_mul_batch_into,
+    silu_mul_fused_batch_into, write_vec_into,
 };
 pub use embedding::{embedding_batch, embedding_batch_vocab_shard, embedding_decode_into};
 #[cfg(feature = "kimi-k2")]

--- a/pegainfer-kernels/src/ops/elementwise.rs
+++ b/pegainfer-kernels/src/ops/elementwise.rs
@@ -42,6 +42,61 @@ pub fn add_batch_into(
     Ok(())
 }
 
+/// In-place scaled add into a row range of `out`: out[row_offset..] += scale * delta.
+pub fn scaled_add_rows_into(
+    ctx: &DeviceContext,
+    delta: &HiddenStates,
+    scale: f32,
+    out: &mut HiddenStates,
+    row_offset: usize,
+) -> Result<()> {
+    assert!(
+        scale.is_finite(),
+        "scaled_add_rows_into scale must be finite"
+    );
+    assert_eq!(
+        delta.seq_len, out.seq_len,
+        "delta seq_len {} != out seq_len {}",
+        delta.seq_len, out.seq_len
+    );
+    assert!(
+        row_offset + delta.hidden_dim <= out.hidden_dim,
+        "row range [{}..{}) exceeds out hidden_dim {}",
+        row_offset,
+        row_offset + delta.hidden_dim,
+        out.hidden_dim
+    );
+
+    let (delta_ptr, _gd) = delta.data.device_ptr(&ctx.stream);
+    let (out_ptr, _go) = out.data.device_ptr_mut(&ctx.stream);
+    let result = unsafe {
+        ffi::scaled_add_rows_cuda(
+            delta_ptr as *const ffi::Half,
+            scale,
+            out_ptr as *mut ffi::Half,
+            out.hidden_dim as i32,
+            row_offset as i32,
+            delta.hidden_dim as i32,
+            delta.seq_len as i32,
+            ctx.stream.cu_stream(),
+        )
+    };
+    result.result()?;
+
+    Ok(())
+}
+
+/// In-place scaled add for tensors with identical shape.
+pub fn scaled_add_batch_into(
+    ctx: &DeviceContext,
+    delta: &HiddenStates,
+    scale: f32,
+    out: &mut HiddenStates,
+) -> Result<()> {
+    assert_eq!(delta.hidden_dim, out.hidden_dim);
+    scaled_add_rows_into(ctx, delta, scale, out, 0)
+}
+
 pub fn bf16_hidden_to_f32_into(
     ctx: &DeviceContext,
     input: &HiddenStates,

--- a/pegainfer-qwen3-4b/Cargo.toml
+++ b/pegainfer-qwen3-4b/Cargo.toml
@@ -38,6 +38,7 @@ kernel-report = [
 
 [dev-dependencies]
 pegainfer-vllm-support = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }
 vllm-text = { workspace = true }
 
 [[bin]]

--- a/pegainfer-qwen3-4b/Cargo.toml
+++ b/pegainfer-qwen3-4b/Cargo.toml
@@ -18,6 +18,7 @@ half = { workspace = true }
 hex = { workspace = true, optional = true }
 log = { workspace = true }
 rand = { workspace = true }
+safetensors = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true, optional = true }

--- a/pegainfer-qwen3-4b/src/batch_decode.rs
+++ b/pegainfer-qwen3-4b/src/batch_decode.rs
@@ -7,6 +7,7 @@ use super::batch_decode_buffers::{
 };
 use super::batch_decode_dag::BatchDecodeDag;
 use super::weights::{Qwen3Model, TransformerBlock};
+use crate::lora::apply_lora_projection_delta;
 use pegainfer_core::kv_pool::{KvLayout, KvState};
 #[cfg(feature = "kernel-call-trace")]
 use pegainfer_core::ops;
@@ -137,7 +138,7 @@ impl Qwen3Model {
         );
 
         for (layer_idx, layer) in self.layers.iter().enumerate() {
-            Self::batch_decode_layer(layer_idx, layer, &dag, bufs)?;
+            self.batch_decode_layer(layer_idx, layer, &dag, bufs)?;
 
             let next_weight = if layer_idx + 1 < num_layers {
                 &self.layers[layer_idx + 1].input_layernorm
@@ -170,6 +171,7 @@ impl Qwen3Model {
 
     #[allow(clippy::too_many_arguments)]
     fn batch_decode_layer(
+        &self,
         layer_idx: usize,
         layer: &TransformerBlock,
         dag: &BatchDecodeDag<'_>,
@@ -189,6 +191,18 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.q,
         );
+        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
+            && let Some(projection) = &lora_layer.q_proj
+        {
+            apply_lora_projection_delta(
+                &self.ctx,
+                projection,
+                &bufs.normed,
+                &mut bufs.q,
+                0,
+                scale,
+            )?;
+        }
         dag.gemm_rows::<KvDim>(
             dag_label!(format!("L{layer_idx}.attn.k_proj")),
             &layer.attention.qkv_proj,
@@ -197,6 +211,18 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.k,
         );
+        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
+            && let Some(projection) = &lora_layer.k_proj
+        {
+            apply_lora_projection_delta(
+                &self.ctx,
+                projection,
+                &bufs.normed,
+                &mut bufs.k,
+                0,
+                scale,
+            )?;
+        }
         dag.gemm_rows::<KvDim>(
             dag_label!(format!("L{layer_idx}.attn.v_proj")),
             &layer.attention.qkv_proj,
@@ -205,6 +231,18 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.v,
         );
+        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
+            && let Some(projection) = &lora_layer.v_proj
+        {
+            apply_lora_projection_delta(
+                &self.ctx,
+                projection,
+                &bufs.normed,
+                &mut bufs.v,
+                0,
+                scale,
+            )?;
+        }
 
         // QK norm + RoPE (batched, per-request positions)
         dag.qk_norm_rope(
@@ -230,6 +268,18 @@ impl Qwen3Model {
             &bufs.attn_out,
             &mut bufs.attn_proj,
         );
+        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
+            && let Some(projection) = &lora_layer.o_proj
+        {
+            apply_lora_projection_delta(
+                &self.ctx,
+                projection,
+                &bufs.attn_out,
+                &mut bufs.attn_proj,
+                0,
+                scale,
+            )?;
+        }
         dag.all_reduce_hidden(
             dag_label!(format!("L{layer_idx}.attn.all_reduce")),
             &mut bufs.attn_proj,
@@ -257,6 +307,28 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.up_out,
         );
+        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx) {
+            if let Some(projection) = &lora_layer.gate_proj {
+                apply_lora_projection_delta(
+                    &self.ctx,
+                    projection,
+                    &bufs.normed,
+                    &mut bufs.gate_out,
+                    0,
+                    scale,
+                )?;
+            }
+            if let Some(projection) = &lora_layer.up_proj {
+                apply_lora_projection_delta(
+                    &self.ctx,
+                    projection,
+                    &bufs.normed,
+                    &mut bufs.up_out,
+                    0,
+                    scale,
+                )?;
+            }
+        }
         dag.silu_mul_split(
             dag_label!(format!("L{layer_idx}.mlp.silu_mul")),
             &bufs.gate_out,
@@ -269,6 +341,18 @@ impl Qwen3Model {
             &bufs.mlp_act,
             &mut bufs.mlp_out,
         );
+        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
+            && let Some(projection) = &lora_layer.down_proj
+        {
+            apply_lora_projection_delta(
+                &self.ctx,
+                projection,
+                &bufs.mlp_act,
+                &mut bufs.mlp_out,
+                0,
+                scale,
+            )?;
+        }
         dag.all_reduce_hidden(
             dag_label!(format!("L{layer_idx}.mlp.all_reduce")),
             &mut bufs.mlp_out,

--- a/pegainfer-qwen3-4b/src/config.rs
+++ b/pegainfer-qwen3-4b/src/config.rs
@@ -19,7 +19,7 @@ impl Default for TensorParallelConfig {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub(crate) struct Config {
     pub(crate) hidden_size: usize,
     pub(crate) intermediate_size: usize,

--- a/pegainfer-qwen3-4b/src/executor.rs
+++ b/pegainfer-qwen3-4b/src/executor.rs
@@ -760,14 +760,35 @@ impl ModelExecutor for Qwen3Executor {
     }
 
     fn load_lora_adapter(&mut self, request: &LoadLoraAdapterRequest) -> Result<()> {
-        let manifest =
-            crate::lora::validate_lora_adapter(&request.lora_path, &self.metadata.config)?;
+        let adapter = crate::lora::load_lora_adapter(&request.lora_path, &self.metadata.config)?;
+        let projection_count: usize = adapter
+            .layers
+            .iter()
+            .map(|layer| layer.projections.len())
+            .sum();
+        let element_count: usize = adapter
+            .layers
+            .iter()
+            .flat_map(|layer| layer.projections.values())
+            .map(|projection| projection.a.data.len() + projection.b.data.len())
+            .sum();
+        let shape_elems: usize = adapter
+            .layers
+            .iter()
+            .flat_map(|layer| layer.projections.values())
+            .map(|projection| {
+                projection.a.rows * projection.a.cols + projection.b.rows * projection.b.cols
+            })
+            .sum();
+        debug_assert_eq!(element_count, shape_elems);
         anyhow::bail!(
-            "Qwen3 LoRA adapter {} validated from {} (rank={}, targets={}) but LoRA math is not implemented yet",
+            "Qwen3 LoRA adapter {} loaded from {} (rank={}, targets={}, projections={}, bf16_elements={}) but LoRA math is not implemented yet",
             request.lora_name,
-            manifest.path.display(),
-            manifest.rank,
-            manifest.target_modules.join(", ")
+            adapter.manifest.path.display(),
+            adapter.manifest.rank,
+            adapter.manifest.target_modules.join(", "),
+            projection_count,
+            element_count
         )
     }
 }

--- a/pegainfer-qwen3-4b/src/executor.rs
+++ b/pegainfer-qwen3-4b/src/executor.rs
@@ -5,9 +5,9 @@ use anyhow::Result;
 use crossbeam_channel as channel;
 
 use crate::batch_decode_buffers::{BATCH_BUCKETS, BatchDecodeBuffers};
-use crate::config::TensorParallelConfig;
+use crate::config::{Config, TensorParallelConfig};
 use crate::weights::{ModelRuntimeConfig, Qwen3Model};
-use pegainfer_core::engine::TokenLogprob;
+use pegainfer_core::engine::{LoadLoraAdapterRequest, TokenLogprob};
 use pegainfer_core::kv_pool::{KvPool, KvState};
 use pegainfer_core::ops;
 use pegainfer_core::sampler::SamplingParams;
@@ -509,11 +509,20 @@ pub(crate) trait ModelExecutor: Send {
     fn execute_prefill(&mut self, plan: PrefillPlan<'_>) -> Result<PrefillResult>;
     fn execute_decode(&mut self, plan: DecodePlan<'_>) -> Result<DecodeResult>;
     fn execute_unified(&mut self, plan: UnifiedPlan<'_>) -> Result<UnifiedResult>;
+
+    fn load_lora_adapter(&mut self, request: &LoadLoraAdapterRequest) -> Result<()> {
+        anyhow::bail!(
+            "Qwen3 LoRA adapter loading is not implemented yet: name={}, path={}",
+            request.lora_name,
+            request.lora_path.display()
+        )
+    }
 }
 
 struct Qwen3ExecutorMetadata {
     page_size: usize,
     stop_token_ids: Vec<u32>,
+    config: Config,
 }
 
 pub struct Qwen3Executor {
@@ -528,6 +537,7 @@ impl Qwen3Executor {
         let metadata = Qwen3ExecutorMetadata {
             page_size: model.kv_pool().layout().page_size,
             stop_token_ids: model.config().stop_token_ids.clone(),
+            config: model.config().clone(),
         };
         let kv_pool = model.kv_pool().clone();
         Ok(Self {
@@ -575,6 +585,7 @@ impl Qwen3Executor {
         let metadata = Qwen3ExecutorMetadata {
             page_size: models[0].kv_pool().layout().page_size,
             stop_token_ids: models[0].config().stop_token_ids.clone(),
+            config: models[0].config().clone(),
         };
 
         let streams = models
@@ -746,6 +757,18 @@ impl ModelExecutor for Qwen3Executor {
                 other.kind()
             )),
         }
+    }
+
+    fn load_lora_adapter(&mut self, request: &LoadLoraAdapterRequest) -> Result<()> {
+        let manifest =
+            crate::lora::validate_lora_adapter(&request.lora_path, &self.metadata.config)?;
+        anyhow::bail!(
+            "Qwen3 LoRA adapter {} validated from {} (rank={}, targets={}) but LoRA math is not implemented yet",
+            request.lora_name,
+            manifest.path.display(),
+            manifest.rank,
+            manifest.target_modules.join(", ")
+        )
     }
 }
 

--- a/pegainfer-qwen3-4b/src/executor.rs
+++ b/pegainfer-qwen3-4b/src/executor.rs
@@ -760,6 +760,10 @@ impl ModelExecutor for Qwen3Executor {
     }
 
     fn load_lora_adapter(&mut self, request: &LoadLoraAdapterRequest) -> Result<()> {
+        anyhow::ensure!(
+            self.workers.is_empty(),
+            "Qwen3 LoRA adapter loading currently supports single-GPU execution only"
+        );
         let adapter = crate::lora::load_lora_adapter(&request.lora_path, &self.metadata.config)?;
         let projection_count: usize = adapter
             .layers
@@ -781,15 +785,23 @@ impl ModelExecutor for Qwen3Executor {
             })
             .sum();
         debug_assert_eq!(element_count, shape_elems);
-        anyhow::bail!(
-            "Qwen3 LoRA adapter {} loaded from {} (rank={}, targets={}, projections={}, bf16_elements={}) but LoRA math is not implemented yet",
+        let rank = adapter.manifest.rank;
+        let targets = adapter.manifest.target_modules.join(", ");
+        let path = adapter.manifest.path.display().to_string();
+        self.primary
+            .load_lora_adapter(request.lora_name.clone(), adapter)?
+            .recv()
+            .map_err(|_| anyhow::anyhow!("primary worker dropped LoRA load response"))??;
+        log::info!(
+            "Loaded Qwen3 LoRA adapter {} from {} (rank={}, targets={}, projections={}, bf16_elements={})",
             request.lora_name,
-            adapter.manifest.path.display(),
-            adapter.manifest.rank,
-            adapter.manifest.target_modules.join(", "),
+            path,
+            rank,
+            targets,
             projection_count,
             element_count
-        )
+        );
+        Ok(())
     }
 }
 
@@ -902,6 +914,13 @@ impl LocalQwen3Lane {
             decode_kv_states,
         )
     }
+
+    fn load_lora_adapter(&mut self, name: String, adapter: crate::lora::LoraAdapter) -> Result<()> {
+        let device_adapter =
+            crate::lora::load_device_lora_adapter(self.model.device_ctx(), name, adapter)?;
+        self.model.set_lora_adapter(device_adapter);
+        Ok(())
+    }
 }
 
 #[derive(Clone)]
@@ -937,6 +956,11 @@ enum WorkerCommand {
     },
     DropRequest {
         request_id: RequestId,
+        resp: channel::Sender<Result<()>>,
+    },
+    LoadLoraAdapter {
+        name: String,
+        adapter: crate::lora::LoraAdapter,
         resp: channel::Sender<Result<()>>,
     },
     Shutdown,
@@ -996,6 +1020,14 @@ impl RankWorker {
                                     request_states.drop_request(request_id);
                                     let _ = resp.send(Ok(()));
                                 }
+                                WorkerCommand::LoadLoraAdapter {
+                                    name,
+                                    adapter,
+                                    resp,
+                                } => {
+                                    let result = lane.load_lora_adapter(name, adapter);
+                                    let _ = resp.send(result);
+                                }
                                 WorkerCommand::Shutdown => break,
                             }
                         }
@@ -1044,6 +1076,22 @@ impl RankWorker {
         resp_rx
             .recv()
             .map_err(|_| anyhow::anyhow!("tensor-parallel worker dropped drop_request response"))?
+    }
+
+    fn load_lora_adapter(
+        &self,
+        name: String,
+        adapter: crate::lora::LoraAdapter,
+    ) -> Result<channel::Receiver<Result<()>>> {
+        let (resp_tx, resp_rx) = channel::bounded(1);
+        self.tx
+            .send(WorkerCommand::LoadLoraAdapter {
+                name,
+                adapter,
+                resp: resp_tx,
+            })
+            .map_err(|_| anyhow::anyhow!("tensor-parallel worker channel closed on LoRA load"))?;
+        Ok(resp_rx)
     }
 
     fn shutdown(&mut self) {

--- a/pegainfer-qwen3-4b/src/lib.rs
+++ b/pegainfer-qwen3-4b/src/lib.rs
@@ -66,3 +66,19 @@ pub fn start_engine(model_path: &Path, options: EngineLoadOptions) -> Result<Eng
         .ok_or_else(|| anyhow::anyhow!("model path must be valid UTF-8"))?;
     scheduler::start_qwen3(model_path, enable_cuda_graph, &device_ordinals, seed)
 }
+
+pub fn start_engine_with_lora_control(
+    model_path: &Path,
+    options: EngineLoadOptions,
+) -> Result<EngineHandle> {
+    let EngineLoadOptions {
+        enable_cuda_graph,
+        device_ordinals,
+        seed,
+        ..
+    } = options;
+    let model_path = model_path
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("model path must be valid UTF-8"))?;
+    scheduler::start_qwen3_with_lora_control(model_path, enable_cuda_graph, &device_ordinals, seed)
+}

--- a/pegainfer-qwen3-4b/src/lib.rs
+++ b/pegainfer-qwen3-4b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod batch_decode_trace;
 mod config;
 mod executor;
 pub mod kernel_bench;
+mod lora;
 mod prefill;
 mod scheduler;
 mod unified_forward;

--- a/pegainfer-qwen3-4b/src/lora.rs
+++ b/pegainfer-qwen3-4b/src/lora.rs
@@ -4,6 +4,8 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail, ensure};
 use half::{bf16, f16};
+use pegainfer_core::ops;
+use pegainfer_core::tensor::{DeviceContext, DeviceMatrix, HiddenStates};
 use safetensors::tensor::TensorView;
 use safetensors::{Dtype, SafeTensors};
 use serde::Deserialize;
@@ -53,6 +55,29 @@ pub(crate) struct LoraMatrix {
     pub(crate) data: Vec<bf16>,
     pub(crate) rows: usize,
     pub(crate) cols: usize,
+}
+
+pub(crate) struct DeviceLoraAdapter {
+    pub(crate) name: String,
+    pub(crate) manifest: LoraAdapterManifest,
+    pub(crate) scale: f32,
+    pub(crate) layers: Vec<DeviceLoraLayer>,
+}
+
+#[derive(Default)]
+pub(crate) struct DeviceLoraLayer {
+    pub(crate) q_proj: Option<DeviceLoraProjection>,
+    pub(crate) k_proj: Option<DeviceLoraProjection>,
+    pub(crate) v_proj: Option<DeviceLoraProjection>,
+    pub(crate) o_proj: Option<DeviceLoraProjection>,
+    pub(crate) gate_proj: Option<DeviceLoraProjection>,
+    pub(crate) up_proj: Option<DeviceLoraProjection>,
+    pub(crate) down_proj: Option<DeviceLoraProjection>,
+}
+
+pub(crate) struct DeviceLoraProjection {
+    pub(crate) a: DeviceMatrix,
+    pub(crate) b: DeviceMatrix,
 }
 
 #[derive(Debug, Deserialize)]
@@ -116,6 +141,57 @@ pub(crate) fn load_lora_adapter(path: &Path, config: &Config) -> Result<LoraAdap
     }
 
     Ok(LoraAdapter { manifest, layers })
+}
+
+pub(crate) fn load_device_lora_adapter(
+    ctx: &DeviceContext,
+    name: String,
+    adapter: LoraAdapter,
+) -> Result<DeviceLoraAdapter> {
+    let scale = adapter.manifest.alpha as f32 / adapter.manifest.rank as f32;
+    let mut layers = Vec::with_capacity(adapter.layers.len());
+    for layer in adapter.layers {
+        let mut device_layer = DeviceLoraLayer::default();
+        for (target, projection) in layer.projections {
+            let device_projection = DeviceLoraProjection {
+                a: projection.a.to_device(ctx)?,
+                b: projection.b.to_device(ctx)?,
+            };
+            match target.as_str() {
+                "q_proj" => device_layer.q_proj = Some(device_projection),
+                "k_proj" => device_layer.k_proj = Some(device_projection),
+                "v_proj" => device_layer.v_proj = Some(device_projection),
+                "o_proj" => device_layer.o_proj = Some(device_projection),
+                "gate_proj" => device_layer.gate_proj = Some(device_projection),
+                "up_proj" => device_layer.up_proj = Some(device_projection),
+                "down_proj" => device_layer.down_proj = Some(device_projection),
+                _ => bail!("unsupported Qwen3 LoRA target module {target}"),
+            }
+        }
+        layers.push(device_layer);
+    }
+
+    Ok(DeviceLoraAdapter {
+        name,
+        manifest: adapter.manifest,
+        scale,
+        layers,
+    })
+}
+
+pub(crate) fn apply_lora_projection_delta(
+    ctx: &DeviceContext,
+    projection: &DeviceLoraProjection,
+    input: &HiddenStates,
+    out: &mut HiddenStates,
+    row_offset: usize,
+    scale: f32,
+) -> Result<()> {
+    let mut rank_out = HiddenStates::zeros(ctx, projection.a.rows, input.seq_len)?;
+    ops::gemm_into(ctx, &projection.a, input, &mut rank_out);
+    let mut delta = HiddenStates::zeros(ctx, projection.b.rows, input.seq_len)?;
+    ops::gemm_into(ctx, &projection.b, &rank_out, &mut delta);
+    ops::scaled_add_rows_into(ctx, &delta, scale, out, row_offset)
 }
 
 fn inspect_lora_adapter(path: &Path, config: &Config) -> Result<(LoraAdapterManifest, Vec<u8>)> {
@@ -347,6 +423,12 @@ fn tensor_to_bf16(tensor: &TensorView<'_>, name: &str) -> Result<Vec<bf16>> {
                 .collect())
         }
         dtype => bail!("LoRA tensor {name} has unsupported dtype {dtype:?}"),
+    }
+}
+
+impl LoraMatrix {
+    fn to_device(&self, ctx: &DeviceContext) -> Result<DeviceMatrix> {
+        DeviceMatrix::from_host(ctx, &self.data, self.rows, self.cols)
     }
 }
 

--- a/pegainfer-qwen3-4b/src/lora.rs
+++ b/pegainfer-qwen3-4b/src/lora.rs
@@ -286,7 +286,7 @@ fn validate_tensor_catalog(
         }
     }
 
-    let actual: BTreeSet<&str> = tensors.names().into_iter().collect();
+    let actual: BTreeSet<String> = tensors.names().into_iter().map(str::to_owned).collect();
     for (name, shape) in &expected {
         let tensor = tensors
             .tensor(name)
@@ -301,7 +301,7 @@ fn validate_tensor_catalog(
     }
 
     for name in actual {
-        if !expected.contains_key(name) {
+        if !expected.contains_key(&name) {
             bail!("unexpected LoRA tensor {name}");
         }
     }

--- a/pegainfer-qwen3-4b/src/lora.rs
+++ b/pegainfer-qwen3-4b/src/lora.rs
@@ -3,6 +3,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail, ensure};
+use half::{bf16, f16};
+use safetensors::tensor::TensorView;
 use safetensors::{Dtype, SafeTensors};
 use serde::Deserialize;
 
@@ -27,6 +29,30 @@ pub(crate) struct LoraAdapterManifest {
     pub(crate) alpha: usize,
     pub(crate) target_modules: Vec<String>,
     pub(crate) tensor_count: usize,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LoraAdapter {
+    pub(crate) manifest: LoraAdapterManifest,
+    pub(crate) layers: Vec<LoraLayer>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct LoraLayer {
+    pub(crate) projections: BTreeMap<String, LoraProjection>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LoraProjection {
+    pub(crate) a: LoraMatrix,
+    pub(crate) b: LoraMatrix,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LoraMatrix {
+    pub(crate) data: Vec<bf16>,
+    pub(crate) rows: usize,
+    pub(crate) cols: usize,
 }
 
 #[derive(Debug, Deserialize)]
@@ -65,7 +91,34 @@ impl TargetModules {
     }
 }
 
-pub(crate) fn validate_lora_adapter(path: &Path, config: &Config) -> Result<LoraAdapterManifest> {
+pub(crate) fn load_lora_adapter(path: &Path, config: &Config) -> Result<LoraAdapter> {
+    let (manifest, raw_weights) = inspect_lora_adapter(path, config)?;
+    let tensors = SafeTensors::deserialize(&raw_weights).with_context(|| {
+        format!(
+            "failed to parse {}",
+            path.join(ADAPTER_WEIGHTS_FILE).display()
+        )
+    })?;
+    let mut layers = Vec::with_capacity(config.num_hidden_layers);
+    for layer_idx in 0..config.num_hidden_layers {
+        let mut layer = LoraLayer::default();
+        for target in &manifest.target_modules {
+            let spec = projection_spec(config, target)?;
+            let a_name = tensor_name(layer_idx, spec.path_segment, "lora_A");
+            let b_name = tensor_name(layer_idx, spec.path_segment, "lora_B");
+            let a = load_matrix(&tensors, &a_name)?;
+            let b = load_matrix(&tensors, &b_name)?;
+            layer
+                .projections
+                .insert(target.clone(), LoraProjection { a, b });
+        }
+        layers.push(layer);
+    }
+
+    Ok(LoraAdapter { manifest, layers })
+}
+
+fn inspect_lora_adapter(path: &Path, config: &Config) -> Result<(LoraAdapterManifest, Vec<u8>)> {
     let adapter_config = load_adapter_config(path)?;
     let rank = adapter_config.lora_rank;
     let alpha = adapter_config.alpha;
@@ -95,13 +148,15 @@ pub(crate) fn validate_lora_adapter(path: &Path, config: &Config) -> Result<Lora
 
     validate_tensor_catalog(&tensors, config, rank, &target_modules)?;
 
-    Ok(LoraAdapterManifest {
+    let manifest = LoraAdapterManifest {
         path: path.to_path_buf(),
         rank,
         alpha,
         target_modules,
         tensor_count: tensors.len(),
-    })
+    };
+
+    Ok((manifest, raw_weights))
 }
 
 fn load_adapter_config(path: &Path) -> Result<PeftAdapterConfig> {
@@ -233,6 +288,68 @@ fn ensure_lora_dtype(name: &str, dtype: Dtype) -> Result<()> {
     Ok(())
 }
 
+fn load_matrix(tensors: &SafeTensors<'_>, name: &str) -> Result<LoraMatrix> {
+    let tensor = tensors
+        .tensor(name)
+        .with_context(|| format!("missing LoRA tensor {name}"))?;
+    ensure!(
+        tensor.shape().len() == 2,
+        "LoRA tensor {name} expected 2D, got {:?}",
+        tensor.shape()
+    );
+    Ok(LoraMatrix {
+        data: tensor_to_bf16(&tensor, name)?,
+        rows: tensor.shape()[0],
+        cols: tensor.shape()[1],
+    })
+}
+
+fn tensor_to_bf16(tensor: &TensorView<'_>, name: &str) -> Result<Vec<bf16>> {
+    ensure_lora_dtype(name, tensor.dtype())?;
+    let elems = tensor.shape().iter().product::<usize>();
+    match tensor.dtype() {
+        Dtype::BF16 => {
+            ensure!(
+                tensor.data().len() == elems * 2,
+                "LoRA tensor {name} BF16 byte length mismatch"
+            );
+            Ok(tensor
+                .data()
+                .chunks_exact(2)
+                .map(|bytes| bf16::from_bits(u16::from_le_bytes([bytes[0], bytes[1]])))
+                .collect())
+        }
+        Dtype::F16 => {
+            ensure!(
+                tensor.data().len() == elems * 2,
+                "LoRA tensor {name} F16 byte length mismatch"
+            );
+            Ok(tensor
+                .data()
+                .chunks_exact(2)
+                .map(|bytes| {
+                    let value = f16::from_bits(u16::from_le_bytes([bytes[0], bytes[1]]));
+                    bf16::from_f32(value.to_f32())
+                })
+                .collect())
+        }
+        Dtype::F32 => {
+            ensure!(
+                tensor.data().len() == elems * 4,
+                "LoRA tensor {name} F32 byte length mismatch"
+            );
+            Ok(tensor
+                .data()
+                .chunks_exact(4)
+                .map(|bytes| {
+                    bf16::from_f32(f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+                })
+                .collect())
+        }
+        dtype => bail!("LoRA tensor {name} has unsupported dtype {dtype:?}"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::borrow::Cow;
@@ -341,15 +458,24 @@ mod tests {
     }
 
     fn push_tensor(tensors: &mut BTreeMap<String, TestTensor>, name: String, shape: Vec<usize>) {
-        let bytes = vec![0_u8; shape.iter().product::<usize>() * 2];
-        tensors.insert(
-            name,
-            TestTensor {
-                dtype: Dtype::BF16,
-                shape,
-                data: bytes,
-            },
-        );
+        push_tensor_with_dtype(tensors, name, shape, Dtype::BF16, 0.0);
+    }
+
+    fn push_tensor_with_dtype(
+        tensors: &mut BTreeMap<String, TestTensor>,
+        name: String,
+        shape: Vec<usize>,
+        dtype: Dtype,
+        value: f32,
+    ) {
+        let elems = shape.iter().product::<usize>();
+        let data = match dtype {
+            Dtype::BF16 => bf16::from_f32(value).to_bits().to_le_bytes().repeat(elems),
+            Dtype::F16 => f16::from_f32(value).to_bits().to_le_bytes().repeat(elems),
+            Dtype::F32 => value.to_le_bytes().repeat(elems),
+            _ => panic!("unsupported test dtype {dtype:?}"),
+        };
+        tensors.insert(name, TestTensor { dtype, shape, data });
     }
 
     #[test]
@@ -360,7 +486,9 @@ mod tests {
         write_adapter_config(&path, targets, 2);
         write_adapter_weights(&path, &config, targets, 2);
 
-        let manifest = validate_lora_adapter(&path, &config).expect("validate adapter");
+        let manifest = load_lora_adapter(&path, &config)
+            .expect("load adapter")
+            .manifest;
 
         assert_eq!(manifest.rank, 2);
         assert_eq!(manifest.alpha, 16);
@@ -372,13 +500,75 @@ mod tests {
     }
 
     #[test]
+    fn loads_lora_tensors_grouped_by_layer_and_target() {
+        let config = tiny_config();
+        let path = temp_adapter_dir("load");
+        write_adapter_config(&path, &["q_proj", "down_proj"], 2);
+        write_adapter_weights(&path, &config, &["q_proj", "down_proj"], 2);
+
+        let adapter = load_lora_adapter(&path, &config).expect("load adapter");
+
+        assert_eq!(adapter.manifest.rank, 2);
+        assert_eq!(adapter.layers.len(), config.num_hidden_layers);
+        let layer0 = &adapter.layers[0];
+        let q_proj = layer0.projections.get("q_proj").expect("q_proj");
+        assert_eq!((q_proj.a.rows, q_proj.a.cols), (2, config.hidden_size));
+        assert_eq!(
+            (q_proj.b.rows, q_proj.b.cols),
+            (config.num_attention_heads * config.head_dim, 2)
+        );
+        let down_proj = layer0.projections.get("down_proj").expect("down_proj");
+        assert_eq!(
+            (down_proj.a.rows, down_proj.a.cols),
+            (2, config.intermediate_size)
+        );
+        assert_eq!(
+            (down_proj.b.rows, down_proj.b.cols),
+            (config.hidden_size, 2)
+        );
+    }
+
+    #[test]
+    fn loads_supported_lora_tensor_dtypes_as_bf16() {
+        let config = tiny_config();
+        let path = temp_adapter_dir("dtype-load");
+        write_adapter_config(&path, &["q_proj"], 2);
+
+        let mut tensors = BTreeMap::new();
+        for layer_idx in 0..config.num_hidden_layers {
+            push_tensor_with_dtype(
+                &mut tensors,
+                tensor_name(layer_idx, "self_attn.q_proj", "lora_A"),
+                vec![2, config.hidden_size],
+                Dtype::F16,
+                1.5,
+            );
+            push_tensor_with_dtype(
+                &mut tensors,
+                tensor_name(layer_idx, "self_attn.q_proj", "lora_B"),
+                vec![config.hidden_size, 2],
+                Dtype::F32,
+                2.25,
+            );
+        }
+        safetensors::serialize_to_file(tensors, None, &path.join(ADAPTER_WEIGHTS_FILE))
+            .expect("write safetensors");
+
+        let adapter = load_lora_adapter(&path, &config).expect("load adapter");
+        let q_proj = adapter.layers[0].projections.get("q_proj").expect("q_proj");
+
+        assert_eq!(q_proj.a.data[0].to_f32(), bf16::from_f32(1.5).to_f32());
+        assert_eq!(q_proj.b.data[0].to_f32(), bf16::from_f32(2.25).to_f32());
+    }
+
+    #[test]
     fn rejects_unsupported_target_module() {
         let config = tiny_config();
         let path = temp_adapter_dir("unsupported-target");
         write_adapter_config(&path, &["q_proj", "embed_tokens"], 2);
         write_adapter_weights(&path, &config, &["q_proj"], 2);
 
-        let error = validate_lora_adapter(&path, &config).expect_err("unsupported target");
+        let error = load_lora_adapter(&path, &config).expect_err("unsupported target");
 
         assert!(error.to_string().contains("unsupported Qwen3 LoRA target"));
     }
@@ -409,7 +599,7 @@ mod tests {
         safetensors::serialize_to_file(tensors, None, &path.join(ADAPTER_WEIGHTS_FILE))
             .expect("write safetensors");
 
-        let error = validate_lora_adapter(&path, &config).expect_err("bad tensor shape");
+        let error = load_lora_adapter(&path, &config).expect_err("bad tensor shape");
 
         assert!(error.to_string().contains("shape mismatch"));
     }

--- a/pegainfer-qwen3-4b/src/lora.rs
+++ b/pegainfer-qwen3-4b/src/lora.rs
@@ -1,0 +1,416 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail, ensure};
+use safetensors::{Dtype, SafeTensors};
+use serde::Deserialize;
+
+use crate::config::Config;
+
+const ADAPTER_CONFIG_FILE: &str = "adapter_config.json";
+const ADAPTER_WEIGHTS_FILE: &str = "adapter_model.safetensors";
+const SUPPORTED_TARGET_MODULES: &[&str] = &[
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj",
+];
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct LoraAdapterManifest {
+    pub(crate) path: PathBuf,
+    pub(crate) rank: usize,
+    pub(crate) alpha: usize,
+    pub(crate) target_modules: Vec<String>,
+    pub(crate) tensor_count: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct PeftAdapterConfig {
+    #[serde(alias = "r")]
+    lora_rank: usize,
+    #[serde(alias = "lora_alpha")]
+    alpha: usize,
+    target_modules: TargetModules,
+    #[serde(default)]
+    peft_type: Option<String>,
+    #[serde(default)]
+    task_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum TargetModules {
+    One(String),
+    Many(Vec<String>),
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ProjectionSpec {
+    path_segment: &'static str,
+    in_dim: usize,
+    out_dim: usize,
+}
+
+impl TargetModules {
+    fn into_vec(self) -> Vec<String> {
+        match self {
+            Self::One(target) => vec![target],
+            Self::Many(targets) => targets,
+        }
+    }
+}
+
+pub(crate) fn validate_lora_adapter(path: &Path, config: &Config) -> Result<LoraAdapterManifest> {
+    let adapter_config = load_adapter_config(path)?;
+    let rank = adapter_config.lora_rank;
+    let alpha = adapter_config.alpha;
+    ensure!(rank > 0, "LoRA rank must be > 0");
+    ensure!(alpha > 0, "LoRA alpha must be > 0");
+    if let Some(peft_type) = &adapter_config.peft_type {
+        ensure!(
+            peft_type.eq_ignore_ascii_case("LORA"),
+            "unsupported peft_type={peft_type}; expected LORA"
+        );
+    }
+    let _task_type = adapter_config.task_type.as_deref();
+
+    let target_modules = normalize_target_modules(adapter_config.target_modules.into_vec())?;
+    let raw_weights = fs::read(path.join(ADAPTER_WEIGHTS_FILE)).with_context(|| {
+        format!(
+            "failed to read LoRA safetensors file {}",
+            path.join(ADAPTER_WEIGHTS_FILE).display()
+        )
+    })?;
+    let tensors = SafeTensors::deserialize(&raw_weights).with_context(|| {
+        format!(
+            "failed to parse {}",
+            path.join(ADAPTER_WEIGHTS_FILE).display()
+        )
+    })?;
+
+    validate_tensor_catalog(&tensors, config, rank, &target_modules)?;
+
+    Ok(LoraAdapterManifest {
+        path: path.to_path_buf(),
+        rank,
+        alpha,
+        target_modules,
+        tensor_count: tensors.len(),
+    })
+}
+
+fn load_adapter_config(path: &Path) -> Result<PeftAdapterConfig> {
+    let config_path = path.join(ADAPTER_CONFIG_FILE);
+    let content = fs::read_to_string(&config_path)
+        .with_context(|| format!("failed to read {}", config_path.display()))?;
+    serde_json::from_str(&content)
+        .with_context(|| format!("failed to parse {}", config_path.display()))
+}
+
+fn normalize_target_modules(target_modules: Vec<String>) -> Result<Vec<String>> {
+    ensure!(
+        !target_modules.is_empty(),
+        "LoRA adapter_config.json target_modules must not be empty"
+    );
+
+    let supported: BTreeSet<&str> = SUPPORTED_TARGET_MODULES.iter().copied().collect();
+    let mut seen = BTreeSet::new();
+    let mut normalized = Vec::with_capacity(target_modules.len());
+    for target in target_modules {
+        ensure!(
+            supported.contains(target.as_str()),
+            "unsupported Qwen3 LoRA target module {target}; supported modules: {}",
+            SUPPORTED_TARGET_MODULES.join(", ")
+        );
+        if seen.insert(target.clone()) {
+            normalized.push(target);
+        }
+    }
+    Ok(normalized)
+}
+
+fn validate_tensor_catalog(
+    tensors: &SafeTensors<'_>,
+    config: &Config,
+    rank: usize,
+    target_modules: &[String],
+) -> Result<()> {
+    let mut expected = BTreeMap::new();
+    for layer_idx in 0..config.num_hidden_layers {
+        for target in target_modules {
+            let spec = projection_spec(config, target)?;
+            expected.insert(
+                tensor_name(layer_idx, spec.path_segment, "lora_A"),
+                vec![rank, spec.in_dim],
+            );
+            expected.insert(
+                tensor_name(layer_idx, spec.path_segment, "lora_B"),
+                vec![spec.out_dim, rank],
+            );
+        }
+    }
+
+    let actual: BTreeSet<&str> = tensors.names().into_iter().collect();
+    for (name, shape) in &expected {
+        let tensor = tensors
+            .tensor(name)
+            .with_context(|| format!("missing LoRA tensor {name}"))?;
+        ensure_lora_dtype(name, tensor.dtype())?;
+        ensure!(
+            tensor.shape() == shape.as_slice(),
+            "LoRA tensor {name} shape mismatch: expected {:?}, got {:?}",
+            shape,
+            tensor.shape()
+        );
+    }
+
+    for name in actual {
+        if !expected.contains_key(name) {
+            bail!("unexpected LoRA tensor {name}");
+        }
+    }
+
+    Ok(())
+}
+
+fn projection_spec(config: &Config, target: &str) -> Result<ProjectionSpec> {
+    let q_dim = config.num_attention_heads * config.head_dim;
+    let kv_dim = config.num_key_value_heads * config.head_dim;
+    match target {
+        "q_proj" => Ok(ProjectionSpec {
+            path_segment: "self_attn.q_proj",
+            in_dim: config.hidden_size,
+            out_dim: q_dim,
+        }),
+        "k_proj" => Ok(ProjectionSpec {
+            path_segment: "self_attn.k_proj",
+            in_dim: config.hidden_size,
+            out_dim: kv_dim,
+        }),
+        "v_proj" => Ok(ProjectionSpec {
+            path_segment: "self_attn.v_proj",
+            in_dim: config.hidden_size,
+            out_dim: kv_dim,
+        }),
+        "o_proj" => Ok(ProjectionSpec {
+            path_segment: "self_attn.o_proj",
+            in_dim: q_dim,
+            out_dim: config.hidden_size,
+        }),
+        "gate_proj" => Ok(ProjectionSpec {
+            path_segment: "mlp.gate_proj",
+            in_dim: config.hidden_size,
+            out_dim: config.intermediate_size,
+        }),
+        "up_proj" => Ok(ProjectionSpec {
+            path_segment: "mlp.up_proj",
+            in_dim: config.hidden_size,
+            out_dim: config.intermediate_size,
+        }),
+        "down_proj" => Ok(ProjectionSpec {
+            path_segment: "mlp.down_proj",
+            in_dim: config.intermediate_size,
+            out_dim: config.hidden_size,
+        }),
+        _ => bail!("unsupported Qwen3 LoRA target module {target}"),
+    }
+}
+
+fn tensor_name(layer_idx: usize, path_segment: &str, lora_side: &str) -> String {
+    format!("base_model.model.model.layers.{layer_idx}.{path_segment}.{lora_side}.weight")
+}
+
+fn ensure_lora_dtype(name: &str, dtype: Dtype) -> Result<()> {
+    ensure!(
+        matches!(dtype, Dtype::F16 | Dtype::BF16 | Dtype::F32),
+        "LoRA tensor {name} has unsupported dtype {dtype:?}; expected F16, BF16, or F32"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+    use std::collections::BTreeMap;
+    use std::fs;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use safetensors::View;
+
+    use super::*;
+
+    static NEXT_TEST_DIR: AtomicUsize = AtomicUsize::new(0);
+
+    fn tiny_config() -> Config {
+        Config {
+            hidden_size: 4,
+            intermediate_size: 6,
+            num_hidden_layers: 2,
+            num_attention_heads: 2,
+            num_key_value_heads: 1,
+            head_dim: 2,
+            vocab_size: 16,
+            rms_norm_eps: 1e-6,
+            rope_theta: 1_000_000.0,
+            eos_token_id: 151645,
+            tie_word_embeddings: false,
+            stop_token_ids: vec![151645],
+        }
+    }
+
+    fn temp_adapter_dir(test_name: &str) -> PathBuf {
+        let id = NEXT_TEST_DIR.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "pegainfer-qwen3-lora-{test_name}-{}-{id}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).expect("create temp adapter dir");
+        path
+    }
+
+    fn write_adapter_config(path: &Path, targets: &[&str], rank: usize) {
+        let targets = targets
+            .iter()
+            .map(|target| format!("\"{target}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        fs::write(
+            path.join(ADAPTER_CONFIG_FILE),
+            format!(
+                r#"{{
+  "peft_type": "LORA",
+  "r": {rank},
+  "lora_alpha": 16,
+  "target_modules": [{targets}]
+}}"#
+            ),
+        )
+        .expect("write adapter config");
+    }
+
+    fn write_adapter_weights(path: &Path, config: &Config, targets: &[&str], rank: usize) {
+        let mut tensors = BTreeMap::new();
+        for layer_idx in 0..config.num_hidden_layers {
+            for target in targets {
+                let spec = projection_spec(config, target).expect("projection spec");
+                push_tensor(
+                    &mut tensors,
+                    tensor_name(layer_idx, spec.path_segment, "lora_A"),
+                    vec![rank, spec.in_dim],
+                );
+                push_tensor(
+                    &mut tensors,
+                    tensor_name(layer_idx, spec.path_segment, "lora_B"),
+                    vec![spec.out_dim, rank],
+                );
+            }
+        }
+        safetensors::serialize_to_file(tensors, None, &path.join(ADAPTER_WEIGHTS_FILE))
+            .expect("write safetensors");
+    }
+
+    #[derive(Clone)]
+    struct TestTensor {
+        dtype: Dtype,
+        shape: Vec<usize>,
+        data: Vec<u8>,
+    }
+
+    impl View for TestTensor {
+        fn dtype(&self) -> Dtype {
+            self.dtype
+        }
+
+        fn shape(&self) -> &[usize] {
+            &self.shape
+        }
+
+        fn data(&self) -> Cow<'_, [u8]> {
+            Cow::Borrowed(&self.data)
+        }
+
+        fn data_len(&self) -> usize {
+            self.data.len()
+        }
+    }
+
+    fn push_tensor(tensors: &mut BTreeMap<String, TestTensor>, name: String, shape: Vec<usize>) {
+        let bytes = vec![0_u8; shape.iter().product::<usize>() * 2];
+        tensors.insert(
+            name,
+            TestTensor {
+                dtype: Dtype::BF16,
+                shape,
+                data: bytes,
+            },
+        );
+    }
+
+    #[test]
+    fn validates_supported_qwen3_lora_adapter() {
+        let config = tiny_config();
+        let path = temp_adapter_dir("valid");
+        let targets = SUPPORTED_TARGET_MODULES;
+        write_adapter_config(&path, targets, 2);
+        write_adapter_weights(&path, &config, targets, 2);
+
+        let manifest = validate_lora_adapter(&path, &config).expect("validate adapter");
+
+        assert_eq!(manifest.rank, 2);
+        assert_eq!(manifest.alpha, 16);
+        assert_eq!(manifest.target_modules, targets);
+        assert_eq!(
+            manifest.tensor_count,
+            config.num_hidden_layers * targets.len() * 2
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_target_module() {
+        let config = tiny_config();
+        let path = temp_adapter_dir("unsupported-target");
+        write_adapter_config(&path, &["q_proj", "embed_tokens"], 2);
+        write_adapter_weights(&path, &config, &["q_proj"], 2);
+
+        let error = validate_lora_adapter(&path, &config).expect_err("unsupported target");
+
+        assert!(error.to_string().contains("unsupported Qwen3 LoRA target"));
+    }
+
+    #[test]
+    fn rejects_wrong_lora_tensor_shape() {
+        let config = tiny_config();
+        let path = temp_adapter_dir("bad-shape");
+        write_adapter_config(&path, &["q_proj"], 2);
+
+        let mut tensors = BTreeMap::new();
+        for layer_idx in 0..config.num_hidden_layers {
+            push_tensor(
+                &mut tensors,
+                tensor_name(layer_idx, "self_attn.q_proj", "lora_A"),
+                vec![2, config.hidden_size],
+            );
+            push_tensor(
+                &mut tensors,
+                tensor_name(layer_idx, "self_attn.q_proj", "lora_B"),
+                if layer_idx == 0 {
+                    vec![config.hidden_size + 1, 2]
+                } else {
+                    vec![config.hidden_size, 2]
+                },
+            );
+        }
+        safetensors::serialize_to_file(tensors, None, &path.join(ADAPTER_WEIGHTS_FILE))
+            .expect("write safetensors");
+
+        let error = validate_lora_adapter(&path, &config).expect_err("bad tensor shape");
+
+        assert!(error.to_string().contains("shape mismatch"));
+    }
+}

--- a/pegainfer-qwen3-4b/src/prefill.rs
+++ b/pegainfer-qwen3-4b/src/prefill.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 
 use super::config::PREFILL_ATTENTION_CTA_TILE_Q;
 use super::weights::{Qwen3Model, TransformerBlock};
+use crate::lora::apply_lora_projection_delta;
 use pegainfer_core::kv_pool::{KvLayout, KvState};
 use pegainfer_core::ops;
 use pegainfer_core::ops::PrefillPagedPlan;
@@ -107,6 +108,18 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.q_batch,
         );
+        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
+            && let Some(projection) = &lora_layer.q_proj
+        {
+            apply_lora_projection_delta(
+                &self.ctx,
+                projection,
+                &bufs.normed,
+                &mut bufs.q_batch,
+                0,
+                scale,
+            )?;
+        }
         ops::gemm_rows_into(
             &self.ctx,
             &layer.attention.qkv_proj,
@@ -115,6 +128,18 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.k_batch,
         );
+        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
+            && let Some(projection) = &lora_layer.k_proj
+        {
+            apply_lora_projection_delta(
+                &self.ctx,
+                projection,
+                &bufs.normed,
+                &mut bufs.k_batch,
+                0,
+                scale,
+            )?;
+        }
         ops::gemm_rows_into(
             &self.ctx,
             &layer.attention.qkv_proj,
@@ -123,6 +148,18 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.v_batch,
         );
+        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
+            && let Some(projection) = &lora_layer.v_proj
+        {
+            apply_lora_projection_delta(
+                &self.ctx,
+                projection,
+                &bufs.normed,
+                &mut bufs.v_batch,
+                0,
+                scale,
+            )?;
+        }
 
         // 3. Paged prefill: norm+RoPE → append K/V to paged → batch attention
         ops::prefill_attention_paged_into(
@@ -153,6 +190,18 @@ impl Qwen3Model {
             &bufs.attn_output,
             &mut bufs.o_buf,
         );
+        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
+            && let Some(projection) = &lora_layer.o_proj
+        {
+            apply_lora_projection_delta(
+                &self.ctx,
+                projection,
+                &bufs.attn_output,
+                &mut bufs.o_buf,
+                0,
+                scale,
+            )?;
+        }
         self.all_reduce_hidden(&mut bufs.o_buf)?;
 
         // 5+6. Residual add + MLP RMSNorm (fused): hidden += o_buf; normed = rms_norm(hidden)
@@ -183,6 +232,28 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.up_out,
         );
+        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx) {
+            if let Some(projection) = &lora_layer.gate_proj {
+                apply_lora_projection_delta(
+                    &self.ctx,
+                    projection,
+                    &bufs.normed,
+                    &mut bufs.gate_out,
+                    0,
+                    scale,
+                )?;
+            }
+            if let Some(projection) = &lora_layer.up_proj {
+                apply_lora_projection_delta(
+                    &self.ctx,
+                    projection,
+                    &bufs.normed,
+                    &mut bufs.up_out,
+                    0,
+                    scale,
+                )?;
+            }
+        }
         ops::silu_mul_batch_into(&self.ctx, &bufs.gate_out, &bufs.up_out, &mut bufs.act_out)?;
         ops::gemm_into(
             &self.ctx,
@@ -190,6 +261,18 @@ impl Qwen3Model {
             &bufs.act_out,
             &mut bufs.o_buf,
         );
+        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
+            && let Some(projection) = &lora_layer.down_proj
+        {
+            apply_lora_projection_delta(
+                &self.ctx,
+                projection,
+                &bufs.act_out,
+                &mut bufs.o_buf,
+                0,
+                scale,
+            )?;
+        }
         self.all_reduce_hidden(&mut bufs.o_buf)?;
 
         // 8. Residual add: attn_residual + mlp_out → bufs.hidden_out (old hidden_in, free to overwrite)

--- a/pegainfer-qwen3-4b/src/scheduler.rs
+++ b/pegainfer-qwen3-4b/src/scheduler.rs
@@ -283,6 +283,22 @@ fn scheduler_loop_with_lora_control<E>(
         let pending = admission.pending;
         deferred = admission.deferred;
 
+        if active.is_empty() && pending.is_empty() {
+            if let Some(command) = command_rx.blocking_recv() {
+                enqueue_engine_command(
+                    command,
+                    &mut deferred,
+                    &mut pending_control,
+                    &mut post_control_deferred,
+                    &mut next_request_id,
+                );
+            } else {
+                info!("Scheduler: all handles dropped, exiting");
+                return;
+            }
+            continue;
+        }
+
         let Some(plan) = build_next_plan(!active.is_empty(), pending) else {
             continue;
         };

--- a/pegainfer-qwen3-4b/src/scheduler.rs
+++ b/pegainfer-qwen3-4b/src/scheduler.rs
@@ -232,7 +232,7 @@ fn scheduler_loop_with_lora_control<E>(
         // 2. Once idle, apply pending control commands before admitting newer
         // generation requests that arrived behind them.
         if active.is_empty() && deferred.is_empty() {
-            drain_idle_control(&mut pending_control);
+            drain_idle_control(&mut executor, &mut pending_control);
             if pending_control.is_empty() && !post_control_deferred.is_empty() {
                 deferred.append(&mut post_control_deferred);
             }
@@ -263,7 +263,7 @@ fn scheduler_loop_with_lora_control<E>(
                 );
             }
             if active.is_empty() && deferred.is_empty() {
-                drain_idle_control(&mut pending_control);
+                drain_idle_control(&mut executor, &mut pending_control);
                 if pending_control.is_empty() && !post_control_deferred.is_empty() {
                     deferred.append(&mut post_control_deferred);
                 }
@@ -321,13 +321,16 @@ fn enqueue_engine_command(
     }
 }
 
-fn drain_idle_control(pending_control: &mut VecDeque<EngineControlRequest>) {
+fn drain_idle_control(
+    executor: &mut impl ModelExecutor,
+    pending_control: &mut VecDeque<EngineControlRequest>,
+) {
     while let Some(control) = pending_control.pop_front() {
-        handle_control_request(control);
+        handle_control_request(executor, control);
     }
 }
 
-fn handle_control_request(control: EngineControlRequest) {
+fn handle_control_request(executor: &mut impl ModelExecutor, control: EngineControlRequest) {
     match control {
         EngineControlRequest::LoadLoraAdapter {
             request,
@@ -338,11 +341,11 @@ fn handle_control_request(control: EngineControlRequest) {
                 request.lora_name,
                 request.lora_path.display()
             );
-            let _ = response_tx.send(Err(format!(
-                "Qwen3 LoRA adapter loading is not implemented yet: name={}, path={}",
-                request.lora_name,
-                request.lora_path.display()
-            )));
+            let _ = response_tx.send(
+                executor
+                    .load_lora_adapter(&request)
+                    .map_err(|error| error.to_string()),
+            );
         }
     }
 }

--- a/pegainfer-qwen3-4b/src/scheduler.rs
+++ b/pegainfer-qwen3-4b/src/scheduler.rs
@@ -9,6 +9,7 @@ mod effects;
 mod plan;
 mod resolve;
 
+use std::collections::VecDeque;
 use std::thread;
 
 use anyhow::Result;
@@ -18,7 +19,9 @@ use rand::rngs::StdRng;
 use tokio::sync::mpsc;
 
 use crate::executor::{ModelExecutor, Qwen3Executor, RequestId};
-use pegainfer_core::engine::{EngineHandle, GenerateRequest, TokenEvent};
+use pegainfer_core::engine::{
+    EngineCommand, EngineControlRequest, EngineHandle, GenerateRequest, TokenEvent,
+};
 use pegainfer_core::sampler::SamplingParams;
 
 use self::effects::apply_effects;
@@ -76,6 +79,16 @@ pub(crate) fn start_qwen3(
     Ok(start_with_executor(executor, seed))
 }
 
+pub(crate) fn start_qwen3_with_lora_control(
+    model_path: &str,
+    enable_cuda_graph: bool,
+    device_ordinals: &[usize],
+    seed: u64,
+) -> Result<EngineHandle> {
+    let executor = Qwen3Executor::from_runtime(model_path, enable_cuda_graph, device_ordinals)?;
+    Ok(start_with_executor_with_lora_control(executor, seed))
+}
+
 pub(crate) fn start_with_executor<E>(executor: E, seed: u64) -> EngineHandle
 where
     E: ModelExecutor + 'static,
@@ -90,6 +103,22 @@ where
         .expect("failed to spawn scheduler thread");
 
     EngineHandle::new(submit_tx)
+}
+
+pub(crate) fn start_with_executor_with_lora_control<E>(executor: E, seed: u64) -> EngineHandle
+where
+    E: ModelExecutor + 'static,
+{
+    let (command_tx, command_rx) = mpsc::unbounded_channel();
+
+    thread::Builder::new()
+        .name("scheduler".into())
+        .spawn(move || {
+            scheduler_loop_with_lora_control(executor, command_rx, seed);
+        })
+        .expect("failed to spawn scheduler thread");
+
+    EngineHandle::new_with_command_channel(command_tx)
 }
 
 // ── Main loop ───────────────────────────────────────────────────────────
@@ -168,6 +197,153 @@ fn scheduler_loop<E>(
         };
         let effects = resolve_step(&executor, &active, artifacts);
         apply_effects(&mut executor, &mut active, effects);
+    }
+}
+
+fn scheduler_loop_with_lora_control<E>(
+    mut executor: E,
+    mut command_rx: mpsc::UnboundedReceiver<EngineCommand>,
+    seed: u64,
+) where
+    E: ModelExecutor,
+{
+    let mut rng = StdRng::seed_from_u64(seed);
+    let mut active: Vec<ActiveRequestState> = Vec::new();
+    let mut next_request_id = 0u64;
+    let mut deferred: Vec<PendingRequest> = Vec::new();
+    let mut pending_control: VecDeque<EngineControlRequest> = VecDeque::new();
+    let mut post_control_deferred: Vec<PendingRequest> = Vec::new();
+
+    info!("Scheduler ready with LoRA control");
+
+    loop {
+        // 1. Drain incoming commands. Generation submitted after a pending
+        // control command waits until that control command is handled at idle.
+        while let Ok(command) = command_rx.try_recv() {
+            enqueue_engine_command(
+                command,
+                &mut deferred,
+                &mut pending_control,
+                &mut post_control_deferred,
+                &mut next_request_id,
+            );
+        }
+
+        // 2. Once idle, apply pending control commands before admitting newer
+        // generation requests that arrived behind them.
+        if active.is_empty() && deferred.is_empty() {
+            drain_idle_control(&mut pending_control);
+            if pending_control.is_empty() && !post_control_deferred.is_empty() {
+                deferred.append(&mut post_control_deferred);
+            }
+        }
+
+        // 3. Nothing active and no deferred generation → block until any
+        // command arrives.
+        if active.is_empty() && deferred.is_empty() {
+            if let Some(command) = command_rx.blocking_recv() {
+                enqueue_engine_command(
+                    command,
+                    &mut deferred,
+                    &mut pending_control,
+                    &mut post_control_deferred,
+                    &mut next_request_id,
+                );
+            } else {
+                info!("Scheduler: all handles dropped, exiting");
+                return;
+            }
+            while let Ok(command) = command_rx.try_recv() {
+                enqueue_engine_command(
+                    command,
+                    &mut deferred,
+                    &mut pending_control,
+                    &mut post_control_deferred,
+                    &mut next_request_id,
+                );
+            }
+            if active.is_empty() && deferred.is_empty() {
+                drain_idle_control(&mut pending_control);
+                if pending_control.is_empty() && !post_control_deferred.is_empty() {
+                    deferred.append(&mut post_control_deferred);
+                }
+            }
+        }
+
+        let admission = admit_deferred_requests(
+            deferred,
+            &active,
+            executor.page_size(),
+            executor.available_pages(),
+            executor.max_request_pages(),
+        );
+        for rejected in &admission.rejected {
+            send_rejection(rejected);
+        }
+        let pending = admission.pending;
+        deferred = admission.deferred;
+
+        let Some(plan) = build_next_plan(!active.is_empty(), pending) else {
+            continue;
+        };
+        let failure_targets = failure_targets_for(&active, &plan);
+        let artifacts = match execute_plan(&mut executor, &mut active, plan, &mut rng) {
+            Ok(v) => v,
+            Err(e) => {
+                warn!("Execution step failed: {e}");
+                fail_touched_requests(&mut executor, &mut active, failure_targets, &e.to_string());
+                continue;
+            }
+        };
+        let effects = resolve_step(&executor, &active, artifacts);
+        apply_effects(&mut executor, &mut active, effects);
+    }
+}
+
+fn enqueue_engine_command(
+    command: EngineCommand,
+    deferred: &mut Vec<PendingRequest>,
+    pending_control: &mut VecDeque<EngineControlRequest>,
+    post_control_deferred: &mut Vec<PendingRequest>,
+    next_request_id: &mut u64,
+) {
+    match command {
+        EngineCommand::Generate(req) => {
+            let pending = PendingRequest::from_scheduler_request(RequestId(*next_request_id), req);
+            *next_request_id += 1;
+            if pending_control.is_empty() {
+                deferred.push(pending);
+            } else {
+                post_control_deferred.push(pending);
+            }
+        }
+        EngineCommand::Control(control) => pending_control.push_back(control),
+    }
+}
+
+fn drain_idle_control(pending_control: &mut VecDeque<EngineControlRequest>) {
+    while let Some(control) = pending_control.pop_front() {
+        handle_control_request(control);
+    }
+}
+
+fn handle_control_request(control: EngineControlRequest) {
+    match control {
+        EngineControlRequest::LoadLoraAdapter {
+            request,
+            response_tx,
+        } => {
+            info!(
+                "LoRA adapter load requested while scheduler is idle: name={}, path={}",
+                request.lora_name,
+                request.lora_path.display()
+            );
+            let _ = response_tx.send(Err(format!(
+                "Qwen3 LoRA adapter loading is not implemented yet: name={}, path={}",
+                request.lora_name,
+                request.lora_path.display()
+            )));
+        }
     }
 }
 
@@ -333,6 +509,7 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use anyhow::Result;
+    use pegainfer_core::engine::{EngineControlError, LoadLoraAdapterRequest};
 
     use super::*;
     use crate::executor::{
@@ -346,6 +523,7 @@ mod tests {
         available_pages: usize,
         held_tokens: HashMap<RequestId, usize>,
         fail_decode_once: bool,
+        decode_delay: Duration,
         dropped: Arc<Mutex<Vec<u64>>>,
     }
 
@@ -357,12 +535,18 @@ mod tests {
                 available_pages: max_request_pages,
                 held_tokens: HashMap::new(),
                 fail_decode_once: false,
+                decode_delay: Duration::ZERO,
                 dropped,
             }
         }
 
         fn with_decode_failure(mut self) -> Self {
             self.fail_decode_once = true;
+            self
+        }
+
+        fn with_decode_delay(mut self, delay: Duration) -> Self {
+            self.decode_delay = delay;
             self
         }
 
@@ -431,6 +615,9 @@ mod tests {
             &mut self,
             plan: DecodePlan<'_>,
         ) -> Result<crate::executor::DecodeResult> {
+            if !self.decode_delay.is_zero() {
+                std::thread::sleep(self.decode_delay);
+            }
             if self.fail_decode_once {
                 self.fail_decode_once = false;
                 anyhow::bail!("fake decode KV capacity exhausted");
@@ -729,5 +916,76 @@ mod tests {
                 .contains(&0)),
             "dropping an active receiver should release request state"
         );
+    }
+
+    #[test]
+    fn lora_control_reports_unimplemented_when_idle() {
+        let dropped = Arc::new(Mutex::new(Vec::new()));
+        let executor = FakeExecutor::new(4, Arc::clone(&dropped));
+        let handle = start_with_executor_with_lora_control(executor, 42);
+
+        let error = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("build runtime")
+            .block_on(handle.load_lora_adapter(LoadLoraAdapterRequest {
+                lora_name: "adapter-a".to_string(),
+                lora_path: "/tmp/adapter-a".into(),
+            }))
+            .expect_err("adapter load should be a stub error");
+
+        match error {
+            EngineControlError::OperationFailed(message) => {
+                assert!(message.contains("not implemented yet"));
+                assert!(message.contains("adapter-a"));
+            }
+            other => panic!("unexpected control error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lora_control_waits_until_scheduler_idle() {
+        let dropped = Arc::new(Mutex::new(Vec::new()));
+        let executor =
+            FakeExecutor::new(4, Arc::clone(&dropped)).with_decode_delay(Duration::from_millis(80));
+        let handle = start_with_executor_with_lora_control(executor, 42);
+
+        let (long_running, mut token_rx) = request(16, 3);
+        handle.submit(long_running).expect("submit long_running");
+        assert!(
+            matches!(
+                token_rx.blocking_recv(),
+                Some(TokenEvent::Token { id: 100, .. })
+            ),
+            "first token should be emitted before decode"
+        );
+
+        let load_done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let load_done_thread = Arc::clone(&load_done);
+        let load_handle = handle.clone();
+        let load_thread = thread::spawn(move || {
+            let result = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .expect("build runtime")
+                .block_on(load_handle.load_lora_adapter(LoadLoraAdapterRequest {
+                    lora_name: "adapter-a".to_string(),
+                    lora_path: "/tmp/adapter-a".into(),
+                }));
+            load_done_thread.store(true, std::sync::atomic::Ordering::SeqCst);
+            result
+        });
+
+        std::thread::sleep(Duration::from_millis(20));
+        assert!(
+            !load_done.load(std::sync::atomic::Ordering::SeqCst),
+            "load_lora_adapter should wait while generation is active"
+        );
+
+        while !matches!(token_rx.blocking_recv(), Some(TokenEvent::Finished { .. })) {}
+
+        let error = load_thread
+            .join()
+            .expect("join load thread")
+            .expect_err("adapter load should be a stub error");
+        assert!(matches!(error, EngineControlError::OperationFailed(_)));
     }
 }

--- a/pegainfer-qwen3-4b/src/unified_forward.rs
+++ b/pegainfer-qwen3-4b/src/unified_forward.rs
@@ -11,6 +11,7 @@ use half::bf16;
 use super::config::PREFILL_ATTENTION_CTA_TILE_Q;
 use super::prefill::PrefillBuffers;
 use super::weights::{Qwen3Model, TransformerBlock};
+use crate::lora::apply_lora_projection_delta;
 use pegainfer_core::ffi;
 use pegainfer_core::kv_pool::{KvLayout, KvState};
 use pegainfer_core::ops;
@@ -288,6 +289,18 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.q_batch,
         );
+        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
+            && let Some(projection) = &lora_layer.q_proj
+        {
+            apply_lora_projection_delta(
+                &self.ctx,
+                projection,
+                &bufs.normed,
+                &mut bufs.q_batch,
+                0,
+                scale,
+            )?;
+        }
         ops::gemm_rows_into(
             &self.ctx,
             &layer.attention.qkv_proj,
@@ -296,6 +309,18 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.k_batch,
         );
+        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
+            && let Some(projection) = &lora_layer.k_proj
+        {
+            apply_lora_projection_delta(
+                &self.ctx,
+                projection,
+                &bufs.normed,
+                &mut bufs.k_batch,
+                0,
+                scale,
+            )?;
+        }
         ops::gemm_rows_into(
             &self.ctx,
             &layer.attention.qkv_proj,
@@ -304,6 +329,18 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.v_batch,
         );
+        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
+            && let Some(projection) = &lora_layer.v_proj
+        {
+            apply_lora_projection_delta(
+                &self.ctx,
+                projection,
+                &bufs.normed,
+                &mut bufs.v_batch,
+                0,
+                scale,
+            )?;
+        }
 
         // ── 3. QK norm + RoPE [all tokens, per-token positions] ──────
         {
@@ -532,6 +569,18 @@ impl Qwen3Model {
             &bufs.attn_output,
             &mut bufs.o_buf,
         );
+        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
+            && let Some(projection) = &lora_layer.o_proj
+        {
+            apply_lora_projection_delta(
+                &self.ctx,
+                projection,
+                &bufs.attn_output,
+                &mut bufs.o_buf,
+                0,
+                scale,
+            )?;
+        }
         self.all_reduce_hidden(&mut bufs.o_buf)?;
 
         // ── 7+8. Residual add + MLP RMSNorm (fused) ─────────────────
@@ -560,6 +609,28 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.up_out,
         );
+        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx) {
+            if let Some(projection) = &lora_layer.gate_proj {
+                apply_lora_projection_delta(
+                    &self.ctx,
+                    projection,
+                    &bufs.normed,
+                    &mut bufs.gate_out,
+                    0,
+                    scale,
+                )?;
+            }
+            if let Some(projection) = &lora_layer.up_proj {
+                apply_lora_projection_delta(
+                    &self.ctx,
+                    projection,
+                    &bufs.normed,
+                    &mut bufs.up_out,
+                    0,
+                    scale,
+                )?;
+            }
+        }
         ops::silu_mul_batch_into(&self.ctx, &bufs.gate_out, &bufs.up_out, &mut bufs.act_out)?;
         ops::gemm_into(
             &self.ctx,
@@ -567,6 +638,18 @@ impl Qwen3Model {
             &bufs.act_out,
             &mut bufs.o_buf,
         );
+        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
+            && let Some(projection) = &lora_layer.down_proj
+        {
+            apply_lora_projection_delta(
+                &self.ctx,
+                projection,
+                &bufs.act_out,
+                &mut bufs.o_buf,
+                0,
+                scale,
+            )?;
+        }
         self.all_reduce_hidden(&mut bufs.o_buf)?;
 
         // ── 9. Residual add → hidden_out ─────────────────────────────

--- a/pegainfer-qwen3-4b/src/weights.rs
+++ b/pegainfer-qwen3-4b/src/weights.rs
@@ -4,6 +4,7 @@ use log::{debug, info};
 use std::time::Instant;
 
 use super::config::{Config, TensorParallelConfig};
+use crate::lora::{DeviceLoraAdapter, DeviceLoraLayer};
 use pegainfer_core::tensor::{DeviceContext, DeviceMatrix, DeviceVec};
 use pegainfer_core::weight_loader::{
     deserialize_shards, load_shard_info, load_tensor_1d, load_tensor_2d, load_tensor_2d_col_shard,
@@ -71,6 +72,7 @@ pub(crate) struct Qwen3Model {
     pub(super) kv_pool: pegainfer_core::kv_pool::KvPool,
     pub(super) tensor_parallel: TensorParallelConfig,
     pub(super) tp_comm: Option<Comm>,
+    pub(super) lora_adapter: Option<DeviceLoraAdapter>,
 }
 
 // SAFETY: Each model instance is pinned to a single CUDA device and is only
@@ -346,6 +348,7 @@ impl Qwen3Model {
             kv_pool,
             tensor_parallel,
             tp_comm: None,
+            lora_adapter: None,
         };
 
         if model.enable_cuda_graph {
@@ -391,6 +394,24 @@ impl Qwen3Model {
 
     pub(crate) fn attach_tp_comm(&mut self, comm: Comm) {
         self.tp_comm = Some(comm);
+    }
+
+    pub(crate) fn set_lora_adapter(&mut self, adapter: DeviceLoraAdapter) {
+        debug!(
+            "Activating Qwen3 LoRA adapter {} from {}",
+            adapter.name,
+            adapter.manifest.path.display()
+        );
+        self.lora_adapter = Some(adapter);
+    }
+
+    pub(crate) fn lora_layer(&self, layer_idx: usize) -> Option<(&DeviceLoraLayer, f32)> {
+        self.lora_adapter.as_ref().and_then(|adapter| {
+            adapter
+                .layers
+                .get(layer_idx)
+                .map(|layer| (layer, adapter.scale))
+        })
     }
 
     pub(crate) fn all_reduce_hidden(

--- a/pegainfer-qwen3-4b/tests/lora_smoke.rs
+++ b/pegainfer-qwen3-4b/tests/lora_smoke.rs
@@ -1,0 +1,228 @@
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use half::bf16;
+use pegainfer_core::engine::{
+    EngineHandle, EngineLoadOptions, FinishReason, GenerateRequest, LoadLoraAdapterRequest,
+    TokenEvent,
+};
+use pegainfer_core::sampler::SamplingParams;
+use safetensors::Dtype;
+use safetensors::tensor::View;
+use serde::Deserialize;
+use tokio::sync::mpsc;
+use vllm_text::tokenizer::DynTokenizer;
+
+mod common;
+
+const MODEL_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../models/Qwen3-4B");
+
+#[derive(Deserialize)]
+struct ModelConfig {
+    hidden_size: usize,
+    intermediate_size: usize,
+    num_hidden_layers: usize,
+    num_attention_heads: usize,
+    num_key_value_heads: usize,
+    head_dim: usize,
+}
+
+#[derive(Clone)]
+struct TestTensor {
+    dtype: Dtype,
+    shape: Vec<usize>,
+    data: Vec<u8>,
+}
+
+impl View for TestTensor {
+    fn dtype(&self) -> Dtype {
+        self.dtype
+    }
+
+    fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    fn data(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(&self.data)
+    }
+
+    fn data_len(&self) -> usize {
+        self.data.len()
+    }
+}
+
+fn get_model_path() -> String {
+    std::env::var("PEGAINFER_TEST_MODEL_PATH").unwrap_or_else(|_| MODEL_PATH.to_string())
+}
+
+fn get_device_ordinal() -> usize {
+    std::env::var("PEGAINFER_TEST_DEVICE_ORDINAL")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(0)
+}
+
+fn load_model_config(model_path: &str) -> ModelConfig {
+    let config_path = Path::new(model_path).join("config.json");
+    let content = fs::read_to_string(&config_path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", config_path.display()));
+    serde_json::from_str(&content)
+        .unwrap_or_else(|err| panic!("failed to parse {}: {err}", config_path.display()))
+}
+
+fn temp_adapter_dir() -> PathBuf {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before unix epoch")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!(
+        "pegainfer-qwen3-lora-smoke-{}-{now}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&path);
+    fs::create_dir_all(&path).expect("create temp adapter dir");
+    path
+}
+
+fn write_zero_lora_adapter(path: &Path, config: &ModelConfig) {
+    let rank = 1;
+    fs::write(
+        path.join("adapter_config.json"),
+        r#"{
+  "peft_type": "LORA",
+  "r": 1,
+  "lora_alpha": 1,
+  "target_modules": ["q_proj", "v_proj"]
+}"#,
+    )
+    .expect("write adapter_config.json");
+
+    let mut tensors = BTreeMap::new();
+    for layer_idx in 0..config.num_hidden_layers {
+        push_zero_tensor(
+            &mut tensors,
+            tensor_name(layer_idx, "self_attn.q_proj", "lora_A"),
+            vec![rank, config.hidden_size],
+        );
+        push_zero_tensor(
+            &mut tensors,
+            tensor_name(layer_idx, "self_attn.q_proj", "lora_B"),
+            vec![config.num_attention_heads * config.head_dim, rank],
+        );
+        push_zero_tensor(
+            &mut tensors,
+            tensor_name(layer_idx, "self_attn.v_proj", "lora_A"),
+            vec![rank, config.hidden_size],
+        );
+        push_zero_tensor(
+            &mut tensors,
+            tensor_name(layer_idx, "self_attn.v_proj", "lora_B"),
+            vec![config.num_key_value_heads * config.head_dim, rank],
+        );
+    }
+
+    safetensors::serialize_to_file(tensors, None, &path.join("adapter_model.safetensors"))
+        .expect("write adapter_model.safetensors");
+}
+
+fn push_zero_tensor(tensors: &mut BTreeMap<String, TestTensor>, name: String, shape: Vec<usize>) {
+    let elems = shape.iter().product::<usize>();
+    tensors.insert(
+        name,
+        TestTensor {
+            dtype: Dtype::BF16,
+            shape,
+            data: bf16::from_f32(0.0).to_bits().to_le_bytes().repeat(elems),
+        },
+    );
+}
+
+fn tensor_name(layer_idx: usize, path_segment: &str, lora_side: &str) -> String {
+    format!("base_model.model.model.layers.{layer_idx}.{path_segment}.{lora_side}.weight")
+}
+
+fn load_adapter(handle: &EngineHandle, adapter_path: PathBuf) {
+    tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("build runtime")
+        .block_on(handle.load_lora_adapter(LoadLoraAdapterRequest {
+            lora_name: "zero-smoke".to_string(),
+            lora_path: adapter_path,
+        }))
+        .expect("load LoRA adapter");
+}
+
+fn generate_tokens(
+    handle: &EngineHandle,
+    tokenizer: &DynTokenizer,
+    prompt: &str,
+    max_tokens: usize,
+) -> (Vec<u32>, FinishReason) {
+    let prompt_tokens = tokenizer.encode(prompt, false).expect("encode failed");
+    let (token_tx, mut token_rx) = mpsc::unbounded_channel();
+
+    handle
+        .submit(GenerateRequest {
+            request_id: None,
+            queued_at_unix_s: None,
+            prompt_tokens,
+            params: SamplingParams::default(),
+            max_tokens,
+            token_tx,
+            logprobs: 0,
+            echo: false,
+        })
+        .expect("submit failed");
+
+    let mut tokens = Vec::new();
+    loop {
+        match token_rx.blocking_recv() {
+            Some(TokenEvent::Token { id, .. }) => tokens.push(id),
+            Some(TokenEvent::PromptTokens { .. } | TokenEvent::Scheduled { .. }) => {}
+            Some(TokenEvent::Finished { finish_reason, .. }) => return (tokens, finish_reason),
+            Some(TokenEvent::Error { message, .. }) => panic!("generation failed: {message}"),
+            Some(TokenEvent::Rejected { message, .. }) => panic!("generation rejected: {message}"),
+            None => panic!("scheduler channel closed without Finished"),
+        }
+    }
+}
+
+#[test]
+#[ignore = "requires Qwen3-4B weights and a CUDA GPU"]
+fn qwen3_lora_loads_adapter_and_generates() {
+    let model_path = get_model_path();
+    let config = load_model_config(&model_path);
+    assert!(
+        config.intermediate_size > config.hidden_size,
+        "unexpected Qwen3 config dimensions"
+    );
+
+    let adapter_path = temp_adapter_dir();
+    write_zero_lora_adapter(&adapter_path, &config);
+
+    let handle = pegainfer_qwen3_4b::start_engine_with_lora_control(
+        Path::new(&model_path),
+        EngineLoadOptions {
+            enable_cuda_graph: false,
+            enable_prefill_profile: false,
+            device_ordinals: vec![get_device_ordinal()],
+            seed: 42,
+        },
+    )
+    .expect("start LoRA-capable Qwen3 engine");
+
+    assert!(handle.supports_lora_control());
+    load_adapter(&handle, adapter_path);
+
+    let tokenizer = common::load_tokenizer(&model_path);
+    let (tokens, finish_reason) = generate_tokens(&handle, &tokenizer, "Hello", 4);
+    assert!(
+        !tokens.is_empty(),
+        "LoRA smoke generation returned no tokens"
+    );
+    assert_eq!(finish_reason, FinishReason::Length);
+}

--- a/pegainfer-server/src/main.rs
+++ b/pegainfer-server/src/main.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::time::Instant;
 
-use anyhow::Context;
+use anyhow::{Context, bail};
 use clap::Parser;
 use log::info;
 use pegainfer::logging;
@@ -34,6 +34,10 @@ struct Args {
     #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
     cuda_graph: bool,
 
+    /// Enable Qwen3 LoRA serving mode.
+    #[arg(long, default_value_t = false)]
+    enable_lora: bool,
+
     /// CUDA device ordinal for single-GPU Qwen3 loads
     #[arg(long, default_value_t = 0)]
     device_ordinal: usize,
@@ -59,6 +63,9 @@ async fn main() -> anyhow::Result<()> {
             args.model_path.display()
         )
     })?;
+    if args.enable_lora && !matches!(model_type, ModelType::Qwen3) {
+        bail!("--enable-lora is currently supported only for Qwen3");
+    }
     let effective_cuda_graph = match model_type {
         #[cfg(feature = "deepseek-v2-lite")]
         ModelType::DeepSeekV2Lite => false,
@@ -66,6 +73,7 @@ async fn main() -> anyhow::Result<()> {
         ModelType::DeepSeekV4 => false,
         #[cfg(feature = "kimi-k2")]
         ModelType::KimiK2 => args.cuda_graph,
+        ModelType::Qwen3 if args.enable_lora => false,
         ModelType::Qwen3 | ModelType::Qwen35 => args.cuda_graph,
     };
 
@@ -73,10 +81,11 @@ async fn main() -> anyhow::Result<()> {
     info!("Loading engine...");
     let start = Instant::now();
     info!(
-        "Runtime options: model_path={}, requested_cuda_graph={}, effective_cuda_graph={}, device_ordinal={}, tp_size={}",
+        "Runtime options: model_path={}, requested_cuda_graph={}, effective_cuda_graph={}, enable_lora={}, device_ordinal={}, tp_size={}",
         args.model_path.display(),
         args.cuda_graph,
         effective_cuda_graph,
+        args.enable_lora,
         args.device_ordinal,
         args.tp_size
     );
@@ -133,20 +142,26 @@ async fn main() -> anyhow::Result<()> {
             handle
         }
         ModelType::Qwen3 => {
+            if args.enable_lora && args.tp_size != 1 {
+                bail!("Qwen3 LoRA PR1 supports --tp-size=1 only");
+            }
             let device_ordinals: Vec<usize> = if args.tp_size == 1 {
                 vec![args.device_ordinal]
             } else {
                 (0..args.tp_size).collect()
             };
-            let handle = pegainfer_qwen3_4b::start_engine(
-                &args.model_path,
-                EngineLoadOptions {
-                    enable_cuda_graph: args.cuda_graph,
-                    enable_prefill_profile: false,
-                    device_ordinals,
-                    seed: 42,
-                },
-            )
+            let options = EngineLoadOptions {
+                enable_cuda_graph: effective_cuda_graph,
+                enable_prefill_profile: false,
+                device_ordinals,
+                seed: 42,
+            };
+            let handle = if args.enable_lora {
+                info!("Starting Qwen3 engine with LoRA control; CUDA Graph is disabled");
+                pegainfer_qwen3_4b::start_engine_with_lora_control(&args.model_path, options)
+            } else {
+                pegainfer_qwen3_4b::start_engine(&args.model_path, options)
+            }
             .context("failed to start Qwen3 engine")?;
 
             info!("Engine loaded: elapsed_ms={}", start.elapsed().as_millis());

--- a/pegainfer-server/src/main.rs
+++ b/pegainfer-server/src/main.rs
@@ -186,14 +186,28 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
-    pegainfer::vllm_frontend::serve(
-        handle,
-        &args.model_path,
-        args.served_model_name.as_deref(),
-        args.port,
-        pegainfer::vllm_frontend::shutdown_token_from_ctrl_c(),
-    )
-    .await
+    if args.enable_lora {
+        let max_model_len =
+            pegainfer::vllm_frontend::load_max_model_len(&args.model_path).unwrap_or(4096);
+        pegainfer::vllm_frontend::serve_model_with_lora_routes(
+            handle,
+            args.model_path.to_string_lossy().into_owned(),
+            args.served_model_name.into_iter().collect(),
+            args.port,
+            max_model_len,
+            pegainfer::vllm_frontend::shutdown_token_from_ctrl_c(),
+        )
+        .await
+    } else {
+        pegainfer::vllm_frontend::serve(
+            handle,
+            &args.model_path,
+            args.served_model_name.as_deref(),
+            args.port,
+            pegainfer::vllm_frontend::shutdown_token_from_ctrl_c(),
+        )
+        .await
+    }
     .context("vLLM frontend server failed")?;
 
     Ok(())

--- a/pegainfer-vllm-frontend/Cargo.toml
+++ b/pegainfer-vllm-frontend/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 pegainfer-engine = { workspace = true }
 anyhow = { workspace = true }
+axum = { workspace = true }
 log = { workspace = true }
 rmp-serde = { workspace = true }
 rmpv = { workspace = true }

--- a/pegainfer-vllm-frontend/Cargo.toml
+++ b/pegainfer-vllm-frontend/Cargo.toml
@@ -8,6 +8,7 @@ pegainfer-engine = { workspace = true }
 anyhow = { workspace = true }
 axum = { workspace = true }
 log = { workspace = true }
+reqwest = { workspace = true }
 rmp-serde = { workspace = true }
 rmpv = { workspace = true }
 serde = { workspace = true }

--- a/pegainfer-vllm-frontend/src/lib.rs
+++ b/pegainfer-vllm-frontend/src/lib.rs
@@ -1,11 +1,15 @@
 use std::collections::{BTreeSet, HashMap};
+use std::net::TcpListener as StdTcpListener;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
 use axum::Json;
 use axum::Router;
-use axum::http::StatusCode;
+use axum::body::{Body, to_bytes};
+use axum::extract::{Request, State};
+use axum::http::{HeaderName, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::post;
 use log::{info, warn};
@@ -38,10 +42,17 @@ use pegainfer_engine::engine::{
 use pegainfer_engine::sampler::SamplingParams;
 
 const ENGINE_INDEX: u32 = 0;
+const PROXY_BODY_LIMIT: usize = 128 * 1024 * 1024;
 
 #[derive(Clone)]
 struct LoraRouteState {
     handle: EngineHandle,
+}
+
+#[derive(Clone)]
+struct ProxyState {
+    client: reqwest::Client,
+    upstream_base_url: Arc<str>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -344,10 +355,70 @@ pub async fn serve_model(
     max_model_len: u32,
     shutdown: CancellationToken,
 ) -> Result<()> {
+    let model_id = model_id.into();
+    serve_model_on_host(
+        handle,
+        model_id,
+        served_model_name,
+        "0.0.0.0".to_string(),
+        port,
+        max_model_len,
+        shutdown,
+    )
+    .await
+}
+
+pub async fn serve_model_with_lora_routes(
+    handle: EngineHandle,
+    model_id: impl Into<String>,
+    served_model_name: Vec<String>,
+    port: u16,
+    max_model_len: u32,
+    shutdown: CancellationToken,
+) -> Result<()> {
+    let model_id = model_id.into();
+    let lora_router = lora_routes(handle.clone());
+    let internal_port = reserve_loopback_port()?;
+    let upstream_base_url: Arc<str> = format!("http://127.0.0.1:{internal_port}").into();
+    let internal_shutdown = shutdown.child_token();
+    let internal_task = tokio::spawn(serve_model_on_host(
+        handle,
+        model_id,
+        served_model_name,
+        "127.0.0.1".to_string(),
+        internal_port,
+        max_model_len,
+        internal_shutdown.clone(),
+    ));
+
+    wait_for_http_health(&upstream_base_url, &shutdown).await?;
+
+    info!(
+        "serving LoRA route proxy: public_port={}, upstream={}",
+        port, upstream_base_url
+    );
+    let proxy_result =
+        serve_lora_proxy(port, upstream_base_url, lora_router, shutdown.child_token()).await;
+
+    internal_shutdown.cancel();
+    let internal_result = internal_task
+        .await
+        .context("LoRA internal server task panicked")?;
+    proxy_result.and(internal_result)
+}
+
+async fn serve_model_on_host(
+    handle: EngineHandle,
+    model_id: String,
+    served_model_name: Vec<String>,
+    host: String,
+    port: u16,
+    max_model_len: u32,
+    shutdown: CancellationToken,
+) -> Result<()> {
     let namespace = local_ipc_namespace()?;
     let input_address = ipc_endpoint(&namespace, "input.sock");
     let output_address = ipc_endpoint(&namespace, "output.sock");
-    let model_id = model_id.into();
 
     let bridge = LocalEngineBridge {
         input_address: input_address.clone(),
@@ -372,10 +443,7 @@ pub async fn serve_model(
         coordinator_mode: CoordinatorMode::None,
         model: model_id,
         served_model_name,
-        listener_mode: HttpListenerMode::BindTcp {
-            host: "0.0.0.0".to_string(),
-            port,
-        },
+        listener_mode: HttpListenerMode::BindTcp { host, port },
         tool_call_parser: ParserSelection::default(),
         reasoning_parser: ParserSelection::default(),
         renderer: RendererSelection::default(),
@@ -392,6 +460,134 @@ pub async fn serve_model(
     bridge_task.abort();
     let _ = std::fs::remove_dir_all(namespace);
     result
+}
+
+fn reserve_loopback_port() -> Result<u16> {
+    let listener = StdTcpListener::bind(("127.0.0.1", 0))
+        .context("failed to reserve loopback port for internal vLLM server")?;
+    Ok(listener.local_addr()?.port())
+}
+
+async fn wait_for_http_health(upstream_base_url: &str, shutdown: &CancellationToken) -> Result<()> {
+    let client = reqwest::Client::new();
+    let health_url = format!("{upstream_base_url}/health");
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        tokio::select! {
+            () = shutdown.cancelled() => return Ok(()),
+            () = tokio::time::sleep(Duration::from_millis(100)) => {}
+        }
+        if tokio::time::Instant::now() >= deadline {
+            bail!("timed out waiting for internal vLLM server health at {health_url}");
+        }
+        match client.get(&health_url).send().await {
+            Ok(response) if response.status().is_success() => return Ok(()),
+            Ok(_) | Err(_) => {}
+        }
+    }
+}
+
+async fn serve_lora_proxy(
+    port: u16,
+    upstream_base_url: Arc<str>,
+    lora_router: Router,
+    shutdown: CancellationToken,
+) -> Result<()> {
+    let state = ProxyState {
+        client: reqwest::Client::new(),
+        upstream_base_url,
+    };
+    let proxy_router = Router::new().fallback(proxy_to_upstream).with_state(state);
+    let app = proxy_router.merge(lora_router);
+    let listener = tokio::net::TcpListener::bind(("0.0.0.0", port))
+        .await
+        .with_context(|| format!("failed to bind LoRA route proxy on 0.0.0.0:{port}"))?;
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown.cancelled_owned())
+        .await
+        .context("LoRA route proxy failed")
+}
+
+async fn proxy_to_upstream(State(state): State<ProxyState>, request: Request) -> Response {
+    match proxy_to_upstream_inner(state, request).await {
+        Ok(response) => response,
+        Err(error) => (
+            StatusCode::BAD_GATEWAY,
+            Json(ErrorBody {
+                error: format!("failed to proxy request to internal vLLM server: {error:#}"),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+async fn proxy_to_upstream_inner(state: ProxyState, request: Request) -> Result<Response> {
+    let (parts, body) = request.into_parts();
+    let path_and_query = parts
+        .uri
+        .path_and_query()
+        .map_or("/", axum::http::uri::PathAndQuery::as_str);
+    let upstream_url = format!("{}{}", state.upstream_base_url, path_and_query);
+    let body = to_bytes(body, PROXY_BODY_LIMIT)
+        .await
+        .context("failed to read proxy request body")?;
+
+    let mut upstream = state.client.request(parts.method, upstream_url);
+    for (name, value) in &parts.headers {
+        if should_forward_request_header(name) {
+            upstream = upstream.header(name.as_str(), value);
+        }
+    }
+
+    let response = upstream
+        .body(body)
+        .send()
+        .await
+        .context("upstream request failed")?;
+    let status = StatusCode::from_u16(response.status().as_u16())
+        .context("upstream returned invalid status")?;
+    let mut builder = Response::builder().status(status);
+    for (name, value) in response.headers() {
+        if should_forward_response_header(name) {
+            builder = builder.header(name, value);
+        }
+    }
+
+    builder
+        .body(Body::from_stream(response.bytes_stream()))
+        .context("failed to build proxy response")
+}
+
+fn should_forward_request_header(name: &HeaderName) -> bool {
+    !matches!(
+        name.as_str(),
+        "connection"
+            | "content-length"
+            | "host"
+            | "keep-alive"
+            | "proxy-authenticate"
+            | "proxy-authorization"
+            | "te"
+            | "trailer"
+            | "transfer-encoding"
+            | "upgrade"
+    )
+}
+
+fn should_forward_response_header(name: &HeaderName) -> bool {
+    !matches!(
+        name.as_str(),
+        "connection"
+            | "content-length"
+            | "keep-alive"
+            | "proxy-authenticate"
+            | "proxy-authorization"
+            | "te"
+            | "trailer"
+            | "transfer-encoding"
+            | "upgrade"
+    )
 }
 
 async fn run_request_stream(
@@ -705,7 +901,7 @@ async fn wait_for_ipc_endpoint(address: &str, shutdown: &CancellationToken) -> R
     }
 }
 
-fn load_max_model_len(model_path: &Path) -> Option<u32> {
+pub fn load_max_model_len(model_path: &Path) -> Option<u32> {
     let content = std::fs::read_to_string(model_path.join("config.json")).ok()?;
     serde_json::from_str::<ModelLenConfig>(&content)
         .ok()?

--- a/pegainfer-vllm-frontend/src/lib.rs
+++ b/pegainfer-vllm-frontend/src/lib.rs
@@ -3,8 +3,13 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
+use axum::Json;
+use axum::Router;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
 use log::{info, warn};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -27,11 +32,99 @@ use zeromq::util::PeerIdentity;
 use zeromq::{DealerSocket, PushSocket, SocketOptions, ZmqMessage};
 
 use pegainfer_engine::engine::{
-    EngineHandle, FinishReason, GenerateRequest, TokenEvent, TokenLogprob,
+    EngineControlError, EngineHandle, FinishReason, GenerateRequest, LoadLoraAdapterRequest,
+    TokenEvent, TokenLogprob,
 };
 use pegainfer_engine::sampler::SamplingParams;
 
 const ENGINE_INDEX: u32 = 0;
+
+#[derive(Clone)]
+struct LoraRouteState {
+    handle: EngineHandle,
+}
+
+#[derive(Debug, Deserialize)]
+struct LoadLoraAdapterHttpRequest {
+    lora_name: String,
+    lora_path: PathBuf,
+    #[serde(default)]
+    load_inplace: bool,
+    #[serde(default)]
+    is_3d_lora_weight: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorBody {
+    error: String,
+}
+
+pub fn lora_routes(handle: EngineHandle) -> Router {
+    Router::new()
+        .route("/v1/load_lora_adapter", post(load_lora_adapter))
+        .with_state(LoraRouteState { handle })
+}
+
+async fn load_lora_adapter(
+    axum::extract::State(state): axum::extract::State<LoraRouteState>,
+    Json(request): Json<LoadLoraAdapterHttpRequest>,
+) -> Response {
+    if request.lora_name.is_empty() {
+        return bad_request("lora_name must not be empty");
+    }
+    if request.lora_path.as_os_str().is_empty() {
+        return bad_request("lora_path must not be empty");
+    }
+    if request.load_inplace {
+        return bad_request("load_inplace=true is not supported by Qwen3 LoRA PR1");
+    }
+    if request.is_3d_lora_weight {
+        return bad_request("is_3d_lora_weight=true is not supported by Qwen3 LoRA PR1");
+    }
+
+    let lora_name = request.lora_name.clone();
+    match state
+        .handle
+        .load_lora_adapter(LoadLoraAdapterRequest {
+            lora_name: request.lora_name,
+            lora_path: request.lora_path,
+        })
+        .await
+    {
+        Ok(()) => (
+            StatusCode::OK,
+            format!("Success: LoRA adapter '{lora_name}' added successfully."),
+        )
+            .into_response(),
+        Err(EngineControlError::Unsupported(message)) => (
+            StatusCode::NOT_FOUND,
+            Json(ErrorBody {
+                error: message.to_string(),
+            }),
+        )
+            .into_response(),
+        Err(EngineControlError::ChannelClosed) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorBody {
+                error: EngineControlError::ChannelClosed.to_string(),
+            }),
+        )
+            .into_response(),
+        Err(EngineControlError::OperationFailed(message)) => {
+            (StatusCode::BAD_REQUEST, Json(ErrorBody { error: message })).into_response()
+        }
+    }
+}
+
+fn bad_request(message: impl Into<String>) -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ErrorBody {
+            error: message.into(),
+        }),
+    )
+        .into_response()
+}
 
 #[derive(Debug, Deserialize)]
 struct ModelLenConfig {
@@ -634,6 +727,46 @@ pub fn shutdown_token_from_ctrl_c() -> CancellationToken {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn load_lora_adapter_route_reports_unsupported_engine() {
+        let (submit_tx, _submit_rx) = mpsc::unbounded_channel::<GenerateRequest>();
+        let state = LoraRouteState {
+            handle: EngineHandle::new(submit_tx),
+        };
+        let response = load_lora_adapter(
+            axum::extract::State(state),
+            Json(LoadLoraAdapterHttpRequest {
+                lora_name: "adapter-a".to_string(),
+                lora_path: PathBuf::from("/tmp/adapter-a"),
+                load_inplace: false,
+                is_3d_lora_weight: false,
+            }),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn load_lora_adapter_route_rejects_pr1_unsupported_fields() {
+        let (submit_tx, _submit_rx) = mpsc::unbounded_channel::<GenerateRequest>();
+        let state = LoraRouteState {
+            handle: EngineHandle::new(submit_tx),
+        };
+        let response = load_lora_adapter(
+            axum::extract::State(state),
+            Json(LoadLoraAdapterHttpRequest {
+                lora_name: "adapter-a".to_string(),
+                lora_path: PathBuf::from("/tmp/adapter-a"),
+                load_inplace: true,
+                is_3d_lora_weight: false,
+            }),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
 
     #[tokio::test]
     async fn rejected_request_is_reported_as_error() {

--- a/pegainfer-vllm-frontend/src/lib.rs
+++ b/pegainfer-vllm-frontend/src/lib.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use axum::Json;
 use axum::Router;
 use axum::body::{Body, to_bytes};
@@ -378,33 +378,65 @@ pub async fn serve_model_with_lora_routes(
 ) -> Result<()> {
     let model_id = model_id.into();
     let lora_router = lora_routes(handle.clone());
-    let internal_port = reserve_loopback_port()?;
-    let upstream_base_url: Arc<str> = format!("http://127.0.0.1:{internal_port}").into();
-    let internal_shutdown = shutdown.child_token();
-    let internal_task = tokio::spawn(serve_model_on_host(
-        handle,
-        model_id,
-        served_model_name,
-        "127.0.0.1".to_string(),
-        internal_port,
-        max_model_len,
-        internal_shutdown.clone(),
-    ));
+    let mut last_error = None;
+    for attempt in 1..=5 {
+        let internal_port = reserve_loopback_port()?;
+        let upstream_base_url: Arc<str> = format!("http://127.0.0.1:{internal_port}").into();
+        let internal_shutdown = shutdown.child_token();
+        let mut internal_task = tokio::spawn(serve_model_on_host(
+            handle.clone(),
+            model_id.clone(),
+            served_model_name.clone(),
+            "127.0.0.1".to_string(),
+            internal_port,
+            max_model_len,
+            internal_shutdown.clone(),
+        ));
 
-    wait_for_http_health(&upstream_base_url, &shutdown).await?;
+        let mut internal_task_finished = false;
+        let health_result = tokio::select! {
+            result = wait_for_http_health(&upstream_base_url, &shutdown) => result,
+            result = &mut internal_task => {
+                internal_task_finished = true;
+                match result {
+                    Ok(Ok(())) => Err(anyhow!("internal vLLM server exited before becoming healthy")),
+                    Ok(Err(error)) => Err(error).context("internal vLLM server exited before becoming healthy"),
+                    Err(error) => Err(error).context("LoRA internal server task panicked"),
+                }
+            }
+        };
 
-    info!(
-        "serving LoRA route proxy: public_port={}, upstream={}",
-        port, upstream_base_url
-    );
-    let proxy_result =
-        serve_lora_proxy(port, upstream_base_url, lora_router, shutdown.child_token()).await;
+        if let Err(error) = health_result {
+            internal_shutdown.cancel();
+            if !internal_task_finished {
+                let _ = internal_task.await;
+            }
+            if attempt == 5 {
+                return Err(error).context("failed to start internal vLLM server for LoRA routes");
+            }
+            warn!(
+                "retrying LoRA internal vLLM server startup after attempt {} failed: {error:#}",
+                attempt
+            );
+            last_error = Some(error);
+            continue;
+        }
 
-    internal_shutdown.cancel();
-    let internal_result = internal_task
-        .await
-        .context("LoRA internal server task panicked")?;
-    proxy_result.and(internal_result)
+        info!(
+            "serving LoRA route proxy: public_port={}, upstream={}",
+            port, upstream_base_url
+        );
+        let proxy_result =
+            serve_lora_proxy(port, upstream_base_url, lora_router, shutdown.child_token()).await;
+
+        internal_shutdown.cancel();
+        let internal_result = internal_task
+            .await
+            .context("LoRA internal server task panicked")?;
+        return proxy_result.and(internal_result);
+    }
+
+    Err(last_error.unwrap_or_else(|| anyhow!("internal vLLM server startup was not attempted")))
 }
 
 async fn serve_model_on_host(
@@ -480,7 +512,12 @@ async fn wait_for_http_health(upstream_base_url: &str, shutdown: &CancellationTo
         if tokio::time::Instant::now() >= deadline {
             bail!("timed out waiting for internal vLLM server health at {health_url}");
         }
-        match client.get(&health_url).send().await {
+        match client
+            .get(&health_url)
+            .timeout(Duration::from_secs(1))
+            .send()
+            .await
+        {
             Ok(response) if response.status().is_success() => return Ok(()),
             Ok(_) | Err(_) => {}
         }

--- a/tools/qwen3_lora_live_parity.py
+++ b/tools/qwen3_lora_live_parity.py
@@ -26,12 +26,12 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--model-path", required=True)
     parser.add_argument("--adapter-path")
-    parser.add_argument("--prompt", default="Hello")
+    parser.add_argument("--prompt", default="Tell me a story")
     parser.add_argument("--max-tokens", type=int, default=8)
     parser.add_argument("--port", type=int, default=18080)
     parser.add_argument("--server-url")
     parser.add_argument("--lora-name", default="parity")
-    parser.add_argument("--scale", type=float, default=0.02)
+    parser.add_argument("--scale", type=float, default=0.001)
     parser.add_argument("--startup-timeout-s", type=float, default=180.0)
     return parser.parse_args()
 
@@ -106,7 +106,7 @@ def hf_peft_reference(model_path: Path, adapter_path: Path, prompt: str, max_tok
     tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
     base = AutoModelForCausalLM.from_pretrained(
         model_path,
-        torch_dtype=torch.bfloat16,
+        dtype=torch.bfloat16,
         trust_remote_code=True,
         low_cpu_mem_usage=True,
     ).to("cuda")

--- a/tools/qwen3_lora_live_parity.py
+++ b/tools/qwen3_lora_live_parity.py
@@ -141,6 +141,54 @@ def hf_peft_reference(model_path: Path, adapter_path: Path, prompt: str, max_tok
     }
 
 
+def encode_generated_text(model_path: Path, text: str) -> list[int]:
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+    return tokenizer(text, add_special_tokens=False)["input_ids"]
+
+
+def first_token_mismatch(
+    hf_token_ids: list[int],
+    pegainfer_token_ids: list[int],
+    model_path: Path,
+) -> dict | None:
+    if hf_token_ids == pegainfer_token_ids:
+        return None
+
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+    for index, (hf_token_id, pegainfer_token_id) in enumerate(
+        zip(hf_token_ids, pegainfer_token_ids),
+        start=1,
+    ):
+        if hf_token_id != pegainfer_token_id:
+            return {
+                "index_1based": index,
+                "hf_token_id": hf_token_id,
+                "pegainfer_token_id": pegainfer_token_id,
+                "hf_piece": tokenizer.decode([hf_token_id]),
+                "pegainfer_piece": tokenizer.decode([pegainfer_token_id]),
+            }
+
+    return {
+        "index_1based": min(len(hf_token_ids), len(pegainfer_token_ids)) + 1,
+        "hf_token_id": hf_token_ids[len(pegainfer_token_ids)]
+        if len(hf_token_ids) > len(pegainfer_token_ids)
+        else None,
+        "pegainfer_token_id": pegainfer_token_ids[len(hf_token_ids)]
+        if len(pegainfer_token_ids) > len(hf_token_ids)
+        else None,
+        "hf_piece": tokenizer.decode([hf_token_ids[len(pegainfer_token_ids)]])
+        if len(hf_token_ids) > len(pegainfer_token_ids)
+        else None,
+        "pegainfer_piece": tokenizer.decode([pegainfer_token_ids[len(hf_token_ids)]])
+        if len(pegainfer_token_ids) > len(hf_token_ids)
+        else None,
+    }
+
+
 def post_json(url: str, payload: dict, timeout: float = 120.0) -> dict | str:
     data = json.dumps(payload).encode("utf-8")
     request = urllib.request.Request(
@@ -301,6 +349,8 @@ def main() -> int:
     if not choices:
         raise RuntimeError(f"completion response has no choices: {completion}")
     pegainfer_text = choices[0].get("text", "")
+    pegainfer_token_ids = encode_generated_text(model_path, pegainfer_text)
+    mismatch = first_token_mismatch(hf["token_ids"], pegainfer_token_ids, model_path)
     summary = {
         "adapter_path": str(adapter_path),
         "hf_text": hf["text"],
@@ -308,6 +358,8 @@ def main() -> int:
         "hf_logit_max_abs_diff_vs_base": hf["logit_max_abs_diff_vs_base"],
         "load_response": load_response,
         "pegainfer_text": pegainfer_text,
+        "pegainfer_token_ids": pegainfer_token_ids,
+        "first_token_mismatch": mismatch,
         "match": pegainfer_text == hf["text"],
     }
     print(json.dumps(summary, indent=2, ensure_ascii=False))

--- a/tools/qwen3_lora_live_parity.py
+++ b/tools/qwen3_lora_live_parity.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Live Qwen3 LoRA parity check against HuggingFace + PEFT.
+
+The script creates a deterministic PEFT-style adapter, obtains the greedy
+reference text from transformers+peft, loads the same adapter through
+PegaInfer's live /v1/load_lora_adapter route, and compares /v1/completions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--adapter-path")
+    parser.add_argument("--prompt", default="Hello")
+    parser.add_argument("--max-tokens", type=int, default=8)
+    parser.add_argument("--port", type=int, default=18080)
+    parser.add_argument("--server-url")
+    parser.add_argument("--lora-name", default="parity")
+    parser.add_argument("--scale", type=float, default=0.02)
+    parser.add_argument("--startup-timeout-s", type=float, default=180.0)
+    return parser.parse_args()
+
+
+def read_config(model_path: Path) -> dict:
+    return json.loads((model_path / "config.json").read_text())
+
+
+def tensor_name(layer_idx: int, path_segment: str, lora_side: str) -> str:
+    return f"base_model.model.model.layers.{layer_idx}.{path_segment}.{lora_side}.weight"
+
+
+def patterned_tensor(torch, shape: tuple[int, ...], seed: int, scale: float):
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(seed)
+    tensor = torch.empty(shape, dtype=torch.float32)
+    tensor.uniform_(-scale, scale, generator=generator)
+    return tensor.to(torch.bfloat16)
+
+
+def write_adapter(model_path: Path, adapter_path: Path, scale: float) -> None:
+    from safetensors.torch import save_file
+    import torch
+
+    config = read_config(model_path)
+    rank = 1
+    adapter_path.mkdir(parents=True, exist_ok=True)
+    (adapter_path / "adapter_config.json").write_text(
+        json.dumps(
+            {
+                "base_model_name_or_path": str(model_path),
+                "bias": "none",
+                "fan_in_fan_out": False,
+                "inference_mode": True,
+                "lora_alpha": 1,
+                "lora_dropout": 0.0,
+                "peft_type": "LORA",
+                "r": rank,
+                "target_modules": ["q_proj", "v_proj"],
+                "task_type": "CAUSAL_LM",
+            },
+            indent=2,
+        )
+    )
+
+    hidden = int(config["hidden_size"])
+    q_out = int(config["num_attention_heads"]) * int(config["head_dim"])
+    v_out = int(config["num_key_value_heads"]) * int(config["head_dim"])
+    tensors = {}
+    for layer_idx in range(int(config["num_hidden_layers"])):
+        base_seed = 1000 + layer_idx * 17
+        tensors[tensor_name(layer_idx, "self_attn.q_proj", "lora_A")] = patterned_tensor(
+            torch, (rank, hidden), base_seed, scale
+        )
+        tensors[tensor_name(layer_idx, "self_attn.q_proj", "lora_B")] = patterned_tensor(
+            torch, (q_out, rank), base_seed + 1, scale
+        )
+        tensors[tensor_name(layer_idx, "self_attn.v_proj", "lora_A")] = patterned_tensor(
+            torch, (rank, hidden), base_seed + 2, scale
+        )
+        tensors[tensor_name(layer_idx, "self_attn.v_proj", "lora_B")] = patterned_tensor(
+            torch, (v_out, rank), base_seed + 3, scale
+        )
+    save_file(tensors, str(adapter_path / "adapter_model.safetensors"))
+
+
+def hf_peft_reference(model_path: Path, adapter_path: Path, prompt: str, max_tokens: int) -> dict:
+    import torch
+    from peft import PeftModel
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+    base = AutoModelForCausalLM.from_pretrained(
+        model_path,
+        torch_dtype=torch.bfloat16,
+        trust_remote_code=True,
+        low_cpu_mem_usage=True,
+    ).to("cuda")
+    model = PeftModel.from_pretrained(base, adapter_path, is_trainable=False).eval()
+    inputs = tokenizer(prompt, return_tensors="pt").to("cuda")
+
+    with torch.no_grad():
+        with model.disable_adapter():
+            base_logits = model(**inputs).logits[:, -1, :].float()
+        lora_logits = model(**inputs).logits[:, -1, :].float()
+        logit_max_abs_diff = (lora_logits - base_logits).abs().max().item()
+        output = model.generate(
+            **inputs,
+            max_new_tokens=max_tokens,
+            do_sample=False,
+            pad_token_id=tokenizer.eos_token_id,
+        )
+
+    new_tokens = output[0, inputs["input_ids"].shape[-1] :].tolist()
+    text = tokenizer.decode(new_tokens, skip_special_tokens=True)
+
+    del model
+    del base
+    del inputs
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    return {
+        "text": text,
+        "token_ids": new_tokens,
+        "logit_max_abs_diff_vs_base": logit_max_abs_diff,
+    }
+
+
+def post_json(url: str, payload: dict, timeout: float = 120.0) -> dict | str:
+    data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        body = response.read().decode("utf-8")
+    with contextlib.suppress(json.JSONDecodeError):
+        return json.loads(body)
+    return body
+
+
+def get(url: str, timeout: float = 5.0) -> str:
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+        return response.read().decode("utf-8")
+
+
+def wait_for_health(server_url: str, timeout_s: float, process: subprocess.Popen | None) -> None:
+    deadline = time.monotonic() + timeout_s
+    last_error = None
+    while time.monotonic() < deadline:
+        if process is not None and process.poll() is not None:
+            raise RuntimeError(f"server exited early with code {process.returncode}")
+        try:
+            get(f"{server_url}/health")
+            return
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+            time.sleep(0.5)
+    raise TimeoutError(f"timed out waiting for {server_url}/health: {last_error}")
+
+
+def start_server(args: argparse.Namespace, repo_root: Path) -> subprocess.Popen:
+    env = os.environ.copy()
+    env.setdefault("PEGAINFER_CUDA_SM", "80")
+    compat = "/usr/local/cuda-12.9/compat"
+    if Path(compat).exists():
+        old = env.get("LD_LIBRARY_PATH")
+        env["LD_LIBRARY_PATH"] = compat if not old else f"{compat}:{old}"
+    command = [
+        "cargo",
+        "run",
+        "--release",
+        "-p",
+        "pegainfer-server",
+        "--",
+        "--model-path",
+        args.model_path,
+        "--enable-lora",
+        "--port",
+        str(args.port),
+    ]
+    log = tempfile.NamedTemporaryFile(
+        prefix="pegainfer-qwen3-lora-server-",
+        suffix=".log",
+        mode="w+",
+        delete=False,
+    )
+    process = subprocess.Popen(
+        command,
+        cwd=repo_root,
+        env=env,
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        text=True,
+        start_new_session=True,
+    )
+    process.pegainfer_log_path = log.name  # type: ignore[attr-defined]
+    log.close()
+    return process
+
+
+def stop_server(process: subprocess.Popen | None) -> None:
+    if process is None or process.poll() is not None:
+        return
+    os.killpg(process.pid, signal.SIGTERM)
+    try:
+        process.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGKILL)
+        process.wait(timeout=5)
+
+
+def tail_server_output(process: subprocess.Popen | None) -> str:
+    if process is None:
+        return ""
+    log_path = getattr(process, "pegainfer_log_path", None)
+    if not log_path:
+        return ""
+    with contextlib.suppress(Exception):
+        return Path(log_path).read_text(errors="replace")[-4000:]
+    return ""
+
+
+def pegainfer_completion(
+    server_url: str,
+    model_name: str,
+    prompt: str,
+    max_tokens: int,
+) -> dict:
+    response = post_json(
+        f"{server_url}/v1/completions",
+        {
+            "model": model_name,
+            "prompt": prompt,
+            "max_tokens": max_tokens,
+            "temperature": 0,
+        },
+    )
+    if not isinstance(response, dict):
+        raise RuntimeError(f"unexpected completion response: {response!r}")
+    return response
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parents[1]
+    model_path = Path(args.model_path).resolve()
+    if args.adapter_path:
+        adapter_path = Path(args.adapter_path).resolve()
+        adapter_path.mkdir(parents=True, exist_ok=True)
+        cleanup = contextlib.nullcontext(adapter_path)
+    else:
+        cleanup = tempfile.TemporaryDirectory(prefix="pegainfer-qwen3-lora-parity-")
+
+    process = None
+    with cleanup as adapter_dir:
+        adapter_path = Path(adapter_dir)
+        write_adapter(model_path, adapter_path, args.scale)
+        hf = hf_peft_reference(model_path, adapter_path, args.prompt, args.max_tokens)
+
+        server_url = args.server_url or f"http://127.0.0.1:{args.port}"
+        if args.server_url is None:
+            process = start_server(args, repo_root)
+        try:
+            wait_for_health(server_url, args.startup_timeout_s, process)
+            load_response = post_json(
+                f"{server_url}/v1/load_lora_adapter",
+                {"lora_name": args.lora_name, "lora_path": str(adapter_path)},
+            )
+            completion = pegainfer_completion(
+                server_url,
+                model_name=str(model_path),
+                prompt=args.prompt,
+                max_tokens=args.max_tokens,
+            )
+        finally:
+            stop_server(process)
+
+    choices = completion.get("choices", [])
+    if not choices:
+        raise RuntimeError(f"completion response has no choices: {completion}")
+    pegainfer_text = choices[0].get("text", "")
+    summary = {
+        "adapter_path": str(adapter_path),
+        "hf_text": hf["text"],
+        "hf_token_ids": hf["token_ids"],
+        "hf_logit_max_abs_diff_vs_base": hf["logit_max_abs_diff_vs_base"],
+        "load_response": load_response,
+        "pegainfer_text": pegainfer_text,
+        "match": pegainfer_text == hf["text"],
+    }
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+
+    if pegainfer_text != hf["text"]:
+        print(tail_server_output(process), file=sys.stderr)
+        return 1
+    if hf["logit_max_abs_diff_vs_base"] == 0.0:
+        print("adapter did not change HF logits", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/qwen3_lora_live_parity.py
+++ b/tools/qwen3_lora_live_parity.py
@@ -33,6 +33,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--lora-name", default="parity")
     parser.add_argument("--scale", type=float, default=0.001)
     parser.add_argument("--startup-timeout-s", type=float, default=180.0)
+    parser.add_argument(
+        "--disable-peft-adapter-autocast",
+        action="store_true",
+        help="Disable PEFT's default adapter dtype autocast for diagnostics.",
+    )
     return parser.parse_args()
 
 
@@ -98,7 +103,13 @@ def write_adapter(model_path: Path, adapter_path: Path, scale: float) -> None:
     save_file(tensors, str(adapter_path / "adapter_model.safetensors"))
 
 
-def hf_peft_reference(model_path: Path, adapter_path: Path, prompt: str, max_tokens: int) -> dict:
+def hf_peft_reference(
+    model_path: Path,
+    adapter_path: Path,
+    prompt: str,
+    max_tokens: int,
+    autocast_adapter_dtype: bool,
+) -> dict:
     import torch
     from peft import PeftModel
     from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -114,7 +125,7 @@ def hf_peft_reference(model_path: Path, adapter_path: Path, prompt: str, max_tok
         base,
         adapter_path,
         is_trainable=False,
-        autocast_adapter_dtype=False,
+        autocast_adapter_dtype=autocast_adapter_dtype,
     ).eval()
     inputs = tokenizer(prompt, return_tensors="pt").to("cuda")
 
@@ -327,7 +338,14 @@ def main() -> int:
     with cleanup as adapter_dir:
         adapter_path = Path(adapter_dir)
         write_adapter(model_path, adapter_path, args.scale)
-        hf = hf_peft_reference(model_path, adapter_path, args.prompt, args.max_tokens)
+        peft_autocast_adapter_dtype = not args.disable_peft_adapter_autocast
+        hf = hf_peft_reference(
+            model_path,
+            adapter_path,
+            args.prompt,
+            args.max_tokens,
+            peft_autocast_adapter_dtype,
+        )
 
         server_url = args.server_url or f"http://127.0.0.1:{args.port}"
         if args.server_url is None:
@@ -361,6 +379,7 @@ def main() -> int:
         "hf_text": hf["text"],
         "hf_token_ids": hf["token_ids"],
         "hf_logit_max_abs_diff_vs_base": hf["logit_max_abs_diff_vs_base"],
+        "peft_autocast_adapter_dtype": peft_autocast_adapter_dtype,
         "load_response": load_response,
         "pegainfer_text": pegainfer_text,
         "pegainfer_token_ids": pegainfer_token_ids,

--- a/tools/qwen3_lora_live_parity.py
+++ b/tools/qwen3_lora_live_parity.py
@@ -212,6 +212,7 @@ def start_server(args: argparse.Namespace, repo_root: Path) -> subprocess.Popen:
         start_new_session=True,
     )
     process.pegainfer_log_path = log.name  # type: ignore[attr-defined]
+    print(f"server_log={log.name}", file=sys.stderr)
     log.close()
     return process
 
@@ -290,6 +291,9 @@ def main() -> int:
                 prompt=args.prompt,
                 max_tokens=args.max_tokens,
             )
+        except Exception:  # noqa: BLE001
+            print(tail_server_output(process), file=sys.stderr)
+            raise
         finally:
             stop_server(process)
 

--- a/tools/qwen3_lora_live_parity.py
+++ b/tools/qwen3_lora_live_parity.py
@@ -110,7 +110,12 @@ def hf_peft_reference(model_path: Path, adapter_path: Path, prompt: str, max_tok
         trust_remote_code=True,
         low_cpu_mem_usage=True,
     ).to("cuda")
-    model = PeftModel.from_pretrained(base, adapter_path, is_trainable=False).eval()
+    model = PeftModel.from_pretrained(
+        base,
+        adapter_path,
+        is_trainable=False,
+        autocast_adapter_dtype=False,
+    ).eval()
     inputs = tokenizer(prompt, return_tensors="pt").to("cuda")
 
     with torch.no_grad():


### PR DESCRIPTION
## Summary

This PR implements the first Qwen3 LoRA inference slice from #173.

It adds an opt-in `--enable-lora` serving mode for Qwen3-4B. In that mode, PegaInfer can dynamically load one PEFT-style LoRA adapter through a vLLM-compatible `POST /v1/load_lora_adapter` endpoint and apply the adapter during generation.

The existing no-LoRA serving path stays unchanged unless `--enable-lora` is passed.

## What is included

- Adds an engine control path for LoRA-capable engines:
  - `EngineCommand`
  - `EngineHandle::load_lora_adapter(...)`
  - unsupported-engine error handling for non-LoRA paths
- Adds Qwen3 LoRA startup support:
  - `--enable-lora`
  - Qwen3-specific LoRA control startup
  - idle-only scheduler mutation for adapter loading
- Adds PEFT adapter loading for Qwen3-4B:
  - reads `adapter_config.json`
  - reads `adapter_model.safetensors`
  - validates tensor names, dtypes, shapes, rank, alpha, layer count, and target modules
  - supports `BF16`, `F16`, and `F32` adapter tensors, converted to host-side `bf16`
- Supports these Qwen3 LoRA target modules:
  - `q_proj`
  - `k_proj`
  - `v_proj`
  - `o_proj`
  - `gate_proj`
  - `up_proj`
  - `down_proj`
- Applies LoRA deltas with correctness-first extra GEMMs:
  - `B @ (A @ x) * alpha / rank`
  - handles fused QKV layout
  - handles fused `gate_proj` / `up_proj` with row-range scaled adds
- Exposes a live vLLM-compatible load route:
  - `POST /v1/load_lora_adapter`
  - accepts `lora_name` and `lora_path`
  - rejects unsupported advanced fields for PR1
- Adds test and validation tooling:
  - Qwen3 adapter loader tests
  - Qwen3 scheduler/control tests
  - ignored Qwen3-4B GPU smoke test
  - live HF/PEFT parity tool

## Scope and intentional limits

This PR is intentionally a single-adapter MVP:

- Qwen3-4B only.
- One active LoRA adapter at a time.
- Adapter loading is serialized through the scheduler and only mutates state when generation is idle.
- `--tp-size > 1` is rejected when `--enable-lora` is set.
- CUDA Graph is disabled in Qwen3 LoRA mode.
- No per-request mixed LoRA batching yet.
- No `/v1/unload_lora_adapter` yet.
- No grouped/optimized LoRA kernels yet.

Those limits keep this PR focused on API shape, adapter loading, and correctness. Multi-GPU TP LoRA, batch-level adapter selection, CUDA Graph cache keys, unload, and performance kernels can be added in follow-up PRs.

## Frontend note

The pinned Rust `vllm_server::serve` API currently owns router construction internally and does not expose a route-extension hook.

To keep the public API compatible with vLLM without forking that dependency, Qwen3 LoRA mode starts the normal vLLM server on an internal loopback port and exposes a same-port axum wrapper:

- `/v1/load_lora_adapter` is handled by PegaInfer.
- Existing OpenAI/vLLM routes are proxied to the internal vLLM server.
- Non-LoRA mode still calls `vllm_server::serve` directly.

This is meant as a narrow workaround for PR1. If `vllm_server` exposes a route-extension API later, this can be replaced with a direct route merge.

## Validation

Local checks:

- `cargo fmt --check`
- `cargo test -p pegainfer-engine --lib`
- `cargo test -p pegainfer-vllm-frontend --lib`
- `PEGAINFER_CUDA_SM=80 cargo test -p pegainfer-qwen3-4b --lib scheduler`
- `PEGAINFER_CUDA_SM=80 cargo test -p pegainfer-qwen3-4b --lib lora -- --nocapture`
- `PEGAINFER_CUDA_SM=80 cargo check -p pegainfer-qwen3-4b`
- `PEGAINFER_CUDA_SM=80 cargo check -p pegainfer-server`
- `cargo metadata --no-deps --format-version 1`
- `python -m py_compile tools/qwen3_lora_live_parity.py`

GPU/model checks on `mint_dev_worker5` with Qwen3-4B:

- `cargo test --release -p pegainfer-qwen3-4b --test lora_smoke -- --ignored --nocapture`
- Live `/v1/load_lora_adapter` + `/v1/completions` HF/PEFT parity smoke passed.
- After rebasing onto the Qwen3 bf16 greedy numerics fix, the deterministic live parity fixture passed with PEFT adapter autocast disabled through:
  - `--max-tokens 48`
  - `--max-tokens 64`
  - `--max-tokens 128`
  - `--max-tokens 180`

The same deterministic fixture first diverges at generated token 181. I am not using that as a broad long-text parity claim for this PR; the PR claim is that the LoRA path loads, serves, applies the adapter, and matches the HF/PEFT reference for the validated smoke range.

## Notes

- PEFT defaults to `autocast_adapter_dtype=True`, which promotes the synthetic bf16 adapter to fp32. PegaInfer currently loads that fixture as bf16, so the longer parity runs use `--disable-peft-adapter-autocast` to compare against the same adapter dtype semantics.
- worker5 required `LD_LIBRARY_PATH=/usr/local/cuda-12.9/compat:$LD_LIBRARY_PATH` because its system driver library does not expose `cuCtxCreate_v4`.

Part of #173.
