### PR TITLE
test(sim): add front e2e tests using the simulated engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,6 @@ jobs:
 
       - name: Check locked Cargo metadata
         run: cargo metadata --locked --no-deps --format-version 1
+
+      - name: Run simulated frontend e2e tests
+        run: cargo test --release -p pegainfer-sim --test frontend_e2e

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3733,7 +3733,10 @@ dependencies = [
  "clap",
  "pegainfer-engine",
  "pegainfer-vllm-frontend",
+ "reqwest",
+ "serde_json",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/docs/subsystems/frontend/simulated-inference-engine.md
+++ b/docs/subsystems/frontend/simulated-inference-engine.md
@@ -2,7 +2,8 @@
 
 **Created**: 2026-05-16
 **Status**: ready for PR review
-**TL;DR**: `pegainfer-sim` is a CPU-only simulated model crate that serves through the existing vLLM/OpenAI frontend with configurable TTFT/TPOT. It is a benchmark and frontend validation harness, not a real-model performance path.
+**Last touched**: 2026-05
+**TL;DR**: `pegainfer-sim` is a CPU-only simulated model crate that serves through the existing vLLM/OpenAI frontend with configurable TTFT/TPOT and lightweight HTTP e2e coverage. It is a benchmark and frontend validation harness, not a real-model performance path.
 
 ## Scope
 
@@ -28,6 +29,19 @@ Out of scope:
 The timing model is intentionally simple: TTFT is `base_ttft_ms + prompt_len / prefill_tokens_per_ms`, and TPOT is a fixed delay between generated tokens. Output token ids cycle through the prompt tokens, using the fallback id for empty prompts.
 
 The frontend still needs tokenizer/model metadata, but the simulator never loads model weights.
+
+## Frontend Metadata Contract
+
+`pegainfer-sim` does not load model weights, but serving it through the
+vLLM/OpenAI frontend still constructs the normal text/chat backend. That
+frontend path requires enough local model metadata to initialize tokenization
+and detokenization.
+
+For CPU-only tests that do not intend to exercise tokenizer encoding, use
+token-id prompts. Generated token ids still pass through detokenization, so the
+test fixture must provide at least a tokenizer source such as `tokenizer.json`.
+`tokenizer_config.json` and `config.json` are useful for EOS and context-window
+metadata, but no weight files are required.
 
 ## Implementation Details
 

--- a/pegainfer-sim/Cargo.toml
+++ b/pegainfer-sim/Cargo.toml
@@ -14,5 +14,10 @@ pegainfer-engine = { workspace = true }
 pegainfer-vllm-frontend = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
+[dev-dependencies]
+reqwest = { workspace = true, features = ["json"] }
+serde_json = { workspace = true }
+tokio-util = { workspace = true }
+
 [lints]
 workspace = true

--- a/pegainfer-sim/tests/frontend_e2e.rs
+++ b/pegainfer-sim/tests/frontend_e2e.rs
@@ -1,0 +1,249 @@
+use std::fs;
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, anyhow, bail};
+use pegainfer_sim::{SimulatedEngineConfig, start_engine};
+use reqwest::Client;
+use serde_json::{Value, json};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+const MODEL_NAME: &str = "pegainfer-sim-e2e";
+
+struct SimServer {
+    base_url: String,
+    shutdown: CancellationToken,
+    task: JoinHandle<Result<()>>,
+    _model_dir: TempModelDir,
+}
+
+impl SimServer {
+    async fn spawn() -> Result<Self> {
+        let model_dir = TempModelDir::create()?;
+        let port = reserve_loopback_port()?;
+        let base_url = format!("http://127.0.0.1:{port}");
+        let shutdown = CancellationToken::new();
+        let engine = start_engine(SimulatedEngineConfig::new(0.0, 1000.0, 0.0, 1)?);
+        let server_shutdown = shutdown.clone();
+        let model_path = model_dir.path.to_string_lossy().into_owned();
+        let mut task = tokio::spawn(async move {
+            pegainfer_vllm_frontend::serve_model(
+                engine,
+                model_path,
+                vec![MODEL_NAME.to_string()],
+                port,
+                128,
+                server_shutdown,
+            )
+            .await
+        });
+
+        let client = Client::new();
+        tokio::select! {
+            result = wait_for_health(&client, &base_url) => result?,
+            result = &mut task => {
+                return match result {
+                    Ok(Ok(())) => Err(anyhow!("sim frontend exited before becoming healthy")),
+                    Ok(Err(error)) => Err(error).context("sim frontend exited before becoming healthy"),
+                    Err(error) => Err(error).context("sim frontend task panicked"),
+                };
+            }
+        }
+
+        Ok(Self {
+            base_url,
+            shutdown,
+            task,
+            _model_dir: model_dir,
+        })
+    }
+
+    async fn shutdown(self) -> Result<()> {
+        self.shutdown.cancel();
+        tokio::time::timeout(Duration::from_secs(10), self.task)
+            .await
+            .context("timed out waiting for sim frontend shutdown")?
+            .context("sim frontend task panicked")?
+    }
+}
+
+struct TempModelDir {
+    path: PathBuf,
+}
+
+impl TempModelDir {
+    fn create() -> Result<Self> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .context("system clock is before Unix epoch")?
+            .as_nanos();
+        let path =
+            std::env::temp_dir().join(format!("pegainfer-sim-e2e-{}-{now}", std::process::id()));
+        fs::create_dir(&path)
+            .with_context(|| format!("failed to create temp model dir {}", path.display()))?;
+
+        // The simulated frontend still builds the normal vLLM text/chat stack.
+        // Token-id prompts avoid tokenizer encode work, but generated ids still
+        // need a tokenizer for detokenization and a tiny config for metadata.
+        fs::write(path.join("tokenizer.json"), TINY_TOKENIZER_JSON)
+            .context("failed to write tiny tokenizer.json")?;
+        fs::write(
+            path.join("tokenizer_config.json"),
+            TINY_TOKENIZER_CONFIG_JSON,
+        )
+        .context("failed to write tiny tokenizer_config.json")?;
+        fs::write(path.join("config.json"), TINY_CONFIG_JSON)
+            .context("failed to write tiny config.json")?;
+
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TempModelDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn simulated_engine_serves_openai_completions_over_http() -> Result<()> {
+    let server = SimServer::spawn().await?;
+    let client = Client::new();
+
+    let models: Value = client
+        .get(format!("{}/v1/models", server.base_url))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    let advertised = models["data"]
+        .as_array()
+        .ok_or_else(|| anyhow!("/v1/models response has no data array"))?;
+    if !advertised.iter().any(|model| model["id"] == MODEL_NAME) {
+        bail!("/v1/models did not advertise {MODEL_NAME}: {models}");
+    }
+
+    let completion: Value = post_completion(&client, &server.base_url, false).await?;
+    let text = completion["choices"][0]["text"]
+        .as_str()
+        .ok_or_else(|| anyhow!("non-streaming completion has no text: {completion}"))?;
+    if text.is_empty() {
+        bail!("non-streaming completion returned empty text for max_tokens > 0");
+    }
+
+    let stream = post_completion_stream(&client, &server.base_url).await?;
+    if !stream.lines().any(|line| line.trim() == "data: [DONE]") {
+        bail!("streaming completion did not emit terminal data: [DONE]: {stream}");
+    }
+
+    server.shutdown().await
+}
+
+async fn post_completion(client: &Client, base_url: &str, stream: bool) -> Result<Value> {
+    let response = client
+        .post(format!("{base_url}/v1/completions"))
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(completion_body(stream).to_string())
+        .send()
+        .await?
+        .error_for_status()?;
+    response
+        .json()
+        .await
+        .context("failed to parse non-streaming completion response")
+}
+
+async fn post_completion_stream(client: &Client, base_url: &str) -> Result<String> {
+    client
+        .post(format!("{base_url}/v1/completions"))
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(completion_body(true).to_string())
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await
+        .context("failed to read streaming completion response")
+}
+
+fn completion_body(stream: bool) -> Value {
+    json!({
+        "model": MODEL_NAME,
+        "prompt": [1, 2],
+        "max_tokens": 3,
+        "temperature": 0.0,
+        "ignore_eos": true,
+        "stream": stream
+    })
+}
+
+async fn wait_for_health(client: &Client, base_url: &str) -> Result<()> {
+    let health_url = format!("{base_url}/health");
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        if tokio::time::Instant::now() >= deadline {
+            bail!("timed out waiting for sim frontend health at {health_url}");
+        }
+
+        match client
+            .get(&health_url)
+            .timeout(Duration::from_secs(1))
+            .send()
+            .await
+        {
+            Ok(response) if response.status().is_success() => return Ok(()),
+            Ok(_) | Err(_) => tokio::time::sleep(Duration::from_millis(100)).await,
+        }
+    }
+}
+
+fn reserve_loopback_port() -> Result<u16> {
+    let listener = TcpListener::bind(("127.0.0.1", 0))
+        .context("failed to reserve loopback port for sim e2e test")?;
+    Ok(listener.local_addr()?.port())
+}
+
+const TINY_TOKENIZER_JSON: &str = r#"{
+  "version": "1.0",
+  "truncation": null,
+  "padding": null,
+  "added_tokens": [
+    {
+      "id": 0,
+      "content": "<unk>",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": false,
+      "special": true
+    }
+  ],
+  "normalizer": null,
+  "pre_tokenizer": {
+    "type": "Whitespace"
+  },
+  "post_processor": null,
+  "decoder": null,
+  "model": {
+    "type": "WordLevel",
+    "vocab": {
+      "<unk>": 0,
+      "alpha": 1,
+      "beta": 2
+    },
+    "unk_token": "<unk>"
+  }
+}"#;
+
+const TINY_TOKENIZER_CONFIG_JSON: &str = r#"{
+  "unk_token": "<unk>",
+  "tokenizer_class": "PreTrainedTokenizerFast"
+}"#;
+
+const TINY_CONFIG_JSON: &str = r#"{
+  "model_type": "pegainfer_sim",
+  "max_position_embeddings": 128
+}"#;

