### PR TITLE
perf(kimi-k2): fuse decode-path small kernels to reduce launch overhead

### DIFF
--- a/pegainfer-kernels/csrc/kimi_k2/kimi_experts.cu
+++ b/pegainfer-kernels/csrc/kimi_k2/kimi_experts.cu
@@ -221,16 +221,19 @@ __global__ void kimi_add_f32_bf16_to_bf16_kernel(
   out[idx] = __float2bfloat16(a[idx] + __bfloat162float(b[idx]));
 }
 
-__global__ void kimi_scaled_add_f32_bf16_to_bf16_kernel(
-    const float* __restrict__ a,
+__global__ void kimi_residual_add_scaled_f32_kernel(
+    const __nv_bfloat16* __restrict__ hidden,
+    const __nv_bfloat16* __restrict__ projected,
+    const float* __restrict__ routed_f32,
     float scale,
-    const __nv_bfloat16* __restrict__ b,
     __nv_bfloat16* __restrict__ out,
     int n) {
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx >= n) return;
-  float scaled = __fmul_rn(a[idx], scale);
-  float sum = __fadd_rn(scaled, __bfloat162float(b[idx]));
+  __nv_bfloat16 rounded = __float2bfloat16(
+      __bfloat162float(hidden[idx]) + __bfloat162float(projected[idx]));
+  float scaled = __fmul_rn(routed_f32[idx], scale);
+  float sum = __fadd_rn(scaled, __bfloat162float(rounded));
   out[idx] = __float2bfloat16(sum);
 }
 
@@ -605,21 +608,23 @@ CUresult kimi_add_f32_bf16_to_bf16_cuda(
   return err == cudaSuccess ? CUDA_SUCCESS : CUDA_ERROR_LAUNCH_FAILED;
 }
 
