### PR TITLE
opt(kimi-k2): TP1/DP8/EP8 PPLX decode kernel picks — cuBLASLt fixed-shape GEMMs, argmax split, router fusion

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -74,7 +74,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 | `models/kimi-k2/pplx-ep-decode.md` | PPLX EP decode bs=1 TPOT 37ms → 17.94ms（−52%），超过 NCCL no-graph 18.52ms。根因是 expert_padding=64 导致 Marlin 98% 计算浪费 + <<<1,1>>> 串行 routing kernel。含完整优化 log、failed approaches、nsys 对比数据。 |
 | `models/kimi-k2/pplx-ep-correctness.md` | TP8/EP8 PPLX correctness baseline：H20 64-token token trace 与 TP8/EP8 NCCL 完全一致，hash `4920f088c2338236`；记录 recv capacity、routed-row top-k weight、F32 combine 边界。 |
 | `models/kimi-k2/dp1-tp8-ep8-performance.md` | DP1 TP8 EP8 性能优化 ledger：从 correctness baseline `72c770b` 起步，目标 bs64 超过 vLLM baseline output `583.9 tok/s` / TPOT median `109.00ms`，每个优化必须带正确性 gate 和 commit。 |
-| `models/kimi-k2/tp1-dp8-ep8-performance.md` | TP1 DP8 EP8 性能优化 ledger：目标 H20 bs64 超过 vLLM TP1 DP8 EP8 baseline；记录 vLLM DPLB/CUDA Graph bucket cliff（8x8 `48ms`，9/8 skew `96ms`），统一压测/profile 命令，并按 profile → 动机预期收益 → microbench → correctness → performance 记录每个优化。 |
+| `models/kimi-k2/tp1-dp8-ep8-performance.md` | TP1 DP8 EP8 性能优化 ledger：O1 prompt_len1 decode admission 过 vLLM bs64 gate；O2 落地 5 个 decode kernel cherry-pick（cuBLASLt fixed-shape GEMM、argmax split、router fusion），精度由 base-vs-opt prefill logits A/B 压在 bf16 ULP 底，PPLX Marlin small-N tile 因 `-inf`/SIGSEGV 被定性为原分支精度破坏点并拒绝；bs64 TPOT 噪声内持平（p50 `40.58→40.09ms`）。 |
 | `models/kimi-k2/source-layout.md` | Kimi-K2 source files over 1k lines were split by responsibility; the largest Rust file under `pegainfer-kimi-k2/src` is now `layers/attention.rs` at 950 lines. |
 | `models/kimi-k2/dp-design.md` | TP×DP 可配置并行：每 DP rank 是独立 decode engine，EP all-to-all 天然 sync，轻量 load balancer 做 request 路由。首批 TP1×DP8 + TP8×DP1。 |
 

--- a/docs/models/kimi-k2/tp1-dp8-ep8-performance.md
+++ b/docs/models/kimi-k2/tp1-dp8-ep8-performance.md
@@ -1,8 +1,8 @@
 # Kimi-K2 TP1 DP8 EP8 performance
 
-> TL;DR: This ledger tracks pegainfer TP1+DP8+EP8 on 8x H20 against the vLLM TP1+DP8+EP8 bs64 target. The vLLM sustained bs64 `~106ms` TPOT is now explained by a DPLB/CUDA-graph bucket cliff: an uneven DP distribution such as `9,8,8,8,8,8,8,7` pads every rank from graph bucket 8 to 16 and doubles TPOT. Every pegainfer optimization must start from a profile, state the expected gain, show a microbench or isolated measurement, then pass correctness and service-level gates before commit.
+> TL;DR: This ledger tracks pegainfer TP1+DP8+EP8 on 8x H20 against the vLLM TP1+DP8+EP8 bs64 target. The vLLM sustained bs64 `~106ms` TPOT is now explained by a DPLB/CUDA-graph bucket cliff: an uneven DP distribution such as `9,8,8,8,8,8,8,7` pads every rank from graph bucket 8 to 16 and doubles TPOT. O2 landed five production decode-kernel picks (cuBLASLt fixed-shape shared_gate_up / o_proj / MLA strided-batch, split-vocab argmax, fused router selector); accuracy held at the bf16 ULP floor by a base-vs-opt prefill logits A/B, and the PPLX Marlin small-N tile was identified as the messy branch's real accuracy break (`-inf` logits + SIGSEGV at small per-rank N) and rejected. bs64 TPOT is unchanged within noise (p50 `40.58 -> 40.09ms`): the per-kernel wins do not resolve above the ±1ms band at this shape. Every pegainfer optimization must start from a profile, state the expected gain, show a microbench or isolated measurement, then pass correctness and service-level gates before commit.
 >
-> Last touched: 2026-05-25
+> Last touched: 2026-06-04
 
 ## Target
 
@@ -63,8 +63,13 @@ LD_LIBRARY_PATH="$NCCL_LIB_DIR:/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-}" \
 PEGAINFER_CUDA_SM=90a \
 PEGAINFER_TRITON_PYTHON="$TRITON_PYTHON" \
 cargo build --release -p pegainfer-server \
