### PR TITLE
feat(qwen3): support tensor-parallel LoRA adapter loading

### DIFF
--- a/pegainfer-qwen3-4b/src/executor.rs
+++ b/pegainfer-qwen3-4b/src/executor.rs
@@ -819,11 +819,8 @@ impl ModelExecutor for Qwen3Executor {
     }
 
     fn load_lora_adapter(&mut self, request: &LoadLoraAdapterRequest) -> Result<()> {
-        anyhow::ensure!(
-            self.workers.is_empty(),
-            "Qwen3 LoRA adapter loading currently supports single-GPU execution only"
-        );
         let adapter = crate::lora::load_lora_adapter(&request.lora_path, &self.metadata.config)?;
+        let world_size = self.workers.len() + 1;
         let projection_count: usize = adapter
             .layers
             .iter()
@@ -847,18 +844,63 @@ impl ModelExecutor for Qwen3Executor {
         let rank = adapter.manifest.rank;
         let targets = adapter.manifest.target_modules.join(", ");
         let path = adapter.manifest.path.display().to_string();
-        self.primary
-            .load_lora_adapter(request.lora_name.clone(), adapter)?
-            .recv()
-            .map_err(|_| anyhow::anyhow!("primary worker dropped LoRA load response"))??;
+        let mut sharded_adapters = Vec::with_capacity(world_size);
+        for rank in 0..world_size {
+            sharded_adapters.push(adapter.shard_for_tensor_parallel(
+                &self.metadata.config,
+                TensorParallelConfig { rank, world_size },
+            )?);
+        }
+
+        let mut sharded_adapters = sharded_adapters.into_iter();
+        let primary_adapter = sharded_adapters
+            .next()
+            .expect("rank 0 adapter must exist for nonzero world_size");
+        let primary_response = self
+            .primary
+            .load_lora_adapter(request.lora_name.clone(), primary_adapter)?;
+        let mut pending = Vec::with_capacity(self.workers.len());
+        for (index, worker) in self.workers.iter().enumerate() {
+            let rank = index + 1;
+            let rank_adapter = sharded_adapters
+                .next()
+                .expect("worker adapter must exist for every tensor-parallel rank");
+            pending.push((
+                rank,
+                worker.load_lora_adapter(request.lora_name.clone(), rank_adapter)?,
+            ));
+        }
+
+        let mut errors = Vec::new();
+        match primary_response.recv() {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => errors.push(format!("rank 0: {err:#}")),
+            Err(_) => errors.push("rank 0: dropped LoRA load response".to_string()),
+        }
+        for (rank, response) in pending {
+            match response.recv() {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => errors.push(format!("rank {rank}: {err:#}")),
+                Err(_) => errors.push(format!("rank {rank}: dropped LoRA load response")),
+            }
+        }
+        if !errors.is_empty() {
+            anyhow::bail!(
+                "failed to load Qwen3 LoRA adapter {} on tensor-parallel ranks: {}",
+                request.lora_name,
+                errors.join("; ")
+            );
+        }
+
         log::info!(
-            "Loaded Qwen3 LoRA adapter {} from {} (rank={}, targets={}, projections={}, bf16_elements={})",
+            "Loaded Qwen3 LoRA adapter {} from {} (rank={}, targets={}, projections={}, bf16_elements={}, tp_world_size={})",
             request.lora_name,
             path,
             rank,
             targets,
             projection_count,
-            element_count
+            element_count,
+            world_size
         );
         Ok(())
     }

--- a/pegainfer-qwen3-4b/src/lora.rs
+++ b/pegainfer-qwen3-4b/src/lora.rs
@@ -10,7 +10,7 @@ use safetensors::tensor::TensorView;
 use safetensors::{Dtype, SafeTensors};
 use serde::Deserialize;
 
-use crate::config::Config;
+use crate::config::{Config, TensorParallelConfig};
 
 const ADAPTER_CONFIG_FILE: &str = "adapter_config.json";
 const ADAPTER_WEIGHTS_FILE: &str = "adapter_model.safetensors";
@@ -113,6 +113,41 @@ impl TargetModules {
             Self::One(target) => vec![target],
             Self::Many(targets) => targets,
         }
+    }
+}
+
+impl LoraAdapter {
+    pub(crate) fn shard_for_tensor_parallel(
+        &self,
+        config: &Config,
+        tensor_parallel: TensorParallelConfig,
+    ) -> Result<Self> {
+        tensor_parallel.validate_for(config)?;
+        if !tensor_parallel.is_sharded() {
+            return Ok(self.clone());
+        }
+
+        let mut layers = Vec::with_capacity(self.layers.len());
+        for layer in &self.layers {
+            let mut sharded_layer = LoraLayer::default();
+            for (target, projection) in &layer.projections {
+                sharded_layer.projections.insert(
+                    target.clone(),
+                    shard_projection_for_tensor_parallel(
+                        config,
+                        tensor_parallel,
+                        target,
+                        projection,
+                    )?,
+                );
+            }
+            layers.push(sharded_layer);
+        }
+
+        Ok(Self {
+            manifest: self.manifest.clone(),
+            layers,
+        })
     }
 }
 