--- a/pegainfer-sim/tests/frontend_e2e.rs
+++ b/pegainfer-sim/tests/frontend_e2e.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::net::TcpListener;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -11,6 +12,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 const MODEL_NAME: &str = "pegainfer-sim-e2e";
+static TEMP_MODEL_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 struct SimServer {
     base_url: String,
@@ -21,7 +23,10 @@ struct SimServer {
 
 impl SimServer {
     async fn spawn() -> Result<Self> {
-        let model_dir = TempModelDir::create()?;
+        Self::spawn_with_model_dir(TempModelDir::with_minimal_metadata()?).await
+    }
+
+    async fn spawn_with_model_dir(model_dir: TempModelDir) -> Result<Self> {
         let port = reserve_loopback_port()?;
         let base_url = format!("http://127.0.0.1:{port}");
         let shutdown = CancellationToken::new();
@@ -74,30 +79,39 @@ struct TempModelDir {
 }
 
 impl TempModelDir {
-    fn create() -> Result<Self> {
+    fn empty() -> Result<Self> {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .context("system clock is before Unix epoch")?
             .as_nanos();
-        let path =
-            std::env::temp_dir().join(format!("pegainfer-sim-e2e-{}-{now}", std::process::id()));
+        let sequence = TEMP_MODEL_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "pegainfer-sim-e2e-{}-{now}-{sequence}",
+            std::process::id()
+        ));
         fs::create_dir(&path)
             .with_context(|| format!("failed to create temp model dir {}", path.display()))?;
+
+        Ok(Self { path })
+    }
+
+    fn with_minimal_metadata() -> Result<Self> {
+        let dir = Self::empty()?;
 
         // The simulated frontend still builds the normal vLLM text/chat stack.
         // Token-id prompts avoid tokenizer encode work, but generated ids still
         // need a tokenizer for detokenization and a tiny config for metadata.
-        fs::write(path.join("tokenizer.json"), TINY_TOKENIZER_JSON)
+        fs::write(dir.path.join("tokenizer.json"), TINY_TOKENIZER_JSON)
             .context("failed to write tiny tokenizer.json")?;
         fs::write(
-            path.join("tokenizer_config.json"),
+            dir.path.join("tokenizer_config.json"),
             TINY_TOKENIZER_CONFIG_JSON,
         )
         .context("failed to write tiny tokenizer_config.json")?;
-        fs::write(path.join("config.json"), TINY_CONFIG_JSON)
+        fs::write(dir.path.join("config.json"), TINY_CONFIG_JSON)
             .context("failed to write tiny config.json")?;
 
-        Ok(Self { path })
+        Ok(dir)
     }
 }
 
@@ -112,8 +126,63 @@ async fn simulated_engine_serves_openai_completions_over_http() -> Result<()> {
     let server = SimServer::spawn().await?;
     let client = Client::new();
 
+    assert_models_endpoint(&client, &server.base_url).await?;
+    assert_non_streaming_completion_has_output(&client, &server.base_url).await?;
+    assert_streaming_completion_emits_done(&client, &server.base_url).await?;
+
+    server.shutdown().await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn non_streaming_completion_returns_nonempty_output_for_positive_max_tokens() -> Result<()> {
+    let server = SimServer::spawn().await?;
+    let client = Client::new();
+
+    assert_non_streaming_completion_has_output(&client, &server.base_url).await?;
+
+    server.shutdown().await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn streaming_completion_emits_terminal_done() -> Result<()> {
+    let server = SimServer::spawn().await?;
+    let client = Client::new();
+
+    assert_streaming_completion_emits_done(&client, &server.base_url).await?;
+
+    server.shutdown().await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn simulated_frontend_metadata_contract_is_executable() -> Result<()> {
+    let model_dir = TempModelDir::with_minimal_metadata()?;
+    for file in ["tokenizer.json", "tokenizer_config.json", "config.json"] {
+        if !model_dir.path.join(file).is_file() {
+            bail!("minimal simulated frontend metadata fixture is missing {file}");
+        }
+    }
+
+    let server = SimServer::spawn_with_model_dir(model_dir).await?;
+    server.shutdown().await?;
+
+    let error = match SimServer::spawn_with_model_dir(TempModelDir::empty()?).await {
+        Ok(server) => {
+            server.shutdown().await?;
+            bail!("empty local model metadata directory should fail frontend startup");
+        }
+        Err(error) => error,
+    };
+    let message = format!("{error:#}");
+    if !message.contains("supported tokenizer file") || !message.contains("tokenizer.json") {
+        bail!("empty metadata dir failed with unexpected error: {message}");
+    }
+
+    Ok(())
+}
+
+async fn assert_models_endpoint(client: &Client, base_url: &str) -> Result<()> {
     let models: Value = client
-        .get(format!("{}/v1/models", server.base_url))
+        .get(format!("{base_url}/v1/models"))
         .send()
         .await?
         .error_for_status()?
@@ -126,7 +195,11 @@ async fn simulated_engine_serves_openai_completions_over_http() -> Result<()> {
         bail!("/v1/models did not advertise {MODEL_NAME}: {models}");
     }
 
-    let completion: Value = post_completion(&client, &server.base_url, false).await?;
+    Ok(())
+}
+
+async fn assert_non_streaming_completion_has_output(client: &Client, base_url: &str) -> Result<()> {
+    let completion: Value = post_completion(client, base_url, false).await?;
     let text = completion["choices"][0]["text"]
         .as_str()
         .ok_or_else(|| anyhow!("non-streaming completion has no text: {completion}"))?;
@@ -134,12 +207,16 @@ async fn simulated_engine_serves_openai_completions_over_http() -> Result<()> {
         bail!("non-streaming completion returned empty text for max_tokens > 0");
     }
 
-    let stream = post_completion_stream(&client, &server.base_url).await?;
+    Ok(())
+}
+
+async fn assert_streaming_completion_emits_done(client: &Client, base_url: &str) -> Result<()> {
+    let stream = post_completion_stream(client, base_url).await?;
     if !stream.lines().any(|line| line.trim() == "data: [DONE]") {
         bail!("streaming completion did not emit terminal data: [DONE]: {stream}");
     }
 
-    server.shutdown().await
+    Ok(())
 }
 
 async fn post_completion(client: &Client, base_url: &str, stream: bool) -> Result<Value> {

--- a/pegainfer-sim/tests/frontend_e2e.rs
+++ b/pegainfer-sim/tests/frontend_e2e.rs
@@ -11,7 +11,9 @@ use serde_json::{Value, json};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
+const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 const MODEL_NAME: &str = "pegainfer-sim-e2e";
+const SERVER_START_ATTEMPTS: usize = 5;
 static TEMP_MODEL_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 struct SimServer {
@@ -27,6 +29,33 @@ impl SimServer {
     }
 
     async fn spawn_with_model_dir(model_dir: TempModelDir) -> Result<Self> {
+        let mut last_error = None;
+        for attempt in 1..=SERVER_START_ATTEMPTS {
+            match Self::spawn_once(&model_dir).await {
+                Ok(started) => {
+                    return Ok(Self {
+                        base_url: started.base_url,
+                        shutdown: started.shutdown,
+                        task: started.task,
+                        _model_dir: model_dir,
+                    });
+                }
+                Err(error) => {
+                    last_error = Some(error);
+                    if attempt < SERVER_START_ATTEMPTS {
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                    }
+                }
+            }
+        }
+
+        Err(last_error.unwrap_or_else(|| anyhow!("sim frontend startup was not attempted")))
+            .with_context(|| {
+                format!("failed to start sim frontend after {SERVER_START_ATTEMPTS} attempts")
+            })
+    }
+
+    async fn spawn_once(model_dir: &TempModelDir) -> Result<StartedSimServer> {
         let port = reserve_loopback_port()?;
         let base_url = format!("http://127.0.0.1:{port}");
         let shutdown = CancellationToken::new();
@@ -45,9 +74,9 @@ impl SimServer {
             .await
         });
 
-        let client = Client::new();
-        tokio::select! {
-            result = wait_for_health(&client, &base_url) => result?,
+        let client = test_client()?;
+        let health_result = tokio::select! {
+            result = wait_for_health(&client, &base_url) => result,
             result = &mut task => {
                 return match result {
                     Ok(Ok(())) => Err(anyhow!("sim frontend exited before becoming healthy")),
@@ -55,13 +84,18 @@ impl SimServer {
                     Err(error) => Err(error).context("sim frontend task panicked"),
                 };
             }
+        };
+
+        if let Err(error) = health_result {
+            shutdown.cancel();
+            let _ = tokio::time::timeout(Duration::from_secs(10), task).await;
+            return Err(error);
         }
 
-        Ok(Self {
+        Ok(StartedSimServer {
             base_url,
             shutdown,
             task,
-            _model_dir: model_dir,
         })
     }
 
@@ -72,6 +106,12 @@ impl SimServer {
             .context("timed out waiting for sim frontend shutdown")?
             .context("sim frontend task panicked")?
     }
+}
+
+struct StartedSimServer {
+    base_url: String,
+    shutdown: CancellationToken,
+    task: JoinHandle<Result<()>>,
 }
 
 struct TempModelDir {
@@ -124,7 +164,7 @@ impl Drop for TempModelDir {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn simulated_engine_serves_openai_completions_over_http() -> Result<()> {
     let server = SimServer::spawn().await?;
-    let client = Client::new();
+    let client = test_client()?;
 
     assert_models_endpoint(&client, &server.base_url).await?;
     assert_non_streaming_completion_has_output(&client, &server.base_url).await?;
@@ -136,7 +176,7 @@ async fn simulated_engine_serves_openai_completions_over_http() -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn non_streaming_completion_returns_nonempty_output_for_positive_max_tokens() -> Result<()> {
     let server = SimServer::spawn().await?;
-    let client = Client::new();
+    let client = test_client()?;
 
     assert_non_streaming_completion_has_output(&client, &server.base_url).await?;
 
@@ -146,7 +186,7 @@ async fn non_streaming_completion_returns_nonempty_output_for_positive_max_token
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn streaming_completion_emits_terminal_done() -> Result<()> {
     let server = SimServer::spawn().await?;
-    let client = Client::new();
+    let client = test_client()?;
 
     assert_streaming_completion_emits_done(&client, &server.base_url).await?;
 
@@ -244,6 +284,13 @@ async fn post_completion_stream(client: &Client, base_url: &str) -> Result<Strin
         .text()
         .await
         .context("failed to read streaming completion response")
+}
+
+fn test_client() -> Result<Client> {
+    Client::builder()
+        .timeout(HTTP_TIMEOUT)
+        .build()
+        .context("failed to build HTTP test client")
 }
 
 fn completion_body(stream: bool) -> Value {


### PR DESCRIPTION
## Summary

Implements #137. Follow-up from #136.

This adds lightweight CPU-only frontend e2e coverage for `pegainfer-sim`. The test starts the simulated engine behind the real vLLM/OpenAI HTTP frontend and verifies:

- `/v1/models`
- non-streaming `/v1/completions`
- streaming `/v1/completions` reaches `data: [DONE]`

The test uses a tiny local tokenizer/model metadata fixture and does not require CUDA, model weights, or real model correctness.

The CPU CI path now runs the simulated frontend e2e test with `cargo test --release -p pegainfer-sim --test frontend_e2e`.

## Evidence

Static / metadata checks:

- `cargo fmt --all --check`
- `cargo metadata --locked --no-deps --format-version 1`

Simulated frontend e2e:

- `cargo test --release -p pegainfer-sim --test frontend_e2e -- --nocapture`

Result:

- `/v1/models`: passed
- non-streaming `/v1/completions`: passed, returned non-empty output for `max_tokens > 0`
- streaming `/v1/completions`: passed, emitted terminal `data: [DONE]`
- metadata contract test: passed, documents the tiny tokenizer/model metadata required by the simulated frontend path

## Claim Boundary

This PR proves the simulated engine can exercise the real vLLM/OpenAI HTTP frontend in a CPU-only test path without CUDA or model weights.

It does not claim real model correctness, GPU/CUDA coverage, throughput improvement, benchmark validity, or production serving performance.

## Follow-up

Future frontend coverage can extend this path to chat/completions variants, request validation, or benchmark-client compatibility while keeping the simulator separate from real model correctness tests.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

- [x] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project (see `docs/areas/coding-style.md`).

- [x] I have performed a self-review of my own code.

- [x] I have formatted my commits according to Commitizen conventions.

- [x] I have run the local test suite and all tests pass (see `CLAUDE.md`).