### PR TITLE
docs: clarify Windows server launch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ uv pip install "triton-windows<3.7"
 $env:PEGAINFER_TRITON_PYTHON = ".venv\Scripts\python.exe"
 
 cargo build --release
-cargo run --release --bin pegainfer -- --model-path models/Qwen3-4B
+cargo run --release -p pegainfer-server -- --model-path models/Qwen3-4B
 ```
 
 </details>


### PR DESCRIPTION
fixes a README mismatch in the Windows quick-start section.

The README already states that the server CLI lives in `pegainfer-server`, but the Windows example still used `cargo run --release --bin pegainfer`.

This change switches the example to `cargo run --release -p pegainfer-server -- --model-path ...` so the Windows snippet matches the surrounding package-level guidance.