-  --features kimi-k2-pplx-ep --bin pegainfer --bin bench_serving
+  --features kimi-k2 --bin pegainfer --bin bench_serving
 ```
+
+(The old `kimi-k2-pplx-ep` feature and `PEGAINFER_KIMI_PARALLEL` env existed only on the
+pre-merge branch; on main the feature is `kimi-k2` and parallel shape is selected by the
+`--tp-size/--dp-size/--ep-backend` CLI flags below. nvcc must also be on `PATH` — the
+`pegainfer-comm` cc-rs build looks it up there, not via `$NVCC`.)
 
 In-process bs64:
 
@@ -75,10 +80,10 @@ NVCC=/usr/local/cuda/bin/nvcc \
 LD_LIBRARY_PATH="$NCCL_LIB_DIR:/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-}" \
 PEGAINFER_CUDA_SM=90a \
 PEGAINFER_TRITON_PYTHON="$TRITON_PYTHON" \
-PEGAINFER_KIMI_PARALLEL=tp1dp8 \
 target/release/bench_serving \
   --model-path "$MODEL_DIR" \
   --cuda-graph false \
+  --tp-size 1 --dp-size 8 --ep-backend pplx \
   --format json \
   --out "$RESULT_ROOT/kimi-tp1dp8/tp1dp8_bs64_o128_${COMMIT}.json" \
   request --prompt-len 1 --output-len 128 --concurrency 64 --warmup 1 --iters 1
@@ -93,8 +98,8 @@ NVCC=/usr/local/cuda/bin/nvcc \
 LD_LIBRARY_PATH="$NCCL_LIB_DIR:/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-}" \
 PEGAINFER_CUDA_SM=90a \
 PEGAINFER_TRITON_PYTHON="$TRITON_PYTHON" \
-PEGAINFER_KIMI_PARALLEL=tp1dp8 \
-target/release/pegainfer --model-path "$MODEL_DIR" --port 8124 --cuda-graph false
+target/release/pegainfer --model-path "$MODEL_DIR" --served-model-name kimi-k2.5 \
+  --port 8124 --cuda-graph false --tp-size 1 --dp-size 8 --ep-backend pplx
 ```
 
 ```bash
@@ -361,6 +366,73 @@ Decision:
   separate reference gate before using TP1 DP8 as an accuracy baseline. Follow-up profiles should
   focus on lowering pegainfer service TPOT from `47ms` toward the H200-reported 30ms-class
   expectation if that target is confirmed on comparable hardware.
+
+### O2 - decode kernel cherry-pick: cuBLASLt fixed-shape GEMMs, argmax split, router fusion
+
+Status: keep (5 commits). One candidate rejected as a real accuracy break (below).
+
+Context: these kernels were developed together on one branch (`opt/kimi-tp1-dp8-decode`)
+along with ~2.4k lines of microbench scaffolding, and that branch produced wrong output
+with no obvious culprit. Salvage was done by production-only cherry-picks onto a clean
+base (`3bec64f`, kimi code identical to main `927a00c`), validating after every pick;
+docs and scaffolding were not picked.
+
+Landed commits (microbench numbers from each commit message; H20, TP1 PPLX, bs=8, ctx=1):
+
+| commit | opt | isolated microbench |
+| --- | --- | --- |
+| `257c9f4` | shared_gate_up cuBLASLt fixed-shape | `1.818ms -> 1.505ms` (1.21x) |
+| `fc9327c` | attention o_proj cuBLASLt fixed-shape | `2.715ms -> 2.374ms` (1.14x) |
+| `f77f729` | MLA absorb/v_up cuBLASLt strided batches | absorb `973.6us -> 748.5us` (1.30x) |
+| `0d52e73` | final argmax split-vocab reduction | `125.3us -> 12.7us` (9.85x) |
+| `8cf932f` | router post-GEMM fused score+topk selector | `3.655ms -> 3.514ms` (1.04x) |
+
+Per-pick validation (in-process bench_serving, TP1 DP8 PPLX, cuda-graph false):
+
+- c1 o128 determinism A/B vs base (concurrency=1 is bitwise reproducible; bs64 is not):
+  all five picks stay coherent (len 128, degenerate 0/64). The greedy hash legitimately
+  changes at the first cuBLASLt pick (bf16 rounding tie-breaks) and then stays at
+  `cb1954bb77d652fb` — the MLA, argmax, and router picks changed nothing further.
+- bs64 o128 steady TPOT p50/p99: base `40.58/44.06ms` -> cumulative 5-opt
+  `40.09/42.87ms`. That is inside the ±1ms run-to-run band at warmup=1/iters=1, so the
+  honest end-to-end claim is "no regression": the per-kernel wins do not resolve above
+  noise at this shape.
+
+Rejected: PPLX Marlin small-N tile (messy-branch `dd69876`) — the accuracy break.
+
+- concurrency=1: `non-finite top logit -inf` on the serving rank -> panic (exit 101).
+- bs64: SIGSEGV (exit 139) with `-inf` on multiple ranks. It never produced one valid bench.
+- Why it hid: its isolated microbench (`250.64 -> 161.45us`, 1.50x) never checks numerics,
+  and a small-N tile only activates at small per-rank token counts — exactly the decode
+  regime, not the regime perf sweeps exercise hardest. Re-land only behind a real small-N
+  decode numeric gate.
+
+Accuracy gate: base-vs-opt prefill logits A/B. GSM8K-class evals are too coarse for
+ULP-level kernel drift, so the gate follows `subsystems/correctness/logits-golden-gate.md`
+with base-pegainfer itself as the reference at the same TP1 DP8 PPLX config: a throwaway
+(uncommitted) hook after the prefill lm_head GEMM in `runner/worker/state.rs` dumps
+full-vocab bf16 logits at every prompt position for 12 fixed raw prompts (en/zh/code/math,
+1..90 tokens) sent through `/v1/completions` at `max_tokens=1`, identical patch on base
+`3bec64f` and the 5-opt tip.
+
+| metric | value | reading |
+| --- | --- | --- |
+| positions | 236 | 12 prompts, every prefill position scored |
+| bit-identical positions | 145/236 | 10/12 prompts fully untouched -> router fusion is bit-exact |
+| head-token abs-dlogprob mean / p50 | 0.0355 / 0.0000 | at the bf16 reduction-order floor (Qwen3-4B floor: 0.032) |
+| top-1 token delta mean / max | 0.029 / 0.283 | drift confined to the 2 prompts whose GEMM shapes engage the cuBLASLt paths |
+| argmax agreement | 233/236 | |
+| worst regret | 0.125 nat | = 1 ULP at logit magnitude ~16; all 3 flips are genuine ties, under the 0.20 tie tolerance |
+
+Coverage note: prefill exercises shared_gate_up / o_proj / router. The MLA strided-batch
+pick is decode-absorb-only and is covered by the c1 greedy hash being bit-identical before
+and after that pick (zero argmax flips over 128 decode steps); the argmax split changes
+selection only, not logit values.
+
+Decision: keep the five production commits; reject the small-N Marlin tile until it passes
+a small-N decode numeric gate. The next perf step at this shape is not more skinny-GEMM
+tuning — re-profile for the dominant decode cost (collectives / MoE path) and measure with
+enough iters to resolve sub-millisecond moves.
 
 ## Open Questions
 

--- a/pegainfer-kernels/build.rs
+++ b/pegainfer-kernels/build.rs
@@ -1376,6 +1376,7 @@ fn main() {
     println!("cargo:rustc-link-lib=static=kernels_cuda");
     println!("cargo:rustc-link-lib=cudart");
     println!("cargo:rustc-link-lib=cublas");
+    println!("cargo:rustc-link-lib=cublasLt");
     if !cutedsl_runtime_lib_dirs.is_empty() {
         println!("cargo:rustc-link-lib=static=cuda_dialect_runtime_static");
     }

--- a/pegainfer-kernels/csrc/argmax.cu
+++ b/pegainfer-kernels/csrc/argmax.cu
@@ -1,6 +1,12 @@
 #include "common.cuh"
 
 #define SAMPLE_BLOCK 256
+#define ARGMAX_BATCH_TILE_ELEMS 4096
+
+__device__ __forceinline__ bool argmax_better(float lhs_val, int lhs_idx,
+                                              float rhs_val, int rhs_idx) {
+  return lhs_val > rhs_val || (lhs_val == rhs_val && lhs_idx < rhs_idx);
+}
 
 __global__ void argmax_kernel(const __nv_bfloat16* __restrict__ x,
                               int* __restrict__ out, int n) {
@@ -15,7 +21,7 @@ __global__ void argmax_kernel(const __nv_bfloat16* __restrict__ x,
   int local_idx = 0;
   for (int i = tid; i < n; i += stride) {
     float val = __bfloat162float(x[i]);
-    if (val > local_max || (val == local_max && i < local_idx)) {
+    if (argmax_better(val, i, local_max, local_idx)) {
       local_max = val;
       local_idx = i;
     }
@@ -26,9 +32,8 @@ __global__ void argmax_kernel(const __nv_bfloat16* __restrict__ x,
 
   for (int s = blockDim.x / 2; s > 0; s >>= 1) {
     if (tid < s) {
-      if (shared_vals[tid + s] > shared_vals[tid] ||
-          (shared_vals[tid + s] == shared_vals[tid] &&
-           shared_idxs[tid + s] < shared_idxs[tid])) {
+      if (argmax_better(shared_vals[tid + s], shared_idxs[tid + s],
+                        shared_vals[tid], shared_idxs[tid])) {
         shared_vals[tid] = shared_vals[tid + s];
         shared_idxs[tid] = shared_idxs[tid + s];
       }
@@ -61,7 +66,7 @@ __global__ void argmax_batch_bf16_kernel(
   int local_idx = 0;
   for (int i = tid; i < n; i += blockDim.x) {
     float val = __bfloat162float(row_x[i]);
-    if (val > local_max || (val == local_max && i < local_idx)) {
+    if (argmax_better(val, i, local_max, local_idx)) {
       local_max = val;
       local_idx = i;
     }
@@ -74,8 +79,108 @@ __global__ void argmax_batch_bf16_kernel(
     if (tid < s) {
       float rhs_val = shared_vals[tid + s];
       int rhs_idx = shared_idxs[tid + s];
-      if (rhs_val > shared_vals[tid] ||
-          (rhs_val == shared_vals[tid] && rhs_idx < shared_idxs[tid])) {
+      if (argmax_better(rhs_val, rhs_idx, shared_vals[tid], shared_idxs[tid])) {
+        shared_vals[tid] = rhs_val;
+        shared_idxs[tid] = rhs_idx;
+      }
+    }
+    __syncthreads();
+  }
+
+  if (tid == 0) {
+    indices[row] = shared_idxs[0];
+    values[row] = __float2bfloat16(shared_vals[0]);
+  }
+}
+
+__global__ void argmax_batch_bf16_partial_kernel(
+    const __nv_bfloat16* __restrict__ x,
+    float* __restrict__ partial_values,
+    int* __restrict__ partial_indices,
+    int rows,
+    int n,
+    int tiles_per_row) {
+  extern __shared__ char shared_mem[];
+  float* shared_vals = reinterpret_cast<float*>(shared_mem);
+  int* shared_idxs =
+      reinterpret_cast<int*>(shared_mem + blockDim.x * sizeof(float));
+
+  int tile = blockIdx.x;
+  int row = blockIdx.y;
+  if (row >= rows || tile >= tiles_per_row) return;
+
+  int start = tile * ARGMAX_BATCH_TILE_ELEMS;
+  int end = start + ARGMAX_BATCH_TILE_ELEMS;
+  if (end > n) end = n;
+  const __nv_bfloat16* row_x = x + static_cast<size_t>(row) * n;
+  int tid = threadIdx.x;
+
+  float local_max = -INFINITY;
+  int local_idx = 0;
+  for (int i = start + tid; i < end; i += blockDim.x) {
+    float val = __bfloat162float(row_x[i]);
+    if (argmax_better(val, i, local_max, local_idx)) {
+      local_max = val;
+      local_idx = i;
+    }
+  }
+  shared_vals[tid] = local_max;
+  shared_idxs[tid] = local_idx;
+  __syncthreads();
+
+  for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+    if (tid < s) {
+      float rhs_val = shared_vals[tid + s];
+      int rhs_idx = shared_idxs[tid + s];
+      if (argmax_better(rhs_val, rhs_idx, shared_vals[tid], shared_idxs[tid])) {
+        shared_vals[tid] = rhs_val;
+        shared_idxs[tid] = rhs_idx;
+      }
+    }
+    __syncthreads();
+  }
+
+  if (tid == 0) {
+    int out = row * tiles_per_row + tile;
+    partial_values[out] = shared_vals[0];
+    partial_indices[out] = shared_idxs[0];
+  }
+}
+
+__global__ void argmax_batch_bf16_finalize_kernel(
+    const float* __restrict__ partial_values,
+    const int* __restrict__ partial_indices,
+    __nv_bfloat16* __restrict__ values,
+    int* __restrict__ indices,
+    int rows,
+    int tiles_per_row) {
+  extern __shared__ char shared_mem[];
+  float* shared_vals = reinterpret_cast<float*>(shared_mem);
+  int* shared_idxs =
+      reinterpret_cast<int*>(shared_mem + blockDim.x * sizeof(float));
+
+  int row = blockIdx.x;
+  int tid = threadIdx.x;
+  int base = row * tiles_per_row;
+  float local_max = -INFINITY;
+  int local_idx = 0;
+  for (int tile = tid; tile < tiles_per_row; tile += blockDim.x) {
+    float val = partial_values[base + tile];
+    int idx = partial_indices[base + tile];
+    if (argmax_better(val, idx, local_max, local_idx)) {
+      local_max = val;
+      local_idx = idx;
+    }
+  }
+  shared_vals[tid] = local_max;
+  shared_idxs[tid] = local_idx;
+  __syncthreads();
+
+  for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+    if (tid < s) {
+      float rhs_val = shared_vals[tid + s];
+      int rhs_idx = shared_idxs[tid + s];
+      if (argmax_better(rhs_val, rhs_idx, shared_vals[tid], shared_idxs[tid])) {
         shared_vals[tid] = rhs_val;
         shared_idxs[tid] = rhs_idx;
       }
@@ -101,5 +206,17 @@ void argmax_batch_bf16_cuda(const __nv_bfloat16* x, __nv_bfloat16* values,
   argmax_batch_bf16_kernel<<<rows, SAMPLE_BLOCK,
                              SAMPLE_BLOCK * (sizeof(float) + sizeof(int)),
                              stream>>>(x, values, indices, rows, n);
+}
+
+void argmax_batch_bf16_split_cuda(const __nv_bfloat16* x, __nv_bfloat16* values,
+                                  int* indices, float* partial_values,
+                                  int* partial_indices, int rows, int n,
+                                  cudaStream_t stream) {
+  int tiles_per_row = (n + ARGMAX_BATCH_TILE_ELEMS - 1) / ARGMAX_BATCH_TILE_ELEMS;
+  size_t smem = SAMPLE_BLOCK * (sizeof(float) + sizeof(int));
+  argmax_batch_bf16_partial_kernel<<<dim3(tiles_per_row, rows), SAMPLE_BLOCK, smem, stream>>>(
+      x, partial_values, partial_indices, rows, n, tiles_per_row);
+  argmax_batch_bf16_finalize_kernel<<<rows, SAMPLE_BLOCK, smem, stream>>>(
+      partial_values, partial_indices, values, indices, rows, tiles_per_row);
 }
 }

--- a/pegainfer-kernels/csrc/kimi_k2/kimi_mla.cu
+++ b/pegainfer-kernels/csrc/kimi_k2/kimi_mla.cu
@@ -589,11 +589,10 @@ int kimi_mla_absorb_q_nope_cuda(const DType* kv_b_proj,
   }
 
   if (local_heads == kMlaLtLocalHeads && batch_size <= kMlaLtMaxBatch) {
-    int lt_status = kimi_mla_absorb_q_nope_cublaslt_cuda(
-        kv_b_proj, q_nope, q_abs_nope, batch_size, local_heads, stream);
-    if (lt_status != static_cast<int>(cudaErrorInvalidResourceHandle)) {
-      return lt_status;
-    }
+    // cuBLASLt owns this shape; a failure propagates as an error instead of
+    // silently falling back to the reference GEMM below.
+    return kimi_mla_absorb_q_nope_cublaslt_cuda(kv_b_proj, q_nope, q_abs_nope,
+                                                batch_size, local_heads, stream);
   }
 
   // kv_b_proj is row-major [local_heads, k_nope + v, kv_lora_rank].
@@ -648,11 +647,10 @@ int kimi_mla_v_up_cuda(const DType* kv_b_proj,
 
   const DType* w_uv = kv_b_proj + static_cast<int64_t>(kNopeDim) * kKvLoraRank;
   if (local_heads == kMlaLtLocalHeads && batch_size <= kMlaLtMaxBatch) {
-    int lt_status = kimi_mla_v_up_cublaslt_cuda(
-        kv_b_proj, latent, output, batch_size, local_heads, stream);
-    if (lt_status != static_cast<int>(cudaErrorInvalidResourceHandle)) {
-      return lt_status;
-    }
+    // cuBLASLt owns this shape; a failure propagates as an error instead of
+    // silently falling back to the reference GEMM below.
+    return kimi_mla_v_up_cublaslt_cuda(kv_b_proj, latent, output, batch_size,
+                                       local_heads, stream);
   }
 
   status = cublasGemmStridedBatchedEx(

--- a/pegainfer-kernels/csrc/kimi_k2/kimi_mla.cu
+++ b/pegainfer-kernels/csrc/kimi_k2/kimi_mla.cu
@@ -14,6 +14,19 @@
 
 extern thread_local cublasHandle_t g_cublas_handle;
 
+extern "C" int kimi_mla_absorb_q_nope_cublaslt_cuda(const __nv_bfloat16* kv_b_proj,
+                                                    const __nv_bfloat16* q_nope,
+                                                    __nv_bfloat16* q_abs_nope,
+                                                    int batch_size,
+                                                    int local_heads,
+                                                    cudaStream_t stream);
+extern "C" int kimi_mla_v_up_cublaslt_cuda(const __nv_bfloat16* kv_b_proj,
+                                           const __nv_bfloat16* latent,
+                                           __nv_bfloat16* output,
+                                           int batch_size,
+                                           int local_heads,
+                                           cudaStream_t stream);
+
 namespace {
 
 using DType = __nv_bfloat16;
@@ -34,6 +47,8 @@ constexpr int kKvBHeadDim = kNopeDim + kVHeadDim;
 constexpr int kLocalHeads = 8;
 constexpr int kQLoraRank = 1536;
 constexpr int kQkvAOut = kQLoraRank + kKvLoraRank + kRopeDim;
+constexpr int kMlaLtLocalHeads = 64;
+constexpr int kMlaLtMaxBatch = 8;
 
 flashinfer::paged_kv_mla_t<DType, IdType> make_paged_kv_mla(void* ckv_cache,
                                                              void* kpe_cache,
@@ -573,6 +588,14 @@ int kimi_mla_absorb_q_nope_cuda(const DType* kv_b_proj,
     return static_cast<int>(cudaErrorInvalidResourceHandle);
   }
 
+  if (local_heads == kMlaLtLocalHeads && batch_size <= kMlaLtMaxBatch) {
+    int lt_status = kimi_mla_absorb_q_nope_cublaslt_cuda(
+        kv_b_proj, q_nope, q_abs_nope, batch_size, local_heads, stream);
+    if (lt_status != static_cast<int>(cudaErrorInvalidResourceHandle)) {
+      return lt_status;
+    }
+  }
+
   // kv_b_proj is row-major [local_heads, k_nope + v, kv_lora_rank].
   // Row-major [k_nope, kv_lora_rank] is the same memory as column-major
   // [kv_lora_rank, k_nope], which is exactly W_UK_T for q absorption.
@@ -624,6 +647,14 @@ int kimi_mla_v_up_cuda(const DType* kv_b_proj,
   }
 
   const DType* w_uv = kv_b_proj + static_cast<int64_t>(kNopeDim) * kKvLoraRank;
+  if (local_heads == kMlaLtLocalHeads && batch_size <= kMlaLtMaxBatch) {
+    int lt_status = kimi_mla_v_up_cublaslt_cuda(
+        kv_b_proj, latent, output, batch_size, local_heads, stream);
+    if (lt_status != static_cast<int>(cudaErrorInvalidResourceHandle)) {
+      return lt_status;
+    }
+  }
+
   status = cublasGemmStridedBatchedEx(
       g_cublas_handle,
       CUBLAS_OP_T,

--- a/pegainfer-kernels/csrc/kimi_k2/kimi_mla_cublaslt.cu
+++ b/pegainfer-kernels/csrc/kimi_k2/kimi_mla_cublaslt.cu
@@ -1,0 +1,378 @@
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cublasLt.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace {
+
+using DType = __nv_bfloat16;
+
+constexpr int kKvLoraRank = 512;
+constexpr int kNopeDim = 128;
+constexpr int kVHeadDim = 128;
+constexpr int kKvBHeadDim = kNopeDim + kVHeadDim;
+constexpr int kCublasStatusErrorOffset = 100000;
+constexpr int kMlaLtLocalHeads = 64;
+constexpr int kMlaLtMaxBatch = 8;
+
+struct MlaLtPlan {
+  int batch_size = 0;
+  bool v_up = false;
+  cublasLtMatmulDesc_t op = nullptr;
+  cublasLtMatrixLayout_t a = nullptr;
+  cublasLtMatrixLayout_t b = nullptr;
+  cublasLtMatrixLayout_t c = nullptr;
+  cublasLtMatrixLayout_t d = nullptr;
+  cublasLtMatmulAlgo_t algo{};
+  bool ready = false;
+};
+
+thread_local cublasLtHandle_t g_mla_lt_handle = nullptr;
+thread_local MlaLtPlan g_absorb_q_nope_plans[kMlaLtMaxBatch];
+thread_local MlaLtPlan g_v_up_plans[kMlaLtMaxBatch];
+
+int cublas_status_to_error(cublasStatus_t status) {
+  if (status == CUBLAS_STATUS_SUCCESS) {
+    return static_cast<int>(cudaSuccess);
+  }
+  return kCublasStatusErrorOffset + static_cast<int>(status);
+}
+
+void destroy_mla_lt_plan(MlaLtPlan& plan) {
+  if (plan.d != nullptr) {
+    cublasLtMatrixLayoutDestroy(plan.d);
+  }
+  if (plan.c != nullptr) {
+    cublasLtMatrixLayoutDestroy(plan.c);
+  }
+  if (plan.b != nullptr) {
+    cublasLtMatrixLayoutDestroy(plan.b);
+  }
+  if (plan.a != nullptr) {
+    cublasLtMatrixLayoutDestroy(plan.a);
+  }
+  if (plan.op != nullptr) {
+    cublasLtMatmulDescDestroy(plan.op);
+  }
+  plan = MlaLtPlan{};
+}
+
+int set_batched_layout(cublasLtMatrixLayout_t layout,
+                       int batch_count,
+                       int64_t stride_elements) {
+  cublasStatus_t status = cublasLtMatrixLayoutSetAttribute(
+      layout, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &batch_count, sizeof(batch_count));
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    return cublas_status_to_error(status);
+  }
+  status = cublasLtMatrixLayoutSetAttribute(
+      layout, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &stride_elements,
+      sizeof(stride_elements));
+  return cublas_status_to_error(status);
+}
+
+int preferred_mla_lt_candidate(bool v_up, int batch_size, int returned) {
+  int preferred = 0;
+  if (v_up) {
+    preferred = batch_size == 1 ? 1 : 0;
+  } else {
+    preferred = batch_size == 1 ? 2 : 1;
+  }
+  return preferred < returned ? preferred : 0;
+}
+
+int build_mla_lt_plan(cublasLtHandle_t handle,
+                      MlaLtPlan& plan,
+                      int batch_size,
+                      bool v_up) {
+  destroy_mla_lt_plan(plan);
+  plan.batch_size = batch_size;
+  plan.v_up = v_up;
+
+  const cublasOperation_t transa = v_up ? CUBLAS_OP_T : CUBLAS_OP_N;
+  const cublasOperation_t transb = CUBLAS_OP_N;
+  cublasStatus_t status =
+      cublasLtMatmulDescCreate(&plan.op, CUBLAS_COMPUTE_32F, CUDA_R_32F);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_mla_lt_plan(plan);
+    return cublas_status_to_error(status);
+  }
+  status = cublasLtMatmulDescSetAttribute(plan.op, CUBLASLT_MATMUL_DESC_TRANSA,
+                                          &transa, sizeof(transa));
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_mla_lt_plan(plan);
+    return cublas_status_to_error(status);
+  }
+  status = cublasLtMatmulDescSetAttribute(plan.op, CUBLASLT_MATMUL_DESC_TRANSB,
+                                          &transb, sizeof(transb));
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_mla_lt_plan(plan);
+    return cublas_status_to_error(status);
+  }
+
+  if (v_up) {
+    status = cublasLtMatrixLayoutCreate(&plan.a, CUDA_R_16BF, kKvLoraRank, kVHeadDim,
+                                        kKvLoraRank);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+      destroy_mla_lt_plan(plan);
+      return cublas_status_to_error(status);
+    }
+    status = cublasLtMatrixLayoutCreate(&plan.b, CUDA_R_16BF, kKvLoraRank, batch_size,
+                                        kMlaLtLocalHeads * kKvLoraRank);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+      destroy_mla_lt_plan(plan);
+      return cublas_status_to_error(status);
+    }
+    status = cublasLtMatrixLayoutCreate(&plan.c, CUDA_R_16BF, kVHeadDim, batch_size,
+                                        kMlaLtLocalHeads * kVHeadDim);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+      destroy_mla_lt_plan(plan);
+      return cublas_status_to_error(status);
+    }
+    status = cublasLtMatrixLayoutCreate(&plan.d, CUDA_R_16BF, kVHeadDim, batch_size,
+                                        kMlaLtLocalHeads * kVHeadDim);
+  } else {
+    status = cublasLtMatrixLayoutCreate(&plan.a, CUDA_R_16BF, kKvLoraRank, kNopeDim,
+                                        kKvLoraRank);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+      destroy_mla_lt_plan(plan);
+      return cublas_status_to_error(status);
+    }
+    status = cublasLtMatrixLayoutCreate(&plan.b, CUDA_R_16BF, kNopeDim, batch_size,
+                                        kMlaLtLocalHeads * kNopeDim);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+      destroy_mla_lt_plan(plan);
+      return cublas_status_to_error(status);
+    }
+    status = cublasLtMatrixLayoutCreate(&plan.c, CUDA_R_16BF, kKvLoraRank, batch_size,
+                                        kMlaLtLocalHeads * kKvLoraRank);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+      destroy_mla_lt_plan(plan);
+      return cublas_status_to_error(status);
+    }
+    status = cublasLtMatrixLayoutCreate(&plan.d, CUDA_R_16BF, kKvLoraRank, batch_size,
+                                        kMlaLtLocalHeads * kKvLoraRank);
+  }
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_mla_lt_plan(plan);
+    return cublas_status_to_error(status);
+  }
+
+  const int64_t weight_stride = static_cast<int64_t>(kKvBHeadDim) * kKvLoraRank;
+  int result = set_batched_layout(plan.a, kMlaLtLocalHeads, weight_stride);
+  if (result != static_cast<int>(cudaSuccess)) {
+    destroy_mla_lt_plan(plan);
+    return result;
+  }
+  result = set_batched_layout(plan.b, kMlaLtLocalHeads, v_up ? kKvLoraRank : kNopeDim);
+  if (result != static_cast<int>(cudaSuccess)) {
+    destroy_mla_lt_plan(plan);
+    return result;
+  }
+  result = set_batched_layout(plan.c, kMlaLtLocalHeads, v_up ? kVHeadDim : kKvLoraRank);
+  if (result != static_cast<int>(cudaSuccess)) {
+    destroy_mla_lt_plan(plan);
+    return result;
+  }
+  result = set_batched_layout(plan.d, kMlaLtLocalHeads, v_up ? kVHeadDim : kKvLoraRank);
+  if (result != static_cast<int>(cudaSuccess)) {
+    destroy_mla_lt_plan(plan);
+    return result;
+  }
+
+  cublasLtMatmulPreference_t preference = nullptr;
+  status = cublasLtMatmulPreferenceCreate(&preference);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_mla_lt_plan(plan);
+    return cublas_status_to_error(status);
+  }
+  std::size_t workspace_bytes = 0;
+  status = cublasLtMatmulPreferenceSetAttribute(
+      preference, CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &workspace_bytes,
+      sizeof(workspace_bytes));
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    cublasLtMatmulPreferenceDestroy(preference);
+    destroy_mla_lt_plan(plan);
+    return cublas_status_to_error(status);
+  }
+
+  cublasLtMatmulHeuristicResult_t heuristics[8] = {};
+  int returned = 0;
+  status = cublasLtMatmulAlgoGetHeuristic(handle, plan.op, plan.a, plan.b, plan.c, plan.d,
+                                          preference, 8, heuristics, &returned);
+  cublasLtMatmulPreferenceDestroy(preference);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_mla_lt_plan(plan);
+    return cublas_status_to_error(status);
+  }
+  if (returned <= 0) {
+    destroy_mla_lt_plan(plan);
+    return cublas_status_to_error(CUBLAS_STATUS_NOT_SUPPORTED);
+  }
+
+  plan.algo = heuristics[preferred_mla_lt_candidate(v_up, batch_size, returned)].algo;
+  plan.ready = true;
+  return static_cast<int>(cudaSuccess);
+}
+
+MlaLtPlan* find_mla_lt_plan(MlaLtPlan* plans, int batch_size) {
+  if (batch_size < 1 || batch_size > kMlaLtMaxBatch) {
+    return nullptr;
+  }
+  MlaLtPlan& plan = plans[batch_size - 1];
+  if (plan.ready && plan.batch_size == batch_size) {
+    return &plan;
+  }
+  return nullptr;
+}
+
+int ensure_mla_lt_initialized() {
+  if (g_mla_lt_handle == nullptr) {
+    cublasStatus_t status = cublasLtCreate(&g_mla_lt_handle);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+      return cublas_status_to_error(status);
+    }
+  }
+  for (int batch_size = 1; batch_size <= kMlaLtMaxBatch; ++batch_size) {
+    int status =
+        build_mla_lt_plan(g_mla_lt_handle, g_absorb_q_nope_plans[batch_size - 1],
+                          batch_size, /*v_up=*/false);
+    if (status != static_cast<int>(cudaSuccess)) {
+      return status;
+    }
+    status = build_mla_lt_plan(g_mla_lt_handle, g_v_up_plans[batch_size - 1],
+                               batch_size, /*v_up=*/true);
+    if (status != static_cast<int>(cudaSuccess)) {
+      return status;
+    }
+  }
+  return static_cast<int>(cudaSuccess);
+}
+
+int run_absorb_q_nope(const DType* kv_b_proj,
+                      const DType* q_nope,
+                      DType* q_abs_nope,
+                      int batch_size,
+                      cudaStream_t stream) {
+  if (g_mla_lt_handle == nullptr) {
+    int status = ensure_mla_lt_initialized();
+    if (status != static_cast<int>(cudaSuccess)) {
+      return status;
+    }
+  }
+  MlaLtPlan* plan = find_mla_lt_plan(g_absorb_q_nope_plans, batch_size);
+  if (plan == nullptr) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+
+  const float alpha = 1.0f;
+  const float beta = 0.0f;
+  cublasStatus_t status = cublasLtMatmul(g_mla_lt_handle,
+                                         plan->op,
+                                         &alpha,
+                                         kv_b_proj,
+                                         plan->a,
+                                         q_nope,
+                                         plan->b,
+                                         &beta,
+                                         q_abs_nope,
+                                         plan->c,
+                                         q_abs_nope,
+                                         plan->d,
+                                         &plan->algo,
+                                         nullptr,
+                                         0,
+                                         stream);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    return cublas_status_to_error(status);
+  }
+  return static_cast<int>(cudaPeekAtLastError());
+}
+
+int run_v_up(const DType* kv_b_proj,
+             const DType* latent,
+             DType* output,
+             int batch_size,
+             cudaStream_t stream) {
+  if (g_mla_lt_handle == nullptr) {
+    int status = ensure_mla_lt_initialized();
+    if (status != static_cast<int>(cudaSuccess)) {
+      return status;
+    }
+  }
+  MlaLtPlan* plan = find_mla_lt_plan(g_v_up_plans, batch_size);
+  if (plan == nullptr) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+
+  const DType* w_uv = kv_b_proj + static_cast<int64_t>(kNopeDim) * kKvLoraRank;
+  const float alpha = 1.0f;
+  const float beta = 0.0f;
+  cublasStatus_t status = cublasLtMatmul(g_mla_lt_handle,
+                                         plan->op,
+                                         &alpha,
+                                         w_uv,
+                                         plan->a,
+                                         latent,
+                                         plan->b,
+                                         &beta,
+                                         output,
+                                         plan->c,
+                                         output,
+                                         plan->d,
+                                         &plan->algo,
+                                         nullptr,
+                                         0,
+                                         stream);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    return cublas_status_to_error(status);
+  }
+  return static_cast<int>(cudaPeekAtLastError());
+}
+
+}  // namespace
+
+extern "C" {
+
+int kimi_mla_cublaslt_init_cuda() {
+  return ensure_mla_lt_initialized();
+}
+
+void kimi_mla_cublaslt_destroy_cuda() {
+  for (int i = 0; i < kMlaLtMaxBatch; ++i) {
+    destroy_mla_lt_plan(g_absorb_q_nope_plans[i]);
+    destroy_mla_lt_plan(g_v_up_plans[i]);
+  }
+  if (g_mla_lt_handle != nullptr) {
+    cublasLtDestroy(g_mla_lt_handle);
+    g_mla_lt_handle = nullptr;
+  }
+}
+
+int kimi_mla_absorb_q_nope_cublaslt_cuda(const DType* kv_b_proj,
+                                         const DType* q_nope,
+                                         DType* q_abs_nope,
+                                         int batch_size,
+                                         int local_heads,
+                                         cudaStream_t stream) {
+  if (local_heads != kMlaLtLocalHeads) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+  return run_absorb_q_nope(kv_b_proj, q_nope, q_abs_nope, batch_size, stream);
+}
+
+int kimi_mla_v_up_cublaslt_cuda(const DType* kv_b_proj,
+                                const DType* latent,
+                                DType* output,
+                                int batch_size,
+                                int local_heads,
+                                cudaStream_t stream) {
+  if (local_heads != kMlaLtLocalHeads) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+  return run_v_up(kv_b_proj, latent, output, batch_size, stream);
+}
+
+}  // extern "C"

--- a/pegainfer-kernels/csrc/kimi_k2/kimi_o_proj.cu
+++ b/pegainfer-kernels/csrc/kimi_k2/kimi_o_proj.cu
@@ -1,0 +1,206 @@
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cublasLt.h>
+
+#include <cstddef>
+#include <cstdint>
+
+static constexpr int CUBLAS_STATUS_ERROR_OFFSET = 100000;
+static constexpr int KIMI_O_PROJ_M = 7168;
+static constexpr int KIMI_O_PROJ_K = 8192;
+static constexpr int KIMI_O_PROJ_MAX_BATCH = 64;
+
+static int cublas_status_to_error(cublasStatus_t status) {
+  if (status == CUBLAS_STATUS_SUCCESS) {
+    return static_cast<int>(cudaSuccess);
+  }
+  return CUBLAS_STATUS_ERROR_OFFSET + static_cast<int>(status);
+}
+
+struct KimiOProjLtPlan {
+  int batch_size = 0;
+  cublasLtMatmulDesc_t op = nullptr;
+  cublasLtMatrixLayout_t a = nullptr;
+  cublasLtMatrixLayout_t b = nullptr;
+  cublasLtMatrixLayout_t c = nullptr;
+  cublasLtMatrixLayout_t d = nullptr;
+  cublasLtMatmulAlgo_t algo{};
+  bool ready = false;
+};
+
+thread_local cublasLtHandle_t g_kimi_o_proj_lt = nullptr;
+thread_local KimiOProjLtPlan g_kimi_o_proj_plans[KIMI_O_PROJ_MAX_BATCH];
+
+static void destroy_plan(KimiOProjLtPlan &plan) {
+  if (plan.d != nullptr) {
+    cublasLtMatrixLayoutDestroy(plan.d);
+  }
+  if (plan.c != nullptr) {
+    cublasLtMatrixLayoutDestroy(plan.c);
+  }
+  if (plan.b != nullptr) {
+    cublasLtMatrixLayoutDestroy(plan.b);
+  }
+  if (plan.a != nullptr) {
+    cublasLtMatrixLayoutDestroy(plan.a);
+  }
+  if (plan.op != nullptr) {
+    cublasLtMatmulDescDestroy(plan.op);
+  }
+  plan = KimiOProjLtPlan{};
+}
+
+static int build_plan(cublasLtHandle_t handle, KimiOProjLtPlan &plan, int batch_size) {
+  destroy_plan(plan);
+  plan.batch_size = batch_size;
+
+  const cublasOperation_t transa = CUBLAS_OP_T;
+  const cublasOperation_t transb = CUBLAS_OP_N;
+  cublasStatus_t status =
+      cublasLtMatmulDescCreate(&plan.op, CUBLAS_COMPUTE_32F, CUDA_R_32F);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_plan(plan);
+    return cublas_status_to_error(status);
+  }
+  status = cublasLtMatmulDescSetAttribute(plan.op, CUBLASLT_MATMUL_DESC_TRANSA,
+                                          &transa, sizeof(transa));
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_plan(plan);
+    return cublas_status_to_error(status);
+  }
+  status = cublasLtMatmulDescSetAttribute(plan.op, CUBLASLT_MATMUL_DESC_TRANSB,
+                                          &transb, sizeof(transb));
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_plan(plan);
+    return cublas_status_to_error(status);
+  }
+
+  status = cublasLtMatrixLayoutCreate(&plan.a, CUDA_R_16BF, KIMI_O_PROJ_K,
+                                      KIMI_O_PROJ_M, KIMI_O_PROJ_K);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_plan(plan);
+    return cublas_status_to_error(status);
+  }
+  status = cublasLtMatrixLayoutCreate(&plan.b, CUDA_R_16BF, KIMI_O_PROJ_K,
+                                      batch_size, KIMI_O_PROJ_K);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_plan(plan);
+    return cublas_status_to_error(status);
+  }
+  status = cublasLtMatrixLayoutCreate(&plan.c, CUDA_R_16BF, KIMI_O_PROJ_M,
+                                      batch_size, KIMI_O_PROJ_M);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_plan(plan);
+    return cublas_status_to_error(status);
+  }
+  status = cublasLtMatrixLayoutCreate(&plan.d, CUDA_R_16BF, KIMI_O_PROJ_M,
+                                      batch_size, KIMI_O_PROJ_M);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_plan(plan);
+    return cublas_status_to_error(status);
+  }
+
+  cublasLtMatmulPreference_t preference = nullptr;
+  status = cublasLtMatmulPreferenceCreate(&preference);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_plan(plan);
+    return cublas_status_to_error(status);
+  }
+  std::size_t workspace_bytes = 0;
+  status = cublasLtMatmulPreferenceSetAttribute(
+      preference, CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &workspace_bytes,
+      sizeof(workspace_bytes));
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    cublasLtMatmulPreferenceDestroy(preference);
+    destroy_plan(plan);
+    return cublas_status_to_error(status);
+  }
+
+  cublasLtMatmulHeuristicResult_t heuristic = {};
+  int returned = 0;
+  status = cublasLtMatmulAlgoGetHeuristic(handle, plan.op, plan.a, plan.b, plan.c, plan.d,
+                                          preference, 1, &heuristic, &returned);
+  cublasLtMatmulPreferenceDestroy(preference);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_plan(plan);
+    return cublas_status_to_error(status);
+  }
+  if (returned != 1) {
+    destroy_plan(plan);
+    return cublas_status_to_error(CUBLAS_STATUS_NOT_SUPPORTED);
+  }
+
+  plan.algo = heuristic.algo;
+  plan.ready = true;
+  return static_cast<int>(cudaSuccess);
+}
+
+static KimiOProjLtPlan *find_plan(int batch_size) {
+  if (batch_size < 1 || batch_size > KIMI_O_PROJ_MAX_BATCH) {
+    return nullptr;
+  }
+  KimiOProjLtPlan &plan = g_kimi_o_proj_plans[batch_size - 1];
+  if (plan.ready && plan.batch_size == batch_size) {
+    return &plan;
+  }
+  return nullptr;
+}
+
+extern "C" {
+
+int kimi_o_proj_cublaslt_init_cuda() {
+  if (g_kimi_o_proj_lt == nullptr) {
+    cublasStatus_t status = cublasLtCreate(&g_kimi_o_proj_lt);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+      return cublas_status_to_error(status);
+    }
+  }
+  for (int batch_size = 1; batch_size <= KIMI_O_PROJ_MAX_BATCH; ++batch_size) {
+    int status = build_plan(g_kimi_o_proj_lt, g_kimi_o_proj_plans[batch_size - 1],
+                            batch_size);
+    if (status != static_cast<int>(cudaSuccess)) {
+      return status;
+    }
+  }
+  return static_cast<int>(cudaSuccess);
+}
+
+void kimi_o_proj_cublaslt_destroy_cuda() {
+  for (int i = 0; i < KIMI_O_PROJ_MAX_BATCH; ++i) {
+    destroy_plan(g_kimi_o_proj_plans[i]);
+  }
+  if (g_kimi_o_proj_lt != nullptr) {
+    cublasLtDestroy(g_kimi_o_proj_lt);
+    g_kimi_o_proj_lt = nullptr;
+  }
+}
+
+int kimi_o_proj_cublaslt_cuda(const __nv_bfloat16 *W, const __nv_bfloat16 *X,
+                              __nv_bfloat16 *Y, int M, int batch_size, int K,
+                              cudaStream_t stream) {
+  if (W == nullptr || X == nullptr || Y == nullptr) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+  if (M != KIMI_O_PROJ_M || K != KIMI_O_PROJ_K) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+  if (g_kimi_o_proj_lt == nullptr) {
+    return static_cast<int>(cudaErrorInvalidResourceHandle);
+  }
+  KimiOProjLtPlan *plan = find_plan(batch_size);
+  if (plan == nullptr) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+
+  const float alpha = 1.0f;
+  const float beta = 0.0f;
+  cublasStatus_t status =
+      cublasLtMatmul(g_kimi_o_proj_lt, plan->op, &alpha, W, plan->a, X, plan->b,
+                     &beta, Y, plan->c, Y, plan->d, &plan->algo, nullptr, 0, stream);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    return cublas_status_to_error(status);
+  }
+  return static_cast<int>(cudaPeekAtLastError());
+}
+
+} // extern "C"

--- a/pegainfer-kernels/csrc/kimi_k2/kimi_router.cu
+++ b/pegainfer-kernels/csrc/kimi_k2/kimi_router.cu
@@ -90,6 +90,85 @@ __global__ void router_topk_normalize_kernel(const float *__restrict__ scores,
   }
 }
 
+__global__ void router_scores_topk_normalize_kernel(
+    const float *__restrict__ logits,
+    const float *__restrict__ e_score_correction_bias,
+    float *__restrict__ scores_out,
+    float *__restrict__ choice_scores_out,
+    float *__restrict__ topk_weight,
+    int *__restrict__ topk_idx,
+    int active_tokens,
+    int padded_tokens,
+    int n_experts,
+    int topk,
+    float route_scale) {
+  int token = blockIdx.x;
+  int tid = threadIdx.x;
+  if (token >= padded_tokens) return;
+
+  extern __shared__ char shared[];
+  float *scores = reinterpret_cast<float *>(shared);
+  float *choice_scores = scores + blockDim.x;
+  float *reduce_values = choice_scores + blockDim.x;
+  int *reduce_indices = reinterpret_cast<int *>(reduce_values + blockDim.x);
+  float *selected_scores = reinterpret_cast<float *>(reduce_indices + blockDim.x);
+
+  const int row_base = token * n_experts;
+  const int expert = tid;
+  if (expert < n_experts) {
+    float score = 1.0f / (1.0f + expf(-logits[row_base + expert]));
+    scores[tid] = score;
+    choice_scores[tid] = score + e_score_correction_bias[expert];
+    scores_out[row_base + expert] = scores[tid];
+    choice_scores_out[row_base + expert] = choice_scores[tid];
+  } else {
+    scores[tid] = 0.0f;
+    choice_scores[tid] = -CUDART_INF_F;
+  }
+  if (token >= active_tokens) return;
+  __syncthreads();
+
+  float selected_sum = 0.0f;
+  for (int route = 0; route < topk; ++route) {
+    reduce_values[tid] = choice_scores[tid];
+    reduce_indices[tid] = expert < n_experts ? expert : n_experts;
+    __syncthreads();
+
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+      if (tid < stride) {
+        const float other_value = reduce_values[tid + stride];
+        const int other_idx = reduce_indices[tid + stride];
+        if (better_router_choice(other_value, other_idx, reduce_values[tid], reduce_indices[tid])) {
+          reduce_values[tid] = other_value;
+          reduce_indices[tid] = other_idx;
+        }
+      }
+      __syncthreads();
+    }
+
+    if (tid == 0) {
+      const int best_idx = reduce_indices[0];
+      const float route_score = best_idx < n_experts ? scores[best_idx] : 0.0f;
+      selected_scores[route] = route_score;
+      topk_idx[token * topk + route] = best_idx;
+      topk_weight[token * topk + route] = route_score;
+      selected_sum += route_score;
+      if (best_idx < n_experts) {
+        choice_scores[best_idx] = -CUDART_INF_F;
+        choice_scores_out[row_base + best_idx] = -CUDART_INF_F;
+      }
+    }
+    __syncthreads();
+  }
+
+  if (tid == 0) {
+    const float scale = selected_sum > 0.0f ? route_scale / selected_sum : 0.0f;
+    for (int route = 0; route < topk; ++route) {
+      topk_weight[token * topk + route] = selected_scores[route] * scale;
+    }
+  }
+}
+
 CUresult map_cuda_error(cudaError_t err) {
   if (err == cudaSuccess) return CUDA_SUCCESS;
   if (err == cudaErrorInvalidValue || err == cudaErrorInvalidDevicePointer) {
@@ -216,18 +295,12 @@ CUresult kimi_k2_router_noaux_tc_cuda(
       hidden, gate_weight, logits, padded_tokens, hidden_dim, n_experts, stream);
   if (result != CUDA_SUCCESS) return result;
 
-  int total_scores = padded_tokens * n_experts;
-  int blocks = (total_scores + kRouterThreads - 1) / kRouterThreads;
-  router_scores_kernel<<<blocks, kRouterThreads, 0, stream>>>(
-      logits, e_score_correction_bias, scores, choice_scores, total_scores, n_experts);
-  result = consume_last_cuda_error();
-  if (result != CUDA_SUCCESS) return result;
-
   size_t select_smem =
-      static_cast<size_t>(kRouterSelectThreads) * (sizeof(float) + sizeof(int)) +
+      static_cast<size_t>(kRouterSelectThreads) * (3 * sizeof(float) + sizeof(int)) +
       static_cast<size_t>(topk) * sizeof(float);
-  router_topk_normalize_kernel<<<active_tokens, kRouterSelectThreads, select_smem, stream>>>(
-      scores, choice_scores, topk_weight, topk_idx, active_tokens, n_experts, topk, route_scale);
+  router_scores_topk_normalize_kernel<<<padded_tokens, kRouterSelectThreads, select_smem, stream>>>(
+      logits, e_score_correction_bias, scores, choice_scores, topk_weight, topk_idx, active_tokens,
+      padded_tokens, n_experts, topk, route_scale);
   result = consume_last_cuda_error();
   if (result != CUDA_SUCCESS) return result;
 

--- a/pegainfer-kernels/csrc/kimi_k2/kimi_shared_gate_up.cu
+++ b/pegainfer-kernels/csrc/kimi_k2/kimi_shared_gate_up.cu
@@ -1,0 +1,206 @@
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cublasLt.h>
+
+#include <cstddef>
+#include <cstdint>
+
+static constexpr int CUBLAS_STATUS_ERROR_OFFSET = 100000;
+static constexpr int KIMI_SHARED_GATE_UP_M = 4096;
+static constexpr int KIMI_SHARED_GATE_UP_K = 7168;
+static constexpr int KIMI_SHARED_GATE_UP_MAX_BATCH = 64;
+
+static int cublas_status_to_error(cublasStatus_t status) {
+  if (status == CUBLAS_STATUS_SUCCESS) {
+    return static_cast<int>(cudaSuccess);
+  }
+  return CUBLAS_STATUS_ERROR_OFFSET + static_cast<int>(status);
+}
+
+struct KimiSharedGateUpLtPlan {
+  int batch_size = 0;
+  cublasLtMatmulDesc_t op = nullptr;
+  cublasLtMatrixLayout_t a = nullptr;
+  cublasLtMatrixLayout_t b = nullptr;
+  cublasLtMatrixLayout_t c = nullptr;
+  cublasLtMatrixLayout_t d = nullptr;
+  cublasLtMatmulAlgo_t algo{};
+  bool ready = false;
+};
+
+thread_local cublasLtHandle_t g_kimi_shared_gate_up_lt = nullptr;
+thread_local KimiSharedGateUpLtPlan g_kimi_shared_gate_up_plans[KIMI_SHARED_GATE_UP_MAX_BATCH];
+
+static void destroy_plan(KimiSharedGateUpLtPlan &plan) {
+  if (plan.d != nullptr) {
+    cublasLtMatrixLayoutDestroy(plan.d);
+  }
+  if (plan.c != nullptr) {
+    cublasLtMatrixLayoutDestroy(plan.c);
+  }
+  if (plan.b != nullptr) {
+    cublasLtMatrixLayoutDestroy(plan.b);
+  }
+  if (plan.a != nullptr) {
+    cublasLtMatrixLayoutDestroy(plan.a);
+  }
+  if (plan.op != nullptr) {
+    cublasLtMatmulDescDestroy(plan.op);
+  }
+  plan = KimiSharedGateUpLtPlan{};
+}
+
+static int build_plan(cublasLtHandle_t handle, KimiSharedGateUpLtPlan &plan, int batch_size) {
+  destroy_plan(plan);
+  plan.batch_size = batch_size;
+
+  const cublasOperation_t transa = CUBLAS_OP_T;
+  const cublasOperation_t transb = CUBLAS_OP_N;
+  cublasStatus_t status =
+      cublasLtMatmulDescCreate(&plan.op, CUBLAS_COMPUTE_32F, CUDA_R_32F);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_plan(plan);
+    return cublas_status_to_error(status);
+  }
+  status = cublasLtMatmulDescSetAttribute(plan.op, CUBLASLT_MATMUL_DESC_TRANSA,
+                                          &transa, sizeof(transa));
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_plan(plan);
+    return cublas_status_to_error(status);
+  }
+  status = cublasLtMatmulDescSetAttribute(plan.op, CUBLASLT_MATMUL_DESC_TRANSB,
+                                          &transb, sizeof(transb));
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_plan(plan);
+    return cublas_status_to_error(status);
+  }
+
+  status = cublasLtMatrixLayoutCreate(&plan.a, CUDA_R_16BF, KIMI_SHARED_GATE_UP_K,
+                                      KIMI_SHARED_GATE_UP_M, KIMI_SHARED_GATE_UP_K);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_plan(plan);
+    return cublas_status_to_error(status);
+  }
+  status = cublasLtMatrixLayoutCreate(&plan.b, CUDA_R_16BF, KIMI_SHARED_GATE_UP_K, batch_size,
+                                      KIMI_SHARED_GATE_UP_K);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_plan(plan);
+    return cublas_status_to_error(status);
+  }
+  status = cublasLtMatrixLayoutCreate(&plan.c, CUDA_R_16BF, KIMI_SHARED_GATE_UP_M, batch_size,
+                                      KIMI_SHARED_GATE_UP_M);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_plan(plan);
+    return cublas_status_to_error(status);
+  }
+  status = cublasLtMatrixLayoutCreate(&plan.d, CUDA_R_16BF, KIMI_SHARED_GATE_UP_M, batch_size,
+                                      KIMI_SHARED_GATE_UP_M);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_plan(plan);
+    return cublas_status_to_error(status);
+  }
+
+  cublasLtMatmulPreference_t preference = nullptr;
+  status = cublasLtMatmulPreferenceCreate(&preference);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_plan(plan);
+    return cublas_status_to_error(status);
+  }
+  std::size_t workspace_bytes = 0;
+  status = cublasLtMatmulPreferenceSetAttribute(
+      preference, CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &workspace_bytes,
+      sizeof(workspace_bytes));
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    cublasLtMatmulPreferenceDestroy(preference);
+    destroy_plan(plan);
+    return cublas_status_to_error(status);
+  }
+
+  cublasLtMatmulHeuristicResult_t heuristic = {};
+  int returned = 0;
+  status = cublasLtMatmulAlgoGetHeuristic(handle, plan.op, plan.a, plan.b, plan.c, plan.d,
+                                          preference, 1, &heuristic, &returned);
+  cublasLtMatmulPreferenceDestroy(preference);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    destroy_plan(plan);
+    return cublas_status_to_error(status);
+  }
+  if (returned != 1) {
+    destroy_plan(plan);
+    return cublas_status_to_error(CUBLAS_STATUS_NOT_SUPPORTED);
+  }
+
+  plan.algo = heuristic.algo;
+  plan.ready = true;
+  return static_cast<int>(cudaSuccess);
+}
+
+static KimiSharedGateUpLtPlan *find_plan(int batch_size) {
+  if (batch_size < 1 || batch_size > KIMI_SHARED_GATE_UP_MAX_BATCH) {
+    return nullptr;
+  }
+  KimiSharedGateUpLtPlan &plan = g_kimi_shared_gate_up_plans[batch_size - 1];
+  if (plan.ready && plan.batch_size == batch_size) {
+    return &plan;
+  }
+  return nullptr;
+}
+
+extern "C" {
+
+int kimi_shared_gate_up_cublaslt_init_cuda() {
+  if (g_kimi_shared_gate_up_lt == nullptr) {
+    cublasStatus_t status = cublasLtCreate(&g_kimi_shared_gate_up_lt);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+      return cublas_status_to_error(status);
+    }
+  }
+  for (int batch_size = 1; batch_size <= KIMI_SHARED_GATE_UP_MAX_BATCH; ++batch_size) {
+    int status = build_plan(g_kimi_shared_gate_up_lt,
+                            g_kimi_shared_gate_up_plans[batch_size - 1], batch_size);
+    if (status != static_cast<int>(cudaSuccess)) {
+      return status;
+    }
+  }
+  return static_cast<int>(cudaSuccess);
+}
+
+void kimi_shared_gate_up_cublaslt_destroy_cuda() {
+  for (int i = 0; i < KIMI_SHARED_GATE_UP_MAX_BATCH; ++i) {
+    destroy_plan(g_kimi_shared_gate_up_plans[i]);
+  }
+  if (g_kimi_shared_gate_up_lt != nullptr) {
+    cublasLtDestroy(g_kimi_shared_gate_up_lt);
+    g_kimi_shared_gate_up_lt = nullptr;
+  }
+}
+
+int kimi_shared_gate_up_cublaslt_cuda(const __nv_bfloat16 *W, const __nv_bfloat16 *X,
+                                      __nv_bfloat16 *Y, int M, int batch_size, int K,
+                                      cudaStream_t stream) {
+  if (W == nullptr || X == nullptr || Y == nullptr) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+  if (M != KIMI_SHARED_GATE_UP_M || K != KIMI_SHARED_GATE_UP_K) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+  if (g_kimi_shared_gate_up_lt == nullptr) {
+    return static_cast<int>(cudaErrorInvalidResourceHandle);
+  }
+  KimiSharedGateUpLtPlan *plan = find_plan(batch_size);
+  if (plan == nullptr) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+
+  const float alpha = 1.0f;
+  const float beta = 0.0f;
+  cublasStatus_t status =
+      cublasLtMatmul(g_kimi_shared_gate_up_lt, plan->op, &alpha, W, plan->a, X, plan->b,
+                     &beta, Y, plan->c, Y, plan->d, &plan->algo, nullptr, 0, stream);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    return cublas_status_to_error(status);
+  }
+  return static_cast<int>(cudaPeekAtLastError());
+}
+
+} // extern "C"

--- a/pegainfer-kernels/src/ffi.rs
+++ b/pegainfer-kernels/src/ffi.rs
@@ -245,6 +245,10 @@ unsafe extern "C" {
         stream: CUstream,
     ) -> i32;
 
+    pub fn kimi_mla_cublaslt_init_cuda() -> i32;
+
+    pub fn kimi_mla_cublaslt_destroy_cuda();
+
     pub fn kimi_int4_expert_metadata_probe_cuda(
         weight_shape: *const i32,
         weight_shape_entries: usize,

--- a/pegainfer-kernels/src/ffi.rs
+++ b/pegainfer-kernels/src/ffi.rs
@@ -152,6 +152,17 @@ unsafe extern "C" {
         stream: CUstream,
     );
 
+    pub fn argmax_batch_bf16_split_cuda(
+        x: *const Half,
+        values: *mut Half,
+        indices: *mut i32,
+        partial_values: *mut f32,
+        partial_indices: *mut i32,
+        rows: i32,
+        n: i32,
+        stream: CUstream,
+    );
+
     pub fn flashinfer_top1_cuda(
         logits: *const Half,
         top1_value_scratch: *mut Half,

--- a/pegainfer-kernels/src/ffi.rs
+++ b/pegainfer-kernels/src/ffi.rs
@@ -231,6 +231,20 @@ unsafe extern "C" {
         stream: CUstream,
     ) -> i32;
 
+    pub fn kimi_o_proj_cublaslt_init_cuda() -> i32;
+
+    pub fn kimi_o_proj_cublaslt_destroy_cuda();
+
+    pub fn kimi_o_proj_cublaslt_cuda(
+        W: *const Half,
+        X: *const Half,
+        Y: *mut Half,
+        M: i32,
+        N: i32,
+        K: i32,
+        stream: CUstream,
+    ) -> i32;
+
     pub fn kimi_int4_expert_metadata_probe_cuda(
         weight_shape: *const i32,
         weight_shape_entries: usize,

--- a/pegainfer-kernels/src/ffi.rs
+++ b/pegainfer-kernels/src/ffi.rs
@@ -217,6 +217,20 @@ unsafe extern "C" {
 
 #[cfg(feature = "kimi-k2")]
 unsafe extern "C" {
+    pub fn kimi_shared_gate_up_cublaslt_init_cuda() -> i32;
+
+    pub fn kimi_shared_gate_up_cublaslt_destroy_cuda();
+
+    pub fn kimi_shared_gate_up_cublaslt_cuda(
+        W: *const Half,
+        X: *const Half,
+        Y: *mut Half,
+        M: i32,
+        N: i32,
+        K: i32,
+        stream: CUstream,
+    ) -> i32;
+
     pub fn kimi_int4_expert_metadata_probe_cuda(
         weight_shape: *const i32,
         weight_shape_entries: usize,

--- a/pegainfer-kernels/src/ops.rs
+++ b/pegainfer-kernels/src/ops.rs
@@ -33,6 +33,7 @@ pub use norm::{
     rms_norm_into, rms_norm_offset_into,
 };
 pub use sampling::{
-    argmax, argmax_batch_bf16_into, flashinfer_top1_batch_into, flashinfer_topk_row_states_bytes,
-    gpu_sample, gpu_sample_into,
+    argmax, argmax_batch_bf16_into, argmax_batch_bf16_split_into,
+    argmax_batch_bf16_split_partials_len, flashinfer_top1_batch_into,
+    flashinfer_topk_row_states_bytes, gpu_sample, gpu_sample_into,
 };

--- a/pegainfer-kernels/src/ops.rs
+++ b/pegainfer-kernels/src/ops.rs
@@ -33,7 +33,6 @@ pub use norm::{
     rms_norm_into, rms_norm_offset_into,
 };
 pub use sampling::{
-    argmax, argmax_batch_bf16_into, argmax_batch_bf16_split_into,
-    argmax_batch_bf16_split_partials_len, flashinfer_top1_batch_into,
-    flashinfer_topk_row_states_bytes, gpu_sample, gpu_sample_into,
+    argmax, argmax_batch_bf16_into, argmax_batch_bf16_split_partials_len,
+    flashinfer_top1_batch_into, flashinfer_topk_row_states_bytes, gpu_sample, gpu_sample_into,
 };

--- a/pegainfer-kernels/src/ops/kimi_k2.rs
+++ b/pegainfer-kernels/src/ops/kimi_k2.rs
@@ -1,11 +1,13 @@
 mod experts;
 mod mla;
 mod mla_rt;
+mod o_proj;
 mod router;
 mod shared_gate_up;
 
 pub use experts::*;
 pub use mla::*;
 pub use mla_rt::*;
+pub use o_proj::*;
 pub use router::*;
 pub use shared_gate_up::*;

--- a/pegainfer-kernels/src/ops/kimi_k2.rs
+++ b/pegainfer-kernels/src/ops/kimi_k2.rs
@@ -2,8 +2,10 @@ mod experts;
 mod mla;
 mod mla_rt;
 mod router;
+mod shared_gate_up;
 
 pub use experts::*;
 pub use mla::*;
 pub use mla_rt::*;
 pub use router::*;
+pub use shared_gate_up::*;

--- a/pegainfer-kernels/src/ops/kimi_k2/experts.rs
+++ b/pegainfer-kernels/src/ops/kimi_k2/experts.rs
@@ -9,6 +9,7 @@ use crate::tensor::{AxisSpec, DeviceContext, GpuTensor, HiddenStates, KernelCall
 
 pub const KIMI_K2_HIDDEN: usize = 7168;
 pub const KIMI_K2_EXPERT_INTERMEDIATE: usize = 2048;
+pub const KIMI_K2_SHARED_GATE_UP: usize = 2 * KIMI_K2_EXPERT_INTERMEDIATE;
 pub const KIMI_K2_ROUTED_EXPERTS: usize = 384;
 pub const KIMI_K2_EP_WORLD: usize = 8;
 pub const KIMI_K2_LOCAL_EXPERTS: usize = KIMI_K2_ROUTED_EXPERTS / KIMI_K2_EP_WORLD;

--- a/pegainfer-kernels/src/ops/kimi_k2/o_proj.rs
+++ b/pegainfer-kernels/src/ops/kimi_k2/o_proj.rs
@@ -1,0 +1,80 @@
+use anyhow::{Result, bail, ensure};
+use cudarc::driver::{DevicePtr, DevicePtrMut};
+
+use crate::ffi;
+use crate::tensor::{DeviceContext, DeviceMatrix, GpuTensor, HiddenStates};
+
+use super::experts::KIMI_K2_HIDDEN;
+use super::mla::KIMI_K2_MLA_V_HEAD_DIM;
+
+pub const KIMI_O_PROJ_CUBLASLT_INPUT: usize = 64 * KIMI_K2_MLA_V_HEAD_DIM;
+const KIMI_O_PROJ_CUBLASLT_MAX_BATCH: usize = 64;
+
+pub fn kimi_o_proj_cublaslt_supports_batch_size(batch_size: usize) -> bool {
+    (1..=KIMI_O_PROJ_CUBLASLT_MAX_BATCH).contains(&batch_size)
+}
+
+pub fn kimi_o_proj_cublaslt_into(
+    ctx: &DeviceContext,
+    weight: &DeviceMatrix,
+    x: &HiddenStates,
+    out: &mut GpuTensor<KIMI_K2_HIDDEN>,
+) -> Result<()> {
+    let batch_size = x.seq_len;
+    ensure!(
+        weight.rows == KIMI_K2_HIDDEN && weight.cols == KIMI_O_PROJ_CUBLASLT_INPUT,
+        "Kimi o_proj cuBLASLt weight shape mismatch: got [{},{}], expected [{},{}]",
+        weight.rows,
+        weight.cols,
+        KIMI_K2_HIDDEN,
+        KIMI_O_PROJ_CUBLASLT_INPUT
+    );
+    ensure!(
+        x.hidden_dim == KIMI_O_PROJ_CUBLASLT_INPUT,
+        "Kimi o_proj cuBLASLt input hidden mismatch: got {}, expected {}",
+        x.hidden_dim,
+        KIMI_O_PROJ_CUBLASLT_INPUT
+    );
+    ensure!(
+        out.seq_len == batch_size,
+        "Kimi o_proj cuBLASLt output batch mismatch: out={}, input={}",
+        out.seq_len,
+        batch_size
+    );
+    ensure!(
+        kimi_o_proj_cublaslt_supports_batch_size(batch_size),
+        "Kimi o_proj cuBLASLt supports batch_size 1..={}; got {}",
+        KIMI_O_PROJ_CUBLASLT_MAX_BATCH,
+        batch_size
+    );
+
+    let (w_ptr, _gw) = weight.data.device_ptr(&ctx.stream);
+    let (x_ptr, _gx) = x.data.device_ptr(&ctx.stream);
+    let (y_ptr, _gy) = out.data.device_ptr_mut(&ctx.stream);
+    unsafe {
+        let status = ffi::kimi_o_proj_cublaslt_cuda(
+            w_ptr as *const ffi::Half,
+            x_ptr as *const ffi::Half,
+            y_ptr as *mut ffi::Half,
+            KIMI_K2_HIDDEN as i32,
+            batch_size as i32,
+            KIMI_O_PROJ_CUBLASLT_INPUT as i32,
+            ctx.stream.cu_stream(),
+        );
+        if status != 0 {
+            if status >= 100_000 {
+                bail!(
+                    "Kimi o_proj cuBLASLt failed: cublas_status={}, batch_size={}",
+                    status - 100_000,
+                    batch_size
+                );
+            }
+            bail!(
+                "Kimi o_proj cuBLASLt launch failed: cuda_status={}, batch_size={}",
+                status,
+                batch_size
+            );
+        }
+    }
+    Ok(())
+}

--- a/pegainfer-kernels/src/ops/kimi_k2/shared_gate_up.rs
+++ b/pegainfer-kernels/src/ops/kimi_k2/shared_gate_up.rs
@@ -1,0 +1,73 @@
+use anyhow::{Result, bail, ensure};
+use cudarc::driver::{DevicePtr, DevicePtrMut};
+
+use crate::ffi;
+use crate::tensor::{DeviceContext, DeviceMatrix, GpuTensor, HiddenStates};
+
+use super::experts::{KIMI_K2_HIDDEN, KIMI_K2_SHARED_GATE_UP};
+
+const KIMI_SHARED_GATE_UP_CUBLASLT_MAX_BATCH: usize = 64;
+
+pub fn kimi_shared_gate_up_cublaslt_supports_batch_size(batch_size: usize) -> bool {
+    (1..=KIMI_SHARED_GATE_UP_CUBLASLT_MAX_BATCH).contains(&batch_size)
+}
+
+pub fn kimi_shared_gate_up_cublaslt_into(
+    ctx: &DeviceContext,
+    weight: &DeviceMatrix,
+    x: &GpuTensor<KIMI_K2_HIDDEN>,
+    out: &mut HiddenStates,
+) -> Result<()> {
+    let batch_size = x.seq_len;
+    ensure!(
+        weight.rows == KIMI_K2_SHARED_GATE_UP && weight.cols == KIMI_K2_HIDDEN,
+        "Kimi shared_gate_up cuBLASLt weight shape mismatch: got [{},{}], expected [{},{}]",
+        weight.rows,
+        weight.cols,
+        KIMI_K2_SHARED_GATE_UP,
+        KIMI_K2_HIDDEN
+    );
+    ensure!(
+        out.hidden_dim == KIMI_K2_SHARED_GATE_UP && out.seq_len == batch_size,
+        "Kimi shared_gate_up cuBLASLt output shape mismatch: out=[{},{}], batch_size={}",
+        out.hidden_dim,
+        out.seq_len,
+        batch_size
+    );
+    ensure!(
+        kimi_shared_gate_up_cublaslt_supports_batch_size(batch_size),
+        "Kimi shared_gate_up cuBLASLt supports batch_size 1..={}; got {}",
+        KIMI_SHARED_GATE_UP_CUBLASLT_MAX_BATCH,
+        batch_size
+    );
+
+    let (w_ptr, _gw) = weight.data.device_ptr(&ctx.stream);
+    let (x_ptr, _gx) = x.data.device_ptr(&ctx.stream);
+    let (y_ptr, _gy) = out.data.device_ptr_mut(&ctx.stream);
+    unsafe {
+        let status = ffi::kimi_shared_gate_up_cublaslt_cuda(
+            w_ptr as *const ffi::Half,
+            x_ptr as *const ffi::Half,
+            y_ptr as *mut ffi::Half,
+            KIMI_K2_SHARED_GATE_UP as i32,
+            batch_size as i32,
+            KIMI_K2_HIDDEN as i32,
+            ctx.stream.cu_stream(),
+        );
+        if status != 0 {
+            if status >= 100_000 {
+                bail!(
+                    "Kimi shared_gate_up cuBLASLt failed: cublas_status={}, batch_size={}",
+                    status - 100_000,
+                    batch_size
+                );
+            }
+            bail!(
+                "Kimi shared_gate_up cuBLASLt launch failed: cuda_status={}, batch_size={}",
+                status,
+                batch_size
+            );
+        }
+    }
+    Ok(())
+}

--- a/pegainfer-kernels/src/ops/sampling.rs
+++ b/pegainfer-kernels/src/ops/sampling.rs
@@ -82,6 +82,69 @@ pub fn argmax_batch_bf16_into(
     Ok(())
 }
 
+pub fn argmax_batch_bf16_split_partials_len(rows: usize, vocab: usize) -> usize {
+    const TILE_ELEMS: usize = 4096;
+    rows * vocab.div_ceil(TILE_ELEMS)
+}
+
+pub fn argmax_batch_bf16_split_into(
+    ctx: &DeviceContext,
+    logits: &HiddenStates,
+    values: &mut CudaSlice<half::bf16>,
+    out: &mut CudaSlice<i32>,
+    partial_values: &mut CudaSlice<f32>,
+    partial_indices: &mut CudaSlice<i32>,
+) -> Result<()> {
+    let rows = logits.seq_len;
+    if rows == 0 {
+        return Err(anyhow!("split argmax batch requires at least one row"));
+    }
+    if values.len() < rows {
+        return Err(anyhow!(
+            "split argmax values scratch too small: have {}, need {}",
+            values.len(),
+            rows
+        ));
+    }
+    if out.len() < rows {
+        return Err(anyhow!(
+            "split argmax output too small: have {}, need {}",
+            out.len(),
+            rows
+        ));
+    }
+    let partials = argmax_batch_bf16_split_partials_len(rows, logits.hidden_dim);
+    if partial_values.len() < partials || partial_indices.len() < partials {
+        return Err(anyhow!(
+            "split argmax partial scratch too small: values={}, indices={}, need {}",
+            partial_values.len(),
+            partial_indices.len(),
+            partials
+        ));
+    }
+
+    let (logits_ptr, _gl) = logits.data.device_ptr(&ctx.stream);
+    let (values_ptr, _gv) = values.device_ptr_mut(&ctx.stream);
+    let (out_ptr, _go) = out.device_ptr_mut(&ctx.stream);
+    let (partial_values_ptr, _gpv) = partial_values.device_ptr_mut(&ctx.stream);
+    let (partial_indices_ptr, _gpi) = partial_indices.device_ptr_mut(&ctx.stream);
+
+    unsafe {
+        ffi::argmax_batch_bf16_split_cuda(
+            logits_ptr as *const ffi::Half,
+            values_ptr as *mut ffi::Half,
+            out_ptr as *mut i32,
+            partial_values_ptr as *mut f32,
+            partial_indices_ptr as *mut i32,
+            rows as i32,
+            logits.hidden_dim as i32,
+            ctx.stream.cu_stream(),
+        );
+    }
+
+    Ok(())
+}
+
 /// GPU sampling: temperature → softmax → top-k → top-p → multinomial.
 /// Allocates a temporary output buffer — use `gpu_sample_into` for the decode loop.
 pub fn gpu_sample(

--- a/pegainfer-kernels/src/ops/sampling.rs
+++ b/pegainfer-kernels/src/ops/sampling.rs
@@ -87,64 +87,6 @@ pub fn argmax_batch_bf16_split_partials_len(rows: usize, vocab: usize) -> usize 
     rows * vocab.div_ceil(TILE_ELEMS)
 }
 
-pub fn argmax_batch_bf16_split_into(
-    ctx: &DeviceContext,
-    logits: &HiddenStates,
-    values: &mut CudaSlice<half::bf16>,
-    out: &mut CudaSlice<i32>,
-    partial_values: &mut CudaSlice<f32>,
-    partial_indices: &mut CudaSlice<i32>,
-) -> Result<()> {
-    let rows = logits.seq_len;
-    if rows == 0 {
-        return Err(anyhow!("split argmax batch requires at least one row"));
-    }
-    if values.len() < rows {
-        return Err(anyhow!(
-            "split argmax values scratch too small: have {}, need {}",
-            values.len(),
-            rows
-        ));
-    }
-    if out.len() < rows {
-        return Err(anyhow!(
-            "split argmax output too small: have {}, need {}",
-            out.len(),
-            rows
-        ));
-    }
-    let partials = argmax_batch_bf16_split_partials_len(rows, logits.hidden_dim);
-    if partial_values.len() < partials || partial_indices.len() < partials {
-        return Err(anyhow!(
-            "split argmax partial scratch too small: values={}, indices={}, need {}",
-            partial_values.len(),
-            partial_indices.len(),
-            partials
-        ));
-    }
-
-    let (logits_ptr, _gl) = logits.data.device_ptr(&ctx.stream);
-    let (values_ptr, _gv) = values.device_ptr_mut(&ctx.stream);
-    let (out_ptr, _go) = out.device_ptr_mut(&ctx.stream);
-    let (partial_values_ptr, _gpv) = partial_values.device_ptr_mut(&ctx.stream);
-    let (partial_indices_ptr, _gpi) = partial_indices.device_ptr_mut(&ctx.stream);
-
-    unsafe {
-        ffi::argmax_batch_bf16_split_cuda(
-            logits_ptr as *const ffi::Half,
-            values_ptr as *mut ffi::Half,
-            out_ptr as *mut i32,
-            partial_values_ptr as *mut f32,
-            partial_indices_ptr as *mut i32,
-            rows as i32,
-            logits.hidden_dim as i32,
-            ctx.stream.cu_stream(),
-        );
-    }
-
-    Ok(())
-}
-
 /// GPU sampling: temperature → softmax → top-k → top-p → multinomial.
 /// Allocates a temporary output buffer — use `gpu_sample_into` for the decode loop.
 pub fn gpu_sample(

--- a/pegainfer-kimi-k2/src/runner/moe_pplx.rs
+++ b/pegainfer-kimi-k2/src/runner/moe_pplx.rs
@@ -27,13 +27,14 @@ use cudarc::nccl::safe::Comm;
 use pegainfer_comm::{EpBackend, ScalarType};
 use pegainfer_kernels::{
     ops::{
-        KIMI_K2_EP_WORLD, KIMI_K2_LOCAL_EXPERTS, KIMI_K2_ROUTER_SCALE, KimiMarlinRouteWorkspace,
-        KimiMarlinWna16Workspace, KimiRouterBatch, KimiRouterConfig, KimiRouterOutput,
-        KimiRouterScratch, kimi_marlin_w13_swiglu, kimi_marlin_w13_swiglu_pplx,
+        KIMI_K2_EP_WORLD, KIMI_K2_LOCAL_EXPERTS, KIMI_K2_ROUTER_SCALE, KIMI_K2_SHARED_GATE_UP,
+        KimiMarlinRouteWorkspace, KimiMarlinWna16Workspace, KimiRouterBatch, KimiRouterConfig,
+        KimiRouterOutput, KimiRouterScratch, kimi_marlin_w13_swiglu, kimi_marlin_w13_swiglu_pplx,
         kimi_marlin_wna16_pplx_w2_gemm, kimi_marlin_wna16_pplx_w13_gemm, kimi_marlin_wna16_w2_gemm,
         kimi_marlin_wna16_w13_gemm, kimi_moe_marlin_align_block_size,
         kimi_pplx_build_marlin_routing_on_stream, kimi_residual_add_scaled_f32,
         kimi_router_noaux_tc_launch, kimi_scatter_marlin_routes_to_compact,
+        kimi_shared_gate_up_cublaslt_into, kimi_shared_gate_up_cublaslt_supports_batch_size,
     },
     tensor::{DeviceContext, GpuTensor, NormWeight},
     typed_ops,
@@ -150,7 +151,7 @@ pub(super) fn forward_moe_layer_decode_pplx_normed(
     scratch: &mut KimiWorkerDecodeScratch,
     pplx: &mut KimiMoePplxScratch,
 ) -> Result<()> {
-    let seq_len = scratch.mla.hidden.seq_len;
+    let batch_size = scratch.mla.hidden.seq_len;
     let stream_raw = ctx.stream.cu_stream() as u64;
     let use_tp8_dp1_duplicate_routes = comm.is_some()
         && ep.world_size() == KIMI_K2_EP_WORLD
@@ -190,9 +191,9 @@ pub(super) fn forward_moe_layer_decode_pplx_normed(
             aux_ctx,
             KimiRouterConfig::kimi_k2(),
             KimiRouterBatch {
-                batch_size: seq_len,
-                active_tokens: seq_len,
-                padded_tokens: seq_len,
+                batch_size,
+                active_tokens: batch_size,
+                padded_tokens: batch_size,
             },
             &scratch.mla.normed,
             &moe.router.gate_weight,
@@ -206,12 +207,23 @@ pub(super) fn forward_moe_layer_decode_pplx_normed(
         .record_event(None)
         .with_context(|| format!("Kimi MoE PPLX layer {layer_idx} record route_ready"))?;
 
-    typed_ops::gemm_dm_typed_to_hs_graphsafe(
-        ctx,
-        &moe.shared_gate_up_proj,
-        &scratch.mla.normed,
-        &mut scratch.shared_expert.gate_up,
-    )?;
+    if moe.shared_gate_up_proj.rows == KIMI_K2_SHARED_GATE_UP
+        && kimi_shared_gate_up_cublaslt_supports_batch_size(batch_size)
+    {
+        kimi_shared_gate_up_cublaslt_into(
+            ctx,
+            &moe.shared_gate_up_proj,
+            &scratch.mla.normed,
+            &mut scratch.shared_expert.gate_up,
+        )?;
+    } else {
+        typed_ops::gemm_dm_typed_to_hs_graphsafe(
+            ctx,
+            &moe.shared_gate_up_proj,
+            &scratch.mla.normed,
+            &mut scratch.shared_expert.gate_up,
+        )?;
+    }
     typed_ops::silu_mul_hs_fused_into(
         ctx,
         &scratch.shared_expert.gate_up,
@@ -242,7 +254,7 @@ pub(super) fn forward_moe_layer_decode_pplx_normed(
             .data
             .device_ptr(&ctx.stream);
         ep.dispatch_send_route_only(
-            seq_len,
+            batch_size,
             idx_ptr as *const i32,
             KIMI_K2_TOPK,
             w_ptr as *const f32,
@@ -261,7 +273,7 @@ pub(super) fn forward_moe_layer_decode_pplx_normed(
             .device_ptr(&ctx.stream);
         let x_stride = KIMI_K2_HIDDEN * std::mem::size_of::<u16>();
         ep.dispatch_send(
-            seq_len,
+            batch_size,
             x_ptr as *const c_void,
             x_stride,
             ptr::null(),
@@ -301,8 +313,8 @@ pub(super) fn forward_moe_layer_decode_pplx_normed(
             ctx,
             &mut scratch.marlin_route_workspace,
             &scratch.router.router_topk_idx.data,
-            seq_len,
-            seq_len,
+            batch_size,
+            batch_size,
             expert_kernels.local_expert_range.start,
         )
         .with_context(|| format!("pplx tp8 build NCCL-layout routing layer {layer_idx}"))?;
@@ -419,7 +431,7 @@ pub(super) fn forward_moe_layer_decode_pplx_normed(
         let (idx_ptr, _g1) = scratch.router.router_topk_idx.data.device_ptr(&ctx.stream);
         let (w_ptr, _g2) = pplx.pplx_dummy_topk_weight.device_ptr(&ctx.stream);
         ep.combine_recv(
-            seq_len,
+            batch_size,
             0,
             ScalarType::BF16,
             out_ptr as *mut c_void,

--- a/pegainfer-kimi-k2/src/runner/worker.rs
+++ b/pegainfer-kimi-k2/src/runner/worker.rs
@@ -21,12 +21,13 @@ use pegainfer_kernels::{
     ops::{
         KIMI_K2_LOCAL_EXPERTS, KIMI_K2_MLA_KV_A_OUT, KIMI_K2_MLA_KV_LORA_RANK,
         KIMI_K2_MLA_Q_HEAD_DIM, KIMI_K2_MLA_QKV_A_OUT, KIMI_K2_MLA_ROPE_DIM,
-        KIMI_K2_MLA_V_HEAD_DIM, KimiMarlinRouteWorkspace, KimiMarlinWna16Workspace,
-        KimiMlaPagedKvLayout, flashinfer_topk_row_states_bytes,
+        KIMI_K2_MLA_V_HEAD_DIM, KIMI_O_PROJ_CUBLASLT_INPUT, KimiMarlinRouteWorkspace,
+        KimiMarlinWna16Workspace, KimiMlaPagedKvLayout, flashinfer_topk_row_states_bytes,
         kimi_flashinfer_batch_decode_mla_rt, kimi_flashinfer_single_prefill_mla_rt,
         kimi_mla_absorb_q_nope_rt, kimi_mla_extract_prefill_v_rt, kimi_mla_paged_kv_append,
         kimi_mla_rope_apply_kpe, kimi_mla_rope_assemble_prefill_rt, kimi_mla_rope_split_decode_rt,
         kimi_mla_split_qkv_a, kimi_mla_split_qkv_a_norm, kimi_mla_v_up_rt,
+        kimi_o_proj_cublaslt_into, kimi_o_proj_cublaslt_supports_batch_size,
     },
     tensor::{
         DeviceContext, DeviceMatrix, DeviceVec, GpuTensor, GpuWeight, HiddenStates, NormWeight,
@@ -526,6 +527,7 @@ struct KimiCublasThreadGuard;
 impl Drop for KimiCublasThreadGuard {
     fn drop(&mut self) {
         unsafe {
+            pegainfer_kernels::ffi::kimi_o_proj_cublaslt_destroy_cuda();
             pegainfer_kernels::ffi::kimi_shared_gate_up_cublaslt_destroy_cuda();
             pegainfer_kernels::ffi::cublas_destroy();
         }
@@ -556,6 +558,18 @@ fn bind_rank_thread(
                 "Kimi shared_gate_up cuBLASLt init failed: cuda_status={}",
                 status
             );
+        }
+        if local_dims.o_proj_in == KIMI_O_PROJ_CUBLASLT_INPUT {
+            let status = pegainfer_kernels::ffi::kimi_o_proj_cublaslt_init_cuda();
+            if status != 0 {
+                if status >= 100_000 {
+                    anyhow::bail!(
+                        "Kimi o_proj cuBLASLt init failed: cublas_status={}",
+                        status - 100_000
+                    );
+                }
+                anyhow::bail!("Kimi o_proj cuBLASLt init failed: cuda_status={}", status);
+            }
         }
     }
     Ok(KimiRankThreadState {

--- a/pegainfer-kimi-k2/src/runner/worker.rs
+++ b/pegainfer-kimi-k2/src/runner/worker.rs
@@ -526,6 +526,7 @@ struct KimiCublasThreadGuard;
 impl Drop for KimiCublasThreadGuard {
     fn drop(&mut self) {
         unsafe {
+            pegainfer_kernels::ffi::kimi_shared_gate_up_cublaslt_destroy_cuda();
             pegainfer_kernels::ffi::cublas_destroy();
         }
     }
@@ -543,6 +544,19 @@ fn bind_rank_thread(
     let decode_aux_ctx = ctx.auxiliary_device_context("decode aux")?;
     unsafe {
         pegainfer_kernels::ffi::cublas_init();
+        let status = pegainfer_kernels::ffi::kimi_shared_gate_up_cublaslt_init_cuda();
+        if status != 0 {
+            if status >= 100_000 {
+                anyhow::bail!(
+                    "Kimi shared_gate_up cuBLASLt init failed: cublas_status={}",
+                    status - 100_000
+                );
+            }
+            anyhow::bail!(
+                "Kimi shared_gate_up cuBLASLt init failed: cuda_status={}",
+                status
+            );
+        }
     }
     Ok(KimiRankThreadState {
         ctx,

--- a/pegainfer-kimi-k2/src/runner/worker.rs
+++ b/pegainfer-kimi-k2/src/runner/worker.rs
@@ -527,6 +527,7 @@ struct KimiCublasThreadGuard;
 impl Drop for KimiCublasThreadGuard {
     fn drop(&mut self) {
         unsafe {
+            pegainfer_kernels::ffi::kimi_mla_cublaslt_destroy_cuda();
             pegainfer_kernels::ffi::kimi_o_proj_cublaslt_destroy_cuda();
             pegainfer_kernels::ffi::kimi_shared_gate_up_cublaslt_destroy_cuda();
             pegainfer_kernels::ffi::cublas_destroy();
@@ -558,6 +559,16 @@ fn bind_rank_thread(
                 "Kimi shared_gate_up cuBLASLt init failed: cuda_status={}",
                 status
             );
+        }
+        let status = pegainfer_kernels::ffi::kimi_mla_cublaslt_init_cuda();
+        if status != 0 {
+            if status >= 100_000 {
+                anyhow::bail!(
+                    "Kimi MLA cuBLASLt init failed: cublas_status={}",
+                    status - 100_000
+                );
+            }
+            anyhow::bail!("Kimi MLA cuBLASLt init failed: cuda_status={}", status);
         }
         if local_dims.o_proj_in == KIMI_O_PROJ_CUBLASLT_INPUT {
             let status = pegainfer_kernels::ffi::kimi_o_proj_cublaslt_init_cuda();

--- a/pegainfer-kimi-k2/src/runner/worker/forward.rs
+++ b/pegainfer-kimi-k2/src/runner/worker/forward.rs
@@ -231,12 +231,24 @@ fn forward_mla_decode_layer_into(
         &mut scratch.mla.attn_out,
         local_heads,
     )?;
-    typed_ops::gemm_dm_hs_to_typed_graphsafe(
-        ctx,
-        &attention.o_proj,
-        &scratch.mla.attn_out,
-        &mut scratch.mla.projected,
-    )?;
+    if attention.o_proj.rows == KIMI_K2_HIDDEN
+        && attention.o_proj.cols == KIMI_O_PROJ_CUBLASLT_INPUT
+        && kimi_o_proj_cublaslt_supports_batch_size(scratch.mla.attn_out.seq_len)
+    {
+        kimi_o_proj_cublaslt_into(
+            ctx,
+            &attention.o_proj,
+            &scratch.mla.attn_out,
+            &mut scratch.mla.projected,
+        )?;
+    } else {
+        typed_ops::gemm_dm_hs_to_typed_graphsafe(
+            ctx,
+            &attention.o_proj,
+            &scratch.mla.attn_out,
+            &mut scratch.mla.projected,
+        )?;
+    }
     Ok(())
 }
 

--- a/pegainfer-kimi-k2/src/runner/worker/forward.rs
+++ b/pegainfer-kimi-k2/src/runner/worker/forward.rs
@@ -116,6 +116,8 @@ pub(super) fn forward_decode_batch_next_token_kernels(
         active_len,
         &mut decode_arena.scratch.sampling.top1_value_scratch,
         &mut decode_arena.scratch.sampling.top1_out,
+        &mut decode_arena.scratch.sampling.top1_partial_values,
+        &mut decode_arena.scratch.sampling.top1_partial_indices,
     )
 }
 

--- a/pegainfer-kimi-k2/src/runner/worker/runtime.rs
+++ b/pegainfer-kimi-k2/src/runner/worker/runtime.rs
@@ -320,6 +320,8 @@ pub(super) fn launch_local_top1_batch(
     active_rows: usize,
     top1_values: &mut CudaSlice<half::bf16>,
     out: &mut CudaSlice<i32>,
+    partial_values: &mut CudaSlice<f32>,
+    partial_indices: &mut CudaSlice<i32>,
 ) -> Result<()> {
     ensure!(
         active_rows > 0 && active_rows <= logits.seq_len,
@@ -333,16 +335,33 @@ pub(super) fn launch_local_top1_batch(
         out.len(),
         active_rows
     );
+    let partials = pegainfer_kernels::ops::argmax_batch_bf16_split_partials_len(
+        active_rows,
+        logits.hidden_dim,
+    );
+    ensure!(
+        partial_values.len() >= partials && partial_indices.len() >= partials,
+        "Kimi batched top1 partial scratch too small: values={}, indices={}, need={}",
+        partial_values.len(),
+        partial_indices.len(),
+        partials
+    );
     {
         let (logits_ptr, _logits_guard) = logits.data.device_ptr(&ctx.stream);
         let (value_ptr, _value_guard) = top1_values.device_ptr_mut(&ctx.stream);
         let (out_ptr, _out_guard) = out.device_ptr_mut(&ctx.stream);
+        let (partial_values_ptr, _partial_values_guard) =
+            partial_values.device_ptr_mut(&ctx.stream);
+        let (partial_indices_ptr, _partial_indices_guard) =
+            partial_indices.device_ptr_mut(&ctx.stream);
 
         unsafe {
-            ffi::argmax_batch_bf16_cuda(
+            ffi::argmax_batch_bf16_split_cuda(
                 logits_ptr as *const ffi::Half,
                 value_ptr as *mut ffi::Half,
                 out_ptr as *mut i32,
+                partial_values_ptr as *mut f32,
+                partial_indices_ptr as *mut i32,
                 active_rows as i32,
                 logits.hidden_dim as i32,
                 ctx.stream.cu_stream(),

--- a/pegainfer-kimi-k2/src/typed_scratch.rs
+++ b/pegainfer-kimi-k2/src/typed_scratch.rs
@@ -7,11 +7,11 @@ use pegainfer_kernels::tensor::{DeviceContext, GpuTensor, HiddenStates};
 
 use crate::config::{
     KIMI_K2_EXPERT_INTERMEDIATE, KIMI_K2_HIDDEN, KIMI_K2_Q_LORA_RANK, KIMI_K2_ROUTED_EXPERTS,
-    KIMI_K2_TOPK, KimiLocalDims,
+    KIMI_K2_TOPK, KIMI_K2_VOCAB, KimiLocalDims,
 };
 use pegainfer_kernels::ops::{
     KIMI_K2_EP_WORLD, KIMI_K2_MLA_KV_LORA_RANK, KIMI_K2_MLA_QKV_A_OUT, KIMI_K2_MLA_ROPE_DIM,
-    KimiMarlinRouteWorkspace, KimiMarlinWna16Workspace,
+    KimiMarlinRouteWorkspace, KimiMarlinWna16Workspace, argmax_batch_bf16_split_partials_len,
 };
 
 pub(crate) const MARLIN_W13_OUT_DIM: usize = 2 * KIMI_K2_EXPERT_INTERMEDIATE;
@@ -175,13 +175,18 @@ impl CommScratch {
 pub(crate) struct SamplingScratch {
     pub(crate) top1_value_scratch: CudaSlice<half::bf16>,
     pub(crate) top1_out: CudaSlice<i32>,
+    pub(crate) top1_partial_values: CudaSlice<f32>,
+    pub(crate) top1_partial_indices: CudaSlice<i32>,
 }
 
 impl SamplingScratch {
     pub(crate) fn new(ctx: &DeviceContext, batch_size: usize) -> Result<Self> {
+        let partials = argmax_batch_bf16_split_partials_len(batch_size, KIMI_K2_VOCAB);
         Ok(Self {
             top1_value_scratch: ctx.stream.alloc_zeros(batch_size)?,
             top1_out: ctx.stream.alloc_zeros(batch_size)?,
+            top1_partial_values: ctx.stream.alloc_zeros(partials)?,
+            top1_partial_indices: ctx.stream.alloc_zeros(partials)?,
         })
     }
 }


### PR DESCRIPTION
## Summary

Salvages the decode-kernel optimizations from the messy `opt/kimi-tp1-dp8-decode` branch by **production-only cherry-picks** onto main (docs + ~2.4k-line microbench scaffolding excluded), with accuracy + perf validation after every pick on H20×8, TP1 DP8 EP8 PPLX, `/data/models/Kimi-K2.5`.

| commit | opt | isolated microbench |
| --- | --- | --- |
| `257c9f4` | shared_gate_up cuBLASLt fixed-shape | 1.818ms → 1.505ms (1.21×) |
| `fc9327c` | attention o_proj cuBLASLt fixed-shape | 2.715ms → 2.374ms (1.14×) |
| `f77f729` | MLA absorb/v_up cuBLASLt strided batches | absorb 973.6µs → 748.5µs (1.30×) |
| `0d52e73` | final argmax split-vocab reduction | 125.3µs → 12.7µs (9.85×) |
| `8cf932f` | router post-GEMM fused score+topk selector | 3.655ms → 3.514ms (1.04×) |

**Rejected (the original branch's accuracy break):** the PPLX Marlin small-N tile (messy-branch `dd69876`). It emits a non-finite `-inf` top logit at concurrency=1 (panic, exit 101) and SIGSEGVs at bs64 (exit 139). Its microbench (1.50×) never checks numerics, and the small-N tile only activates at small per-rank token counts — exactly the decode regime — so perf sweeps never surfaced it. Not picked; re-land only behind a small-N decode numeric gate.

## Validation

- **Per-pick (bench_serving, TP1 DP8 PPLX):** c1 o128 deterministic A/B + bs64 o128 — all five coherent (degenerate 0/64, no non-finite). Greedy hash shifts once at the first cuBLASLt pick (bf16 rounding tie-breaks) then stays at `cb1954bb77d652fb` through MLA/argmax/router picks.
- **Accuracy gate (base-vs-opt prefill logits A/B,** per `subsystems/correctness/logits-golden-gate.md`, base-pegainfer as exact reference, 12 raw prompts / 236 teacher-forced positions, full-vocab bf16 logits): 145/236 positions bit-identical (router fusion is bit-exact); head-token |Δlogprob| mean 0.0355 / p50 0.0000 (bf16 reduction-order floor); argmax agreement 233/236 with **worst regret 0.125 nat = 1 ULP** — all 3 flips are genuine ties, under the 0.20 tolerance.
- **Perf honesty:** bs64 o128 steady TPOT p50/p99 `40.58/44.06ms` → `40.09/42.87ms` — inside the ±1ms run-to-run band. The per-kernel wins are real but don't resolve above noise end-to-end at this shape; claim is "no regression", next lever is the collectives/MoE path.
- Per-commit clippy `-D warnings` passed; adversarial review pass done (its two findings — a dead wrapper and a dead fallback sentinel — removed in `cb5c3de`).

Full record: `docs/models/kimi-k2/tp1-dp8-ep8-performance.md` O2 (added in `466184d`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)