### PR TITLE
feat(deepseek-v2-lite): add EP2 batch attribution gate

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -59,7 +59,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 | Path | TL;DR |
 | --- | --- |
 | `models/deepseek-v2-lite/hf-accuracy-gate.md` | DeepSeek-V2-Lite EP2 HF accuracy gate after PR #149/#150: HF incremental greedy, host-staged EP2, and NCCL EP2 are token/text exact for `Hello`, output_len=16. |
-| `models/deepseek-v2-lite/decode-attribution-gate.md` | DeepSeek-V2-Lite EP2 decode attribution gate for the same `Hello`/16-token shape: structured JSON with accuracy hashes, CPU-side timing, selected CUDA event/NVTX attribution, host-staged/NCCL EP counts, and explicit no-throughput claim boundary. |
+| `models/deepseek-v2-lite/decode-attribution-gate.md` | DeepSeek-V2-Lite EP2 decode attribution gate for `Hello`/16-token batch sizes 1/4/8: structured JSON with accuracy hashes, CPU-side timing, selected CUDA event/NVTX attribution, host-staged/NCCL EP counts, and explicit no-throughput claim boundary. |
 
 ## models / kimi-k2
 

--- a/docs/models/deepseek-v2-lite/decode-attribution-gate.md
+++ b/docs/models/deepseek-v2-lite/decode-attribution-gate.md
@@ -1,18 +1,18 @@
 # DeepSeek-V2-Lite EP2 Decode Attribution Gate
 
-> **TL;DR:** DeepSeek-V2-Lite now has a narrow EP2 decode attribution report for the same correctness shape as the HF gate: `batch=1`, `prompt="Hello"`, `output_len=16`, host-staged backend, and NCCL backend. The report combines CPU-side attribution, selected CUDA event timing, optional NVTX ranges, and route/transfer counts; it is evidence for the next bottleneck decision, not a throughput or production EP claim.
+> **TL;DR:** DeepSeek-V2-Lite now has a narrow EP2 decode attribution report for the same correctness shape as the HF gate and the true-batch benchmark follow-up: `prompt="Hello"`, `output_len=16`, `batch-size=1/4/8`, host-staged backend, and NCCL backend. The report combines CPU-side attribution, selected CUDA event timing, optional NVTX ranges, and route/transfer counts; it is evidence for the next bottleneck decision, not a throughput or production EP claim.
 >
-> **Status:** Passing for the covered EP2 `Hello` / 16-token host-staged and NCCL attribution gate.
+> **Status:** Passing for the covered EP2 `Hello` / 16-token host-staged and NCCL attribution gate. The batch attribution mode is diagnostic and uses the same-prompt, fixed-length shape as the direct benchmark path.
 
 ## Scope
 
 This gate deliberately stays model-specific and shape-specific:
 
 - Model: DeepSeek-V2-Lite.
-- Shape: batch `1`, prompt `Hello`, prompt token ids `[17464]`, output length `16`.
+- Shape: batch size `1`, `4`, or `8`, prompt `Hello`, prompt token ids `[17464]`, output length `16`.
 - Backends: default host-staged EP2 and `PEGAINFER_DSV2_LITE_EP_BACKEND=nccl`.
 - Accuracy oracle: the same generated token/text/hash gate used by `hf-accuracy-gate.md`.
-- Attribution source: `DeepSeekV2LiteEp2Generator::generate_greedy_with_attribution`.
+- Attribution source: `DeepSeekV2LiteEp2Generator::generate_greedy_with_attribution` for `batch-size=1`, and `DeepSeekV2LiteEp2Generator::generate_greedy_batch_same_prompt_with_attribution` for `batch-size>1`.
 - GPU attribution source: CUDA events around selected stream sections in the explicit attribution path.
 - NVTX source: set `PEGAINFER_DSV2_LITE_NVTX=1` to emit matching ranges for those selected sections during a profiler run.
 
@@ -21,7 +21,7 @@ Out of scope:
 - sparse dispatch;
 - pegainfer-comm / NVLink backend;
 - multi-node or generic EP topology;
-- batch > 1 or broader prompts;
+- production continuous batching or broader prompts;
 - performance improvement or throughput claims.
 
 ## Report Shape
@@ -29,7 +29,7 @@ Out of scope:
 `dsv2_lite_ep2_decode_attribution` emits structured JSON:
 
 - `report_type`, `model`, `phase`, `backend`, and fixed-shape `config`;
-- nested `accuracy` with generated token ids, generated text, token sha256, and text sha256;
+- nested `accuracy` with generated token ids, generated text, token sha256, and text sha256; batch reports also include per-row token/text/hash fields and require same-prompt rows to stay exact;
 - CPU-side `timing` with total generation, the prefill-produced first output token, `per_output_token_us`, the 15 true decode-token samples for `output_len=16`, and latency stats;
 - `gpu_timing`, `by_gpu_section`, and `by_gpu_call_site` with CUDA event timing for selected GPU/NCCL stream sections, plus a `failure_count` for event-timing failures that did not replace the token/text hash oracle;
 - `by_section`, `by_op`, and `by_call_site` rollups in the same vocabulary family as the Qwen3 model report;
@@ -70,13 +70,14 @@ python tools/accuracy/compare_dsv2_lite_ep2_outputs.py \
   --require-all-exact
 ```
 
-Then collect attribution for the same two pegainfer backends:
+Then collect attribution for the same two pegainfer backends. Use `--batch-size 1` for the original single-row gate, and `--batch-size 4` / `--batch-size 8` for the true-batch benchmark attribution shape:
 
 ```bash
 cargo run --release -p pegainfer-deepseek-v2-lite \
   --features deepseek-v2-lite \
   --bin dsv2_lite_ep2_decode_attribution \
   -- --model-path models/DeepSeek-V2-Lite \
