### PR TITLE
feat(qwen3): prefix caching with full-block kvbm matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5355,6 +5355,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cudarc",
+ "dynamo-kv-hashing",
  "half",
  "kvbm-logical",
  "pegainfer-kernels",

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 | Path | TL;DR |
 | --- | --- |
 | `models/qwen3/model-crate.md` | `pegainfer-qwen3-4b` owns Qwen3 config/weights/executor/scheduler/tests/kernel plan; root sees generic `EngineHandle`; split-K retuned to `256/64`, with 4k/64 serving TPOT p50 at `6.46ms` on RTX 5090. |
+| `models/qwen3/prefix-cache.md` | Prefix caching on by default for Qwen3-4B: full-block kvbm radix matching at the executor, suffix-only prefill. Repeated ~1900-token prompt TTFT 141.8 → 16.3ms p50 (8.7×); warm TTFT ≈ TPOT + ~5ms setup. Includes the RoPE scalar-path corruption fix and the drain-the-stream TTFT measurement pitfall. |
 | `models/qwen3/accuracy-gate.md` | Qwen3-4B instance of the logits golden gate (`tests/hf_golden_gate.rs`): 48 teacher-forced sequences / 816 positions vs a stored HF bf16 golden, replayed over bs=1 / batched eager / CUDA-graph. Strict guards: regret check + mean ≤ 0.06 + p99 ≤ 0.20; absolute max printed but not asserted (coverage-unstable). Methodology in `subsystems/correctness/`. |
 | `models/qwen3/kernels-crate.md` | Phase 1 split implemented and 5090-verified: Qwen3-4B kernel surface lives in `pegainfer-kernels`; release build, test-target compile, accuracy gate, and bench snapshot pass. |
 | `models/qwen3/tp-design.md` | Qwen3 tensor-parallel design: `TP=2` milestone scope plus the controller/worker broadcast execution model, request identity, and coarse-grained step protocol for future TP/MoE work. |

--- a/docs/models/qwen3/prefix-cache.md
+++ b/docs/models/qwen3/prefix-cache.md
@@ -1,0 +1,66 @@
+# Qwen3-4B prefix cache
+
+**TL;DR**: Prefix caching is on by default for Qwen3-4B. Full-block token-hash matching via the vendored kvbm radix tree, wired at the executor level. Repeated ~1900-token prompt: TTFT 141.8ms → 16.3ms p50 (8.7×); warm TTFT ≈ 1 decode TPOT (11.4ms) + ~5ms request-setup/eager-launch overhead. Accuracy gated by `hf_golden_gate` cached-replay surfaces (warm deltas at the cold bf16 floor).
+
+Last touched: 2026-06
+
+## How it works
+
+- `Qwen3Executor::execute_prefill`/`execute_unified` call `RequestKv::match_and_add_prefix` before scheduling. Matched blocks advance `prefill_position`/`kv_position`; only the uncached suffix is forwarded (`PrefillStepItem::as_slice()` skips `cached_tokens`).
+- Matching is full-block only (block = 16 tokens), keyed on kvbm `SequenceHash` (positional lineage hash of token content). Partial tail blocks never match.
+- **Full-block cap**: `SchedulableSequence::match_and_add_prefix` caps matches at `(num_input_tokens - 1) / block_size` — a fully-cached prompt still recomputes ≥ 1 token (vLLM does the same). Without the cap the schedule/apply state machine deadlocks: prefill is "complete" with no forward pass to emit the first token, and the dangling-block count is wrong.
+- **Echo requests skip matching** — prompt logprobs need every position forwarded.
+- Eviction safety: matched blocks are held as `ImmutableBlock` (strong Arc) in the sequence's assignments for the request lifetime; the inactive-pool LRU cannot reclaim them mid-request.
+- Toggle: `Qwen3Executor::set_prefix_cache_enabled(false)` — used by tests that need cold determinism; there is no server flag.
+
+## Numbers (RTX 5090, 2026-06, drained-stream measurement)
+
+| Metric | p50 | p99 |
+|---|---|---|
+| cold TTFT (unique ~1900-token prompts) | 141.8ms | 205.8ms |
+| warm TTFT (repeated prompt) | 16.3ms | 16.7ms |
+| decode TPOT (bs=1) | 11.4ms | — |
+
+Warm TTFT theory: the suffix is 1..16 tokens (cap + prompt length mod 16), and at 4B the forward is weight-bandwidth bound, so GPU time ≈ one decode step. The ~5.4ms gap over TPOT decomposes (measured by varying one factor at a time):
+
+| Component | Cost | How isolated |
+|---|---|---|
+| tokenize ~1900-token prompt | ~2.9ms | warm TTFT − cold 16-token-prompt TTFT (16.8 − 13.9); HF tokenizers on the same string measures 3.2ms standalone, so radix match + block-table H2D inside this bucket are sub-ms |
+| request setup (HTTP parse, admission, FlashInfer prefill-plan build, sampling readback, SSE) | ~1.7ms | cold 16-token-prompt TTFT − graph TPOT − eager-launch share |
+| eager per-layer launches (suffix prefill is not graph-captured) | ~0.8ms | eager-decode TPOT (`--cuda-graph=false`) 12.18ms − graph TPOT 11.40ms |
+
+Tokenization is the single largest term — for cached long prompts the CPU tokenizer costs more than everything the scheduler and kernels add on top of the forward pass. So the next lever for warm TTFT is the tokenizer, not the GPU path; graph-capturing the suffix prefill only buys ~0.8ms.
+
+Supporting measurements behind the decomposition (all drained-stream, n=20, same session):
+
+| Measurement | p50 |
+|---|---|
+| TTFT, 1-token prompt, cold | 13.4ms |
+| TTFT, 16-token prompt, cold | 13.9ms |
+| TTFT, ~1900-token prompt, warm | 16.8ms |
+| TPOT, graph decode | 11.40ms |
+| TPOT, eager decode (`--cuda-graph=false`) | 12.18ms |
+| tokenize 1500-word prompt standalone (HF `tokenizers`, 1502 tokens) | 3.2ms |
+
+Negative result: registering 40 extra unique ~1900-token prompts did not move warm TTFT p50 at all — radix-tree matching cost is flat at this registry scale (~5k blocks), so don't reach for match-cost optimizations without first reproducing a regression.
+
+## Pitfalls
+
+- **RoPE scalar-path corruption (fixed on this branch).** `prefill_attention_paged_into` had a `batch_size == 1` fast path that used a scalar `start_pos` (always 0 from the qwen3 call site) instead of the plan's per-token positions array. Cold runs were unaffected (start really is 0); warm bs=1 prefills rotated the suffix K/Q from position 0 and scattered the mis-rotated K into KV pages — decode drift up to 3.3 nat in `hf_golden_gate` cached replay. The scalar branch and its dead kernel wrapper (`prefill_qk_norm_rope_only_cuda`) are deleted; all callers go through the positions array, which is bit-identical for cold runs (both C entry points launched the same kernel). Lesson: a "fast path" that duplicates position logic is a fork that only breaks when positions stop being trivial.
+- **TTFT measurement: drain the stream.** The server has no abort-on-disconnect — a client that hangs up after the first token leaves the request decoding its remaining tokens, and the *next* request's prefill contends with that zombie decode. Early-disconnect measurement inflated warm TTFT 16.3 → 25.5ms p50. Always read SSE to `[DONE]` between samples.
+- **Cache-off runs still register blocks.** Disabling matching only skips lookup; completed blocks are still registered on apply. Tests use this: phase 1 (off) builds cold baselines *and* populates the cache for phase 2 (on).
+
+## Tests
+
+- `pegainfer-qwen3-4b/tests/prefix_cache.rs` — behavioral contract: exact cached-token counts (3-block hit + tail recompute, extension match, full-block cap edge), mixed cold+warm batch in one plan, unified prefill+decode path, warm-vs-cold logit bounds (regret + mean, golden-gate methodology).
+- `pegainfer-qwen3-4b/tests/hf_golden_gate.rs` — cached-replay surfaces (sequential bs=1 eager, batched eager, batched cuda-graph) vs the HF golden: warm mean 0.0316 / p99 0.1215 vs cold floor 0.0317 / 0.1196.
+
+```bash
+PEGAINFER_TEST_MODEL_PATH=/data/models/Qwen3-4B cargo test --release -p pegainfer-qwen3-4b --test prefix_cache
+PEGAINFER_TEST_MODEL_PATH=/data/models/Qwen3-4B cargo test --release -p pegainfer-qwen3-4b --test hf_golden_gate
+```
+
+## Next
+
+- Abort-on-disconnect filed as #215 (zombie decode wastes GPU and pollutes TTFT measurement).
+- Qwen3.5-4B adoption: the executor wiring pattern transfers, but the GDR linear-attention state is positional — cached prefix reuse needs the recurrent state snapshot, not just KV pages. Needs its own design note before attempting.

--- a/docs/models/qwen3/prefix-cache.md
+++ b/docs/models/qwen3/prefix-cache.md
@@ -10,6 +10,7 @@ Last touched: 2026-06
 - Matching is full-block only (block = 16 tokens), keyed on kvbm `SequenceHash` (positional lineage hash of token content). Partial tail blocks never match.
 - **Full-block cap**: `SchedulableSequence::match_and_add_prefix` caps matches at `(num_input_tokens - 1) / block_size` — a fully-cached prompt still recomputes ≥ 1 token (vLLM does the same). Without the cap the schedule/apply state machine deadlocks: prefill is "complete" with no forward pass to emit the first token, and the dangling-block count is wrong.
 - **Echo requests skip matching** — prompt logprobs need every position forwarded.
+- **LoRA-scoped**: the active adapter name is folded into the block-hash chain as a salt (`compute_salt_hash`, upstream router-parity recipe), so KV computed under one adapter (or the base model) never matches a request running under another. Same tokens + same adapter still share.
 - Eviction safety: matched blocks are held as `ImmutableBlock` (strong Arc) in the sequence's assignments for the request lifetime; the inactive-pool LRU cannot reclaim them mid-request.
 - Toggle: `Qwen3Executor::set_prefix_cache_enabled(false)` — used by tests that need cold determinism; there is no server flag.
 

--- a/docs/subsystems/kernels/kernel-op-reports.md
+++ b/docs/subsystems/kernels/kernel-op-reports.md
@@ -159,7 +159,7 @@
 
 ### Step 12: Split prefill stages
 - Treated `prefill_attention_paged_into` as a wrapper over three separately measurable kernel stages:
-  - `prefill_qk_norm_rope`: `prefill_qk_norm_rope_only_cuda`
+  - `prefill_qk_norm_rope`: `qk_norm_rope_batched_decode_cuda` (per-token positions; the scalar `prefill_qk_norm_rope_only_cuda` wrapper was removed with the prefix-cache RoPE fix)
   - `prefill_kv_scatter`: `paged_kv_scatter_cuda`
   - `prefill_attention_core`: `batch_prefill_paged_cuda`
 - Added `PrefillStage` launch paths in `kernel_bench.rs`. For stage reports, prerequisites run outside the timed/profiled launch and then L2 is swept before the measured stage. This keeps each stage report tied to one target kernel while still preparing valid inputs.

--- a/kvbm/dynamo-kv-hashing/src/lib.rs
+++ b/kvbm/dynamo-kv-hashing/src/lib.rs
@@ -25,6 +25,7 @@ mod salt;
 pub use block::UniversalBlock;
 pub use error::KvHashingError;
 pub use request::{Request, RequestBuilder, RequestMmObjectInfo};