@@ -430,6 +465,92 @@ impl LoraMatrix {
     fn to_device(&self, ctx: &DeviceContext) -> Result<DeviceMatrix> {
         DeviceMatrix::from_host(ctx, &self.data, self.rows, self.cols)
     }
+
+    fn row_shard(&self, row_offset: usize, rows: usize) -> Result<Self> {
+        ensure!(
+            row_offset + rows <= self.rows,
+            "LoRA row shard out of bounds: row_offset={} rows={} total_rows={}",
+            row_offset,
+            rows,
+            self.rows
+        );
+        let start = row_offset * self.cols;
+        let end = (row_offset + rows) * self.cols;
+        Ok(Self {
+            data: self.data[start..end].to_vec(),
+            rows,
+            cols: self.cols,
+        })
+    }
+
+    fn col_shard(&self, col_offset: usize, cols: usize) -> Result<Self> {
+        ensure!(
+            col_offset + cols <= self.cols,
+            "LoRA col shard out of bounds: col_offset={} cols={} total_cols={}",
+            col_offset,
+            cols,
+            self.cols
+        );
+        let mut data = Vec::with_capacity(self.rows * cols);
+        for row in 0..self.rows {
+            let start = row * self.cols + col_offset;
+            data.extend_from_slice(&self.data[start..start + cols]);
+        }
+        Ok(Self {
+            data,
+            rows: self.rows,
+            cols,
+        })
+    }
+}
+
+fn shard_projection_for_tensor_parallel(
+    config: &Config,
+    tensor_parallel: TensorParallelConfig,
+    target: &str,
+    projection: &LoraProjection,
+) -> Result<LoraProjection> {
+    match target {
+        "q_proj" => {
+            let (row_offset, rows) =
+                tensor_parallel.shard_range(config.num_attention_heads * config.head_dim);
+            Ok(LoraProjection {
+                a: projection.a.clone(),
+                b: projection.b.row_shard(row_offset, rows)?,
+            })
+        }
+        "k_proj" | "v_proj" => {
+            let (row_offset, rows) =
+                tensor_parallel.shard_range(config.num_key_value_heads * config.head_dim);
+            Ok(LoraProjection {
+                a: projection.a.clone(),
+                b: projection.b.row_shard(row_offset, rows)?,
+            })
+        }
+        "gate_proj" | "up_proj" => {
+            let (row_offset, rows) = tensor_parallel.shard_range(config.intermediate_size);
+            Ok(LoraProjection {
+                a: projection.a.clone(),
+                b: projection.b.row_shard(row_offset, rows)?,
+            })
+        }
+        "o_proj" => {
+            let (col_offset, cols) =
+                tensor_parallel.shard_range(config.num_attention_heads * config.head_dim);
+            Ok(LoraProjection {
+                a: projection.a.col_shard(col_offset, cols)?,
+                b: projection.b.clone(),
+            })
+        }
+        "down_proj" => {
+            let (col_offset, cols) = tensor_parallel.shard_range(config.intermediate_size);
+            Ok(LoraProjection {
+                a: projection.a.col_shard(col_offset, cols)?,
+                b: projection.b.clone(),
+            })
+        }
+        _ => bail!("unsupported Qwen3 LoRA target module {target}"),
+    }
 }
 
 #[cfg(test)]
