### PR TITLE
fix(deepseek-v2-lite): use true batched decode benchmark path

### DIFF
--- a/docs/models/deepseek-v2-lite/decode-attribution-gate.md
+++ b/docs/models/deepseek-v2-lite/decode-attribution-gate.md
@@ -104,13 +104,13 @@ The HF oracle needs a Python environment that can load DeepSeek-V2-Lite with `tr
 
 ## Latest Validation
 
-The full gate was last rerun on 2026-05-26 with DeepSeek-V2-Lite, `prompt="Hello"`, `output_len=16`, and 2x A800-SXM4-80GB. The refreshed token/text oracle is confirmed by a real HF `AutoModelForCausalLM.generate(..., do_sample=false, use_cache=true)` run on the same model snapshot as the Rust E2E gate.
+The full gate was last rerun on 2026-05-27 with DeepSeek-V2-Lite snapshot `604d5664dddd88a0433dbae533b7fe9472482de0`, `prompt="Hello"`, `output_len=16`, and 2x RTX 5090. The refreshed token/text oracle is confirmed by a real HF `AutoModelForCausalLM.generate(..., do_sample=false, use_cache=true)` run on the same model snapshot as the Rust E2E gate.
 
-The earlier 2026-05-24 hash is superseded because that record did not preserve enough HF/runtime provenance to reproduce the truth-source environment. Treat only the hash below as the active oracle. This refresh does not claim a model-runtime improvement, a manual-loop root cause, or a transport issue.
+The earlier 2026-05-26 hash is superseded for the active gate because it was produced from a different local model snapshot. Treat only the hash below as the active oracle for snapshot `604d5664dddd88a0433dbae533b7fe9472482de0`. This refresh does not claim a model-runtime improvement, a manual-loop root cause, or a transport issue.
 
 - HF / host-staged / NCCL comparison: `all_token_text_exact`.
-- Token SHA256: `d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8`.
-- Text SHA256: `4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6`.
+- Token SHA256: `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225`.
+- Text SHA256: `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347`.
 - Host-staged attribution: `dispatch_calls=416`, `combine_calls=416`, `dispatch_elements=5111808`, `combine_elements=5111808`, `local_route_count=1284`, `remote_route_count=1212`.
 - NCCL attribution: `nccl_exchange_calls=416`, `nccl_combine_calls=416`, `nccl_exchange_elements=851968`, `nccl_combine_elements=851968`, `local_route_count=1284`, `remote_route_count=1212`.
 - GPU event timing: selected GPU/NCCL attribution sections are reported separately from CPU-side section timing; host-staged emitted `gpu_timing.sample_count=5056`, NCCL emitted `gpu_timing.sample_count=5888`, and both reported `gpu_timing.failure_count=0`.

--- a/docs/models/deepseek-v2-lite/hf-accuracy-gate.md
+++ b/docs/models/deepseek-v2-lite/hf-accuracy-gate.md
@@ -76,15 +76,15 @@ On Blackwell-class GPUs, make sure the selected NCCL runtime supports the device
 
 ## Latest Evidence
 
-2026-05-26, single-node 2 GPU validation with the same `models/DeepSeek-V2-Lite` snapshot for all three outputs. The HF truth source used `AutoModelForCausalLM.generate(..., do_sample=false, use_cache=true)` with `torch==2.11.0+cu130` and `transformers==4.40.2`:
+2026-05-27, single-node 2 GPU validation with the same `models/DeepSeek-V2-Lite` snapshot for all three outputs. The model snapshot metadata recorded commit `604d5664dddd88a0433dbae533b7fe9472482de0`. The HF truth source used `AutoModelForCausalLM.generate(..., do_sample=false, use_cache=true)` with `torch==2.7.0+cu128` and `transformers==4.40.2`:
 
-The earlier 2026-05-21 hash is superseded because that record did not preserve enough HF/runtime provenance to reproduce the truth-source environment. Treat only the hash below as the active oracle. This refresh does not claim a model-runtime improvement, a manual-loop root cause, or a transport issue.
+The earlier 2026-05-26 hash is superseded for the active gate because it was produced from a different local model snapshot. Treat only the hash below as the active oracle for snapshot `604d5664dddd88a0433dbae533b7fe9472482de0`. This refresh does not claim a model-runtime improvement, a manual-loop root cause, or a transport issue.
 
 | Source | Backend | Tokens | Token SHA256 | Text SHA256 | Text |
 | --- | --- | ---: | --- | --- | --- |
-| HF | `generate(use_cache=true)` | 16 | `d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8` | `4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6` | `, I am a 20 year old female and I have been having a` |
-| pegainfer | host-staged | 16 | `d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8` | `4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6` | `, I am a 20 year old female and I have been having a` |
-| pegainfer | NCCL | 16 | `d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8` | `4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6` | `, I am a 20 year old female and I have been having a` |
+| HF | `generate(use_cache=true)` | 16 | `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225` | `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347` | `, I am a 19 year old girl from the UK. I am` |
+| pegainfer | host-staged | 16 | `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225` | `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347` | `, I am a 19 year old girl from the UK. I am` |
+| pegainfer | NCCL | 16 | `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225` | `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347` | `, I am a 19 year old girl from the UK. I am` |
 
 Classification: `all_token_text_exact`.
 

--- a/pegainfer-core/src/ops.rs
+++ b/pegainfer-core/src/ops.rs
@@ -16,17 +16,19 @@ pub use attention::{
 pub use paged_plan::PrefillPagedPlan;
 pub use pegainfer_kernels::ops::{
     add_batch, add_batch_into, embedding_decode_into, extract_vec, extract_vec_into,
-    fused_add_rms_norm_into, gemm, gemv, linear, qk_norm_partial_rope_batched_decode_hd256_into,
-    rms_norm, rms_norm_batch_offset_into, rms_norm_gated_batch_into, rms_norm_into,
-    rms_norm_offset_into, scaled_add_batch_into, scaled_add_rows_into, silu_mul_batch,
-    silu_mul_batch_into, write_vec_into,
+    fused_add_rms_norm_into, gemm, gemm_per_token, gemv, linear,
+    qk_norm_partial_rope_batched_decode_hd256_into, rms_norm, rms_norm_batch_offset_into,
+    rms_norm_gated_batch_into, rms_norm_into, rms_norm_offset_into, scaled_add_batch_into,
+    scaled_add_rows_into, silu_mul_batch, silu_mul_batch_into, write_vec_into,
 };
 #[cfg(not(feature = "kernel-call-trace"))]
 pub use pegainfer_kernels::ops::{
     embedding_batch, fused_add_rms_norm_batch_into, gemm_into, gemm_rows_into,
     qk_norm_rope_batch_decode_into, rms_norm_batch_into, silu_mul_fused_batch_into,
 };
-pub use sampling::{argmax, flashinfer_topk_row_states_bytes, gpu_sample, gpu_sample_into};
+pub use sampling::{
+    argmax, argmax_batch_bf16_into, flashinfer_topk_row_states_bytes, gpu_sample, gpu_sample_into,
+};
 #[cfg(feature = "kernel-call-trace")]
 pub use traced::{
     embedding_batch, fused_add_rms_norm_batch_into, gemm_into, gemm_rows_into,

--- a/pegainfer-core/src/ops/sampling.rs
+++ b/pegainfer-core/src/ops/sampling.rs
@@ -4,7 +4,9 @@ use cudarc::driver::CudaSlice;
 use crate::sampler::SamplingParams;
 use crate::tensor::{DeviceContext, DeviceVec};
 
-pub use pegainfer_kernels::ops::{argmax, flashinfer_topk_row_states_bytes};
+pub use pegainfer_kernels::ops::{
+    argmax, argmax_batch_bf16_into, flashinfer_topk_row_states_bytes,
+};
 
 /// GPU sampling: temperature -> softmax -> top-k -> top-p -> multinomial.
 ///

--- a/pegainfer-deepseek-v2-lite/src/bin/dsv2_lite_ep2_decode_attribution.rs
+++ b/pegainfer-deepseek-v2-lite/src/bin/dsv2_lite_ep2_decode_attribution.rs
@@ -13,9 +13,9 @@ use vllm_text::tokenizer::{HuggingFaceTokenizer, Tokenizer};
 const PROMPT: &str = "Hello";
 const OUTPUT_LEN: usize = 16;
 const EXPECTED_OUTPUT_TOKEN_SHA256: &str =
-    "d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8";
+    "4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225";
 const EXPECTED_OUTPUT_TEXT_SHA256: &str =
-    "4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6";
+    "0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347";
 
 struct Cli {
     model_path: String,

--- a/pegainfer-deepseek-v2-lite/src/host_ops.rs
+++ b/pegainfer-deepseek-v2-lite/src/host_ops.rs
@@ -142,6 +142,37 @@ pub(crate) fn append_kv_and_build_queries(
     }
 }
 
+pub(crate) fn append_kv_and_build_queries_decode_batch(
+    config: &Config,
+    q_host: &[f32],
+    kv_a_host: &[f32],
+    kv_b_host: &[f32],
+    position: usize,
+    queries: &mut [f32],
+    caches: &mut [&mut LayerCache],
+) {
+    let batch_size = caches.len();
+    assert_eq!(q_host.len(), config.q_proj_rows() * batch_size);
+    assert_eq!(kv_a_host.len(), config.kv_a_proj_rows() * batch_size);
+    assert_eq!(kv_b_host.len(), config.kv_b_proj_rows() * batch_size);
+    let query_stride = config.num_attention_heads * config.query_head_dim();
+    assert_eq!(queries.len(), query_stride * batch_size);
+
+    for row in 0..batch_size {
+        assert_eq!(caches[row].len(config), position);
+        append_kv_and_build_queries(
+            config,
+            &q_host[row * config.q_proj_rows()..(row + 1) * config.q_proj_rows()],
+            &kv_a_host[row * config.kv_a_proj_rows()..(row + 1) * config.kv_a_proj_rows()],
+            &kv_b_host[row * config.kv_b_proj_rows()..(row + 1) * config.kv_b_proj_rows()],
+            position,
+            1,
+            &mut queries[row * query_stride..(row + 1) * query_stride],
+            caches[row],
+        );
+    }
+}
+
 fn apply_deepseek_v2_rope(
     input: &[f32],
     pos: usize,
@@ -261,6 +292,33 @@ pub(crate) fn compute_attention_host(
                 }
             }
         }
+    }
+
+    out
+}
+
+pub(crate) fn compute_attention_host_decode_batch(
+    config: &Config,
+    queries: &[f32],
+    caches: &[&LayerCache],
+    position: usize,
+) -> Vec<f32> {
+    let batch_size = caches.len();
+    let query_stride = config.num_attention_heads * config.query_head_dim();
+    assert_eq!(queries.len(), batch_size * query_stride);
+    let mut out = vec![0.0f32; batch_size * config.o_proj_cols()];
+
+    for row in 0..batch_size {
+        let cache = caches[row];
+        assert_eq!(cache.len(config), position + 1);
+        let row_out = compute_attention_host(
+            config,
+            &queries[row * query_stride..(row + 1) * query_stride],
+            cache,
+            position,
+            1,
+        );
+        out[row * config.o_proj_cols()..(row + 1) * config.o_proj_cols()].copy_from_slice(&row_out);
     }
 
     out
@@ -454,5 +512,116 @@ mod tests {
         let experts: Vec<_> = routes[0].iter().map(|(expert, _)| *expert).collect();
 
         assert_eq!(experts, vec![7, 10, 20, 41, 54, 58]);
+    }
+
+    #[test]
+    fn decode_batch_attention_matches_independent_single_row_caches() {
+        let mut config = test_lite_config();
+        config.num_attention_heads = 2;
+        config.num_key_value_heads = 2;
+        config.kv_lora_rank = 3;
+        config.qk_nope_head_dim = 2;
+        config.qk_rope_head_dim = 2;
+        config.v_head_dim = 2;
+        config.rope_scaling = None;
+
+        let batch_size = 2;
+        let position = 2;
+        let mut single_caches = Vec::with_capacity(batch_size);
+        for row in 0..batch_size {
+            let q_host = patterned(row, config.q_proj_rows() * position, 0.01);
+            let kv_a_host = patterned(row + 10, config.kv_a_proj_rows() * position, 0.02);
+            let kv_b_host = patterned(row + 20, config.kv_b_proj_rows() * position, 0.03);
+            let mut cache = LayerCache::default();
+            let mut queries =
+                vec![0.0; config.num_attention_heads * config.query_head_dim() * position];
+            append_kv_and_build_queries(
+                &config,
+                &q_host,
+                &kv_a_host,
+                &kv_b_host,
+                0,
+                position,
+                &mut queries,
+                &mut cache,
+            );
+            single_caches.push(cache);
+        }
+        let mut batch_caches: Vec<_> = single_caches
+            .iter()
+            .map(|cache| LayerCache {
+                keys: cache.keys.clone(),
+                values: cache.values.clone(),
+            })
+            .collect();
+
+        let mut q_decode = Vec::new();
+        let mut kv_a_decode = Vec::new();
+        let mut kv_b_decode = Vec::new();
+        let mut expected = Vec::new();
+        for row in 0..batch_size {
+            let q_host = patterned(row + 30, config.q_proj_rows(), 0.04);
+            let kv_a_host = patterned(row + 40, config.kv_a_proj_rows(), 0.05);
+            let kv_b_host = patterned(row + 50, config.kv_b_proj_rows(), 0.06);
+            q_decode.extend_from_slice(&q_host);
+            kv_a_decode.extend_from_slice(&kv_a_host);
+            kv_b_decode.extend_from_slice(&kv_b_host);
+
+            let mut queries = vec![0.0; config.num_attention_heads * config.query_head_dim()];
+            append_kv_and_build_queries(
+                &config,
+                &q_host,
+                &kv_a_host,
+                &kv_b_host,
+                position,
+                1,
+                &mut queries,
+                &mut single_caches[row],
+            );
+            expected.extend(compute_attention_host(
+                &config,
+                &queries,
+                &single_caches[row],
+                position,
+                1,
+            ));
+        }
+
+        let mut batch_queries =
+            vec![0.0; batch_size * config.num_attention_heads * config.query_head_dim()];
+        let mut batch_cache_refs: Vec<_> = batch_caches.iter_mut().collect();
+        append_kv_and_build_queries_decode_batch(
+            &config,
+            &q_decode,
+            &kv_a_decode,
+            &kv_b_decode,
+            position,
+            &mut batch_queries,
+            &mut batch_cache_refs,
+        );
+        let batch_cache_views: Vec<_> = batch_cache_refs
+            .iter()
+            .map(|cache| &**cache as &LayerCache)
+            .collect();
+        let actual = compute_attention_host_decode_batch(
+            &config,
+            &batch_queries,
+            &batch_cache_views,
+            position,
+        );
+
+        assert_eq!(actual, expected);
+        for cache in batch_cache_refs {
+            assert_eq!(cache.len(&config), position + 1);
+        }
+    }
+
+    fn patterned(seed: usize, len: usize, scale: f32) -> Vec<f32> {
+        (0..len)
+            .map(|idx| {
+                let value = ((seed * 31 + idx * 17) % 23) as f32 - 11.0;
+                value * scale
+            })
+            .collect()
     }
 }

--- a/pegainfer-deepseek-v2-lite/src/model.rs
+++ b/pegainfer-deepseek-v2-lite/src/model.rs
@@ -414,3 +414,15 @@ pub(crate) fn dense_mlp_forward(
     ops::silu_mul_fused_batch_into(ctx, &gate_up, &mut act);
     ops::gemm(ctx, &mlp.down_proj, &act)
 }
+
+pub(crate) fn dense_mlp_forward_per_token(
+    ctx: &DeviceContext,
+    mlp: &DenseMlp,
+    input: &HiddenStates,
+) -> Result<HiddenStates> {
+    activate(ctx)?;
+    let gate_up = ops::gemm_per_token(ctx, &mlp.gate_up_proj, input)?;
+    let mut act = HiddenStates::zeros(ctx, gate_up.hidden_dim / 2, input.seq_len)?;
+    ops::silu_mul_fused_batch_into(ctx, &gate_up, &mut act);
+    ops::gemm_per_token(ctx, &mlp.down_proj, &act)
+}

--- a/pegainfer-deepseek-v2-lite/src/runtime.rs
+++ b/pegainfer-deepseek-v2-lite/src/runtime.rs
@@ -19,14 +19,15 @@ use crate::{
     device::activate,
     ep::ExpertParallelConfig,
     host_ops::{
-        DecodeCache, LayerCache, append_kv_and_build_queries, compute_attention_host,
-        gate_logits_host, hidden_from_bf16_host, hidden_from_f32_host, hidden_to_bf16,
-        hidden_to_f32, normalize_compressed_kv, rms_norm_hidden_host, rms_norm_host,
-        topk_softmax_routes,
+        DecodeCache, LayerCache, append_kv_and_build_queries,
+        append_kv_and_build_queries_decode_batch, compute_attention_host,
+        compute_attention_host_decode_batch, gate_logits_host, hidden_from_bf16_host,
+        hidden_from_f32_host, hidden_to_bf16, hidden_to_f32, normalize_compressed_kv,
+        rms_norm_hidden_host, rms_norm_host, topk_softmax_routes,
     },
     model::{
         AttentionWeights, DriverRankModel, ExpertMlp, ExpertRankModel, MlpWeights, MoeMlp,
-        dense_mlp_forward,
+        dense_mlp_forward, dense_mlp_forward_per_token,
     },
     nccl_backend::NaiveNcclEp2Backend,
     weights::{ModelManifest, RankLoadPlan},
@@ -284,7 +285,9 @@ impl DeepSeekV2LiteEp2Generator {
         let mut caches: Vec<_> = (0..batch_size)
             .map(|_| DecodeCache::new(&self.config))
             .collect();
-        let mut generated = vec![Vec::with_capacity(max_new_tokens); batch_size];
+        let mut generated: Vec<Vec<u32>> = (0..batch_size)
+            .map(|_| Vec::with_capacity(max_new_tokens))
+            .collect();
         let mut prefill_next_token_us = Vec::with_capacity(batch_size);
 
         for row in 0..batch_size {
@@ -310,27 +313,26 @@ impl DeepSeekV2LiteEp2Generator {
                 .collect();
             let position = prompt_tokens.len() + token_index - 1;
             let decode_start = Instant::now();
-            // This is a correctness-first lockstep batch benchmark path. All
-            // rows advance under one batch decode step/timing sample, while the
-            // row forward reuses the already-gated single-row EP2 oracle until a
-            // fused batched DSV2-Lite forward has its own accuracy gate.
-            let mut next_tokens = Vec::with_capacity(batch_size);
-            for row in 0..batch_size {
-                next_tokens.push(self.decode_next_token(
-                    input_tokens[row],
-                    position,
-                    &mut caches[row],
-                    &mut stats,
-                    &mut attribution,
-                    token_index,
-                )?);
-            }
+            let next_tokens = self.decode_next_tokens_batch(
+                &input_tokens,
+                position,
+                &mut caches,
+                &mut stats,
+                &mut attribution,
+                token_index,
+            )?;
+            ensure!(
+                next_tokens.len() == batch_size,
+                "batched decode returned {} tokens for batch_size={batch_size}",
+                next_tokens.len()
+            );
             per_token_decode_us.push(duration_micros(decode_start.elapsed()));
             for (row, token) in next_tokens.into_iter().enumerate() {
                 generated[row].push(token);
             }
         }
 
+        ensure_same_prompt_batch_rows_match(&generated)?;
         Ok(BatchedGenerationResult {
             tokens: generated,
             prefill_next_token_us,
@@ -471,6 +473,51 @@ impl DeepSeekV2LiteEp2Generator {
         )
     }
 
+    fn decode_next_tokens_batch(
+        &mut self,
+        tokens: &[u32],
+        position: usize,
+        caches: &mut [DecodeCache],
+        stats: &mut GenerationStats,
+        attribution: &mut DecodeAttributionProfile,
+        token_index: usize,
+    ) -> Result<Vec<u32>> {
+        ensure!(
+            !tokens.is_empty(),
+            "batched decode tokens must not be empty"
+        );
+        ensure!(
+            tokens.len() == caches.len(),
+            "batched decode token/cache mismatch: tokens={}, caches={}",
+            tokens.len(),
+            caches.len()
+        );
+        let mut hidden = attribution.record_result(
+            "decode",
+            "embedding",
+            || "decode.batch_embedding",
+            None,
+            Some(token_index),
+            || self.embed_tokens(tokens),
+        )?;
+        hidden = self.forward_layers_decode_batch(
+            hidden,
+            position,
+            caches,
+            stats,
+            attribution,
+            token_index,
+        )?;
+        attribution.record_result(
+            "decode",
+            "sample_last_token",
+            || "decode.batch_sample_tokens",
+            None,
+            Some(token_index),
+            || self.sample_tokens(&hidden),
+        )
+    }
+
     fn embed_tokens(&self, token_ids: &[u32]) -> Result<HiddenStates> {
         activate(&self.rank0.ctx)?;
         let token_ids_gpu = self.rank0.ctx.stream.clone_htod(token_ids)?;
@@ -512,6 +559,47 @@ impl DeepSeekV2LiteEp2Generator {
                     token_index,
                 )
                 .with_context(|| format!("DeepSeek-V2-Lite layer {layer_idx}"))?;
+        }
+        Ok(hidden)
+    }
+
+    fn forward_layers_decode_batch(
+        &mut self,
+        mut hidden: HiddenStates,
+        position: usize,
+        caches: &mut [DecodeCache],
+        stats: &mut GenerationStats,
+        attribution: &mut DecodeAttributionProfile,
+        token_index: usize,
+    ) -> Result<HiddenStates> {
+        ensure!(
+            caches.len() == hidden.seq_len,
+            "batched decode cache count {} must match hidden seq_len {}",
+            caches.len(),
+            hidden.seq_len
+        );
+        ensure!(
+            caches
+                .iter()
+                .all(|cache| cache.layers.len() == self.rank0.layers.len()),
+            "batched decode cache layer count mismatch"
+        );
+        for layer_idx in 0..self.rank0.layers.len() {
+            let mut layer_caches: Vec<_> = caches
+                .iter_mut()
+                .map(|cache| &mut cache.layers[layer_idx])
+                .collect();
+            hidden = self
+                .forward_layer_decode_batch(
+                    layer_idx,
+                    &hidden,
+                    position,
+                    &mut layer_caches,
+                    stats,
+                    attribution,
+                    token_index,
+                )
+                .with_context(|| format!("DeepSeek-V2-Lite batched layer {layer_idx}"))?;
         }
         Ok(hidden)
     }
@@ -591,8 +679,15 @@ impl DeepSeekV2LiteEp2Generator {
                 0,
             ),
             MlpWeights::Moe(moe) => {
-                let (ffn_out, local_routes, remote_routes) =
-                    self.moe_forward(layer_idx, &ffn_norm, moe, attribution, phase, token_index)?;
+                let (ffn_out, local_routes, remote_routes) = self.moe_forward(
+                    layer_idx,
+                    &ffn_norm,
+                    moe,
+                    attribution,
+                    phase,
+                    token_index,
+                    false,
+                )?;
                 match self.backend.kind() {
                     EpBackendKind::HostStaged => {
                         stats.record_host_staged_moe(
@@ -615,6 +710,121 @@ impl DeepSeekV2LiteEp2Generator {
             || format!("layer.{layer_idx}.ffn_residual_add"),
             Some(layer_idx),
             token_index,
+            || ops::add_batch(&self.rank0.ctx, &after_attn, &ffn_out),
+        )
+    }
+
+    fn forward_layer_decode_batch(
+        &mut self,
+        layer_idx: usize,
+        hidden: &HiddenStates,
+        position: usize,
+        caches: &mut [&mut LayerCache],
+        stats: &mut GenerationStats,
+        attribution: &mut DecodeAttributionProfile,
+        token_index: usize,
+    ) -> Result<HiddenStates> {
+        ensure!(
+            hidden.seq_len == caches.len(),
+            "batched layer hidden seq_len {} must match cache rows {}",
+            hidden.seq_len,
+            caches.len()
+        );
+        activate(&self.rank0.ctx)?;
+
+        let layer = &self.rank0.layers[layer_idx];
+        let normed = attribution.record_result(
+            "decode",
+            "host_rms_norm",
+            || format!("layer.{layer_idx}.batch_input_rms_norm"),
+            Some(layer_idx),
+            Some(token_index),
+            || self.rms_norm_hidden(hidden, &layer.input_layernorm_host),
+        )?;
+
+        let attn = attribution.record_result(
+            "decode",
+            "attention_host_path",
+            || format!("layer.{layer_idx}.batch_attention_host_path"),
+            Some(layer_idx),
+            Some(token_index),
+            || self.attention_forward_decode_batch(&normed, &layer.attention, position, caches),
+        )?;
+        activate(&self.rank0.ctx)?;
+        let attn_projected = attribution.record_gpu_result(
+            &self.rank0.ctx,
+            "decode",
+            "gpu_o_proj_enqueue",
+            || format!("layer.{layer_idx}.batch_attention_o_proj"),
+            Some(layer_idx),
+            Some(token_index),
+            || ops::gemm_per_token(&self.rank0.ctx, &layer.attention.o_proj, &attn),
+        )?;
+        let after_attn = attribution.record_gpu_result(
+            &self.rank0.ctx,
+            "decode",
+            "gpu_residual_add_enqueue",
+            || format!("layer.{layer_idx}.batch_attention_residual_add"),
+            Some(layer_idx),
+            Some(token_index),
+            || ops::add_batch(&self.rank0.ctx, hidden, &attn_projected),
+        )?;
+
+        let ffn_norm = attribution.record_result(
+            "decode",
+            "host_rms_norm",
+            || format!("layer.{layer_idx}.batch_post_attention_rms_norm"),
+            Some(layer_idx),
+            Some(token_index),
+            || self.rms_norm_hidden(&after_attn, &layer.post_attention_layernorm_host),
+        )?;
+
+        let (ffn_out, local_routes, remote_routes) = match &layer.mlp {
+            MlpWeights::Dense(dense) => (
+                attribution.record_gpu_result(
+                    &self.rank0.ctx,
+                    "decode",
+                    "dense_mlp_enqueue",
+                    || format!("layer.{layer_idx}.batch_dense_mlp"),
+                    Some(layer_idx),
+                    Some(token_index),
+                    || dense_mlp_forward_per_token(&self.rank0.ctx, dense, &ffn_norm),
+                )?,
+                0,
+                0,
+            ),
+            MlpWeights::Moe(moe) => {
+                let (ffn_out, local_routes, remote_routes) = self.moe_forward(
+                    layer_idx,
+                    &ffn_norm,
+                    moe,
+                    attribution,
+                    "decode",
+                    Some(token_index),
+                    true,
+                )?;
+                match self.backend.kind() {
+                    EpBackendKind::HostStaged => {
+                        stats.record_host_staged_moe(
+                            ffn_norm.hidden_dim,
+                            local_routes + remote_routes,
+                        );
+                    }
+                    EpBackendKind::Nccl => {
+                        stats.record_nccl_moe_collectives(ffn_norm.hidden_dim, ffn_norm.seq_len);
+                    }
+                }
+                (ffn_out, local_routes, remote_routes)
+            }
+        };
+        stats.record_routes(self.backend.kind(), local_routes, remote_routes);
+        attribution.record_gpu_result(
+            &self.rank0.ctx,
+            "decode",
+            "gpu_residual_add_enqueue",
+            || format!("layer.{layer_idx}.batch_ffn_residual_add"),
+            Some(layer_idx),
+            Some(token_index),
             || ops::add_batch(&self.rank0.ctx, &after_attn, &ffn_out),
         )
     }
@@ -680,6 +890,75 @@ impl DeepSeekV2LiteEp2Generator {
         )
     }
 
+    fn attention_forward_decode_batch(
+        &self,
+        input: &HiddenStates,
+        attn: &AttentionWeights,
+        position: usize,
+        caches: &mut [&mut LayerCache],
+    ) -> Result<HiddenStates> {
+        activate(&self.rank0.ctx)?;
+        ensure!(
+            input.seq_len == caches.len(),
+            "batched attention input seq_len {} must match cache rows {}",
+            input.seq_len,
+            caches.len()
+        );
+        for (row, cache) in caches.iter().enumerate() {
+            ensure!(
+                cache.len(&self.config) == position,
+                "batched attention cache row {row} position mismatch: cache_len={}, position={position}",
+                cache.len(&self.config)
+            );
+        }
+
+        let q = ops::gemm_per_token(&self.rank0.ctx, &attn.q_proj, input)?;
+        let kv_a = ops::gemm_per_token(&self.rank0.ctx, &attn.kv_a_proj, input)?;
+        let q_host = hidden_to_f32(&self.rank0.ctx, &q)?;
+        let kv_a_host = hidden_to_f32(&self.rank0.ctx, &kv_a)?;
+
+        let compressed_norm = normalize_compressed_kv(
+            &self.config,
+            &kv_a_host,
+            &attn.kv_a_norm_host,
+            input.seq_len,
+        );
+        let compressed = hidden_from_bf16_host(
+            &self.rank0.ctx,
+            &compressed_norm,
+            self.config.kv_lora_rank,
+            input.seq_len,
+        )?;
+        activate(&self.rank0.ctx)?;
+        let kv_b = ops::gemm_per_token(&self.rank0.ctx, &attn.kv_b_proj, &compressed)?;
+        let kv_b_host = hidden_to_f32(&self.rank0.ctx, &kv_b)?;
+
+        let mut queries =
+            vec![
+                0.0f32;
+                input.seq_len * self.config.num_attention_heads * self.config.query_head_dim()
+            ];
+        append_kv_and_build_queries_decode_batch(
+            &self.config,
+            &q_host,
+            &kv_a_host,
+            &kv_b_host,
+            position,
+            &mut queries,
+            caches,
+        );
+
+        let cache_views: Vec<_> = caches.iter().map(|cache| &**cache as &LayerCache).collect();
+        let out_host =
+            compute_attention_host_decode_batch(&self.config, &queries, &cache_views, position);
+        hidden_from_f32_host(
+            &self.rank0.ctx,
+            &out_host,
+            self.config.o_proj_cols(),
+            input.seq_len,
+        )
+    }
+
     fn moe_forward(
         &self,
         layer_idx: usize,
@@ -688,14 +967,28 @@ impl DeepSeekV2LiteEp2Generator {
         attribution: &mut DecodeAttributionProfile,
         phase: &'static str,
         token_index: Option<usize>,
+        shared_per_token_gemm: bool,
     ) -> Result<(HiddenStates, usize, usize)> {
         match &self.backend {
-            EpBackendRuntime::HostStaged => {
-                self.moe_forward_host_staged(layer_idx, input, moe, attribution, phase, token_index)
-            }
-            EpBackendRuntime::Nccl(nccl) => {
-                self.moe_forward_nccl(nccl, layer_idx, input, moe, attribution, phase, token_index)
-            }
+            EpBackendRuntime::HostStaged => self.moe_forward_host_staged(
+                layer_idx,
+                input,
+                moe,
+                attribution,
+                phase,
+                token_index,
+                shared_per_token_gemm,
+            ),
+            EpBackendRuntime::Nccl(nccl) => self.moe_forward_nccl(
+                nccl,
+                layer_idx,
+                input,
+                moe,
+                attribution,
+                phase,
+                token_index,
+                shared_per_token_gemm,
+            ),
         }
     }
 
@@ -707,6 +1000,7 @@ impl DeepSeekV2LiteEp2Generator {
         attribution: &mut DecodeAttributionProfile,
         phase: &'static str,
         token_index: Option<usize>,
+        shared_per_token_gemm: bool,
     ) -> Result<(HiddenStates, usize, usize)> {
         activate(&self.rank0.ctx)?;
         let (input_host, routes) = attribution.record_result(
@@ -730,9 +1024,16 @@ impl DeepSeekV2LiteEp2Generator {
             || format!("layer.{layer_idx}.shared_expert"),
             Some(layer_idx),
             token_index,
-            || dense_mlp_forward(&self.rank0.ctx, &moe.shared, input),
+            || {
+                if shared_per_token_gemm {
+                    dense_mlp_forward_per_token(&self.rank0.ctx, &moe.shared, input)
+                } else {
+                    dense_mlp_forward(&self.rank0.ctx, &moe.shared, input)
+                }
+            },
         )?;
-        let mut routed_accum = vec![0.0f32; input.seq_len * self.config.hidden_size];
+        let mut rank0_contrib = vec![0.0f32; input.seq_len * self.config.hidden_size];
+        let mut rank1_contrib = vec![0.0f32; rank0_contrib.len()];
         let mut local_routes = 0usize;
         let mut remote_routes = 0usize;
 
@@ -750,6 +1051,11 @@ impl DeepSeekV2LiteEp2Generator {
                     &self.rank0.ctx
                 } else {
                     &self.rank1.ctx
+                };
+                let dst = if owner_rank == 0 {
+                    &mut rank0_contrib
+                } else {
+                    &mut rank1_contrib
                 };
                 let (out, is_remote) = attribution.record_gpu_result(
                     expert_ctx,
@@ -773,7 +1079,7 @@ impl DeepSeekV2LiteEp2Generator {
                     Some(layer_idx),
                     token_index,
                     || {
-                        for (dst, value) in routed_accum[offset..offset + self.config.hidden_size]
+                        for (dst, value) in dst[offset..offset + self.config.hidden_size]
                             .iter_mut()
                             .zip(out)
                         {
@@ -784,6 +1090,11 @@ impl DeepSeekV2LiteEp2Generator {
                 )?;
             }
         }
+        let routed_accum: Vec<_> = rank0_contrib
+            .into_iter()
+            .zip(rank1_contrib)
+            .map(|(rank0, rank1)| rank0 + rank1)
+            .collect();
 
         let routed = attribution.record_gpu_result(
             &self.rank0.ctx,
@@ -823,6 +1134,7 @@ impl DeepSeekV2LiteEp2Generator {
         attribution: &mut DecodeAttributionProfile,
         phase: &'static str,
         token_index: Option<usize>,
+        shared_per_token_gemm: bool,
     ) -> Result<(HiddenStates, usize, usize)> {
         activate(&self.rank0.ctx)?;
         let routes = attribution.record_result(
@@ -849,7 +1161,13 @@ impl DeepSeekV2LiteEp2Generator {
             || format!("layer.{layer_idx}.shared_expert"),
             Some(layer_idx),
             token_index,
-            || dense_mlp_forward(&self.rank0.ctx, &moe.shared, input),
+            || {
+                if shared_per_token_gemm {
+                    dense_mlp_forward_per_token(&self.rank0.ctx, &moe.shared, input)
+                } else {
+                    dense_mlp_forward(&self.rank0.ctx, &moe.shared, input)
+                }
+            },
         )?;
         let mut rank0_contrib = vec![0.0f32; input.seq_len * self.config.hidden_size];
         let mut rank1_contrib = vec![0.0f32; rank0_contrib.len()];
@@ -1007,9 +1325,41 @@ impl DeepSeekV2LiteEp2Generator {
     }
 
     fn sample_last_token(&self, hidden: &HiddenStates) -> Result<u32> {
+        self.sample_token_at(hidden, hidden.seq_len - 1)
+    }
+
+    fn sample_tokens(&self, hidden: &HiddenStates) -> Result<Vec<u32>> {
         activate(&self.rank0.ctx)?;
-        let last = ops::extract_vec(&self.rank0.ctx, hidden, hidden.seq_len - 1)?;
-        let normed = self.rms_norm_vec(&last, &self.rank0.norm_host)?;
+        ensure!(hidden.seq_len != 0, "cannot sample an empty hidden batch");
+
+        let normed = self.rms_norm_hidden(hidden, &self.rank0.norm_host)?;
+        activate(&self.rank0.ctx)?;
+        let logits = ops::gemm_per_token(&self.rank0.ctx, &self.rank0.lm_head, &normed)?;
+        let mut values = self.rank0.ctx.stream.alloc_zeros(hidden.seq_len)?;
+        let mut out = self.rank0.ctx.stream.alloc_zeros(hidden.seq_len)?;
+        ops::argmax_batch_bf16_into(&self.rank0.ctx, &logits, &mut values, &mut out)?;
+
+        let out_host = self.rank0.ctx.stream.clone_dtoh(&out)?;
+        self.rank0.ctx.sync()?;
+
+        out_host
+            .into_iter()
+            .map(|token| {
+                ensure!(token >= 0, "argmax returned negative token id {token}");
+                Ok(token as u32)
+            })
+            .collect()
+    }
+
+    fn sample_token_at(&self, hidden: &HiddenStates, row: usize) -> Result<u32> {
+        activate(&self.rank0.ctx)?;
+        ensure!(
+            row < hidden.seq_len,
+            "sample row {row} out of range for seq_len {}",
+            hidden.seq_len
+        );
+        let state = ops::extract_vec(&self.rank0.ctx, hidden, row)?;
+        let normed = self.rms_norm_vec(&state, &self.rank0.norm_host)?;
         let logits = ops::linear(&self.rank0.ctx, &normed, &self.rank0.lm_head)?;
         ops::argmax(&self.rank0.ctx, &logits)
     }
@@ -1074,6 +1424,27 @@ fn token_sha256(tokens: &[u32]) -> String {
     hex::encode(hasher.finalize())
 }
 
+fn ensure_same_prompt_batch_rows_match(rows: &[Vec<u32>]) -> Result<()> {
+    let Some(first) = rows.first() else {
+        return Ok(());
+    };
+    for (row_idx, row) in rows.iter().enumerate().skip(1) {
+        if row != first {
+            let first_diff = first
+                .iter()
+                .zip(row)
+                .position(|(lhs, rhs)| lhs != rhs)
+                .unwrap_or_else(|| first.len().min(row.len()));
+            bail!(
+                "same-prompt batched decode row {row_idx} differs from row 0 at generated token index {first_diff}: row0_sha256={}, row_sha256={}",
+                token_sha256(first),
+                token_sha256(row)
+            );
+        }
+    }
+    Ok(())
+}
+
 fn duration_micros(duration: Duration) -> u64 {
     duration.as_micros().min(u128::from(u64::MAX)) as u64
 }
@@ -1113,6 +1484,23 @@ mod tests {
 
         assert_eq!(finish_reason, None);
         assert_eq!(generated, vec![10, 11, 100_001]);
+    }
+
+    #[test]
+    fn same_prompt_batch_rows_must_match() {
+        ensure_same_prompt_batch_rows_match(&[
+            vec![11, 304, 608],
+            vec![11, 304, 608],
+            vec![11, 304, 608],
+        ])
+        .unwrap();
+
+        let err = ensure_same_prompt_batch_rows_match(&[vec![11, 304, 608], vec![11, 463, 608]])
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("generated token index 1"),
+            "unexpected error: {err:#}"
+        );
     }
 
     #[test]

--- a/pegainfer-deepseek-v2-lite/tests/e2e_ep2.rs
+++ b/pegainfer-deepseek-v2-lite/tests/e2e_ep2.rs
@@ -11,9 +11,9 @@ use vllm_text::tokenizer::{HuggingFaceTokenizer, Tokenizer};
 
 const EXPECTED_GENERATED_TOKENS: usize = 16;
 const EXPECTED_OUTPUT_TOKEN_SHA256: &str =
-    "d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8";
+    "4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225";
 const EXPECTED_OUTPUT_TEXT_SHA256: &str =
-    "4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6";
+    "0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347";
 const DSV2_LITE_HIDDEN_SIZE: usize = 2048;
 const DSV2_LITE_MOE_LAYERS: usize = 26;
 const E2E_JSON_OUT_ENV: &str = "PEGAINFER_DSV2_LITE_E2E_JSON_OUT";

--- a/pegainfer-kernels/KERNELS.md
+++ b/pegainfer-kernels/KERNELS.md
@@ -4,6 +4,13 @@
 
 Use this file as the LLM entrypoint before editing kernels. Start from `op_id`, then jump to the Rust wrapper, FFI symbol, and source file.
 
+## Shared Dense And Sampling Helpers
+
+| op_id | Runtime owner | Rust wrapper | FFI symbol | Source | Backend | Shape / layout notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| `shared.linear.gemm_per_token` | model-specific decode accuracy gates | `ops::gemm_per_token` / `ops::gemm_per_token_into_checked` | `gemm_per_token_cuda` | `csrc/linear.cu` | cuBLAS | computes each row through the N=1 decode GEMM boundary; used when row-wise parity is required before performance optimization |
+| `shared.sampling.argmax_batch_bf16` | batched greedy gates | `ops::argmax_batch_bf16_into` | `argmax_batch_bf16_cuda` | `csrc/argmax.cu` | CUDA | one greedy top-1 result per row over contiguous `HiddenStates` logits |
+
 ## Qwen3-4B Dense Full-Attention Path
 
 Qwen3-4B uses bf16 dense full attention with `hidden_size=2560`, `num_attention_heads=32`, `num_key_value_heads=8`, `head_dim=128`, and GQA group size 4. TP shards these head/intermediate dimensions per rank; the kernel IDs remain the same.

--- a/pegainfer-kernels/src/ops.rs
+++ b/pegainfer-kernels/src/ops.rs
@@ -24,8 +24,8 @@ pub use embedding::{embedding_batch, embedding_batch_vocab_shard, embedding_deco
 #[cfg(feature = "kimi-k2")]
 pub use kimi_k2::*;
 pub use linear::{
-    gemm, gemm_graphsafe_into_checked, gemm_into, gemm_into_checked, gemm_rows_into,
-    gemm_rows_into_checked, gemv, linear,
+    gemm, gemm_graphsafe_into_checked, gemm_into, gemm_into_checked, gemm_per_token,
+    gemm_per_token_into_checked, gemm_rows_into, gemm_rows_into_checked, gemv, linear,
 };
 pub use norm::{
     fused_add_rms_norm_batch_into, fused_add_rms_norm_into, fused_add_rms_norm_round_batch_into,
@@ -33,6 +33,6 @@ pub use norm::{
     rms_norm_into, rms_norm_offset_into,
 };
 pub use sampling::{
-    argmax, flashinfer_top1_batch_into, flashinfer_topk_row_states_bytes, gpu_sample,
-    gpu_sample_into,
+    argmax, argmax_batch_bf16_into, flashinfer_top1_batch_into, flashinfer_topk_row_states_bytes,
+    gpu_sample, gpu_sample_into,
 };

--- a/pegainfer-kernels/src/ops/linear.rs
+++ b/pegainfer-kernels/src/ops/linear.rs
@@ -85,6 +85,19 @@ pub fn gemm(ctx: &DeviceContext, weight: &DeviceMatrix, x: &HiddenStates) -> Res
     Ok(out)
 }
 
+/// Per-token GEMM: each row is computed through the same N=1 cuBLAS boundary
+/// used by decode. This is useful for narrow batch-shaped accuracy gates where
+/// row-wise parity with the serial decode oracle matters more than throughput.
+pub fn gemm_per_token(
+    ctx: &DeviceContext,
+    weight: &DeviceMatrix,
+    x: &HiddenStates,
+) -> Result<HiddenStates> {
+    let mut out = HiddenStates::zeros(ctx, weight.rows, x.seq_len)?;
+    gemm_per_token_into_checked(ctx, weight, x, &mut out)?;
+    Ok(out)
+}
+
 /// GEMM into pre-allocated output buffer (zero allocation).
 /// For seq_len=1, uses the graph-safe cuBLAS handle (no workspace) for lower
 /// latency while preserving numerical parity with the prefill path.
@@ -118,6 +131,64 @@ pub fn gemm_graphsafe_into_checked(
     out: &mut HiddenStates,
 ) -> Result<()> {
     gemm_into_with_policy(ctx, weight, x, out, true)
+}
+
+pub fn gemm_per_token_into_checked(
+    ctx: &DeviceContext,
+    weight: &DeviceMatrix,
+    x: &HiddenStates,
+    out: &mut HiddenStates,
+) -> Result<()> {
+    assert_eq!(
+        weight.cols, x.hidden_dim,
+        "weight cols {} != hidden_dim {}",
+        weight.cols, x.hidden_dim
+    );
+    assert_eq!(
+        out.hidden_dim, weight.rows,
+        "out hidden_dim {} != weight rows {}",
+        out.hidden_dim, weight.rows
+    );
+    assert_eq!(
+        out.seq_len, x.seq_len,
+        "out seq_len {} != x seq_len {}",
+        out.seq_len, x.seq_len
+    );
+
+    let (w_ptr, _gw) = weight.data.device_ptr(&ctx.stream);
+    let (x_ptr, _gx) = x.data.device_ptr(&ctx.stream);
+    let (y_ptr, _gy) = out.data.device_ptr_mut(&ctx.stream);
+
+    unsafe {
+        let status = ffi::gemm_per_token_cuda(
+            w_ptr as *const ffi::Half,
+            x_ptr as *const ffi::Half,
+            y_ptr as *mut ffi::Half,
+            weight.rows as i32,
+            x.seq_len as i32,
+            weight.cols as i32,
+            ctx.stream.cu_stream(),
+        );
+        if status != 0 {
+            if status >= 100000 {
+                bail!(
+                    "cuBLAS per-token GEMM failed: cublas_status={}, m={}, batch={}, k={}",
+                    status - 100000,
+                    weight.rows,
+                    x.seq_len,
+                    weight.cols
+                );
+            }
+            bail!(
+                "CUDA per-token GEMM launch failed: cuda_status={}, m={}, batch={}, k={}",
+                status,
+                weight.rows,
+                x.seq_len,
+                weight.cols
+            );
+        }
+    }
+    Ok(())
 }
 
 fn gemm_into_with_policy(

--- a/pegainfer-kernels/src/ops/sampling.rs
+++ b/pegainfer-kernels/src/ops/sampling.rs
@@ -30,14 +30,56 @@ pub fn argmax(ctx: &DeviceContext, x: &DeviceVec) -> Result<u32> {
         }
     }
 
-    ctx.sync()?;
-
     let result = ctx
         .stream
         .clone_dtoh(&out_gpu)
         .map_err(|e| anyhow!("D2H copy failed: {}", e))?;
+    ctx.sync()?;
 
     Ok(result[0] as u32)
+}
+
+pub fn argmax_batch_bf16_into(
+    ctx: &DeviceContext,
+    logits: &HiddenStates,
+    values: &mut CudaSlice<half::bf16>,
+    out: &mut CudaSlice<i32>,
+) -> Result<()> {
+    let rows = logits.seq_len;
+    if rows == 0 {
+        return Err(anyhow!("argmax batch requires at least one row"));
+    }
+    if values.len() < rows {
+        return Err(anyhow!(
+            "argmax batch values scratch too small: have {}, need {}",
+            values.len(),
+            rows
+        ));
+    }
+    if out.len() < rows {
+        return Err(anyhow!(
+            "argmax batch output too small: have {}, need {}",
+            out.len(),
+            rows
+        ));
+    }
+
+    let (logits_ptr, _gl) = logits.data.device_ptr(&ctx.stream);
+    let (values_ptr, _gv) = values.device_ptr_mut(&ctx.stream);
+    let (out_ptr, _go) = out.device_ptr_mut(&ctx.stream);
+
+    unsafe {
+        ffi::argmax_batch_bf16_cuda(
+            logits_ptr as *const ffi::Half,
+            values_ptr as *mut ffi::Half,
+            out_ptr as *mut i32,
+            rows as i32,
+            logits.hidden_dim as i32,
+            ctx.stream.cu_stream(),
+        );
+    }
+
+    Ok(())
 }
 
 /// GPU sampling: temperature → softmax → top-k → top-p → multinomial.
@@ -154,12 +196,11 @@ fn gpu_sample_core(
             );
         }
     }
-    ctx.sync()?;
-
     let result = ctx
         .stream
         .clone_dtoh(out)
         .map_err(|e| anyhow!("D2H sample read failed: {}", e))?;
+    ctx.sync()?;
 
     Ok(result[0] as u32)
 }

--- a/pegainfer-server/src/bin/bench_serving.rs
+++ b/pegainfer-server/src/bin/bench_serving.rs
@@ -1057,7 +1057,7 @@ impl BenchModel for DeepSeekV2LiteBenchModel {
     fn validate_concurrency(&self, concurrency: usize) -> Result<()> {
         ensure!(
             concurrency > 0 && concurrency <= 8,
-            "DeepSeek-V2-Lite direct benchmark supports --concurrency 1..=8 through the narrow same-prompt lockstep batch path, got {concurrency}"
+            "DeepSeek-V2-Lite direct benchmark supports --concurrency 1..=8; concurrency=1 is the single-row control and >1 uses the narrow same-prompt batched decode path, got {concurrency}"
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary

This PR fixes the DeepSeek-V2-Lite EP2 direct benchmark path so `bench_serving request --concurrency > 1` no longer measures a row loop over the single-row decode path.

The new path is deliberately narrow: same prompt, greedy decode, fixed output length, and batch sizes `1..=8`. `concurrency=1` remains the single-row control; `concurrency=4/8` now advance rows through a batch-shaped decode step and report TPOT from shared decode-step timing.

## Scope

In scope:
- Add a DeepSeek-V2-Lite EP2 same-prompt batched decode path for direct benchmark measurement.
- Keep prefill row-by-row; only decode advances rows through a batch-shaped step.
- Keep internal projection boundaries conservative for HF/hash parity before performance optimization.
- Require same-prompt batch rows to produce identical token traces before reporting benchmark numbers.
- Reuse the existing HF / host-staged / NCCL hash oracle.
- Add shared wrappers for existing `gemm_per_token_cuda` and `argmax_batch_bf16_cuda` kernel paths.
- Update `KERNELS.md` for the newly exposed runtime-facing wrappers.

Out of scope:
- Production continuous batching.
- vLLM parity or performance optimization claims.
- Sparse dispatch, pegainfer-comm/NVLink, multi-node, or generic EP topology.
- Changing the NCCL transport path beyond preserving parity with host-staged output.

## Evidence

Local checks on the pushed commit:
- `cargo fmt --check` passed
- `git diff --check` passed
- Private host/path/credential scan over changed files passed
- Stale `batched-benchmark-gate.md` reference scan passed

GPU/model evidence collected on the same DeepSeek-V2-Lite snapshot for this true-batch implementation:
- HF / host-staged / NCCL comparison: `all_token_text_exact`
- Generated ids: `[11, 304, 608, 245, 207, 16, 24, 1012, 1712, 5075, 473, 254, 7312, 13, 304, 608]`
- Generated text: `, I am a 19 year old girl from the UK. I am`
- Token SHA256: `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225`
- Text SHA256: `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347`

PegaInfer direct benchmark snapshot, 2x RTX 5090, same model snapshot:

| Batch | Backend | steady TPOT p50 ms | steady TPOT avg ms | decode tok/s | Trace |
| ---: | --- | ---: | ---: | ---: | --- |
| 1 | host-staged | 58.558 | 62.009 | 16.144 | HF trace |
| 1 | NCCL | 193.650 | 201.276 | 4.982 | HF trace |
| 4 | host-staged | 202.186 | 210.409 | 19.124 | HF trace |
| 4 | NCCL | 333.321 | 344.764 | 11.528 | HF trace |
| 8 | host-staged | 394.753 | 411.348 | 19.423 | HF trace |
| 8 | NCCL | 522.917 | 539.643 | 14.874 | HF trace |

## Claim Boundary

This PR only fixes the measurement contract for the narrow DeepSeek-V2-Lite EP2 direct benchmark path. It does not claim a performance improvement, production batching support, or vLLM parity.

Refs #170