+pub use salt::compute_salt_hash;
 
 // Re-export the underlying primitives so consumers can depend solely on this crate.
 pub use dynamo_tokens::{

--- a/kvbm/dynamo-kv-hashing/src/salt.rs
+++ b/kvbm/dynamo-kv-hashing/src/salt.rs
@@ -39,7 +39,7 @@ use crate::error::KvHashingError;
 /// `lib/kv-router/src/protocols.rs:79` (`options.lora_name.filter(|n| !n.is_empty())`)
 /// so a client that sends `lora_name = ""` shares the cache with a client that sends
 /// `lora_name = None`.
-pub(crate) fn compute_salt_hash(
+pub fn compute_salt_hash(
     salt: Option<&str>,
     lora_name: Option<&str>,
 ) -> Result<SaltHash, KvHashingError> {

--- a/kvbm/kvbm-logical/src/integrations/request.rs
+++ b/kvbm/kvbm-logical/src/integrations/request.rs
@@ -42,7 +42,7 @@
 //! // total_tokens=8, num_blocks=2, nothing allocated yet
 //!
 //! // 2. Prefix match against the cache
-//! let matched_count = seq.match_and_add_prefix(&manager).unwrap();
+//! let matched_count = seq.match_and_add_prefix(&manager, usize::MAX).unwrap();
 //!
 //! // 3. Allocate blocks for the rest
 //! let remaining = seq.num_blocks() - matched_count;
@@ -176,6 +176,11 @@ impl<T: BlockMetadata> RequestSequence<T> {
     /// sequence. Combines [`match_prefix`](Self::match_prefix) and
     /// [`add_matched_blocks`](Self::add_matched_blocks).
     ///
+    /// At most `max_blocks` matched blocks are added; the rest are dropped
+    /// (their `ImmutableBlock` handles return to the pools via RAII).
+    /// Callers that drive a prefill protocol use this to keep at least one
+    /// input token uncached so the final prefill chunk can emit a token.
+    ///
     /// # Panics
     ///
     /// Panics if the sequence already has assigned blocks (i.e. this is
@@ -183,12 +188,14 @@ impl<T: BlockMetadata> RequestSequence<T> {
     pub fn match_and_add_prefix(
         &mut self,
         manager: &BlockManager<T>,
+        max_blocks: usize,
     ) -> Result<usize, LogicalBlockAssignmentError<T>> {
         assert!(
             self.assignments.is_empty(),
             "match_and_add_prefix called on sequence with existing assignments"
         );
-        let matched = self.match_prefix(manager);
+        let mut matched = self.match_prefix(manager);
+        matched.truncate(max_blocks);
         if matched.is_empty() {
             return Ok(0);
         }
@@ -563,7 +570,7 @@ mod tests {
     ) -> Option<RequestSequence<TestMeta>> {
         let mut seq = RequestSequence::new(tokens, max_output_tokens, block_size);
         let completed_blocks = seq.num_blocks();
-        let matched_count = seq.match_and_add_prefix(manager).ok()?;
+        let matched_count = seq.match_and_add_prefix(manager, usize::MAX).ok()?;
         let remaining_complete = completed_blocks - matched_count;
         let needs_generation = max_output_tokens > 0;
         let total_to_allocate = remaining_complete + usize::from(needs_generation);
@@ -864,7 +871,7 @@ mod tests {
         drop(registered);
 
         let mut seq = RequestSequence::<TestMeta>::new(tokens, 10, BLOCK_SIZE);
-        let matched_count = seq.match_and_add_prefix(&manager).unwrap();
+        let matched_count = seq.match_and_add_prefix(&manager, usize::MAX).unwrap();
         assert_eq!(matched_count, 1);
         assert_eq!(seq.prefix_matched_blocks(), 1);
 

--- a/kvbm/kvbm-logical/src/integrations/request.rs
+++ b/kvbm/kvbm-logical/src/integrations/request.rs
@@ -106,7 +106,7 @@ use crate::blocks::{BlockMetadata, ImmutableBlock};
 use crate::manager::BlockManager;
 use crate::sequence::{BlockSequence, LogicalBlockAssignmentError, LogicalBlockAssignments};
 
-use dynamo_tokens::Token;
+use dynamo_tokens::{SaltHash, Token};
 
 /// Manages a request's block lifecycle through direct RAII integration with
 /// [`BlockManager`], bypassing the `MoveBlock` signal protocol.
@@ -144,6 +144,11 @@ impl<T: BlockMetadata> RequestSequence<T> {
     /// Creates a `RequestSequence` with token data only. No blocks are
     /// allocated and no manager interaction occurs.
     ///
+    /// `salt_hash` seeds the block-hash chain — it is the prefix-cache
+    /// isolation key. Requests that must not share cached blocks (e.g.
+    /// different LoRA adapters) pass different salts; `None` is the shared
+    /// base namespace.
+    ///
     /// The caller must use [`match_and_add_prefix`], [`allocate_blocks`],
     /// and [`complete_and_register_pending`] to search, allocate, and
     /// register blocks.
@@ -151,9 +156,14 @@ impl<T: BlockMetadata> RequestSequence<T> {
     /// [`match_and_add_prefix`]: Self::match_and_add_prefix
     /// [`allocate_blocks`]: Self::allocate_blocks
     /// [`complete_and_register_pending`]: Self::complete_and_register_pending
-    pub fn new(tokens: Vec<Token>, max_output_tokens: usize, block_size: u32) -> Self {
+    pub fn new(
+        tokens: Vec<Token>,
+        max_output_tokens: usize,
+        block_size: u32,
+        salt_hash: Option<SaltHash>,
+    ) -> Self {
         let num_input_tokens = tokens.len();
-        let sequence = BlockSequence::new(tokens, block_size, None);
+        let sequence = BlockSequence::new(tokens, block_size, salt_hash);
         let assignments = LogicalBlockAssignments::new();
 
         Self {
@@ -568,7 +578,7 @@ mod tests {
         block_size: u32,
         manager: &BlockManager<TestMeta>,
     ) -> Option<RequestSequence<TestMeta>> {
-        let mut seq = RequestSequence::new(tokens, max_output_tokens, block_size);
+        let mut seq = RequestSequence::new(tokens, max_output_tokens, block_size, None);
         let completed_blocks = seq.num_blocks();
         let matched_count = seq.match_and_add_prefix(manager, usize::MAX).ok()?;
         let remaining_complete = completed_blocks - matched_count;
@@ -588,7 +598,7 @@ mod tests {
     #[test]
     fn test_new_minimal_constructor() {
         let tokens = make_tokens(8);
-        let seq = RequestSequence::<TestMeta>::new(tokens, 10, BLOCK_SIZE);
+        let seq = RequestSequence::<TestMeta>::new(tokens, 10, BLOCK_SIZE, None);
 
         assert_eq!(seq.num_input_tokens(), 8);
         assert_eq!(seq.total_tokens(), 8);
@@ -704,7 +714,7 @@ mod tests {
     #[should_panic(expected = "matched blocks exceed completed sequence blocks")]
     fn test_add_matched_blocks_panics_when_matched_exceeds_completed() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq = RequestSequence::<TestMeta>::new(make_tokens(4), 10, BLOCK_SIZE);
+        let mut seq = RequestSequence::<TestMeta>::new(make_tokens(4), 10, BLOCK_SIZE, None);
 
         let source = BlockSequence::new(make_tokens(8), BLOCK_SIZE, None);
         let mutables = manager.allocate_blocks(2).unwrap();
@@ -720,7 +730,7 @@ mod tests {
     #[test]
     fn test_add_matched_blocks_returns_error_on_hash_mismatch() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq = RequestSequence::<TestMeta>::new(make_tokens(4), 10, BLOCK_SIZE);
+        let mut seq = RequestSequence::<TestMeta>::new(make_tokens(4), 10, BLOCK_SIZE, None);
 
         let source = BlockSequence::new(vec![100, 101, 102, 103], BLOCK_SIZE, None);
         let mutable = manager
@@ -815,7 +825,7 @@ mod tests {
 
     #[test]
     fn test_is_complete_zero_max() {
-        let seq = RequestSequence::<TestMeta>::new(make_tokens(4), 0, BLOCK_SIZE);
+        let seq = RequestSequence::<TestMeta>::new(make_tokens(4), 0, BLOCK_SIZE, None);
         assert!(seq.is_complete());
     }
 
@@ -870,7 +880,7 @@ mod tests {
             .collect();
         drop(registered);
 
-        let mut seq = RequestSequence::<TestMeta>::new(tokens, 10, BLOCK_SIZE);
+        let mut seq = RequestSequence::<TestMeta>::new(tokens, 10, BLOCK_SIZE, None);
         let matched_count = seq.match_and_add_prefix(&manager, usize::MAX).unwrap();
         assert_eq!(matched_count, 1);
         assert_eq!(seq.prefix_matched_blocks(), 1);
@@ -890,7 +900,7 @@ mod tests {
     #[test]
     fn test_allocate_blocks_failure() {
         let manager = create_test_manager::<TestMeta>(2);
-        let mut seq = RequestSequence::<TestMeta>::new(make_tokens(4), 10, BLOCK_SIZE);
+        let mut seq = RequestSequence::<TestMeta>::new(make_tokens(4), 10, BLOCK_SIZE, None);
 
         assert!(!seq.allocate_blocks(3, &manager));
         assert!(seq.allocate_blocks(2, &manager));
@@ -900,7 +910,7 @@ mod tests {
     #[test]
     fn test_allocate_blocks_zero() {
         let manager = create_test_manager::<TestMeta>(2);
-        let mut seq = RequestSequence::<TestMeta>::new(make_tokens(4), 10, BLOCK_SIZE);
+        let mut seq = RequestSequence::<TestMeta>::new(make_tokens(4), 10, BLOCK_SIZE, None);
 
         assert!(seq.allocate_blocks(0, &manager));
         assert_eq!(seq.unassigned_blocks(), 0);

--- a/kvbm/kvbm-logical/src/integrations/scheduled.rs
+++ b/kvbm/kvbm-logical/src/integrations/scheduled.rs
@@ -410,15 +410,22 @@ impl<T: BlockMetadata> SchedulableSequence<T> {
     /// Match and add prefix blocks from the manager's pools.
     ///
     /// Advances `prefill_position` by `matched_blocks * block_size`.
+    ///
+    /// Matching is capped so at least one input token remains uncached:
+    /// the final prefill chunk must run to emit the first generated token,
+    /// and a full-prompt match would otherwise leave the state machine
+    /// with prefill complete but zero dangling tokens — no legal next step.
     pub fn match_and_add_prefix(
         &mut self,
         manager: &BlockManager<T>,
     ) -> Result<usize, ScheduleError> {
         self.require_idle()?;
 
+        let bs = self.inner.block_size();
+        let max_blocks = self.inner.num_input_tokens().saturating_sub(1) / bs;
         let count = self
             .inner
-            .match_and_add_prefix(manager)
+            .match_and_add_prefix(manager, max_blocks)
             .unwrap_or_else(|_| panic!("prefix match should not produce duplicates"));
 
         if count > 0 {
@@ -1834,6 +1841,39 @@ mod tests {
         assert_eq!(seq.assigned_blocks(), 2);
         assert_eq!(seq.unassigned_blocks(), 0); // no gen block
         assert_eq!(seq.tail_tokens(), 1);
+    }
+
+    #[test]
+    fn test_match_and_add_prefix_full_match_keeps_one_prefill_token() {
+        let manager = create_test_manager::<TestMeta>(20);
+        let tokens = make_tokens(8); // exactly 2 full blocks
+
+        // Populate cache with ALL blocks of the prompt.
+        let seq_for_populate = crate::BlockSequence::new(tokens.clone(), BLOCK_SIZE, None);
+        let mutables = manager.allocate_blocks(2).unwrap();
+        let registered: Vec<_> = mutables
+            .into_iter()
+            .zip(seq_for_populate.blocks().iter())
+            .map(|(m, tb)| manager.register_block(m.complete(tb).unwrap()))
+            .collect();
+        drop(registered);
+
+        let mut seq = SchedulableSequence::<TestMeta>::new(tokens, 10, BLOCK_SIZE, noop_delegate());
+        // Cap: (8 - 1) / 4 = 1 block, even though 2 would match.
+        let matched = seq.match_and_add_prefix(&manager).unwrap();
+        assert_eq!(matched, 1);
+        assert_eq!(seq.prefill_position(), 4);
+        assert!(!seq.is_prefill_complete());
+
+        // The remaining block prefills normally and can emit a token.
+        seq.schedule_prefill(4, &manager).unwrap();
+        seq.apply_prefill(Some(1000), &manager).unwrap();
+        assert!(seq.is_prefill_complete());
+        assert_eq!(seq.tail_tokens(), 1);
+
+        // Decode proceeds — the state machine is not bricked.
+        seq.schedule_decode(&manager).unwrap();
+        seq.apply_decode(100, &manager).unwrap();
     }
 
     #[test]

--- a/kvbm/kvbm-logical/src/integrations/scheduled.rs
+++ b/kvbm/kvbm-logical/src/integrations/scheduled.rs
@@ -154,7 +154,7 @@ use crate::blocks::BlockMetadata;
 use crate::manager::BlockManager;
 
 use super::request::RequestSequence;
-use dynamo_tokens::Token;
+use dynamo_tokens::{SaltHash, Token};
 
 // =============================================================================
 // State types
@@ -276,6 +276,10 @@ pub struct SchedulableSequenceParams {
     block_size: u32,
     #[builder(default, setter(custom))]
     delegate: Option<Arc<dyn SequenceDelegate>>,
+    /// Prefix-cache isolation key (e.g. derived from a LoRA adapter name).
+    /// Sequences with different salts never match each other's blocks.
+    #[builder(default)]
+    salt_hash: Option<SaltHash>,
 }
 
 impl SchedulableSequenceBuilder {
@@ -291,6 +295,7 @@ impl SchedulableSequenceBuilder {
             params.max_output_tokens,
             params.block_size,
             params.delegate,
+            params.salt_hash,
         ))
     }
 }
@@ -386,8 +391,9 @@ impl<T: BlockMetadata> SchedulableSequence<T> {
         max_output_tokens: usize,
         block_size: u32,
         delegate: Option<Arc<dyn SequenceDelegate>>,
+        salt_hash: Option<SaltHash>,
     ) -> Self {
-        let inner = RequestSequence::new(tokens, max_output_tokens, block_size);
+        let inner = RequestSequence::new(tokens, max_output_tokens, block_size, salt_hash);
         let delegate = delegate.unwrap_or_else(|| Arc::new(NoopDelegate));
         delegate.on_event(&SequenceEvent::Created {
             num_input_tokens: inner.num_input_tokens(),
@@ -1077,6 +1083,7 @@ mod tests {
             10,
             BLOCK_SIZE,
             Some(delegate.clone()),
+            None,
         );
 
         assert_eq!(seq.state(), SequenceState::Idle);
@@ -1107,8 +1114,13 @@ mod tests {
     #[test]
     fn test_schedule_prefill_requires_idle() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(8), 10, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(8),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         seq.schedule_prefill(4, &manager).unwrap();
         let err = seq.schedule_prefill(4, &manager).unwrap_err();
@@ -1118,8 +1130,13 @@ mod tests {
     #[test]
     fn test_schedule_decode_requires_idle() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(4), 10, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(4),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         // Prefill first
         seq.schedule_prefill(4, &manager).unwrap();
@@ -1134,8 +1151,13 @@ mod tests {
     #[test]
     fn test_apply_prefill_requires_scheduled() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(8), 10, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(8),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         let err = seq.apply_prefill(None, &manager).unwrap_err();
         assert!(matches!(err, ApplyError::WrongState { .. }));
@@ -1144,8 +1166,13 @@ mod tests {
     #[test]
     fn test_apply_decode_requires_scheduled() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(4), 10, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(4),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         let err = seq.apply_decode(100, &manager).unwrap_err();
         assert!(matches!(err, ApplyError::WrongState { .. }));
@@ -1154,8 +1181,13 @@ mod tests {
     #[test]
     fn test_decode_requires_prefill_complete() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(8), 10, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(8),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         let err = seq.schedule_decode(&manager).unwrap_err();
         assert!(matches!(err, ScheduleError::PrefillNotComplete { .. }));
@@ -1164,8 +1196,13 @@ mod tests {
     #[test]
     fn test_speculative_requires_prefill_complete() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(8), 10, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(8),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         let err = seq.schedule_speculative(3, &manager).unwrap_err();
         assert!(matches!(err, ScheduleError::PrefillNotComplete { .. }));
@@ -1178,8 +1215,13 @@ mod tests {
     #[test]
     fn test_prefill_single_chunk() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(8), 10, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(8),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         // Schedule and apply the full prefill (no gen block allocated)
         seq.schedule_prefill(8, &manager).unwrap();
@@ -1204,8 +1246,13 @@ mod tests {
     #[test]
     fn test_prefill_chunked() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(8), 10, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(8),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         // Chunk 1: first 4 tokens (1 block, non-final)
         seq.schedule_prefill(4, &manager).unwrap();
@@ -1229,8 +1276,13 @@ mod tests {
     #[test]
     fn test_prefill_final_with_first_token() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(4), 10, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(4),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         seq.schedule_prefill(4, &manager).unwrap();
         seq.apply_prefill(Some(100), &manager).unwrap();
@@ -1245,8 +1297,13 @@ mod tests {
     #[test]
     fn test_prefill_token_on_non_final_rejected() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(8), 10, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(8),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         seq.schedule_prefill(4, &manager).unwrap();
         let err = seq.apply_prefill(Some(100), &manager).unwrap_err();
@@ -1256,8 +1313,13 @@ mod tests {
     #[test]
     fn test_prefill_overrun_rejected() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(8), 10, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(8),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         let err = seq.schedule_prefill(9, &manager).unwrap_err();
         assert!(matches!(err, ScheduleError::PrefillOverrun { .. }));
@@ -1266,8 +1328,13 @@ mod tests {
     #[test]
     fn test_prefill_allocation_failure() {
         let manager = create_test_manager::<TestMeta>(1); // only 1 block
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(8), 10, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(8),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         let err = seq.schedule_prefill(8, &manager).unwrap_err();
         assert!(matches!(err, ScheduleError::AllocationFailed { .. }));
@@ -1278,8 +1345,13 @@ mod tests {
     #[test]
     fn test_schedule_prefill_after_complete_rejected() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(4), 10, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(4),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         seq.schedule_prefill(4, &manager).unwrap();
         seq.apply_prefill(Some(1000), &manager).unwrap();
@@ -1291,8 +1363,13 @@ mod tests {
     #[test]
     fn test_apply_prefill_none_on_final_rejected() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(4), 10, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(4),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         seq.schedule_prefill(4, &manager).unwrap();
         let err = seq.apply_prefill(None, &manager).unwrap_err();
@@ -1317,6 +1394,7 @@ mod tests {
             max_output,
             BLOCK_SIZE,
             noop_delegate(),
+            None,
         );
         if num_input > 0 {
             seq.schedule_prefill(num_input, manager).unwrap();
@@ -1463,7 +1541,7 @@ mod tests {
         let manager = create_test_manager::<TestMeta>(20);
         let delegate = Arc::new(CollectingDelegate::new());
         let mut seq =
-            SchedulableSequence::new(make_tokens(4), 10, BLOCK_SIZE, Some(delegate.clone()));
+            SchedulableSequence::new(make_tokens(4), 10, BLOCK_SIZE, Some(delegate.clone()), None);
         seq.schedule_prefill(4, &manager).unwrap();
         seq.apply_prefill(Some(1000), &manager).unwrap();
         // After prefill: total=5, assigned=1, unassigned=0
@@ -1568,8 +1646,13 @@ mod tests {
     #[test]
     fn test_revert_prefill() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(8), 10, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(8),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         let avail_before = manager.available_blocks();
         seq.schedule_prefill(4, &manager).unwrap();
@@ -1621,8 +1704,13 @@ mod tests {
     #[test]
     fn test_revert_returns_blocks_to_manager() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(8), 10, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(8),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         let avail_before = manager.available_blocks();
         seq.schedule_prefill(8, &manager).unwrap();
@@ -1698,6 +1786,7 @@ mod tests {
             3,
             BLOCK_SIZE,
             Some(delegate.clone()),
+            None,
         );
 
         // Prefill
@@ -1736,8 +1825,13 @@ mod tests {
     fn test_full_lifecycle_prefill_decode_release() {
         let manager = create_test_manager::<TestMeta>(20);
         // max_output=7: 1 from prefill + 6 decodes
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(6), 7, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(6),
+            7,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         // Prefill 6 tokens → 1 complete block + 2 partial
         seq.schedule_prefill(6, &manager).unwrap();
@@ -1777,8 +1871,13 @@ mod tests {
     #[test]
     fn test_preempt_and_reacquire() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(8), 10, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(8),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         // Prefill
         seq.schedule_prefill(8, &manager).unwrap();
@@ -1828,7 +1927,8 @@ mod tests {
             .collect();
         drop(registered);
 
-        let mut seq = SchedulableSequence::<TestMeta>::new(tokens, 10, BLOCK_SIZE, noop_delegate());
+        let mut seq =
+            SchedulableSequence::<TestMeta>::new(tokens, 10, BLOCK_SIZE, noop_delegate(), None);
         let matched = seq.match_and_add_prefix(&manager).unwrap();
         assert_eq!(matched, 1);
         assert_eq!(seq.prefill_position(), 4); // 1 block * 4 tokens
@@ -1858,7 +1958,8 @@ mod tests {
             .collect();
         drop(registered);
 
-        let mut seq = SchedulableSequence::<TestMeta>::new(tokens, 10, BLOCK_SIZE, noop_delegate());
+        let mut seq =
+            SchedulableSequence::<TestMeta>::new(tokens, 10, BLOCK_SIZE, noop_delegate(), None);
         // Cap: (8 - 1) / 4 = 1 block, even though 2 would match.
         let matched = seq.match_and_add_prefix(&manager).unwrap();
         assert_eq!(matched, 1);
@@ -1879,8 +1980,13 @@ mod tests {
     #[test]
     fn test_match_and_add_prefix_no_hits() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(8), 10, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(8),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         let matched = seq.match_and_add_prefix(&manager).unwrap();
         assert_eq!(matched, 0);
@@ -1894,7 +2000,8 @@ mod tests {
     #[test]
     fn test_empty_tokens_prefill() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq = SchedulableSequence::<TestMeta>::new(vec![], 10, BLOCK_SIZE, noop_delegate());
+        let mut seq =
+            SchedulableSequence::<TestMeta>::new(vec![], 10, BLOCK_SIZE, noop_delegate(), None);
 
         assert!(seq.is_prefill_complete());
 
@@ -1918,8 +2025,13 @@ mod tests {
     #[test]
     fn test_zero_max_output_no_gen_block() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(4), 0, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(4),
+            0,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         seq.schedule_prefill(4, &manager).unwrap();
         seq.apply_prefill(None, &manager).unwrap();
@@ -1934,8 +2046,13 @@ mod tests {
 
     #[test]
     fn test_debug_impl() {
-        let seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(8), 10, BLOCK_SIZE, noop_delegate());
+        let seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(8),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
         let debug_str = format!("{seq:?}");
         assert!(debug_str.contains("SchedulableSequence"));
         assert!(debug_str.contains("Idle"));
@@ -1943,8 +2060,13 @@ mod tests {
 
     #[test]
     fn test_revert_idle_rejected() {
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(8), 10, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(8),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
         let err = seq.revert_schedule().unwrap_err();
         assert!(matches!(err, ApplyError::WrongState { .. }));
     }
@@ -1952,8 +2074,13 @@ mod tests {
     #[test]
     fn test_release_while_scheduled_rejected() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(8), 10, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(8),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         seq.schedule_prefill(4, &manager).unwrap();
         let err = seq.release().unwrap_err();
@@ -1963,8 +2090,13 @@ mod tests {
     #[test]
     fn test_reacquire_while_scheduled_rejected() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(8), 10, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(8),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         seq.schedule_prefill(4, &manager).unwrap();
         let err = seq.reacquire(&manager).unwrap_err();
@@ -1978,8 +2110,13 @@ mod tests {
     #[test]
     fn test_dangling_tokens_tracking() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(8), 20, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(8),
+            20,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         // Before prefill: all tokens are "not yet computed"
         assert_eq!(seq.kv_position(), 0);
@@ -2009,7 +2146,8 @@ mod tests {
         let manager = create_test_manager::<TestMeta>(20);
 
         // 0 dangling: empty sequence with no tokens
-        let mut seq = SchedulableSequence::<TestMeta>::new(vec![], 10, BLOCK_SIZE, noop_delegate());
+        let mut seq =
+            SchedulableSequence::<TestMeta>::new(vec![], 10, BLOCK_SIZE, noop_delegate(), None);
         let err = seq.schedule_decode(&manager).unwrap_err();
         assert!(matches!(
             err,
@@ -2035,7 +2173,8 @@ mod tests {
     #[test]
     fn test_append_tokens_creates_dangling() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq = SchedulableSequence::<TestMeta>::new(vec![], 10, BLOCK_SIZE, noop_delegate());
+        let mut seq =
+            SchedulableSequence::<TestMeta>::new(vec![], 10, BLOCK_SIZE, noop_delegate(), None);
 
         assert_eq!(seq.tail_tokens(), 0);
 
@@ -2053,7 +2192,8 @@ mod tests {
 
     #[test]
     fn test_append_tokens_exceeding_remaining_returns_error_without_mutation() {
-        let mut seq = SchedulableSequence::<TestMeta>::new(vec![], 1, BLOCK_SIZE, noop_delegate());
+        let mut seq =
+            SchedulableSequence::<TestMeta>::new(vec![], 1, BLOCK_SIZE, noop_delegate(), None);
 
         let err = seq.append_tokens(&[100, 101]).unwrap_err();
 
@@ -2074,8 +2214,13 @@ mod tests {
     #[test]
     fn test_kv_position_through_lifecycle() {
         let manager = create_test_manager::<TestMeta>(20);
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(8), 20, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(8),
+            20,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         assert_eq!(seq.kv_position(), 0);
 
@@ -2103,8 +2248,13 @@ mod tests {
     fn test_pending_completion_staged_during_decode() {
         let manager = create_test_manager::<TestMeta>(20);
         // 7 input tokens: block 0 complete (0-3), block 1 partial (4-6)
-        let mut seq =
-            SchedulableSequence::<TestMeta>::new(make_tokens(7), 10, BLOCK_SIZE, noop_delegate());
+        let mut seq = SchedulableSequence::<TestMeta>::new(
+            make_tokens(7),
+            10,
+            BLOCK_SIZE,
+            noop_delegate(),
+            None,
+        );
 
         seq.schedule_prefill(7, &manager).unwrap();
         seq.apply_prefill(Some(1000), &manager).unwrap();

--- a/kvbm/kvbm-logical/src/manager/tests.rs
+++ b/kvbm/kvbm-logical/src/manager/tests.rs
@@ -2584,6 +2584,7 @@ mod race_regression_tests {
 // `#[should_panic]` mismatch flags the regression.
 // ============================================================================
 
+#[cfg(debug_assertions)]
 mod lock_order_enforcement_tests {
     use tracing_mutex::parkinglot::Mutex;
 
@@ -2593,6 +2594,12 @@ mod lock_order_enforcement_tests {
     /// real locks use under `#[cfg(test)]`. The DAG must detect the
     /// cycle and panic. Failing this test means lock-order
     /// enforcement is no longer in place crate-wide.
+    ///
+    /// Debug-only: `tracing_mutex::parkinglot::Mutex` is a plain
+    /// parking_lot mutex in release builds (no DAG, no panic), so the
+    /// `#[should_panic]` expectation can only hold under
+    /// `debug_assertions` — exactly where the enforcement it guards
+    /// exists.
     #[test]
     #[should_panic(expected = "Found cycle in mutex dependency graph")]
     fn deliberate_inversion_is_caught_by_tracing_mutex_dag() {

--- a/pegainfer-core/src/ops/attention.rs
+++ b/pegainfer-core/src/ops/attention.rs
@@ -28,7 +28,6 @@ pub fn prefill_attention_paged_into(
     num_q_heads: usize,
     num_kv_heads: usize,
     head_dim: usize,
-    start_pos: usize,
     rms_eps: f32,
 ) -> Result<()> {
     pegainfer_kernels::ops::prefill_attention_paged_into(
@@ -48,7 +47,6 @@ pub fn prefill_attention_paged_into(
         num_q_heads,
         num_kv_heads,
         head_dim,
-        start_pos,
         rms_eps,
     )
 }

--- a/pegainfer-kernels/csrc/paged_attention.cu
+++ b/pegainfer-kernels/csrc/paged_attention.cu
@@ -315,7 +315,7 @@ int paged_kv_scatter_cuda(
 //
 // Reads Q from col-major [q_dim, seq_len] layout (= HiddenStates).
 // Reads K/V from paged layout (page-first, NHD within each block).
-// No RoPE inside (caller does RoPE beforehand via prefill_qk_norm_rope_only_cuda).
+// No RoPE inside (caller does RoPE beforehand via qk_norm_rope_batched_decode_cuda).
 // Causal mask, no split-KV (partition_kv=false).
 //
 // Plan metadata (request_indices, qo_tile_indices, etc.) is pre-computed by Rust

--- a/pegainfer-kernels/csrc/prefill_attention.cu
+++ b/pegainfer-kernels/csrc/prefill_attention.cu
@@ -94,40 +94,11 @@ __global__ void prefill_qk_norm_rope_kernel(
 extern "C" {
 
 // ============================================================================
-// C API: QK norm + RoPE only (no cache write).
+// Batched QK norm + RoPE with per-token positions from a GPU array.
 //
-// Same as prefill_attention_prep_cuda but skips the KV cache write kernel.
-// Used when KV is written to paged layout separately (via AppendPagedKVCache).
-// ============================================================================
-void prefill_qk_norm_rope_only_cuda(
-    __nv_bfloat16* q_batch,          // [q_dim, seq_len] modified in-place (normed+RoPE'd)
-    __nv_bfloat16* k_batch,          // [kv_dim, seq_len] modified in-place (normed+RoPE'd)
-    const __nv_bfloat16* q_norm_weight,
-    const __nv_bfloat16* k_norm_weight,
-    const __nv_bfloat16* cos_cache,
-    const __nv_bfloat16* sin_cache,
-    int num_q_heads,
-    int num_kv_heads,
-    int head_dim,
-    int seq_len,
-    int start_pos,
-    float rms_eps,
-    cudaStream_t stream
-) {
-    int q_dim = num_q_heads * head_dim;
-    int kv_dim = num_kv_heads * head_dim;
-
-    dim3 norm_grid(num_q_heads + num_kv_heads, seq_len);
-    prefill_qk_norm_rope_kernel<<<norm_grid, head_dim, 0, stream>>>(
-        q_batch, k_batch, q_norm_weight, k_norm_weight,
-        cos_cache, sin_cache,
-        num_q_heads, num_kv_heads, head_dim,
-        seq_len, q_dim, kv_dim, start_pos, /*start_pos_d=*/nullptr, rms_eps
-    );
-}
-
-// ============================================================================
-// Batched QK norm + RoPE for decode: per-request positions from GPU array.
+// Serves both decode (one token per request) and paged prefill (the plan's
+// positions array carries each token's absolute position, so requests
+// resuming from a cached prefix rotate at their true offsets).
 //
 // Q layout: [q_dim, batch_size], K layout: [kv_dim, batch_size]
 // Grid: (num_q_heads + num_kv_heads, batch_size), Block: head_dim

--- a/pegainfer-kernels/src/ffi.rs
+++ b/pegainfer-kernels/src/ffi.rs
@@ -610,23 +610,6 @@ unsafe extern "C" {
     pub fn cublas_destroy();
     pub fn cuda_set_device(device_ordinal: i32) -> i32;
 
-    // Prefill QK norm + RoPE only (no KV cache write). For paged prefill path.
-    pub fn prefill_qk_norm_rope_only_cuda(
-        q_batch: *mut Half,
-        k_batch: *mut Half,
-        q_norm_weight: *const Half,
-        k_norm_weight: *const Half,
-        cos_cache: *const Half,
-        sin_cache: *const Half,
-        num_q_heads: i32,
-        num_kv_heads: i32,
-        head_dim: i32,
-        seq_len: i32,
-        start_pos: i32,
-        rms_eps: f32,
-        stream: CUstream,
-    );
-
     // Qwen3.5 full-attention prefill prep: Q/K norm + partial RoPE + KV cache write.
     pub fn prefill_attention_hd256_prep_cuda(
         q_full_batch: *const Half,

--- a/pegainfer-kernels/src/ops/attention.rs
+++ b/pegainfer-kernels/src/ops/attention.rs
@@ -304,8 +304,9 @@ impl PrefillPagedPlan {
 
 /// Per-layer paged prefill: QK norm + RoPE, append K/V to paged, batch prefill attention.
 ///
-/// Supports both single-request and multi-request plans. For single-request,
-/// uses scalar start_pos for RoPE. For multi-request, uses per-token positions.
+/// Token positions (RoPE, scatter, attention) come from the plan's per-token
+/// position array, so chunked or prefix-cached prefill (start > 0) works for
+/// any batch size.
 #[allow(clippy::too_many_arguments)]
 pub fn prefill_attention_paged_into(
     ctx: &DeviceContext,
@@ -324,7 +325,6 @@ pub fn prefill_attention_paged_into(
     num_q_heads: usize,
     num_kv_heads: usize,
     head_dim: usize,
-    start_pos: usize,
     rms_eps: f32,
 ) -> Result<()> {
     let total_tokens = plan.total_tokens;
@@ -359,41 +359,26 @@ pub fn prefill_attention_paged_into(
     let stream = ctx.stream.cu_stream();
 
     unsafe {
-        if plan.batch_size == 1 {
-            // Single-request: scalar start_pos (no GPU positions array needed)
-            ffi::prefill_qk_norm_rope_only_cuda(
-                q_ptr as *mut ffi::Half,
-                k_ptr as *mut ffi::Half,
-                qn_ptr as *const ffi::Half,
-                kn_ptr as *const ffi::Half,
-                cos_ptr as *const ffi::Half,
-                sin_ptr as *const ffi::Half,
-                num_q_heads as i32,
-                num_kv_heads as i32,
-                head_dim as i32,
-                total_tokens as i32,
-                start_pos as i32,
-                rms_eps,
-                stream,
-            );
-        } else {
-            // Multi-request: per-token positions from plan
-            ffi::qk_norm_rope_batched_decode_cuda(
-                q_ptr as *mut ffi::Half,
-                k_ptr as *mut ffi::Half,
-                qn_ptr as *const ffi::Half,
-                kn_ptr as *const ffi::Half,
-                cos_ptr as *const ffi::Half,
-                sin_ptr as *const ffi::Half,
-                pos_ptr as *const i32,
-                num_q_heads as i32,
-                num_kv_heads as i32,
-                head_dim as i32,
-                total_tokens as i32,
-                rms_eps,
-                stream,
-            );
-        }
+        // RoPE positions always come from the plan's per-token array — it is
+        // the single source of truth for each token's absolute position. A
+        // scalar-start_pos fast path for batch_size == 1 used to live here;
+        // it silently rotated prefix-cache-hit suffixes from position 0 and
+        // both entry points launch the same kernel anyway.
+        ffi::qk_norm_rope_batched_decode_cuda(
+            q_ptr as *mut ffi::Half,
+            k_ptr as *mut ffi::Half,
+            qn_ptr as *const ffi::Half,
+            kn_ptr as *const ffi::Half,
+            cos_ptr as *const ffi::Half,
+            sin_ptr as *const ffi::Half,
+            pos_ptr as *const i32,
+            num_q_heads as i32,
+            num_kv_heads as i32,
+            head_dim as i32,
+            total_tokens as i32,
+            rms_eps,
+            stream,
+        );
 
         let src_stride_n = kv_dim as i64;
         let src_stride_h = head_dim as i64;

--- a/pegainfer-kv-cache/Cargo.toml
+++ b/pegainfer-kv-cache/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 pegainfer-kernels = { workspace = true }
 kvbm-logical = { workspace = true }
+dynamo-kv-hashing = { workspace = true }
 anyhow = { workspace = true }
 cudarc = { workspace = true }
 half = { workspace = true }

--- a/pegainfer-kv-cache/src/manager.rs
+++ b/pegainfer-kv-cache/src/manager.rs
@@ -121,6 +121,23 @@ pub struct RequestKv {
 }
 
 impl RequestKv {
+    // ── Prefix cache ───────────────────────────────────────────────────
+
+    /// Match the prompt's full blocks against registered blocks and skip
+    /// their prefill. Returns the number of cached tokens; `kv_position()`
+    /// advances by the same amount. Must be called on a fresh request,
+    /// before the first `schedule_prefill`.
+    ///
+    /// Matching always leaves at least one prompt token uncached so the
+    /// final prefill chunk can emit the first generated token.
+    pub fn match_and_add_prefix(&mut self, manager: &KvCacheManager) -> anyhow::Result<usize> {
+        let blocks = self
+            .seq
+            .match_and_add_prefix(&manager.block_manager)
+            .map_err(|e| anyhow::anyhow!("match_and_add_prefix: {e}"))?;
+        Ok(blocks * self.seq.block_size())
+    }
+
     // ── Scheduling (allocates blocks) ──────────────────────────────────
 
     pub fn schedule_prefill(

--- a/pegainfer-kv-cache/src/manager.rs
+++ b/pegainfer-kv-cache/src/manager.rs
@@ -101,12 +101,25 @@ impl KvCacheManager {
         self.block_manager.total_blocks().saturating_sub(1)
     }
 
-    pub fn new_request(&self, prompt_tokens: Vec<u32>, max_output_tokens: usize) -> RequestKv {
+    /// `lora_name` scopes the prefix cache: blocks registered under one
+    /// adapter (or the base model, `None`) never match a request running
+    /// under a different adapter — the name is folded into the block-hash
+    /// chain as a salt, so K/V computed with different weights can't be
+    /// silently reused.
+    pub fn new_request(
+        &self,
+        prompt_tokens: Vec<u32>,
+        max_output_tokens: usize,
+        lora_name: Option<&str>,
+    ) -> RequestKv {
+        let salt_hash = dynamo_kv_hashing::compute_salt_hash(None, lora_name)
+            .expect("salt hash from lora name is infallible");
         let seq = SchedulableSequence::new(
             prompt_tokens,
             max_output_tokens,
             self.block_size as u32,
             None,
+            Some(salt_hash),
         );
         RequestKv { seq }
     }

--- a/pegainfer-kv-cache/tests/lifecycle.rs
+++ b/pegainfer-kv-cache/tests/lifecycle.rs
@@ -16,7 +16,7 @@ fn single_request_prefill_decode_release() {
     assert_eq!(initial_avail, 31); // 32 - 1 padding
 
     // New request: 10-token prompt, up to 6 output tokens
-    let mut req = mgr.new_request(vec![1; 10], 6);
+    let mut req = mgr.new_request(vec![1; 10], 6, None);
     assert_eq!(req.kv_position(), 0);
 
     // Schedule prefill for 10 tokens → needs 1 block (ceil(10/16))
@@ -55,7 +55,7 @@ fn multiple_requests_share_capacity() {
     assert_eq!(mgr.available_blocks(), 9);
 
     // Request A: 16 tokens prompt → 1 block, max 16 output → needs ceil(31/16)=2 blocks total
-    let mut a = mgr.new_request(vec![1; 16], 16);
+    let mut a = mgr.new_request(vec![1; 16], 16, None);
     a.schedule_prefill(16, &mgr).expect("a prefill schedule");
     a.apply_prefill(42, &mgr).expect("a prefill apply");
 
@@ -63,7 +63,7 @@ fn multiple_requests_share_capacity() {
     assert!(after_a < 9);
 
     // Request B: 16 tokens prompt → 1 block
-    let mut b = mgr.new_request(vec![2; 16], 1);
+    let mut b = mgr.new_request(vec![2; 16], 1, None);
     b.schedule_prefill(16, &mgr).expect("b prefill schedule");
     b.apply_prefill(43, &mgr).expect("b prefill apply");
 
@@ -82,7 +82,7 @@ fn page_boundary_crossing() {
 
     // Prompt exactly 16 tokens (fills block 0 exactly), then decode
     // 1 token which should cross into block 1.
-    let mut req = mgr.new_request(vec![1; 16], 2);
+    let mut req = mgr.new_request(vec![1; 16], 2, None);
     req.schedule_prefill(16, &mgr).expect("schedule_prefill");
 
     let view = req.prefill_view(16);
@@ -106,7 +106,7 @@ fn page_boundary_crossing() {
 #[test]
 fn kv_view_desc_has_correct_layout() {
     let mgr = make_manager(10);
-    let mut req = mgr.new_request(vec![1; 5], 1);
+    let mut req = mgr.new_request(vec![1; 5], 1, None);
 
     req.schedule_prefill(5, &mgr).expect("schedule_prefill");
     let view = req.prefill_view(5);
@@ -130,7 +130,7 @@ fn padding_block_id_is_stable() {
     let pid = mgr.padding_block_id();
     assert!(pid >= 0);
     // Allocate and release — padding ID must not change.
-    let mut req = mgr.new_request(vec![1; 8], 1);
+    let mut req = mgr.new_request(vec![1; 8], 1, None);
     req.schedule_prefill(8, &mgr).unwrap();
     req.apply_prefill(1, &mgr).unwrap();
     req.release().unwrap();
@@ -144,7 +144,7 @@ fn exhaust_capacity_returns_error() {
     // Each request with 16-token prompt needs 1 block.
     let mut reqs: Vec<_> = (0..3)
         .map(|_| {
-            let mut r = mgr.new_request(vec![1; 16], 1);
+            let mut r = mgr.new_request(vec![1; 16], 1, None);
             r.schedule_prefill(16, &mgr).expect("schedule");
             r.apply_prefill(42, &mgr).expect("apply");
             r
@@ -154,7 +154,7 @@ fn exhaust_capacity_returns_error() {
     assert_eq!(mgr.available_blocks(), 0);
 
     // Next request should fail to schedule.
-    let mut overflow = mgr.new_request(vec![1; 16], 1);
+    let mut overflow = mgr.new_request(vec![1; 16], 1, None);
     let result = overflow.schedule_prefill(16, &mgr);
     assert!(result.is_err(), "should fail when no blocks available");
 
@@ -172,7 +172,7 @@ fn schedule_without_apply_returns_blocks_on_drop() {
     let before = mgr.available_blocks();
 
     {
-        let mut req = mgr.new_request(vec![1; 32], 1);
+        let mut req = mgr.new_request(vec![1; 32], 1, None);
         // 32 tokens → ceil(32/16) = 2 blocks scheduled
         req.schedule_prefill(32, &mgr).expect("schedule_prefill");
         assert!(mgr.available_blocks() < before);
@@ -187,7 +187,7 @@ fn schedule_without_apply_returns_blocks_on_drop() {
 #[test]
 fn ensure_capacity_rejects_insufficient_pages() {
     let mgr = make_manager(10);
-    let mut req = mgr.new_request(vec![1; 8], 1);
+    let mut req = mgr.new_request(vec![1; 8], 1, None);
 
     req.schedule_prefill(8, &mgr).expect("schedule_prefill");
     let view = req.prefill_view(8);
@@ -210,7 +210,7 @@ fn ensure_capacity_rejects_insufficient_pages() {
 #[test]
 fn decode_view_seq_len_invariant() {
     let mgr = make_manager(10);
-    let mut req = mgr.new_request(vec![1; 10], 4);
+    let mut req = mgr.new_request(vec![1; 10], 4, None);
 
     req.schedule_prefill(10, &mgr).unwrap();
     req.apply_prefill(42, &mgr).unwrap();
@@ -235,7 +235,7 @@ fn decode_view_seq_len_invariant() {
 #[test]
 fn prefill_view_covers_target_seq_len() {
     let mgr = make_manager(10);
-    let mut req = mgr.new_request(vec![1; 20], 1);
+    let mut req = mgr.new_request(vec![1; 20], 1, None);
 
     req.schedule_prefill(20, &mgr).unwrap();
     let view = req.prefill_view(20);
@@ -250,4 +250,38 @@ fn prefill_view_covers_target_seq_len() {
 
     req.apply_prefill(42, &mgr).unwrap();
     req.release().unwrap();
+}
+
+#[test]
+fn lora_salt_isolates_prefix_cache() {
+    let mgr = make_manager(32);
+    let prompt = vec![7u32; 48]; // 3 full blocks
+
+    // Register the prompt's blocks under adapter "a"; release leaves them
+    // in the inactive pool, still matchable.
+    let mut a = mgr.new_request(prompt.clone(), 4, Some("a"));
+    a.schedule_prefill(48, &mgr).expect("a prefill schedule");
+    a.apply_prefill(42, &mgr).expect("a prefill apply");
+    a.release().expect("a release");
+
+    // Base model (no adapter): same tokens, different salt — zero hits.
+    let mut base = mgr.new_request(prompt.clone(), 4, None);
+    assert_eq!(
+        base.match_and_add_prefix(&mgr).expect("base match"),
+        0,
+        "base request must not reuse KV computed under adapter 'a'"
+    );
+
+    // Different adapter: same tokens — zero hits.
+    let mut b = mgr.new_request(prompt.clone(), 4, Some("b"));
+    assert_eq!(
+        b.match_and_add_prefix(&mgr).expect("b match"),
+        0,
+        "adapter 'b' must not reuse KV computed under adapter 'a'"
+    );
+
+    // Same adapter: hits, capped to leave the last block for prefill
+    // ((48-1)/16 = 2 blocks = 32 tokens).
+    let mut a2 = mgr.new_request(prompt, 4, Some("a"));
+    assert_eq!(a2.match_and_add_prefix(&mgr).expect("a2 match"), 32);
 }

--- a/pegainfer-qwen3-4b/src/batch_decode_trace.rs
+++ b/pegainfer-qwen3-4b/src/batch_decode_trace.rs
@@ -58,7 +58,7 @@ pub fn trace_decode_kernel_calls(
     let dummy_prompt_len = if kv_len > 1 { kv_len - 1 } else { 1 };
     let mut rkvs = (0..batch_size)
         .map(|_| {
-            let mut rkv = kv_mgr.new_request(vec![0; dummy_prompt_len], 1);
+            let mut rkv = kv_mgr.new_request(vec![0; dummy_prompt_len], 1, None);
             rkv.schedule_prefill(dummy_prompt_len, &kv_mgr)
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
             rkv.apply_prefill(0, &kv_mgr)?;

--- a/pegainfer-qwen3-4b/src/executor.rs
+++ b/pegainfer-qwen3-4b/src/executor.rs
@@ -36,6 +36,10 @@ pub struct PrefillStepItem {
     pub(crate) logprobs: usize,
     pub(crate) echo: bool,
     pub(crate) random_val: f32,
+    /// Leading prompt tokens whose KV came from the prefix cache.
+    /// Set by the executor after matching; the forward pass only computes
+    /// the remaining suffix.
+    pub(crate) cached_tokens: usize,
 }
 
 impl PrefillStepItem {
@@ -56,11 +60,17 @@ impl PrefillStepItem {
             logprobs,
             echo,
             random_val,
+            cached_tokens: 0,
         }
     }
 
+    /// Prompt tokens that still need prefill (cached prefix excluded).
     fn as_slice(&self) -> &[u32] {
-        &self.prompt_tokens
+        &self.prompt_tokens[self.cached_tokens..]
+    }
+
+    fn suffix_len(&self) -> usize {
+        self.prompt_tokens.len() - self.cached_tokens
     }
 }
 
@@ -134,12 +144,13 @@ fn build_prefill_request_results(
         } else {
             None
         };
-        token_offset += req.prompt_tokens.len();
+        token_offset += req.suffix_len();
         outputs.push(PrefillRequestResult {
             request_id: req.request_id,
             first_token,
             first_token_logprob,
             prompt_logprobs,
+            cached_tokens: req.cached_tokens,
         });
     }
     Ok(outputs)
@@ -359,6 +370,8 @@ pub struct PrefillRequestResult {
     pub first_token: u32,
     pub first_token_logprob: Option<TokenLogprob>,
     pub prompt_logprobs: Option<Vec<Option<TokenLogprob>>>,
+    /// Prompt tokens served from the prefix cache (KV reused, not recomputed).
+    pub cached_tokens: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -432,6 +445,7 @@ pub struct Qwen3Executor {
     primary: RankWorker,
     workers: Vec<RankWorker>,
     loaded_lora_adapters: HashSet<String>,
+    prefix_cache_enabled: bool,
 }
 
 impl Qwen3Executor {
@@ -463,6 +477,7 @@ impl Qwen3Executor {
             )?,
             workers: Vec::new(),
             loaded_lora_adapters: HashSet::new(),
+            prefix_cache_enabled: true,
         })
     }
 
@@ -576,6 +591,7 @@ impl Qwen3Executor {
             primary,
             workers,
             loaded_lora_adapters: HashSet::new(),
+            prefix_cache_enabled: true,
         })
     }
 
@@ -613,6 +629,13 @@ impl Qwen3Executor {
 
     pub fn activate_lora_adapter(&mut self, adapter: Option<&str>) -> Result<()> {
         <Self as ModelExecutor>::activate_lora_adapter(self, adapter)
+    }
+
+    /// Prefix caching is on by default; tests that assert bit-identical
+    /// replay disable it (a cache hit changes prefill GEMM shapes, which
+    /// drifts logits by bf16 ULPs).
+    pub fn set_prefix_cache_enabled(&mut self, enabled: bool) {
+        self.prefix_cache_enabled = enabled;
     }
 
     fn wait_for_step_ack(
@@ -709,28 +732,33 @@ impl ModelExecutor for Qwen3Executor {
     }
 
     fn execute_prefill(&mut self, plan: PrefillPlan<'_>) -> Result<PrefillResult> {
-        // 1. Create RequestKvs and schedule prefill
-        for req in plan.requests {
+        // 1. Create RequestKvs, reuse cached prefix blocks, schedule the rest
+        let mut requests = plan.requests.to_vec();
+        for req in &mut requests {
             let mut rkv = self
                 .kv_mgr
                 .new_request(req.prompt_tokens.clone(), req.max_output_tokens);
-            rkv.schedule_prefill(req.prompt_tokens.len(), &self.kv_mgr)
+            // Echo needs logits for every prompt position; cached positions
+            // are never forwarded, so echo requests prefill from scratch.
+            if self.prefix_cache_enabled && !req.echo {
+                req.cached_tokens = rkv.match_and_add_prefix(&self.kv_mgr)?;
+            }
+            rkv.schedule_prefill(req.suffix_len(), &self.kv_mgr)
                 .map_err(|e| {
                     anyhow::anyhow!("schedule_prefill failed for {:?}: {e}", req.request_id)
                 })?;
             self.request_kvs.insert(req.request_id, rkv);
         }
 
-        // 2. Build KvViews
-        let kv_views: Vec<KvView> = plan
-            .requests
+        // 2. Build KvViews (seq_len = cached prefix + new suffix)
+        let kv_views: Vec<KvView> = requests
             .iter()
-            .map(|req| self.request_kvs[&req.request_id].prefill_view(req.prompt_tokens.len()))
+            .map(|req| self.request_kvs[&req.request_id].prefill_view(req.suffix_len()))
             .collect();
 
         // 3. Execute forward
         let step = StepCommand::Prefill {
-            requests: plan.requests.to_vec(),
+            requests,
             kv_views,
             echo: plan.echo,
         };
@@ -805,12 +833,17 @@ impl ModelExecutor for Qwen3Executor {
     }
 
     fn execute_unified(&mut self, plan: UnifiedPlan<'_>) -> Result<UnifiedResult> {
-        // 1. Create RequestKvs for prefill requests and schedule
-        for req in plan.prefill_requests {
+        // 1. Create RequestKvs for prefill requests, reuse cached prefix
+        // blocks, and schedule the rest
+        let mut prefill_requests = plan.prefill_requests.to_vec();
+        for req in &mut prefill_requests {
             let mut rkv = self
                 .kv_mgr
                 .new_request(req.prompt_tokens.clone(), req.max_output_tokens);
-            rkv.schedule_prefill(req.prompt_tokens.len(), &self.kv_mgr)
+            if self.prefix_cache_enabled && !req.echo {
+                req.cached_tokens = rkv.match_and_add_prefix(&self.kv_mgr)?;
+            }
+            rkv.schedule_prefill(req.suffix_len(), &self.kv_mgr)
                 .map_err(|e| {
                     anyhow::anyhow!("schedule_prefill failed for {:?}: {e}", req.request_id)
                 })?;
@@ -829,10 +862,9 @@ impl ModelExecutor for Qwen3Executor {
         }
 
         // 2. Build KvViews
-        let prefill_kv_views: Vec<KvView> = plan
-            .prefill_requests
+        let prefill_kv_views: Vec<KvView> = prefill_requests
             .iter()
-            .map(|req| self.request_kvs[&req.request_id].prefill_view(req.prompt_tokens.len()))
+            .map(|req| self.request_kvs[&req.request_id].prefill_view(req.suffix_len()))
             .collect();
         let decode_kv_views: Vec<KvView> = plan
             .decode_requests
@@ -842,7 +874,7 @@ impl ModelExecutor for Qwen3Executor {
 
         // 3. Execute forward
         let step = StepCommand::Unified {
-            prefill_requests: plan.prefill_requests.to_vec(),
+            prefill_requests,
             prefill_kv_views,
             decode_requests: plan.decode_requests.to_vec(),
             decode_kv_views,

--- a/pegainfer-qwen3-4b/src/executor.rs
+++ b/pegainfer-qwen3-4b/src/executor.rs
@@ -445,6 +445,9 @@ pub struct Qwen3Executor {
     primary: RankWorker,
     workers: Vec<RankWorker>,
     loaded_lora_adapters: HashSet<String>,
+    /// Adapter currently activated on the workers; scopes prefix-cache
+    /// block hashes so KV computed under different adapters never mixes.
+    active_lora_adapter: Option<String>,
     prefix_cache_enabled: bool,
 }
 
@@ -477,6 +480,7 @@ impl Qwen3Executor {
             )?,
             workers: Vec::new(),
             loaded_lora_adapters: HashSet::new(),
+            active_lora_adapter: None,
             prefix_cache_enabled: true,
         })
     }
@@ -591,6 +595,7 @@ impl Qwen3Executor {
             primary,
             workers,
             loaded_lora_adapters: HashSet::new(),
+            active_lora_adapter: None,
             prefix_cache_enabled: true,
         })
     }
@@ -735,9 +740,11 @@ impl ModelExecutor for Qwen3Executor {
         // 1. Create RequestKvs, reuse cached prefix blocks, schedule the rest
         let mut requests = plan.requests.to_vec();
         for req in &mut requests {
-            let mut rkv = self
-                .kv_mgr
-                .new_request(req.prompt_tokens.clone(), req.max_output_tokens);
+            let mut rkv = self.kv_mgr.new_request(
+                req.prompt_tokens.clone(),
+                req.max_output_tokens,
+                self.active_lora_adapter.as_deref(),
+            );
             // Echo needs logits for every prompt position; cached positions
             // are never forwarded, so echo requests prefill from scratch.
             if self.prefix_cache_enabled && !req.echo {
@@ -837,9 +844,11 @@ impl ModelExecutor for Qwen3Executor {
         // blocks, and schedule the rest
         let mut prefill_requests = plan.prefill_requests.to_vec();
         for req in &mut prefill_requests {
-            let mut rkv = self
-                .kv_mgr
-                .new_request(req.prompt_tokens.clone(), req.max_output_tokens);
+            let mut rkv = self.kv_mgr.new_request(
+                req.prompt_tokens.clone(),
+                req.max_output_tokens,
+                self.active_lora_adapter.as_deref(),
+            );
             if self.prefix_cache_enabled && !req.echo {
                 req.cached_tokens = rkv.match_and_add_prefix(&self.kv_mgr)?;
             }
@@ -913,7 +922,9 @@ impl ModelExecutor for Qwen3Executor {
         self.run_worker_command(
             |worker| worker.activate_lora_adapter(adapter.map(str::to_string)),
             "LoRA activation",
-        )
+        )?;
+        self.active_lora_adapter = adapter.map(str::to_string);
+        Ok(())
     }
 
     fn load_lora_adapter(&mut self, request: &LoadLoraAdapterRequest) -> Result<()> {

--- a/pegainfer-qwen3-4b/src/kernel_bench.rs
+++ b/pegainfer-qwen3-4b/src/kernel_bench.rs
@@ -760,7 +760,6 @@ impl AttentionPrefillCase {
             NUM_QO_HEADS,
             NUM_KV_HEADS,
             HEAD_DIM,
-            0,
             1.0e-6,
         )
     }
@@ -806,42 +805,24 @@ impl AttentionPrefillCase {
         let (cos_ptr, _cos_guard) = self.cos_cache.data.device_ptr(&self.ctx.stream);
         let (sin_ptr, _sin_guard) = self.sin_cache.data.device_ptr(&self.ctx.stream);
 
+        let (positions_ptr, _positions_guard) =
+            self.plan.positions_d().device_ptr(&self.ctx.stream);
         unsafe {
-            if self.plan.batch_size() == 1 {
-                ffi::prefill_qk_norm_rope_only_cuda(
-                    q_ptr as *mut ffi::Half,
-                    k_ptr as *mut ffi::Half,
-                    qn_ptr as *const ffi::Half,
-                    kn_ptr as *const ffi::Half,
-                    cos_ptr as *const ffi::Half,
-                    sin_ptr as *const ffi::Half,
-                    NUM_QO_HEADS as i32,
-                    NUM_KV_HEADS as i32,
-                    HEAD_DIM as i32,
-                    total_tokens as i32,
-                    0,
-                    1.0e-6,
-                    self.ctx.stream.cu_stream(),
-                );
-            } else {
-                let (positions_ptr, _positions_guard) =
-                    self.plan.positions_d().device_ptr(&self.ctx.stream);
-                ffi::qk_norm_rope_batched_decode_cuda(
-                    q_ptr as *mut ffi::Half,
-                    k_ptr as *mut ffi::Half,
-                    qn_ptr as *const ffi::Half,
-                    kn_ptr as *const ffi::Half,
-                    cos_ptr as *const ffi::Half,
-                    sin_ptr as *const ffi::Half,
-                    positions_ptr as *const i32,
-                    NUM_QO_HEADS as i32,
-                    NUM_KV_HEADS as i32,
-                    HEAD_DIM as i32,
-                    total_tokens as i32,
-                    1.0e-6,
-                    self.ctx.stream.cu_stream(),
-                );
-            }
+            ffi::qk_norm_rope_batched_decode_cuda(
+                q_ptr as *mut ffi::Half,
+                k_ptr as *mut ffi::Half,
+                qn_ptr as *const ffi::Half,
+                kn_ptr as *const ffi::Half,
+                cos_ptr as *const ffi::Half,
+                sin_ptr as *const ffi::Half,
+                positions_ptr as *const i32,
+                NUM_QO_HEADS as i32,
+                NUM_KV_HEADS as i32,
+                HEAD_DIM as i32,
+                total_tokens as i32,
+                1.0e-6,
+                self.ctx.stream.cu_stream(),
+            );
         }
     }
 

--- a/pegainfer-qwen3-4b/src/prefill.rs
+++ b/pegainfer-qwen3-4b/src/prefill.rs
@@ -81,7 +81,6 @@ impl Qwen3Model {
         layer_idx: usize,
         layer: &TransformerBlock,
         hidden: &mut HiddenStates,
-        start_pos: usize,
         kv_buffer: &cudarc::driver::CudaSlice<half::bf16>,
         layout: &pegainfer_core::kv_pool::KvLayout,
         plan: &PrefillPagedPlan,
@@ -182,7 +181,6 @@ impl Qwen3Model {
             num_heads,
             num_kv_heads,
             head_dim,
-            start_pos,
             self.config.rms_norm_eps,
         )?;
 
@@ -410,7 +408,6 @@ impl Qwen3Model {
                 layer_idx,
                 layer,
                 &mut hidden,
-                0, // start_pos unused for multi-request (plan has per-token positions)
                 kv_buffer,
                 layout,
                 plan,

--- a/pegainfer-qwen3-4b/src/scheduler.rs
+++ b/pegainfer-qwen3-4b/src/scheduler.rs
@@ -765,6 +765,7 @@ mod tests {
                         first_token: 100 + req.request_id.get() as u32,
                         first_token_logprob: None,
                         prompt_logprobs: None,
+                        cached_tokens: 0,
                     })
                     .collect(),
             })
@@ -844,6 +845,7 @@ mod tests {
                         first_token: 100 + req.request_id.get() as u32,
                         first_token_logprob: None,
                         prompt_logprobs: None,
+                        cached_tokens: 0,
                     })
                     .collect(),
                 decode_requests: plan

--- a/pegainfer-qwen3-4b/src/scheduler/plan.rs
+++ b/pegainfer-qwen3-4b/src/scheduler/plan.rs
@@ -207,6 +207,7 @@ fn build_prefill_items(
                 logprobs: r.logprobs,
                 echo: r.echo,
                 random_val: rand::RngExt::random(rng),
+                cached_tokens: 0,
             }
         })
         .collect()

--- a/pegainfer-qwen3-4b/tests/hf_golden_gate.rs
+++ b/pegainfer-qwen3-4b/tests/hf_golden_gate.rs
@@ -156,6 +156,9 @@ struct Stats {
     argmax_violations: Vec<String>,
     head_deltas: Vec<f32>, // |pega - HF| logprob on the head tokens
     worst: Option<(f32, usize, usize, u32, f32, f32)>, // delta, seq, pos, token, pega, hf
+    /// Prompt tokens served from the prefix cache, summed over all prefills.
+    /// Zero when caching is disabled; the cached-replay passes assert it is not.
+    cached_tokens: usize,
 }
 
 /// Fold one position into `stats`. `hf` and `pega` are top-K `(token, logprob)`,
@@ -315,6 +318,7 @@ fn run(g: &Golden, ex: &mut Qwen3Executor, seqs: &[usize], batched: bool) -> (St
             })
             .expect("prefill");
         for (i, &s) in seqs.iter().enumerate() {
+            stats.cached_tokens += pr.requests[i].cached_tokens;
             fold(
                 &mut stats,
                 s,
@@ -352,6 +356,7 @@ fn run(g: &Golden, ex: &mut Qwen3Executor, seqs: &[usize], batched: bool) -> (St
                     echo: false,
                 })
                 .expect("prefill");
+            stats.cached_tokens += pr.requests[0].cached_tokens;
             fold(
                 &mut stats,
                 seq,
@@ -444,6 +449,10 @@ fn pega_logprobs_match_hf_golden_within_bf16_tolerance() {
     {
         let mut ex =
             Qwen3Executor::from_runtime(&model_path, false, &[0]).expect("build eager executor");
+        // The determinism and isolation passes need bit-replayable prefill: a
+        // prefix-cache hit shrinks the prefill GEMM to the uncached suffix,
+        // which drifts logits by bf16 ULPs. Caching gets its own pass below.
+        ex.set_prefix_cache_enabled(false);
 
         // bs=1 sequential over *every* golden sequence — this is the breadth of
         // the prompt/length coverage (one request's KV at a time, so it scales to
@@ -468,6 +477,24 @@ fn pega_logprobs_match_hf_golden_within_bf16_tolerance() {
         let n = BUCKET_STRADDLES[0];
         let (batched, _) = run(&golden, &mut ex, &all[..n], true);
         report_and_assert(&format!("batched eager ({n}, no pad)"), &batched);
+
+        // Prefix-cached replay. Every block is already registered (the runs
+        // above register blocks even with matching disabled), so these rerun
+        // with warm caches: prefill skips the cached prefix and attention spans
+        // cached KV + recomputed suffix (kv_len > q_len). Same HF tolerances —
+        // a wrong RoPE offset, mask, or stale page would blow far past them.
+        ex.set_prefix_cache_enabled(true);
+        let (cached, _) = run(&golden, &mut ex, &all, false);
+        assert!(
+            cached.cached_tokens > 0,
+            "cached replay matched no prefix blocks — the cache path was not exercised"
+        );
+        report_and_assert("sequential bs=1 eager cached replay", &cached);
+        let (cached_batched, _) = run(&golden, &mut ex, &all[..n], true);
+        report_and_assert(
+            &format!("batched eager cached replay ({n})"),
+            &cached_batched,
+        );
     }
 
     // CUDA-graph decode is captured per bucket and pads the batch up to it, so
@@ -476,9 +503,21 @@ fn pega_logprobs_match_hf_golden_within_bf16_tolerance() {
     {
         let mut ex = Qwen3Executor::from_runtime(&model_path, true, &[0])
             .expect("build cuda-graph executor");
+        ex.set_prefix_cache_enabled(false);
         for n in BUCKET_STRADDLES {
             let (batched, _) = run(&golden, &mut ex, &all[..n], true);
             report_and_assert(&format!("batched cuda-graph ({n} padded)"), &batched);
         }
+
+        // Graph decode over shared cached pages: the captured graph reads page
+        // tables that now point at blocks written by earlier requests.
+        ex.set_prefix_cache_enabled(true);
+        let n = BUCKET_STRADDLES[1];
+        let (cached, _) = run(&golden, &mut ex, &all[..n], true);
+        assert!(
+            cached.cached_tokens > 0,
+            "cuda-graph cached replay matched no prefix blocks"
+        );
+        report_and_assert(&format!("batched cuda-graph cached replay ({n})"), &cached);
     }
 }

--- a/pegainfer-qwen3-4b/tests/prefix_cache.rs
+++ b/pegainfer-qwen3-4b/tests/prefix_cache.rs
@@ -1,0 +1,272 @@
+//! Behavioral gate for the Qwen3-4B prefix cache.
+//!
+//! `hf_golden_gate`'s cached-replay surfaces own the accuracy story (warm
+//! logits vs the HF golden). This test pins the behavioral contract of the
+//! cache itself — what gets matched, what gets recomputed:
+//!   * exact cached-token counts: full prompt blocks hit, the partial tail
+//!     is always recomputed
+//!   * the full-block cap: a prompt whose length divides the block size and
+//!     is fully cached still keeps one block of prefill, so the final chunk
+//!     can emit a token
+//!   * prefix extension: a longer prompt reuses a shorter prompt's blocks
+//!   * mixed batch: a cold and a warm request share one prefill plan
+//!     (per-request start positions) without corrupting each other
+//!   * the unified prefill+decode path matches through the same code
+//!
+//! Each warm run is also bounded against the same executor's cache-off run:
+//! the only legitimate difference is the prefill GEMM shrinking to the
+//! uncached suffix, so logits must agree within bf16 reduction-order noise.
+//! A wrong RoPE offset, causal-mask offset, or stale page is whole nats off
+//! and cannot hide inside these tolerances.
+//!
+//! Requires a CUDA GPU and Qwen3-4B weights; skips cleanly when absent
+//! (point `PEGAINFER_TEST_MODEL_PATH` at the weights to run it).
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use pegainfer_core::engine::TokenLogprob;
+use pegainfer_core::sampler::SamplingParams;
+use pegainfer_qwen3_4b::runtime::{
+    DecodePlan, DecodeStepItem, PrefillPlan, PrefillStepItem, Qwen3Executor, RequestId, UnifiedPlan,
+};
+
+const MODEL_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../models/Qwen3-4B");
+const BLOCK: usize = 16;
+const LOGPROBS: usize = 16;
+const MAX_OUTPUT: usize = 8;
+/// Teacher-forced tokens fed after each prefill, so cold and warm runs are
+/// compared on identical inputs at every decode position.
+const DECODE_FED: [u32; 4] = [11, 22, 33, 44];
+
+/// Warm-vs-cold self-consistency bounds, following the golden-gate
+/// methodology: the warm argmax must sit within `REGRET_TOL` of the cold
+/// argmax (structural wrong-token guard), and the *mean* head-token delta —
+/// coverage-stable, unlike the absolute max — must stay at the bf16
+/// reduction-order floor. Individual tail tokens can swing several ULPs
+/// (≈0.6 nat observed on these synthetic prompts), so the per-token max is
+/// printed, never asserted.
+const REGRET_TOL: f32 = 0.20;
+const MEAN_TOL: f32 = 0.06;
+
+fn model_path_or_skip() -> Option<String> {
+    match std::env::var("PEGAINFER_TEST_MODEL_PATH") {
+        Ok(path) => Some(path),
+        Err(_) if Path::new(MODEL_PATH).join("config.json").exists() => {
+            Some(MODEL_PATH.to_string())
+        }
+        Err(_) => {
+            eprintln!(
+                "skipping qwen3 prefix_cache: {MODEL_PATH}/config.json is missing; set PEGAINFER_TEST_MODEL_PATH to run it"
+            );
+            None
+        }
+    }
+}
+
+/// Deterministic synthetic prompt; different seeds share no prefix.
+fn prompt(seed: usize, len: usize) -> Vec<u32> {
+    (0..len)
+        .map(|i| ((seed * 100_003 + i * 17) % 50_000 + 1_000) as u32)
+        .collect()
+}
+
+fn prefill_item(id: u64, prompt: &[u32]) -> PrefillStepItem {
+    PrefillStepItem::new(
+        RequestId::new(id),
+        prompt.to_vec(),
+        MAX_OUTPUT,
+        SamplingParams::default(),
+        LOGPROBS,
+        false,
+        0.0,
+    )
+}
+
+fn decode_item(id: u64, fed: u32) -> DecodeStepItem {
+    DecodeStepItem::new(
+        RequestId::new(id),
+        fed,
+        SamplingParams::default(),
+        LOGPROBS,
+        0.0,
+    )
+}
+
+fn top_logprobs(lp: Option<&TokenLogprob>) -> Vec<(u32, f32)> {
+    lp.expect("logprobs requested but none returned")
+        .top_logprobs
+        .clone()
+}
+
+/// Prefill `prompt`, teacher-force `DECODE_FED`, drop the request. Returns
+/// the cached-token count and the top-K logprobs at every position.
+fn run_one(ex: &mut Qwen3Executor, id: u64, prompt: &[u32]) -> (usize, Vec<Vec<(u32, f32)>>) {
+    let pr = ex
+        .execute_prefill(PrefillPlan {
+            requests: &[prefill_item(id, prompt)],
+            echo: false,
+        })
+        .expect("prefill");
+    let cached = pr.requests[0].cached_tokens;
+    let mut positions = vec![top_logprobs(pr.requests[0].first_token_logprob.as_ref())];
+    for fed in DECODE_FED {
+        let dr = ex
+            .execute_decode(DecodePlan {
+                requests: &[decode_item(id, fed)],
+            })
+            .expect("decode");
+        positions.push(top_logprobs(dr.requests[0].logprob.as_ref()));
+    }
+    ex.drop_request(RequestId::new(id)).expect("drop request");
+    (cached, positions)
+}
+
+/// Warm logits must agree with cold logits up to bf16 reduction-order noise:
+/// the warm argmax may sit at most `REGRET_TOL` below the cold argmax (in the
+/// cold run's own logprobs), and the mean delta over head tokens common to
+/// both top-Ks must stay under `MEAN_TOL`. The worst single delta is printed
+/// but not asserted — it is coverage-unstable bf16 tail.
+fn assert_close(label: &str, cold: &[Vec<(u32, f32)>], warm: &[Vec<(u32, f32)>]) {
+    assert_eq!(cold.len(), warm.len(), "[{label}] position count mismatch");
+    let mut deltas = Vec::new();
+    for (pos, (c, w)) in cold.iter().zip(warm).enumerate() {
+        let cold_map: HashMap<u32, f32> = c.iter().copied().collect();
+        let cold_top = c[0].1;
+        match cold_map.get(&w[0].0) {
+            None => panic!(
+                "[{label}] pos {pos}: warm argmax {} absent from cold top-{}",
+                w[0].0,
+                c.len()
+            ),
+            Some(&clp) => assert!(
+                cold_top - clp <= REGRET_TOL,
+                "[{label}] pos {pos}: warm argmax {} sits {:.4} nat below cold argmax",
+                w[0].0,
+                cold_top - clp
+            ),
+        }
+        for &(token, wlp) in w.iter().take(8) {
+            if let Some(&clp) = cold_map.get(&token) {
+                deltas.push((wlp - clp).abs());
+            }
+        }
+    }
+    assert!(!deltas.is_empty(), "[{label}] no head-token overlap");
+    let mean = deltas.iter().sum::<f32>() / deltas.len() as f32;
+    let max = deltas.iter().copied().fold(0.0f32, f32::max);
+    eprintln!(
+        "prefix_cache [{label}]: {} head deltas — mean {mean:.4} max {max:.4}",
+        deltas.len()
+    );
+    assert!(
+        mean <= MEAN_TOL,
+        "[{label}] mean head logprob delta {mean:.4} > {MEAN_TOL} — warm logits drifted past bf16 noise"
+    );
+}
+
+#[test]
+fn prefix_cache_behavior() {
+    let Some(model_path) = model_path_or_skip() else {
+        return;
+    };
+    let mut ex =
+        Qwen3Executor::from_runtime(&model_path, false, &[0]).expect("build eager executor");
+
+    let a = prompt(1, 50); // 3 full blocks + 2-token tail
+    let b = [a.clone(), prompt(2, 16)].concat(); // 66 = A extended; 4 full blocks + 2
+    let c = prompt(3, 64); // exactly 4 blocks — the cap edge
+    let d = prompt(4, 40); // never seen before the mixed batch
+
+    // ── Phase 1: matching disabled — true cold baselines. apply_prefill /
+    // apply_decode still register completed blocks, so phase 2 finds them.
+    ex.set_prefix_cache_enabled(false);
+    let (cached, a_cold) = run_one(&mut ex, 1, &a);
+    assert_eq!(
+        cached, 0,
+        "matching disabled must report zero cached tokens"
+    );
+    let (_, b_cold) = run_one(&mut ex, 2, &b);
+    let (_, c_cold) = run_one(&mut ex, 3, &c);
+
+    // ── Phase 2: warm replays.
+    ex.set_prefix_cache_enabled(true);
+
+    let (cached, a_warm) = run_one(&mut ex, 11, &a);
+    assert_eq!(
+        cached,
+        3 * BLOCK,
+        "A: 3 full blocks hit, 2-token tail recomputed"
+    );
+    assert_close("A warm", &a_cold, &a_warm);
+
+    let (cached, b_warm) = run_one(&mut ex, 12, &b);
+    assert_eq!(cached, 4 * BLOCK, "B: A's 3 blocks + B's own 4th block hit");
+    assert_close("B warm (extension)", &b_cold, &b_warm);
+
+    let (cached, c_warm) = run_one(&mut ex, 13, &c);
+    assert_eq!(
+        cached,
+        3 * BLOCK,
+        "C: all 4 blocks are cached but the cap must keep one block of prefill"
+    );
+    assert_close("C warm (full-block cap)", &c_cold, &c_warm);
+
+    // ── Mixed batch: cold D and warm A share one prefill plan. Their start
+    // positions differ (0 vs 48) inside a single kernel plan; each request's
+    // logits must be unaffected by the neighbour.
+    let pr = ex
+        .execute_prefill(PrefillPlan {
+            requests: &[prefill_item(21, &d), prefill_item(22, &a)],
+            echo: false,
+        })
+        .expect("mixed prefill");
+    assert_eq!(pr.requests[0].cached_tokens, 0, "D is unseen — cold");
+    assert_eq!(pr.requests[1].cached_tokens, 3 * BLOCK, "A is warm");
+    let d_mixed = vec![top_logprobs(pr.requests[0].first_token_logprob.as_ref())];
+    let a_mixed = vec![top_logprobs(pr.requests[1].first_token_logprob.as_ref())];
+    assert_close("A in mixed batch", &a_cold[..1].to_vec(), &a_mixed);
+    ex.drop_request(RequestId::new(21)).expect("drop");
+    ex.drop_request(RequestId::new(22)).expect("drop");
+
+    // D's baseline: a cache-off solo prefill. Differs from the mixed run only
+    // by batching — so this bounds cross-request interference from the warm
+    // neighbour's nonzero start position.
+    ex.set_prefix_cache_enabled(false);
+    let pr = ex
+        .execute_prefill(PrefillPlan {
+            requests: &[prefill_item(31, &d)],
+            echo: false,
+        })
+        .expect("D solo prefill");
+    let d_solo = vec![top_logprobs(pr.requests[0].first_token_logprob.as_ref())];
+    ex.drop_request(RequestId::new(31)).expect("drop");
+    assert_close("D cold in mixed batch", &d_solo, &d_mixed);
+    ex.set_prefix_cache_enabled(true);
+
+    // ── Unified path: warm prefill of A while another request decodes.
+    let pr = ex
+        .execute_prefill(PrefillPlan {
+            requests: &[prefill_item(41, &b)],
+            echo: false,
+        })
+        .expect("B prefill for unified decode");
+    assert_eq!(pr.requests[0].cached_tokens, 4 * BLOCK);
+    let ur = ex
+        .execute_unified(UnifiedPlan {
+            prefill_requests: &[prefill_item(42, &a)],
+            decode_requests: &[decode_item(41, DECODE_FED[0])],
+        })
+        .expect("unified");
+    assert_eq!(
+        ur.prefill_requests[0].cached_tokens,
+        3 * BLOCK,
+        "unified prefill matches through the same path"
+    );
+    let a_unified = vec![top_logprobs(
+        ur.prefill_requests[0].first_token_logprob.as_ref(),
+    )];
+    assert_close("A in unified plan", &a_cold[..1].to_vec(), &a_unified);
+    ex.drop_request(RequestId::new(41)).expect("drop");
+    ex.drop_request(RequestId::new(42)).expect("drop");
+}


### PR DESCRIPTION
## What

Prefix caching for Qwen3-4B, **on by default**. `Qwen3Executor` matches registered KV blocks (vendored kvbm radix tree, full 16-token blocks only) before scheduling; only the uncached suffix is prefilled. Echo requests skip matching (prompt logprobs need every position).

Key pieces:
- kvbm `SchedulableSequence::match_and_add_prefix` caps matches at `(n-1)/block_size` so a fully cached prompt still recomputes ≥1 token (a full match deadlocks the schedule/apply state machine).
- **RoPE fix**: `prefill_attention_paged_into` had a `bs==1` scalar `start_pos` path that ignored the plan's per-token positions — warm bs=1 prefills rotated cache-hit suffixes from position 0 and scattered corrupted K into KV pages (up to 3.3 nat decode drift). Scalar branch + dead `prefill_qk_norm_rope_only_cuda` wrapper removed; all callers use the positions array (bit-identical for cold runs).
- kvbm tracing-mutex sentinel test gated to debug builds (release tracing-mutex is plain parking_lot; pre-existing failure on main).

## Tests

- New `tests/prefix_cache.rs` behavioral gate: exact cached-token counts, full-block cap edge, prefix extension, mixed cold+warm batch in one plan, unified path.
- `hf_golden_gate` gained cached-replay surfaces (bs=1 eager / batched eager / cuda-graph): warm mean 0.0316 / p99 0.1215 vs cold floor 0.0317 / 0.1196 — at the bf16 reduction-order floor.
- Workspace lib tests green (the one failure, `gdr_copy_flag_GPU`, is pre-existing on main — verified via stash).

## Perf (RTX 5090, drained-stream measurement)

| Metric | p50 | p99 |
|---|---|---|
| cold TTFT (~1900-token prompt) | 141.8ms | 205.8ms |
| warm TTFT (repeated prompt) | **16.3ms (8.7×)** | 16.7ms |

Warm TTFT = TPOT 11.4ms + tokenize ~2.9ms + request setup ~1.7ms + eager-launch ~0.8ms; full decomposition in `docs/models/qwen3/prefix-cache.md`.

Found along the way: the server has no abort-on-disconnect (zombie decode) — filed as #215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)