### PR TITLE
perf(vllm-frontend): batch consecutive token bridge outputs

### DIFF
--- a/pegainfer-vllm-frontend/src/lib.rs
+++ b/pegainfer-vllm-frontend/src/lib.rs
@@ -14,6 +14,7 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::post;
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::{RwLock, mpsc};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -843,7 +844,15 @@ async fn run_request_stream(
 ) {
     let mut first_token_events = None;
     let mut first_token_prefill_stats = None;
-    while let Some(event) = token_rx.recv().await {
+    let mut pending_event = None;
+    loop {
+        let event = match pending_event.take() {
+            Some(event) => event,
+            None => match token_rx.recv().await {
+                Some(event) => event,
+                None => return,
+            },
+        };
         match event {
             TokenEvent::Scheduled {
                 queued_at_unix_s,
@@ -869,11 +878,17 @@ async fn run_request_stream(
                 });
             }
             TokenEvent::Token { id, logprob } => {
+                // Yield once so a token burst from the engine can accumulate
+                // before we drain the ready queue into one bridge output.
+                tokio::task::yield_now().await;
+                let (token_ids, batched_logprobs, next_event) =
+                    collect_ready_token_batch(id, logprob, &mut token_rx);
+                pending_event = next_event;
                 if send_token_output(
                     &output_tx,
                     &request_id,
-                    id,
-                    logprob,
+                    token_ids,
+                    batched_logprobs,
                     first_token_events.take(),
                     first_token_prefill_stats.take(),
                 )
@@ -933,8 +948,8 @@ async fn output_loop(
 fn send_token_output(
     output_tx: &mpsc::UnboundedSender<EngineCoreOutputs>,
     request_id: &str,
-    token_id: u32,
-    logprob: Option<TokenLogprob>,
+    token_ids: Vec<u32>,
+    logprobs: Option<MaybeWireLogprobs>,
     events: Option<Vec<EngineCoreEvent>>,
     prefill_stats: Option<PrefillStats>,
 ) -> Result<()> {
@@ -944,8 +959,8 @@ fn send_token_output(
             engine_index: ENGINE_INDEX,
             outputs: vec![engine_output(
                 request_id.to_string(),
-                vec![token_id],
-                to_wire_logprobs(token_id, logprob),
+                token_ids,
+                logprobs,
                 None,
                 None,
                 events,
@@ -1046,7 +1061,57 @@ fn engine_output(
     }
 }
 
+fn collect_ready_token_batch(
+    first_id: u32,
+    first_logprob: Option<TokenLogprob>,
+    token_rx: &mut mpsc::UnboundedReceiver<TokenEvent>,
+) -> (Vec<u32>, Option<MaybeWireLogprobs>, Option<TokenEvent>) {
+    let mut token_ids = Vec::with_capacity(4);
+    let mut positions = Vec::with_capacity(4);
+    let mut has_logprobs = false;
+
+    let mut push_token = |token_id: u32, logprob: Option<TokenLogprob>| {
+        token_ids.push(token_id);
+        if let Some(position) = to_wire_position_logprobs(token_id, logprob) {
+            has_logprobs = true;
+            positions.push(position);
+        }
+    };
+    push_token(first_id, first_logprob);
+
+    loop {
+        match token_rx.try_recv() {
+            Ok(TokenEvent::Token { id, logprob }) => push_token(id, logprob),
+            Ok(other) => {
+                return (
+                    token_ids,
+                    has_logprobs.then(|| MaybeWireLogprobs::Direct(Logprobs { positions })),
+                    Some(other),
+                );
+            }
+            Err(TryRecvError::Empty | TryRecvError::Disconnected) => {
+                return (
+                    token_ids,
+                    has_logprobs.then(|| MaybeWireLogprobs::Direct(Logprobs { positions })),
+                    None,
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
 fn to_wire_logprobs(token_id: u32, logprob: Option<TokenLogprob>) -> Option<MaybeWireLogprobs> {
+    let position = to_wire_position_logprobs(token_id, logprob)?;
+    Some(MaybeWireLogprobs::Direct(Logprobs {
+        positions: vec![position],
+    }))
+}
+
+fn to_wire_position_logprobs(
+    token_id: u32,
+    logprob: Option<TokenLogprob>,
+) -> Option<PositionLogprobs> {
     let lp = logprob?;
     let mut entries = Vec::with_capacity(1 + lp.top_logprobs.len());
     // pegainfer-core does not currently expose the sampled token's vocab rank.
@@ -1068,9 +1133,7 @@ fn to_wire_logprobs(token_id: u32, logprob: Option<TokenLogprob>) -> Option<Mayb
             rank: (index + 1) as u32,
         });
     }
-    Some(MaybeWireLogprobs::Direct(Logprobs {
-        positions: vec![PositionLogprobs { entries }],
-    }))
+    Some(PositionLogprobs { entries })
 }
 
 fn convert_sampling(params: &EngineCoreSamplingParams) -> SamplingParams {
@@ -1361,6 +1424,126 @@ mod tests {
                 "request is too large for KV cache".to_string()
             ))
         );
+    }
+
+    #[tokio::test]
+    async fn consecutive_tokens_are_batched_into_one_output() {
+        let (token_tx, token_rx) = mpsc::unbounded_channel();
+        let (output_tx, mut output_rx) = mpsc::unbounded_channel();
+
+        token_tx
+            .send(TokenEvent::Scheduled {
+                queued_at_unix_s: 1.0,
+                scheduled_at_unix_s: 2.0,
+                prompt_tokens: 16,
+            })
+            .expect("send scheduled");
+        token_tx
+            .send(TokenEvent::Token {
+                id: 11,
+                logprob: Some(TokenLogprob {
+                    logprob: -0.1,
+                    top_logprobs: vec![(11, -0.1), (12, -0.5)],
+                }),
+            })
+            .expect("send token 1");
+        token_tx
+            .send(TokenEvent::Token {
+                id: 21,
+                logprob: Some(TokenLogprob {
+                    logprob: -0.2,
+                    top_logprobs: vec![(21, -0.2), (22, -0.6)],
+                }),
+            })
+            .expect("send token 2");
+        token_tx
+            .send(TokenEvent::Finished {
+                finish_reason: FinishReason::Length,
+                prompt_tokens: 16,
+                completion_tokens: 2,
+            })
+            .expect("send finished");
+        drop(token_tx);
+
+        run_request_stream("req-1".to_string(), token_rx, output_tx).await;
+
+        let token_outputs = output_rx.recv().await.expect("token output");
+        assert_eq!(token_outputs.outputs.len(), 1);
+        assert_eq!(token_outputs.outputs[0].request_id, "req-1");
+        assert_eq!(token_outputs.outputs[0].new_token_ids, vec![11, 21]);
+        assert!(token_outputs.outputs[0].finish_reason.is_none());
+        assert!(token_outputs.outputs[0].events.is_some());
+        assert!(token_outputs.outputs[0].prefill_stats.is_some());
+
+        let direct = match token_outputs.outputs[0]
+            .new_logprobs
+            .as_ref()
+            .expect("batched logprobs")
+        {
+            MaybeWireLogprobs::Direct(direct) => direct,
+            MaybeWireLogprobs::Wire(_) => panic!("expected direct batched logprobs"),
+        };
+        assert_eq!(direct.positions.len(), 2);
+        assert_eq!(direct.positions[0].entries[0].token_id, 11);
+        assert_eq!(direct.positions[1].entries[0].token_id, 21);
+
+        let terminal = output_rx.recv().await.expect("terminal output");
+        assert_eq!(
+            terminal.outputs[0].finish_reason,
+            Some(EngineCoreFinishReason::Length)
+        );
+        assert!(
+            terminal
+                .finished_requests
+                .as_ref()
+                .is_some_and(|requests| requests.contains("req-1"))
+        );
+        assert!(output_rx.recv().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn first_token_metadata_is_only_sent_with_first_batch() {
+        let (token_tx, token_rx) = mpsc::unbounded_channel();
+        let (output_tx, mut output_rx) = mpsc::unbounded_channel();
+
+        token_tx
+            .send(TokenEvent::Scheduled {
+                queued_at_unix_s: 1.0,
+                scheduled_at_unix_s: 2.0,
+                prompt_tokens: 8,
+            })
+            .expect("send scheduled");
+        token_tx
+            .send(TokenEvent::Token {
+                id: 1,
+                logprob: None,
+            })
+            .expect("send first token");
+        token_tx
+            .send(TokenEvent::PromptTokens {
+                ids: vec![9],
+                logprobs: vec![None],
+            })
+            .expect("send prompt token metadata");
+        token_tx
+            .send(TokenEvent::Token {
+                id: 2,
+                logprob: None,
+            })
+            .expect("send second token");
+        drop(token_tx);
+
+        run_request_stream("req-2".to_string(), token_rx, output_tx).await;
+
+        let first_batch = output_rx.recv().await.expect("first batch");
+        let second_batch = output_rx.recv().await.expect("second batch");
+        assert_eq!(first_batch.outputs[0].new_token_ids, vec![1]);
+        assert_eq!(second_batch.outputs[0].new_token_ids, vec![2]);
+        assert!(first_batch.outputs[0].events.is_some());
+        assert!(first_batch.outputs[0].prefill_stats.is_some());
+        assert!(second_batch.outputs[0].events.is_none());
+        assert!(second_batch.outputs[0].prefill_stats.is_none());
+        assert!(output_rx.recv().await.is_none());
     }
 
     fn assert_logprob_eq(actual: f32, expected: f32) {

--- a/pegainfer-vllm-frontend/src/lib.rs
+++ b/pegainfer-vllm-frontend/src/lib.rs
@@ -844,6 +844,7 @@ async fn run_request_stream(
 ) {
     let mut first_token_events = None;
     let mut first_token_prefill_stats = None;
+    let mut has_sent_token_output = false;
     let mut pending_event = None;
     loop {
         let event = match pending_event.take() {
@@ -878,9 +879,13 @@ async fn run_request_stream(
                 });
             }
             TokenEvent::Token { id, logprob } => {
-                // Yield once so a token burst from the engine can accumulate
-                // before we drain the ready queue into one bridge output.
-                tokio::task::yield_now().await;
+                // Keep the first streamed token on the direct path so TTFT
+                // does not pay an extra scheduler turn. Later decode bursts
+                // still benefit from one-turn coalescing before draining the
+                // ready queue into one bridge output.
+                if has_sent_token_output {
+                    tokio::task::yield_now().await;
+                }
                 let (token_ids, batched_logprobs, next_event) =
                     collect_ready_token_batch(id, logprob, &mut token_rx);
                 pending_event = next_event;
@@ -896,6 +901,7 @@ async fn run_request_stream(
                 {
                     return;
                 }
+                has_sent_token_output = true;
             }
             TokenEvent::PromptTokens { .. } => {
                 // Prompt logprobs are intentionally deferred for this bridge.
@@ -1075,6 +1081,10 @@ fn collect_ready_token_batch(
         if let Some(position) = to_wire_position_logprobs(token_id, logprob) {
             has_logprobs = true;
             positions.push(position);
+        } else {
+            positions.push(PositionLogprobs {
+                entries: Vec::new(),
+            });
         }
     };
     push_token(first_id, first_logprob);
@@ -1543,6 +1553,47 @@ mod tests {
         assert!(first_batch.outputs[0].prefill_stats.is_some());
         assert!(second_batch.outputs[0].events.is_none());
         assert!(second_batch.outputs[0].prefill_stats.is_none());
+        assert!(output_rx.recv().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn mixed_logprob_batch_keeps_token_alignment() {
+        let (token_tx, token_rx) = mpsc::unbounded_channel();
+        let (output_tx, mut output_rx) = mpsc::unbounded_channel();
+
+        token_tx
+            .send(TokenEvent::Token {
+                id: 31,
+                logprob: None,
+            })
+            .expect("send token without logprob");
+        token_tx
+            .send(TokenEvent::Token {
+                id: 32,
+                logprob: Some(TokenLogprob {
+                    logprob: -0.3,
+                    top_logprobs: vec![(32, -0.3), (33, -0.7)],
+                }),
+            })
+            .expect("send token with logprob");
+        drop(token_tx);
+
+        run_request_stream("req-3".to_string(), token_rx, output_tx).await;
+
+        let batch = output_rx.recv().await.expect("batched output");
+        let direct = match batch.outputs[0]
+            .new_logprobs
+            .as_ref()
+            .expect("batched logprobs")
+        {
+            MaybeWireLogprobs::Direct(direct) => direct,
+            MaybeWireLogprobs::Wire(_) => panic!("expected direct batched logprobs"),
+        };
+
+        assert_eq!(batch.outputs[0].new_token_ids, vec![31, 32]);
+        assert_eq!(direct.positions.len(), 2);
+        assert!(direct.positions[0].entries.is_empty());
+        assert_eq!(direct.positions[1].entries[0].token_id, 32);
         assert!(output_rx.recv().await.is_none());
     }
 


### PR DESCRIPTION
1. Summary

This batches consecutive TokenEvent::Token items in the vLLM frontend bridge into fewer EngineCoreOutputs payloads.

The old path paid one local channel send, one msgpack encode, and one ZMQ send per token. Under the simulated frontend benchmark from #160, that left fixed per-message cost on the table.

The new path keeps the first streamed token on the direct path, then coalesces later decode bursts by draining ready token events with try_recv() into one multi-token EngineCoreOutput.

2. Invariants

The patch does not change request scheduling, decode semantics, or the external HTTP API shape.

The first batch still carries queued/scheduled events and prefill stats exactly once.

Batched logprobs now keep strict positional alignment with token_ids, including mixed batches where some tokens do not carry logprobs.

Terminal outputs and finished_requests behavior stay the same.

3. Validation

rustfmt +nightly-2026-01-01 --edition 2024 --check pegainfer-vllm-frontend/src/lib.rs
cargo +nightly-2026-01-01 test -p pegainfer-vllm-frontend --lib -- --nocapture

Focused tests added in this PR:

1. consecutive_tokens_are_batched_into_one_output
2. first_token_metadata_is_only_sent_with_first_batch
3. mixed_logprob_batch_keeps_token_alignment

4. Benchmark

Commands and machine notes:
- temporary WSL verification environment
- server: pegainfer-sim --tpot-ms 0 --base-ttft-ms 0 --prefill-tokens-per-ms 10000
- server pinned to CPUs 0-1, client pinned to CPUs 2-15
- shape: 3000 requests, max concurrency 128, random prompt words 256, random output len 128

benchmark                         shape                      before         after          delta
request throughput                3000 req / conc 128       679.32 req/s   761.21 req/s   +12.1%
output token throughput           out len 128               86952.55 tok/s 97434.27 tok/s +12.1%
mean TTFT                         same                       9.56 ms        9.60 ms        +0.4%
mean TPOT                         same                       1.3681 ms      1.2407 ms      -9.3%
p99 TPOT                          same                       5.6240 ms      6.2400 ms      +11.0%
mean streamed token-event count   same                       128.0          124.646        -2.6%
server CPU seconds                same                       3.96           4.19           +5.8%

The strongest signal here is lower streamed event count with higher request and token throughput at essentially unchanged TTFT. The CPU-seconds number moved the wrong way in this rerun, so I do not claim a clean CPU reduction from this version of the patch.

5. Related

Related to #160.