+  --batch-size 1 \
   --out target/accuracy/dsv2-lite-ep2/host-staged-attribution.json
 
 PEGAINFER_DSV2_LITE_EP_BACKEND=nccl \
@@ -84,7 +85,25 @@ PEGAINFER_DSV2_LITE_EP_BACKEND=nccl \
   --features deepseek-v2-lite \
   --bin dsv2_lite_ep2_decode_attribution \
   -- --model-path models/DeepSeek-V2-Lite \
+  --batch-size 1 \
   --out target/accuracy/dsv2-lite-ep2/nccl-attribution.json
+
+for batch in 4 8; do
+  cargo run --release -p pegainfer-deepseek-v2-lite \
+    --features deepseek-v2-lite \
+    --bin dsv2_lite_ep2_decode_attribution \
+    -- --model-path models/DeepSeek-V2-Lite \
+    --batch-size "$batch" \
+    --out "target/accuracy/dsv2-lite-ep2/host-staged-batch${batch}-attribution.json"
+
+  PEGAINFER_DSV2_LITE_EP_BACKEND=nccl \
+    cargo run --release -p pegainfer-deepseek-v2-lite \
+    --features deepseek-v2-lite \
+    --bin dsv2_lite_ep2_decode_attribution \
+    -- --model-path models/DeepSeek-V2-Lite \
+    --batch-size "$batch" \
+    --out "target/accuracy/dsv2-lite-ep2/nccl-batch${batch}-attribution.json"
+done
 ```
 
 For an Nsight Systems pass, run the same attribution command under the profiler and set `PEGAINFER_DSV2_LITE_NVTX=1`; the JSON `coverage` row then records `nvtx_ranges=emitted`. The NVTX labels are correlation markers for the selected GPU/NCCL sections, not timing evidence by themselves. Their wall-clock span can include CPU-side wrapper work, event setup, and synchronization around the section, so compare JSON `by_gpu_*` rows only with CUDA event timing, not with raw NVTX range duration.
@@ -104,17 +123,25 @@ The HF oracle needs a Python environment that can load DeepSeek-V2-Lite with `tr
 
 ## Latest Validation
 
-The full gate was last rerun on 2026-05-27 with DeepSeek-V2-Lite snapshot `604d5664dddd88a0433dbae533b7fe9472482de0`, `prompt="Hello"`, `output_len=16`, and 2x RTX 5090. The refreshed token/text oracle is confirmed by a real HF `AutoModelForCausalLM.generate(..., do_sample=false, use_cache=true)` run on the same model snapshot as the Rust E2E gate.
+The full gate was last rerun on 2026-05-30 with DeepSeek-V2-Lite snapshot `604d5664dddd88a0433dbae533b7fe9472482de0`, `prompt="Hello"`, `output_len=16`, and 2x A800-SXM4-80GB. The token/text oracle is confirmed by a real HF `AutoModelForCausalLM.generate(..., do_sample=false, use_cache=true)` run on the same model directory as the Rust E2E and attribution gates.
 
-The earlier 2026-05-26 hash is superseded for the active gate because it was produced from a different local model snapshot. Treat only the hash below as the active oracle for snapshot `604d5664dddd88a0433dbae533b7fe9472482de0`. This refresh does not claim a model-runtime improvement, a manual-loop root cause, or a transport issue.
+The Rust E2E accepts the known HF-confirmed RTX 5090 and A800 hash pairs for this narrow shape, but the comparison gate remains stricter: HF, host-staged, and NCCL JSON must be dumped from the same model/runtime and compared with `--require-all-exact`. This refresh does not claim a model-runtime improvement, a manual-loop root cause, or a transport issue.
 
 - HF / host-staged / NCCL comparison: `all_token_text_exact`.
-- Token SHA256: `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225`.
-- Text SHA256: `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347`.
-- Host-staged attribution: `dispatch_calls=416`, `combine_calls=416`, `dispatch_elements=5111808`, `combine_elements=5111808`, `local_route_count=1284`, `remote_route_count=1212`.
-- NCCL attribution: `nccl_exchange_calls=416`, `nccl_combine_calls=416`, `nccl_exchange_elements=851968`, `nccl_combine_elements=851968`, `local_route_count=1284`, `remote_route_count=1212`.
-- GPU event timing: selected GPU/NCCL attribution sections are reported separately from CPU-side section timing; host-staged emitted `gpu_timing.sample_count=5056`, NCCL emitted `gpu_timing.sample_count=5888`, and both reported `gpu_timing.failure_count=0`.
-- NVTX smoke: with `PEGAINFER_DSV2_LITE_NVTX=1`, host-staged emitted `nvtx_range_count=5056` and `coverage.nvtx_ranges=emitted`.
+- Token SHA256: `d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8`.
+- Text SHA256: `4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6`.
+- Generated text: `, I am a 20 year old female and I have been having a`.
+
+| Backend | Batch | Decode steps | Mean shared decode us | GPU event samples | GPU failures | Route / collective counters |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| host-staged | 1 | 15 | 69128.2 | 5056 | 0 | `dispatch_calls=416`, `combine_calls=416`, `local=1284`, `remote=1212` |
+| NCCL | 1 | 15 | 592081.8 | 5888 | 0 | `nccl_exchange_calls=416`, `nccl_combine_calls=416`, `local=1284`, `remote=1212` |
+| host-staged | 4 | 15 | 256487.9 | 13024 | 0 | `dispatch_calls=494`, `combine_calls=494`, `local=5136`, `remote=4848` |
+| NCCL | 4 | 15 | 985367.7 | 14012 | 0 | `nccl_exchange_calls=494`, `nccl_combine_calls=494`, `local=5136`, `remote=4848` |
+| host-staged | 8 | 15 | 502502.3 | 23648 | 0 | `dispatch_calls=598`, `combine_calls=598`, `local=10272`, `remote=9696` |
+| NCCL | 8 | 15 | 1560818.4 | 24844 | 0 | `nccl_exchange_calls=598`, `nccl_combine_calls=598`, `local=10272`, `remote=9696` |
+
+For batch `4` and `8`, every same-prompt row reported `same_prompt_rows_exact=true` and the same token/text hashes as the HF comparison run.
 
 ## Claim Boundary
 