-CUresult kimi_scaled_add_f32_bf16_to_bf16_cuda(
-    const float* a,
+CUresult kimi_residual_add_scaled_f32_cuda(
+    const __nv_bfloat16* hidden,
+    const __nv_bfloat16* projected,
+    const float* routed_f32,
     float scale,
-    const __nv_bfloat16* b,
     __nv_bfloat16* out,
     int n,
     cudaStream_t stream) {
-  if (a == nullptr || b == nullptr || out == nullptr || n < 0) {
+  if (hidden == nullptr || projected == nullptr || routed_f32 == nullptr ||
+      out == nullptr || n < 0) {
     return CUDA_ERROR_INVALID_VALUE;
   }
   if (n == 0) return CUDA_SUCCESS;
   constexpr int threads = 256;
   int blocks = (n + threads - 1) / threads;
-  kimi_scaled_add_f32_bf16_to_bf16_kernel<<<blocks, threads, 0, stream>>>(
-      a, scale, b, out, n);
+  kimi_residual_add_scaled_f32_kernel<<<blocks, threads, 0, stream>>>(
+      hidden, projected, routed_f32, scale, out, n);
   cudaError_t err = cudaGetLastError();
   return err == cudaSuccess ? CUDA_SUCCESS : CUDA_ERROR_LAUNCH_FAILED;
 }

--- a/pegainfer-kernels/csrc/kimi_k2/kimi_mla.cu
+++ b/pegainfer-kernels/csrc/kimi_k2/kimi_mla.cu
@@ -84,6 +84,129 @@ __global__ void split_qkv_a_kernel(const DType* __restrict__ qkv_a,
   }
 }
 
+__device__ __forceinline__ float fi_rsqrt_norm(float x) {
+  float y;
+  asm volatile("rsqrt.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+  return y;
+}
+
+__device__ __forceinline__ float fi_shfl_xor(float x, int lane_mask) {
+  return __shfl_xor_sync(0xffffffff, x, lane_mask);
+}
+
+__global__ void split_qkv_a_norm_kernel(
+    const DType* __restrict__ qkv_a,
+    const DType* __restrict__ q_a_weight,
+    const DType* __restrict__ ckv_weight,
+    DType* __restrict__ q_a_normed,
+    DType* __restrict__ ckv_normed,
+    DType* __restrict__ k_rope_out,
+    float eps,
+    int batch_size) {
+
+  const int token = blockIdx.x;
+  if (token >= batch_size) return;
+
+  const uint32_t tx = threadIdx.x;
+  const uint32_t ty = threadIdx.y;
+  constexpr uint32_t kWarpSize = 32;
+  const uint32_t thread_id = tx + ty * kWarpSize;
+
+  constexpr int VEC = 8;
+  constexpr int CKV_THREADS = kKvLoraRank / VEC;
+  constexpr int ROPE_THREADS = kRopeDim / VEC;
+  constexpr int Q_WARPS = 6;
+  constexpr int CKV_WARPS = 2;
+
+  extern __shared__ float smem[];
+  float* smem_q = smem;
+  float* smem_ckv = smem + Q_WARPS;
+
+  const DType* token_qkv = qkv_a + token * kQkvAOut;
+
+  float q_vals[VEC];
+  float sum_sq_q = 0.f;
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  asm volatile("griddepcontrol.wait;");
+#endif
+  {
+    const DType* src = token_qkv + thread_id * VEC;
+#pragma unroll
+    for (int j = 0; j < VEC; j++) {
+      q_vals[j] = __bfloat162float(src[j]);
+      sum_sq_q += q_vals[j] * q_vals[j];
+    }
+  }
+
+  float ckv_vals[VEC];
+  float sum_sq_ckv = 0.f;
+  if (thread_id < CKV_THREADS) {
+    const DType* src = token_qkv + kQLoraRank + thread_id * VEC;
+#pragma unroll
+    for (int j = 0; j < VEC; j++) {
+      ckv_vals[j] = __bfloat162float(src[j]);
+      sum_sq_ckv += ckv_vals[j] * ckv_vals[j];
+    }
+  }
+
+#pragma unroll
+  for (int offset = kWarpSize / 2; offset > 0; offset /= 2)
+    sum_sq_q += fi_shfl_xor(sum_sq_q, offset);
+  smem_q[ty] = sum_sq_q;
+
+#pragma unroll
+  for (int offset = kWarpSize / 2; offset > 0; offset /= 2)
+    sum_sq_ckv += fi_shfl_xor(sum_sq_ckv, offset);
+  smem_ckv[ty] = sum_sq_ckv;
+
+  __syncthreads();
+
+  if (ty == 0) {
+    float total_q = (tx < Q_WARPS) ? smem_q[tx] : 0.f;
+#pragma unroll
+    for (int offset = kWarpSize / 2; offset > 0; offset /= 2)
+      total_q += fi_shfl_xor(total_q, offset);
+    smem_q[0] = total_q;
+
+    float total_ckv = (tx < CKV_WARPS) ? smem_ckv[tx] : 0.f;
+#pragma unroll
+    for (int offset = kWarpSize / 2; offset > 0; offset /= 2)
+      total_ckv += fi_shfl_xor(total_ckv, offset);
+    smem_ckv[0] = total_ckv;
+  }
+  __syncthreads();
+
+  float rms_rcp_q = fi_rsqrt_norm(smem_q[0] / float(kQLoraRank) + eps);
+  float rms_rcp_ckv = fi_rsqrt_norm(smem_ckv[0] / float(kKvLoraRank) + eps);
+
+  {
+    DType* dst = q_a_normed + token * kQLoraRank + thread_id * VEC;
+    const DType* w = q_a_weight + thread_id * VEC;
+#pragma unroll
+    for (int j = 0; j < VEC; j++)
+      dst[j] = __float2bfloat16(q_vals[j] * rms_rcp_q * __bfloat162float(w[j]));
+  }
+
+  if (thread_id < CKV_THREADS) {
+    DType* dst = ckv_normed + token * kKvLoraRank + thread_id * VEC;
+    const DType* w = ckv_weight + thread_id * VEC;
+#pragma unroll
+    for (int j = 0; j < VEC; j++)
+      dst[j] = __float2bfloat16(ckv_vals[j] * rms_rcp_ckv * __bfloat162float(w[j]));
+  }
+
+  if (thread_id < ROPE_THREADS) {
+    const DType* src = token_qkv + kQLoraRank + kKvLoraRank + thread_id * VEC;
+    DType* dst = k_rope_out + token * kRopeDim + thread_id * VEC;
+#pragma unroll
+    for (int j = 0; j < VEC; j++)
+      dst[j] = src[j];
+  }
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  asm volatile("griddepcontrol.launch_dependents;");
+#endif
+}
+
 __device__ __forceinline__ DType rope_out(DType even, DType odd, DType cos_v,
                                           DType sin_v, bool upper) {
   float x_even = __bfloat162float(even);
@@ -270,6 +393,28 @@ cudaError_t kimi_mla_split_qkv_a_cuda(const DType* qkv_a,
   int threads = 256;
   int blocks = (total + threads - 1) / threads;
   split_qkv_a_kernel<<<blocks, threads, 0, stream>>>(qkv_a, q_a, compressed, k_rope, seq_len);
+  return cudaGetLastError();
+}
+
+cudaError_t kimi_mla_split_qkv_a_norm_cuda(const DType* qkv_a,
+                                            const DType* q_a_weight,
+                                            const DType* ckv_weight,
+                                            DType* q_a_normed,
+                                            DType* ckv_normed,
+                                            DType* k_rope,
+                                            float eps,
+                                            int batch_size,
+                                            cudaStream_t stream) {
+  if (batch_size <= 0) {
+    return cudaErrorInvalidValue;
+  }
+  constexpr int Q_WARPS = 6;
+  int smem_bytes = (Q_WARPS + Q_WARPS) * static_cast<int>(sizeof(float));
+  dim3 grid(batch_size);
+  dim3 block(32, Q_WARPS);
+  split_qkv_a_norm_kernel<<<grid, block, smem_bytes, stream>>>(
+      qkv_a, q_a_weight, ckv_weight,
+      q_a_normed, ckv_normed, k_rope, eps, batch_size);
   return cudaGetLastError();
 }
 

--- a/pegainfer-kernels/src/ffi.rs
+++ b/pegainfer-kernels/src/ffi.rs
@@ -269,10 +269,11 @@ unsafe extern "C" {
         stream: CUstream,
     ) -> CUresult;
 
-    pub fn kimi_scaled_add_f32_bf16_to_bf16_cuda(
-        a: *const f32,
+    pub fn kimi_residual_add_scaled_f32_cuda(
+        hidden: *const Half,
+        projected: *const Half,
+        routed_f32: *const f32,
         scale: f32,
-        b: *const Half,
         out: *mut Half,
         n: i32,
         stream: CUstream,
@@ -284,6 +285,18 @@ unsafe extern "C" {
         compressed: *mut Half,
         k_rope: *mut Half,
         seq_len: i32,
+        stream: CUstream,
+    ) -> CUresult;
+
+    pub fn kimi_mla_split_qkv_a_norm_cuda(
+        qkv_a: *const Half,
+        q_a_weight: *const Half,
+        ckv_weight: *const Half,
+        q_a_normed: *mut Half,
+        ckv_normed: *mut Half,
+        k_rope: *mut Half,
+        eps: f32,
+        batch_size: i32,
         stream: CUstream,
     ) -> CUresult;
 

--- a/pegainfer-kernels/src/ops/kimi_k2/experts.rs
+++ b/pegainfer-kernels/src/ops/kimi_k2/experts.rs
@@ -51,35 +51,39 @@ pub fn kimi_add_f32_bf16_to_bf16<const DIM: usize>(
     Ok(())
 }
 
-pub fn kimi_scaled_add_f32_bf16_to_bf16<const DIM: usize>(
+pub fn kimi_residual_add_scaled_f32<const DIM: usize>(
     ctx: &DeviceContext,
-    a: &CudaSlice<f32>,
+    hidden: &GpuTensor<DIM>,
+    projected: &GpuTensor<DIM>,
+    routed_f32: &CudaSlice<f32>,
     scale: f32,
-    b: &GpuTensor<DIM>,
     out: &mut GpuTensor<DIM>,
 ) -> Result<()> {
-    let elems = DIM * b.seq_len;
+    let elems = DIM * hidden.seq_len;
     ensure!(
-        out.seq_len == b.seq_len,
-        "Kimi scaled f32 add seq_len mismatch: b={}, output={}",
-        b.seq_len,
+        projected.seq_len == hidden.seq_len && out.seq_len == hidden.seq_len,
+        "Kimi residual_add_scaled_f32 seq_len mismatch: hidden={}, projected={}, out={}",
+        hidden.seq_len,
+        projected.seq_len,
         out.seq_len
     );
     ensure!(
-        a.len() >= elems,
-        "Kimi scaled f32 add input too small: have {}, need {}",
-        a.len(),
+        routed_f32.len() >= elems,
+        "Kimi residual_add_scaled_f32 routed_f32 too small: have {}, need {}",
+        routed_f32.len(),
         elems
     );
 
-    let (a_ptr, _a_guard) = a.device_ptr(&ctx.stream);
-    let (b_ptr, _b_guard) = b.data.device_ptr(&ctx.stream);
-    let (out_ptr, _out_guard) = out.data.device_ptr_mut(&ctx.stream);
+    let (hidden_ptr, _g0) = hidden.data.device_ptr(&ctx.stream);
+    let (projected_ptr, _g1) = projected.data.device_ptr(&ctx.stream);
+    let (routed_ptr, _g2) = routed_f32.device_ptr(&ctx.stream);
+    let (out_ptr, _g3) = out.data.device_ptr_mut(&ctx.stream);
     let result = unsafe {
-        ffi::kimi_scaled_add_f32_bf16_to_bf16_cuda(
-            a_ptr as *const f32,
+        ffi::kimi_residual_add_scaled_f32_cuda(
+            hidden_ptr as *const ffi::Half,
+            projected_ptr as *const ffi::Half,
+            routed_ptr as *const f32,
             scale,
-            b_ptr as *const ffi::Half,
             out_ptr as *mut ffi::Half,
             elems as i32,
             ctx.stream.cu_stream(),

--- a/pegainfer-kernels/src/ops/kimi_k2/mla.rs
+++ b/pegainfer-kernels/src/ops/kimi_k2/mla.rs
@@ -3,7 +3,7 @@ use cudarc::driver::{CudaSlice, DevicePtr, DevicePtrMut};
 
 use crate::{
     ffi,
-    tensor::{DeviceContext, GpuTensor, GpuWeight},
+    tensor::{DeviceContext, GpuTensor, GpuWeight, NormWeight},
 };
 
 pub const KIMI_K2_MLA_LOCAL_HEADS_TP8: usize = 8;
@@ -160,6 +160,49 @@ pub fn kimi_mla_split_qkv_a(
             q_a_ptr as *mut ffi::Half,
             compressed_ptr as *mut ffi::Half,
             k_rope_ptr as *mut ffi::Half,
+            qkv_a.seq_len as i32,
+            ctx.stream.cu_stream(),
+        )
+    };
+    result.result()?;
+    Ok(())
+}
+
+pub fn kimi_mla_split_qkv_a_norm(
+    ctx: &DeviceContext,
+    qkv_a: &GpuTensor<KIMI_K2_MLA_QKV_A_OUT>,
+    q_a_weight: &NormWeight<KIMI_K2_MLA_Q_LORA_RANK>,
+    ckv_weight: &NormWeight<KIMI_K2_MLA_KV_LORA_RANK>,
+    q_a_normed: &mut GpuTensor<KIMI_K2_MLA_Q_LORA_RANK>,
+    ckv_normed: &mut GpuTensor<KIMI_K2_MLA_KV_LORA_RANK>,
+    k_rope: &mut GpuTensor<KIMI_K2_MLA_ROPE_DIM>,
+    eps: f32,
+) -> Result<()> {
+    ensure!(
+        q_a_normed.seq_len == qkv_a.seq_len
+            && ckv_normed.seq_len == qkv_a.seq_len
+            && k_rope.seq_len == qkv_a.seq_len,
+        "Kimi MLA split+norm seq_len mismatch: qkv_a={}, q_a_normed={}, ckv_normed={}, k_rope={}",
+        qkv_a.seq_len,
+        q_a_normed.seq_len,
+        ckv_normed.seq_len,
+        k_rope.seq_len
+    );
+    let (qkv_a_ptr, _g0) = qkv_a.data.device_ptr(&ctx.stream);
+    let (q_w_ptr, _g1) = q_a_weight.data.device_ptr(&ctx.stream);
+    let (ckv_w_ptr, _g2) = ckv_weight.data.device_ptr(&ctx.stream);
+    let (q_out_ptr, _g3) = q_a_normed.data.device_ptr_mut(&ctx.stream);
+    let (ckv_out_ptr, _g4) = ckv_normed.data.device_ptr_mut(&ctx.stream);
+    let (rope_ptr, _g5) = k_rope.data.device_ptr_mut(&ctx.stream);
+    let result = unsafe {
+        ffi::kimi_mla_split_qkv_a_norm_cuda(
+            qkv_a_ptr as *const ffi::Half,
+            q_w_ptr as *const ffi::Half,
+            ckv_w_ptr as *const ffi::Half,
+            q_out_ptr as *mut ffi::Half,
+            ckv_out_ptr as *mut ffi::Half,
+            rope_ptr as *mut ffi::Half,
+            eps,
             qkv_a.seq_len as i32,
             ctx.stream.cu_stream(),
         )

--- a/pegainfer-kimi-k2/src/batch_decode_trace.rs
+++ b/pegainfer-kimi-k2/src/batch_decode_trace.rs
@@ -199,26 +199,22 @@ fn push_attention_layer(
         batch,
     ));
     calls.push(
-        KernelCall::new("kimi_mla_split_qkv_a", format!("{prefix}.split_qkv_a"))
-            .input("qkv_a", hidden(KIMI_K2_MLA_QKV_A_OUT, batch))
-            .output("q_a", hidden(KIMI_K2_Q_LORA_RANK, batch))
-            .output("compressed_kv", hidden(KIMI_K2_MLA_KV_LORA_RANK, batch))
-            .output("k_rope", hidden(KIMI_K2_MLA_ROPE_DIM, batch)),
+        KernelCall::new(
+            "kimi_mla_split_qkv_a_norm",
+            format!("{prefix}.split_qkv_a_norm"),
+        )
+        .input("qkv_a", hidden(KIMI_K2_MLA_QKV_A_OUT, batch))
+        .output("q_a_normed", hidden(KIMI_K2_Q_LORA_RANK, batch))
+        .output(
+            "compressed_kv_normed",
+            hidden(KIMI_K2_MLA_KV_LORA_RANK, batch),
+        )
+        .output("k_rope", hidden(KIMI_K2_MLA_ROPE_DIM, batch)),
     );
-    calls.push(rms_dim(
-        &format!("{prefix}.q_a_norm"),
-        KIMI_K2_Q_LORA_RANK,
-        batch,
-    ));
     calls.push(gemm(
         &format!("{prefix}.q_b"),
         KIMI_K2_MLA_Q_LOCAL_OUT_TP8,
         KIMI_K2_Q_LORA_RANK,
-        batch,
-    ));
-    calls.push(rms_dim(
-        &format!("{prefix}.kv_a_norm"),
-        KIMI_K2_MLA_KV_LORA_RANK,
         batch,
     ));
     calls.push(
@@ -465,17 +461,17 @@ fn push_moe_layer(calls: &mut Vec<KernelCall>, layer_idx: usize, batch: usize) {
         EP_WORLD_SIZE,
         "f32",
     ));
-    calls.push(add(&format!("{prefix}.shared_residual"), batch));
     calls.push(
         KernelCall::new(
-            "kimi_scaled_add_f32_bf16_to_bf16",
-            format!("{prefix}.routed_residual"),
+            "kimi_residual_add_scaled_f32",
+            format!("{prefix}.residual_add_scaled"),
         )
+        .input("hidden", hidden(KIMI_K2_HIDDEN, batch))
+        .input("projected", hidden(KIMI_K2_HIDDEN, batch))
         .input(
-            "a",
+            "routed_f32",
             TensorSpec::new::<F32, Contiguous1D>([AxisSpec::named("elem", batch * KIMI_K2_HIDDEN)]),
         )
-        .input("b", hidden(KIMI_K2_HIDDEN, batch))
         .output("out", hidden(KIMI_K2_HIDDEN, batch))
         .attr("scale", KIMI_K2_ROUTER_SCALE.to_string()),
     );

--- a/pegainfer-kimi-k2/src/kernel_report.rs
+++ b/pegainfer-kimi-k2/src/kernel_report.rs
@@ -15,14 +15,15 @@ use pegainfer_kernels::{
         fused_add_rms_norm_round_batch_into, gemm_graphsafe_into_checked,
         kimi_add_f32_bf16_to_bf16, kimi_flashinfer_batch_decode_mla, kimi_marlin_sum_topk_rows_f32,
         kimi_marlin_w13_swiglu, kimi_marlin_wna16_w2_gemm, kimi_marlin_wna16_w13_gemm,
-        kimi_mla_absorb_q_nope, kimi_mla_rope_split_decode, kimi_mla_split_qkv_a, kimi_mla_v_up,
-        kimi_moe_marlin_align_block_size, kimi_router_noaux_tc_launch,
-        kimi_scaled_add_f32_bf16_to_bf16, repeat_f32_for_reduce_scatter_into, rms_norm_batch_into,
-        scale_f32_in_place, silu_mul_batch_into,
+        kimi_mla_absorb_q_nope, kimi_mla_rope_split_decode, kimi_mla_split_qkv_a,
+        kimi_mla_split_qkv_a_norm, kimi_mla_v_up, kimi_moe_marlin_align_block_size,
+        kimi_residual_add_scaled_f32, kimi_router_noaux_tc_launch,
+        repeat_f32_for_reduce_scatter_into, rms_norm_batch_into, scale_f32_in_place,
+        silu_mul_batch_into,
     },
     tensor::{
         DeviceContext, DeviceMatrix, DeviceVec, GpuTensor, GpuWeight, HiddenStates, KernelCall,
-        TensorSpec,
+        NormWeight, TensorSpec,
     },
 };
 use serde::Serialize;
@@ -55,10 +56,11 @@ pub fn measure_call(call: &KernelCall, iters: u64) -> Result<MeasuredCall> {
         "add_batch" => Some(measure_add(call, iters)?),
         "scale_f32_in_place" => Some(measure_scale_f32(call, iters)?),
         "kimi_add_f32_bf16_to_bf16" => Some(measure_add_f32_bf16(call, iters)?),
-        "kimi_scaled_add_f32_bf16_to_bf16" => Some(measure_scaled_add_f32_bf16(call, iters)?),
+        "kimi_residual_add_scaled_f32" => Some(measure_residual_add_scaled_f32(call, iters)?),
         "embedding_batch_vocab_shard" => Some(measure_embedding(call, iters)?),
         "top1_batch" => Some(measure_top1(call, iters)?),
         "kimi_mla_split_qkv_a" => Some(measure_mla_split_qkv_a(call, iters)?),
+        "kimi_mla_split_qkv_a_norm" => Some(measure_mla_split_qkv_a_norm(call, iters)?),
         "kimi_mla_rope_split_decode" => Some(measure_mla_rope_split(call, iters)?),
         "kimi_mla_absorb_q_nope" => Some(measure_mla_absorb_q(call, iters)?),
         "kimi_mla_v_up" => Some(measure_mla_v_up(call, iters)?),
@@ -288,13 +290,13 @@ fn measure_add_f32_bf16(call: &KernelCall, iters: u64) -> Result<LatencyStats> {
     })
 }
 
-fn measure_scaled_add_f32_bf16(call: &KernelCall, iters: u64) -> Result<LatencyStats> {
-    let b = input(call, "b")?;
-    let hidden = axis(b, "hidden")?;
-    let batch = axis(b, "batch")?;
+fn measure_residual_add_scaled_f32(call: &KernelCall, iters: u64) -> Result<LatencyStats> {
+    let h = input(call, "hidden")?;
+    let hidden = axis(h, "hidden")?;
+    let batch = axis(h, "batch")?;
     ensure!(
         hidden == KIMI_K2_HIDDEN,
-        "{} typed Kimi scaled-add expects hidden={KIMI_K2_HIDDEN}, got {hidden}",
+        "{} expects hidden={KIMI_K2_HIDDEN}, got {hidden}",
         call.label
     );
     let scale = call
@@ -304,11 +306,12 @@ fn measure_scaled_add_f32_bf16(call: &KernelCall, iters: u64) -> Result<LatencyS
         .and_then(|attr| attr.value.parse::<f32>().ok())
         .unwrap_or(2.827);
     let ctx = DeviceContext::new()?;
-    let a: CudaSlice<f32> = ctx.stream.alloc_zeros(hidden * batch)?;
-    let b = GpuTensor::<KIMI_K2_HIDDEN>::zeros(&ctx, batch)?;
+    let hidden_t = GpuTensor::<KIMI_K2_HIDDEN>::zeros(&ctx, batch)?;
+    let projected = GpuTensor::<KIMI_K2_HIDDEN>::zeros(&ctx, batch)?;
+    let routed_f32: CudaSlice<f32> = ctx.stream.alloc_zeros(KIMI_K2_HIDDEN * batch)?;
     let mut out = GpuTensor::<KIMI_K2_HIDDEN>::zeros(&ctx, batch)?;
     measure_loop(&ctx, iters, || {
-        kimi_scaled_add_f32_bf16_to_bf16(&ctx, &a, scale, &b, &mut out)
+        kimi_residual_add_scaled_f32(&ctx, &hidden_t, &projected, &routed_f32, scale, &mut out)
     })
 }
 
@@ -352,6 +355,34 @@ fn measure_mla_split_qkv_a(call: &KernelCall, iters: u64) -> Result<LatencyStats
     let mut k_rope = GpuTensor::<KIMI_K2_MLA_ROPE_DIM>::zeros(&ctx, batch)?;
     measure_loop(&ctx, iters, || {
         kimi_mla_split_qkv_a(&ctx, &qkv_a, &mut q_a, &mut compressed, &mut k_rope)
+    })
+}
+
+fn measure_mla_split_qkv_a_norm(call: &KernelCall, iters: u64) -> Result<LatencyStats> {
+    let qkv_a_spec = input(call, "qkv_a")?;
+    let batch = axis(qkv_a_spec, "batch")?;
+    let ctx = DeviceContext::new()?;
+    let qkv_a = GpuTensor::<KIMI_K2_MLA_QKV_A_OUT>::zeros(&ctx, batch)?;
+    let q_a_weight = NormWeight::<{ crate::config::KIMI_K2_Q_LORA_RANK }> {
+        data: ctx.stream.alloc_zeros(crate::config::KIMI_K2_Q_LORA_RANK)?,
+    };
+    let ckv_weight = NormWeight::<KIMI_K2_MLA_KV_LORA_RANK> {
+        data: ctx.stream.alloc_zeros(KIMI_K2_MLA_KV_LORA_RANK)?,
+    };
+    let mut q_a_normed = GpuTensor::<{ crate::config::KIMI_K2_Q_LORA_RANK }>::zeros(&ctx, batch)?;
+    let mut ckv_normed = GpuTensor::<KIMI_K2_MLA_KV_LORA_RANK>::zeros(&ctx, batch)?;
+    let mut k_rope = GpuTensor::<KIMI_K2_MLA_ROPE_DIM>::zeros(&ctx, batch)?;
+    measure_loop(&ctx, iters, || {
+        kimi_mla_split_qkv_a_norm(
+            &ctx,
+            &qkv_a,
+            &q_a_weight,
+            &ckv_weight,
+            &mut q_a_normed,
+            &mut ckv_normed,
+            &mut k_rope,
+            1e-6,
+        )
     })
 }
 

--- a/pegainfer-kimi-k2/src/runner/moe_pplx.rs
+++ b/pegainfer-kimi-k2/src/runner/moe_pplx.rs
@@ -32,7 +32,7 @@ use pegainfer_kernels::{
         kimi_marlin_w13_swiglu_pplx, kimi_marlin_wna16_pplx_w2_gemm,
         kimi_marlin_wna16_pplx_w13_gemm, kimi_marlin_wna16_w2_gemm, kimi_marlin_wna16_w13_gemm,
         kimi_moe_marlin_align_block_size, kimi_pplx_build_marlin_routing_on_stream,
-        kimi_router_noaux_tc_launch, kimi_scaled_add_f32_bf16_to_bf16,
+        kimi_residual_add_scaled_f32, kimi_router_noaux_tc_launch,
         kimi_scatter_marlin_routes_to_compact,
     },
     tensor::{DeviceContext, GpuTensor, NormWeight},
@@ -436,20 +436,15 @@ pub(super) fn forward_moe_layer_decode_pplx_normed(
         )
         .with_context(|| format!("pplx combine_recv layer {layer_idx}"))?;
     }
-    // Combine: hidden = hidden + shared + routed * scale
-    typed_ops::add_into(
+    kimi_residual_add_scaled_f32(
         ctx,
         &scratch.mla.hidden,
         &scratch.mla.projected,
-        &mut scratch.mla.normed,
-    )?;
-    kimi_scaled_add_f32_bf16_to_bf16(
-        ctx,
         &pplx.pplx_routed_f32,
         KIMI_K2_ROUTER_SCALE,
-        &scratch.mla.normed,
-        &mut scratch.mla.hidden,
+        &mut scratch.mla.normed,
     )?;
+    std::mem::swap(&mut scratch.mla.hidden, &mut scratch.mla.normed);
     Ok(())
 }
 
@@ -675,14 +670,14 @@ pub(super) fn forward_moe_layer_prefill_pplx(
         .with_context(|| format!("pplx prefill combine_recv layer {layer_idx}"))?;
     }
 
-    // ---- 12. Combine: hidden = hidden + shared + routed * scale ----
-    typed_ops::add_into(ctx, hidden, &shared_out, next_hidden)?;
-    kimi_scaled_add_f32_bf16_to_bf16(
+    kimi_residual_add_scaled_f32(
         ctx,
+        hidden,
+        &shared_out,
         &pplx.pplx_routed_f32,
         KIMI_K2_ROUTER_SCALE,
         next_hidden,
-        hidden,
     )?;
+    std::mem::swap(hidden, next_hidden);
     Ok(())
 }

--- a/pegainfer-kimi-k2/src/runner/worker.rs
+++ b/pegainfer-kimi-k2/src/runner/worker.rs
@@ -27,9 +27,10 @@ use pegainfer_kernels::{
         kimi_marlin_w13_swiglu, kimi_marlin_wna16_w2_gemm, kimi_marlin_wna16_w13_gemm,
         kimi_mla_absorb_q_nope_rt, kimi_mla_extract_prefill_v_rt, kimi_mla_paged_kv_append,
         kimi_mla_rope_apply_kpe, kimi_mla_rope_assemble_prefill_rt, kimi_mla_rope_split_decode_rt,
-        kimi_mla_split_qkv_a, kimi_mla_v_up_rt, kimi_moe_marlin_align_block_size,
+        kimi_mla_split_qkv_a, kimi_mla_split_qkv_a_norm, kimi_mla_v_up_rt,
+        kimi_moe_marlin_align_block_size, kimi_residual_add_scaled_f32,
         kimi_router_noaux_tc_launch, kimi_router_noaux_tc_per_token_launch,
-        kimi_scaled_add_f32_bf16_to_bf16, repeat_f32_for_reduce_scatter_into, scale_f32_in_place,
+        repeat_f32_for_reduce_scatter_into, scale_f32_in_place,
     },
     tensor::{
         DeviceContext, DeviceMatrix, DeviceVec, GpuTensor, GpuWeight, HiddenStates, NormWeight,

--- a/pegainfer-kimi-k2/src/runner/worker/forward.rs
+++ b/pegainfer-kimi-k2/src/runner/worker/forward.rs
@@ -201,32 +201,21 @@ pub(super) fn forward_mla_decode_layer_into(
         &scratch.mla.normed,
         &mut scratch.mla.qkv_a,
     )?;
-    kimi_mla_split_qkv_a(
+    kimi_mla_split_qkv_a_norm(
         ctx,
         &scratch.mla.qkv_a,
-        &mut scratch.mla.q_a,
-        &mut scratch.mla.compressed_kv,
-        &mut scratch.mla.k_rope,
-    )?;
-    typed_ops::rms_norm_into(
-        ctx,
-        &scratch.mla.q_a,
         &attention.q_a_norm,
-        KIMI_K2_RMS_NORM_EPS,
+        &attention.kv_a_norm,
         &mut scratch.mla.q_a_normed,
+        &mut scratch.mla.compressed_normed,
+        &mut scratch.mla.k_rope,
+        KIMI_K2_RMS_NORM_EPS,
     )?;
     typed_ops::gemm_dm_typed_to_hs_graphsafe(
         ctx,
         &attention.q_b_proj,
         &scratch.mla.q_a_normed,
         &mut scratch.mla.q_proj,
-    )?;
-    typed_ops::rms_norm_into(
-        ctx,
-        &scratch.mla.compressed_kv,
-        &attention.kv_a_norm,
-        KIMI_K2_RMS_NORM_EPS,
-        &mut scratch.mla.compressed_normed,
     )?;
     kimi_mla_rope_split_decode_rt(
         ctx,
@@ -999,18 +988,14 @@ fn forward_moe_layer_decode_normed_after_event_into(
         nccl_comm,
     )?;
 
-    typed_ops::add_into(
+    kimi_residual_add_scaled_f32(
         ctx,
         &scratch.mla.hidden,
         &scratch.mla.projected,
-        &mut scratch.mla.normed,
-    )?;
-    kimi_scaled_add_f32_bf16_to_bf16(
-        ctx,
         &scratch.comm.routed_out_f32,
         KIMI_K2_ROUTER_SCALE,
-        &scratch.mla.normed,
-        &mut scratch.mla.hidden,
+        &mut scratch.mla.normed,
     )?;
+    std::mem::swap(&mut scratch.mla.hidden, &mut scratch.mla.normed);
     Ok(())
 }


### PR DESCRIPTION
## Summary

- **Fusion 1**: `split_qkv_a` + 2× `rms_norm` → single `kimi_mla_split_qkv_a_norm` kernel (3→1 launch, ×61 layers, 9.5→3.5μs on H20)
- **Fusion 2**: `add_into` + `scaled_add` → single `kimi_residual_add_scaled_f32` kernel (2→1 launch, ×60 MoE layers, 6.3→2.8μs on H20)
- Both fused kernels are **bitwise equal** to the original path
- Total: 182 fewer kernel launches per decode step, ~0.58ms TPOT reduction at bs=1

## E2E Results (H20, TP1 DP8 EP8 PPLX, bs=64, output_len=128)

| Metric | Baseline | Fused | Delta |
|--------|----------|-------|-------|
| TPOT p50 | 40.10ms | 39.64ms | −0.46ms (−1.1%) |
| TPOT p99 | 43.72ms | 43.36ms | −0.36ms |

## Test plan

- [x] Standalone C++ bench: bitwise correctness at B∈{1,4,8,16,32,64}
- [x] ncu profile: confirmed launch reduction and kernel duration improvement
- [x] E2E `bench_serving` dp8 tp1 ep8 bs64 on H20 cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)