### PR TITLE
fix(core): preserve noisy-module suppression with RUST_LOG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
           toolchain: nightly
           components: rustfmt, clippy
 
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
       - name: Check formatting
         run: cargo fmt --all --check
 

--- a/pegainfer-core/src/logging.rs
+++ b/pegainfer-core/src/logging.rs
@@ -1,10 +1,12 @@
 //! Unified logging configuration.
 
+use std::str::FromStr;
 use std::sync::Once;
 
 use colored::Color::{Green, Red, Yellow};
 use logforth::diagnostic::ThreadLocalDiagnostic;
 use logforth::layout::TextLayout;
+use logforth::record::Level;
 
 static INIT: Once = Once::new();
 
@@ -46,8 +48,39 @@ fn apply_default_module_levels(mut filter: String) -> String {
     filter
 }
 
+fn bare_global_level(filter: &str) -> Option<Option<Level>> {
+    let mut global_level = None;
+
+    for directive in filter
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+    {
+        if directive.contains('=') {
+            continue;
+        }
+
+        if directive.eq_ignore_ascii_case("off") {
+            global_level = Some(None);
+        } else if let Ok(level) = Level::from_str(directive) {
+            global_level = Some(Some(level));
+        }
+    }
+
+    global_level
+}
+
+fn should_apply_default_module_levels(filter: &str) -> bool {
+    matches!(bare_global_level(filter), Some(Some(level)) if level < Level::Warn)
+}
+
 fn resolved_filter_string(level: String, rust_log: Option<String>) -> String {
-    apply_default_module_levels(rust_log.unwrap_or(level))
+    let filter = rust_log.unwrap_or(level);
+    if should_apply_default_module_levels(&filter) {
+        apply_default_module_levels(filter)
+    } else {
+        filter
+    }
 }
 
 fn init(config: LoggingConfig) {
@@ -109,5 +142,25 @@ mod tests {
         assert!(filter.contains("axum=warn"));
         assert!(filter.contains("tower=warn"));
         assert!(!filter.contains("h2=warn"));
+    }
+
+    #[test]
+    fn does_not_relax_stricter_global_rust_log_levels() {
+        let error_filter = resolved_filter_string("info".to_string(), Some("error".to_string()));
+        let off_filter = resolved_filter_string("info".to_string(), Some("off".to_string()));
+
+        assert_eq!(error_filter, "error");
+        assert_eq!(off_filter, "off");
+    }
+
+    #[test]
+    fn does_not_add_default_module_levels_without_a_global_level() {
+        let filter = resolved_filter_string("info".to_string(), Some("h2=trace".to_string()));
+
+        assert_eq!(filter, "h2=trace");
+        assert!(!filter.contains("hyper=warn"));
+        assert!(!filter.contains("hyper_util=warn"));
+        assert!(!filter.contains("axum=warn"));
+        assert!(!filter.contains("tower=warn"));
     }
 }

--- a/pegainfer-core/src/logging.rs
+++ b/pegainfer-core/src/logging.rs
@@ -46,11 +46,14 @@ fn apply_default_module_levels(mut filter: String) -> String {
     filter
 }
 
+fn resolved_filter_string(level: String, rust_log: Option<String>) -> String {
+    apply_default_module_levels(rust_log.unwrap_or(level))
+}
+
 fn init(config: LoggingConfig) {
     INIT.call_once(|| {
         let LoggingConfig { level, colored } = config;
-        let filter_str =
-            std::env::var("RUST_LOG").unwrap_or_else(|_| apply_default_module_levels(level));
+        let filter_str = resolved_filter_string(level, std::env::var("RUST_LOG").ok());
         let filter =
             logforth::filter::env_filter::EnvFilterBuilder::from_env_or("RUST_LOG", filter_str)
                 .build();
@@ -78,13 +81,35 @@ fn init(config: LoggingConfig) {
     });
 }
 
-pub fn init_stderr(level: &str) {
-    init(LoggingConfig {
-        level: level.to_string(),
-        colored: false,
-    });
-}
-
 pub fn init_default() {
     init(LoggingConfig::default());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolved_filter_string;
+
+    #[test]
+    fn applies_default_noisy_module_levels_when_rust_log_is_debug() {
+        let filter = resolved_filter_string("info".to_string(), Some("debug".to_string()));
+
+        assert!(filter.starts_with("debug"));
+        assert!(filter.contains("h2=warn"));
+        assert!(filter.contains("hyper=warn"));
+        assert!(filter.contains("hyper_util=warn"));
+        assert!(filter.contains("axum=warn"));
+        assert!(filter.contains("tower=warn"));
+    }
+
+    #[test]
+    fn preserves_explicit_module_overrides_from_rust_log() {
+        let filter = resolved_filter_string("info".to_string(), Some("debug,h2=trace".to_string()));
+
+        assert!(filter.starts_with("debug,h2=trace"));
+        assert!(filter.contains("hyper=warn"));
+        assert!(filter.contains("hyper_util=warn"));
+        assert!(filter.contains("axum=warn"));
+        assert!(filter.contains("tower=warn"));
+        assert!(!filter.contains("h2=warn"));
+    }
 }

--- a/pegainfer-core/src/logging.rs
+++ b/pegainfer-core/src/logging.rs
@@ -54,9 +54,7 @@ fn init(config: LoggingConfig) {
     INIT.call_once(|| {
         let LoggingConfig { level, colored } = config;
         let filter_str = resolved_filter_string(level, std::env::var("RUST_LOG").ok());
-        let filter =
-            logforth::filter::env_filter::EnvFilterBuilder::from_env_or("RUST_LOG", filter_str)
-                .build();
+        let filter = logforth::filter::env_filter::EnvFilterBuilder::from_spec(filter_str).build();
 
         let mut builder = logforth::starter_log::builder();
         if colored {


### PR DESCRIPTION
Summary
1. Preserve the default noisy-module suppression when `RUST_LOG` is set.
2. Parse the merged filter spec directly so logger init does not re-read `RUST_LOG` and drop the suppression entries.
3. Only append the default noisy-module `warn` caps when the resolved spec contains a bare global level looser than `warn`, so stricter globals such as `error` and `off` stay strict.
4. Remove the unused `init_stderr` helper.
5. Install `protobuf-compiler` in CI so the simulated frontend e2e step can build the `vllm-server` dependency chain.

Invariants
1. Explicit per-module overrides from `RUST_LOG` still win. `RUST_LOG=debug,h2=trace` keeps `h2=trace`.
2. Existing default suppression still applies to modules the user did not configure when the resolved global level is more verbose than `warn`: `h2`, `hyper`, `hyper_util`, `axum`, `tower`.
3. Stricter global filters are not relaxed by the defaults. `RUST_LOG=error` and `RUST_LOG=off` stay `error` and `off`.
4. This patch does not change logger initialization order or output backend selection.
5. The CI change only adds the missing system dependency required by the existing `pegainfer-sim` frontend e2e job.

Validation
1. `cargo fmt --all --check`
2. `cargo test --release -p pegainfer-core logging::tests:: -- --nocapture`
3. `cargo test --release -p pegainfer-sim --test frontend_e2e`
4. GitHub Actions evidence on this branch:
   before the CI change, `Run simulated frontend e2e tests` failed with `Could not find protoc`
   after installing `protobuf-compiler`, `CPU checks` passed

Related
1. Closes #211