--- a/docs/models/deepseek-v2-lite/hf-accuracy-gate.md
+++ b/docs/models/deepseek-v2-lite/hf-accuracy-gate.md
@@ -76,15 +76,22 @@ On Blackwell-class GPUs, make sure the selected NCCL runtime supports the device
 
 ## Latest Evidence
 
-2026-05-27, single-node 2 GPU validation with the same `models/DeepSeek-V2-Lite` snapshot for all three outputs. The model snapshot metadata recorded commit `604d5664dddd88a0433dbae533b7fe9472482de0`. The HF truth source used `AutoModelForCausalLM.generate(..., do_sample=false, use_cache=true)` with `torch==2.7.0+cu128` and `transformers==4.40.2`:
+2026-05-30, single-node 2 GPU validation with the same `models/DeepSeek-V2-Lite` snapshot for all three outputs. The model snapshot metadata recorded commit `604d5664dddd88a0433dbae533b7fe9472482de0`. The HF truth source used `AutoModelForCausalLM.generate(..., do_sample=false, use_cache=true)` with `torch==2.7.0+cu128` and `transformers==4.40.2` on 2x A800-SXM4-80GB:
 
-The earlier 2026-05-26 hash is superseded for the active gate because it was produced from a different local model snapshot. Treat only the hash below as the active oracle for snapshot `604d5664dddd88a0433dbae533b7fe9472482de0`. This refresh does not claim a model-runtime improvement, a manual-loop root cause, or a transport issue.
+The comparison gate must be run with an HF JSON dumped on the same model directory and runtime as the pegainfer outputs. The Rust E2E keeps known HF-confirmed hash pairs for this narrow `Hello`/16 shape because the same snapshot has produced different greedy text on RTX 5090 and A800 while still matching HF on each host. This does not claim a model-runtime improvement, a manual-loop root cause, or a transport issue.
 
 | Source | Backend | Tokens | Token SHA256 | Text SHA256 | Text |
 | --- | --- | ---: | --- | --- | --- |
-| HF | `generate(use_cache=true)` | 16 | `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225` | `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347` | `, I am a 19 year old girl from the UK. I am` |
-| pegainfer | host-staged | 16 | `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225` | `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347` | `, I am a 19 year old girl from the UK. I am` |
-| pegainfer | NCCL | 16 | `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225` | `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347` | `, I am a 19 year old girl from the UK. I am` |
+| HF | `generate(use_cache=true)` | 16 | `d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8` | `4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6` | `, I am a 20 year old female and I have been having a` |
+| pegainfer | host-staged | 16 | `d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8` | `4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6` | `, I am a 20 year old female and I have been having a` |
+| pegainfer | NCCL | 16 | `d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8` | `4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6` | `, I am a 20 year old female and I have been having a` |
+
+Known HF-confirmed static E2E pairs for snapshot `604d5664dddd88a0433dbae533b7fe9472482de0`:
+
+| Host | Token SHA256 | Text SHA256 | Text |
+| --- | --- | --- | --- |
+| 2x RTX 5090, torch 2.7.0, transformers 4.40.2 | `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225` | `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347` | `, I am a 19 year old girl from the UK. I am` |
+| 2x A800-SXM4-80GB, torch 2.7.0, transformers 4.40.2 | `d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8` | `4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6` | `, I am a 20 year old female and I have been having a` |
 
 Classification: `all_token_text_exact`.
 

--- a/pegainfer-deepseek-v2-lite/src/bin/dsv2_lite_ep2_decode_attribution.rs
+++ b/pegainfer-deepseek-v2-lite/src/bin/dsv2_lite_ep2_decode_attribution.rs
@@ -12,13 +12,23 @@ use vllm_text::tokenizer::{HuggingFaceTokenizer, Tokenizer};
 
 const PROMPT: &str = "Hello";
 const OUTPUT_LEN: usize = 16;
-const EXPECTED_OUTPUT_TOKEN_SHA256: &str =
-    "4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225";
-const EXPECTED_OUTPUT_TEXT_SHA256: &str =
-    "0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347";
+const MAX_BATCH_SIZE: usize = 8;
+const EXPECTED_OUTPUT_SHA256_PAIRS: &[(&str, &str, &str)] = &[
+    (
+        "4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225",
+        "0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347",
+        "DeepSeek-V2-Lite snapshot 604d5664 on 2x RTX 5090, torch 2.7.0, transformers 4.40.2",
+    ),
+    (
+        "d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8",
+        "4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6",
+        "DeepSeek-V2-Lite snapshot 604d5664 on 2x A800-SXM4-80GB, torch 2.7.0, transformers 4.40.2",
+    ),
+];
 
 struct Cli {
     model_path: String,
+    batch_size: usize,
     out: Option<PathBuf>,
 }
 
@@ -52,53 +62,58 @@ fn main() -> Result<()> {
             seed: 42,
         },
     )?;