@@ -451,7 +572,7 @@ mod tests {
             intermediate_size: 6,
             num_hidden_layers: 2,
             num_attention_heads: 2,
-            num_key_value_heads: 1,
+            num_key_value_heads: 2,
             head_dim: 2,
             vocab_size: 16,
             rms_norm_eps: 1e-6,
@@ -558,6 +679,17 @@ mod tests {
             _ => panic!("unsupported test dtype {dtype:?}"),
         };
         tensors.insert(name, TestTensor { dtype, shape, data });
+    }
+
+    fn matrix(rows: usize, cols: usize) -> LoraMatrix {
+        let data = (0..rows * cols)
+            .map(|idx| bf16::from_f32(idx as f32))
+            .collect();
+        LoraMatrix { data, rows, cols }
+    }
+
+    fn values(matrix: &LoraMatrix) -> Vec<f32> {
+        matrix.data.iter().map(|value| value.to_f32()).collect()
     }
 
     #[test]
@@ -684,5 +816,80 @@ mod tests {
         let error = load_lora_adapter(&path, &config).expect_err("bad tensor shape");
 
         assert!(error.to_string().contains("shape mismatch"));
+    }
+
+    #[test]
+    fn shards_column_parallel_lora_b_rows_for_tp_rank() {
+        let config = tiny_config();
+        let tp = TensorParallelConfig {
+            rank: 1,
+            world_size: 2,
+        };
+        let projection = LoraProjection {
+            a: matrix(2, config.hidden_size),
+            b: matrix(config.intermediate_size, 2),
+        };
+
+        let sharded = shard_projection_for_tensor_parallel(&config, tp, "gate_proj", &projection)
+            .expect("shard gate_proj");
+
+        assert_eq!((sharded.a.rows, sharded.a.cols), (2, config.hidden_size));
+        assert_eq!(values(&sharded.a), values(&projection.a));
+        assert_eq!((sharded.b.rows, sharded.b.cols), (3, 2));
+        assert_eq!(values(&sharded.b), vec![6.0, 7.0, 8.0, 9.0, 10.0, 11.0]);
+    }
+
+    #[test]
+    fn shards_row_parallel_lora_a_cols_for_tp_rank() {
+        let config = tiny_config();
+        let tp = TensorParallelConfig {
+            rank: 1,
+            world_size: 2,
+        };
+        let projection = LoraProjection {
+            a: matrix(2, config.intermediate_size),
+            b: matrix(config.hidden_size, 2),
+        };
+
+        let sharded = shard_projection_for_tensor_parallel(&config, tp, "down_proj", &projection)
+            .expect("shard down_proj");
+
+        assert_eq!((sharded.a.rows, sharded.a.cols), (2, 3));
+        assert_eq!(values(&sharded.a), vec![3.0, 4.0, 5.0, 9.0, 10.0, 11.0]);
+        assert_eq!((sharded.b.rows, sharded.b.cols), (config.hidden_size, 2));
+        assert_eq!(values(&sharded.b), values(&projection.b));
+    }
+
+    #[test]
+    fn shards_full_adapter_for_tensor_parallel() {
+        let config = tiny_config();
+        let path = temp_adapter_dir("tp-shard");
+        write_adapter_config(&path, &["q_proj", "down_proj"], 2);
+        write_adapter_weights(&path, &config, &["q_proj", "down_proj"], 2);
+        let adapter = load_lora_adapter(&path, &config).expect("load adapter");
+
+        let sharded = adapter
+            .shard_for_tensor_parallel(
+                &config,
+                TensorParallelConfig {
+                    rank: 1,
+                    world_size: 2,
+                },
+            )
+            .expect("shard adapter");
+
+        let q_proj = sharded.layers[0].projections.get("q_proj").expect("q_proj");
+        assert_eq!((q_proj.a.rows, q_proj.a.cols), (2, config.hidden_size));
+        assert_eq!((q_proj.b.rows, q_proj.b.cols), (2, 2));
+
+        let down_proj = sharded.layers[0]
+            .projections
+            .get("down_proj")
+            .expect("down_proj");
+        assert_eq!((down_proj.a.rows, down_proj.a.cols), (2, 3));
+        assert_eq!(
+            (down_proj.b.rows, down_proj.b.cols),
+            (config.hidden_size, 2)
+        );
     }
 }

