### PR TITLE
feat(qwen3): execute mixed LoRA batches

### DIFF
--- a/pegainfer-core/src/ops.rs
+++ b/pegainfer-core/src/ops.rs
@@ -18,10 +18,11 @@ pub use pegainfer_kernels::ops::{
     LoraDecodeGroupedProjection, add_batch, add_batch_into, embedding_decode_into, extract_vec,
     extract_vec_into, fused_add_rms_norm_into, gather_hidden_tokens_into, gemm, gemm_into_checked,
     gemm_per_token, gemv, linear, lora_decode_fused_delta_group3_into,
-    lora_decode_fused_delta_into, qk_norm_partial_rope_batched_decode_hd256_into, rms_norm,
-    rms_norm_batch_offset_into, rms_norm_gated_batch_into, rms_norm_into, rms_norm_offset_into,
-    scaled_add_batch_into, scaled_add_rows_indexed_into, scaled_add_rows_into,
-    scaled_add_rows_token_range_into, silu_mul_batch, silu_mul_batch_into, write_vec_into,
+    lora_decode_fused_delta_into, pack_lora_b_rows_into,
+    qk_norm_partial_rope_batched_decode_hd256_into, rms_norm, rms_norm_batch_offset_into,
+    rms_norm_gated_batch_into, rms_norm_into, rms_norm_offset_into, scaled_add_batch_into,
+    scaled_add_rows_indexed_into, scaled_add_rows_into, scaled_add_rows_token_range_into,
+    silu_mul_batch, silu_mul_batch_into, write_vec_into,
 };
 #[cfg(not(feature = "kernel-call-trace"))]
 pub use pegainfer_kernels::ops::{

--- a/pegainfer-core/src/ops.rs
+++ b/pegainfer-core/src/ops.rs
@@ -15,16 +15,19 @@ pub use attention::{
 };
 pub use paged_plan::PrefillPagedPlan;
 pub use pegainfer_kernels::ops::{
-    add_batch, add_batch_into, embedding_decode_into, extract_vec, extract_vec_into,
-    fused_add_rms_norm_into, gemm, gemm_per_token, gemv, linear,
-    qk_norm_partial_rope_batched_decode_hd256_into, rms_norm, rms_norm_batch_offset_into,
-    rms_norm_gated_batch_into, rms_norm_into, rms_norm_offset_into, scaled_add_batch_into,
-    scaled_add_rows_into, silu_mul_batch, silu_mul_batch_into, write_vec_into,
+    LoraDecodeGroupedProjection, add_batch, add_batch_into, embedding_decode_into, extract_vec,
+    extract_vec_into, fused_add_rms_norm_into, gather_hidden_tokens_into, gemm, gemm_into_checked,
+    gemm_per_token, gemv, linear, lora_decode_fused_delta_group3_into,
+    lora_decode_fused_delta_into, qk_norm_partial_rope_batched_decode_hd256_into, rms_norm,
+    rms_norm_batch_offset_into, rms_norm_gated_batch_into, rms_norm_into, rms_norm_offset_into,
+    scaled_add_batch_into, scaled_add_rows_indexed_into, scaled_add_rows_into,
+    scaled_add_rows_token_range_into, silu_mul_batch, silu_mul_batch_into, write_vec_into,
 };
 #[cfg(not(feature = "kernel-call-trace"))]
 pub use pegainfer_kernels::ops::{
     embedding_batch, fused_add_rms_norm_batch_into, gemm_into, gemm_rows_into,
-    qk_norm_rope_batch_decode_into, rms_norm_batch_into, silu_mul_fused_batch_into,
+    gemm_token_range_into_checked, qk_norm_rope_batch_decode_into, rms_norm_batch_into,
+    silu_mul_fused_batch_into,
 };
 pub use sampling::{
     argmax, argmax_batch_bf16_into, flashinfer_topk_row_states_bytes, gpu_sample, gpu_sample_into,
@@ -32,5 +35,6 @@ pub use sampling::{
 #[cfg(feature = "kernel-call-trace")]
 pub use traced::{
     embedding_batch, fused_add_rms_norm_batch_into, gemm_into, gemm_rows_into,
-    qk_norm_rope_batch_decode_into, rms_norm_batch_into, silu_mul_fused_batch_into,
+    gemm_token_range_into_checked, qk_norm_rope_batch_decode_into, rms_norm_batch_into,
+    silu_mul_fused_batch_into,
 };

--- a/pegainfer-core/src/ops/traced.rs
+++ b/pegainfer-core/src/ops/traced.rs
@@ -86,6 +86,25 @@ pub fn gemm_into(
     pegainfer_kernels::ops::gemm_into(ctx, weight, x, out);
 }
 
+pub fn gemm_token_range_into_checked(
+    ctx: &DeviceContext,
+    weight: &DeviceMatrix,
+    x: &HiddenStates,
+    token_offset: usize,
+    out: &mut HiddenStates,
+) -> Result<()> {
+    if call_trace::is_enabled() {
+        let label = call_trace::current_label("gemm_token_range");
+        call_trace::record_call(gemm_call::<OutDim, InDim>(
+            label,
+            weight.rows,
+            weight.cols,
+            out.seq_len,
+        ));
+    }
+    pegainfer_kernels::ops::gemm_token_range_into_checked(ctx, weight, x, token_offset, out)
+}
+
 pub fn qk_norm_rope_batch_decode_into(
     ctx: &DeviceContext,
     q: &mut HiddenStates,

--- a/pegainfer-kernels/csrc/lora_fused.cu
+++ b/pegainfer-kernels/csrc/lora_fused.cu
@@ -1,0 +1,686 @@
+#include "common.cuh"
+#include <cuda.h>
+#include <cstdint>
+
+__global__ void lora_decode_fused_delta_kernel(
+    const __nv_bfloat16 *__restrict__ a_packed,
+    const __nv_bfloat16 *__restrict__ b_packed,
+    const float *__restrict__ scales,
+    const int *__restrict__ token_slots,
+    const __nv_bfloat16 *__restrict__ input,
+    __nv_bfloat16 *__restrict__ out,
+    int batch,
+    int max_loras,
+    int max_rank,
+    int rank,
+    int in_dim,
+    int out_dim,
+    int out_hidden_dim,
+    int row_offset) {
+  extern __shared__ float rank_buf[];
+
+  int token = blockIdx.x;
+  if (token >= batch) {
+    return;
+  }
+
+  int slot = token_slots[token];
+  if (slot < 0 || slot >= max_loras) {
+    return;
+  }
+
+  float scale = scales[slot];
+  if (scale == 0.0f) {
+    return;
+  }
+
+  const __nv_bfloat16 *a =
+      a_packed + (static_cast<int64_t>(slot) * max_rank * in_dim);
+  const __nv_bfloat16 *b =
+      b_packed + (static_cast<int64_t>(slot) * out_dim * max_rank);
+  const __nv_bfloat16 *x =
+      input + (static_cast<int64_t>(token) * in_dim);
+
+  for (int r = threadIdx.x; r < rank; r += blockDim.x) {
+    float rank_val = 0.0f;
+    const __nv_bfloat16 *a_row = a + static_cast<int64_t>(r) * in_dim;
+    for (int col = 0; col < in_dim; ++col) {
+      rank_val += __bfloat162float(a_row[col]) * __bfloat162float(x[col]);
+    }
+    rank_buf[r] = rank_val;
+  }
+  __syncthreads();
+
+  for (int row = threadIdx.x; row < out_dim; row += blockDim.x) {
+    float delta = 0.0f;
+    const __nv_bfloat16 *b_row = b + static_cast<int64_t>(row) * max_rank;
+    for (int r = 0; r < rank; ++r) {
+      delta += __bfloat162float(b_row[r]) * rank_buf[r];
+    }
+
+    int out_idx = token * out_hidden_dim + row_offset + row;
+    float base = __bfloat162float(out[out_idx]);
+    out[out_idx] = __float2bfloat16(base + scale * delta);
+  }
+}
+
+template <int RANK>
+__global__ void lora_decode_fused_delta_rank_kernel(
+    const __nv_bfloat16 *__restrict__ a_packed,
+    const __nv_bfloat16 *__restrict__ b_packed,
+    const float *__restrict__ scales,
+    const int *__restrict__ token_slots,
+    const __nv_bfloat16 *__restrict__ input,
+    __nv_bfloat16 *__restrict__ out,
+    int batch,
+    int max_loras,
+    int max_rank,
+    int in_dim,
+    int out_dim,
+    int out_hidden_dim,
+    int row_offset) {
+  extern __shared__ float rank_buf[];
+
+  int token = blockIdx.x;
+  if (token >= batch) {
+    return;
+  }
+
+  int slot = token_slots[token];
+  if (slot < 0 || slot >= max_loras) {
+    return;
+  }
+
+  float scale = scales[slot];
+  if (scale == 0.0f) {
+    return;
+  }
+
+  const __nv_bfloat16 *a =
+      a_packed + (static_cast<int64_t>(slot) * max_rank * in_dim);
+  const __nv_bfloat16 *b =
+      b_packed + (static_cast<int64_t>(slot) * out_dim * max_rank);
+  const __nv_bfloat16 *x =
+      input + (static_cast<int64_t>(token) * in_dim);
+
+  for (int r = threadIdx.x; r < RANK; r += blockDim.x) {
+    float rank_val = 0.0f;
+    const __nv_bfloat16 *a_row = a + static_cast<int64_t>(r) * in_dim;
+    for (int col = 0; col < in_dim; ++col) {
+      rank_val += __bfloat162float(a_row[col]) * __bfloat162float(x[col]);
+    }
+    rank_buf[r] = rank_val;
+  }
+  __syncthreads();
+
+  for (int row = threadIdx.x; row < out_dim; row += blockDim.x) {
+    float delta = 0.0f;
+    const __nv_bfloat16 *b_row = b + static_cast<int64_t>(row) * max_rank;
+    for (int r = 0; r < RANK; ++r) {
+      delta += __bfloat162float(b_row[r]) * rank_buf[r];
+    }
+
+    int out_idx = token * out_hidden_dim + row_offset + row;
+    float base = __bfloat162float(out[out_idx]);
+    out[out_idx] = __float2bfloat16(base + scale * delta);
+  }
+}
+
+__device__ void apply_lora_decode_projection(
+    const __nv_bfloat16 *__restrict__ a_packed,
+    const __nv_bfloat16 *__restrict__ b_packed,
+    const float *__restrict__ scales,
+    const int slot,
+    const __nv_bfloat16 *__restrict__ x,
+    __nv_bfloat16 *__restrict__ out,
+    int token,
+    int max_rank,
+    int rank,
+    int in_dim,
+    int out_dim,
+    int out_hidden_dim,
+    float *__restrict__ rank_buf) {
+  if (a_packed == nullptr || b_packed == nullptr || scales == nullptr ||
+      out == nullptr || rank <= 0 || out_dim <= 0) {
+    return;
+  }
+
+  float scale = scales[slot];
+  if (scale == 0.0f) {
+    return;
+  }
+
+  const __nv_bfloat16 *a =
+      a_packed + (static_cast<int64_t>(slot) * max_rank * in_dim);
+  const __nv_bfloat16 *b =
+      b_packed + (static_cast<int64_t>(slot) * out_dim * max_rank);
+
+  for (int r = threadIdx.x; r < rank; r += blockDim.x) {
+    float rank_val = 0.0f;
+    const __nv_bfloat16 *a_row = a + static_cast<int64_t>(r) * in_dim;
+    for (int col = 0; col < in_dim; ++col) {
+      rank_val += __bfloat162float(a_row[col]) * __bfloat162float(x[col]);
+    }
+    rank_buf[r] = rank_val;
+  }
+  __syncthreads();
+
+  for (int row = threadIdx.x; row < out_dim; row += blockDim.x) {
+    float delta = 0.0f;
+    const __nv_bfloat16 *b_row = b + static_cast<int64_t>(row) * max_rank;
+    for (int r = 0; r < rank; ++r) {
+      delta += __bfloat162float(b_row[r]) * rank_buf[r];
+    }
+
+    int out_idx = token * out_hidden_dim + row;
+    float base = __bfloat162float(out[out_idx]);
+    out[out_idx] = __float2bfloat16(base + scale * delta);
+  }
+  __syncthreads();
+}
+
+template <int RANK>
+__device__ void apply_lora_decode_projection_rank(
+    const __nv_bfloat16 *__restrict__ a_packed,
+    const __nv_bfloat16 *__restrict__ b_packed,
+    const float *__restrict__ scales,
+    const int slot,
+    const __nv_bfloat16 *__restrict__ x,
+    __nv_bfloat16 *__restrict__ out,
+    int token,
+    int max_rank,
+    int rank,
+    int in_dim,
+    int out_dim,
+    int out_hidden_dim,
+    float *__restrict__ rank_buf) {
+  if (a_packed == nullptr || b_packed == nullptr || scales == nullptr ||
+      out == nullptr || rank <= 0 || out_dim <= 0) {
+    return;
+  }
+
+  float scale = scales[slot];
+  if (scale == 0.0f) {
+    return;
+  }
+
+  const __nv_bfloat16 *a =
+      a_packed + (static_cast<int64_t>(slot) * max_rank * in_dim);
+  const __nv_bfloat16 *b =
+      b_packed + (static_cast<int64_t>(slot) * out_dim * max_rank);
+
+  for (int r = threadIdx.x; r < RANK; r += blockDim.x) {
+    float rank_val = 0.0f;
+    const __nv_bfloat16 *a_row = a + static_cast<int64_t>(r) * in_dim;
+    for (int col = 0; col < in_dim; ++col) {
+      rank_val += __bfloat162float(a_row[col]) * __bfloat162float(x[col]);
+    }
+    rank_buf[r] = rank_val;
+  }
+  __syncthreads();
+
+  for (int row = threadIdx.x; row < out_dim; row += blockDim.x) {
+    float delta = 0.0f;
+    const __nv_bfloat16 *b_row = b + static_cast<int64_t>(row) * max_rank;
+    for (int r = 0; r < RANK; ++r) {
+      delta += __bfloat162float(b_row[r]) * rank_buf[r];
+    }
+
+    int out_idx = token * out_hidden_dim + row;
+    float base = __bfloat162float(out[out_idx]);
+    out[out_idx] = __float2bfloat16(base + scale * delta);
+  }
+  __syncthreads();
+}
+
+__global__ void lora_decode_fused_delta_group3_kernel(
+    const __nv_bfloat16 *__restrict__ a0,
+    const __nv_bfloat16 *__restrict__ b0,
+    const float *__restrict__ scales0,
+    __nv_bfloat16 *__restrict__ out0,
+    int rank0,
+    int out_dim0,
+    int out_hidden_dim0,
+    const __nv_bfloat16 *__restrict__ a1,
+    const __nv_bfloat16 *__restrict__ b1,
+    const float *__restrict__ scales1,
+    __nv_bfloat16 *__restrict__ out1,
+    int rank1,
+    int out_dim1,
+    int out_hidden_dim1,
+    const __nv_bfloat16 *__restrict__ a2,
+    const __nv_bfloat16 *__restrict__ b2,
+    const float *__restrict__ scales2,
+    __nv_bfloat16 *__restrict__ out2,
+    int rank2,
+    int out_dim2,
+    int out_hidden_dim2,
+    const int *__restrict__ token_slots,
+    const __nv_bfloat16 *__restrict__ input,
+    int batch,
+    int max_loras,
+    int max_rank,
+    int in_dim) {
+  extern __shared__ float rank_buf[];
+
+  int token = blockIdx.x;
+  if (token >= batch) {
+    return;
+  }
+
+  int slot = token_slots[token];
+  if (slot < 0 || slot >= max_loras) {
+    return;
+  }
+
+  const __nv_bfloat16 *x =
+      input + (static_cast<int64_t>(token) * in_dim);
+
+  apply_lora_decode_projection(a0, b0, scales0, slot, x, out0, token,
+                               max_rank, rank0, in_dim, out_dim0,
+                               out_hidden_dim0, rank_buf);
+  apply_lora_decode_projection(a1, b1, scales1, slot, x, out1, token,
+                               max_rank, rank1, in_dim, out_dim1,
+                               out_hidden_dim1, rank_buf);
+  apply_lora_decode_projection(a2, b2, scales2, slot, x, out2, token,
+                               max_rank, rank2, in_dim, out_dim2,
+                               out_hidden_dim2, rank_buf);
+}
+
+template <int RANK>
+__global__ void lora_decode_fused_delta_group3_rank_kernel(
+    const __nv_bfloat16 *__restrict__ a0,
+    const __nv_bfloat16 *__restrict__ b0,
+    const float *__restrict__ scales0,
+    __nv_bfloat16 *__restrict__ out0,
+    int rank0,
+    int out_dim0,
+    int out_hidden_dim0,
+    const __nv_bfloat16 *__restrict__ a1,
+    const __nv_bfloat16 *__restrict__ b1,
+    const float *__restrict__ scales1,
+    __nv_bfloat16 *__restrict__ out1,
+    int rank1,
+    int out_dim1,
+    int out_hidden_dim1,
+    const __nv_bfloat16 *__restrict__ a2,
+    const __nv_bfloat16 *__restrict__ b2,
+    const float *__restrict__ scales2,
+    __nv_bfloat16 *__restrict__ out2,
+    int rank2,
+    int out_dim2,
+    int out_hidden_dim2,
+    const int *__restrict__ token_slots,
+    const __nv_bfloat16 *__restrict__ input,
+    int batch,
+    int max_loras,
+    int max_rank,
+    int in_dim) {
+  extern __shared__ float rank_buf[];
+
+  int token = blockIdx.x;
+  if (token >= batch) {
+    return;
+  }
+
+  int slot = token_slots[token];
+  if (slot < 0 || slot >= max_loras) {
+    return;
+  }
+
+  const __nv_bfloat16 *x =
+      input + (static_cast<int64_t>(token) * in_dim);
+
+  apply_lora_decode_projection_rank<RANK>(
+      a0, b0, scales0, slot, x, out0, token, max_rank, rank0, in_dim,
+      out_dim0, out_hidden_dim0, rank_buf);
+  apply_lora_decode_projection_rank<RANK>(
+      a1, b1, scales1, slot, x, out1, token, max_rank, rank1, in_dim,
+      out_dim1, out_hidden_dim1, rank_buf);
+  apply_lora_decode_projection_rank<RANK>(
+      a2, b2, scales2, slot, x, out2, token, max_rank, rank2, in_dim,
+      out_dim2, out_hidden_dim2, rank_buf);
+}
+
+static bool valid_lora_group_projection(bool has,
+                                        const __nv_bfloat16 *a,
+                                        const __nv_bfloat16 *b,
+                                        const float *scales,
+                                        const __nv_bfloat16 *out,
+                                        int rank,
+                                        int out_dim,
+                                        int out_hidden_dim,
+                                        int max_rank) {
+  if (!has) {
+    return true;
+  }
+  return a != nullptr && b != nullptr && scales != nullptr && out != nullptr &&
+         rank > 0 && rank <= max_rank && out_dim > 0 &&
+         out_hidden_dim >= out_dim;
+}
+
+template <int RANK>
+static CUresult launch_lora_decode_fused_delta_rank(
+    const __nv_bfloat16 *a_packed,
+    const __nv_bfloat16 *b_packed,
+    const float *scales,
+    const int *token_slots,
+    const __nv_bfloat16 *input,
+    __nv_bfloat16 *out,
+    int batch,
+    int max_loras,
+    int max_rank,
+    int in_dim,
+    int out_dim,
+    int out_hidden_dim,
+    int row_offset,
+    cudaStream_t stream) {
+  dim3 block(256);
+  dim3 grid(batch);
+  size_t smem_bytes = static_cast<size_t>(RANK) * sizeof(float);
+  lora_decode_fused_delta_rank_kernel<RANK><<<grid, block, smem_bytes, stream>>>(
+      a_packed, b_packed, scales, token_slots, input, out, batch, max_loras,
+      max_rank, in_dim, out_dim, out_hidden_dim, row_offset);
+  return (CUresult)cudaGetLastError();
+}
+
+static CUresult launch_lora_decode_fused_delta(
+    const __nv_bfloat16 *a_packed,
+    const __nv_bfloat16 *b_packed,
+    const float *scales,
+    const int *token_slots,
+    const __nv_bfloat16 *input,
+    __nv_bfloat16 *out,
+    int batch,
+    int max_loras,
+    int max_rank,
+    int rank,
+    int in_dim,
+    int out_dim,
+    int out_hidden_dim,
+    int row_offset,
+    cudaStream_t stream) {
+  switch (rank) {
+  case 1:
+    return launch_lora_decode_fused_delta_rank<1>(
+        a_packed, b_packed, scales, token_slots, input, out, batch, max_loras,
+        max_rank, in_dim, out_dim, out_hidden_dim, row_offset, stream);
+  case 8:
+    return launch_lora_decode_fused_delta_rank<8>(
+        a_packed, b_packed, scales, token_slots, input, out, batch, max_loras,
+        max_rank, in_dim, out_dim, out_hidden_dim, row_offset, stream);
+  case 16:
+    return launch_lora_decode_fused_delta_rank<16>(
+        a_packed, b_packed, scales, token_slots, input, out, batch, max_loras,
+        max_rank, in_dim, out_dim, out_hidden_dim, row_offset, stream);
+  case 32:
+    return launch_lora_decode_fused_delta_rank<32>(
+        a_packed, b_packed, scales, token_slots, input, out, batch, max_loras,
+        max_rank, in_dim, out_dim, out_hidden_dim, row_offset, stream);
+  case 64:
+    return launch_lora_decode_fused_delta_rank<64>(
+        a_packed, b_packed, scales, token_slots, input, out, batch, max_loras,
+        max_rank, in_dim, out_dim, out_hidden_dim, row_offset, stream);
+  case 128:
+    return launch_lora_decode_fused_delta_rank<128>(
+        a_packed, b_packed, scales, token_slots, input, out, batch, max_loras,
+        max_rank, in_dim, out_dim, out_hidden_dim, row_offset, stream);
+  case 256:
+    return launch_lora_decode_fused_delta_rank<256>(
+        a_packed, b_packed, scales, token_slots, input, out, batch, max_loras,
+        max_rank, in_dim, out_dim, out_hidden_dim, row_offset, stream);
+  case 320:
+    return launch_lora_decode_fused_delta_rank<320>(
+        a_packed, b_packed, scales, token_slots, input, out, batch, max_loras,
+        max_rank, in_dim, out_dim, out_hidden_dim, row_offset, stream);
+  case 512:
+    return launch_lora_decode_fused_delta_rank<512>(
+        a_packed, b_packed, scales, token_slots, input, out, batch, max_loras,
+        max_rank, in_dim, out_dim, out_hidden_dim, row_offset, stream);
+  default:
+    dim3 block(256);
+    dim3 grid(batch);
+    size_t smem_bytes = static_cast<size_t>(rank) * sizeof(float);
+    lora_decode_fused_delta_kernel<<<grid, block, smem_bytes, stream>>>(
+        a_packed, b_packed, scales, token_slots, input, out, batch, max_loras,
+        max_rank, rank, in_dim, out_dim, out_hidden_dim, row_offset);
+    return (CUresult)cudaGetLastError();
+  }
+}
+
+template <int RANK>
+static CUresult launch_lora_decode_fused_delta_group3_rank(
+    const __nv_bfloat16 *a0,
+    const __nv_bfloat16 *b0,
+    const float *scales0,
+    __nv_bfloat16 *out0,
+    int rank0,
+    int out_dim0,
+    int out_hidden_dim0,
+    const __nv_bfloat16 *a1,
+    const __nv_bfloat16 *b1,
+    const float *scales1,
+    __nv_bfloat16 *out1,
+    int rank1,
+    int out_dim1,
+    int out_hidden_dim1,
+    const __nv_bfloat16 *a2,
+    const __nv_bfloat16 *b2,
+    const float *scales2,
+    __nv_bfloat16 *out2,
+    int rank2,
+    int out_dim2,
+    int out_hidden_dim2,
+    const int *token_slots,
+    const __nv_bfloat16 *input,
+    int batch,
+    int max_loras,
+    int max_rank,
+    int in_dim,
+    cudaStream_t stream) {
+  dim3 block(256);
+  dim3 grid(batch);
+  size_t smem_bytes = static_cast<size_t>(RANK) * sizeof(float);
+  lora_decode_fused_delta_group3_rank_kernel<RANK>
+      <<<grid, block, smem_bytes, stream>>>(
+          a0, b0, scales0, out0, rank0, out_dim0, out_hidden_dim0, a1, b1,
+          scales1, out1, rank1, out_dim1, out_hidden_dim1, a2, b2, scales2,
+          out2, rank2, out_dim2, out_hidden_dim2, token_slots, input, batch,
+          max_loras, max_rank, in_dim);
+  return (CUresult)cudaGetLastError();
+}
+
+static CUresult launch_lora_decode_fused_delta_group3(
+    const __nv_bfloat16 *a0,
+    const __nv_bfloat16 *b0,
+    const float *scales0,
+    __nv_bfloat16 *out0,
+    int rank0,
+    int out_dim0,
+    int out_hidden_dim0,
+    const __nv_bfloat16 *a1,
+    const __nv_bfloat16 *b1,
+    const float *scales1,
+    __nv_bfloat16 *out1,
+    int rank1,
+    int out_dim1,
+    int out_hidden_dim1,
+    const __nv_bfloat16 *a2,
+    const __nv_bfloat16 *b2,
+    const float *scales2,
+    __nv_bfloat16 *out2,
+    int rank2,
+    int out_dim2,
+    int out_hidden_dim2,
+    const int *token_slots,
+    const __nv_bfloat16 *input,
+    int batch,
+    int max_loras,
+    int max_rank,
+    int in_dim,
+    int shared_rank,
+    cudaStream_t stream) {
+  switch (shared_rank) {
+  case 1:
+    return launch_lora_decode_fused_delta_group3_rank<1>(
+        a0, b0, scales0, out0, rank0, out_dim0, out_hidden_dim0, a1, b1,
+        scales1, out1, rank1, out_dim1, out_hidden_dim1, a2, b2, scales2,
+        out2, rank2, out_dim2, out_hidden_dim2, token_slots, input, batch,
+        max_loras, max_rank, in_dim, stream);
+  case 8:
+    return launch_lora_decode_fused_delta_group3_rank<8>(
+        a0, b0, scales0, out0, rank0, out_dim0, out_hidden_dim0, a1, b1,
+        scales1, out1, rank1, out_dim1, out_hidden_dim1, a2, b2, scales2,
+        out2, rank2, out_dim2, out_hidden_dim2, token_slots, input, batch,
+        max_loras, max_rank, in_dim, stream);
+  case 16:
+    return launch_lora_decode_fused_delta_group3_rank<16>(
+        a0, b0, scales0, out0, rank0, out_dim0, out_hidden_dim0, a1, b1,
+        scales1, out1, rank1, out_dim1, out_hidden_dim1, a2, b2, scales2,
+        out2, rank2, out_dim2, out_hidden_dim2, token_slots, input, batch,
+        max_loras, max_rank, in_dim, stream);
+  case 32:
+    return launch_lora_decode_fused_delta_group3_rank<32>(
+        a0, b0, scales0, out0, rank0, out_dim0, out_hidden_dim0, a1, b1,
+        scales1, out1, rank1, out_dim1, out_hidden_dim1, a2, b2, scales2,
+        out2, rank2, out_dim2, out_hidden_dim2, token_slots, input, batch,
+        max_loras, max_rank, in_dim, stream);
+  case 64:
+    return launch_lora_decode_fused_delta_group3_rank<64>(
+        a0, b0, scales0, out0, rank0, out_dim0, out_hidden_dim0, a1, b1,
+        scales1, out1, rank1, out_dim1, out_hidden_dim1, a2, b2, scales2,
+        out2, rank2, out_dim2, out_hidden_dim2, token_slots, input, batch,
+        max_loras, max_rank, in_dim, stream);
+  case 128:
+    return launch_lora_decode_fused_delta_group3_rank<128>(
+        a0, b0, scales0, out0, rank0, out_dim0, out_hidden_dim0, a1, b1,
+        scales1, out1, rank1, out_dim1, out_hidden_dim1, a2, b2, scales2,
+        out2, rank2, out_dim2, out_hidden_dim2, token_slots, input, batch,
+        max_loras, max_rank, in_dim, stream);
+  case 256:
+    return launch_lora_decode_fused_delta_group3_rank<256>(
+        a0, b0, scales0, out0, rank0, out_dim0, out_hidden_dim0, a1, b1,
+        scales1, out1, rank1, out_dim1, out_hidden_dim1, a2, b2, scales2,
+        out2, rank2, out_dim2, out_hidden_dim2, token_slots, input, batch,
+        max_loras, max_rank, in_dim, stream);
+  case 320:
+    return launch_lora_decode_fused_delta_group3_rank<320>(
+        a0, b0, scales0, out0, rank0, out_dim0, out_hidden_dim0, a1, b1,
+        scales1, out1, rank1, out_dim1, out_hidden_dim1, a2, b2, scales2,
+        out2, rank2, out_dim2, out_hidden_dim2, token_slots, input, batch,
+        max_loras, max_rank, in_dim, stream);
+  case 512:
+    return launch_lora_decode_fused_delta_group3_rank<512>(
+        a0, b0, scales0, out0, rank0, out_dim0, out_hidden_dim0, a1, b1,
+        scales1, out1, rank1, out_dim1, out_hidden_dim1, a2, b2, scales2,
+        out2, rank2, out_dim2, out_hidden_dim2, token_slots, input, batch,
+        max_loras, max_rank, in_dim, stream);
+  default:
+    dim3 block(256);
+    dim3 grid(batch);
+    size_t smem_bytes = static_cast<size_t>(shared_rank) * sizeof(float);
+    lora_decode_fused_delta_group3_kernel<<<grid, block, smem_bytes, stream>>>(
+        a0, b0, scales0, out0, rank0, out_dim0, out_hidden_dim0, a1, b1,
+        scales1, out1, rank1, out_dim1, out_hidden_dim1, a2, b2, scales2,
+        out2, rank2, out_dim2, out_hidden_dim2, token_slots, input, batch,
+        max_loras, max_rank, in_dim);
+    return (CUresult)cudaGetLastError();
+  }
+}
+
+extern "C" {
+
+CUresult lora_decode_fused_delta_cuda(
+    const __nv_bfloat16 *a_packed,
+    const __nv_bfloat16 *b_packed,
+    const float *scales,
+    const int *token_slots,
+    const __nv_bfloat16 *input,
+    __nv_bfloat16 *out,
+    int batch,
+    int max_loras,
+    int max_rank,
+    int rank,
+    int in_dim,
+    int out_dim,
+    int out_hidden_dim,
+    int row_offset,
+    cudaStream_t stream) {
+  if (a_packed == nullptr || b_packed == nullptr || scales == nullptr ||
+      token_slots == nullptr || input == nullptr || out == nullptr ||
+      batch <= 0 || max_loras <= 0 || max_rank <= 0 || rank <= 0 ||
+      rank > max_rank || in_dim <= 0 || out_dim <= 0 || out_hidden_dim <= 0 ||
+      row_offset < 0 || row_offset + out_dim > out_hidden_dim) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  return launch_lora_decode_fused_delta(
+      a_packed, b_packed, scales, token_slots, input, out, batch, max_loras,
+      max_rank, rank, in_dim, out_dim, out_hidden_dim, row_offset, stream);
+}
+
+CUresult lora_decode_fused_delta_group3_cuda(
+    const __nv_bfloat16 *a0,
+    const __nv_bfloat16 *b0,
+    const float *scales0,
+    __nv_bfloat16 *out0,
+    int rank0,
+    int out_dim0,
+    int out_hidden_dim0,
+    const __nv_bfloat16 *a1,
+    const __nv_bfloat16 *b1,
+    const float *scales1,
+    __nv_bfloat16 *out1,
+    int rank1,
+    int out_dim1,
+    int out_hidden_dim1,
+    const __nv_bfloat16 *a2,
+    const __nv_bfloat16 *b2,
+    const float *scales2,
+    __nv_bfloat16 *out2,
+    int rank2,
+    int out_dim2,
+    int out_hidden_dim2,
+    const int *token_slots,
+    const __nv_bfloat16 *input,
+    int batch,
+    int max_loras,
+    int max_rank,
+    int in_dim,
+    cudaStream_t stream) {
+  bool has0 = a0 != nullptr || b0 != nullptr || scales0 != nullptr ||
+              out0 != nullptr || rank0 != 0 || out_dim0 != 0 ||
+              out_hidden_dim0 != 0;
+  bool has1 = a1 != nullptr || b1 != nullptr || scales1 != nullptr ||
+              out1 != nullptr || rank1 != 0 || out_dim1 != 0 ||
+              out_hidden_dim1 != 0;
+  bool has2 = a2 != nullptr || b2 != nullptr || scales2 != nullptr ||
+              out2 != nullptr || rank2 != 0 || out_dim2 != 0 ||
+              out_hidden_dim2 != 0;
+  if (token_slots == nullptr || input == nullptr || batch <= 0 ||
+      max_loras <= 0 || max_rank <= 0 || in_dim <= 0 ||
+      (!has0 && !has1 && !has2) ||
+      !valid_lora_group_projection(has0, a0, b0, scales0, out0, rank0,
+                                   out_dim0, out_hidden_dim0, max_rank) ||
+      !valid_lora_group_projection(has1, a1, b1, scales1, out1, rank1,
+                                   out_dim1, out_hidden_dim1, max_rank) ||
+      !valid_lora_group_projection(has2, a2, b2, scales2, out2, rank2,
+                                   out_dim2, out_hidden_dim2, max_rank)) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  int shared_rank = rank0;
+  if (rank1 > shared_rank) {
+    shared_rank = rank1;
+  }
+  if (rank2 > shared_rank) {
+    shared_rank = rank2;
+  }
+  return launch_lora_decode_fused_delta_group3(
+      a0, b0, scales0, out0, rank0, out_dim0, out_hidden_dim0, a1, b1,
+      scales1, out1, rank1, out_dim1, out_hidden_dim1, a2, b2, scales2,
+      out2, rank2, out_dim2, out_hidden_dim2, token_slots, input, batch,
+      max_loras, max_rank, in_dim, shared_rank, stream);
+}
+
+} // extern "C"

--- a/pegainfer-kernels/csrc/lora_fused.cu
+++ b/pegainfer-kernels/csrc/lora_fused.cu
@@ -26,7 +26,7 @@ __device__ __forceinline__ float block_reduce_sum(float value,
 }
 
 static size_t lora_rank_smem_bytes(int rank) {
-  int floats = rank == 1 ? 32 : rank;
+  int floats = rank < 32 ? 32 : rank;
   return static_cast<size_t>(floats) * sizeof(float);
 }
 

--- a/pegainfer-kernels/csrc/lora_fused.cu
+++ b/pegainfer-kernels/csrc/lora_fused.cu
@@ -2,6 +2,34 @@
 #include <cuda.h>
 #include <cstdint>
 
+__device__ __forceinline__ float block_reduce_sum(float value,
+                                                  float *scratch) {
+  int lane = threadIdx.x & (warpSize - 1);
+  int warp = threadIdx.x / warpSize;
+  int num_warps = (blockDim.x + warpSize - 1) / warpSize;
+
+  value = warp_reduce_sum(value);
+  if (lane == 0) {
+    scratch[warp] = value;
+  }
+  __syncthreads();
+
+  value = threadIdx.x < num_warps ? scratch[lane] : 0.0f;
+  if (warp == 0) {
+    value = warp_reduce_sum(value);
+  }
+  if (threadIdx.x == 0) {
+    scratch[0] = value;
+  }
+  __syncthreads();
+  return scratch[0];
+}
+
+static size_t lora_rank_smem_bytes(int rank) {
+  int floats = rank == 1 ? 32 : rank;
+  return static_cast<size_t>(floats) * sizeof(float);
+}
+
 __global__ void lora_decode_fused_delta_kernel(
     const __nv_bfloat16 *__restrict__ a_packed,
     const __nv_bfloat16 *__restrict__ b_packed,
@@ -103,13 +131,24 @@ __global__ void lora_decode_fused_delta_rank_kernel(
   const __nv_bfloat16 *x =
       input + (static_cast<int64_t>(token) * in_dim);
 
-  for (int r = threadIdx.x; r < RANK; r += blockDim.x) {
+  if (RANK == 1) {
     float rank_val = 0.0f;
-    const __nv_bfloat16 *a_row = a + static_cast<int64_t>(r) * in_dim;
-    for (int col = 0; col < in_dim; ++col) {
-      rank_val += __bfloat162float(a_row[col]) * __bfloat162float(x[col]);
+    for (int col = threadIdx.x; col < in_dim; col += blockDim.x) {
+      rank_val += __bfloat162float(a[col]) * __bfloat162float(x[col]);
     }
-    rank_buf[r] = rank_val;
+    rank_val = block_reduce_sum(rank_val, rank_buf);
+    if (threadIdx.x == 0) {
+      rank_buf[0] = rank_val;
+    }
+  } else {
+    for (int r = threadIdx.x; r < RANK; r += blockDim.x) {
+      float rank_val = 0.0f;
+      const __nv_bfloat16 *a_row = a + static_cast<int64_t>(r) * in_dim;
+      for (int col = 0; col < in_dim; ++col) {
+        rank_val += __bfloat162float(a_row[col]) * __bfloat162float(x[col]);
+      }
+      rank_buf[r] = rank_val;
+    }
   }
   __syncthreads();
 
@@ -209,13 +248,24 @@ __device__ void apply_lora_decode_projection_rank(
   const __nv_bfloat16 *b =
       b_packed + (static_cast<int64_t>(slot) * out_dim * max_rank);
 
-  for (int r = threadIdx.x; r < RANK; r += blockDim.x) {
+  if (RANK == 1) {
     float rank_val = 0.0f;
-    const __nv_bfloat16 *a_row = a + static_cast<int64_t>(r) * in_dim;
-    for (int col = 0; col < in_dim; ++col) {
-      rank_val += __bfloat162float(a_row[col]) * __bfloat162float(x[col]);
+    for (int col = threadIdx.x; col < in_dim; col += blockDim.x) {
+      rank_val += __bfloat162float(a[col]) * __bfloat162float(x[col]);
     }
-    rank_buf[r] = rank_val;
+    rank_val = block_reduce_sum(rank_val, rank_buf);
+    if (threadIdx.x == 0) {
+      rank_buf[0] = rank_val;
+    }
+  } else {
+    for (int r = threadIdx.x; r < RANK; r += blockDim.x) {
+      float rank_val = 0.0f;
+      const __nv_bfloat16 *a_row = a + static_cast<int64_t>(r) * in_dim;
+      for (int col = 0; col < in_dim; ++col) {
+        rank_val += __bfloat162float(a_row[col]) * __bfloat162float(x[col]);
+      }
+      rank_buf[r] = rank_val;
+    }
   }
   __syncthreads();
 
@@ -377,7 +427,7 @@ static CUresult launch_lora_decode_fused_delta_rank(
     cudaStream_t stream) {
   dim3 block(256);
   dim3 grid(batch);
-  size_t smem_bytes = static_cast<size_t>(RANK) * sizeof(float);
+  size_t smem_bytes = lora_rank_smem_bytes(RANK);
   lora_decode_fused_delta_rank_kernel<RANK><<<grid, block, smem_bytes, stream>>>(
       a_packed, b_packed, scales, token_slots, input, out, batch, max_loras,
       max_rank, in_dim, out_dim, out_hidden_dim, row_offset);
@@ -440,7 +490,7 @@ static CUresult launch_lora_decode_fused_delta(
   default:
     dim3 block(256);
     dim3 grid(batch);
-    size_t smem_bytes = static_cast<size_t>(rank) * sizeof(float);
+    size_t smem_bytes = lora_rank_smem_bytes(rank);
     lora_decode_fused_delta_kernel<<<grid, block, smem_bytes, stream>>>(
         a_packed, b_packed, scales, token_slots, input, out, batch, max_loras,
         max_rank, rank, in_dim, out_dim, out_hidden_dim, row_offset);
@@ -480,7 +530,7 @@ static CUresult launch_lora_decode_fused_delta_group3_rank(
     cudaStream_t stream) {
   dim3 block(256);
   dim3 grid(batch);
-  size_t smem_bytes = static_cast<size_t>(RANK) * sizeof(float);
+  size_t smem_bytes = lora_rank_smem_bytes(RANK);
   lora_decode_fused_delta_group3_rank_kernel<RANK>
       <<<grid, block, smem_bytes, stream>>>(
           a0, b0, scales0, out0, rank0, out_dim0, out_hidden_dim0, a1, b1,
@@ -578,7 +628,7 @@ static CUresult launch_lora_decode_fused_delta_group3(
   default:
     dim3 block(256);
     dim3 grid(batch);
-    size_t smem_bytes = static_cast<size_t>(shared_rank) * sizeof(float);
+    size_t smem_bytes = lora_rank_smem_bytes(shared_rank);
     lora_decode_fused_delta_group3_kernel<<<grid, block, smem_bytes, stream>>>(
         a0, b0, scales0, out0, rank0, out_dim0, out_hidden_dim0, a1, b1,
         scales1, out1, rank1, out_dim1, out_hidden_dim1, a2, b2, scales2,

--- a/pegainfer-kernels/csrc/lora_fused.cu
+++ b/pegainfer-kernels/csrc/lora_fused.cu
@@ -30,6 +30,75 @@ static size_t lora_rank_smem_bytes(int rank) {
   return static_cast<size_t>(floats) * sizeof(float);
 }
 
+template <int RANK>
+__device__ __forceinline__ void compute_lora_rank_dot(
+    const __nv_bfloat16 *__restrict__ a,
+    const __nv_bfloat16 *__restrict__ x,
+    int rank,
+    int in_dim,
+    float *__restrict__ rank_buf) {
+  if (RANK == 1) {
+    float rank_val = 0.0f;
+    for (int col = threadIdx.x; col < in_dim; col += blockDim.x) {
+      rank_val += __bfloat162float(a[col]) * __bfloat162float(x[col]);
+    }
+    rank_val = block_reduce_sum(rank_val, rank_buf);
+    if (threadIdx.x == 0) {
+      rank_buf[0] = rank_val;
+    }
+    return;
+  }
+
+  constexpr int WARPS_PER_BLOCK = 8;
+  int lane = threadIdx.x & (warpSize - 1);
+  int warp = threadIdx.x / warpSize;
+  for (int r = warp; r < rank; r += WARPS_PER_BLOCK) {
+    float rank_val = 0.0f;
+    const __nv_bfloat16 *a_row = a + static_cast<int64_t>(r) * in_dim;
+    for (int col = lane; col < in_dim; col += warpSize) {
+      rank_val += __bfloat162float(a_row[col]) * __bfloat162float(x[col]);
+    }
+    rank_val = warp_reduce_sum(rank_val);
+    if (lane == 0) {
+      rank_buf[r] = rank_val;
+    }
+  }
+}
+
+__device__ __forceinline__ void compute_lora_rank_dot_runtime(
+    const __nv_bfloat16 *__restrict__ a,
+    const __nv_bfloat16 *__restrict__ x,
+    int rank,
+    int in_dim,
+    float *__restrict__ rank_buf) {
+  if (rank == 1) {
+    float rank_val = 0.0f;
+    for (int col = threadIdx.x; col < in_dim; col += blockDim.x) {
+      rank_val += __bfloat162float(a[col]) * __bfloat162float(x[col]);
+    }
+    rank_val = block_reduce_sum(rank_val, rank_buf);
+    if (threadIdx.x == 0) {
+      rank_buf[0] = rank_val;
+    }
+    return;
+  }
+
+  constexpr int WARPS_PER_BLOCK = 8;
+  int lane = threadIdx.x & (warpSize - 1);
+  int warp = threadIdx.x / warpSize;
+  for (int r = warp; r < rank; r += WARPS_PER_BLOCK) {
+    float rank_val = 0.0f;
+    const __nv_bfloat16 *a_row = a + static_cast<int64_t>(r) * in_dim;
+    for (int col = lane; col < in_dim; col += warpSize) {
+      rank_val += __bfloat162float(a_row[col]) * __bfloat162float(x[col]);
+    }
+    rank_val = warp_reduce_sum(rank_val);
+    if (lane == 0) {
+      rank_buf[r] = rank_val;
+    }
+  }
+}
+
 __global__ void lora_pack_b_rows_kernel(
     const __nv_bfloat16 *__restrict__ src,
     __nv_bfloat16 *__restrict__ dst,
@@ -84,14 +153,7 @@ __global__ void lora_decode_fused_delta_kernel(
   const __nv_bfloat16 *x =
       input + (static_cast<int64_t>(token) * in_dim);
 
-  for (int r = threadIdx.x; r < rank; r += blockDim.x) {
-    float rank_val = 0.0f;
-    const __nv_bfloat16 *a_row = a + static_cast<int64_t>(r) * in_dim;
-    for (int col = 0; col < in_dim; ++col) {
-      rank_val += __bfloat162float(a_row[col]) * __bfloat162float(x[col]);
-    }
-    rank_buf[r] = rank_val;
-  }
+  compute_lora_rank_dot_runtime(a, x, rank, in_dim, rank_buf);
   __syncthreads();
 
   for (int row = threadIdx.x; row < out_dim; row += blockDim.x) {
@@ -146,25 +208,7 @@ __global__ void lora_decode_fused_delta_rank_kernel(
   const __nv_bfloat16 *x =
       input + (static_cast<int64_t>(token) * in_dim);
 
-  if (RANK == 1) {
-    float rank_val = 0.0f;
-    for (int col = threadIdx.x; col < in_dim; col += blockDim.x) {
-      rank_val += __bfloat162float(a[col]) * __bfloat162float(x[col]);
-    }
-    rank_val = block_reduce_sum(rank_val, rank_buf);
-    if (threadIdx.x == 0) {
-      rank_buf[0] = rank_val;
-    }
-  } else {
-    for (int r = threadIdx.x; r < RANK; r += blockDim.x) {
-      float rank_val = 0.0f;
-      const __nv_bfloat16 *a_row = a + static_cast<int64_t>(r) * in_dim;
-      for (int col = 0; col < in_dim; ++col) {
-        rank_val += __bfloat162float(a_row[col]) * __bfloat162float(x[col]);
-      }
-      rank_buf[r] = rank_val;
-    }
-  }
+  compute_lora_rank_dot<RANK>(a, x, RANK, in_dim, rank_buf);
   __syncthreads();
 
   for (int row = threadIdx.x; row < out_dim; row += blockDim.x) {
@@ -209,14 +253,7 @@ __device__ void apply_lora_decode_projection(
   const __nv_bfloat16 *b =
       b_packed + (static_cast<int64_t>(slot) * out_dim * max_rank);
 
-  for (int r = threadIdx.x; r < rank; r += blockDim.x) {
-    float rank_val = 0.0f;
-    const __nv_bfloat16 *a_row = a + static_cast<int64_t>(r) * in_dim;
-    for (int col = 0; col < in_dim; ++col) {
-      rank_val += __bfloat162float(a_row[col]) * __bfloat162float(x[col]);
-    }
-    rank_buf[r] = rank_val;
-  }
+  compute_lora_rank_dot_runtime(a, x, rank, in_dim, rank_buf);
   __syncthreads();
 
   for (int row = threadIdx.x; row < out_dim; row += blockDim.x) {
@@ -263,25 +300,7 @@ __device__ void apply_lora_decode_projection_rank(
   const __nv_bfloat16 *b =
       b_packed + (static_cast<int64_t>(slot) * out_dim * max_rank);
 
-  if (RANK == 1) {
-    float rank_val = 0.0f;
-    for (int col = threadIdx.x; col < in_dim; col += blockDim.x) {
-      rank_val += __bfloat162float(a[col]) * __bfloat162float(x[col]);
-    }
-    rank_val = block_reduce_sum(rank_val, rank_buf);
-    if (threadIdx.x == 0) {
-      rank_buf[0] = rank_val;
-    }
-  } else {
-    for (int r = threadIdx.x; r < RANK; r += blockDim.x) {
-      float rank_val = 0.0f;
-      const __nv_bfloat16 *a_row = a + static_cast<int64_t>(r) * in_dim;
-      for (int col = 0; col < in_dim; ++col) {
-        rank_val += __bfloat162float(a_row[col]) * __bfloat162float(x[col]);
-      }
-      rank_buf[r] = rank_val;
-    }
-  }
+  compute_lora_rank_dot<RANK>(a, x, RANK, in_dim, rank_buf);
   __syncthreads();
 
   for (int row = threadIdx.x; row < out_dim; row += blockDim.x) {

--- a/pegainfer-kernels/csrc/lora_fused.cu
+++ b/pegainfer-kernels/csrc/lora_fused.cu
@@ -49,10 +49,10 @@ __device__ __forceinline__ void compute_lora_rank_dot(
     return;
   }
 
-  constexpr int WARPS_PER_BLOCK = 8;
   int lane = threadIdx.x & (warpSize - 1);
   int warp = threadIdx.x / warpSize;
-  for (int r = warp; r < rank; r += WARPS_PER_BLOCK) {
+  int num_warps = (blockDim.x + warpSize - 1) / warpSize;
+  for (int r = warp; r < rank; r += num_warps) {
     float rank_val = 0.0f;
     const __nv_bfloat16 *a_row = a + static_cast<int64_t>(r) * in_dim;
     for (int col = lane; col < in_dim; col += warpSize) {
@@ -83,10 +83,10 @@ __device__ __forceinline__ void compute_lora_rank_dot_runtime(
     return;
   }
 
-  constexpr int WARPS_PER_BLOCK = 8;
   int lane = threadIdx.x & (warpSize - 1);
   int warp = threadIdx.x / warpSize;
-  for (int r = warp; r < rank; r += WARPS_PER_BLOCK) {
+  int num_warps = (blockDim.x + warpSize - 1) / warpSize;
+  for (int r = warp; r < rank; r += num_warps) {
     float rank_val = 0.0f;
     const __nv_bfloat16 *a_row = a + static_cast<int64_t>(r) * in_dim;
     for (int col = lane; col < in_dim; col += warpSize) {

--- a/pegainfer-kernels/csrc/lora_fused.cu
+++ b/pegainfer-kernels/csrc/lora_fused.cu
@@ -30,6 +30,21 @@ static size_t lora_rank_smem_bytes(int rank) {
   return static_cast<size_t>(floats) * sizeof(float);
 }
 
+__global__ void lora_pack_b_rows_kernel(
+    const __nv_bfloat16 *__restrict__ src,
+    __nv_bfloat16 *__restrict__ dst,
+    int rank,
+    int max_rank,
+    int out_dim) {
+  int total = out_dim * rank;
+  for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < total;
+       idx += blockDim.x * gridDim.x) {
+    int row = idx / rank;
+    int col = idx - row * rank;
+    dst[static_cast<int64_t>(row) * max_rank + col] = src[idx];
+  }
+}
+
 __global__ void lora_decode_fused_delta_kernel(
     const __nv_bfloat16 *__restrict__ a_packed,
     const __nv_bfloat16 *__restrict__ b_packed,
@@ -639,6 +654,26 @@ static CUresult launch_lora_decode_fused_delta_group3(
 }
 
 extern "C" {
+
+CUresult lora_pack_b_rows_cuda(
+    const __nv_bfloat16 *src,
+    __nv_bfloat16 *dst,
+    int rank,
+    int max_rank,
+    int out_dim,
+    cudaStream_t stream) {
+  if (src == nullptr || dst == nullptr || rank <= 0 || max_rank <= 0 ||
+      rank > max_rank || out_dim <= 0) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  int total = out_dim * rank;
+  dim3 block(256);
+  dim3 grid((total + block.x - 1) / block.x);
+  lora_pack_b_rows_kernel<<<grid, block, 0, stream>>>(
+      src, dst, rank, max_rank, out_dim);
+  return (CUresult)cudaGetLastError();
+}
 
 CUresult lora_decode_fused_delta_cuda(
     const __nv_bfloat16 *a_packed,

--- a/pegainfer-kernels/csrc/shared/elementwise.cu
+++ b/pegainfer-kernels/csrc/shared/elementwise.cu
@@ -42,6 +42,56 @@ __global__ void scaled_add_rows_kernel(
   }
 }
 
+__global__ void gather_hidden_tokens_kernel(
+    const __nv_bfloat16 *__restrict__ input,
+    const int *__restrict__ token_indices,
+    __nv_bfloat16 *__restrict__ out,
+    int hidden_dim,
+    int token_count,
+    int input_seq_len) {
+  int total = hidden_dim * token_count;
+  for (int idx = blockIdx.x * blockDim.x + threadIdx.x;
+       idx < total;
+       idx += gridDim.x * blockDim.x) {
+    int token = idx / hidden_dim;
+    int row = idx % hidden_dim;
+    int src_token = token_indices[token];
+    if (src_token < 0 || src_token >= input_seq_len) {
+      continue;
+    }
+    out[idx] = input[(size_t)src_token * hidden_dim + row];
+  }
+}
+
+__global__ void scaled_add_rows_indexed_kernel(
+    const __nv_bfloat16 *__restrict__ delta,
+    float scale,
+    const int *__restrict__ token_indices,
+    __nv_bfloat16 *__restrict__ out,
+    int out_hidden_dim,
+    int row_offset,
+    int rows,
+    int token_count,
+    int out_seq_len) {
+  for (int token = blockIdx.y * blockDim.y + threadIdx.y;
+       token < token_count;
+       token += gridDim.y * blockDim.y) {
+    int out_token = token_indices[token];
+    if (out_token < 0 || out_token >= out_seq_len) {
+      continue;
+    }
+    for (int row = blockIdx.x * blockDim.x + threadIdx.x;
+         row < rows;
+         row += gridDim.x * blockDim.x) {
+      int delta_idx = token * rows + row;
+      int out_idx = out_token * out_hidden_dim + row_offset + row;
+      float base = __bfloat162float(out[out_idx]);
+      float add = __bfloat162float(delta[delta_idx]) * scale;
+      out[out_idx] = __float2bfloat16(base + add);
+    }
+  }
+}
+
 // ============================================================================
 // Type conversion helpers for deterministic decode collectives.
 // ============================================================================
@@ -214,6 +264,55 @@ CUresult scaled_add_rows_cuda(
   dim3 grid(grid_x, grid_y);
   scaled_add_rows_kernel<<<grid, block, 0, stream>>>(
       delta, scale, out, out_hidden_dim, row_offset, rows, seq_len);
+  return (CUresult)cudaGetLastError();
+}
+
+CUresult gather_hidden_tokens_cuda(
+    const __nv_bfloat16 *input,
+    const int *token_indices,
+    __nv_bfloat16 *out,
+    int hidden_dim,
+    int token_count,
+    int input_seq_len,
+    cudaStream_t stream) {
+  if (input == nullptr || token_indices == nullptr || out == nullptr ||
+      hidden_dim <= 0 || token_count <= 0 || input_seq_len <= 0) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  int total = hidden_dim * token_count;
+  int block = 256;
+  int grid = (total + block - 1) / block;
+  gather_hidden_tokens_kernel<<<grid, block, 0, stream>>>(
+      input, token_indices, out, hidden_dim, token_count, input_seq_len);
+  return (CUresult)cudaGetLastError();
+}
+
+CUresult scaled_add_rows_indexed_cuda(
+    const __nv_bfloat16 *delta,
+    float scale,
+    const int *token_indices,
+    __nv_bfloat16 *out,
+    int out_hidden_dim,
+    int row_offset,
+    int rows,
+    int token_count,
+    int out_seq_len,
+    cudaStream_t stream) {
+  if (delta == nullptr || token_indices == nullptr || out == nullptr ||
+      out_hidden_dim <= 0 || row_offset < 0 || rows <= 0 ||
+      token_count <= 0 || out_seq_len <= 0 ||
+      row_offset + rows > out_hidden_dim) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  dim3 block(32, 8);
+  int grid_x = (rows + block.x - 1) / block.x;
+  int grid_y = (token_count + block.y - 1) / block.y;
+  grid_x = grid_x > 65535 ? 65535 : grid_x;
+  grid_y = grid_y > 65535 ? 65535 : grid_y;
+  dim3 grid(grid_x, grid_y);
+  scaled_add_rows_indexed_kernel<<<grid, block, 0, stream>>>(
+      delta, scale, token_indices, out, out_hidden_dim, row_offset, rows,
+      token_count, out_seq_len);
   return (CUresult)cudaGetLastError();
 }
 

--- a/pegainfer-kernels/src/ffi.rs
+++ b/pegainfer-kernels/src/ffi.rs
@@ -7,10 +7,12 @@ pub type Half = u16;
 mod deepseek;
 #[cfg(feature = "kimi-k2")]
 mod kimi;
+mod lora;
 mod qwen35;
 mod shared;
 pub use deepseek::*;
 #[cfg(feature = "kimi-k2")]
 pub use kimi::*;
+pub use lora::*;
 pub use qwen35::*;
 pub use shared::*;

--- a/pegainfer-kernels/src/ffi/lora.rs
+++ b/pegainfer-kernels/src/ffi/lora.rs
@@ -3,6 +3,15 @@ use cudarc::driver::sys::{CUresult, CUstream};
 
 // Qwen3 LoRA fused decode kernels.
 unsafe extern "C" {
+    pub fn lora_pack_b_rows_cuda(
+        src: *const Half,
+        dst: *mut Half,
+        rank: i32,
+        max_rank: i32,
+        out_dim: i32,
+        stream: CUstream,
+    ) -> CUresult;
+
     pub fn lora_decode_fused_delta_cuda(
         a_packed: *const Half,
         b_packed: *const Half,

--- a/pegainfer-kernels/src/ffi/lora.rs
+++ b/pegainfer-kernels/src/ffi/lora.rs
@@ -1,0 +1,54 @@
+use super::Half;
+use cudarc::driver::sys::{CUresult, CUstream};
+
+// Qwen3 LoRA fused decode kernels.
+unsafe extern "C" {
+    pub fn lora_decode_fused_delta_cuda(
+        a_packed: *const Half,
+        b_packed: *const Half,
+        scales: *const f32,
+        token_slots: *const i32,
+        input: *const Half,
+        out: *mut Half,
+        batch: i32,
+        max_loras: i32,
+        max_rank: i32,
+        rank: i32,
+        in_dim: i32,
+        out_dim: i32,
+        out_hidden_dim: i32,
+        row_offset: i32,
+        stream: CUstream,
+    ) -> CUresult;
+
+    pub fn lora_decode_fused_delta_group3_cuda(
+        a0: *const Half,
+        b0: *const Half,
+        scales0: *const f32,
+        out0: *mut Half,
+        rank0: i32,
+        out_dim0: i32,
+        out_hidden_dim0: i32,
+        a1: *const Half,
+        b1: *const Half,
+        scales1: *const f32,
+        out1: *mut Half,
+        rank1: i32,
+        out_dim1: i32,
+        out_hidden_dim1: i32,
+        a2: *const Half,
+        b2: *const Half,
+        scales2: *const f32,
+        out2: *mut Half,
+        rank2: i32,
+        out_dim2: i32,
+        out_hidden_dim2: i32,
+        token_slots: *const i32,
+        input: *const Half,
+        batch: i32,
+        max_loras: i32,
+        max_rank: i32,
+        in_dim: i32,
+        stream: CUstream,
+    ) -> CUresult;
+}

--- a/pegainfer-kernels/src/ffi/shared.rs
+++ b/pegainfer-kernels/src/ffi/shared.rs
@@ -475,6 +475,29 @@ unsafe extern "C" {
         stream: CUstream,
     ) -> CUresult;
 
+    pub fn gather_hidden_tokens_cuda(
+        input: *const Half,
+        token_indices: *const i32,
+        out: *mut Half,
+        hidden_dim: i32,
+        token_count: i32,
+        input_seq_len: i32,
+        stream: CUstream,
+    ) -> CUresult;
+
+    pub fn scaled_add_rows_indexed_cuda(
+        delta: *const Half,
+        scale: f32,
+        token_indices: *const i32,
+        out: *mut Half,
+        out_hidden_dim: i32,
+        row_offset: i32,
+        rows: i32,
+        token_count: i32,
+        out_seq_len: i32,
+        stream: CUstream,
+    ) -> CUresult;
+
     pub fn scale_f32_cuda(values: *mut f32, scale: f32, n: i32, stream: CUstream) -> CUresult;
 
 }

--- a/pegainfer-kernels/src/ops.rs
+++ b/pegainfer-kernels/src/ops.rs
@@ -6,6 +6,7 @@ mod embedding;
 #[cfg(feature = "kimi-k2")]
 mod kimi_k2;
 mod linear;
+mod lora;
 mod norm;
 mod sampling;
 
@@ -16,8 +17,9 @@ pub use attention::{
 };
 pub use elementwise::{
     add_batch, add_batch_into, bf16_hidden_to_f32_into, extract_vec, extract_vec_into,
-    f32_to_bf16_hidden_into, repeat_f32_for_reduce_scatter_into, scale_f32_in_place,
-    scaled_add_batch_into, scaled_add_rows_into, silu_mul_batch, silu_mul_batch_into,
+    f32_to_bf16_hidden_into, gather_hidden_tokens_into, repeat_f32_for_reduce_scatter_into,
+    scale_f32_in_place, scaled_add_batch_into, scaled_add_rows_indexed_into, scaled_add_rows_into,
+    scaled_add_rows_token_range_into, silu_mul_batch, silu_mul_batch_into,
     silu_mul_fused_batch_into, write_vec_into,
 };
 pub use embedding::{embedding_batch, embedding_batch_vocab_shard, embedding_decode_into};
@@ -25,7 +27,11 @@ pub use embedding::{embedding_batch, embedding_batch_vocab_shard, embedding_deco
 pub use kimi_k2::*;
 pub use linear::{
     gemm, gemm_graphsafe_into_checked, gemm_into, gemm_into_checked, gemm_per_token,
-    gemm_per_token_into_checked, gemm_rows_into, gemm_rows_into_checked, gemv, linear,
+    gemm_per_token_into_checked, gemm_rows_into, gemm_rows_into_checked,
+    gemm_token_range_into_checked, gemv, linear,
+};
+pub use lora::{
+    LoraDecodeGroupedProjection, lora_decode_fused_delta_group3_into, lora_decode_fused_delta_into,
 };
 pub use norm::{
     fused_add_rms_norm_batch_into, fused_add_rms_norm_into, fused_add_rms_norm_round_batch_into,

--- a/pegainfer-kernels/src/ops.rs
+++ b/pegainfer-kernels/src/ops.rs
@@ -32,6 +32,7 @@ pub use linear::{
 };
 pub use lora::{
     LoraDecodeGroupedProjection, lora_decode_fused_delta_group3_into, lora_decode_fused_delta_into,
+    pack_lora_b_rows_into,
 };
 pub use norm::{
     fused_add_rms_norm_batch_into, fused_add_rms_norm_into, fused_add_rms_norm_round_batch_into,

--- a/pegainfer-kernels/src/ops/elementwise.rs
+++ b/pegainfer-kernels/src/ops/elementwise.rs
@@ -86,6 +86,149 @@ pub fn scaled_add_rows_into(
     Ok(())
 }
 
+/// In-place scaled add into a row range of a contiguous token range in `out`.
+pub fn scaled_add_rows_token_range_into(
+    ctx: &DeviceContext,
+    delta: &HiddenStates,
+    scale: f32,
+    out: &mut HiddenStates,
+    row_offset: usize,
+    token_offset: usize,
+) -> Result<()> {
+    assert!(
+        scale.is_finite(),
+        "scaled_add_rows_token_range_into scale must be finite"
+    );
+    assert!(
+        row_offset + delta.hidden_dim <= out.hidden_dim,
+        "row range [{}..{}) exceeds out hidden_dim {}",
+        row_offset,
+        row_offset + delta.hidden_dim,
+        out.hidden_dim
+    );
+    assert!(
+        token_offset + delta.seq_len <= out.seq_len,
+        "token range [{}..{}) exceeds out seq_len {}",
+        token_offset,
+        token_offset + delta.seq_len,
+        out.seq_len
+    );
+
+    let (delta_ptr, _gd) = delta.data.device_ptr(&ctx.stream);
+    let (out_base, _go) = out.data.device_ptr_mut(&ctx.stream);
+    let out_ptr =
+        out_base + (token_offset * out.hidden_dim * std::mem::size_of::<half::bf16>()) as u64;
+    let result = unsafe {
+        ffi::scaled_add_rows_cuda(
+            delta_ptr as *const ffi::Half,
+            scale,
+            out_ptr as *mut ffi::Half,
+            out.hidden_dim as i32,
+            row_offset as i32,
+            delta.hidden_dim as i32,
+            delta.seq_len as i32,
+            ctx.stream.cu_stream(),
+        )
+    };
+    result.result()?;
+
+    Ok(())
+}
+
+pub fn gather_hidden_tokens_into(
+    ctx: &DeviceContext,
+    input: &HiddenStates,
+    token_indices: &CudaSlice<i32>,
+    token_count: usize,
+    out: &mut HiddenStates,
+) -> Result<()> {
+    assert_eq!(
+        out.hidden_dim, input.hidden_dim,
+        "gather output hidden_dim {} != input hidden_dim {}",
+        out.hidden_dim, input.hidden_dim
+    );
+    assert_eq!(
+        out.seq_len, token_count,
+        "gather output seq_len {} != token_count {}",
+        out.seq_len, token_count
+    );
+    assert!(
+        token_count <= token_indices.len(),
+        "token_count {} exceeds indices len {}",
+        token_count,
+        token_indices.len()
+    );
+    let (input_ptr, _gi) = input.data.device_ptr(&ctx.stream);
+    let (indices_ptr, _gidx) = token_indices.device_ptr(&ctx.stream);
+    let (out_ptr, _go) = out.data.device_ptr_mut(&ctx.stream);
+    let result = unsafe {
+        ffi::gather_hidden_tokens_cuda(
+            input_ptr as *const ffi::Half,
+            indices_ptr as *const i32,
+            out_ptr as *mut ffi::Half,
+            input.hidden_dim as i32,
+            token_count as i32,
+            input.seq_len as i32,
+            ctx.stream.cu_stream(),
+        )
+    };
+    result.result()?;
+    Ok(())
+}
+
+pub fn scaled_add_rows_indexed_into(
+    ctx: &DeviceContext,
+    delta: &HiddenStates,
+    scale: f32,
+    token_indices: &CudaSlice<i32>,
+    token_count: usize,
+    out: &mut HiddenStates,
+    row_offset: usize,
+) -> Result<()> {
+    assert!(
+        scale.is_finite(),
+        "scaled_add_rows_indexed_into scale must be finite"
+    );
+    assert_eq!(
+        delta.seq_len, token_count,
+        "delta seq_len {} != token_count {}",
+        delta.seq_len, token_count
+    );
+    assert!(
+        token_count <= token_indices.len(),
+        "token_count {} exceeds indices len {}",
+        token_count,
+        token_indices.len()
+    );
+    assert!(
+        row_offset + delta.hidden_dim <= out.hidden_dim,
+        "row range [{}..{}) exceeds out hidden_dim {}",
+        row_offset,
+        row_offset + delta.hidden_dim,
+        out.hidden_dim
+    );
+
+    let (delta_ptr, _gd) = delta.data.device_ptr(&ctx.stream);
+    let (indices_ptr, _gidx) = token_indices.device_ptr(&ctx.stream);
+    let (out_ptr, _go) = out.data.device_ptr_mut(&ctx.stream);
+    let result = unsafe {
+        ffi::scaled_add_rows_indexed_cuda(
+            delta_ptr as *const ffi::Half,
+            scale,
+            indices_ptr as *const i32,
+            out_ptr as *mut ffi::Half,
+            out.hidden_dim as i32,
+            row_offset as i32,
+            delta.hidden_dim as i32,
+            token_count as i32,
+            out.seq_len as i32,
+            ctx.stream.cu_stream(),
+        )
+    };
+    result.result()?;
+    Ok(())
+}
+
 /// In-place scaled add for tensors with identical shape.
 pub fn scaled_add_batch_into(
     ctx: &DeviceContext,

--- a/pegainfer-kernels/src/ops/linear.rs
+++ b/pegainfer-kernels/src/ops/linear.rs
@@ -121,6 +121,49 @@ pub fn gemm_into_checked(
     gemm_into_with_policy(ctx, weight, x, out, x.seq_len == 1)
 }
 
+/// GEMM for a contiguous token range in `x` into a compact output buffer.
+pub fn gemm_token_range_into_checked(
+    ctx: &DeviceContext,
+    weight: &DeviceMatrix,
+    x: &HiddenStates,
+    token_offset: usize,
+    out: &mut HiddenStates,
+) -> Result<()> {
+    assert_eq!(
+        weight.cols, x.hidden_dim,
+        "weight cols {} != hidden_dim {}",
+        weight.cols, x.hidden_dim
+    );
+    assert_eq!(
+        out.hidden_dim, weight.rows,
+        "out hidden_dim {} != weight rows {}",
+        out.hidden_dim, weight.rows
+    );
+    assert!(
+        token_offset + out.seq_len <= x.seq_len,
+        "token range [{}..{}) exceeds input seq_len {}",
+        token_offset,
+        token_offset + out.seq_len,
+        x.seq_len
+    );
+
+    let (w_ptr, _gw) = weight.data.device_ptr(&ctx.stream);
+    let (x_base, _gx) = x.data.device_ptr(&ctx.stream);
+    let x_ptr = x_base + (token_offset * x.hidden_dim * std::mem::size_of::<half::bf16>()) as u64;
+    let (y_ptr, _gy) = out.data.device_ptr_mut(&ctx.stream);
+
+    launch_gemm(
+        w_ptr as *const ffi::Half,
+        x_ptr as *const ffi::Half,
+        y_ptr as *mut ffi::Half,
+        weight.rows,
+        out.seq_len,
+        weight.cols,
+        out.seq_len == 1,
+        ctx,
+    )
+}
+
 /// Checked GEMM that always uses the workspace-free cuBLAS handle. Kimi decode
 /// uses this for active-batch sizes 1..=4 so graph-readiness is not tied to a
 /// bs1-only condition.

--- a/pegainfer-kernels/src/ops/lora.rs
+++ b/pegainfer-kernels/src/ops/lora.rs
@@ -16,6 +16,44 @@ pub struct LoraDecodeGroupedProjection<'a> {
     pub out_dim: usize,
 }
 
+pub fn pack_lora_b_rows_into(
+    ctx: &DeviceContext,
+    src: &CudaSlice<half::bf16>,
+    dst: &mut CudaSlice<half::bf16>,
+    dst_offset: usize,
+    rank: usize,
+    max_rank: usize,
+    out_dim: usize,
+) -> Result<()> {
+    assert!(rank > 0, "LoRA rank must be > 0");
+    assert!(rank <= max_rank, "LoRA rank exceeds packed max_rank");
+    assert!(
+        src.len() >= out_dim * rank,
+        "LoRA B source is smaller than out_dim * rank"
+    );
+    assert!(
+        dst.len() >= dst_offset + out_dim * max_rank,
+        "LoRA B destination slot exceeds packed storage"
+    );
+
+    let (src_ptr, _gs) = src.device_ptr(&ctx.stream);
+    let (dst_ptr, _gd) = dst.device_ptr_mut(&ctx.stream);
+    let dst_ptr = dst_ptr + (dst_offset * std::mem::size_of::<half::bf16>()) as u64;
+    let result = unsafe {
+        ffi::lora_pack_b_rows_cuda(
+            src_ptr as *const ffi::Half,
+            dst_ptr as *mut ffi::Half,
+            rank as i32,
+            max_rank as i32,
+            out_dim as i32,
+            ctx.stream.cu_stream(),
+        )
+    };
+    result.result()?;
+
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn lora_decode_fused_delta_into(
     ctx: &DeviceContext,

--- a/pegainfer-kernels/src/ops/lora.rs
+++ b/pegainfer-kernels/src/ops/lora.rs
@@ -1,0 +1,271 @@
+use anyhow::Result;
+use cudarc::driver::{CudaSlice, DevicePtr, DevicePtrMut};
+use std::ptr::{null, null_mut};
+
+use crate::ffi;
+use crate::tensor::{DeviceContext, HiddenStates};
+
+pub struct LoraDecodeGroupedProjection<'a> {
+    pub a_packed: &'a CudaSlice<half::bf16>,
+    pub b_packed: &'a CudaSlice<half::bf16>,
+    pub scales: &'a CudaSlice<f32>,
+    pub out: &'a mut HiddenStates,
+    pub max_loras: usize,
+    pub max_rank: usize,
+    pub rank: usize,
+    pub out_dim: usize,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn lora_decode_fused_delta_into(
+    ctx: &DeviceContext,
+    a_packed: &CudaSlice<half::bf16>,
+    b_packed: &CudaSlice<half::bf16>,
+    scales: &CudaSlice<f32>,
+    token_slots: &CudaSlice<i32>,
+    input: &HiddenStates,
+    out: &mut HiddenStates,
+    max_loras: usize,
+    max_rank: usize,
+    rank: usize,
+    out_dim: usize,
+    row_offset: usize,
+) -> Result<()> {
+    assert!(rank > 0, "LoRA rank must be > 0");
+    assert!(rank <= max_rank, "LoRA rank exceeds packed max_rank");
+    assert!(
+        row_offset + out_dim <= out.hidden_dim,
+        "LoRA output row range exceeds output hidden dimension"
+    );
+    assert_eq!(
+        input.seq_len, out.seq_len,
+        "LoRA decode input/output batch mismatch"
+    );
+
+    let (a_ptr, _ga) = a_packed.device_ptr(&ctx.stream);
+    let (b_ptr, _gb) = b_packed.device_ptr(&ctx.stream);
+    let (scales_ptr, _gs) = scales.device_ptr(&ctx.stream);
+    let (slots_ptr, _gslot) = token_slots.device_ptr(&ctx.stream);
+    let (input_ptr, _gi) = input.data.device_ptr(&ctx.stream);
+    let (out_ptr, _go) = out.data.device_ptr_mut(&ctx.stream);
+
+    let result = unsafe {
+        ffi::lora_decode_fused_delta_cuda(
+            a_ptr as *const ffi::Half,
+            b_ptr as *const ffi::Half,
+            scales_ptr as *const f32,
+            slots_ptr as *const i32,
+            input_ptr as *const ffi::Half,
+            out_ptr as *mut ffi::Half,
+            input.seq_len as i32,
+            max_loras as i32,
+            max_rank as i32,
+            rank as i32,
+            input.hidden_dim as i32,
+            out_dim as i32,
+            out.hidden_dim as i32,
+            row_offset as i32,
+            ctx.stream.cu_stream(),
+        )
+    };
+    result.result()?;
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn lora_decode_fused_delta_group3_into(
+    ctx: &DeviceContext,
+    token_slots: &CudaSlice<i32>,
+    input: &HiddenStates,
+    mut p0: Option<LoraDecodeGroupedProjection<'_>>,
+    mut p1: Option<LoraDecodeGroupedProjection<'_>>,
+    mut p2: Option<LoraDecodeGroupedProjection<'_>>,
+) -> Result<()> {
+    let Some((max_loras, max_rank)) = p0.as_ref().or(p1.as_ref()).or(p2.as_ref()).map(|p| {
+        assert!(p.rank > 0, "LoRA rank must be > 0");
+        assert!(p.rank <= p.max_rank, "LoRA rank exceeds packed max_rank");
+        (p.max_loras, p.max_rank)
+    }) else {
+        return Ok(());
+    };
+    validate_group_projection(&p0, input, max_loras, max_rank);
+    validate_group_projection(&p1, input, max_loras, max_rank);
+    validate_group_projection(&p2, input, max_loras, max_rank);
+
+    let (slots_ptr, _gslot) = token_slots.device_ptr(&ctx.stream);
+    let (input_ptr, _gi) = input.data.device_ptr(&ctx.stream);
+
+    let mut _p0_a_guard = None;
+    let mut _p0_b_guard = None;
+    let mut _p0_scales_guard = None;
+    let mut _p0_out_guard = None;
+    let (p0_a, p0_b, p0_scales, p0_out, p0_rank, p0_out_dim, p0_out_hidden_dim) =
+        if let Some(projection) = p0.as_mut() {
+            let (a_ptr, ga) = projection.a_packed.device_ptr(&ctx.stream);
+            _p0_a_guard = Some(ga);
+            let (b_ptr, gb) = projection.b_packed.device_ptr(&ctx.stream);
+            _p0_b_guard = Some(gb);
+            let (scales_ptr, gs) = projection.scales.device_ptr(&ctx.stream);
+            _p0_scales_guard = Some(gs);
+            let (out_ptr, go) = projection.out.data.device_ptr_mut(&ctx.stream);
+            _p0_out_guard = Some(go);
+            (
+                a_ptr as *const half::bf16,
+                b_ptr as *const half::bf16,
+                scales_ptr as *const f32,
+                out_ptr as *mut half::bf16,
+                projection.rank as i32,
+                projection.out_dim as i32,
+                projection.out.hidden_dim as i32,
+            )
+        } else {
+            (
+                null::<half::bf16>(),
+                null::<half::bf16>(),
+                null::<f32>(),
+                null_mut(),
+                0,
+                0,
+                0,
+            )
+        };
+
+    let mut _p1_a_guard = None;
+    let mut _p1_b_guard = None;
+    let mut _p1_scales_guard = None;
+    let mut _p1_out_guard = None;
+    let (p1_a, p1_b, p1_scales, p1_out, p1_rank, p1_out_dim, p1_out_hidden_dim) =
+        if let Some(projection) = p1.as_mut() {
+            let (a_ptr, ga) = projection.a_packed.device_ptr(&ctx.stream);
+            _p1_a_guard = Some(ga);
+            let (b_ptr, gb) = projection.b_packed.device_ptr(&ctx.stream);
+            _p1_b_guard = Some(gb);
+            let (scales_ptr, gs) = projection.scales.device_ptr(&ctx.stream);
+            _p1_scales_guard = Some(gs);
+            let (out_ptr, go) = projection.out.data.device_ptr_mut(&ctx.stream);
+            _p1_out_guard = Some(go);
+            (
+                a_ptr as *const half::bf16,
+                b_ptr as *const half::bf16,
+                scales_ptr as *const f32,
+                out_ptr as *mut half::bf16,
+                projection.rank as i32,
+                projection.out_dim as i32,
+                projection.out.hidden_dim as i32,
+            )
+        } else {
+            (
+                null::<half::bf16>(),
+                null::<half::bf16>(),
+                null::<f32>(),
+                null_mut(),
+                0,
+                0,
+                0,
+            )
+        };
+
+    let mut _p2_a_guard = None;
+    let mut _p2_b_guard = None;
+    let mut _p2_scales_guard = None;
+    let mut _p2_out_guard = None;
+    let (p2_a, p2_b, p2_scales, p2_out, p2_rank, p2_out_dim, p2_out_hidden_dim) =
+        if let Some(projection) = p2.as_mut() {
+            let (a_ptr, ga) = projection.a_packed.device_ptr(&ctx.stream);
+            _p2_a_guard = Some(ga);
+            let (b_ptr, gb) = projection.b_packed.device_ptr(&ctx.stream);
+            _p2_b_guard = Some(gb);
+            let (scales_ptr, gs) = projection.scales.device_ptr(&ctx.stream);
+            _p2_scales_guard = Some(gs);
+            let (out_ptr, go) = projection.out.data.device_ptr_mut(&ctx.stream);
+            _p2_out_guard = Some(go);
+            (
+                a_ptr as *const half::bf16,
+                b_ptr as *const half::bf16,
+                scales_ptr as *const f32,
+                out_ptr as *mut half::bf16,
+                projection.rank as i32,
+                projection.out_dim as i32,
+                projection.out.hidden_dim as i32,
+            )
+        } else {
+            (
+                null::<half::bf16>(),
+                null::<half::bf16>(),
+                null::<f32>(),
+                null_mut(),
+                0,
+                0,
+                0,
+            )
+        };
+
+    let result = unsafe {
+        ffi::lora_decode_fused_delta_group3_cuda(
+            p0_a as *const ffi::Half,
+            p0_b as *const ffi::Half,
+            p0_scales,
+            p0_out as *mut ffi::Half,
+            p0_rank,
+            p0_out_dim,
+            p0_out_hidden_dim,
+            p1_a as *const ffi::Half,
+            p1_b as *const ffi::Half,
+            p1_scales,
+            p1_out as *mut ffi::Half,
+            p1_rank,
+            p1_out_dim,
+            p1_out_hidden_dim,
+            p2_a as *const ffi::Half,
+            p2_b as *const ffi::Half,
+            p2_scales,
+            p2_out as *mut ffi::Half,
+            p2_rank,
+            p2_out_dim,
+            p2_out_hidden_dim,
+            slots_ptr as *const i32,
+            input_ptr as *const ffi::Half,
+            input.seq_len as i32,
+            max_loras as i32,
+            max_rank as i32,
+            input.hidden_dim as i32,
+            ctx.stream.cu_stream(),
+        )
+    };
+    result.result()?;
+
+    Ok(())
+}
+
+fn validate_group_projection(
+    projection: &Option<LoraDecodeGroupedProjection<'_>>,
+    input: &HiddenStates,
+    max_loras: usize,
+    max_rank: usize,
+) {
+    let Some(projection) = projection else {
+        return;
+    };
+    assert!(projection.rank > 0, "LoRA rank must be > 0");
+    assert!(
+        projection.rank <= projection.max_rank,
+        "LoRA rank exceeds packed max_rank"
+    );
+    assert_eq!(
+        projection.max_loras, max_loras,
+        "grouped LoRA projection max_loras mismatch"
+    );
+    assert_eq!(
+        projection.max_rank, max_rank,
+        "grouped LoRA projection max_rank mismatch"
+    );
+    assert_eq!(
+        input.seq_len, projection.out.seq_len,
+        "LoRA decode input/output batch mismatch"
+    );
+    assert!(
+        projection.out_dim <= projection.out.hidden_dim,
+        "LoRA output row range exceeds output hidden dimension"
+    );
+}

--- a/pegainfer-qwen3-4b/src/batch_decode.rs
+++ b/pegainfer-qwen3-4b/src/batch_decode.rs
@@ -10,7 +10,9 @@ use super::batch_decode_buffers::{
 };
 use super::batch_decode_dag::BatchDecodeDag;
 use super::weights::{PackedLoraProjection, Qwen3Model, TransformerBlock};
-use crate::lora::{LoraProjectionKind, LoraTokenRange, build_lora_token_ranges};
+use crate::lora::{
+    DeviceLoraTokenGroup, LoraProjectionKind, build_lora_token_ranges, prepare_lora_token_groups,
+};
 use pegainfer_core::kv_pool::KvLayout;
 use pegainfer_core::ops;
 use pegainfer_kernels::tensor::{KvDim, QDim};
@@ -64,6 +66,7 @@ impl Qwen3Model {
         assert!(bs > 0);
         let lora_ranges =
             build_lora_token_ranges(std::iter::repeat_n(1, bs), lora_adapters.iter().copied());
+        let lora_groups = prepare_lora_token_groups(&self.ctx, &lora_ranges)?;
         let lora_slots = self.decode_lora_slots(lora_adapters)?;
         let use_cuda_graph = self.enable_cuda_graph && lora_ranges.is_empty();
 
@@ -110,7 +113,7 @@ impl Qwen3Model {
                         layout,
                         padded_bs,
                         attention_path,
-                        &lora_ranges,
+                        &lora_groups,
                         lora_slots.is_some(),
                         bufs,
                     )
@@ -125,7 +128,7 @@ impl Qwen3Model {
                     layout,
                     padded_bs,
                     attention_path,
-                    &lora_ranges,
+                    &lora_groups,
                     lora_slots.is_some(),
                     bufs,
                 )
@@ -141,7 +144,7 @@ impl Qwen3Model {
         layout: &KvLayout,
         bs: usize,
         attention_path: DecodeAttentionPath,
-        lora_ranges: &[LoraTokenRange<'_>],
+        lora_groups: &[DeviceLoraTokenGroup<'_>],
         use_fused_lora: bool,
         bufs: &mut BatchDecodeBuffers,
     ) -> Result<()> {
@@ -160,7 +163,7 @@ impl Qwen3Model {
         );
 
         for (layer_idx, layer) in self.layers.iter().enumerate() {
-            self.batch_decode_layer(layer_idx, layer, &dag, lora_ranges, use_fused_lora, bufs)?;
+            self.batch_decode_layer(layer_idx, layer, &dag, lora_groups, use_fused_lora, bufs)?;
 
             let next_weight = if layer_idx + 1 < num_layers {
                 &self.layers[layer_idx + 1].input_layernorm
@@ -197,7 +200,7 @@ impl Qwen3Model {
         layer_idx: usize,
         layer: &TransformerBlock,
         dag: &BatchDecodeDag<'_>,
-        lora_ranges: &[LoraTokenRange<'_>],
+        lora_groups: &[DeviceLoraTokenGroup<'_>],
         use_fused_lora: bool,
         bufs: &mut BatchDecodeBuffers,
     ) -> Result<()> {
@@ -236,7 +239,7 @@ impl Qwen3Model {
             LoraProjectionKind::Q,
             LoraProjectionKind::K,
             LoraProjectionKind::V,
-            lora_ranges,
+            lora_groups,
             use_fused_lora,
             &bufs.normed,
             &mut bufs.q,
@@ -272,7 +275,7 @@ impl Qwen3Model {
         self.apply_decode_lora_projection(
             layer_idx,
             LoraProjectionKind::O,
-            lora_ranges,
+            lora_groups,
             use_fused_lora,
             &bufs.attn_out,
             &mut bufs.attn_proj,
@@ -310,7 +313,7 @@ impl Qwen3Model {
             layer_idx,
             LoraProjectionKind::Gate,
             LoraProjectionKind::Up,
-            lora_ranges,
+            lora_groups,
             use_fused_lora,
             &bufs.normed,
             &mut bufs.gate_out,
@@ -332,7 +335,7 @@ impl Qwen3Model {
         self.apply_decode_lora_projection(
             layer_idx,
             LoraProjectionKind::Down,
-            lora_ranges,
+            lora_groups,
             use_fused_lora,
             &bufs.mlp_act,
             &mut bufs.mlp_out,
@@ -353,7 +356,7 @@ impl Qwen3Model {
         layer_idx: usize,
         kind0: LoraProjectionKind,
         kind1: LoraProjectionKind,
-        lora_ranges: &[LoraTokenRange<'_>],
+        lora_groups: &[DeviceLoraTokenGroup<'_>],
         use_fused_lora: bool,
         input: &pegainfer_core::tensor::HiddenStates,
         out0: &mut pegainfer_core::tensor::HiddenStates,
@@ -363,7 +366,7 @@ impl Qwen3Model {
         if !use_fused_lora {
             self.apply_lora_projection_ranges(
                 layer_idx,
-                lora_ranges,
+                lora_groups,
                 |layer| layer.projection(kind0),
                 input,
                 out0,
@@ -371,7 +374,7 @@ impl Qwen3Model {
             )?;
             self.apply_lora_projection_ranges(
                 layer_idx,
-                lora_ranges,
+                lora_groups,
                 |layer| layer.projection(kind1),
                 input,
                 out1,
@@ -392,7 +395,7 @@ impl Qwen3Model {
         kind0: LoraProjectionKind,
         kind1: LoraProjectionKind,
         kind2: LoraProjectionKind,
-        lora_ranges: &[LoraTokenRange<'_>],
+        lora_groups: &[DeviceLoraTokenGroup<'_>],
         use_fused_lora: bool,
         input: &pegainfer_core::tensor::HiddenStates,
         out0: &mut pegainfer_core::tensor::HiddenStates,
@@ -403,7 +406,7 @@ impl Qwen3Model {
         if !use_fused_lora {
             self.apply_lora_projection_ranges(
                 layer_idx,
-                lora_ranges,
+                lora_groups,
                 |layer| layer.projection(kind0),
                 input,
                 out0,
@@ -411,7 +414,7 @@ impl Qwen3Model {
             )?;
             self.apply_lora_projection_ranges(
                 layer_idx,
-                lora_ranges,
+                lora_groups,
                 |layer| layer.projection(kind1),
                 input,
                 out1,
@@ -419,7 +422,7 @@ impl Qwen3Model {
             )?;
             self.apply_lora_projection_ranges(
                 layer_idx,
-                lora_ranges,
+                lora_groups,
                 |layer| layer.projection(kind2),
                 input,
                 out2,
@@ -449,7 +452,7 @@ impl Qwen3Model {
         &self,
         layer_idx: usize,
         kind: LoraProjectionKind,
-        lora_ranges: &[LoraTokenRange<'_>],
+        lora_groups: &[DeviceLoraTokenGroup<'_>],
         use_fused_lora: bool,
         input: &pegainfer_core::tensor::HiddenStates,
         out: &mut pegainfer_core::tensor::HiddenStates,
@@ -459,7 +462,7 @@ impl Qwen3Model {
         if !use_fused_lora {
             return self.apply_lora_projection_ranges(
                 layer_idx,
-                lora_ranges,
+                lora_groups,
                 |layer| layer.projection(kind),
                 input,
                 out,

--- a/pegainfer-qwen3-4b/src/batch_decode.rs
+++ b/pegainfer-qwen3-4b/src/batch_decode.rs
@@ -9,10 +9,9 @@ use super::batch_decode_buffers::{
     BATCH_BUCKETS, BatchDecodeBuffers, DecodeAttentionPath, bucket_for,
 };
 use super::batch_decode_dag::BatchDecodeDag;
-use super::weights::{Qwen3Model, TransformerBlock};
-use crate::lora::apply_lora_projection_delta;
+use super::weights::{PackedLoraProjection, Qwen3Model, TransformerBlock};
+use crate::lora::{LoraProjectionKind, LoraTokenRange, build_lora_token_ranges};
 use pegainfer_core::kv_pool::KvLayout;
-#[cfg(feature = "kernel-call-trace")]
 use pegainfer_core::ops;
 use pegainfer_kernels::tensor::{KvDim, QDim};
 use pegainfer_kv_cache::KvView;
@@ -46,29 +45,33 @@ macro_rules! trace_decode_kv_len {
 impl Qwen3Model {
     /// Batch decode step: N requests, 1 new token each, one forward pass.
     ///
-    /// When `enable_cuda_graph` is set, pads to the nearest bucket size and
-    /// uses per-bucket CUDA Graph capture/replay.
+    /// When `enable_cuda_graph` is set and the batch does not use LoRA, pads
+    /// to the nearest bucket size and uses per-bucket CUDA Graph capture/replay.
+    /// LoRA batches currently run eager because packed LoRA slots are not part
+    /// of the CUDA Graph cache key yet.
     pub(crate) fn batch_decode(
         &self,
         token_ids: &[u32],
         kv_views: &[KvView],
+        lora_adapters: &[Option<&str>],
         kv_buffer: &CudaSlice<bf16>,
         layout: &KvLayout,
         bufs: &mut BatchDecodeBuffers,
     ) -> Result<()> {
         let bs = token_ids.len();
         assert_eq!(bs, kv_views.len());
+        assert_eq!(bs, lora_adapters.len());
         assert!(bs > 0);
+        let lora_ranges =
+            build_lora_token_ranges(std::iter::repeat_n(1, bs), lora_adapters.iter().copied());
+        let lora_slots = self.decode_lora_slots(lora_adapters)?;
+        let use_cuda_graph = self.enable_cuda_graph && lora_ranges.is_empty();
 
         // Derive positions from views (seq_len - 1 = position of the new token)
         let mut positions: Vec<i32> = kv_views.iter().map(|v| (v.seq_len() - 1) as i32).collect();
 
         // Pad to bucket size for CUDA Graph stability
-        let padded_bs = if self.enable_cuda_graph {
-            bucket_for(bs)
-        } else {
-            bs
-        };
+        let padded_bs = if use_cuda_graph { bucket_for(bs) } else { bs };
 
         // Set batch size on all buffers (padded — kernels run at bucket width)
         bufs.set_batch_size(padded_bs);
@@ -84,27 +87,48 @@ impl Qwen3Model {
         self.ctx
             .stream
             .memcpy_htod(&positions, &mut bufs.positions_d)?;
+        if let Some(lora_slots) = &lora_slots {
+            self.ctx
+                .stream
+                .memcpy_htod(lora_slots, &mut bufs.lora_token_slots_d)?;
+        }
 
         let kv_refs: Vec<&KvView> = kv_views.iter().collect();
         bufs.sync_paged_meta(&self.ctx, &kv_refs, padded_bs)?;
         let attention_path = bufs.attention_path(padded_bs);
         #[cfg(feature = "kernel-call-trace")]
         let trace_kv_len = kv_views.iter().map(|v| v.seq_len()).max().unwrap_or(0);
-        if self.enable_cuda_graph {
+        if use_cuda_graph {
             let bucket_idx = BATCH_BUCKETS.iter().position(|&b| b == padded_bs).unwrap();
             let graph_idx = BatchDecodeBuffers::graph_index(bucket_idx, attention_path);
             // Take graphs out of bufs to avoid split-borrow conflict with closure
             let mut graphs = std::mem::take(&mut bufs.graphs);
             let result = graphs[graph_idx].run_or_capture(&self.ctx, || {
                 trace_decode_kv_len!(trace_kv_len, {
-                    self.batch_decode_kernels(kv_buffer, layout, padded_bs, attention_path, bufs)
+                    self.batch_decode_kernels(
+                        kv_buffer,
+                        layout,
+                        padded_bs,
+                        attention_path,
+                        &lora_ranges,
+                        lora_slots.is_some(),
+                        bufs,
+                    )
                 })
             });
             bufs.graphs = graphs;
             result?;
         } else {
             trace_decode_kv_len!(trace_kv_len, {
-                self.batch_decode_kernels(kv_buffer, layout, padded_bs, attention_path, bufs)
+                self.batch_decode_kernels(
+                    kv_buffer,
+                    layout,
+                    padded_bs,
+                    attention_path,
+                    &lora_ranges,
+                    lora_slots.is_some(),
+                    bufs,
+                )
             })?;
         }
 
@@ -117,6 +141,8 @@ impl Qwen3Model {
         layout: &KvLayout,
         bs: usize,
         attention_path: DecodeAttentionPath,
+        lora_ranges: &[LoraTokenRange<'_>],
+        use_fused_lora: bool,
         bufs: &mut BatchDecodeBuffers,
     ) -> Result<()> {
         let num_layers = self.layers.len();
@@ -134,7 +160,7 @@ impl Qwen3Model {
         );
 
         for (layer_idx, layer) in self.layers.iter().enumerate() {
-            self.batch_decode_layer(layer_idx, layer, &dag, bufs)?;
+            self.batch_decode_layer(layer_idx, layer, &dag, lora_ranges, use_fused_lora, bufs)?;
 
             let next_weight = if layer_idx + 1 < num_layers {
                 &self.layers[layer_idx + 1].input_layernorm
@@ -171,6 +197,8 @@ impl Qwen3Model {
         layer_idx: usize,
         layer: &TransformerBlock,
         dag: &BatchDecodeDag<'_>,
+        lora_ranges: &[LoraTokenRange<'_>],
+        use_fused_lora: bool,
         bufs: &mut BatchDecodeBuffers,
     ) -> Result<()> {
         // Match prefill numerics: compute Q/K/V via row-sliced GEMMs instead of
@@ -187,18 +215,6 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.q,
         );
-        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
-            && let Some(projection) = &lora_layer.q_proj
-        {
-            apply_lora_projection_delta(
-                &self.ctx,
-                projection,
-                &bufs.normed,
-                &mut bufs.q,
-                0,
-                scale,
-            )?;
-        }
         dag.gemm_rows::<KvDim>(
             dag_label!(format!("L{layer_idx}.attn.k_proj")),
             &layer.attention.qkv_proj,
@@ -207,18 +223,6 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.k,
         );
-        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
-            && let Some(projection) = &lora_layer.k_proj
-        {
-            apply_lora_projection_delta(
-                &self.ctx,
-                projection,
-                &bufs.normed,
-                &mut bufs.k,
-                0,
-                scale,
-            )?;
-        }
         dag.gemm_rows::<KvDim>(
             dag_label!(format!("L{layer_idx}.attn.v_proj")),
             &layer.attention.qkv_proj,
@@ -227,18 +231,19 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.v,
         );
-        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
-            && let Some(projection) = &lora_layer.v_proj
-        {
-            apply_lora_projection_delta(
-                &self.ctx,
-                projection,
-                &bufs.normed,
-                &mut bufs.v,
-                0,
-                scale,
-            )?;
-        }
+        self.apply_decode_lora_projection_group3(
+            layer_idx,
+            LoraProjectionKind::Q,
+            LoraProjectionKind::K,
+            LoraProjectionKind::V,
+            lora_ranges,
+            use_fused_lora,
+            &bufs.normed,
+            &mut bufs.q,
+            &mut bufs.k,
+            &mut bufs.v,
+            &bufs.lora_token_slots_d,
+        )?;
 
         // QK norm + RoPE (batched, per-request positions)
         dag.qk_norm_rope(
@@ -264,18 +269,16 @@ impl Qwen3Model {
             &bufs.attn_out,
             &mut bufs.attn_proj,
         );
-        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
-            && let Some(projection) = &lora_layer.o_proj
-        {
-            apply_lora_projection_delta(
-                &self.ctx,
-                projection,
-                &bufs.attn_out,
-                &mut bufs.attn_proj,
-                0,
-                scale,
-            )?;
-        }
+        self.apply_decode_lora_projection(
+            layer_idx,
+            LoraProjectionKind::O,
+            lora_ranges,
+            use_fused_lora,
+            &bufs.attn_out,
+            &mut bufs.attn_proj,
+            0,
+            &bufs.lora_token_slots_d,
+        )?;
         dag.all_reduce_hidden(
             dag_label!(format!("L{layer_idx}.attn.all_reduce")),
             &mut bufs.attn_proj,
@@ -303,28 +306,17 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.up_out,
         );
-        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx) {
-            if let Some(projection) = &lora_layer.gate_proj {
-                apply_lora_projection_delta(
-                    &self.ctx,
-                    projection,
-                    &bufs.normed,
-                    &mut bufs.gate_out,
-                    0,
-                    scale,
-                )?;
-            }
-            if let Some(projection) = &lora_layer.up_proj {
-                apply_lora_projection_delta(
-                    &self.ctx,
-                    projection,
-                    &bufs.normed,
-                    &mut bufs.up_out,
-                    0,
-                    scale,
-                )?;
-            }
-        }
+        self.apply_decode_lora_projection_group2(
+            layer_idx,
+            LoraProjectionKind::Gate,
+            LoraProjectionKind::Up,
+            lora_ranges,
+            use_fused_lora,
+            &bufs.normed,
+            &mut bufs.gate_out,
+            &mut bufs.up_out,
+            &bufs.lora_token_slots_d,
+        )?;
         dag.silu_mul_split(
             dag_label!(format!("L{layer_idx}.mlp.silu_mul")),
             &bufs.gate_out,
@@ -337,23 +329,602 @@ impl Qwen3Model {
             &bufs.mlp_act,
             &mut bufs.mlp_out,
         );
-        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
-            && let Some(projection) = &lora_layer.down_proj
-        {
-            apply_lora_projection_delta(
-                &self.ctx,
-                projection,
-                &bufs.mlp_act,
-                &mut bufs.mlp_out,
-                0,
-                scale,
-            )?;
-        }
+        self.apply_decode_lora_projection(
+            layer_idx,
+            LoraProjectionKind::Down,
+            lora_ranges,
+            use_fused_lora,
+            &bufs.mlp_act,
+            &mut bufs.mlp_out,
+            0,
+            &bufs.lora_token_slots_d,
+        )?;
         dag.all_reduce_hidden(
             dag_label!(format!("L{layer_idx}.mlp.all_reduce")),
             &mut bufs.mlp_out,
         )?;
 
         Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn apply_decode_lora_projection_group2(
+        &self,
+        layer_idx: usize,
+        kind0: LoraProjectionKind,
+        kind1: LoraProjectionKind,
+        lora_ranges: &[LoraTokenRange<'_>],
+        use_fused_lora: bool,
+        input: &pegainfer_core::tensor::HiddenStates,
+        out0: &mut pegainfer_core::tensor::HiddenStates,
+        out1: &mut pegainfer_core::tensor::HiddenStates,
+        token_slots: &CudaSlice<i32>,
+    ) -> Result<()> {
+        if !use_fused_lora {
+            self.apply_lora_projection_ranges(
+                layer_idx,
+                lora_ranges,
+                |layer| layer.projection(kind0),
+                input,
+                out0,
+                0,
+            )?;
+            self.apply_lora_projection_ranges(
+                layer_idx,
+                lora_ranges,
+                |layer| layer.projection(kind1),
+                input,
+                out1,
+                0,
+            )?;
+            return Ok(());
+        }
+
+        let p0 = self.decode_grouped_lora_projection(layer_idx, kind0, out0);
+        let p1 = self.decode_grouped_lora_projection(layer_idx, kind1, out1);
+        ops::lora_decode_fused_delta_group3_into(&self.ctx, token_slots, input, p0, p1, None)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn apply_decode_lora_projection_group3(
+        &self,
+        layer_idx: usize,
+        kind0: LoraProjectionKind,
+        kind1: LoraProjectionKind,
+        kind2: LoraProjectionKind,
+        lora_ranges: &[LoraTokenRange<'_>],
+        use_fused_lora: bool,
+        input: &pegainfer_core::tensor::HiddenStates,
+        out0: &mut pegainfer_core::tensor::HiddenStates,
+        out1: &mut pegainfer_core::tensor::HiddenStates,
+        out2: &mut pegainfer_core::tensor::HiddenStates,
+        token_slots: &CudaSlice<i32>,
+    ) -> Result<()> {
+        if !use_fused_lora {
+            self.apply_lora_projection_ranges(
+                layer_idx,
+                lora_ranges,
+                |layer| layer.projection(kind0),
+                input,
+                out0,
+                0,
+            )?;
+            self.apply_lora_projection_ranges(
+                layer_idx,
+                lora_ranges,
+                |layer| layer.projection(kind1),
+                input,
+                out1,
+                0,
+            )?;
+            self.apply_lora_projection_ranges(
+                layer_idx,
+                lora_ranges,
+                |layer| layer.projection(kind2),
+                input,
+                out2,
+                0,
+            )?;
+            return Ok(());
+        }
+
+        let p0 = self.decode_grouped_lora_projection(layer_idx, kind0, out0);
+        let p1 = self.decode_grouped_lora_projection(layer_idx, kind1, out1);
+        let p2 = self.decode_grouped_lora_projection(layer_idx, kind2, out2);
+        ops::lora_decode_fused_delta_group3_into(&self.ctx, token_slots, input, p0, p1, p2)
+    }
+
+    fn decode_grouped_lora_projection<'a>(
+        &'a self,
+        layer_idx: usize,
+        kind: LoraProjectionKind,
+        out: &'a mut pegainfer_core::tensor::HiddenStates,
+    ) -> Option<ops::LoraDecodeGroupedProjection<'a>> {
+        let packed = self.packed_lora_projection(layer_idx, kind)?;
+        Some(grouped_projection_from_packed(packed, out))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn apply_decode_lora_projection(
+        &self,
+        layer_idx: usize,
+        kind: LoraProjectionKind,
+        lora_ranges: &[LoraTokenRange<'_>],
+        use_fused_lora: bool,
+        input: &pegainfer_core::tensor::HiddenStates,
+        out: &mut pegainfer_core::tensor::HiddenStates,
+        row_offset: usize,
+        token_slots: &CudaSlice<i32>,
+    ) -> Result<()> {
+        if !use_fused_lora {
+            return self.apply_lora_projection_ranges(
+                layer_idx,
+                lora_ranges,
+                |layer| layer.projection(kind),
+                input,
+                out,
+                row_offset,
+            );
+        }
+
+        let Some(packed) = self.packed_lora_projection(layer_idx, kind) else {
+            return Ok(());
+        };
+        ops::lora_decode_fused_delta_into(
+            &self.ctx,
+            &packed.a,
+            &packed.b,
+            &packed.scales,
+            token_slots,
+            input,
+            out,
+            packed.max_loras,
+            packed.max_rank,
+            packed.rank,
+            packed.out_dim,
+            row_offset,
+        )
+    }
+}
+
+fn grouped_projection_from_packed<'a>(
+    packed: &'a PackedLoraProjection,
+    out: &'a mut pegainfer_core::tensor::HiddenStates,
+) -> ops::LoraDecodeGroupedProjection<'a> {
+    ops::LoraDecodeGroupedProjection {
+        a_packed: &packed.a,
+        b_packed: &packed.b,
+        scales: &packed.scales,
+        out,
+        max_loras: packed.max_loras,
+        max_rank: packed.max_rank,
+        rank: packed.rank,
+        out_dim: packed.out_dim,
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::batch_decode_buffers::BatchDecodeBuffers;
+    use crate::weights::ModelRuntimeConfig;
+    use pegainfer_core::ops;
+    use pegainfer_core::sampler::SamplingParams;
+    use pegainfer_core::tensor::DeviceVec;
+    use pegainfer_kv_cache::{KvCacheManager, RequestKv};
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+    use std::path::Path;
+
+    const MODEL_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../models/Qwen3-4B");
+
+    fn get_model_path_or_skip() -> Option<String> {
+        match std::env::var("PEGAINFER_TEST_MODEL_PATH") {
+            Ok(path) => Some(path),
+            Err(_) if Path::new(MODEL_PATH).join("config.json").exists() => {
+                Some(MODEL_PATH.to_string())
+            }
+            Err(_) => {
+                eprintln!(
+                    "skipping Qwen3 batch decode model test because {MODEL_PATH}/config.json is missing; set PEGAINFER_TEST_MODEL_PATH to run it"
+                );
+                None
+            }
+        }
+    }
+
+    fn make_kv_mgr(model: &Qwen3Model) -> KvCacheManager {
+        let budget = model.kv_budget();
+        KvCacheManager::new(
+            &model.ctx.stream,
+            budget.num_layers,
+            budget.num_kv_heads,
+            budget.head_dim,
+            budget.block_size,
+            budget.num_blocks,
+        )
+        .unwrap()
+    }
+
+    fn core_layout(mgr: &KvCacheManager) -> KvLayout {
+        let l = mgr.buffer().layout();
+        KvLayout::new(l.num_layers, l.num_kv_heads, l.head_dim, l.page_size)
+    }
+
+    fn sample_batch_tokens(
+        model: &Qwen3Model,
+        bufs: &BatchDecodeBuffers,
+        params: &[&SamplingParams],
+        rng: &mut StdRng,
+    ) -> Vec<u32> {
+        let mut scratch_probs = model
+            .ctx
+            .stream
+            .alloc_zeros(model.config.vocab_size)
+            .unwrap();
+        let mut scratch_top1 = model.ctx.stream.alloc_zeros(1).unwrap();
+        let mut scratch_row_states = model
+            .ctx
+            .stream
+            .alloc_zeros(pegainfer_core::ops::flashinfer_topk_row_states_bytes())
+            .unwrap();
+        let mut scratch_valid = model.ctx.stream.alloc_zeros(1).unwrap();
+        let mut scratch_out = model.ctx.stream.alloc_zeros(1).unwrap();
+        (0..params.len())
+            .map(|i| {
+                let logits_i = ops::extract_vec(&model.ctx, &bufs.logits, i).unwrap();
+                let random_val: f32 = rand::RngExt::random(rng);
+                ops::gpu_sample_into(
+                    &model.ctx,
+                    &logits_i,
+                    &mut scratch_probs,
+                    &mut scratch_top1,
+                    &mut scratch_row_states,
+                    &mut scratch_valid,
+                    &mut scratch_out,
+                    params[i],
+                    random_val,
+                )
+                .unwrap()
+            })
+            .collect()
+    }
+
+    fn sample_logits(
+        model: &Qwen3Model,
+        logits: &DeviceVec,
+        params: &SamplingParams,
+        rng: &mut StdRng,
+    ) -> u32 {
+        let mut probs: cudarc::driver::CudaSlice<f32> = model
+            .ctx
+            .stream
+            .alloc_zeros(model.config.vocab_size)
+            .unwrap();
+        let mut top1_value: cudarc::driver::CudaSlice<half::bf16> =
+            model.ctx.stream.alloc_zeros(1).unwrap();
+        let mut row_states: cudarc::driver::CudaSlice<u8> = model
+            .ctx
+            .stream
+            .alloc_zeros(pegainfer_core::ops::flashinfer_topk_row_states_bytes())
+            .unwrap();
+        let mut valid: cudarc::driver::CudaSlice<u8> = model.ctx.stream.alloc_zeros(1).unwrap();
+        let mut out: cudarc::driver::CudaSlice<i32> = model.ctx.stream.alloc_zeros(1).unwrap();
+        let random_val: f32 = rand::RngExt::random(rng);
+        ops::gpu_sample_into(
+            &model.ctx,
+            logits,
+            &mut probs,
+            &mut top1_value,
+            &mut row_states,
+            &mut valid,
+            &mut out,
+            params,
+            random_val,
+        )
+        .unwrap()
+    }
+
+    fn prefill_one(
+        model: &Qwen3Model,
+        mgr: &KvCacheManager,
+        layout: &KvLayout,
+        prompt_tokens: &[u32],
+        params: &SamplingParams,
+        rng: &mut StdRng,
+    ) -> (RequestKv, u32) {
+        let mut rkv = mgr.new_request(prompt_tokens.to_vec(), 256);
+        rkv.schedule_prefill(prompt_tokens.len(), mgr).unwrap();
+        let view = rkv.prefill_view(prompt_tokens.len());
+        let (logits_vec, _) = model
+            .batch_prefill(
+                &[prompt_tokens],
+                &[view],
+                &[None],
+                mgr.buffer().buffer(),
+                layout,
+                false,
+            )
+            .unwrap();
+        let first_token = sample_logits(model, &logits_vec[0], params, rng);
+        rkv.apply_prefill(first_token, mgr).unwrap();
+        (rkv, first_token)
+    }
+
+    fn sequential_decode(
+        model: &Qwen3Model,
+        mgr: &KvCacheManager,
+        layout: &KvLayout,
+        prompt_tokens: &[u32],
+        num_decode_steps: usize,
+        seed: u64,
+    ) -> Vec<u32> {
+        let params = SamplingParams::default();
+        let mut rng = StdRng::seed_from_u64(seed);
+
+        let (mut rkv, first_token) =
+            prefill_one(model, mgr, layout, prompt_tokens, &params, &mut rng);
+
+        let mut bufs = BatchDecodeBuffers::new(
+            &model.ctx,
+            model.config.hidden_size,
+            model.local_q_dim(),
+            model.local_kv_dim(),
+            model.local_intermediate_size(),
+            model.config.vocab_size,
+            1,
+            mgr.total_blocks(),
+            mgr.padding_block_id(),
+            model.local_num_attention_heads(),
+        )
+        .unwrap();
+
+        let mut tokens = vec![first_token];
+        for _ in 1..num_decode_steps {
+            let token_ids = [*tokens.last().unwrap()];
+            rkv.schedule_decode(mgr).unwrap();
+            let view = rkv.decode_view();
+            model
+                .batch_decode(
+                    &token_ids,
+                    &[view],
+                    &[None],
+                    mgr.buffer().buffer(),
+                    layout,
+                    &mut bufs,
+                )
+                .unwrap();
+            let params_refs: Vec<&SamplingParams> = vec![&params];
+            let batch_tokens = sample_batch_tokens(model, &bufs, &params_refs, &mut rng);
+            rkv.apply_decode(batch_tokens[0], mgr).unwrap();
+            tokens.push(batch_tokens[0]);
+        }
+        rkv.release().unwrap();
+        tokens
+    }
+
+    fn batch_decode_run(
+        model: &Qwen3Model,
+        mgr: &KvCacheManager,
+        layout: &KvLayout,
+        prompts: &[&[u32]],
+        num_decode_steps: usize,
+        seed: u64,
+    ) -> Vec<Vec<u32>> {
+        let bs = prompts.len();
+        let params = SamplingParams::default();
+        let mut rng = StdRng::seed_from_u64(seed);
+
+        // Prefill all requests
+        let mut rkvs: Vec<RequestKv> = Vec::with_capacity(bs);
+        for &prompt in prompts {
+            let mut rkv = mgr.new_request(prompt.to_vec(), 256);
+            rkv.schedule_prefill(prompt.len(), mgr).unwrap();
+            rkvs.push(rkv);
+        }
+        let views: Vec<_> = rkvs
+            .iter()
+            .zip(prompts.iter())
+            .map(|(r, p)| r.prefill_view(p.len()))
+            .collect();
+        let (logits_vec, _) = model
+            .batch_prefill(
+                prompts,
+                &views,
+                &vec![None; prompts.len()],
+                mgr.buffer().buffer(),
+                layout,
+                false,
+            )
+            .unwrap();
+        let first_tokens: Vec<u32> = logits_vec
+            .iter()
+            .map(|logits| sample_logits(model, logits, &params, &mut rng))
+            .collect();
+        for (rkv, &tok) in rkvs.iter_mut().zip(&first_tokens) {
+            rkv.apply_prefill(tok, mgr).unwrap();
+        }
+
+        let mut all_tokens: Vec<Vec<u32>> = first_tokens.iter().map(|&t| vec![t]).collect();
+
+        let max_bs = if model.enable_cuda_graph {
+            bucket_for(bs)
+        } else {
+            bs
+        };
+        let mut bufs = BatchDecodeBuffers::new(
+            &model.ctx,
+            model.config.hidden_size,
+            model.local_q_dim(),
+            model.local_kv_dim(),
+            model.local_intermediate_size(),
+            model.config.vocab_size,
+            max_bs,
+            mgr.total_blocks(),
+            mgr.padding_block_id(),
+            model.local_num_attention_heads(),
+        )
+        .unwrap();
+
+        for _ in 1..num_decode_steps {
+            let token_ids: Vec<u32> = all_tokens.iter().map(|t| *t.last().unwrap()).collect();
+            for rkv in &mut rkvs {
+                rkv.schedule_decode(mgr).unwrap();
+            }
+            let views: Vec<_> = rkvs.iter().map(|r| r.decode_view()).collect();
+            model
+                .batch_decode(
+                    &token_ids,
+                    &views,
+                    &vec![None; token_ids.len()],
+                    mgr.buffer().buffer(),
+                    layout,
+                    &mut bufs,
+                )
+                .unwrap();
+            let params_refs: Vec<&SamplingParams> = (0..bs).map(|_| &params).collect();
+            let tokens = sample_batch_tokens(model, &bufs, &params_refs, &mut rng);
+            for (i, &tok) in tokens.iter().enumerate() {
+                rkvs[i].apply_decode(tok, mgr).unwrap();
+                all_tokens[i].push(tok);
+            }
+        }
+
+        for rkv in &mut rkvs {
+            rkv.release().unwrap();
+        }
+        all_tokens
+    }
+
+    #[test]
+    fn batch_matches_sequential() {
+        let Some(model_path) = get_model_path_or_skip() else {
+            return;
+        };
+        let prompt_a: Vec<u32> = vec![9707];
+        let prompt_b: Vec<u32> = vec![3838, 374, 220, 17, 10, 17];
+        let num_steps = 10;
+        let seed = 42;
+
+        // --- Phase 1: batch prefill + batch decode (no CUDA Graph) ---
+        {
+            let model = Qwen3Model::from_safetensors_with_runtime(
+                &model_path,
+                ModelRuntimeConfig {
+                    enable_cuda_graph: false,
+                    tensor_parallel: None,
+                    device_ordinal: 0,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+            let mgr = make_kv_mgr(&model);
+            let layout = core_layout(&mgr);
+
+            // Batch prefill: multi-token prompts
+            let prefill_a: Vec<u32> = vec![3838, 374, 220, 17, 10, 17];
+            let prefill_b: Vec<u32> = (1..65).collect();
+            let prefill_c: Vec<u32> = (1..129).collect();
+            let params = SamplingParams::default();
+
+            let mut seq_first_tokens = Vec::new();
+            for prompt in [&prefill_a, &prefill_b, &prefill_c] {
+                let mut rng = StdRng::seed_from_u64(seed);
+                let (_rkv, token) =
+                    prefill_one(&model, &mgr, &layout, prompt.as_slice(), &params, &mut rng);
+                seq_first_tokens.push(token);
+            }
+
+            // Batch prefill all three at once
+            let prompts: Vec<&[u32]> = vec![&prefill_a, &prefill_b, &prefill_c];
+            let mut rkvs: Vec<RequestKv> = prompts
+                .iter()
+                .map(|p| {
+                    let mut r = mgr.new_request(p.to_vec(), 256);
+                    r.schedule_prefill(p.len(), &mgr).unwrap();
+                    r
+                })
+                .collect();
+            let views: Vec<_> = rkvs
+                .iter()
+                .zip(&prompts)
+                .map(|(r, p)| r.prefill_view(p.len()))
+                .collect();
+            let (logits_vec, _) = model
+                .batch_prefill(
+                    &prompts,
+                    &views,
+                    &vec![None; prompts.len()],
+                    mgr.buffer().buffer(),
+                    &layout,
+                    false,
+                )
+                .unwrap();
+
+            let mut batch_first_tokens = Vec::new();
+            for (i, logits) in logits_vec.iter().enumerate() {
+                let mut rng = StdRng::seed_from_u64(seed);
+                let token = sample_logits(&model, logits, &params, &mut rng);
+                rkvs[i].apply_prefill(token, &mgr).unwrap();
+                batch_first_tokens.push(token);
+            }
+            for rkv in &mut rkvs {
+                rkv.release().unwrap();
+            }
+
+            for (i, (seq_tok, batch_tok)) in seq_first_tokens
+                .iter()
+                .zip(batch_first_tokens.iter())
+                .enumerate()
+            {
+                assert_eq!(
+                    seq_tok, batch_tok,
+                    "Prefill first token mismatch for prompt {i}: seq={seq_tok}, batch={batch_tok}"
+                );
+            }
+
+            let seq_a = sequential_decode(&model, &mgr, &layout, &prompt_a, num_steps, seed);
+            let seq_b = sequential_decode(&model, &mgr, &layout, &prompt_b, num_steps, seed);
+            let batch = batch_decode_run(
+                &model,
+                &mgr,
+                &layout,
+                &[&prompt_a, &prompt_b],
+                num_steps,
+                seed,
+            );
+
+            assert_eq!(batch[0], seq_a, "Decode request A mismatch");
+            assert_eq!(batch[1], seq_b, "Decode request B mismatch");
+        }
+
+        // --- Phase 2: batch decode with CUDA Graph ---
+        {
+            let model = Qwen3Model::from_safetensors_with_runtime(
+                &model_path,
+                ModelRuntimeConfig {
+                    enable_cuda_graph: true,
+                    tensor_parallel: None,
+                    device_ordinal: 0,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+            let mgr = make_kv_mgr(&model);
+            let layout = core_layout(&mgr);
+
+            let seq_a = sequential_decode(&model, &mgr, &layout, &prompt_a, num_steps, seed);
+            let seq_b = sequential_decode(&model, &mgr, &layout, &prompt_b, num_steps, seed);
+            let batch = batch_decode_run(
+                &model,
+                &mgr,
+                &layout,
+                &[&prompt_a, &prompt_b],
+                num_steps,
+                seed,
+            );
+
+            assert_eq!(batch[0], seq_a, "Graph request A mismatch");
+            assert_eq!(batch[1], seq_b, "Graph request B mismatch");
+        }
     }
 }

--- a/pegainfer-qwen3-4b/src/batch_decode.rs
+++ b/pegainfer-qwen3-4b/src/batch_decode.rs
@@ -10,9 +10,7 @@ use super::batch_decode_buffers::{
 };
 use super::batch_decode_dag::BatchDecodeDag;
 use super::weights::{PackedLoraProjection, Qwen3Model, TransformerBlock};
-use crate::lora::{
-    DeviceLoraTokenGroup, LoraProjectionKind, build_lora_token_ranges, prepare_lora_token_groups,
-};
+use crate::lora::LoraProjectionKind;
 use pegainfer_core::kv_pool::KvLayout;
 use pegainfer_core::ops;
 use pegainfer_kernels::tensor::{KvDim, QDim};
@@ -64,11 +62,9 @@ impl Qwen3Model {
         assert_eq!(bs, kv_views.len());
         assert_eq!(bs, lora_adapters.len());
         assert!(bs > 0);
-        let lora_ranges =
-            build_lora_token_ranges(std::iter::repeat_n(1, bs), lora_adapters.iter().copied());
-        let lora_groups = prepare_lora_token_groups(&self.ctx, &lora_ranges)?;
         let lora_slots = self.decode_lora_slots(lora_adapters)?;
-        let use_cuda_graph = self.enable_cuda_graph && lora_ranges.is_empty();
+        let use_lora = lora_slots.is_some();
+        let use_cuda_graph = self.enable_cuda_graph && lora_slots.is_none();
 
         // Derive positions from views (seq_len - 1 = position of the new token)
         let mut positions: Vec<i32> = kv_views.iter().map(|v| (v.seq_len() - 1) as i32).collect();
@@ -113,8 +109,7 @@ impl Qwen3Model {
                         layout,
                         padded_bs,
                         attention_path,
-                        &lora_groups,
-                        lora_slots.is_some(),
+                        use_lora,
                         bufs,
                     )
                 })
@@ -128,8 +123,7 @@ impl Qwen3Model {
                     layout,
                     padded_bs,
                     attention_path,
-                    &lora_groups,
-                    lora_slots.is_some(),
+                    use_lora,
                     bufs,
                 )
             })?;
@@ -144,8 +138,7 @@ impl Qwen3Model {
         layout: &KvLayout,
         bs: usize,
         attention_path: DecodeAttentionPath,
-        lora_groups: &[DeviceLoraTokenGroup<'_>],
-        use_fused_lora: bool,
+        use_lora: bool,
         bufs: &mut BatchDecodeBuffers,
     ) -> Result<()> {
         let num_layers = self.layers.len();
@@ -163,7 +156,7 @@ impl Qwen3Model {
         );
 
         for (layer_idx, layer) in self.layers.iter().enumerate() {
-            self.batch_decode_layer(layer_idx, layer, &dag, lora_groups, use_fused_lora, bufs)?;
+            self.batch_decode_layer(layer_idx, layer, &dag, use_lora, bufs)?;
 
             let next_weight = if layer_idx + 1 < num_layers {
                 &self.layers[layer_idx + 1].input_layernorm
@@ -200,8 +193,7 @@ impl Qwen3Model {
         layer_idx: usize,
         layer: &TransformerBlock,
         dag: &BatchDecodeDag<'_>,
-        lora_groups: &[DeviceLoraTokenGroup<'_>],
-        use_fused_lora: bool,
+        use_lora: bool,
         bufs: &mut BatchDecodeBuffers,
     ) -> Result<()> {
         // Match prefill numerics: compute Q/K/V via row-sliced GEMMs instead of
@@ -239,8 +231,7 @@ impl Qwen3Model {
             LoraProjectionKind::Q,
             LoraProjectionKind::K,
             LoraProjectionKind::V,
-            lora_groups,
-            use_fused_lora,
+            use_lora,
             &bufs.normed,
             &mut bufs.q,
             &mut bufs.k,
@@ -275,8 +266,7 @@ impl Qwen3Model {
         self.apply_decode_lora_projection(
             layer_idx,
             LoraProjectionKind::O,
-            lora_groups,
-            use_fused_lora,
+            use_lora,
             &bufs.attn_out,
             &mut bufs.attn_proj,
             0,
@@ -313,8 +303,7 @@ impl Qwen3Model {
             layer_idx,
             LoraProjectionKind::Gate,
             LoraProjectionKind::Up,
-            lora_groups,
-            use_fused_lora,
+            use_lora,
             &bufs.normed,
             &mut bufs.gate_out,
             &mut bufs.up_out,
@@ -335,8 +324,7 @@ impl Qwen3Model {
         self.apply_decode_lora_projection(
             layer_idx,
             LoraProjectionKind::Down,
-            lora_groups,
-            use_fused_lora,
+            use_lora,
             &bufs.mlp_act,
             &mut bufs.mlp_out,
             0,
@@ -356,30 +344,13 @@ impl Qwen3Model {
         layer_idx: usize,
         kind0: LoraProjectionKind,
         kind1: LoraProjectionKind,
-        lora_groups: &[DeviceLoraTokenGroup<'_>],
-        use_fused_lora: bool,
+        use_lora: bool,
         input: &pegainfer_core::tensor::HiddenStates,
         out0: &mut pegainfer_core::tensor::HiddenStates,
         out1: &mut pegainfer_core::tensor::HiddenStates,
         token_slots: &CudaSlice<i32>,
     ) -> Result<()> {
-        if !use_fused_lora {
-            self.apply_lora_projection_ranges(
-                layer_idx,
-                lora_groups,
-                |layer| layer.projection(kind0),
-                input,
-                out0,
-                0,
-            )?;
-            self.apply_lora_projection_ranges(
-                layer_idx,
-                lora_groups,
-                |layer| layer.projection(kind1),
-                input,
-                out1,
-                0,
-            )?;
+        if !use_lora {
             return Ok(());
         }
 
@@ -395,39 +366,14 @@ impl Qwen3Model {
         kind0: LoraProjectionKind,
         kind1: LoraProjectionKind,
         kind2: LoraProjectionKind,
-        lora_groups: &[DeviceLoraTokenGroup<'_>],
-        use_fused_lora: bool,
+        use_lora: bool,
         input: &pegainfer_core::tensor::HiddenStates,
         out0: &mut pegainfer_core::tensor::HiddenStates,
         out1: &mut pegainfer_core::tensor::HiddenStates,
         out2: &mut pegainfer_core::tensor::HiddenStates,
         token_slots: &CudaSlice<i32>,
     ) -> Result<()> {
-        if !use_fused_lora {
-            self.apply_lora_projection_ranges(
-                layer_idx,
-                lora_groups,
-                |layer| layer.projection(kind0),
-                input,
-                out0,
-                0,
-            )?;
-            self.apply_lora_projection_ranges(
-                layer_idx,
-                lora_groups,
-                |layer| layer.projection(kind1),
-                input,
-                out1,
-                0,
-            )?;
-            self.apply_lora_projection_ranges(
-                layer_idx,
-                lora_groups,
-                |layer| layer.projection(kind2),
-                input,
-                out2,
-                0,
-            )?;
+        if !use_lora {
             return Ok(());
         }
 
@@ -452,22 +398,14 @@ impl Qwen3Model {
         &self,
         layer_idx: usize,
         kind: LoraProjectionKind,
-        lora_groups: &[DeviceLoraTokenGroup<'_>],
-        use_fused_lora: bool,
+        use_lora: bool,
         input: &pegainfer_core::tensor::HiddenStates,
         out: &mut pegainfer_core::tensor::HiddenStates,
         row_offset: usize,
         token_slots: &CudaSlice<i32>,
     ) -> Result<()> {
-        if !use_fused_lora {
-            return self.apply_lora_projection_ranges(
-                layer_idx,
-                lora_groups,
-                |layer| layer.projection(kind),
-                input,
-                out,
-                row_offset,
-            );
+        if !use_lora {
+            return Ok(());
         }
 
         let Some(packed) = self.packed_lora_projection(layer_idx, kind) else {

--- a/pegainfer-qwen3-4b/src/batch_decode.rs
+++ b/pegainfer-qwen3-4b/src/batch_decode.rs
@@ -573,8 +573,9 @@ mod tests {
         params: &SamplingParams,
         rng: &mut StdRng,
     ) -> (RequestKv, u32) {
-        let mut rkv = mgr.new_request(prompt_tokens.to_vec(), 256);
-        rkv.schedule_prefill(prompt_tokens.len(), mgr).unwrap();
+        let mut rkv = mgr.pool().new_request(prompt_tokens.to_vec(), 256, None);
+        rkv.schedule_prefill(prompt_tokens.len(), mgr.pool())
+            .unwrap();
         let view = rkv.prefill_view(prompt_tokens.len());
         let (logits_vec, _) = model
             .batch_prefill(
@@ -587,7 +588,7 @@ mod tests {
             )
             .unwrap();
         let first_token = sample_logits(model, &logits_vec[0], params, rng);
-        rkv.apply_prefill(first_token, mgr).unwrap();
+        rkv.apply_prefill(first_token, mgr.pool()).unwrap();
         (rkv, first_token)
     }
 
@@ -613,8 +614,8 @@ mod tests {
             model.local_intermediate_size(),
             model.config.vocab_size,
             1,
-            mgr.total_blocks(),
-            mgr.padding_block_id(),
+            mgr.pool().total_blocks(),
+            mgr.pool().padding_block_id(),
             model.local_num_attention_heads(),
         )
         .unwrap();
@@ -622,7 +623,7 @@ mod tests {
         let mut tokens = vec![first_token];
         for _ in 1..num_decode_steps {
             let token_ids = [*tokens.last().unwrap()];
-            rkv.schedule_decode(mgr).unwrap();
+            rkv.schedule_decode(mgr.pool()).unwrap();
             let view = rkv.decode_view();
             model
                 .batch_decode(
@@ -636,7 +637,7 @@ mod tests {
                 .unwrap();
             let params_refs: Vec<&SamplingParams> = vec![&params];
             let batch_tokens = sample_batch_tokens(model, &bufs, &params_refs, &mut rng);
-            rkv.apply_decode(batch_tokens[0], mgr).unwrap();
+            rkv.apply_decode(batch_tokens[0], mgr.pool()).unwrap();
             tokens.push(batch_tokens[0]);
         }
         rkv.release().unwrap();
@@ -658,8 +659,8 @@ mod tests {
         // Prefill all requests
         let mut rkvs: Vec<RequestKv> = Vec::with_capacity(bs);
         for &prompt in prompts {
-            let mut rkv = mgr.new_request(prompt.to_vec(), 256);
-            rkv.schedule_prefill(prompt.len(), mgr).unwrap();
+            let mut rkv = mgr.pool().new_request(prompt.to_vec(), 256, None);
+            rkv.schedule_prefill(prompt.len(), mgr.pool()).unwrap();
             rkvs.push(rkv);
         }
         let views: Vec<_> = rkvs
@@ -682,7 +683,7 @@ mod tests {
             .map(|logits| sample_logits(model, logits, &params, &mut rng))
             .collect();
         for (rkv, &tok) in rkvs.iter_mut().zip(&first_tokens) {
-            rkv.apply_prefill(tok, mgr).unwrap();
+            rkv.apply_prefill(tok, mgr.pool()).unwrap();
         }
 
         let mut all_tokens: Vec<Vec<u32>> = first_tokens.iter().map(|&t| vec![t]).collect();
@@ -700,8 +701,8 @@ mod tests {
             model.local_intermediate_size(),
             model.config.vocab_size,
             max_bs,
-            mgr.total_blocks(),
-            mgr.padding_block_id(),
+            mgr.pool().total_blocks(),
+            mgr.pool().padding_block_id(),
             model.local_num_attention_heads(),
         )
         .unwrap();
@@ -709,7 +710,7 @@ mod tests {
         for _ in 1..num_decode_steps {
             let token_ids: Vec<u32> = all_tokens.iter().map(|t| *t.last().unwrap()).collect();
             for rkv in &mut rkvs {
-                rkv.schedule_decode(mgr).unwrap();
+                rkv.schedule_decode(mgr.pool()).unwrap();
             }
             let views: Vec<_> = rkvs.iter().map(|r| r.decode_view()).collect();
             model
@@ -725,7 +726,7 @@ mod tests {
             let params_refs: Vec<&SamplingParams> = (0..bs).map(|_| &params).collect();
             let tokens = sample_batch_tokens(model, &bufs, &params_refs, &mut rng);
             for (i, &tok) in tokens.iter().enumerate() {
-                rkvs[i].apply_decode(tok, mgr).unwrap();
+                rkvs[i].apply_decode(tok, mgr.pool()).unwrap();
                 all_tokens[i].push(tok);
             }
         }
@@ -780,8 +781,8 @@ mod tests {
             let mut rkvs: Vec<RequestKv> = prompts
                 .iter()
                 .map(|p| {
-                    let mut r = mgr.new_request(p.to_vec(), 256);
-                    r.schedule_prefill(p.len(), &mgr).unwrap();
+                    let mut r = mgr.pool().new_request(p.to_vec(), 256, None);
+                    r.schedule_prefill(p.len(), mgr.pool()).unwrap();
                     r
                 })
                 .collect();
@@ -805,7 +806,7 @@ mod tests {
             for (i, logits) in logits_vec.iter().enumerate() {
                 let mut rng = StdRng::seed_from_u64(seed);
                 let token = sample_logits(&model, logits, &params, &mut rng);
-                rkvs[i].apply_prefill(token, &mgr).unwrap();
+                rkvs[i].apply_prefill(token, mgr.pool()).unwrap();
                 batch_first_tokens.push(token);
             }
             for rkv in &mut rkvs {

--- a/pegainfer-qwen3-4b/src/batch_decode_buffers.rs
+++ b/pegainfer-qwen3-4b/src/batch_decode_buffers.rs
@@ -72,6 +72,7 @@ pub(crate) struct BatchDecodeBuffers {
     // GPU metadata
     pub(crate) token_ids_d: CudaSlice<u32>,
     pub(crate) positions_d: CudaSlice<i32>,
+    pub(crate) lora_token_slots_d: CudaSlice<i32>,
 
     // Paged attention metadata (concatenated across requests, CSR format)
     pub(crate) page_indices_d: CudaSlice<i32>,
@@ -132,6 +133,7 @@ impl BatchDecodeBuffers {
             logits: HiddenStates::zeros(ctx, vocab_size, bs)?,
             token_ids_d: ctx.stream.alloc_zeros(bs)?,
             positions_d: ctx.stream.alloc_zeros(bs)?,
+            lora_token_slots_d: ctx.stream.alloc_zeros(bs)?,
             // Paged attention: worst case all requests use max_total_pages + padding slots
             page_indices_d: ctx.stream.alloc_zeros(max_total_pages + bs)?,
             page_indptr_d: ctx.stream.alloc_zeros(bs + 1)?,

--- a/pegainfer-qwen3-4b/src/batch_decode_trace.rs
+++ b/pegainfer-qwen3-4b/src/batch_decode_trace.rs
@@ -36,6 +36,7 @@ pub fn trace_decode_kernel_calls(
             enable_cuda_graph: false,
             tensor_parallel: None,
             device_ordinal: 0,
+            ..Default::default()
         },
     )?;
     let budget = model.kv_budget();
@@ -89,6 +90,7 @@ pub fn trace_decode_kernel_calls(
         model.batch_decode(
             &token_ids,
             &views,
+            &vec![None; batch_size],
             kv_mgr.buffer().buffer(),
             &layout,
             &mut bufs,

--- a/pegainfer-qwen3-4b/src/executor.rs
+++ b/pegainfer-qwen3-4b/src/executor.rs
@@ -36,6 +36,7 @@ pub struct PrefillStepItem {
     pub(crate) params: SamplingParams,
     pub(crate) logprobs: usize,
     pub(crate) echo: bool,
+    pub(crate) lora_adapter: Option<String>,
     pub(crate) random_val: f32,
     /// Leading prompt tokens whose KV came from the prefix cache.
     /// Set by the executor after matching; the forward pass only computes
@@ -60,6 +61,7 @@ impl PrefillStepItem {
             params,
             logprobs,
             echo,
+            lora_adapter: None,
             random_val,
             cached_tokens: 0,
         }
@@ -81,6 +83,7 @@ pub struct DecodeStepItem {
     pub(crate) token_id: u32,
     pub(crate) params: SamplingParams,
     pub(crate) logprobs: usize,
+    pub(crate) lora_adapter: Option<String>,
     pub(crate) random_val: f32,
 }
 
@@ -97,6 +100,7 @@ impl DecodeStepItem {
             token_id,
             params,
             logprobs,
+            lora_adapter: None,
             random_val,
         }
     }
@@ -191,7 +195,12 @@ fn execute_step_on_lane(
             echo,
         } => {
             let prompts: Vec<&[u32]> = requests.iter().map(PrefillStepItem::as_slice).collect();
-            let (logits, all_position_logits) = lane.execute_prefill(&prompts, kv_views, *echo)?;
+            let lora_adapters: Vec<Option<&str>> = requests
+                .iter()
+                .map(|req| req.lora_adapter.as_deref())
+                .collect();
+            let (logits, all_position_logits) =
+                lane.execute_prefill(&prompts, kv_views, &lora_adapters, *echo)?;
             if collect_result {
                 Ok(WorkerStepOutcome::Prefill(PrefillResult {
                     requests: build_prefill_request_results(
@@ -208,7 +217,11 @@ fn execute_step_on_lane(
         }
         StepCommand::Decode { requests, kv_views } => {
             let token_ids: Vec<u32> = requests.iter().map(|req| req.token_id).collect();
-            lane.execute_decode(&token_ids, kv_views)?;
+            let lora_adapters: Vec<Option<&str>> = requests
+                .iter()
+                .map(|req| req.lora_adapter.as_deref())
+                .collect();
+            lane.execute_decode(&token_ids, kv_views, &lora_adapters)?;
             if collect_result {
                 let logits: Vec<DeviceVec> = (0..requests.len())
                     .map(|i| ops::extract_vec(lane.model.device_ctx(), &lane.bufs.logits, i))
@@ -231,11 +244,21 @@ fn execute_step_on_lane(
                 .map(PrefillStepItem::as_slice)
                 .collect();
             let decode_tokens: Vec<u32> = decode_requests.iter().map(|req| req.token_id).collect();
+            let prefill_lora_adapters: Vec<Option<&str>> = prefill_requests
+                .iter()
+                .map(|req| req.lora_adapter.as_deref())
+                .collect();
+            let decode_lora_adapters: Vec<Option<&str>> = decode_requests
+                .iter()
+                .map(|req| req.lora_adapter.as_deref())
+                .collect();
             let (prefill_logits, decode_logits) = lane.execute_unified(
                 &prefill_prompts,
                 prefill_kv_views,
+                &prefill_lora_adapters,
                 &decode_tokens,
                 decode_kv_views,
+                &decode_lora_adapters,
             )?;
             if collect_result {
                 Ok(WorkerStepOutcome::Unified(UnifiedResult {
@@ -407,13 +430,6 @@ pub(crate) trait ModelExecutor: Send {
     fn execute_decode(&mut self, plan: DecodePlan<'_>) -> Result<DecodeResult>;
     fn execute_unified(&mut self, plan: UnifiedPlan<'_>) -> Result<UnifiedResult>;
 
-    fn activate_lora_adapter(&mut self, adapter: Option<&str>) -> Result<()> {
-        if let Some(adapter) = adapter {
-            anyhow::bail!("Qwen3 LoRA adapter {adapter} is not loaded");
-        }
-        Ok(())
-    }
-
     fn load_lora_adapter(&mut self, request: &LoadLoraAdapterRequest) -> Result<()> {
         anyhow::bail!(
             "Qwen3 LoRA adapter loading is not implemented yet: name={}, path={}",
@@ -447,9 +463,6 @@ pub struct Qwen3Executor {
     primary: RankWorker,
     workers: Vec<RankWorker>,
     loaded_lora_adapters: HashSet<String>,
-    /// Adapter currently activated on the workers; scopes prefix-cache
-    /// block hashes so KV computed under different adapters never mixes.
-    active_lora_adapter: Option<String>,
     prefix_cache_enabled: bool,
     lora_options: Qwen3LoraOptions,
 }
@@ -483,7 +496,6 @@ impl Qwen3Executor {
             )?,
             workers: Vec::new(),
             loaded_lora_adapters: HashSet::new(),
-            active_lora_adapter: None,
             prefix_cache_enabled: true,
             lora_options: Qwen3LoraOptions::default(),
         })
@@ -520,6 +532,8 @@ impl Qwen3Executor {
                     enable_cuda_graph,
                     tensor_parallel: None,
                     device_ordinal: device_ordinals[0],
+                    max_loras: lora_options.max_loras,
+                    max_lora_rank: lora_options.max_lora_rank,
                 },
             )?;
             let mut executor = Self::single(model)?;
@@ -536,6 +550,8 @@ impl Qwen3Executor {
                     enable_cuda_graph,
                     tensor_parallel: Some(TensorParallelConfig { rank, world_size }),
                     device_ordinal,
+                    max_loras: lora_options.max_loras,
+                    max_lora_rank: lora_options.max_lora_rank,
                 },
             )?);
         }
@@ -616,7 +632,6 @@ impl Qwen3Executor {
             primary,
             workers,
             loaded_lora_adapters: HashSet::new(),
-            active_lora_adapter: None,
             prefix_cache_enabled: true,
             lora_options,
         })
@@ -652,10 +667,6 @@ impl Qwen3Executor {
 
     pub fn execute_unified(&mut self, plan: UnifiedPlan<'_>) -> Result<UnifiedResult> {
         <Self as ModelExecutor>::execute_unified(self, plan)
-    }
-
-    pub fn activate_lora_adapter(&mut self, adapter: Option<&str>) -> Result<()> {
-        <Self as ModelExecutor>::activate_lora_adapter(self, adapter)
     }
 
     /// Prefix caching is on by default; tests that assert bit-identical
@@ -697,40 +708,6 @@ impl Qwen3Executor {
             .map_err(|_| anyhow::anyhow!("primary worker dropped step response"))??;
         Self::wait_for_step_ack(pending, step.kind())?;
         Ok(primary_result)
-    }
-
-    fn run_worker_command(
-        &self,
-        command: impl Fn(&RankWorker) -> Result<channel::Receiver<Result<()>>>,
-        op_name: &'static str,
-    ) -> Result<()> {
-        let primary = command(&self.primary)?;
-        let mut pending = Vec::with_capacity(self.workers.len());
-        for worker in &self.workers {
-            pending.push(command(worker)?);
-        }
-
-        let mut errors = Vec::new();
-        match primary.recv() {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => errors.push(format!("rank 0: {err:#}")),
-            Err(_) => errors.push(format!("rank 0: dropped {op_name} response")),
-        }
-        for (index, response) in pending.into_iter().enumerate() {
-            let rank = index + 1;
-            match response.recv() {
-                Ok(Ok(())) => {}
-                Ok(Err(err)) => errors.push(format!("rank {rank}: {err:#}")),
-                Err(_) => errors.push(format!("rank {rank}: dropped {op_name} response")),
-            }
-        }
-        if !errors.is_empty() {
-            anyhow::bail!(
-                "failed to run Qwen3 {op_name} on tensor-parallel ranks: {}",
-                errors.join("; ")
-            );
-        }
-        Ok(())
     }
 }
 
@@ -787,7 +764,7 @@ impl ModelExecutor for Qwen3Executor {
             let mut rkv = self.kv_mgr.pool().new_request(
                 req.prompt_tokens.clone(),
                 req.max_output_tokens,
-                self.active_lora_adapter.as_deref(),
+                req.lora_adapter.as_deref(),
             );
             // Echo needs logits for every prompt position; cached positions
             // are never forwarded, so echo requests prefill from scratch.
@@ -891,7 +868,7 @@ impl ModelExecutor for Qwen3Executor {
             let mut rkv = self.kv_mgr.pool().new_request(
                 req.prompt_tokens.clone(),
                 req.max_output_tokens,
-                self.active_lora_adapter.as_deref(),
+                req.lora_adapter.as_deref(),
             );
             if self.prefix_cache_enabled && !req.echo {
                 req.cached_tokens = rkv.match_and_add_prefix(self.kv_mgr.pool())?;
@@ -960,15 +937,6 @@ impl ModelExecutor for Qwen3Executor {
         }
 
         Ok(result)
-    }
-
-    fn activate_lora_adapter(&mut self, adapter: Option<&str>) -> Result<()> {
-        self.run_worker_command(
-            |worker| worker.activate_lora_adapter(adapter.map(str::to_string)),
-            "LoRA activation",
-        )?;
-        self.active_lora_adapter = adapter.map(str::to_string);
-        Ok(())
     }
 
     fn load_lora_adapter(&mut self, request: &LoadLoraAdapterRequest) -> Result<()> {
@@ -1253,21 +1221,29 @@ impl LocalQwen3Lane {
         &mut self,
         prompts: &[&[u32]],
         kv_views: &[KvView],
+        lora_adapters: &[Option<&str>],
         echo: bool,
     ) -> Result<(Vec<DeviceVec>, Option<HiddenStates>)> {
         self.model.batch_prefill(
             prompts,
             kv_views,
+            lora_adapters,
             self.kv_buffer.buffer(),
             &self.layout,
             echo,
         )
     }
 
-    fn execute_decode(&mut self, token_ids: &[u32], kv_views: &[KvView]) -> Result<()> {
+    fn execute_decode(
+        &mut self,
+        token_ids: &[u32],
+        kv_views: &[KvView],
+        lora_adapters: &[Option<&str>],
+    ) -> Result<()> {
         self.model.batch_decode(
             token_ids,
             kv_views,
+            lora_adapters,
             self.kv_buffer.buffer(),
             &self.layout,
             &mut self.bufs,
@@ -1278,14 +1254,18 @@ impl LocalQwen3Lane {
         &mut self,
         prefill_prompts: &[&[u32]],
         prefill_views: &[KvView],
+        prefill_lora_adapters: &[Option<&str>],
         decode_tokens: &[u32],
         decode_views: &[KvView],
+        decode_lora_adapters: &[Option<&str>],
     ) -> Result<(Vec<DeviceVec>, Vec<DeviceVec>)> {
         self.model.unified_step(
             prefill_prompts,
             prefill_views,
+            prefill_lora_adapters,
             decode_tokens,
             decode_views,
+            decode_lora_adapters,
             self.kv_buffer.buffer(),
             &self.layout,
         )
@@ -1305,10 +1285,6 @@ impl LocalQwen3Lane {
 
     fn unload_lora_adapter(&mut self, name: &str) -> Result<()> {
         self.model.uninstall_lora_adapter(name)
-    }
-
-    fn activate_lora_adapter(&mut self, adapter: Option<&str>) -> Result<()> {
-        self.model.activate_lora_adapter(adapter)
     }
 }
 
@@ -1355,10 +1331,6 @@ enum WorkerCommand {
     },
     UnloadLoraAdapter {
         name: String,
-        resp: channel::Sender<Result<()>>,
-    },
-    ActivateLoraAdapter {
-        name: Option<String>,
         resp: channel::Sender<Result<()>>,
     },
     Shutdown,
@@ -1423,10 +1395,6 @@ impl RankWorker {
                                     let result = lane.unload_lora_adapter(&name);
                                     let _ = resp.send(result);
                                 }
-                                WorkerCommand::ActivateLoraAdapter { name, resp } => {
-                                    let result = lane.activate_lora_adapter(name.as_deref());
-                                    let _ = resp.send(result);
-                                }
                                 WorkerCommand::Shutdown => break,
                             }
                         }
@@ -1477,19 +1445,6 @@ impl RankWorker {
                 resp: resp_tx,
             })
             .map_err(|_| anyhow::anyhow!("tensor-parallel worker channel closed on LoRA load"))?;
-        Ok(resp_rx)
-    }
-
-    fn activate_lora_adapter(&self, name: Option<String>) -> Result<channel::Receiver<Result<()>>> {
-        let (resp_tx, resp_rx) = channel::bounded(1);
-        self.tx
-            .send(WorkerCommand::ActivateLoraAdapter {
-                name,
-                resp: resp_tx,
-            })
-            .map_err(|_| {
-                anyhow::anyhow!("tensor-parallel worker channel closed on LoRA activation")
-            })?;
         Ok(resp_rx)
     }
 

--- a/pegainfer-qwen3-4b/src/executor.rs
+++ b/pegainfer-qwen3-4b/src/executor.rs
@@ -4,6 +4,7 @@ use std::thread;
 use anyhow::Result;
 use crossbeam_channel as channel;
 
+use crate::Qwen3LoraOptions;
 use crate::batch_decode_buffers::{BATCH_BUCKETS, BatchDecodeBuffers};
 use crate::config::{Config, TensorParallelConfig};
 use crate::weights::{ModelRuntimeConfig, Qwen3Model};
@@ -450,6 +451,7 @@ pub struct Qwen3Executor {
     /// block hashes so KV computed under different adapters never mixes.
     active_lora_adapter: Option<String>,
     prefix_cache_enabled: bool,
+    lora_options: Qwen3LoraOptions,
 }
 
 impl Qwen3Executor {
@@ -483,6 +485,7 @@ impl Qwen3Executor {
             loaded_lora_adapters: HashSet::new(),
             active_lora_adapter: None,
             prefix_cache_enabled: true,
+            lora_options: Qwen3LoraOptions::default(),
         })
     }
 
@@ -491,6 +494,21 @@ impl Qwen3Executor {
         enable_cuda_graph: bool,
         device_ordinals: &[usize],
     ) -> Result<Self> {
+        Self::from_runtime_with_lora_options(
+            model_path,
+            enable_cuda_graph,
+            device_ordinals,
+            Qwen3LoraOptions::default(),
+        )
+    }
+
+    pub fn from_runtime_with_lora_options(
+        model_path: &str,
+        enable_cuda_graph: bool,
+        device_ordinals: &[usize],
+        lora_options: Qwen3LoraOptions,
+    ) -> Result<Self> {
+        let lora_options = lora_options.validate()?;
         anyhow::ensure!(
             !device_ordinals.is_empty(),
             "Qwen3 executor requires at least one device"
@@ -504,7 +522,9 @@ impl Qwen3Executor {
                     device_ordinal: device_ordinals[0],
                 },
             )?;
-            return Self::single(model);
+            let mut executor = Self::single(model)?;
+            executor.lora_options = lora_options;
+            return Ok(executor);
         }
 
         let world_size = device_ordinals.len();
@@ -598,6 +618,7 @@ impl Qwen3Executor {
             loaded_lora_adapters: HashSet::new(),
             active_lora_adapter: None,
             prefix_cache_enabled: true,
+            lora_options,
         })
     }
 
@@ -711,6 +732,24 @@ impl Qwen3Executor {
         }
         Ok(())
     }
+}
+
+fn ensure_lora_capacity(
+    loaded_lora_adapters: &HashSet<String>,
+    lora_name: &str,
+    max_loras: usize,
+) -> Result<()> {
+    if loaded_lora_adapters.contains(lora_name) {
+        return Ok(());
+    }
+    anyhow::ensure!(
+        loaded_lora_adapters.len() < max_loras,
+        "Qwen3 LoRA adapter capacity exceeded: max_loras={}, loaded_adapters={}, requested={}",
+        max_loras,
+        loaded_lora_adapters.len(),
+        lora_name
+    );
+    Ok(())
 }
 
 impl ModelExecutor for Qwen3Executor {
@@ -933,7 +972,16 @@ impl ModelExecutor for Qwen3Executor {
     }
 
     fn load_lora_adapter(&mut self, request: &LoadLoraAdapterRequest) -> Result<()> {
-        let adapter = crate::lora::load_lora_adapter(&request.lora_path, &self.metadata.config)?;
+        ensure_lora_capacity(
+            &self.loaded_lora_adapters,
+            &request.lora_name,
+            self.lora_options.max_loras,
+        )?;
+        let adapter = crate::lora::load_lora_adapter(
+            &request.lora_path,
+            &self.metadata.config,
+            self.lora_options.max_lora_rank,
+        )?;
         let world_size = self.workers.len() + 1;
         let projection_count: usize = adapter
             .layers
@@ -1069,6 +1117,31 @@ impl ModelExecutor for Qwen3Executor {
         let mut names: Vec<_> = self.loaded_lora_adapters.iter().cloned().collect();
         names.sort();
         names
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_lora_capacity;
+    use std::collections::HashSet;
+
+    #[test]
+    fn lora_capacity_rejects_new_adapter_at_limit() {
+        let loaded = HashSet::from(["adapter-a".to_string()]);
+
+        let error = ensure_lora_capacity(&loaded, "adapter-b", 1)
+            .expect_err("new adapter should exceed capacity")
+            .to_string();
+
+        assert!(error.contains("max_loras=1"));
+        assert!(error.contains("requested=adapter-b"));
+    }
+
+    #[test]
+    fn lora_capacity_allows_existing_adapter_replacement_at_limit() {
+        let loaded = HashSet::from(["adapter-a".to_string()]);
+
+        ensure_lora_capacity(&loaded, "adapter-a", 1).expect("existing adapter should fit");
     }
 }
 

--- a/pegainfer-qwen3-4b/src/executor.rs
+++ b/pegainfer-qwen3-4b/src/executor.rs
@@ -422,6 +422,7 @@ pub(crate) trait ModelExecutor: Send {
     fn block_size(&self) -> usize;
     fn max_request_blocks(&self) -> usize;
     fn max_context_tokens(&self) -> usize;
+    fn max_decode_batch_size(&self) -> usize;
     fn available_blocks(&self) -> usize;
     fn is_stop_token(&self, token_id: u32) -> bool;
     fn drop_request(&mut self, request_id: RequestId) -> Result<()>;
@@ -715,8 +716,13 @@ fn ensure_lora_capacity(
     loaded_lora_adapters: &HashSet<String>,
     lora_name: &str,
     max_loras: usize,
+    load_inplace: bool,
 ) -> Result<()> {
     if loaded_lora_adapters.contains(lora_name) {
+        anyhow::ensure!(
+            load_inplace,
+            "Qwen3 LoRA adapter {lora_name} is already loaded"
+        );
         return Ok(());
     }
     anyhow::ensure!(
@@ -740,6 +746,10 @@ impl ModelExecutor for Qwen3Executor {
 
     fn max_context_tokens(&self) -> usize {
         self.metadata.config.max_position_embeddings
+    }
+
+    fn max_decode_batch_size(&self) -> usize {
+        *BATCH_BUCKETS.last().unwrap()
     }
 
     fn available_blocks(&self) -> usize {
@@ -944,6 +954,7 @@ impl ModelExecutor for Qwen3Executor {
             &self.loaded_lora_adapters,
             &request.lora_name,
             self.lora_options.max_loras,
+            request.load_inplace,
         )?;
         let adapter = crate::lora::load_lora_adapter(
             &request.lora_path,
@@ -992,22 +1003,22 @@ impl ModelExecutor for Qwen3Executor {
             request.load_inplace,
         )?;
         let mut pending = Vec::with_capacity(self.workers.len());
+        let mut errors = Vec::new();
         for (index, worker) in self.workers.iter().enumerate() {
             let rank = index + 1;
             let rank_adapter = sharded_adapters
                 .next()
                 .expect("worker adapter must exist for every tensor-parallel rank");
-            pending.push((
-                rank,
-                worker.load_lora_adapter(
-                    request.lora_name.clone(),
-                    rank_adapter,
-                    request.load_inplace,
-                )?,
-            ));
+            match worker.load_lora_adapter(
+                request.lora_name.clone(),
+                rank_adapter,
+                request.load_inplace,
+            ) {
+                Ok(response) => pending.push((rank, response)),
+                Err(err) => errors.push(format!("rank {rank} dispatch: {err:#}")),
+            }
         }
 
-        let mut errors = Vec::new();
         match primary_response.recv() {
             Ok(Ok(())) => {}
             Ok(Err(err)) => errors.push(format!("rank 0: {err:#}")),
@@ -1021,10 +1032,46 @@ impl ModelExecutor for Qwen3Executor {
             }
         }
         if !errors.is_empty() {
+            let mut cleanup_errors = Vec::new();
+            match self.primary.discard_lora_adapter(request.lora_name.clone()) {
+                Ok(response) => match response.recv() {
+                    Ok(Ok(())) => {}
+                    Ok(Err(err)) => cleanup_errors.push(format!("rank 0 cleanup: {err:#}")),
+                    Err(_) => cleanup_errors
+                        .push("rank 0 cleanup: dropped LoRA discard response".to_string()),
+                },
+                Err(err) => cleanup_errors.push(format!("rank 0 cleanup dispatch: {err:#}")),
+            }
+            for (index, worker) in self.workers.iter().enumerate() {
+                let rank = index + 1;
+                match worker.discard_lora_adapter(request.lora_name.clone()) {
+                    Ok(response) => match response.recv() {
+                        Ok(Ok(())) => {}
+                        Ok(Err(err)) => {
+                            cleanup_errors.push(format!("rank {rank} cleanup: {err:#}"))
+                        }
+                        Err(_) => cleanup_errors.push(format!(
+                            "rank {rank} cleanup: dropped LoRA discard response"
+                        )),
+                    },
+                    Err(err) => {
+                        cleanup_errors.push(format!("rank {rank} cleanup dispatch: {err:#}"))
+                    }
+                }
+            }
+            if cleanup_errors.is_empty() {
+                self.loaded_lora_adapters.remove(&request.lora_name);
+            }
+            let cleanup_suffix = if cleanup_errors.is_empty() {
+                String::new()
+            } else {
+                format!("; cleanup errors: {}", cleanup_errors.join("; "))
+            };
             anyhow::bail!(
-                "failed to load Qwen3 LoRA adapter {} on tensor-parallel ranks: {}",
+                "failed to load Qwen3 LoRA adapter {} on tensor-parallel ranks: {}{}",
                 request.lora_name,
-                errors.join("; ")
+                errors.join("; "),
+                cleanup_suffix
             );
         }
 
@@ -1097,7 +1144,7 @@ mod tests {
     fn lora_capacity_rejects_new_adapter_at_limit() {
         let loaded = HashSet::from(["adapter-a".to_string()]);
 
-        let error = ensure_lora_capacity(&loaded, "adapter-b", 1)
+        let error = ensure_lora_capacity(&loaded, "adapter-b", 1, false)
             .expect_err("new adapter should exceed capacity")
             .to_string();
 
@@ -1106,10 +1153,22 @@ mod tests {
     }
 
     #[test]
-    fn lora_capacity_allows_existing_adapter_replacement_at_limit() {
+    fn lora_capacity_allows_existing_adapter_replacement_at_limit_with_load_inplace() {
         let loaded = HashSet::from(["adapter-a".to_string()]);
 
-        ensure_lora_capacity(&loaded, "adapter-a", 1).expect("existing adapter should fit");
+        ensure_lora_capacity(&loaded, "adapter-a", 1, true)
+            .expect("existing adapter should fit with load_inplace");
+    }
+
+    #[test]
+    fn lora_capacity_rejects_duplicate_without_load_inplace() {
+        let loaded = HashSet::from(["adapter-a".to_string()]);
+
+        let error = ensure_lora_capacity(&loaded, "adapter-a", 1, false)
+            .expect_err("duplicate without load_inplace should fail")
+            .to_string();
+
+        assert!(error.contains("already loaded"));
     }
 }
 
@@ -1286,6 +1345,10 @@ impl LocalQwen3Lane {
     fn unload_lora_adapter(&mut self, name: &str) -> Result<()> {
         self.model.uninstall_lora_adapter(name)
     }
+
+    fn discard_lora_adapter(&mut self, name: &str) -> Result<()> {
+        self.model.discard_lora_adapter(name)
+    }
 }
 
 #[derive(Clone)]
@@ -1330,6 +1393,10 @@ enum WorkerCommand {
         resp: channel::Sender<Result<()>>,
     },
     UnloadLoraAdapter {
+        name: String,
+        resp: channel::Sender<Result<()>>,
+    },
+    DiscardLoraAdapter {
         name: String,
         resp: channel::Sender<Result<()>>,
     },
@@ -1395,6 +1462,10 @@ impl RankWorker {
                                     let result = lane.unload_lora_adapter(&name);
                                     let _ = resp.send(result);
                                 }
+                                WorkerCommand::DiscardLoraAdapter { name, resp } => {
+                                    let result = lane.discard_lora_adapter(&name);
+                                    let _ = resp.send(result);
+                                }
                                 WorkerCommand::Shutdown => break,
                             }
                         }
@@ -1456,6 +1527,19 @@ impl RankWorker {
                 resp: resp_tx,
             })
             .map_err(|_| anyhow::anyhow!("tensor-parallel worker channel closed on LoRA unload"))?;
+        Ok(resp_rx)
+    }
+
+    fn discard_lora_adapter(&self, name: String) -> Result<channel::Receiver<Result<()>>> {
+        let (resp_tx, resp_rx) = channel::bounded(1);
+        self.tx
+            .send(WorkerCommand::DiscardLoraAdapter {
+                name,
+                resp: resp_tx,
+            })
+            .map_err(|_| {
+                anyhow::anyhow!("tensor-parallel worker channel closed on LoRA discard")
+            })?;
         Ok(resp_rx)
     }
 

--- a/pegainfer-qwen3-4b/src/lib.rs
+++ b/pegainfer-qwen3-4b/src/lib.rs
@@ -20,6 +20,49 @@ use pegainfer_core::engine::{EngineHandle, EngineLoadOptions, ModelInfo};
 
 pub use kernel_plan::kernel_plan;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Qwen3LoraOptions {
+    pub max_loras: usize,
+    pub max_lora_rank: usize,
+}
+
+impl Qwen3LoraOptions {
+    pub const DEFAULT_MAX_LORAS: usize = 1;
+    pub const DEFAULT_MAX_LORA_RANK: usize = 16;
+    pub const SUPPORTED_MAX_LORA_RANKS: [usize; 9] = [1, 8, 16, 32, 64, 128, 256, 320, 512];
+
+    pub fn validate(self) -> Result<Self> {
+        anyhow::ensure!(self.max_loras > 0, "max_loras must be >= 1");
+        anyhow::ensure!(
+            Self::is_supported_max_lora_rank(self.max_lora_rank),
+            "max_lora_rank must be one of: {}",
+            Self::supported_max_lora_ranks_display()
+        );
+        Ok(self)
+    }
+
+    pub fn is_supported_max_lora_rank(rank: usize) -> bool {
+        Self::SUPPORTED_MAX_LORA_RANKS.contains(&rank)
+    }
+
+    pub fn supported_max_lora_ranks_display() -> String {
+        Self::SUPPORTED_MAX_LORA_RANKS
+            .iter()
+            .map(usize::to_string)
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+impl Default for Qwen3LoraOptions {
+    fn default() -> Self {
+        Self {
+            max_loras: Self::DEFAULT_MAX_LORAS,
+            max_lora_rank: Self::DEFAULT_MAX_LORA_RANK,
+        }
+    }
+}
+
 /// Low-level Qwen3 execution interface.
 ///
 /// This is the production phase boundary used by the Qwen3 scheduler and by
@@ -71,6 +114,7 @@ pub fn start_engine(model_path: &Path, options: EngineLoadOptions) -> Result<Eng
 pub fn start_engine_with_lora_control(
     model_path: &Path,
     options: EngineLoadOptions,
+    lora_options: Qwen3LoraOptions,
 ) -> Result<EngineHandle> {
     let EngineLoadOptions {
         enable_cuda_graph,
@@ -81,5 +125,11 @@ pub fn start_engine_with_lora_control(
     let model_path = model_path
         .to_str()
         .ok_or_else(|| anyhow::anyhow!("model path must be valid UTF-8"))?;
-    scheduler::start_qwen3_with_lora_control(model_path, enable_cuda_graph, &device_ordinals, seed)
+    scheduler::start_qwen3_with_lora_control(
+        model_path,
+        enable_cuda_graph,
+        &device_ordinals,
+        seed,
+        lora_options.validate()?,
+    )
 }

--- a/pegainfer-qwen3-4b/src/lib.rs
+++ b/pegainfer-qwen3-4b/src/lib.rs
@@ -28,7 +28,7 @@ pub struct Qwen3LoraOptions {
 
 impl Qwen3LoraOptions {
     pub const DEFAULT_MAX_LORAS: usize = 1;
-    pub const DEFAULT_MAX_LORA_RANK: usize = 16;
+    pub const DEFAULT_MAX_LORA_RANK: usize = 64;
     pub const SUPPORTED_MAX_LORA_RANKS: [usize; 9] = [1, 8, 16, 32, 64, 128, 256, 320, 512];
 
     pub fn validate(self) -> Result<Self> {

--- a/pegainfer-qwen3-4b/src/lora.rs
+++ b/pegainfer-qwen3-4b/src/lora.rs
@@ -151,8 +151,12 @@ impl LoraAdapter {
     }
 }
 
-pub(crate) fn load_lora_adapter(path: &Path, config: &Config) -> Result<LoraAdapter> {
-    let (manifest, raw_weights) = inspect_lora_adapter(path, config)?;
+pub(crate) fn load_lora_adapter(
+    path: &Path,
+    config: &Config,
+    max_lora_rank: usize,
+) -> Result<LoraAdapter> {
+    let (manifest, raw_weights) = inspect_lora_adapter(path, config, max_lora_rank)?;
     let tensors = SafeTensors::deserialize(&raw_weights).with_context(|| {
         format!(
             "failed to parse {}",
@@ -229,11 +233,19 @@ pub(crate) fn apply_lora_projection_delta(
     ops::scaled_add_rows_into(ctx, &delta, scale, out, row_offset)
 }
 
-fn inspect_lora_adapter(path: &Path, config: &Config) -> Result<(LoraAdapterManifest, Vec<u8>)> {
+fn inspect_lora_adapter(
+    path: &Path,
+    config: &Config,
+    max_lora_rank: usize,
+) -> Result<(LoraAdapterManifest, Vec<u8>)> {
     let adapter_config = load_adapter_config(path)?;
     let rank = adapter_config.lora_rank;
     let alpha = adapter_config.alpha;
     ensure!(rank > 0, "LoRA rank must be > 0");
+    ensure!(
+        rank <= max_lora_rank,
+        "LoRA rank {rank} exceeds max_lora_rank {max_lora_rank}"
+    );
     ensure!(alpha > 0, "LoRA alpha must be > 0");
     if let Some(peft_type) = &adapter_config.peft_type {
         ensure!(
@@ -701,9 +713,13 @@ mod tests {
         write_adapter_config(&path, targets, 2);
         write_adapter_weights(&path, &config, targets, 2);
 
-        let manifest = load_lora_adapter(&path, &config)
-            .expect("load adapter")
-            .manifest;
+        let manifest = load_lora_adapter(
+            &path,
+            &config,
+            crate::Qwen3LoraOptions::DEFAULT_MAX_LORA_RANK,
+        )
+        .expect("load adapter")
+        .manifest;
 
         assert_eq!(manifest.rank, 2);
         assert_eq!(manifest.alpha, 16);
@@ -721,7 +737,12 @@ mod tests {
         write_adapter_config(&path, &["q_proj", "down_proj"], 2);
         write_adapter_weights(&path, &config, &["q_proj", "down_proj"], 2);
 
-        let adapter = load_lora_adapter(&path, &config).expect("load adapter");
+        let adapter = load_lora_adapter(
+            &path,
+            &config,
+            crate::Qwen3LoraOptions::DEFAULT_MAX_LORA_RANK,
+        )
+        .expect("load adapter");
 
         assert_eq!(adapter.manifest.rank, 2);
         assert_eq!(adapter.layers.len(), config.num_hidden_layers);
@@ -769,7 +790,12 @@ mod tests {
         safetensors::serialize_to_file(tensors, None, &path.join(ADAPTER_WEIGHTS_FILE))
             .expect("write safetensors");
 
-        let adapter = load_lora_adapter(&path, &config).expect("load adapter");
+        let adapter = load_lora_adapter(
+            &path,
+            &config,
+            crate::Qwen3LoraOptions::DEFAULT_MAX_LORA_RANK,
+        )
+        .expect("load adapter");
         let q_proj = adapter.layers[0].projections.get("q_proj").expect("q_proj");
 
         assert_eq!(q_proj.a.data[0].to_f32(), bf16::from_f32(1.5).to_f32());
@@ -783,9 +809,28 @@ mod tests {
         write_adapter_config(&path, &["q_proj", "embed_tokens"], 2);
         write_adapter_weights(&path, &config, &["q_proj"], 2);
 
-        let error = load_lora_adapter(&path, &config).expect_err("unsupported target");
+        let error = load_lora_adapter(
+            &path,
+            &config,
+            crate::Qwen3LoraOptions::DEFAULT_MAX_LORA_RANK,
+        )
+        .expect_err("unsupported target");
 
         assert!(error.to_string().contains("unsupported Qwen3 LoRA target"));
+    }
+
+    #[test]
+    fn rejects_lora_rank_above_configured_limit() {
+        let config = tiny_config();
+        let path = temp_adapter_dir("rank-limit");
+        write_adapter_config(&path, &["q_proj"], 2);
+        write_adapter_weights(&path, &config, &["q_proj"], 2);
+
+        let error = load_lora_adapter(&path, &config, 1)
+            .expect_err("rank above max_lora_rank should fail")
+            .to_string();
+
+        assert!(error.contains("LoRA rank 2 exceeds max_lora_rank 1"));
     }
 
     #[test]
@@ -814,7 +859,12 @@ mod tests {
         safetensors::serialize_to_file(tensors, None, &path.join(ADAPTER_WEIGHTS_FILE))
             .expect("write safetensors");
 
-        let error = load_lora_adapter(&path, &config).expect_err("bad tensor shape");
+        let error = load_lora_adapter(
+            &path,
+            &config,
+            crate::Qwen3LoraOptions::DEFAULT_MAX_LORA_RANK,
+        )
+        .expect_err("bad tensor shape");
 
         assert!(error.to_string().contains("shape mismatch"));
     }
@@ -867,7 +917,12 @@ mod tests {
         let path = temp_adapter_dir("tp-shard");
         write_adapter_config(&path, &["q_proj", "down_proj"], 2);
         write_adapter_weights(&path, &config, &["q_proj", "down_proj"], 2);
-        let adapter = load_lora_adapter(&path, &config).expect("load adapter");
+        let adapter = load_lora_adapter(
+            &path,
+            &config,
+            crate::Qwen3LoraOptions::DEFAULT_MAX_LORA_RANK,
+        )
+        .expect("load adapter");
 
         let sharded = adapter
             .shard_for_tensor_parallel(

--- a/pegainfer-qwen3-4b/src/lora.rs
+++ b/pegainfer-qwen3-4b/src/lora.rs
@@ -80,6 +80,118 @@ pub(crate) struct DeviceLoraProjection {
     pub(crate) b: DeviceMatrix,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LoraProjectionKind {
+    Q,
+    K,
+    V,
+    O,
+    Gate,
+    Up,
+    Down,
+}
+
+impl LoraProjectionKind {
+    pub(crate) const ALL: [Self; 7] = [
+        Self::Q,
+        Self::K,
+        Self::V,
+        Self::O,
+        Self::Gate,
+        Self::Up,
+        Self::Down,
+    ];
+
+    pub(crate) const fn index(self) -> usize {
+        match self {
+            Self::Q => 0,
+            Self::K => 1,
+            Self::V => 2,
+            Self::O => 3,
+            Self::Gate => 4,
+            Self::Up => 5,
+            Self::Down => 6,
+        }
+    }
+}
+
+impl DeviceLoraLayer {
+    pub(crate) fn projection(&self, kind: LoraProjectionKind) -> Option<&DeviceLoraProjection> {
+        match kind {
+            LoraProjectionKind::Q => self.q_proj.as_ref(),
+            LoraProjectionKind::K => self.k_proj.as_ref(),
+            LoraProjectionKind::V => self.v_proj.as_ref(),
+            LoraProjectionKind::O => self.o_proj.as_ref(),
+            LoraProjectionKind::Gate => self.gate_proj.as_ref(),
+            LoraProjectionKind::Up => self.up_proj.as_ref(),
+            LoraProjectionKind::Down => self.down_proj.as_ref(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct LoraTokenRange<'a> {
+    pub(crate) adapter: &'a str,
+    pub(crate) token_offset: usize,
+    pub(crate) token_len: usize,
+}
+
+pub(crate) struct LoraTokenGroup<'a> {
+    pub(crate) adapter: &'a str,
+    pub(crate) ranges: Vec<&'a LoraTokenRange<'a>>,
+    pub(crate) token_count: usize,
+}
+
+pub(crate) fn build_lora_token_ranges<'a>(
+    seq_lens: impl IntoIterator<Item = usize>,
+    adapters: impl IntoIterator<Item = Option<&'a str>>,
+) -> Vec<LoraTokenRange<'a>> {
+    let mut ranges: Vec<LoraTokenRange<'a>> = Vec::new();
+    let mut token_offset = 0usize;
+    for (seq_len, adapter) in seq_lens.into_iter().zip(adapters) {
+        if let Some(adapter) = adapter
+            && seq_len > 0
+        {
+            if let Some(prev) = ranges.last_mut()
+                && prev.adapter == adapter
+                && prev.token_offset + prev.token_len == token_offset
+            {
+                prev.token_len += seq_len;
+            } else {
+                ranges.push(LoraTokenRange {
+                    adapter,
+                    token_offset,
+                    token_len: seq_len,
+                });
+            }
+        }
+        token_offset += seq_len;
+    }
+    ranges
+}
+
+pub(crate) fn group_lora_token_ranges<'a>(
+    ranges: &'a [LoraTokenRange<'a>],
+) -> Vec<LoraTokenGroup<'a>> {
+    let mut groups: Vec<LoraTokenGroup<'a>> = Vec::new();
+    for range in ranges {
+        if let Some(group) = groups
+            .iter_mut()
+            .find(|group| group.adapter == range.adapter)
+        {
+            group.token_count += range.token_len;
+            group.ranges.push(range);
+        } else {
+            groups.push(LoraTokenGroup {
+                adapter: range.adapter,
+                ranges: vec![range],
+                token_count: range.token_len,
+            });
+        }
+    }
+    groups
+}
+
 #[derive(Debug, Deserialize)]
 struct PeftAdapterConfig {
     #[serde(alias = "r")]
@@ -218,19 +330,65 @@ pub(crate) fn load_device_lora_adapter(
     })
 }
 
-pub(crate) fn apply_lora_projection_delta(
+pub(crate) fn apply_lora_projection_delta_range(
     ctx: &DeviceContext,
     projection: &DeviceLoraProjection,
     input: &HiddenStates,
     out: &mut HiddenStates,
     row_offset: usize,
+    token_offset: usize,
+    token_len: usize,
     scale: f32,
 ) -> Result<()> {
-    let mut rank_out = HiddenStates::zeros(ctx, projection.a.rows, input.seq_len)?;
-    ops::gemm_into(ctx, &projection.a, input, &mut rank_out);
-    let mut delta = HiddenStates::zeros(ctx, projection.b.rows, input.seq_len)?;
+    if token_len == 0 {
+        return Ok(());
+    }
+    let mut rank_out = HiddenStates::zeros(ctx, projection.a.rows, token_len)?;
+    ops::gemm_token_range_into_checked(ctx, &projection.a, input, token_offset, &mut rank_out)?;
+    let mut delta = HiddenStates::zeros(ctx, projection.b.rows, token_len)?;
     ops::gemm_into(ctx, &projection.b, &rank_out, &mut delta);
-    ops::scaled_add_rows_into(ctx, &delta, scale, out, row_offset)
+    ops::scaled_add_rows_token_range_into(ctx, &delta, scale, out, row_offset, token_offset)
+}
+
+pub(crate) fn apply_lora_projection_delta_indexed(
+    ctx: &DeviceContext,
+    projection: &DeviceLoraProjection,
+    input: &HiddenStates,
+    out: &mut HiddenStates,
+    row_offset: usize,
+    token_indices: &[i32],
+    scale: f32,
+) -> Result<()> {
+    if token_indices.is_empty() {
+        return Ok(());
+    }
+    let token_indices_d = ctx
+        .stream
+        .clone_htod(token_indices)
+        .map_err(|e| anyhow::anyhow!("LoRA indexed token copy failed: {e}"))?;
+    let token_count = token_indices.len();
+    let mut compact_input = HiddenStates::zeros(ctx, input.hidden_dim, token_count)?;
+    ops::gather_hidden_tokens_into(
+        ctx,
+        input,
+        &token_indices_d,
+        token_count,
+        &mut compact_input,
+    )?;
+
+    let mut rank_out = HiddenStates::zeros(ctx, projection.a.rows, token_count)?;
+    ops::gemm_into_checked(ctx, &projection.a, &compact_input, &mut rank_out)?;
+    let mut delta = HiddenStates::zeros(ctx, projection.b.rows, token_count)?;
+    ops::gemm_into(ctx, &projection.b, &rank_out, &mut delta);
+    ops::scaled_add_rows_indexed_into(
+        ctx,
+        &delta,
+        scale,
+        &token_indices_d,
+        token_count,
+        out,
+        row_offset,
+    )
 }
 
 fn inspect_lora_adapter(
@@ -831,6 +989,36 @@ mod tests {
             .to_string();
 
         assert!(error.contains("LoRA rank 2 exceeds max_lora_rank 1"));
+    }
+
+    #[test]
+    fn groups_non_contiguous_lora_ranges_by_adapter() {
+        let ranges = build_lora_token_ranges(
+            [2usize, 3, 1, 4],
+            [
+                Some("adapter-a"),
+                Some("adapter-b"),
+                Some("adapter-a"),
+                None,
+            ],
+        );
+
+        assert_eq!(ranges.len(), 3);
+        assert_eq!(ranges[0].adapter, "adapter-a");
+        assert_eq!((ranges[0].token_offset, ranges[0].token_len), (0, 2));
+        assert_eq!(ranges[1].adapter, "adapter-b");
+        assert_eq!((ranges[1].token_offset, ranges[1].token_len), (2, 3));
+        assert_eq!(ranges[2].adapter, "adapter-a");
+        assert_eq!((ranges[2].token_offset, ranges[2].token_len), (5, 1));
+
+        let groups = group_lora_token_ranges(&ranges);
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].adapter, "adapter-a");
+        assert_eq!(groups[0].token_count, 3);
+        assert_eq!(groups[0].ranges.len(), 2);
+        assert_eq!(groups[1].adapter, "adapter-b");
+        assert_eq!(groups[1].token_count, 3);
+        assert_eq!(groups[1].ranges.len(), 1);
     }
 
     #[test]

--- a/pegainfer-qwen3-4b/src/lora.rs
+++ b/pegainfer-qwen3-4b/src/lora.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail, ensure};
+use cudarc::driver::CudaSlice;
 use half::{bf16, f16};
 use pegainfer_core::ops;
 use pegainfer_core::tensor::{DeviceContext, DeviceMatrix, HiddenStates};
@@ -142,6 +143,13 @@ pub(crate) struct LoraTokenGroup<'a> {
     pub(crate) token_count: usize,
 }
 
+pub(crate) struct DeviceLoraTokenGroup<'a> {
+    pub(crate) adapter: &'a str,
+    pub(crate) ranges: Vec<&'a LoraTokenRange<'a>>,
+    pub(crate) token_count: usize,
+    pub(crate) token_indices_d: Option<CudaSlice<i32>>,
+}
+
 pub(crate) fn build_lora_token_ranges<'a>(
     seq_lens: impl IntoIterator<Item = usize>,
     adapters: impl IntoIterator<Item = Option<&'a str>>,
@@ -190,6 +198,39 @@ pub(crate) fn group_lora_token_ranges<'a>(
         }
     }
     groups
+}
+
+pub(crate) fn prepare_lora_token_groups<'a>(
+    ctx: &DeviceContext,
+    ranges: &'a [LoraTokenRange<'a>],
+) -> Result<Vec<DeviceLoraTokenGroup<'a>>> {
+    let mut prepared = Vec::new();
+    for group in group_lora_token_ranges(ranges) {
+        let token_indices_d = if group.ranges.len() == 1 {
+            None
+        } else {
+            let mut token_indices = Vec::with_capacity(group.token_count);
+            for grouped_range in &group.ranges {
+                token_indices.extend(
+                    (grouped_range.token_offset
+                        ..grouped_range.token_offset + grouped_range.token_len)
+                        .map(|idx| idx as i32),
+                );
+            }
+            Some(
+                ctx.stream
+                    .clone_htod(&token_indices)
+                    .map_err(|e| anyhow::anyhow!("LoRA indexed token copy failed: {e}"))?,
+            )
+        };
+        prepared.push(DeviceLoraTokenGroup {
+            adapter: group.adapter,
+            ranges: group.ranges,
+            token_count: group.token_count,
+            token_indices_d,
+        });
+    }
+    Ok(prepared)
 }
 
 #[derive(Debug, Deserialize)]
@@ -356,25 +397,15 @@ pub(crate) fn apply_lora_projection_delta_indexed(
     input: &HiddenStates,
     out: &mut HiddenStates,
     row_offset: usize,
-    token_indices: &[i32],
+    token_indices_d: &CudaSlice<i32>,
+    token_count: usize,
     scale: f32,
 ) -> Result<()> {
-    if token_indices.is_empty() {
+    if token_count == 0 {
         return Ok(());
     }
-    let token_indices_d = ctx
-        .stream
-        .clone_htod(token_indices)
-        .map_err(|e| anyhow::anyhow!("LoRA indexed token copy failed: {e}"))?;
-    let token_count = token_indices.len();
     let mut compact_input = HiddenStates::zeros(ctx, input.hidden_dim, token_count)?;
-    ops::gather_hidden_tokens_into(
-        ctx,
-        input,
-        &token_indices_d,
-        token_count,
-        &mut compact_input,
-    )?;
+    ops::gather_hidden_tokens_into(ctx, input, token_indices_d, token_count, &mut compact_input)?;
 
     let mut rank_out = HiddenStates::zeros(ctx, projection.a.rows, token_count)?;
     ops::gemm_into_checked(ctx, &projection.a, &compact_input, &mut rank_out)?;
@@ -384,7 +415,7 @@ pub(crate) fn apply_lora_projection_delta_indexed(
         ctx,
         &delta,
         scale,
-        &token_indices_d,
+        token_indices_d,
         token_count,
         out,
         row_offset,
@@ -1019,6 +1050,32 @@ mod tests {
         assert_eq!(groups[1].adapter, "adapter-b");
         assert_eq!(groups[1].token_count, 3);
         assert_eq!(groups[1].ranges.len(), 1);
+    }
+
+    #[test]
+    fn prepares_indexed_lora_ranges_once_per_adapter_group() {
+        let Ok(ctx) = DeviceContext::new() else {
+            eprintln!("skipping CUDA test");
+            return;
+        };
+        let ranges = build_lora_token_ranges(
+            [2usize, 3, 1, 4],
+            [
+                Some("adapter-a"),
+                Some("adapter-b"),
+                Some("adapter-a"),
+                None,
+            ],
+        );
+
+        let groups = prepare_lora_token_groups(&ctx, &ranges).expect("prepare LoRA token groups");
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].adapter, "adapter-a");
+        assert_eq!(groups[0].token_count, 3);
+        assert!(groups[0].token_indices_d.is_some());
+        assert_eq!(groups[1].adapter, "adapter-b");
+        assert_eq!(groups[1].token_count, 3);
+        assert!(groups[1].token_indices_d.is_none());
     }
 
     #[test]

--- a/pegainfer-qwen3-4b/src/prefill.rs
+++ b/pegainfer-qwen3-4b/src/prefill.rs
@@ -4,7 +4,7 @@ use half::bf16;
 
 use super::config::PREFILL_ATTENTION_CTA_TILE_Q;
 use super::weights::{Qwen3Model, TransformerBlock};
-use crate::lora::apply_lora_projection_delta;
+use crate::lora::{LoraTokenRange, build_lora_token_ranges};
 use pegainfer_core::kv_pool::KvLayout;
 use pegainfer_core::ops;
 use pegainfer_core::ops::PrefillPagedPlan;
@@ -84,6 +84,7 @@ impl Qwen3Model {
         kv_buffer: &cudarc::driver::CudaSlice<half::bf16>,
         layout: &pegainfer_core::kv_pool::KvLayout,
         plan: &PrefillPagedPlan,
+        lora_ranges: &[LoraTokenRange<'_>],
         bufs: &mut PrefillBuffers,
     ) -> Result<()> {
         let num_heads = self.local_num_attention_heads();
@@ -110,18 +111,14 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.q_batch,
         );
-        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
-            && let Some(projection) = &lora_layer.q_proj
-        {
-            apply_lora_projection_delta(
-                &self.ctx,
-                projection,
-                &bufs.normed,
-                &mut bufs.q_batch,
-                0,
-                scale,
-            )?;
-        }
+        self.apply_lora_projection_ranges(
+            layer_idx,
+            lora_ranges,
+            |layer| layer.q_proj.as_ref(),
+            &bufs.normed,
+            &mut bufs.q_batch,
+            0,
+        )?;
         ops::gemm_rows_into(
             &self.ctx,
             &layer.attention.qkv_proj,
@@ -130,18 +127,14 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.k_batch,
         );
-        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
-            && let Some(projection) = &lora_layer.k_proj
-        {
-            apply_lora_projection_delta(
-                &self.ctx,
-                projection,
-                &bufs.normed,
-                &mut bufs.k_batch,
-                0,
-                scale,
-            )?;
-        }
+        self.apply_lora_projection_ranges(
+            layer_idx,
+            lora_ranges,
+            |layer| layer.k_proj.as_ref(),
+            &bufs.normed,
+            &mut bufs.k_batch,
+            0,
+        )?;
         ops::gemm_rows_into(
             &self.ctx,
             &layer.attention.qkv_proj,
@@ -150,18 +143,14 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.v_batch,
         );
-        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
-            && let Some(projection) = &lora_layer.v_proj
-        {
-            apply_lora_projection_delta(
-                &self.ctx,
-                projection,
-                &bufs.normed,
-                &mut bufs.v_batch,
-                0,
-                scale,
-            )?;
-        }
+        self.apply_lora_projection_ranges(
+            layer_idx,
+            lora_ranges,
+            |layer| layer.v_proj.as_ref(),
+            &bufs.normed,
+            &mut bufs.v_batch,
+            0,
+        )?;
 
         // 3. Paged prefill: norm+RoPE → append K/V to paged → batch attention
         ops::prefill_attention_paged_into(
@@ -191,18 +180,14 @@ impl Qwen3Model {
             &bufs.attn_output,
             &mut bufs.o_buf,
         );
-        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
-            && let Some(projection) = &lora_layer.o_proj
-        {
-            apply_lora_projection_delta(
-                &self.ctx,
-                projection,
-                &bufs.attn_output,
-                &mut bufs.o_buf,
-                0,
-                scale,
-            )?;
-        }
+        self.apply_lora_projection_ranges(
+            layer_idx,
+            lora_ranges,
+            |layer| layer.o_proj.as_ref(),
+            &bufs.attn_output,
+            &mut bufs.o_buf,
+            0,
+        )?;
         self.all_reduce_hidden(&mut bufs.o_buf)?;
 
         // 5+6. Residual add + MLP RMSNorm (fused): hidden += o_buf; normed = rms_norm(hidden)
@@ -233,28 +218,22 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.up_out,
         );
-        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx) {
-            if let Some(projection) = &lora_layer.gate_proj {
-                apply_lora_projection_delta(
-                    &self.ctx,
-                    projection,
-                    &bufs.normed,
-                    &mut bufs.gate_out,
-                    0,
-                    scale,
-                )?;
-            }
-            if let Some(projection) = &lora_layer.up_proj {
-                apply_lora_projection_delta(
-                    &self.ctx,
-                    projection,
-                    &bufs.normed,
-                    &mut bufs.up_out,
-                    0,
-                    scale,
-                )?;
-            }
-        }
+        self.apply_lora_projection_ranges(
+            layer_idx,
+            lora_ranges,
+            |layer| layer.gate_proj.as_ref(),
+            &bufs.normed,
+            &mut bufs.gate_out,
+            0,
+        )?;
+        self.apply_lora_projection_ranges(
+            layer_idx,
+            lora_ranges,
+            |layer| layer.up_proj.as_ref(),
+            &bufs.normed,
+            &mut bufs.up_out,
+            0,
+        )?;
         ops::silu_mul_batch_into(&self.ctx, &bufs.gate_out, &bufs.up_out, &mut bufs.act_out)?;
         ops::gemm_into(
             &self.ctx,
@@ -262,18 +241,14 @@ impl Qwen3Model {
             &bufs.act_out,
             &mut bufs.o_buf,
         );
-        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
-            && let Some(projection) = &lora_layer.down_proj
-        {
-            apply_lora_projection_delta(
-                &self.ctx,
-                projection,
-                &bufs.act_out,
-                &mut bufs.o_buf,
-                0,
-                scale,
-            )?;
-        }
+        self.apply_lora_projection_ranges(
+            layer_idx,
+            lora_ranges,
+            |layer| layer.down_proj.as_ref(),
+            &bufs.act_out,
+            &mut bufs.o_buf,
+            0,
+        )?;
         self.all_reduce_hidden(&mut bufs.o_buf)?;
 
         // 8. Residual add: attn_residual + mlp_out → bufs.hidden_out (old hidden_in, free to overwrite)
@@ -318,14 +293,18 @@ impl Qwen3Model {
         &self,
         prompts: &[&[u32]],
         kv_views: &[KvView],
+        lora_adapters: &[Option<&str>],
         kv_buffer: &CudaSlice<bf16>,
         layout: &KvLayout,
         echo: bool,
     ) -> Result<(Vec<DeviceVec>, Option<HiddenStates>)> {
         let batch_size = prompts.len();
         assert_eq!(batch_size, kv_views.len());
+        assert_eq!(batch_size, lora_adapters.len());
 
         let seq_lens: Vec<usize> = prompts.iter().map(|p| p.len()).collect();
+        let lora_ranges =
+            build_lora_token_ranges(seq_lens.iter().copied(), lora_adapters.iter().copied());
         let start_positions: Vec<usize> = kv_views
             .iter()
             .zip(prompts.iter())
@@ -353,7 +332,8 @@ impl Qwen3Model {
         )?;
 
         // Forward through all layers
-        let hidden = self.process_all_layers_batch_multi(hidden, layout, kv_buffer, &plan)?;
+        let hidden =
+            self.process_all_layers_batch_multi(hidden, layout, kv_buffer, &plan, &lora_ranges)?;
 
         // All-position logits for echo (before we extract last-token logits)
         let all_logits = if echo {
@@ -388,6 +368,7 @@ impl Qwen3Model {
         layout: &KvLayout,
         kv_buffer: &cudarc::driver::CudaSlice<half::bf16>,
         plan: &PrefillPagedPlan,
+        lora_ranges: &[LoraTokenRange<'_>],
     ) -> Result<HiddenStates> {
         let total_tokens = hidden.seq_len;
         let inter_dim = self.local_intermediate_size();
@@ -411,6 +392,7 @@ impl Qwen3Model {
                 kv_buffer,
                 layout,
                 plan,
+                lora_ranges,
                 &mut bufs,
             )?;
         }

--- a/pegainfer-qwen3-4b/src/prefill.rs
+++ b/pegainfer-qwen3-4b/src/prefill.rs
@@ -4,7 +4,7 @@ use half::bf16;
 
 use super::config::PREFILL_ATTENTION_CTA_TILE_Q;
 use super::weights::{Qwen3Model, TransformerBlock};
-use crate::lora::{LoraTokenRange, build_lora_token_ranges};
+use crate::lora::{DeviceLoraTokenGroup, build_lora_token_ranges, prepare_lora_token_groups};
 use pegainfer_core::kv_pool::KvLayout;
 use pegainfer_core::ops;
 use pegainfer_core::ops::PrefillPagedPlan;
@@ -84,7 +84,7 @@ impl Qwen3Model {
         kv_buffer: &cudarc::driver::CudaSlice<half::bf16>,
         layout: &pegainfer_core::kv_pool::KvLayout,
         plan: &PrefillPagedPlan,
-        lora_ranges: &[LoraTokenRange<'_>],
+        lora_groups: &[DeviceLoraTokenGroup<'_>],
         bufs: &mut PrefillBuffers,
     ) -> Result<()> {
         let num_heads = self.local_num_attention_heads();
@@ -113,7 +113,7 @@ impl Qwen3Model {
         );
         self.apply_lora_projection_ranges(
             layer_idx,
-            lora_ranges,
+            lora_groups,
             |layer| layer.q_proj.as_ref(),
             &bufs.normed,
             &mut bufs.q_batch,
@@ -129,7 +129,7 @@ impl Qwen3Model {
         );
         self.apply_lora_projection_ranges(
             layer_idx,
-            lora_ranges,
+            lora_groups,
             |layer| layer.k_proj.as_ref(),
             &bufs.normed,
             &mut bufs.k_batch,
@@ -145,7 +145,7 @@ impl Qwen3Model {
         );
         self.apply_lora_projection_ranges(
             layer_idx,
-            lora_ranges,
+            lora_groups,
             |layer| layer.v_proj.as_ref(),
             &bufs.normed,
             &mut bufs.v_batch,
@@ -182,7 +182,7 @@ impl Qwen3Model {
         );
         self.apply_lora_projection_ranges(
             layer_idx,
-            lora_ranges,
+            lora_groups,
             |layer| layer.o_proj.as_ref(),
             &bufs.attn_output,
             &mut bufs.o_buf,
@@ -220,7 +220,7 @@ impl Qwen3Model {
         );
         self.apply_lora_projection_ranges(
             layer_idx,
-            lora_ranges,
+            lora_groups,
             |layer| layer.gate_proj.as_ref(),
             &bufs.normed,
             &mut bufs.gate_out,
@@ -228,7 +228,7 @@ impl Qwen3Model {
         )?;
         self.apply_lora_projection_ranges(
             layer_idx,
-            lora_ranges,
+            lora_groups,
             |layer| layer.up_proj.as_ref(),
             &bufs.normed,
             &mut bufs.up_out,
@@ -243,7 +243,7 @@ impl Qwen3Model {
         );
         self.apply_lora_projection_ranges(
             layer_idx,
-            lora_ranges,
+            lora_groups,
             |layer| layer.down_proj.as_ref(),
             &bufs.act_out,
             &mut bufs.o_buf,
@@ -305,6 +305,7 @@ impl Qwen3Model {
         let seq_lens: Vec<usize> = prompts.iter().map(|p| p.len()).collect();
         let lora_ranges =
             build_lora_token_ranges(seq_lens.iter().copied(), lora_adapters.iter().copied());
+        let lora_groups = prepare_lora_token_groups(&self.ctx, &lora_ranges)?;
         let start_positions: Vec<usize> = kv_views
             .iter()
             .zip(prompts.iter())
@@ -333,7 +334,7 @@ impl Qwen3Model {
 
         // Forward through all layers
         let hidden =
-            self.process_all_layers_batch_multi(hidden, layout, kv_buffer, &plan, &lora_ranges)?;
+            self.process_all_layers_batch_multi(hidden, layout, kv_buffer, &plan, &lora_groups)?;
 
         // All-position logits for echo (before we extract last-token logits)
         let all_logits = if echo {
@@ -368,7 +369,7 @@ impl Qwen3Model {
         layout: &KvLayout,
         kv_buffer: &cudarc::driver::CudaSlice<half::bf16>,
         plan: &PrefillPagedPlan,
-        lora_ranges: &[LoraTokenRange<'_>],
+        lora_groups: &[DeviceLoraTokenGroup<'_>],
     ) -> Result<HiddenStates> {
         let total_tokens = hidden.seq_len;
         let inter_dim = self.local_intermediate_size();
@@ -392,7 +393,7 @@ impl Qwen3Model {
                 kv_buffer,
                 layout,
                 plan,
-                lora_ranges,
+                lora_groups,
                 &mut bufs,
             )?;
         }

--- a/pegainfer-qwen3-4b/src/scheduler.rs
+++ b/pegainfer-qwen3-4b/src/scheduler.rs
@@ -656,11 +656,11 @@ mod tests {
         fail_decode_once: bool,
         decode_delay: Duration,
         loaded_lora_adapters: HashSet<String>,
-        active_lora_adapter: Option<String>,
-        lora_activations: Arc<Mutex<Vec<Option<String>>>>,
         dropped: Arc<Mutex<Vec<u64>>>,
         prefill_batches: Arc<Mutex<Vec<Vec<RequestId>>>>,
         decode_batches: Arc<Mutex<Vec<Vec<RequestId>>>>,
+        prefill_lora_batches: Arc<Mutex<Vec<Vec<Option<String>>>>>,
+        decode_lora_batches: Arc<Mutex<Vec<Vec<Option<String>>>>>,
     }
 
     impl FakeExecutor {
@@ -674,11 +674,11 @@ mod tests {
                 fail_decode_once: false,
                 decode_delay: Duration::ZERO,
                 loaded_lora_adapters: HashSet::new(),
-                active_lora_adapter: None,
-                lora_activations: Arc::new(Mutex::new(Vec::new())),
                 dropped,
                 prefill_batches: Arc::new(Mutex::new(Vec::new())),
                 decode_batches: Arc::new(Mutex::new(Vec::new())),
+                prefill_lora_batches: Arc::new(Mutex::new(Vec::new())),
+                decode_lora_batches: Arc::new(Mutex::new(Vec::new())),
             }
         }
 
@@ -697,13 +697,8 @@ mod tests {
             self
         }
 
-        fn with_lora_adapters(
-            mut self,
-            names: &[&str],
-            activations: Arc<Mutex<Vec<Option<String>>>>,
-        ) -> Self {
+        fn with_lora_adapters(mut self, names: &[&str]) -> Self {
             self.loaded_lora_adapters = names.iter().map(|name| (*name).to_string()).collect();
-            self.lora_activations = activations;
             self
         }
 
@@ -714,6 +709,16 @@ mod tests {
         ) -> Self {
             self.prefill_batches = prefill_batches;
             self.decode_batches = decode_batches;
+            self
+        }
+
+        fn with_lora_batch_records(
+            mut self,
+            prefill_lora_batches: Arc<Mutex<Vec<Vec<Option<String>>>>>,
+            decode_lora_batches: Arc<Mutex<Vec<Vec<Option<String>>>>>,
+        ) -> Self {
+            self.prefill_lora_batches = prefill_lora_batches;
+            self.decode_lora_batches = decode_lora_batches;
             self
         }
 
@@ -764,20 +769,6 @@ mod tests {
             Ok(())
         }
 
-        fn activate_lora_adapter(&mut self, adapter: Option<&str>) -> Result<()> {
-            if let Some(adapter) = adapter {
-                if !self.loaded_lora_adapters.contains(adapter) {
-                    anyhow::bail!("LoRA adapter is not loaded: {adapter}");
-                }
-            }
-            self.active_lora_adapter = adapter.map(ToString::to_string);
-            self.lora_activations
-                .lock()
-                .unwrap()
-                .push(self.active_lora_adapter.clone());
-            Ok(())
-        }
-
         fn list_lora_adapters(&self) -> Vec<String> {
             let mut names: Vec<_> = self.loaded_lora_adapters.iter().cloned().collect();
             names.sort();
@@ -790,9 +781,6 @@ mod tests {
                 "LoRA adapter is not loaded: {}",
                 request.lora_name
             );
-            if self.active_lora_adapter.as_deref() == Some(request.lora_name.as_str()) {
-                self.active_lora_adapter = None;
-            }
             Ok(())
         }
 
@@ -801,6 +789,12 @@ mod tests {
                 plan.requests
                     .iter()
                     .map(|request| request.request_id)
+                    .collect(),
+            );
+            self.prefill_lora_batches.lock().unwrap().push(
+                plan.requests
+                    .iter()
+                    .map(|request| request.lora_adapter.clone())
                     .collect(),
             );
             for req in plan.requests {
@@ -839,6 +833,12 @@ mod tests {
                     .map(|request| request.request_id)
                     .collect(),
             );
+            self.decode_lora_batches.lock().unwrap().push(
+                plan.requests
+                    .iter()
+                    .map(|request| request.lora_adapter.clone())
+                    .collect(),
+            );
             for req in plan.requests {
                 let current_tokens = self
                     .held_tokens
@@ -868,10 +868,22 @@ mod tests {
                     .map(|request| request.request_id)
                     .collect(),
             );
+            self.prefill_lora_batches.lock().unwrap().push(
+                plan.prefill_requests
+                    .iter()
+                    .map(|request| request.lora_adapter.clone())
+                    .collect(),
+            );
             self.decode_batches.lock().unwrap().push(
                 plan.decode_requests
                     .iter()
                     .map(|request| request.request_id)
+                    .collect(),
+            );
+            self.decode_lora_batches.lock().unwrap().push(
+                plan.decode_requests
+                    .iter()
+                    .map(|request| request.lora_adapter.clone())
                     .collect(),
             );
             for req in plan.prefill_requests {
@@ -1219,14 +1231,19 @@ mod tests {
     }
 
     #[test]
-    fn mixed_lora_prefill_requests_run_in_adapter_groups() {
+    fn mixed_lora_prefill_requests_run_in_one_batch() {
         let dropped = Arc::new(Mutex::new(Vec::new()));
-        let activations = Arc::new(Mutex::new(Vec::new()));
         let prefill_batches = Arc::new(Mutex::new(Vec::new()));
         let decode_batches = Arc::new(Mutex::new(Vec::new()));
+        let prefill_lora_batches = Arc::new(Mutex::new(Vec::new()));
+        let decode_lora_batches = Arc::new(Mutex::new(Vec::new()));
         let mut executor = FakeExecutor::new(4, Arc::clone(&dropped))
-            .with_lora_adapters(&["adapter-a", "adapter-b"], Arc::clone(&activations))
-            .with_batch_records(Arc::clone(&prefill_batches), Arc::clone(&decode_batches));
+            .with_lora_adapters(&["adapter-a", "adapter-b"])
+            .with_batch_records(Arc::clone(&prefill_batches), Arc::clone(&decode_batches))
+            .with_lora_batch_records(
+                Arc::clone(&prefill_lora_batches),
+                Arc::clone(&decode_lora_batches),
+            );
         let mut rng = StdRng::seed_from_u64(42);
         let mut active = Vec::new();
 
@@ -1245,7 +1262,7 @@ mod tests {
             plan::ExecutionPlan::Prefill { pending },
             &mut rng,
         )
-        .expect("execute grouped prefill");
+        .expect("execute mixed-LoRA prefill");
         let plan::ExecutionArtifacts::Prefill { result, .. } = artifacts else {
             panic!("expected prefill artifacts");
         };
@@ -1259,21 +1276,26 @@ mod tests {
             vec![RequestId(0), RequestId(1), RequestId(2)]
         );
         assert_eq!(
-            *activations.lock().unwrap(),
-            vec![
-                None,
-                Some("adapter-a".to_string()),
-                Some("adapter-b".to_string())
-            ]
+            *prefill_batches.lock().unwrap(),
+            vec![vec![RequestId(0), RequestId(1), RequestId(2)]],
+            "one execution plan should run as one mixed-LoRA prefill batch"
         );
         assert_eq!(
-            *prefill_batches.lock().unwrap(),
-            vec![vec![RequestId(1)], vec![RequestId(2)], vec![RequestId(0)]],
-            "one execution plan should be split into base, adapter-a, and adapter-b groups"
+            *prefill_lora_batches.lock().unwrap(),
+            vec![vec![
+                Some("adapter-b".to_string()),
+                None,
+                Some("adapter-a".to_string())
+            ]],
+            "mixed-LoRA batch should preserve per-request adapter metadata"
         );
         assert!(
             decode_batches.lock().unwrap().is_empty(),
             "prefill-only plan should not execute decode batches"
+        );
+        assert!(
+            decode_lora_batches.lock().unwrap().is_empty(),
+            "prefill-only plan should not record decode LoRA metadata"
         );
     }
 
@@ -1485,8 +1507,8 @@ mod tests {
     #[test]
     fn lora_control_unloads_adapter_when_idle() {
         let dropped = Arc::new(Mutex::new(Vec::new()));
-        let executor = FakeExecutor::new(4, Arc::clone(&dropped))
-            .with_lora_adapters(&["adapter-a"], Arc::new(Mutex::new(Vec::new())));
+        let executor =
+            FakeExecutor::new(4, Arc::clone(&dropped)).with_lora_adapters(&["adapter-a"]);
         let handle = start_with_executor_with_lora_control(executor, 42);
 
         let runtime = tokio::runtime::Builder::new_current_thread()

--- a/pegainfer-qwen3-4b/src/scheduler.rs
+++ b/pegainfer-qwen3-4b/src/scheduler.rs
@@ -192,6 +192,7 @@ fn scheduler_loop<E>(
             executor.available_blocks(),
             executor.max_request_blocks(),
             executor.max_context_tokens(),
+            executor.max_decode_batch_size(),
         );
         for (rejected, reason) in &admission.rejected {
             send_rejection(rejected, *reason);
@@ -298,6 +299,7 @@ fn scheduler_loop_with_lora_control<E>(
             executor.available_blocks(),
             executor.max_request_blocks(),
             executor.max_context_tokens(),
+            executor.max_decode_batch_size(),
         );
         for (rejected, reason) in &admission.rejected {
             send_rejection(rejected, *reason);
@@ -500,8 +502,10 @@ fn admit_deferred_requests(
     available_blocks: usize,
     max_request_blocks: usize,
     max_context_tokens: usize,
+    max_decode_batch_size: usize,
 ) -> AdmissionOutcome {
     let mut budget = available_blocks.saturating_sub(active_future_blocks(active, block_size));
+    let mut decode_slots = max_decode_batch_size.saturating_sub(active.len());
     let mut pending = Vec::new();
     let mut still_deferred = Vec::new();
     let mut rejected = Vec::new();
@@ -524,8 +528,9 @@ fn admit_deferred_requests(
             continue;
         }
 
-        if max_needed <= budget {
+        if max_needed <= budget && decode_slots > 0 {
             budget -= max_needed;
+            decode_slots -= 1;
             pending.push(req);
         } else {
             still_deferred.push(req);
@@ -751,6 +756,10 @@ mod tests {
 
         fn max_context_tokens(&self) -> usize {
             self.max_context_tokens
+        }
+
+        fn max_decode_batch_size(&self) -> usize {
+            64
         }
 
         fn available_blocks(&self) -> usize {
@@ -990,7 +999,7 @@ mod tests {
         ];
 
         // available 4 blocks - 2 reserved for active growth = budget of 2.
-        let outcome = admit_deferred_requests(deferred, &active, 16, 4, 4, usize::MAX);
+        let outcome = admit_deferred_requests(deferred, &active, 16, 4, 4, usize::MAX, 64);
 
         let ids =
             |reqs: &[PendingRequest]| reqs.iter().map(|r| r.request_id.get()).collect::<Vec<_>>();
@@ -1029,7 +1038,7 @@ mod tests {
             mk(3, 40, 1), // request 3: 40 prompt + 1 max = 41 total: overflows by 9 tokens → rejected
         ];
 
-        let outcome = admit_deferred_requests(deferred, &active, 16, 1000, 1000, 32);
+        let outcome = admit_deferred_requests(deferred, &active, 16, 1000, 1000, 32, 64);
 
         let pending_ids = outcome
             .pending
@@ -1054,6 +1063,40 @@ mod tests {
                 "rejected on the context window, not the KV budget"
             );
         }
+    }
+
+    #[test]
+    fn admission_respects_decode_batch_capacity() {
+        let mut active = Vec::new();
+        for id in 0..64 {
+            let (token_tx, _rx) = mpsc::unbounded_channel();
+            active.push(ActiveRequestState {
+                request_id: RequestId(id),
+                lora_adapter: None,
+                token_tx,
+                last_token: 1,
+                generated_count: 1,
+                max_tokens: 2,
+                prompt_len: 16,
+                params: SamplingParams::default(),
+                logprobs: 0,
+            });
+        }
+        let pending = PendingRequest::from_scheduler_request(RequestId(64), request(16, 1).0);
+
+        let outcome =
+            admit_deferred_requests(vec![pending], &active, 16, 1024, 1024, usize::MAX, 64);
+
+        assert!(
+            outcome.pending.is_empty(),
+            "new request must not be admitted past decode scratch capacity"
+        );
+        assert_eq!(
+            outcome.deferred[0].request_id,
+            RequestId(64),
+            "capacity-starved request should stay deferred"
+        );
+        assert!(outcome.rejected.is_empty());
     }
 
     #[test]

--- a/pegainfer-qwen3-4b/src/scheduler.rs
+++ b/pegainfer-qwen3-4b/src/scheduler.rs
@@ -18,6 +18,7 @@ use rand::SeedableRng;
 use rand::rngs::StdRng;
 use tokio::sync::mpsc;
 
+use crate::Qwen3LoraOptions;
 use crate::executor::{ModelExecutor, Qwen3Executor, RequestId};
 use pegainfer_core::engine::{
     EngineCommand, EngineControlRequest, EngineHandle, GenerateRequest, TokenEvent,
@@ -87,8 +88,14 @@ pub(crate) fn start_qwen3_with_lora_control(
     enable_cuda_graph: bool,
     device_ordinals: &[usize],
     seed: u64,
+    lora_options: Qwen3LoraOptions,
 ) -> Result<EngineHandle> {
-    let executor = Qwen3Executor::from_runtime(model_path, enable_cuda_graph, device_ordinals)?;
+    let executor = Qwen3Executor::from_runtime_with_lora_options(
+        model_path,
+        enable_cuda_graph,
+        device_ordinals,
+        lora_options,
+    )?;
     Ok(start_with_executor_with_lora_control(executor, seed))
 }
 

--- a/pegainfer-qwen3-4b/src/scheduler/plan.rs
+++ b/pegainfer-qwen3-4b/src/scheduler/plan.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use anyhow::Result;
 use rand::rngs::StdRng;
 
@@ -30,28 +28,6 @@ pub(super) enum ExecutionArtifacts {
     },
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-enum LoraGroupKey {
-    Base,
-    Adapter(String),
-}
-
-impl LoraGroupKey {
-    fn from_option(adapter: &Option<String>) -> Self {
-        match adapter {
-            Some(adapter) => Self::Adapter(adapter.clone()),
-            None => Self::Base,
-        }
-    }
-
-    fn as_deref(&self) -> Option<&str> {
-        match self {
-            Self::Base => None,
-            Self::Adapter(adapter) => Some(adapter.as_str()),
-        }
-    }
-}
-
 pub(super) fn build_next_plan(
     have_active: bool,
     pending: Vec<PendingRequest>,
@@ -75,119 +51,39 @@ pub(super) fn execute_plan(
 ) -> Result<ExecutionArtifacts> {
     match plan {
         ExecutionPlan::Prefill { pending } => {
-            let mut result = PrefillResult {
-                requests: Vec::with_capacity(pending.len()),
-            };
-            for (key, group) in group_pending_indices(&pending) {
-                executor.activate_lora_adapter(key.as_deref())?;
-                let requests = build_prefill_items(&pending, &group, rng);
-                let any_echo = group.iter().any(|&index| pending[index].echo);
-                let group_result = executor.execute_prefill(PrefillPlan {
-                    requests: &requests,
-                    echo: any_echo,
-                })?;
-                result.requests.extend(group_result.requests);
-            }
+            let indices: Vec<usize> = (0..pending.len()).collect();
+            let requests = build_prefill_items(&pending, &indices, rng);
+            let any_echo = pending.iter().any(|req| req.echo);
+            let mut result = executor.execute_prefill(PrefillPlan {
+                requests: &requests,
+                echo: any_echo,
+            })?;
             sort_prefill_results(&mut result.requests);
             Ok(ExecutionArtifacts::Prefill { pending, result })
         }
         ExecutionPlan::Decode => {
-            let mut result = DecodeResult {
-                requests: Vec::with_capacity(active.len()),
-            };
-            for (key, group) in group_active_indices(active) {
-                executor.activate_lora_adapter(key.as_deref())?;
-                let requests = build_decode_items(active, &group, rng);
-                let group_result = executor.execute_decode(DecodePlan {
-                    requests: &requests,
-                })?;
-                result.requests.extend(group_result.requests);
-            }
+            let indices: Vec<usize> = (0..active.len()).collect();
+            let requests = build_decode_items(active, &indices, rng);
+            let mut result = executor.execute_decode(DecodePlan {
+                requests: &requests,
+            })?;
             sort_decode_results(&mut result.requests);
             Ok(ExecutionArtifacts::Decode { result })
         }
         ExecutionPlan::Unified { pending } => {
-            let mut result = UnifiedResult {
-                prefill_requests: Vec::with_capacity(pending.len()),
-                decode_requests: Vec::with_capacity(active.len()),
-            };
-            let pending_groups = group_pending_indices(&pending);
-            let active_groups = group_active_indices(active);
-            let keys = union_group_keys(&pending_groups, &active_groups);
-
-            for key in keys {
-                executor.activate_lora_adapter(key.as_deref())?;
-                let pending_group = pending_groups.get(&key).cloned().unwrap_or_default();
-                let active_group = active_groups.get(&key).cloned().unwrap_or_default();
-                match (pending_group.is_empty(), active_group.is_empty()) {
-                    (false, false) => {
-                        let prefill_requests = build_prefill_items(&pending, &pending_group, rng);
-                        let decode_requests = build_decode_items(active, &active_group, rng);
-                        let group_result = executor.execute_unified(UnifiedPlan {
-                            prefill_requests: &prefill_requests,
-                            decode_requests: &decode_requests,
-                        })?;
-                        result
-                            .prefill_requests
-                            .extend(group_result.prefill_requests);
-                        result.decode_requests.extend(group_result.decode_requests);
-                    }
-                    (false, true) => {
-                        let prefill_requests = build_prefill_items(&pending, &pending_group, rng);
-                        let any_echo = pending_group.iter().any(|&index| pending[index].echo);
-                        let group_result = executor.execute_prefill(PrefillPlan {
-                            requests: &prefill_requests,
-                            echo: any_echo,
-                        })?;
-                        result.prefill_requests.extend(group_result.requests);
-                    }
-                    (true, false) => {
-                        let decode_requests = build_decode_items(active, &active_group, rng);
-                        let group_result = executor.execute_decode(DecodePlan {
-                            requests: &decode_requests,
-                        })?;
-                        result.decode_requests.extend(group_result.requests);
-                    }
-                    (true, true) => {}
-                }
-            }
+            let pending_indices: Vec<usize> = (0..pending.len()).collect();
+            let active_indices: Vec<usize> = (0..active.len()).collect();
+            let prefill_requests = build_prefill_items(&pending, &pending_indices, rng);
+            let decode_requests = build_decode_items(active, &active_indices, rng);
+            let mut result = executor.execute_unified(UnifiedPlan {
+                prefill_requests: &prefill_requests,
+                decode_requests: &decode_requests,
+            })?;
             sort_prefill_results(&mut result.prefill_requests);
             sort_decode_results(&mut result.decode_requests);
             Ok(ExecutionArtifacts::Unified { pending, result })
         }
     }
-}
-
-fn group_pending_indices(pending: &[PendingRequest]) -> BTreeMap<LoraGroupKey, Vec<usize>> {
-    let mut groups = BTreeMap::new();
-    for (index, req) in pending.iter().enumerate() {
-        groups
-            .entry(LoraGroupKey::from_option(&req.lora_adapter))
-            .or_insert_with(Vec::new)
-            .push(index);
-    }
-    groups
-}
-
-fn group_active_indices(active: &[ActiveRequestState]) -> BTreeMap<LoraGroupKey, Vec<usize>> {
-    let mut groups = BTreeMap::new();
-    for (index, req) in active.iter().enumerate() {
-        groups
-            .entry(LoraGroupKey::from_option(&req.lora_adapter))
-            .or_insert_with(Vec::new)
-            .push(index);
-    }
-    groups
-}
-
-fn union_group_keys(
-    pending: &BTreeMap<LoraGroupKey, Vec<usize>>,
-    active: &BTreeMap<LoraGroupKey, Vec<usize>>,
-) -> Vec<LoraGroupKey> {
-    let mut keys: Vec<LoraGroupKey> = pending.keys().chain(active.keys()).cloned().collect();
-    keys.sort();
-    keys.dedup();
-    keys
 }
 
 fn build_prefill_items(
@@ -206,6 +102,7 @@ fn build_prefill_items(
                 params: r.params,
                 logprobs: r.logprobs,
                 echo: r.echo,
+                lora_adapter: r.lora_adapter.clone(),
                 random_val: rand::RngExt::random(rng),
                 cached_tokens: 0,
             }
@@ -227,6 +124,7 @@ fn build_decode_items(
                 token_id: r.last_token,
                 params: r.params,
                 logprobs: r.logprobs,
+                lora_adapter: r.lora_adapter.clone(),
                 random_val: rand::RngExt::random(rng),
             }
         })

--- a/pegainfer-qwen3-4b/src/unified_forward.rs
+++ b/pegainfer-qwen3-4b/src/unified_forward.rs
@@ -11,7 +11,7 @@ use half::bf16;
 use super::config::PREFILL_ATTENTION_CTA_TILE_Q;
 use super::prefill::PrefillBuffers;
 use super::weights::{Qwen3Model, TransformerBlock};
-use crate::lora::{LoraTokenRange, build_lora_token_ranges};
+use crate::lora::{DeviceLoraTokenGroup, build_lora_token_ranges, prepare_lora_token_groups};
 use pegainfer_core::ffi;
 use pegainfer_core::kv_pool::KvLayout;
 use pegainfer_core::ops;
@@ -113,6 +113,7 @@ impl Qwen3Model {
                 range
             }),
         );
+        let lora_groups = prepare_lora_token_groups(&self.ctx, &lora_ranges)?;
 
         // ── 1. Concatenate all tokens and get embeddings ──────────────
         let mut all_tokens: Vec<u32> = Vec::with_capacity(total_tokens);
@@ -175,7 +176,7 @@ impl Qwen3Model {
             &positions_d,
             &prefill_plan,
             &decode_meta,
-            &lora_ranges,
+            &lora_groups,
             kv_buffer,
             layout,
         )?;
@@ -224,7 +225,7 @@ impl Qwen3Model {
         positions_d: &CudaSlice<i32>,
         prefill_plan: &PrefillPagedPlan,
         decode_meta: &DecodeAttentionMeta,
-        lora_ranges: &[LoraTokenRange<'_>],
+        lora_groups: &[DeviceLoraTokenGroup<'_>],
         kv_buffer: &CudaSlice<bf16>,
         layout: &KvLayout,
     ) -> Result<HiddenStates> {
@@ -253,7 +254,7 @@ impl Qwen3Model {
                 positions_d,
                 prefill_plan,
                 decode_meta,
-                lora_ranges,
+                lora_groups,
                 kv_buffer,
                 layout,
             )?;
@@ -274,7 +275,7 @@ impl Qwen3Model {
         positions_d: &CudaSlice<i32>,
         prefill_plan: &PrefillPagedPlan,
         decode_meta: &DecodeAttentionMeta,
-        lora_ranges: &[LoraTokenRange<'_>],
+        lora_groups: &[DeviceLoraTokenGroup<'_>],
         kv_buffer: &CudaSlice<bf16>,
         layout: &KvLayout,
     ) -> Result<()> {
@@ -312,7 +313,7 @@ impl Qwen3Model {
         );
         self.apply_lora_projection_ranges(
             layer_idx,
-            lora_ranges,
+            lora_groups,
             |layer| layer.q_proj.as_ref(),
             &bufs.normed,
             &mut bufs.q_batch,
@@ -328,7 +329,7 @@ impl Qwen3Model {
         );
         self.apply_lora_projection_ranges(
             layer_idx,
-            lora_ranges,
+            lora_groups,
             |layer| layer.k_proj.as_ref(),
             &bufs.normed,
             &mut bufs.k_batch,
@@ -344,7 +345,7 @@ impl Qwen3Model {
         );
         self.apply_lora_projection_ranges(
             layer_idx,
-            lora_ranges,
+            lora_groups,
             |layer| layer.v_proj.as_ref(),
             &bufs.normed,
             &mut bufs.v_batch,
@@ -581,7 +582,7 @@ impl Qwen3Model {
         );
         self.apply_lora_projection_ranges(
             layer_idx,
-            lora_ranges,
+            lora_groups,
             |layer| layer.o_proj.as_ref(),
             &bufs.attn_output,
             &mut bufs.o_buf,
@@ -617,7 +618,7 @@ impl Qwen3Model {
         );
         self.apply_lora_projection_ranges(
             layer_idx,
-            lora_ranges,
+            lora_groups,
             |layer| layer.gate_proj.as_ref(),
             &bufs.normed,
             &mut bufs.gate_out,
@@ -625,7 +626,7 @@ impl Qwen3Model {
         )?;
         self.apply_lora_projection_ranges(
             layer_idx,
-            lora_ranges,
+            lora_groups,
             |layer| layer.up_proj.as_ref(),
             &bufs.normed,
             &mut bufs.up_out,
@@ -640,7 +641,7 @@ impl Qwen3Model {
         );
         self.apply_lora_projection_ranges(
             layer_idx,
-            lora_ranges,
+            lora_groups,
             |layer| layer.down_proj.as_ref(),
             &bufs.act_out,
             &mut bufs.o_buf,

--- a/pegainfer-qwen3-4b/src/unified_forward.rs
+++ b/pegainfer-qwen3-4b/src/unified_forward.rs
@@ -11,7 +11,7 @@ use half::bf16;
 use super::config::PREFILL_ATTENTION_CTA_TILE_Q;
 use super::prefill::PrefillBuffers;
 use super::weights::{Qwen3Model, TransformerBlock};
-use crate::lora::apply_lora_projection_delta;
+use crate::lora::{LoraTokenRange, build_lora_token_ranges};
 use pegainfer_core::ffi;
 use pegainfer_core::kv_pool::KvLayout;
 use pegainfer_core::ops;
@@ -80,20 +80,39 @@ impl Qwen3Model {
         &self,
         prefill_prompts: &[&[u32]],
         prefill_views: &[KvView],
+        prefill_lora_adapters: &[Option<&str>],
         decode_tokens: &[u32],
         decode_views: &[KvView],
+        decode_lora_adapters: &[Option<&str>],
         kv_buffer: &CudaSlice<bf16>,
         layout: &KvLayout,
     ) -> Result<(Vec<DeviceVec>, Vec<DeviceVec>)> {
         let num_prefill_reqs = prefill_prompts.len();
         let num_decode_reqs = decode_tokens.len();
         assert_eq!(num_prefill_reqs, prefill_views.len());
+        assert_eq!(num_prefill_reqs, prefill_lora_adapters.len());
         assert_eq!(num_decode_reqs, decode_views.len());
+        assert_eq!(num_decode_reqs, decode_lora_adapters.len());
         assert!(num_prefill_reqs > 0 && num_decode_reqs > 0);
 
         let prefill_seq_lens: Vec<usize> = prefill_prompts.iter().map(|p| p.len()).collect();
         let total_prefill: usize = prefill_seq_lens.iter().sum();
         let total_tokens = total_prefill + num_decode_reqs;
+        let mut lora_ranges = build_lora_token_ranges(
+            prefill_seq_lens.iter().copied(),
+            prefill_lora_adapters.iter().copied(),
+        );
+        lora_ranges.extend(
+            build_lora_token_ranges(
+                std::iter::repeat_n(1, num_decode_reqs),
+                decode_lora_adapters.iter().copied(),
+            )
+            .into_iter()
+            .map(|mut range| {
+                range.token_offset += total_prefill;
+                range
+            }),
+        );
 
         // ── 1. Concatenate all tokens and get embeddings ──────────────
         let mut all_tokens: Vec<u32> = Vec::with_capacity(total_tokens);
@@ -156,6 +175,7 @@ impl Qwen3Model {
             &positions_d,
             &prefill_plan,
             &decode_meta,
+            &lora_ranges,
             kv_buffer,
             layout,
         )?;
@@ -204,6 +224,7 @@ impl Qwen3Model {
         positions_d: &CudaSlice<i32>,
         prefill_plan: &PrefillPagedPlan,
         decode_meta: &DecodeAttentionMeta,
+        lora_ranges: &[LoraTokenRange<'_>],
         kv_buffer: &CudaSlice<bf16>,
         layout: &KvLayout,
     ) -> Result<HiddenStates> {
@@ -232,6 +253,7 @@ impl Qwen3Model {
                 positions_d,
                 prefill_plan,
                 decode_meta,
+                lora_ranges,
                 kv_buffer,
                 layout,
             )?;
@@ -252,6 +274,7 @@ impl Qwen3Model {
         positions_d: &CudaSlice<i32>,
         prefill_plan: &PrefillPagedPlan,
         decode_meta: &DecodeAttentionMeta,
+        lora_ranges: &[LoraTokenRange<'_>],
         kv_buffer: &CudaSlice<bf16>,
         layout: &KvLayout,
     ) -> Result<()> {
@@ -287,18 +310,14 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.q_batch,
         );
-        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
-            && let Some(projection) = &lora_layer.q_proj
-        {
-            apply_lora_projection_delta(
-                &self.ctx,
-                projection,
-                &bufs.normed,
-                &mut bufs.q_batch,
-                0,
-                scale,
-            )?;
-        }
+        self.apply_lora_projection_ranges(
+            layer_idx,
+            lora_ranges,
+            |layer| layer.q_proj.as_ref(),
+            &bufs.normed,
+            &mut bufs.q_batch,
+            0,
+        )?;
         ops::gemm_rows_into(
             &self.ctx,
             &layer.attention.qkv_proj,
@@ -307,18 +326,14 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.k_batch,
         );
-        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
-            && let Some(projection) = &lora_layer.k_proj
-        {
-            apply_lora_projection_delta(
-                &self.ctx,
-                projection,
-                &bufs.normed,
-                &mut bufs.k_batch,
-                0,
-                scale,
-            )?;
-        }
+        self.apply_lora_projection_ranges(
+            layer_idx,
+            lora_ranges,
+            |layer| layer.k_proj.as_ref(),
+            &bufs.normed,
+            &mut bufs.k_batch,
+            0,
+        )?;
         ops::gemm_rows_into(
             &self.ctx,
             &layer.attention.qkv_proj,
@@ -327,18 +342,14 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.v_batch,
         );
-        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
-            && let Some(projection) = &lora_layer.v_proj
-        {
-            apply_lora_projection_delta(
-                &self.ctx,
-                projection,
-                &bufs.normed,
-                &mut bufs.v_batch,
-                0,
-                scale,
-            )?;
-        }
+        self.apply_lora_projection_ranges(
+            layer_idx,
+            lora_ranges,
+            |layer| layer.v_proj.as_ref(),
+            &bufs.normed,
+            &mut bufs.v_batch,
+            0,
+        )?;
 
         // ── 3. QK norm + RoPE [all tokens, per-token positions] ──────
         {
@@ -568,18 +579,14 @@ impl Qwen3Model {
             &bufs.attn_output,
             &mut bufs.o_buf,
         );
-        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
-            && let Some(projection) = &lora_layer.o_proj
-        {
-            apply_lora_projection_delta(
-                &self.ctx,
-                projection,
-                &bufs.attn_output,
-                &mut bufs.o_buf,
-                0,
-                scale,
-            )?;
-        }
+        self.apply_lora_projection_ranges(
+            layer_idx,
+            lora_ranges,
+            |layer| layer.o_proj.as_ref(),
+            &bufs.attn_output,
+            &mut bufs.o_buf,
+            0,
+        )?;
         self.all_reduce_hidden(&mut bufs.o_buf)?;
 
         // ── 7+8. Residual add + MLP RMSNorm (fused) ─────────────────
@@ -608,28 +615,22 @@ impl Qwen3Model {
             &bufs.normed,
             &mut bufs.up_out,
         );
-        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx) {
-            if let Some(projection) = &lora_layer.gate_proj {
-                apply_lora_projection_delta(
-                    &self.ctx,
-                    projection,
-                    &bufs.normed,
-                    &mut bufs.gate_out,
-                    0,
-                    scale,
-                )?;
-            }
-            if let Some(projection) = &lora_layer.up_proj {
-                apply_lora_projection_delta(
-                    &self.ctx,
-                    projection,
-                    &bufs.normed,
-                    &mut bufs.up_out,
-                    0,
-                    scale,
-                )?;
-            }
-        }
+        self.apply_lora_projection_ranges(
+            layer_idx,
+            lora_ranges,
+            |layer| layer.gate_proj.as_ref(),
+            &bufs.normed,
+            &mut bufs.gate_out,
+            0,
+        )?;
+        self.apply_lora_projection_ranges(
+            layer_idx,
+            lora_ranges,
+            |layer| layer.up_proj.as_ref(),
+            &bufs.normed,
+            &mut bufs.up_out,
+            0,
+        )?;
         ops::silu_mul_batch_into(&self.ctx, &bufs.gate_out, &bufs.up_out, &mut bufs.act_out)?;
         ops::gemm_into(
             &self.ctx,
@@ -637,18 +638,14 @@ impl Qwen3Model {
             &bufs.act_out,
             &mut bufs.o_buf,
         );
-        if let Some((lora_layer, scale)) = self.lora_layer(layer_idx)
-            && let Some(projection) = &lora_layer.down_proj
-        {
-            apply_lora_projection_delta(
-                &self.ctx,
-                projection,
-                &bufs.act_out,
-                &mut bufs.o_buf,
-                0,
-                scale,
-            )?;
-        }
+        self.apply_lora_projection_ranges(
+            layer_idx,
+            lora_ranges,
+            |layer| layer.down_proj.as_ref(),
+            &bufs.act_out,
+            &mut bufs.o_buf,
+            0,
+        )?;
         self.all_reduce_hidden(&mut bufs.o_buf)?;
 
         // ── 9. Residual add → hidden_out ─────────────────────────────

--- a/pegainfer-qwen3-4b/src/weights.rs
+++ b/pegainfer-qwen3-4b/src/weights.rs
@@ -152,14 +152,17 @@ impl PackedLoraProjection {
             .memcpy_dtod(&a_src, &mut a_dst)
             .map_err(|e| anyhow::anyhow!("packed LoRA A copy failed: {e}"))?;
 
-        for row in 0..self.out_dim {
-            let src = projection.b.data.slice(row * rank..(row + 1) * rank);
-            let dst_offset = slot * self.out_dim * self.max_rank + row * self.max_rank;
-            let mut dst = self.b.slice_mut(dst_offset..dst_offset + rank);
-            ctx.stream
-                .memcpy_dtod(&src, &mut dst)
-                .map_err(|e| anyhow::anyhow!("packed LoRA B copy failed: {e}"))?;
-        }
+        let b_offset = slot * self.out_dim * self.max_rank;
+        pegainfer_core::ops::pack_lora_b_rows_into(
+            ctx,
+            &projection.b.data,
+            &mut self.b,
+            b_offset,
+            rank,
+            self.max_rank,
+            self.out_dim,
+        )
+        .map_err(|e| anyhow::anyhow!("packed LoRA B copy failed: {e}"))?;
 
         let mut scale_slot = self.scales.slice_mut(slot..slot + 1);
         ctx.stream

--- a/pegainfer-qwen3-4b/src/weights.rs
+++ b/pegainfer-qwen3-4b/src/weights.rs
@@ -8,8 +8,13 @@ use std::time::Instant;
 use super::config::{Config, TensorParallelConfig};
 use std::collections::HashMap;
 
-use crate::lora::{DeviceLoraAdapter, DeviceLoraLayer};
-use pegainfer_core::tensor::{DeviceContext, DeviceMatrix, DeviceVec};
+use crate::lora::{
+    DeviceLoraAdapter, DeviceLoraLayer, DeviceLoraProjection, LoraProjectionKind, LoraTokenRange,
+    apply_lora_projection_delta_indexed, apply_lora_projection_delta_range,
+    group_lora_token_ranges,
+};
+use half::bf16;
+use pegainfer_core::tensor::{DeviceContext, DeviceMatrix, DeviceVec, HiddenStates};
 use pegainfer_core::weight_loader::{
     deserialize_shards, load_shard_info, load_tensor_1d, load_tensor_2d, load_tensor_2d_col_shard,
     load_tensor_2d_row_shard, mmap_shards, precompute_rope,
@@ -28,6 +33,8 @@ pub(crate) struct ModelRuntimeConfig {
     pub(crate) enable_cuda_graph: bool,
     pub(crate) tensor_parallel: Option<TensorParallelConfig>,
     pub(crate) device_ordinal: usize,
+    pub(crate) max_loras: usize,
+    pub(crate) max_lora_rank: usize,
 }
 
 impl Default for ModelRuntimeConfig {
@@ -36,6 +43,8 @@ impl Default for ModelRuntimeConfig {
             enable_cuda_graph: true,
             tensor_parallel: None,
             device_ordinal: 0,
+            max_loras: crate::Qwen3LoraOptions::DEFAULT_MAX_LORAS,
+            max_lora_rank: crate::Qwen3LoraOptions::DEFAULT_MAX_LORA_RANK,
         }
     }
 }
@@ -70,6 +79,204 @@ pub(super) struct TransformerBlock {
     pub(super) mlp: MLP,
 }
 
+pub(crate) struct PackedLoraProjection {
+    pub(crate) a: cudarc::driver::CudaSlice<bf16>,
+    pub(crate) b: cudarc::driver::CudaSlice<bf16>,
+    pub(crate) scales: cudarc::driver::CudaSlice<f32>,
+    pub(crate) max_loras: usize,
+    pub(crate) max_rank: usize,
+    pub(crate) rank: usize,
+    pub(crate) in_dim: usize,
+    pub(crate) out_dim: usize,
+    slot_ranks: Vec<usize>,
+}
+
+impl PackedLoraProjection {
+    fn new(
+        ctx: &DeviceContext,
+        max_loras: usize,
+        max_rank: usize,
+        in_dim: usize,
+        out_dim: usize,
+    ) -> Result<Self> {
+        let a_elems = max_loras * max_rank * in_dim;
+        let b_elems = max_loras * out_dim * max_rank;
+        let a = ctx
+            .stream
+            .alloc_zeros(a_elems)
+            .map_err(|e| anyhow::anyhow!("packed LoRA A alloc failed: {e}"))?;
+        let b = ctx
+            .stream
+            .alloc_zeros(b_elems)
+            .map_err(|e| anyhow::anyhow!("packed LoRA B alloc failed: {e}"))?;
+        let scales = ctx
+            .stream
+            .alloc_zeros(max_loras)
+            .map_err(|e| anyhow::anyhow!("packed LoRA scales alloc failed: {e}"))?;
+        Ok(Self {
+            a,
+            b,
+            scales,
+            max_loras,
+            max_rank,
+            rank: 0,
+            in_dim,
+            out_dim,
+            slot_ranks: vec![0; max_loras],
+        })
+    }
+
+    fn write_slot(
+        &mut self,
+        ctx: &DeviceContext,
+        slot: usize,
+        projection: &DeviceLoraProjection,
+        scale: f32,
+    ) -> Result<()> {
+        anyhow::ensure!(slot < self.max_loras, "packed LoRA slot out of range");
+        anyhow::ensure!(
+            projection.a.rows <= self.max_rank && projection.a.cols == self.in_dim,
+            "inconsistent LoRA A shape in packed projection"
+        );
+        anyhow::ensure!(
+            projection.b.rows == self.out_dim && projection.b.cols == projection.a.rows,
+            "inconsistent LoRA B shape in packed projection"
+        );
+        self.clear_slot(ctx, slot)?;
+
+        let rank = projection.a.rows;
+        let a_src = projection.a.data.slice(..rank * self.in_dim);
+        let a_offset = slot * self.max_rank * self.in_dim;
+        let mut a_dst = self.a.slice_mut(a_offset..a_offset + rank * self.in_dim);
+        ctx.stream
+            .memcpy_dtod(&a_src, &mut a_dst)
+            .map_err(|e| anyhow::anyhow!("packed LoRA A copy failed: {e}"))?;
+
+        for row in 0..self.out_dim {
+            let src = projection.b.data.slice(row * rank..(row + 1) * rank);
+            let dst_offset = slot * self.out_dim * self.max_rank + row * self.max_rank;
+            let mut dst = self.b.slice_mut(dst_offset..dst_offset + rank);
+            ctx.stream
+                .memcpy_dtod(&src, &mut dst)
+                .map_err(|e| anyhow::anyhow!("packed LoRA B copy failed: {e}"))?;
+        }
+
+        let mut scale_slot = self.scales.slice_mut(slot..slot + 1);
+        ctx.stream
+            .memcpy_htod(&[scale], &mut scale_slot)
+            .map_err(|e| anyhow::anyhow!("packed LoRA scale copy failed: {e}"))?;
+        self.slot_ranks[slot] = rank;
+        self.refresh_rank();
+        Ok(())
+    }
+
+    fn clear_slot(&mut self, ctx: &DeviceContext, slot: usize) -> Result<()> {
+        anyhow::ensure!(slot < self.max_loras, "packed LoRA slot out of range");
+
+        let zero_a = vec![bf16::ZERO; self.max_rank * self.in_dim];
+        let a_offset = slot * self.max_rank * self.in_dim;
+        let mut a_dst = self
+            .a
+            .slice_mut(a_offset..a_offset + self.max_rank * self.in_dim);
+        ctx.stream
+            .memcpy_htod(&zero_a, &mut a_dst)
+            .map_err(|e| anyhow::anyhow!("packed LoRA A clear failed: {e}"))?;
+
+        let zero_b = vec![bf16::ZERO; self.out_dim * self.max_rank];
+        let b_offset = slot * self.out_dim * self.max_rank;
+        let mut b_dst = self
+            .b
+            .slice_mut(b_offset..b_offset + self.out_dim * self.max_rank);
+        ctx.stream
+            .memcpy_htod(&zero_b, &mut b_dst)
+            .map_err(|e| anyhow::anyhow!("packed LoRA B clear failed: {e}"))?;
+
+        let mut scale_slot = self.scales.slice_mut(slot..slot + 1);
+        ctx.stream
+            .memcpy_htod(&[0.0f32], &mut scale_slot)
+            .map_err(|e| anyhow::anyhow!("packed LoRA scale clear failed: {e}"))?;
+        self.slot_ranks[slot] = 0;
+        self.refresh_rank();
+        Ok(())
+    }
+
+    fn refresh_rank(&mut self) {
+        self.rank = self.slot_ranks.iter().copied().max().unwrap_or(0);
+    }
+}
+
+pub(crate) struct PackedLoraLayer {
+    pub(crate) projections: Vec<Option<PackedLoraProjection>>,
+}
+
+impl PackedLoraLayer {
+    fn empty() -> Self {
+        Self {
+            projections: (0..LoraProjectionKind::ALL.len())
+                .map(|_| None)
+                .collect::<Vec<Option<PackedLoraProjection>>>(),
+        }
+    }
+
+    pub(crate) fn projection(&self, kind: LoraProjectionKind) -> Option<&PackedLoraProjection> {
+        self.projections
+            .get(kind.index())
+            .and_then(Option::as_ref)
+            .filter(|projection| projection.rank > 0)
+    }
+}
+
+pub(crate) struct PackedLoraRegistry {
+    slots_by_name: HashMap<String, usize>,
+    slot_names: Vec<Option<String>>,
+    packed_layers: Vec<PackedLoraLayer>,
+}
+
+impl PackedLoraRegistry {
+    fn empty(max_loras: usize, num_layers: usize) -> Self {
+        Self {
+            slots_by_name: HashMap::new(),
+            slot_names: vec![None; max_loras],
+            packed_layers: (0..num_layers).map(|_| PackedLoraLayer::empty()).collect(),
+        }
+    }
+
+    pub(crate) fn slot_for(&self, name: &str) -> Option<usize> {
+        self.slots_by_name.get(name).copied()
+    }
+
+    pub(crate) fn layer(&self, layer_idx: usize) -> Option<&PackedLoraLayer> {
+        self.packed_layers.get(layer_idx)
+    }
+
+    fn slot_for_install(&self, name: &str, load_inplace: bool) -> Result<usize> {
+        if let Some(slot) = self.slot_for(name) {
+            anyhow::ensure!(load_inplace, "Qwen3 LoRA adapter {name} is already loaded");
+            return Ok(slot);
+        }
+        self.slot_names
+            .iter()
+            .position(Option::is_none)
+            .ok_or_else(|| anyhow::anyhow!("Qwen3 LoRA adapter capacity exceeded"))
+    }
+
+    fn bind_slot(&mut self, slot: usize, name: &str) {
+        if let Some(previous_name) = self.slot_names[slot].replace(name.to_string()) {
+            self.slots_by_name.remove(&previous_name);
+        }
+        self.slots_by_name.insert(name.to_string(), slot);
+    }
+
+    fn release_slot(&mut self, name: &str) -> Result<usize> {
+        let slot = self
+            .slots_by_name
+            .remove(name)
+            .ok_or_else(|| anyhow::anyhow!("Qwen3 LoRA adapter {name} is not loaded"))?;
+        self.slot_names[slot] = None;
+        Ok(slot)
+    }
+}
+
 /// Qwen3 model — weights and config only. Request state is owned by the executor.
 pub(crate) struct Qwen3Model {
     pub(super) ctx: DeviceContext,
@@ -84,7 +291,9 @@ pub(crate) struct Qwen3Model {
     pub(super) tensor_parallel: TensorParallelConfig,
     pub(super) tp_comm: Option<Comm>,
     pub(super) lora_adapters: HashMap<String, DeviceLoraAdapter>,
-    pub(super) active_lora_adapter: Option<String>,
+    pub(super) packed_lora: PackedLoraRegistry,
+    pub(super) max_loras: usize,
+    pub(super) max_lora_rank: usize,
 }
 
 // SAFETY: Each model instance is pinned to a single CUDA device and is only
@@ -324,6 +533,7 @@ impl Qwen3Model {
         );
         info!("GPU model loaded successfully");
 
+        let num_hidden_layers = config.num_hidden_layers;
         let model = Self {
             ctx,
             config,
@@ -337,7 +547,9 @@ impl Qwen3Model {
             tensor_parallel,
             tp_comm: None,
             lora_adapters: HashMap::new(),
-            active_lora_adapter: None,
+            packed_lora: PackedLoraRegistry::empty(runtime.max_loras, num_hidden_layers),
+            max_loras: runtime.max_loras,
+            max_lora_rank: runtime.max_lora_rank,
         };
 
         if model.enable_cuda_graph {
@@ -395,42 +607,181 @@ impl Qwen3Model {
             adapter.name,
             adapter.manifest.path.display()
         );
-        install_lora_adapter_in_registry(&mut self.lora_adapters, adapter, load_inplace)
+        let name = adapter.name.clone();
+        let slot = self.packed_lora.slot_for_install(&name, load_inplace)?;
+        self.update_packed_lora_slot(slot, &adapter)?;
+        install_lora_adapter_in_registry(&mut self.lora_adapters, adapter, load_inplace)?;
+        self.packed_lora.bind_slot(slot, &name);
+        Ok(())
     }
 
     pub(crate) fn uninstall_lora_adapter(&mut self, name: &str) -> Result<()> {
-        anyhow::ensure!(
-            self.lora_adapters.remove(name).is_some(),
-            "Qwen3 LoRA adapter {name} is not loaded"
-        );
-        if self.active_lora_adapter.as_deref() == Some(name) {
-            self.active_lora_adapter = None;
-        }
+        let slot = self
+            .packed_lora
+            .slot_for(name)
+            .ok_or_else(|| anyhow::anyhow!("Qwen3 LoRA adapter {name} is not loaded"))?;
+        self.clear_packed_lora_slot(slot)?;
+        self.packed_lora.release_slot(name)?;
+        self.lora_adapters
+            .remove(name)
+            .expect("packed LoRA slot map and adapter registry must be consistent");
         Ok(())
     }
 
-    pub(crate) fn activate_lora_adapter(&mut self, name: Option<&str>) -> Result<()> {
-        match name {
-            Some(name) => {
-                anyhow::ensure!(
-                    self.lora_adapters.contains_key(name),
-                    "Qwen3 LoRA adapter {name} is not loaded"
-                );
-                self.active_lora_adapter = Some(name.to_string());
-            }
-            None => self.active_lora_adapter = None,
-        }
-        Ok(())
-    }
-
-    pub(crate) fn lora_layer(&self, layer_idx: usize) -> Option<(&DeviceLoraLayer, f32)> {
-        self.active_lora_adapter.as_ref().and_then(|name| {
-            let adapter = self.lora_adapters.get(name)?;
+    pub(crate) fn lora_layer_for(
+        &self,
+        name: &str,
+        layer_idx: usize,
+    ) -> Option<(&DeviceLoraLayer, f32)> {
+        self.lora_adapters.get(name).and_then(|adapter| {
             adapter
                 .layers
                 .get(layer_idx)
                 .map(|layer| (layer, adapter.scale))
         })
+    }
+
+    pub(crate) fn apply_lora_projection_ranges(
+        &self,
+        layer_idx: usize,
+        ranges: &[LoraTokenRange<'_>],
+        projection: impl for<'a> Fn(&'a DeviceLoraLayer) -> Option<&'a DeviceLoraProjection>,
+        input: &HiddenStates,
+        out: &mut HiddenStates,
+        row_offset: usize,
+    ) -> Result<()> {
+        for group in group_lora_token_ranges(ranges) {
+            let Some((layer, scale)) = self.lora_layer_for(group.adapter, layer_idx) else {
+                anyhow::bail!("Qwen3 LoRA adapter {} is not loaded", group.adapter);
+            };
+            if let Some(projection) = projection(layer) {
+                if group.ranges.len() == 1 {
+                    let range = group.ranges[0];
+                    apply_lora_projection_delta_range(
+                        &self.ctx,
+                        projection,
+                        input,
+                        out,
+                        row_offset,
+                        range.token_offset,
+                        range.token_len,
+                        scale,
+                    )?;
+                } else {
+                    let mut token_indices = Vec::with_capacity(group.token_count);
+                    for grouped_range in group.ranges {
+                        token_indices.extend(
+                            (grouped_range.token_offset
+                                ..grouped_range.token_offset + grouped_range.token_len)
+                                .map(|idx| idx as i32),
+                        );
+                    }
+                    apply_lora_projection_delta_indexed(
+                        &self.ctx,
+                        projection,
+                        input,
+                        out,
+                        row_offset,
+                        &token_indices,
+                        scale,
+                    )?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn decode_lora_slots(&self, adapters: &[Option<&str>]) -> Result<Option<Vec<i32>>> {
+        let mut slots = Vec::with_capacity(adapters.len());
+        let mut any_lora = false;
+        for adapter in adapters {
+            match adapter {
+                Some(name) => {
+                    let Some(slot) = self.packed_lora.slot_for(name) else {
+                        anyhow::bail!("Qwen3 LoRA adapter {name} is not loaded");
+                    };
+                    slots.push(slot as i32);
+                    any_lora = true;
+                }
+                None => slots.push(-1),
+            }
+        }
+        Ok(any_lora.then_some(slots))
+    }
+
+    pub(crate) fn packed_lora_projection(
+        &self,
+        layer_idx: usize,
+        kind: LoraProjectionKind,
+    ) -> Option<&PackedLoraProjection> {
+        self.packed_lora
+            .layer(layer_idx)
+            .and_then(|layer| layer.projection(kind))
+    }
+
+    fn update_packed_lora_slot(&mut self, slot: usize, adapter: &DeviceLoraAdapter) -> Result<()> {
+        self.clear_packed_lora_slot(slot)?;
+        for layer_idx in 0..self.config.num_hidden_layers {
+            let Some(layer) = adapter.layers.get(layer_idx) else {
+                continue;
+            };
+            for kind in LoraProjectionKind::ALL {
+                let Some(projection) = layer.projection(kind) else {
+                    continue;
+                };
+                self.pack_lora_projection_slot(slot, projection, adapter.scale, layer_idx, kind)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn clear_packed_lora_projection_slot(
+        &mut self,
+        slot: usize,
+        layer_idx: usize,
+        kind: LoraProjectionKind,
+    ) -> Result<()> {
+        if let Some(packed) =
+            self.packed_lora.packed_layers[layer_idx].projections[kind.index()].as_mut()
+        {
+            packed.clear_slot(&self.ctx, slot)?;
+        }
+        Ok(())
+    }
+
+    fn clear_packed_lora_slot(&mut self, slot: usize) -> Result<()> {
+        for layer_idx in 0..self.config.num_hidden_layers {
+            for kind in LoraProjectionKind::ALL {
+                self.clear_packed_lora_projection_slot(slot, layer_idx, kind)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn pack_lora_projection_slot(
+        &mut self,
+        slot: usize,
+        projection: &DeviceLoraProjection,
+        scale: f32,
+        layer_idx: usize,
+        kind: LoraProjectionKind,
+    ) -> Result<()> {
+        let max_loras = self.max_loras;
+        let max_rank = self.max_lora_rank;
+        let packed_slot = &mut self.packed_lora.packed_layers[layer_idx].projections[kind.index()];
+        if packed_slot.is_none() {
+            *packed_slot = Some(PackedLoraProjection::new(
+                &self.ctx,
+                max_loras,
+                max_rank,
+                projection.a.cols,
+                projection.b.rows,
+            )?);
+        }
+        let packed = packed_slot
+            .as_mut()
+            .expect("packed LoRA projection was initialized");
+        packed.write_slot(&self.ctx, slot, projection, scale)
     }
 
     pub(crate) fn all_reduce_hidden(
@@ -572,5 +923,40 @@ mod tests {
                 .map(|adapter| adapter.manifest.path.as_path()),
             Some(second_path.as_path()),
         );
+    }
+
+    #[test]
+    fn packed_lora_registry_keeps_fixed_slots() {
+        let mut registry = PackedLoraRegistry::empty(2, 1);
+
+        let slot_a = registry
+            .slot_for_install("adapter-a", false)
+            .expect("first slot");
+        assert_eq!(slot_a, 0);
+        registry.bind_slot(slot_a, "adapter-a");
+        assert_eq!(registry.slot_for("adapter-a"), Some(0));
+
+        let slot_b = registry
+            .slot_for_install("adapter-b", false)
+            .expect("second slot");
+        assert_eq!(slot_b, 1);
+        registry.bind_slot(slot_b, "adapter-b");
+
+        let replacement_slot = registry
+            .slot_for_install("adapter-a", true)
+            .expect("replacement slot");
+        assert_eq!(replacement_slot, 0);
+
+        let duplicate = registry
+            .slot_for_install("adapter-a", false)
+            .expect_err("duplicate without load_inplace should fail")
+            .to_string();
+        assert!(duplicate.contains("already loaded"));
+
+        assert_eq!(registry.release_slot("adapter-a").expect("release"), 0);
+        let slot_c = registry
+            .slot_for_install("adapter-c", false)
+            .expect("released slot should be reused");
+        assert_eq!(slot_c, 0);
     }
 }

--- a/pegainfer-qwen3-4b/src/weights.rs
+++ b/pegainfer-qwen3-4b/src/weights.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use cudarc::nccl::safe::{Comm, ReduceOp};
 use log::{debug, info};
 #[cfg(test)]
@@ -611,7 +611,17 @@ impl Qwen3Model {
         );
         let name = adapter.name.clone();
         let slot = self.packed_lora.slot_for_install(&name, load_inplace)?;
-        self.update_packed_lora_slot(slot, &adapter)?;
+        if let Err(err) = self.update_packed_lora_slot(slot, &adapter) {
+            self.lora_adapters.remove(&name);
+            if self.packed_lora.slot_for(&name) == Some(slot) {
+                let _ = self.packed_lora.release_slot(&name);
+            }
+            return Err(err).with_context(|| {
+                format!(
+                    "failed to update packed LoRA slot {slot} for adapter {name}; adapter was removed to keep packed decode state consistent"
+                )
+            });
+        }
         install_lora_adapter_in_registry(&mut self.lora_adapters, adapter, load_inplace)?;
         self.packed_lora.bind_slot(slot, &name);
         Ok(())
@@ -627,6 +637,14 @@ impl Qwen3Model {
         self.lora_adapters
             .remove(name)
             .expect("packed LoRA slot map and adapter registry must be consistent");
+        Ok(())
+    }
+
+    pub(crate) fn discard_lora_adapter(&mut self, name: &str) -> Result<()> {
+        if self.packed_lora.slot_for(name).is_some() {
+            self.packed_lora.release_slot(name)?;
+        }
+        self.lora_adapters.remove(name);
         Ok(())
     }
 

--- a/pegainfer-qwen3-4b/src/weights.rs
+++ b/pegainfer-qwen3-4b/src/weights.rs
@@ -9,9 +9,8 @@ use super::config::{Config, TensorParallelConfig};
 use std::collections::HashMap;
 
 use crate::lora::{
-    DeviceLoraAdapter, DeviceLoraLayer, DeviceLoraProjection, LoraProjectionKind, LoraTokenRange,
-    apply_lora_projection_delta_indexed, apply_lora_projection_delta_range,
-    group_lora_token_ranges,
+    DeviceLoraAdapter, DeviceLoraLayer, DeviceLoraProjection, DeviceLoraTokenGroup,
+    LoraProjectionKind, apply_lora_projection_delta_indexed, apply_lora_projection_delta_range,
 };
 use half::bf16;
 use pegainfer_core::tensor::{DeviceContext, DeviceMatrix, DeviceVec, HiddenStates};
@@ -647,13 +646,13 @@ impl Qwen3Model {
     pub(crate) fn apply_lora_projection_ranges(
         &self,
         layer_idx: usize,
-        ranges: &[LoraTokenRange<'_>],
+        groups: &[DeviceLoraTokenGroup<'_>],
         projection: impl for<'a> Fn(&'a DeviceLoraLayer) -> Option<&'a DeviceLoraProjection>,
         input: &HiddenStates,
         out: &mut HiddenStates,
         row_offset: usize,
     ) -> Result<()> {
-        for group in group_lora_token_ranges(ranges) {
+        for group in groups {
             let Some((layer, scale)) = self.lora_layer_for(group.adapter, layer_idx) else {
                 anyhow::bail!("Qwen3 LoRA adapter {} is not loaded", group.adapter);
             };
@@ -671,21 +670,18 @@ impl Qwen3Model {
                         scale,
                     )?;
                 } else {
-                    let mut token_indices = Vec::with_capacity(group.token_count);
-                    for grouped_range in group.ranges {
-                        token_indices.extend(
-                            (grouped_range.token_offset
-                                ..grouped_range.token_offset + grouped_range.token_len)
-                                .map(|idx| idx as i32),
-                        );
-                    }
+                    let token_indices_d = group
+                        .token_indices_d
+                        .as_ref()
+                        .expect("non-contiguous LoRA token group must have device indices");
                     apply_lora_projection_delta_indexed(
                         &self.ctx,
                         projection,
                         input,
                         out,
                         row_offset,
-                        &token_indices,
+                        token_indices_d,
+                        group.token_count,
                         scale,
                     )?;
                 }

--- a/pegainfer-qwen3-4b/tests/lora_smoke.rs
+++ b/pegainfer-qwen3-4b/tests/lora_smoke.rs
@@ -88,16 +88,17 @@ fn temp_adapter_dir() -> PathBuf {
     path
 }
 
-fn write_zero_lora_adapter(path: &Path, config: &ModelConfig) {
-    let rank = 1;
+fn write_zero_lora_adapter(path: &Path, config: &ModelConfig, rank: usize) {
     fs::write(
         path.join("adapter_config.json"),
-        r#"{
+        format!(
+            r#"{{
   "peft_type": "LORA",
-  "r": 1,
-  "lora_alpha": 1,
+  "r": {rank},
+  "lora_alpha": {rank},
   "target_modules": ["q_proj", "v_proj"]
-}"#,
+}}"#
+        ),
     )
     .expect("write adapter_config.json");
 
@@ -145,12 +146,12 @@ fn tensor_name(layer_idx: usize, path_segment: &str, lora_side: &str) -> String 
     format!("base_model.model.model.layers.{layer_idx}.{path_segment}.{lora_side}.weight")
 }
 
-fn load_adapter(handle: &EngineHandle, adapter_path: PathBuf) {
+fn load_adapter(handle: &EngineHandle, adapter_name: &str, adapter_path: PathBuf) {
     tokio::runtime::Builder::new_current_thread()
         .build()
         .expect("build runtime")
         .block_on(handle.load_lora_adapter(LoadLoraAdapterRequest {
-            lora_name: "zero-smoke".to_string(),
+            lora_name: adapter_name.to_string(),
             lora_path: adapter_path,
             load_inplace: false,
         }))
@@ -197,6 +198,16 @@ fn generate_tokens(
 #[test]
 #[ignore = "requires Qwen3-4B weights and a CUDA GPU"]
 fn qwen3_lora_loads_adapter_and_generates() {
+    qwen3_lora_loads_rank_and_generates(1, "zero-smoke");
+}
+
+#[test]
+#[ignore = "requires Qwen3-4B weights and a CUDA GPU"]
+fn qwen3_lora_loads_rank64_adapter_and_generates() {
+    qwen3_lora_loads_rank_and_generates(64, "zero-rank64-smoke");
+}
+
+fn qwen3_lora_loads_rank_and_generates(rank: usize, adapter_name: &str) {
     let model_path = get_model_path();
     let config = load_model_config(&model_path);
     assert!(
@@ -205,7 +216,7 @@ fn qwen3_lora_loads_adapter_and_generates() {
     );
 
     let adapter_path = temp_adapter_dir();
-    write_zero_lora_adapter(&adapter_path, &config);
+    write_zero_lora_adapter(&adapter_path, &config, rank);
 
     let handle = pegainfer_qwen3_4b::start_engine_with_lora_control(
         Path::new(&model_path),
@@ -221,7 +232,7 @@ fn qwen3_lora_loads_adapter_and_generates() {
     .expect("start LoRA-capable Qwen3 engine");
 
     assert!(handle.supports_lora_control());
-    load_adapter(&handle, adapter_path);
+    load_adapter(&handle, adapter_name, adapter_path);
 
     let tokenizer = common::load_tokenizer(&model_path);
     let (tokens, finish_reason) = generate_tokens(
@@ -229,7 +240,7 @@ fn qwen3_lora_loads_adapter_and_generates() {
         &tokenizer,
         "Hello",
         4,
-        Some("zero-smoke".to_string()),
+        Some(adapter_name.to_string()),
     );
     assert!(
         !tokens.is_empty(),

--- a/pegainfer-qwen3-4b/tests/lora_smoke.rs
+++ b/pegainfer-qwen3-4b/tests/lora_smoke.rs
@@ -216,6 +216,7 @@ fn qwen3_lora_loads_adapter_and_generates() {
             seed: 42,
             ..EngineLoadOptions::default()
         },
+        pegainfer_qwen3_4b::Qwen3LoraOptions::default(),
     )
     .expect("start LoRA-capable Qwen3 engine");
 

--- a/pegainfer-server/src/main.rs
+++ b/pegainfer-server/src/main.rs
@@ -415,6 +415,11 @@ mod tests {
     }
 
     #[test]
+    fn qwen3_lora_default_rank_is_64() {
+        assert_eq!(Qwen3LoraOptions::default().max_lora_rank, 64);
+    }
+
+    #[test]
     fn rejects_unsupported_max_lora_rank() {
         let error = parse_max_lora_rank_arg("7").expect_err("rank should be unsupported");
 

--- a/pegainfer-server/src/main.rs
+++ b/pegainfer-server/src/main.rs
@@ -7,10 +7,10 @@ use log::info;
 use pegainfer::logging;
 use pegainfer::server_engine::{ModelType, detect_model_type};
 use pegainfer::vllm_frontend::LoraModule;
-use pegainfer_core::{
-    engine::{EngineLoadOptions, EpBackend},
-    parallel::ParallelConfig,
-};
+use pegainfer_core::engine::{EngineLoadOptions, EpBackend};
+#[cfg(feature = "kimi-k2")]
+use pegainfer_core::parallel::ParallelConfig;
+use pegainfer_qwen3_4b::Qwen3LoraOptions;
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
@@ -46,6 +46,14 @@ struct Args {
     /// object, or JSON list object entries with `name` and `path`.
     #[arg(long = "lora-modules", value_parser = parse_lora_modules_arg)]
     lora_modules: Vec<LoraModule>,
+
+    /// Maximum number of resident LoRA adapters in Qwen3 LoRA mode.
+    #[arg(long = "max-loras", default_value_t = Qwen3LoraOptions::DEFAULT_MAX_LORAS)]
+    max_loras: usize,
+
+    /// Maximum supported LoRA rank in Qwen3 LoRA mode.
+    #[arg(long = "max-lora-rank", default_value_t = Qwen3LoraOptions::DEFAULT_MAX_LORA_RANK, value_parser = parse_max_lora_rank_arg)]
+    max_lora_rank: usize,
 
     /// CUDA device ordinal for single-GPU Qwen3 loads
     #[arg(long, default_value_t = 0)]
@@ -116,11 +124,13 @@ async fn main() -> anyhow::Result<()> {
     info!("Loading engine...");
     let start = Instant::now();
     info!(
-        "Runtime options: model_path={}, requested_cuda_graph={}, effective_cuda_graph={}, enable_lora={}, device_ordinal={}, tp_size={}, dp_size={}, ep_backend={:?}",
+        "Runtime options: model_path={}, requested_cuda_graph={}, effective_cuda_graph={}, enable_lora={}, max_loras={}, max_lora_rank={}, device_ordinal={}, tp_size={}, dp_size={}, ep_backend={:?}",
         args.model_path.display(),
         args.cuda_graph,
         effective_cuda_graph,
         args.enable_lora,
+        args.max_loras,
+        args.max_lora_rank,
         args.device_ordinal,
         args.tp_size,
         args.dp_size,
@@ -200,8 +210,19 @@ async fn main() -> anyhow::Result<()> {
                 seed: 42,
             };
             let handle = if args.enable_lora {
-                info!("Starting Qwen3 engine with LoRA control; CUDA Graph is disabled");
-                pegainfer_qwen3_4b::start_engine_with_lora_control(&args.model_path, options)
+                let lora_options = Qwen3LoraOptions {
+                    max_loras: args.max_loras,
+                    max_lora_rank: args.max_lora_rank,
+                };
+                info!(
+                    "Starting Qwen3 engine with LoRA control; CUDA Graph is disabled; max_loras={}, max_lora_rank={}",
+                    lora_options.max_loras, lora_options.max_lora_rank
+                );
+                pegainfer_qwen3_4b::start_engine_with_lora_control(
+                    &args.model_path,
+                    options,
+                    lora_options,
+                )
             } else {
                 pegainfer_qwen3_4b::start_engine(&args.model_path, options)
             }
@@ -321,6 +342,20 @@ fn parse_lora_modules_arg(value: &str) -> Result<LoraModule, String> {
     }
 }
 
+fn parse_max_lora_rank_arg(value: &str) -> Result<usize, String> {
+    let rank = value
+        .parse::<usize>()
+        .map_err(|error| format!("invalid --max-lora-rank: {error}"))?;
+    if Qwen3LoraOptions::is_supported_max_lora_rank(rank) {
+        Ok(rank)
+    } else {
+        Err(format!(
+            "--max-lora-rank must be one of: {}",
+            Qwen3LoraOptions::supported_max_lora_ranks_display()
+        ))
+    }
+}
+
 fn parse_lora_module_fields(name: &str, path: &str) -> Result<LoraModule, String> {
     if name.is_empty() {
         return Err("--lora-modules name must not be empty".to_string());
@@ -371,5 +406,19 @@ mod tests {
                 path: PathBuf::from("/tmp/adapter-a"),
             }
         );
+    }
+
+    #[test]
+    fn parses_supported_max_lora_rank() {
+        assert_eq!(parse_max_lora_rank_arg("16").expect("parse rank"), 16);
+        assert_eq!(parse_max_lora_rank_arg("320").expect("parse rank"), 320);
+    }
+
+    #[test]
+    fn rejects_unsupported_max_lora_rank() {
+        let error = parse_max_lora_rank_arg("7").expect_err("rank should be unsupported");
+
+        assert!(error.contains("--max-lora-rank must be one of"));
+        assert!(error.contains("16"));
     }
 }

--- a/tools/lora/qwen3_lora_live_parity.py
+++ b/tools/lora/qwen3_lora_live_parity.py
@@ -328,7 +328,7 @@ def pegainfer_completion(
 
 def main() -> int:
     args = parse_args()
-    repo_root = Path(__file__).resolve().parents[1]
+    repo_root = Path(__file__).resolve().parents[2]
     model_path = Path(args.model_path).resolve()
     if args.adapter_path:
         adapter_path = Path(args.adapter_path).resolve()

--- a/tools/lora/qwen3_lora_live_stress.py
+++ b/tools/lora/qwen3_lora_live_stress.py
@@ -39,6 +39,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--concurrency", type=int, default=12)
     parser.add_argument("--rounds", type=int, default=3)
     parser.add_argument("--max-tokens", type=int, default=8)
+    parser.add_argument("--max-loras", type=int, default=3)
     parser.add_argument("--prompt", default="Write one short sentence about systems software.")
     return parser.parse_args()
 
@@ -171,6 +172,8 @@ def start_server(args: argparse.Namespace, repo_root: Path) -> subprocess.Popen:
         "--enable-lora",
         "--served-model-name",
         "qwen3-base",
+        "--max-loras",
+        str(args.max_loras),
         "--tp-size",
         str(args.tp_size),
         "--port",
@@ -281,7 +284,7 @@ def completion(server_url: str, model: str, prompt: str, max_tokens: int) -> str
 
 def main() -> int:
     args = parse_args()
-    repo_root = Path(__file__).resolve().parents[1]
+    repo_root = Path(__file__).resolve().parents[2]
     model_path = Path(args.model_path).resolve()
     server_url = args.server_url or f"http://127.0.0.1:{args.port}"
     process = None


### PR DESCRIPTION
## Summary

This PR makes Qwen3 LoRA serving execute mixed base/LoRA requests in one scheduler, executor, and model batch instead of serializing by adapter.

Main changes:

- Add Qwen3 LoRA capacity guardrails and server flags:
  - `--max-loras`
  - `--max-lora-rank`
- Set conservative built-in defaults for the supported knobs: `max_loras=1`, `max_lora_rank=64`.
- Carry per-request LoRA adapter metadata through scheduler plans, worker commands, executor calls, and Qwen3 forward paths.
- Remove the old global active-LoRA execution state and the tensor-parallel activation command.
- Run mixed-LoRA prefill, decode, and unified batches as one batch instead of one sub-batch per adapter.
- Add packed decode LoRA slots, per-token slot ids, grouped decode LoRA delta kernels, rank-specialized decode dispatch, and fixed-slot packed registry updates.
- Optimize rank-1 decode LoRA dot products with a block-wide reduction.
- Optimize packed LoRA B-slot loading with one CUDA pack kernel per projection slot instead of thousands of row-by-row D2D copies.
- Compact repeated-adapter prefill/unified ranges so non-contiguous requests using the same adapter share one compact LoRA delta path.
- Cap scheduler admission at the decode scratch/CUDA Graph bucket capacity so oversized active decode batches queue instead of panicking.
- Clean up LoRA packed slots and registry state on failed load/reload so packed decode state cannot diverge from the adapter registry.

## Behavior

Before this PR, the scheduler could admit requests using different adapters into one plan, but execution grouped by adapter and ran serial model forwards under a global active adapter. That preserved correctness but lost the main batching benefit for mixed base/LoRA traffic.

After this PR:

- The base model batch runs once for mixed base/LoRA traffic.
- Each request carries its adapter identity, or base/no-LoRA.
- Decode LoRA deltas are applied from packed adapter slots using per-token slot ids.
- Prefill/unified LoRA deltas are applied by adapter-grouped compact token ranges.
- No-LoRA decode still uses the existing CUDA Graph path.
- LoRA decode remains eager in this PR because packed LoRA slot versions are not part of the CUDA Graph cache key yet.

## Performance

### Mixed-LoRA serving

Environment:

- GPU: `NVIDIA A800-SXM4-80GB`
- Model: Qwen3-4B
- API: HTTP `/v1/completions`
- Workload: `concurrency=12`, `rounds=5`, `60` measured requests, `max_tokens=16`
- Model mix after warmup: `qwen3-base`, `stress-a`, `stress-b`, `stress-c`

| Stage | Throughput | Mean latency | p50 | p90 | p99 |
| --- | ---: | ---: | ---: | ---: | ---: |
| Capacity baseline | `19.88 req/s` | `0.602s` | `0.601s` | `0.611s` | `0.613s` |
| Mixed-LoRA batch | `44.13 req/s` | `0.271s` | `0.270s` | `0.280s` | `0.281s` |

Delta:

- Throughput: `2.22x`
- Mean latency: `-54.94%`
- p50 latency: `-54.99%`
- p99 latency: `-54.15%`

### Rank-1 decode dot optimization

Environment is the same A800 workload as above.

| Stage | Throughput | Mean latency | p50 | p99 |
| --- | ---: | ---: | ---: | ---: |
| Mixed-LoRA batch | `44.13 req/s` | `0.271s` | `0.270s` | `0.281s` |
| Rank-1 block reduction | `60.94 req/s` | `0.196s` | `0.195s` | `0.203s` |

Delta vs mixed-LoRA batch:

- Throughput: `1.38x`
- Mean latency: `-27.67%`
- p50 latency: `-27.74%`
- p99 latency: `-27.89%`

Delta vs capacity baseline:

- Throughput: `3.07x`
- Mean latency: `-67.41%`
- p50 latency: `-67.48%`
- p99 latency: `-66.93%`

### Rank sweep after non-rank1 dot optimization

I also benchmarked a single-adapter q/v LoRA workload across common ranks after extending the decode dot path beyond rank 1.

Environment:

- GPU: `NVIDIA A800-SXM4-80GB`
- Model: Qwen3-4B
- API: HTTP `/v1/completions`
- Workload: one loaded q/v LoRA adapter, `concurrency=12`, `rounds=10`, `120` measured requests, `max_tokens=16`

| Rank | Throughput | Mean latency | p50 | p99 | Adapter load |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | `63.73 req/s` | `0.188s` | `0.188s` | `0.191s` | `0.0107s` |
| 2 | `60.13 req/s` | `0.199s` | `0.199s` | `0.202s` | `0.0127s` |
| 4 | `58.80 req/s` | `0.204s` | `0.204s` | `0.207s` | `0.0174s` |
| 8 | `52.36 req/s` | `0.229s` | `0.229s` | `0.232s` | `0.0181s` |
| 16 | `43.64 req/s` | `0.275s` | `0.275s` | `0.278s` | `0.0271s` |
| 32 | `32.75 req/s` | `0.366s` | `0.366s` | `0.369s` | `0.0472s` |
| 64 | `21.77 req/s` | `0.551s` | `0.551s` | `0.554s` | `0.0901s` |

In a same-workload historical comparison against the pre-fix non-rank1 decode dot path, this change improved:

- rank 8: `+45.2%` throughput
- rank 16: `+40.0%` throughput
- rank 32: `+34.4%` throughput
- rank 64: `+5.0%` throughput

Rank 64 still scales down materially because more of the cost shifts to the LoRA B expansion and total decode work.

### Adapter load optimization

The mixed path originally made adapter load slower because packed LoRA slots were populated at load time. This PR fixes that with a CUDA B-slot packing kernel.

Environment:

- GPU: `NVIDIA A800-SXM4-80GB`
- Model: Qwen3-4B
- API/workload: same mixed base/LoRA HTTP shape as above

Forward order:

| Stage | Adapter load mean | Throughput | Mean latency | p99 |
| --- | ---: | ---: | ---: | ---: |
| Before pack-B load kernel | `0.503s` | `56.04 req/s` | `0.213s` | `0.225s` |
| After pack-B load kernel | `0.00669s` | `56.70 req/s` | `0.210s` | `0.223s` |

Reverse order:

| Stage | Adapter load mean | Throughput | Mean latency | p99 |
| --- | ---: | ---: | ---: | ---: |
| After pack-B load kernel | `0.00671s` | `55.98 req/s` | `0.213s` | `0.227s` |
| Before pack-B load kernel | `0.490s` | `56.23 req/s` | `0.212s` | `0.225s` |

Conclusion:

- Adapter load improves from roughly `0.49-0.50s` to millisecond-scale loads; current-head reruns measured `~0.010-0.012s` for rank-1/mixed adapters, with the original forward/reverse comparison measuring `0.0067s`.
- Steady serving throughput after adapters are loaded is unchanged within benchmark noise for this workload.

### Steady-state nsys result

I also captured a steady-state mixed base/LoRA HTTP nsys trace before deciding whether to continue narrow LoRA kernel fusion.

These percentages come from one steady-state nsys profile over the measured request phase, not a general model-wide attribution.

Workload:

- Requests: `240`
- Concurrency: `12`
- `max_tokens=16`
- Models: `qwen3-base`, `stress-a`, `stress-b`, `stress-c`

Profiled request phase:

- Throughput: `58.98 req/s`
- Mean latency: `0.203s`
- p99 latency: `0.221s`

GPU kernel time composition:

- Base GEMM/cuBLAS-like projection kernels: `~67.8%`
- `argmax_kernel`: `15.9%`
- `lora_decode_fused_delta_group3_rank_kernel<1>`: `6.8%`
- Decode attention FlashInfer: `1.9%`
- Append paged KV: `1.0%`
- QK norm/RoPE: `1.4%`
- Fused add RMSNorm: `2.4%`
- `silu_mul`: `1.3%`

CUDA API time composition:

- Kernel launch APIs: `~27.8%`
- `cuMemcpyDtoHAsync_v2`: `65.8%`
- `cuStreamSynchronize`: `0.2%`

Follow-up priority from profiling:

- LoRA decode is `6.8%` of GPU kernel time in this measured steady-state workload.
- The next serving work should prioritize sampling/logits selection and D2H readback, then the base GEMM/MLP decode path.
- Revisit LoRA delta fusion for workloads with more target modules or higher ranks.

## Validation

Formatting and static checks:

```bash
cargo fmt --all --check
git diff --check
python -m py_compile tools/lora/qwen3_lora_live_parity.py tools/lora/qwen3_lora_live_stress.py
rg -n "activate_lora_adapter|active_lora_adapter|ActivateLoraAdapter|lora_layer\\(|apply_lora_projection_delta\\(" pegainfer-qwen3-4b pegainfer-core pegainfer-server pegainfer-kernels
```

The residual scan for the deleted global activation path returned no matches.

Build and unit tests run:

```bash
PEGAINFER_CUDA_SM=80 cargo check --release -p pegainfer-server --bin pegainfer
PEGAINFER_CUDA_SM=80 cargo check --release -p pegainfer-qwen3-4b --lib
PEGAINFER_CUDA_SM=80 cargo test --release -p pegainfer-qwen3-4b --lib -- --nocapture
PEGAINFER_CUDA_SM=80 cargo test --release -p pegainfer-qwen3-4b --lib lora -- --nocapture
PEGAINFER_CUDA_SM=80 cargo test --release -p pegainfer-qwen3-4b --lib admission -- --nocapture
PEGAINFER_CUDA_SM=80 cargo test --release -p pegainfer-qwen3-4b --lib packed_lora_registry_keeps_fixed_slots -- --nocapture
PEGAINFER_CUDA_SM=80 cargo test --release -p pegainfer-qwen3-4b --lib groups_non_contiguous_lora_ranges_by_adapter -- --nocapture
PEGAINFER_CUDA_SM=80 cargo test --release -p pegainfer-server --bin pegainfer lora -- --nocapture
PEGAINFER_CUDA_SM=80 cargo test --release -p pegainfer-qwen3-4b --test lora_smoke qwen3_lora_loads_rank64_adapter_and_generates -- --ignored --nocapture
```

Model-required validation:

`PEGAINFER_TEST_MODEL_PATH=<Qwen3-4B weights> cargo test --release -p pegainfer-qwen3-4b --test hf_golden_gate -- --nocapture` passed on A800:

| Gate pass | Positions | Head deltas | Mean | p50 | p99 | Max |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| sequential bs=1 eager | `816` | `6528` | `0.0318` | `0.0248` | `0.1180` | `0.3749` |
| batched eager (9, no pad) | `153` | `1224` | `0.0333` | `0.0257` | `0.1280` | `0.3749` |
| sequential bs=1 eager cached replay | `816` | `6528` | `0.0312` | `0.0246` | `0.1183` | `0.3749` |
| batched eager cached replay (9) | `153` | `1224` | `0.0308` | `0.0245` | `0.1250` | `0.1625` |
| batched cuda-graph (9 padded) | `153` | `1224` | `0.0300` | `0.0223` | `0.1281` | `0.1774` |
| batched cuda-graph (5 padded) | `85` | `680` | `0.0309` | `0.0262` | `0.1116` | `0.1777` |
| batched cuda-graph cached replay (5) | `85` | `680` | `0.0310` | `0.0240` | `0.1142` | `0.1826` |

Final result: `1 passed; 0 failed; finished in 32.53s`.

GPU runtime validation:

- On A800, `PEGAINFER_CUDA_SM=80 cargo test --release -p pegainfer-qwen3-4b --lib -- --nocapture` passed: `27` tests.
- With the shared Qwen3-4B model and CUDA compat libraries, `batch_decode::tests::batch_matches_sequential` passed.
- With the same model/runtime env, `cargo test --release -p pegainfer-qwen3-4b --test lora_smoke -- --ignored --nocapture` passed.
- A rank-64 zero LoRA adapter load + smoke generation test passed with the new default `max_lora_rank=64`.
- Rank sweep serving benchmarks completed for ranks `1/2/4/8/16/32/64`.
- Current-head mixed and rank-sweep HTTP benchmarks were re-run on two A800 validation hosts and matched the reported throughput/latency range.
- Mixed base/LoRA HTTP benchmarks completed on A800.
- Steady-state nsys profiling completed on A800.

## Known Boundaries / Follow-ups

- PegaInfer currently maps `max_loras` to resident loaded adapter capacity because there is no CPU adapter cache yet.
- LoRA decode remains eager. No-LoRA decode still uses the existing CUDA Graph path.
- LoRA CUDA Graph support would need packed-slot versioning in graph cache keys, otherwise adapter load/replacement can invalidate captured assumptions.
- Decode now has packed/grouped/rank-specialized LoRA delta kernels, but this is not full Punica parity.
- Based on the nsys trace, the next meaningful serving optimizations should target:
  - sampling/logits selection and D2H readback;
  - base GEMM/MLP decode projection cost;
  - only then revisit LoRA delta fusion for workloads with more target modules or higher ranks.