-    let (result, attribution) =
-        generator.generate_greedy_with_attribution(&prompt_tokens, OUTPUT_LEN, false)?;
+    let report = if cli.batch_size == 1 {
+        let (result, attribution) =
+            generator.generate_greedy_with_attribution(&prompt_tokens, OUTPUT_LEN, false)?;
+        single_report(&tokenizer, &prompt_tokens, result, attribution)?
+    } else {
+        let (result, attribution) = generator.generate_greedy_batch_same_prompt_with_attribution(
+            &prompt_tokens,
+            cli.batch_size,
+            OUTPUT_LEN,
+            true,
+        )?;
+        batch_report(&tokenizer, &prompt_tokens, result, attribution)?
+    };
+
+    let text = serde_json::to_string_pretty(&report)?;
+    if let Some(out) = cli.out {
+        let path = resolve_workspace_path(out);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+        }
+        fs::write(&path, format!("{text}\n"))
+            .with_context(|| format!("write {}", path.display()))?;
+        eprintln!("wrote {}", path.display());
+    }
+    println!("{text}");
+    Ok(())
+}
+
+fn single_report(
+    tokenizer: &HuggingFaceTokenizer,
+    prompt_tokens: &[u32],
+    result: pegainfer_deepseek_v2_lite::GenerationResult,
+    attribution: pegainfer_deepseek_v2_lite::DecodeAttributionProfile,
+) -> Result<Value> {
     let generated_text = tokenizer
         .decode(&result.tokens, false)
         .map_err(|err| anyhow::anyhow!("decode output failed: {err:?}"))?;
     let text_sha256 = sha256_text(&generated_text);
-
-    ensure!(
-        result.stats.output_token_sha256 == EXPECTED_OUTPUT_TOKEN_SHA256,
-        "DeepSeek-V2-Lite attribution token hash drift: got {}, expected {}",
-        result.stats.output_token_sha256,
-        EXPECTED_OUTPUT_TOKEN_SHA256
-    );
-    ensure!(
-        text_sha256 == EXPECTED_OUTPUT_TEXT_SHA256,
-        "DeepSeek-V2-Lite attribution text hash drift: got {}, expected {}",
-        text_sha256,
-        EXPECTED_OUTPUT_TEXT_SHA256
-    );
+    let (expected_token_sha256, expected_text_sha256, matched_oracle) =
+        expect_output_oracle(&result.stats.output_token_sha256, &text_sha256)?;
 
     let by_section = attribution.by_section();
     let by_gpu_section = attribution.by_gpu_section();
     let by_gpu_call_site = attribution.by_gpu_call_site();
-    let by_op: Vec<Value> = by_section
-        .iter()
-        .map(|row| {
-            json!({
-                "op": row.section,
-                "calls": row.calls,
-                "total_us": row.total_us,
-                "mean_us": row.mean_us,
-                "min_us": row.min_us,
-                "p50_us": row.p50_us,
-                "p95_us": row.p95_us,
-                "p99_us": row.p99_us,
-                "max_us": row.max_us,
-                "pct": row.pct,
-            })
-        })
-        .collect();
+    let by_op = by_op_rows(&by_section);
     let mut per_output_token_us = Vec::with_capacity(OUTPUT_LEN);
     if let Some(prefill_next_token_us) = attribution.prefill_next_token_us() {
         per_output_token_us.push(prefill_next_token_us);
     }
     per_output_token_us.extend_from_slice(attribution.per_token_decode_us());
 
-    let report = json!({
+    Ok(json!({
         "schema": 1,
         "report_type": "deepseek-v2-lite-ep2-decode-attribution",
         "model": "DeepSeek-V2-Lite",
@@ -117,8 +132,10 @@ fn main() -> Result<()> {
             "generated_text": &generated_text,
             "token_sha256": &result.stats.output_token_sha256,
             "text_sha256": &text_sha256,
-            "expected_token_sha256": EXPECTED_OUTPUT_TOKEN_SHA256,
-            "expected_text_sha256": EXPECTED_OUTPUT_TEXT_SHA256,
+            "expected_token_sha256": expected_token_sha256,
+            "expected_text_sha256": expected_text_sha256,
+            "matched_output_oracle": matched_oracle,
+            "known_output_sha256_pairs": expected_output_sha256_pairs(),
             "token_hash_exact": true,
             "text_hash_exact": true,
         },
@@ -146,27 +163,118 @@ fn main() -> Result<()> {
         "by_call_site": attribution.by_call_site(),
         "by_gpu_section": by_gpu_section,
         "by_gpu_call_site": by_gpu_call_site,
-        "coverage": coverage_rows(&result.stats.ep_backend, &attribution),
+        "coverage": coverage_rows(&result.stats.ep_backend, 1, &attribution),
         "ep": ep_report(&result.stats),
         "claim_boundary": "Attribution only for the covered EP2 Hello/16 decode gate. CPU-side section timing, selected CUDA event timing, NVTX ranges, and route/collective counts are not a throughput, sparse-dispatch, multi-node, or production EP readiness claim.",
-    });
+    }))
+}
 
-    let text = serde_json::to_string_pretty(&report)?;
-    if let Some(out) = cli.out {
-        let path = resolve_workspace_path(out);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
-        }
-        fs::write(&path, format!("{text}\n"))
-            .with_context(|| format!("write {}", path.display()))?;
-        eprintln!("wrote {}", path.display());
+fn batch_report(
+    tokenizer: &HuggingFaceTokenizer,
+    prompt_tokens: &[u32],
+    result: pegainfer_deepseek_v2_lite::BatchedGenerationResult,
+    attribution: pegainfer_deepseek_v2_lite::DecodeAttributionProfile,
+) -> Result<Value> {
+    ensure!(
+        result.per_token_decode_us == attribution.per_token_decode_us(),
+        "batch result decode timings differ from attribution decode timings"
+    );
+    let mut generated_text_by_row = Vec::with_capacity(result.tokens.len());
+    let mut token_sha256_by_row = Vec::with_capacity(result.tokens.len());
+    let mut text_sha256_by_row = Vec::with_capacity(result.tokens.len());
+    for row in &result.tokens {
+        let generated_text = tokenizer
+            .decode(row, false)
+            .map_err(|err| anyhow::anyhow!("decode batch output failed: {err:?}"))?;
+        token_sha256_by_row.push(sha256_tokens(row));
+        text_sha256_by_row.push(sha256_text(&generated_text));
+        generated_text_by_row.push(generated_text);
     }
-    println!("{text}");
-    Ok(())
+    ensure!(
+        token_sha256_by_row
+            .iter()
+            .all(|hash| hash == &token_sha256_by_row[0])
+            && text_sha256_by_row
+                .iter()
+                .all(|hash| hash == &text_sha256_by_row[0]),
+        "DeepSeek-V2-Lite batch attribution rows are not hash-identical"
+    );
+    let (expected_token_sha256, expected_text_sha256, matched_oracle) =
+        expect_output_oracle(&token_sha256_by_row[0], &text_sha256_by_row[0])?;
+
+    let by_section = attribution.by_section();
+    let by_gpu_section = attribution.by_gpu_section();
+    let by_gpu_call_site = attribution.by_gpu_call_site();
+    let by_op = by_op_rows(&by_section);
+
+    Ok(json!({
+        "schema": 1,
+        "report_type": "deepseek-v2-lite-ep2-decode-attribution",
+        "model": "DeepSeek-V2-Lite",
+        "phase": "decode",
+        "backend": &result.stats.ep_backend,
+        "config": {
+            "batch_size": result.tokens.len(),
+            "prompt": PROMPT,
+            "prompt_token_ids": prompt_tokens,
+            "output_len": OUTPUT_LEN,
+            "ignore_eos": true,
+            "ep_size": result.stats.ep_size,
+            "device_ordinals": &result.stats.device_ordinals,
+        },
+        "accuracy": {
+            "generated_token_ids": &result.tokens[0],
+            "generated_text": &generated_text_by_row[0],
+            "token_sha256": &token_sha256_by_row[0],
+            "text_sha256": &text_sha256_by_row[0],
+            "generated_token_ids_by_row": &result.tokens,
+            "generated_text_by_row": &generated_text_by_row,
+            "token_sha256_by_row": &token_sha256_by_row,
+            "text_sha256_by_row": &text_sha256_by_row,
+            "same_prompt_rows_exact": true,
+            "expected_token_sha256": expected_token_sha256,
+            "expected_text_sha256": expected_text_sha256,
+            "matched_output_oracle": matched_oracle,
+            "known_output_sha256_pairs": expected_output_sha256_pairs(),
+            "token_hash_exact": true,
+            "text_hash_exact": true,
+        },
+        "timing": {
+            "source": "CPU-side wall-clock sections around the existing DeepSeek-V2-Lite EP2 same-prompt batched greedy path",
+            "total_generation_us": result.total_generation_us,
+            "prefill_next_token_us_by_row": &result.prefill_next_token_us,
+            "per_shared_decode_step_us": &result.per_token_decode_us,
+            "decode_step_count": result.per_token_decode_us.len(),
+            "per_token_decode_us": attribution.per_token_decode_us(),
+            "per_token_decode_stats": latency_stats(attribution.per_token_decode_us()),
+        },
+        "attribution_source": "DeepSeekV2LiteEp2Generator::generate_greedy_batch_same_prompt_with_attribution; CPU sections use host wall-clock timers, and selected GPU/NCCL sections also carry CUDA event timing plus optional NVTX ranges.",
+        "gpu_timing": {
+            "source": "CUDA event timing around selected DeepSeek-V2-Lite EP2 GPU/NCCL stream sections in the explicit batched attribution path",
+            "sample_count": attribution.gpu_sample_count(),
+            "failure_count": attribution.gpu_timing_failure_count(),
+            "nvtx_enabled": attribution.nvtx_enabled(),
+            "nvtx_range_count": attribution.nvtx_range_count(),
+            "scope": "selected GPU/NCCL sections only; host routing, host accumulation, and the mixed attention_host_path remain CPU-side attribution rows; GPU timing failures do not replace the token/text hash oracle; NVTX range wall time is only a profiler correlation marker and may include host/event overhead",
+        },
+        "schedule_source": format!(
+            "fixed DeepSeek-V2-Lite EP2 greedy gate: batch_size={}, prompt=Hello, output_len=16, cuda_graph=false, device_ordinals=[0,1]",
+            result.tokens.len()
+        ),
+        "by_section": by_section,
+        "by_op": by_op,
+        "by_call_site": attribution.by_call_site(),
+        "by_gpu_section": by_gpu_section,
+        "by_gpu_call_site": by_gpu_call_site,
+        "coverage": coverage_rows(&result.stats.ep_backend, result.tokens.len(), &attribution),
+        "ep": ep_report(&result.stats),
+        "claim_boundary": "Attribution only for the covered EP2 Hello/16 same-prompt batched decode gate. CPU-side section timing, selected CUDA event timing, NVTX ranges, and route/collective counts are not a throughput, sparse-dispatch, multi-node, or production EP readiness claim.",
+    }))
 }
 
 fn parse_cli() -> Result<Cli> {
     let mut model_path = "models/DeepSeek-V2-Lite".to_string();
+    let mut batch_size = 1;
     let mut out = None;
     let mut args = env::args().skip(1);
     while let Some(arg) = args.next() {
@@ -176,6 +284,17 @@ fn parse_cli() -> Result<Cli> {
                     .next()
                     .context("--model-path requires a path argument")?;
             }
+            "--batch-size" => {
+                batch_size = args
+                    .next()
+                    .context("--batch-size requires an integer argument")?
+                    .parse()
+                    .context("--batch-size must be an integer")?;
+                ensure!(
+                    (1..=MAX_BATCH_SIZE).contains(&batch_size),
+                    "--batch-size must be in 1..={MAX_BATCH_SIZE}, got {batch_size}"
+                );
+            }
             "--out" => {
                 out = Some(PathBuf::from(
                     args.next().context("--out requires a path argument")?,
@@ -183,16 +302,20 @@ fn parse_cli() -> Result<Cli> {
             }
             "-h" | "--help" => {
                 println!(
-                    "DeepSeek-V2-Lite EP2 decode attribution gate\n\nUSAGE:\n  dsv2_lite_ep2_decode_attribution [--model-path PATH] [--out PATH]\n\nThe gate is intentionally fixed to batch=1, prompt=Hello, output_len=16. Select NCCL with PEGAINFER_DSV2_LITE_EP_BACKEND=nccl."
+                    "DeepSeek-V2-Lite EP2 decode attribution gate\n\nUSAGE:\n  dsv2_lite_ep2_decode_attribution [--model-path PATH] [--batch-size N] [--out PATH]\n\nThe gate is intentionally fixed to prompt=Hello, output_len=16, with batch-size in 1..=8. Select NCCL with PEGAINFER_DSV2_LITE_EP_BACKEND=nccl."
                 );
                 std::process::exit(0);
             }
             other => bail!(
-                "unsupported argument `{other}`; supported flags: --model-path PATH, --out PATH"
+                "unsupported argument `{other}`; supported flags: --model-path PATH, --batch-size N, --out PATH"
             ),
         }
     }
-    Ok(Cli { model_path, out })
+    Ok(Cli {
+        model_path,
+        batch_size,
+        out,
+    })
 }
 
 fn ep_report(stats: &pegainfer_deepseek_v2_lite::GenerationStats) -> Value {
@@ -226,8 +349,28 @@ fn ep_report(stats: &pegainfer_deepseek_v2_lite::GenerationStats) -> Value {
     })
 }
 
+fn by_op_rows(rows: &[pegainfer_deepseek_v2_lite::SectionRollup]) -> Vec<Value> {
+    rows.iter()
+        .map(|row| {
+            json!({
+                "op": row.section,
+                "calls": row.calls,
+                "total_us": row.total_us,
+                "mean_us": row.mean_us,
+                "min_us": row.min_us,
+                "p50_us": row.p50_us,
+                "p95_us": row.p95_us,
+                "p99_us": row.p99_us,
+                "max_us": row.max_us,
+                "pct": row.pct,
+            })
+        })
+        .collect()
+}
+
 fn coverage_rows(
     backend: &str,
+    batch_size: usize,
     attribution: &pegainfer_deepseek_v2_lite::DecodeAttributionProfile,
 ) -> Vec<Value> {
     vec![
@@ -259,7 +402,7 @@ fn coverage_rows(
         json!({
             "item": "throughput_or_production_ep_readiness",
             "status": "not_claimed",
-            "source": "single batch=1 prompt=Hello output_len=16 diagnostic gate only",
+            "source": format!("batch={batch_size} prompt=Hello output_len=16 diagnostic gate only"),
         }),
     ]
 }
@@ -274,6 +417,43 @@ fn gpu_timing_status(attribution: &pegainfer_deepseek_v2_lite::DecodeAttribution
         (_, 0) => "measured",
         (_, _) => "measured_with_failures",
     }
+}
+
+fn expect_output_oracle(
+    token_sha256: &str,
+    text_sha256: &str,
+) -> Result<(&'static str, &'static str, &'static str)> {
+    matched_expected_output_oracle(token_sha256, text_sha256).with_context(|| {
+        format!(
+            "DeepSeek-V2-Lite attribution hash drift: got token_sha256={token_sha256} text_sha256={text_sha256}, expected one HF-confirmed pair from {:?}",
+            EXPECTED_OUTPUT_SHA256_PAIRS
+        )
+    })
+}
+
+fn matched_expected_output_oracle(
+    token_sha256: &str,
+    text_sha256: &str,
+) -> Option<(&'static str, &'static str, &'static str)> {
+    EXPECTED_OUTPUT_SHA256_PAIRS
+        .iter()
+        .find(|(expected_token, expected_text, _)| {
+            token_sha256 == *expected_token && text_sha256 == *expected_text
+        })
+        .copied()
+}
+
+fn expected_output_sha256_pairs() -> Vec<Value> {
+    EXPECTED_OUTPUT_SHA256_PAIRS
+        .iter()
+        .map(|(token_sha256, text_sha256, source)| {
+            json!({
+                "token_sha256": token_sha256,
+                "text_sha256": text_sha256,
+                "source": source,
+            })
+        })
+        .collect()
 }
 
 fn latency_stats(samples: &[u64]) -> Value {
@@ -312,6 +492,14 @@ fn percentile(sorted: &[u64], quantile: f64) -> u64 {
 fn sha256_text(text: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(text.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+fn sha256_tokens(tokens: &[u32]) -> String {
+    let mut hasher = Sha256::new();
+    for token in tokens {
+        hasher.update(token.to_le_bytes());
+    }
     hex::encode(hasher.finalize())
 }
 

--- a/pegainfer-deepseek-v2-lite/src/runtime.rs
+++ b/pegainfer-deepseek-v2-lite/src/runtime.rs
@@ -74,6 +74,7 @@ pub struct BatchedGenerationResult {
     pub prefill_next_token_us: Vec<u64>,
     pub per_token_decode_us: Vec<u64>,
     pub total_generation_us: u64,
+    pub stats: GenerationStats,
 }
 
 pub struct DeepSeekV2LiteEp2Generator {
@@ -251,6 +252,42 @@ impl DeepSeekV2LiteEp2Generator {
         max_new_tokens: usize,
         ignore_eos: bool,
     ) -> Result<BatchedGenerationResult> {
+        let mut attribution = DecodeAttributionProfile::disabled();
+        self.generate_greedy_batch_same_prompt_inner(
+            prompt_tokens,
+            batch_size,
+            max_new_tokens,
+            ignore_eos,
+            &mut attribution,
+        )
+    }
+
+    pub fn generate_greedy_batch_same_prompt_with_attribution(
+        &mut self,
+        prompt_tokens: &[u32],
+        batch_size: usize,
+        max_new_tokens: usize,
+        ignore_eos: bool,
+    ) -> Result<(BatchedGenerationResult, DecodeAttributionProfile)> {
+        let mut attribution = DecodeAttributionProfile::enabled();
+        let result = self.generate_greedy_batch_same_prompt_inner(
+            prompt_tokens,
+            batch_size,
+            max_new_tokens,
+            ignore_eos,
+            &mut attribution,
+        )?;
+        Ok((result, attribution))
+    }
+
+    fn generate_greedy_batch_same_prompt_inner(
+        &mut self,
+        prompt_tokens: &[u32],
+        batch_size: usize,
+        max_new_tokens: usize,
+        ignore_eos: bool,
+        attribution: &mut DecodeAttributionProfile,
+    ) -> Result<BatchedGenerationResult> {
         ensure!(!prompt_tokens.is_empty(), "prompt_tokens must not be empty");
         ensure!(batch_size > 0, "batch_size must be positive");
         ensure!(
@@ -273,7 +310,6 @@ impl DeepSeekV2LiteEp2Generator {
         );
 
         let generation_start = Instant::now();
-        let mut attribution = DecodeAttributionProfile::disabled();
         let mut stats = GenerationStats {
             model_path: self.model_path.clone(),
             device_ordinals: self.device_ordinals.clone(),
@@ -291,12 +327,8 @@ impl DeepSeekV2LiteEp2Generator {
         let mut prefill_next_token_us = Vec::with_capacity(batch_size);
 
         for row in 0..batch_size {
-            let next = self.prefill_next_token(
-                prompt_tokens,
-                &mut caches[row],
-                &mut stats,
-                &mut attribution,
-            )?;
+            let next =
+                self.prefill_next_token(prompt_tokens, &mut caches[row], &mut stats, attribution)?;
             prefill_next_token_us.push(duration_micros(generation_start.elapsed()));
             generated[row].push(next);
         }
@@ -318,7 +350,7 @@ impl DeepSeekV2LiteEp2Generator {
                 position,
                 &mut caches,
                 &mut stats,
-                &mut attribution,
+                attribution,
                 token_index,
             )?;
             ensure!(
@@ -326,18 +358,25 @@ impl DeepSeekV2LiteEp2Generator {
                 "batched decode returned {} tokens for batch_size={batch_size}",
                 next_tokens.len()
             );
-            per_token_decode_us.push(duration_micros(decode_start.elapsed()));
+            let decode_elapsed = decode_start.elapsed();
+            per_token_decode_us.push(duration_micros(decode_elapsed));
+            attribution.push_decode_token(decode_elapsed);
             for (row, token) in next_tokens.into_iter().enumerate() {
                 generated[row].push(token);
             }
         }
 
         ensure_same_prompt_batch_rows_match(&generated)?;
+        stats.generated_tokens = generated.iter().map(Vec::len).sum();
+        stats.output_token_sha256 = token_sha256(&generated[0]);
+        let total_generation = generation_start.elapsed();
+        attribution.set_total_generation(total_generation);
         Ok(BatchedGenerationResult {
             tokens: generated,
             prefill_next_token_us,
             per_token_decode_us,
-            total_generation_us: duration_micros(generation_start.elapsed()),
+            total_generation_us: duration_micros(total_generation),
+            stats,
         })
     }
 

--- a/pegainfer-deepseek-v2-lite/tests/e2e_ep2.rs
+++ b/pegainfer-deepseek-v2-lite/tests/e2e_ep2.rs
@@ -10,10 +10,18 @@ use sha2::{Digest, Sha256};
 use vllm_text::tokenizer::{HuggingFaceTokenizer, Tokenizer};
 
 const EXPECTED_GENERATED_TOKENS: usize = 16;
-const EXPECTED_OUTPUT_TOKEN_SHA256: &str =
-    "4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225";
-const EXPECTED_OUTPUT_TEXT_SHA256: &str =
-    "0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347";
+const EXPECTED_OUTPUT_SHA256_PAIRS: &[(&str, &str, &str)] = &[
+    (
+        "4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225",
+        "0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347",
+        "DeepSeek-V2-Lite snapshot 604d5664 on 2x RTX 5090, torch 2.7.0, transformers 4.40.2",
+    ),
+    (
+        "d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8",
+        "4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6",
+        "DeepSeek-V2-Lite snapshot 604d5664 on 2x A800-SXM4-80GB, torch 2.7.0, transformers 4.40.2",
+    ),
+];
 const DSV2_LITE_HIDDEN_SIZE: usize = 2048;
 const DSV2_LITE_MOE_LAYERS: usize = 26;
 const E2E_JSON_OUT_ENV: &str = "PEGAINFER_DSV2_LITE_E2E_JSON_OUT";
@@ -179,6 +187,8 @@ fn run_rust_generation(model_path_label: &str, model_path: &Path) -> Result<()> 
     let mut hasher = Sha256::new();
     hasher.update(output_text.as_bytes());
     let output_text_sha256 = hex::encode(hasher.finalize());
+    let matched_output_oracle =
+        matched_expected_output_oracle(&result.stats.output_token_sha256, &output_text_sha256);
     let payload = serde_json::json!({
         "model_path": model_path_label,
         "gpu_count": 2,
@@ -194,6 +204,7 @@ fn run_rust_generation(model_path_label: &str, model_path: &Path) -> Result<()> 
         "generated_text": &output_text,
         "output_token_sha256": result.stats.output_token_sha256,
         "output_text_sha256": output_text_sha256,
+        "matched_output_oracle": matched_output_oracle,
         "token_sha256_algorithm": "sha256 over generated token ids encoded as little-endian u32",
         "text_sha256_algorithm": "sha256 over UTF-8 generated text bytes",
         "host_dispatch_calls": result.stats.host_dispatch_calls,
@@ -226,18 +237,22 @@ fn run_rust_generation(model_path_label: &str, model_path: &Path) -> Result<()> 
     }
     println!("{payload_text}");
     ensure!(
-        result.stats.output_token_sha256 == EXPECTED_OUTPUT_TOKEN_SHA256,
-        "DeepSeek-V2-Lite E2E token hash drift: got {}, expected {}",
+        matched_output_oracle.is_some(),
+        "DeepSeek-V2-Lite E2E hash drift: got token_sha256={} text_sha256={}, expected one HF-confirmed pair from {:?}",
         result.stats.output_token_sha256,
-        EXPECTED_OUTPUT_TOKEN_SHA256
-    );
-    ensure!(
-        output_text_sha256 == EXPECTED_OUTPUT_TEXT_SHA256,
-        "DeepSeek-V2-Lite E2E text hash drift: got {}, expected {}",
         output_text_sha256,
-        EXPECTED_OUTPUT_TEXT_SHA256
+        EXPECTED_OUTPUT_SHA256_PAIRS
     );
     Ok(())
+}
+
+fn matched_expected_output_oracle(token_sha256: &str, text_sha256: &str) -> Option<&'static str> {
+    EXPECTED_OUTPUT_SHA256_PAIRS
+        .iter()
+        .find(|(expected_token, expected_text, _)| {
+            token_sha256 == *expected_token && text_sha256 == *expected_text
+        })
+        .map(|(_, _, source)| *source)
 }
 
 fn current_backend() -> String {

--- a/pegainfer-server/src/bin/bench_serving.rs
+++ b/pegainfer-server/src/bin/bench_serving.rs
@@ -2232,6 +2232,7 @@ mod tests {
                 prefill_next_token_us: vec![20_000, 21_000],
                 per_token_decode_us: vec![19_000, 18_000],
                 total_generation_us: 80_000,
+                stats: pegainfer_deepseek_v2_lite::GenerationStats::default(),
             },
             3,
         );


### PR DESCRIPTION
## Description

Refs #170.

This PR extends the DeepSeek-V2-Lite EP2 decode attribution gate from the original `batch=1` shape to the same-prompt diagnostic batch shapes needed before further EP2 optimization work:

- `batch-size=1/4/8`
- `prompt="Hello"`
- `output_len=16`
- host-staged EP2 backend
- naive NCCL EP2 backend

The attribution binary now reports per-row batch accuracy, shared decode-step timings, GPU event timing counters, and EP route / collective counters. The direct benchmark path continues to use the existing same-prompt batched generation path, while attribution now uses the same runtime path with `DecodeAttributionProfile` enabled.

One validation detail surfaced during the A800 run: the same DeepSeek-V2-Lite snapshot has produced different HF greedy text on RTX 5090 and A800, but pegainfer matched HF on each host. The static Rust E2E therefore accepts the small set of HF-confirmed hash pairs for this narrow shape, while the stricter same-host HF / host-staged / NCCL comparison gate remains `--require-all-exact`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Evidence

Validated on 2x A800-SXM4-80GB with DeepSeek-V2-Lite snapshot `604d5664dddd88a0433dbae533b7fe9472482de0`.

Accuracy gate:

- HF / host-staged / NCCL classification: `all_token_text_exact`
- Token SHA256: `d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8`
- Text SHA256: `4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6`
- Generated text: `, I am a 20 year old female and I have been having a`

Attribution gate:

| Backend | Batch | Decode steps | GPU timing failures | Accuracy |
| --- | ---: | ---: | ---: | --- |
| host-staged | 1 | 15 | 0 | exact |
| NCCL | 1 | 15 | 0 | exact |
| host-staged | 4 | 15 | 0 | exact, rows exact |
| NCCL | 4 | 15 | 0 | exact, rows exact |
| host-staged | 8 | 15 | 0 | exact, rows exact |
| NCCL | 8 | 15 | 0 | exact, rows exact |

Commands run:

- `cargo fmt --check`
- `git diff --check`
- `cargo check --release -p pegainfer-comm`
- `cargo check --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite`
- `cargo check --release -p pegainfer-server --features deepseek-v2-lite`
- `cargo test --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite --lib -- --nocapture`
- `cargo test --release -p pegainfer-server --features deepseek-v2-lite --bin bench_serving dsv2_lite -- --nocapture`
- HF dump + host-staged E2E + NCCL E2E + `compare_dsv2_lite_ep2_outputs.py --require-all-exact`
- `dsv2_lite_ep2_decode_attribution` for host-staged and NCCL at batch sizes `1`, `4`, and `8`
- Direct `bench_serving request` smoke for host-staged and NCCL at concurrency `1`, `4`, and `8`

All commands exited with status 0.

## Claim Boundary

This is a correctness and attribution gate for the narrow DeepSeek-V2-Lite EP2 `Hello` / 16-token same-prompt batch shapes. It does not claim a performance improvement, sparse dispatch readiness, production batching, multi-node behavior, or generic EP support.

## Checklist

- [x] My code follows the style guidelines of this project (see `docs/areas/coding-style.md`).
- [x] I have performed a self-review of my own code.
- [x] I have formatted my commits according to Commitizen conventions.
- [x] I have run the local test suite and all tests pass (see `CLAUDE.md`).