--- a/pegainfer-server/src/main.rs
+++ b/pegainfer-server/src/main.rs
@@ -142,9 +142,6 @@ async fn main() -> anyhow::Result<()> {
             handle
         }
         ModelType::Qwen3 => {
-            if args.enable_lora && args.tp_size != 1 {
-                bail!("Qwen3 LoRA PR1 supports --tp-size=1 only");
-            }
             let device_ordinals: Vec<usize> = if args.tp_size == 1 {
                 vec![args.device_ordinal]
             } else {

--- a/tools/qwen3_lora_live_parity.py
+++ b/tools/qwen3_lora_live_parity.py
@@ -30,6 +30,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--max-tokens", type=int, default=8)
     parser.add_argument("--port", type=int, default=18080)
     parser.add_argument("--server-url")
+    parser.add_argument("--tp-size", type=int, default=1)
     parser.add_argument("--lora-name", default="parity")
     parser.add_argument("--scale", type=float, default=0.001)
     parser.add_argument("--startup-timeout-s", type=float, default=180.0)
@@ -257,6 +258,8 @@ def start_server(args: argparse.Namespace, repo_root: Path) -> subprocess.Popen:
         "--model-path",
         args.model_path,
         "--enable-lora",
+        "--tp-size",
+        str(args.tp_size),
         "--port",
         str(args.port),
     ]


### PR DESCRIPTION
## Summary

Part of #173.

This PR extends the Qwen3 LoRA MVP from PR1 to tensor-parallel execution while keeping the same correctness-first scope:

- single active adapter per engine
- dynamic `/v1/load_lora_adapter`
- adapter loading only when the scheduler is idle
- CUDA Graph disabled in LoRA mode
- no per-request or mixed-adapter batching yet

The branch is stacked on the PR1 LoRA control/API work until PR1 lands.

## What Changed

- Added rank-local LoRA adapter sharding for Qwen3 TP:
  - `q_proj`, `k_proj`, `v_proj`, `gate_proj`, `up_proj`: replicate LoRA `A`, row-shard LoRA `B`.
  - `o_proj`, `down_proj`: column-shard LoRA `A`, replicate LoRA `B`.
- Updated Qwen3 executor LoRA loading to install the same adapter name on all TP ranks and aggregate per-rank load errors.
- Removed the Qwen3 server-side `--enable-lora && --tp-size != 1` rejection.
- Added `--tp-size` to `tools/qwen3_lora_live_parity.py` so the live HF/PEFT parity smoke can exercise TP.
- Added unit coverage for TP sharding shape/range behavior.

## Scope Boundary

This PR does not add:

- multiple active adapters
- per-request adapter selection
- mixed base + LoRA batching
- `/v1/unload_lora_adapter`
- CUDA Graph cache keys per adapter
- optimized grouped LoRA kernels

Those remain follow-up work for the later staged LoRA PRs in #173.

## Validation

Local checks:

- `cargo fmt --check`
- `PEGAINFER_CUDA_SM=80 cargo test -p pegainfer-qwen3-4b --lib lora -- --nocapture`
- `PEGAINFER_CUDA_SM=80 cargo test -p pegainfer-qwen3-4b --lib scheduler -- --nocapture`
- `PEGAINFER_CUDA_SM=80 cargo check -p pegainfer-server`
- `python -m py_compile tools/qwen3_lora_live_parity.py`
- `git diff --check`

Worker5 TP2 live parity:

- Branch commit: `ac91cff`
- Model: `Qwen3-4B`
- Command shape:

```bash
python tools/qwen3_lora_live_parity.py \
  --model-path Qwen3-4B \
  --port 18112 \
  --startup-timeout-s 360 \
  --max-tokens 8 \
  --disable-peft-adapter-autocast \
  --tp-size 2
```

Result:

- Server started with `--enable-lora --tp-size 2`.
- `/v1/load_lora_adapter` returned `Success: LoRA adapter 'parity' added successfully.`
- HF/PEFT and PegaInfer both generated ` about a young girl named Lila who`.
- Token IDs matched exactly: `[911, 264, 3908, 3743, 6941, 444, 10524, 879]`.
- Result summary had `"match": true` and `"first_token_mismatch": null`.
