### PR TITLE
test(deepseek-v2-lite): add NCCL CUDA Graph readiness smoke

### DIFF
--- a/docs/models/deepseek-v2-lite/decode-attribution-gate.md
+++ b/docs/models/deepseek-v2-lite/decode-attribution-gate.md
@@ -1,6 +1,6 @@
 # DeepSeek-V2-Lite EP2 Decode Attribution Gate
 
-> **TL;DR:** DeepSeek-V2-Lite now has a narrow EP2 decode attribution report for the same correctness shape as the HF gate and the true-batch benchmark follow-up: `prompt="Hello"`, `output_len=16`, `batch-size=1/4/8`, host-staged backend, and NCCL backend. The report combines CPU-side attribution, selected CUDA event timing, optional NVTX ranges, and route/transfer counts; it is evidence for the next bottleneck decision, not a throughput or production EP claim.
+> **TL;DR:** DeepSeek-V2-Lite now has a narrow EP2 decode attribution report for the same correctness shape as the HF gate and the true-batch benchmark follow-up: `prompt="Hello"`, `output_len=16`, `batch-size=1/4/8`, host-staged backend, and NCCL backend. The report combines CPU-side attribution, selected CUDA event timing, optional NVTX ranges, route/transfer counts, and a fail-closed CUDA Graph readiness section; it is evidence for the next bottleneck decision, not a throughput or production EP claim.
 >
 > **Status:** Passing for the covered EP2 `Hello` / 16-token host-staged and NCCL attribution gate. The batch attribution mode is diagnostic and uses the same-prompt, fixed-length shape as the direct benchmark path.
 
@@ -34,7 +34,8 @@ Out of scope:
 - `gpu_timing`, `by_gpu_section`, and `by_gpu_call_site` with CUDA event timing for selected GPU/NCCL stream sections, plus a `failure_count` for event-timing failures that did not replace the token/text hash oracle;
 - `by_section`, `by_op`, and `by_call_site` rollups in the same vocabulary family as the Qwen3 model report;
 - `coverage` rows that distinguish CPU section timing, selected GPU event timing, optional NVTX ranges, and unclaimed throughput;
-- `ep` counters for host-staged dispatch/combine and NCCL dense exchange/combine plus local/remote route counts.
+- `ep` counters for host-staged dispatch/combine and NCCL dense exchange/combine plus local/remote route counts;
+- `cuda_graph_readiness` with backend, batch size, fail-closed blockers, route/collective metrics, and an optional NCCL graph smoke result.
 
 Host-staged `dispatch_calls` / `combine_calls` count MoE layer invocations in the fixed greedy run. Host-staged `dispatch_elements` / `combine_elements` count selected routed hidden vectors, so the value is route count times hidden size. NCCL `exchange` and `combine` counters count the dense all-reduce calls and elements used by the current naive NCCL gate.
 
@@ -108,6 +109,21 @@ done
 
 For an Nsight Systems pass, run the same attribution command under the profiler and set `PEGAINFER_DSV2_LITE_NVTX=1`; the JSON `coverage` row then records `nvtx_ranges=emitted`. The NVTX labels are correlation markers for the selected GPU/NCCL sections, not timing evidence by themselves. Their wall-clock span can include CPU-side wrapper work, event setup, and synchronization around the section, so compare JSON `by_gpu_*` rows only with CUDA event timing, not with raw NVTX range duration.
 
+To inspect the CUDA Graph readiness boundary for the current NCCL backend, run the attribution binary with the optional smoke flag:
+
+```bash
+PEGAINFER_DSV2_LITE_EP_BACKEND=nccl \
+  cargo run --release -p pegainfer-deepseek-v2-lite \
+  --features deepseek-v2-lite \
+  --bin dsv2_lite_ep2_decode_attribution \
+  -- --model-path models/DeepSeek-V2-Lite \
+  --batch-size 1 \
+  --nccl-graph-smoke \
+  --out target/accuracy/dsv2-lite-ep2/nccl-graph-smoke.json
+```
+
+The smoke uses one preallocated f32 NCCL all-reduce over the existing two rank streams. With `--nccl-graph-smoke`, the command exits non-zero unless capture, replay, and verification all pass. Passing proves only basic collective capture/replay in this runtime. It does not prove full decode CUDA Graph coverage.
+
 ## Environment Notes
 
 The NCCL path depends on a runtime that supports the selected GPU. On newer GPUs, older NCCL runtimes may fail communicator initialization before the model-level comparison runs, for example with a shared-memory init error like:
@@ -123,7 +139,7 @@ The HF oracle needs a Python environment that can load DeepSeek-V2-Lite with `tr
 
 ## Latest Validation
 
-The full gate was last rerun on 2026-05-30 with DeepSeek-V2-Lite snapshot `604d5664dddd88a0433dbae533b7fe9472482de0`, `prompt="Hello"`, `output_len=16`, and 2x A800-SXM4-80GB. The token/text oracle is confirmed by a real HF `AutoModelForCausalLM.generate(..., do_sample=false, use_cache=true)` run on the same model directory as the Rust E2E and attribution gates.
+The strict same-host accuracy gate was last rerun on 2026-06-04 with DeepSeek-V2-Lite snapshot `604d5664dddd88a0433dbae533b7fe9472482de0`, `prompt="Hello"`, `output_len=16`, and 2x A800-SXM4-80GB. The token/text oracle is confirmed by a real HF `AutoModelForCausalLM.generate(..., do_sample=false, use_cache=true)` run on the same model directory as the Rust E2E gate.
 
 The Rust E2E accepts the known HF-confirmed RTX 5090 and A800 hash pairs for this narrow shape, but the comparison gate remains stricter: HF, host-staged, and NCCL JSON must be dumped from the same model/runtime and compared with `--require-all-exact`. This refresh does not claim a model-runtime improvement, a manual-loop root cause, or a transport issue.
 
@@ -131,6 +147,17 @@ The Rust E2E accepts the known HF-confirmed RTX 5090 and A800 hash pairs for thi
 - Token SHA256: `d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8`.
 - Text SHA256: `4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6`.
 - Generated text: `, I am a 20 year old female and I have been having a`.
+
+The graph-readiness diagnostic was rerun on 2026-06-04 on the same model snapshot and 2x A800-SXM4-80GB:
+
+- `full_decode_capture_ready=false`;
+- `status=blocked_full_decode_path`;
+- NCCL blockers reported: per-call dense-exchange allocation/sync, host-side route iteration, host-side contribution accumulation, combine H2D copy, combine allocation, combine sync, and combine D2H copy;
+- optional `nccl_cuda_graph_smoke=captured_replayed_verified`;
+- smoke capture mode: `thread_local`;
+- smoke result: `captured=true`, `replayed=true`, `verified=true`, `rank0_value=3.0`, `rank1_value=3.0`, with no `capture_error`, `replay_error`, or `verification_error`.
+
+The attribution table below is the retained 2026-05-30 batch `1/4/8` diagnostic snapshot.
 
 | Backend | Batch | Decode steps | Mean shared decode us | GPU event samples | GPU failures | Route / collective counters |
 | --- | ---: | ---: | ---: | ---: | ---: | --- |

--- a/docs/models/deepseek-v2-lite/status.md
+++ b/docs/models/deepseek-v2-lite/status.md
@@ -13,6 +13,7 @@ Last touched: 2026-06
 | HF token/text/hash gate | Available | PR #154 establishes the HF / host-staged / NCCL comparison; PR #176 refreshes it to Transformers `generate(..., use_cache=true)`. |
 | Decode attribution | Available | PR #162 and PR #169 add CPU/GPU attribution, route counts, NCCL counters, CUDA event timing, and optional NVTX correlation. |
 | Direct same-prompt diagnostic batch | Available | PR #184 and PR #196 cover batch sizes `1`, `4`, and `8` for the fixed same-prompt direct path. |
+| NCCL CUDA Graph readiness | Diagnostic only | The attribution binary now emits `cuda_graph_readiness`. Current NCCL full decode capture is blocked; the optional preallocated f32 NCCL graph smoke captures, replays, and verifies. |
 | Production continuous batching | Not available | The direct diagnostic batch path is not mixed-request HTTP serving. |
 | vLLM production parity | Not claimed | The manual vLLM snapshot below is for understanding the gap requested in issue #170. |
 
@@ -97,6 +98,8 @@ Do not claim:
 ## Next Gates
 
 Issue #205 records the model roadmap. Maintainer feedback there calls out NCCL plus CUDA Graph as the likely best decode direction, with host staging possibly deprecated later. Treat that as a future direction, not as current evidence.
+
+The current graph-readiness diagnostic is intentionally fail-closed: `full_decode_capture_ready=false` for NCCL. A basic preallocated f32 NCCL all-reduce smoke now captures, replays, and verifies on the latest A800 run, but that proves only the collective smoke shape. It is not full decode CUDA Graph coverage. HF, host-staged, and NCCL remain token/text exact for the narrow greedy gate.
 
 The next implementation should be chosen from measured evidence:
 

--- a/pegainfer-deepseek-v2-lite/src/bin/dsv2_lite_ep2_decode_attribution.rs
+++ b/pegainfer-deepseek-v2-lite/src/bin/dsv2_lite_ep2_decode_attribution.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::{Context, Result, bail, ensure};
-use pegainfer_deepseek_v2_lite::DeepSeekV2LiteEp2Generator;
+use pegainfer_deepseek_v2_lite::{DecodeGraphReadinessReport, DeepSeekV2LiteEp2Generator};
 use pegainfer_engine::engine::EngineLoadOptions;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -29,6 +29,7 @@ const EXPECTED_OUTPUT_SHA256_PAIRS: &[(&str, &str, &str)] = &[
 struct Cli {
     model_path: String,
     batch_size: usize,
+    nccl_graph_smoke: bool,
     out: Option<PathBuf>,
 }
 
@@ -66,7 +67,15 @@ fn main() -> Result<()> {
     let report = if cli.batch_size == 1 {
         let (result, attribution) =
             generator.generate_greedy_with_attribution(&prompt_tokens, OUTPUT_LEN, false)?;
-        single_report(&tokenizer, &prompt_tokens, result, attribution)?
+        let graph_readiness =
+            generator.decode_graph_readiness_report(&result.stats, 1, cli.nccl_graph_smoke)?;
+        single_report(
+            &tokenizer,
+            &prompt_tokens,
+            result,
+            attribution,
+            graph_readiness,
+        )?
     } else {
         let (result, attribution) = generator.generate_greedy_batch_same_prompt_with_attribution(
             &prompt_tokens,
@@ -74,7 +83,18 @@ fn main() -> Result<()> {
             OUTPUT_LEN,
             true,
         )?;
-        batch_report(&tokenizer, &prompt_tokens, result, attribution)?
+        let graph_readiness = generator.decode_graph_readiness_report(
+            &result.stats,
+            cli.batch_size,
+            cli.nccl_graph_smoke,
+        )?;
+        batch_report(
+            &tokenizer,
+            &prompt_tokens,
+            result,
+            attribution,
+            graph_readiness,
+        )?
     };
 
     let text = serde_json::to_string_pretty(&report)?;
@@ -96,6 +116,7 @@ fn single_report(
     prompt_tokens: &[u32],
     result: pegainfer_deepseek_v2_lite::GenerationResult,
     attribution: pegainfer_deepseek_v2_lite::DecodeAttributionProfile,
+    graph_readiness: DecodeGraphReadinessReport,
 ) -> Result<Value> {
     let generated_text = tokenizer
         .decode(&result.tokens, false)
@@ -164,8 +185,9 @@ fn single_report(
         "by_call_site": attribution.by_call_site(),
         "by_gpu_section": by_gpu_section,
         "by_gpu_call_site": by_gpu_call_site,
-        "coverage": coverage_rows(&result.stats.ep_backend, 1, &attribution),
+        "coverage": coverage_rows(&result.stats.ep_backend, 1, &attribution, &graph_readiness),
         "ep": ep_report(&result.stats),
+        "cuda_graph_readiness": graph_readiness,
         "claim_boundary": "Attribution only for the covered EP2 Hello/16 decode gate. CPU-side section timing, selected CUDA event timing, NVTX ranges, and route/collective counts are not a throughput, sparse-dispatch, multi-node, or production EP readiness claim.",
     }))
 }
@@ -175,6 +197,7 @@ fn batch_report(
     prompt_tokens: &[u32],
     result: pegainfer_deepseek_v2_lite::BatchedGenerationResult,
     attribution: pegainfer_deepseek_v2_lite::DecodeAttributionProfile,
+    graph_readiness: DecodeGraphReadinessReport,
 ) -> Result<Value> {
     ensure!(
         result.per_token_decode_us == attribution.per_token_decode_us(),
@@ -267,8 +290,9 @@ fn batch_report(
         "by_call_site": attribution.by_call_site(),
         "by_gpu_section": by_gpu_section,
         "by_gpu_call_site": by_gpu_call_site,
-        "coverage": coverage_rows(&result.stats.ep_backend, result.tokens.len(), &attribution),
+        "coverage": coverage_rows(&result.stats.ep_backend, result.tokens.len(), &attribution, &graph_readiness),
         "ep": ep_report(&result.stats),
+        "cuda_graph_readiness": graph_readiness,
         "claim_boundary": "Attribution only for the covered EP2 Hello/16 same-prompt batched decode gate. CPU-side section timing, selected CUDA event timing, NVTX ranges, and route/collective counts are not a throughput, sparse-dispatch, multi-node, or production EP readiness claim.",
     }))
 }
@@ -276,6 +300,7 @@ fn batch_report(
 fn parse_cli() -> Result<Cli> {
     let mut model_path = "models/DeepSeek-V2-Lite".to_string();
     let mut batch_size = 1;
+    let mut nccl_graph_smoke = false;
     let mut out = None;
     let mut args = env::args().skip(1);
     while let Some(arg) = args.next() {
@@ -301,20 +326,24 @@ fn parse_cli() -> Result<Cli> {
                     args.next().context("--out requires a path argument")?,
                 ));
             }
+            "--nccl-graph-smoke" => {
+                nccl_graph_smoke = true;
+            }
             "-h" | "--help" => {
                 println!(
-                    "DeepSeek-V2-Lite EP2 decode attribution gate\n\nUSAGE:\n  dsv2_lite_ep2_decode_attribution [--model-path PATH] [--batch-size N] [--out PATH]\n\nThe gate is intentionally fixed to prompt=Hello, output_len=16, with batch-size in 1..=8. Select NCCL with PEGAINFER_DSV2_LITE_EP_BACKEND=nccl."
+                    "DeepSeek-V2-Lite EP2 decode attribution gate\n\nUSAGE:\n  dsv2_lite_ep2_decode_attribution [--model-path PATH] [--batch-size N] [--nccl-graph-smoke] [--out PATH]\n\nThe gate is intentionally fixed to prompt=Hello, output_len=16, with batch-size in 1..=8. Select NCCL with PEGAINFER_DSV2_LITE_EP_BACKEND=nccl. Use --nccl-graph-smoke to run a preallocated f32 NCCL all-reduce CUDA Graph capture/replay smoke after attribution."
                 );
                 std::process::exit(0);
             }
             other => bail!(
-                "unsupported argument `{other}`; supported flags: --model-path PATH, --batch-size N, --out PATH"
+                "unsupported argument `{other}`; supported flags: --model-path PATH, --batch-size N, --nccl-graph-smoke, --out PATH"
             ),
         }
     }
     Ok(Cli {
         model_path,
         batch_size,
+        nccl_graph_smoke,
         out,
     })
 }
@@ -373,6 +402,7 @@ fn coverage_rows(
     backend: &str,
     batch_size: usize,
     attribution: &pegainfer_deepseek_v2_lite::DecodeAttributionProfile,
+    graph_readiness: &DecodeGraphReadinessReport,
 ) -> Vec<Value> {
     vec![
         json!({
@@ -404,6 +434,16 @@ fn coverage_rows(
             "item": "throughput_or_production_ep_readiness",
             "status": "not_claimed",
             "source": format!("batch={batch_size} prompt=Hello output_len=16 diagnostic gate only"),
+        }),
+        json!({
+            "item": "full_decode_cuda_graph_capture",
+            "status": if graph_readiness.full_decode_capture_ready() { "ready" } else { "blocked" },
+            "source": format!("{} blocker(s) reported by the DeepSeek-V2-Lite EP2 graph-readiness diagnostic", graph_readiness.blocker_count()),
+        }),
+        json!({
+            "item": "nccl_cuda_graph_smoke",
+            "status": graph_readiness.nccl_graph_smoke_status(),
+            "source": "optional preallocated f32 NCCL all-reduce capture/replay smoke; this is not full decode graph coverage",
         }),
     ]
 }

--- a/pegainfer-deepseek-v2-lite/src/lib.rs
+++ b/pegainfer-deepseek-v2-lite/src/lib.rs
@@ -19,7 +19,8 @@ pub use config::Config;
 use config::SUPPORTED_HIDDEN_SIZE;
 use ep::SUPPORTED_ROUTED_EXPERTS;
 pub use runtime::{
-    BatchedGenerationResult, DeepSeekV2LiteEp2Generator, GenerationResult, GenerationStats,
+    BatchedGenerationResult, DecodeGraphReadinessReport, DeepSeekV2LiteEp2Generator,
+    GenerationResult, GenerationStats,
 };
 
 pub fn probe_config_json(json: &serde_json::Value) -> Result<bool> {

--- a/pegainfer-deepseek-v2-lite/src/nccl_backend.rs
+++ b/pegainfer-deepseek-v2-lite/src/nccl_backend.rs
@@ -331,14 +331,17 @@ impl NaiveNcclEp2Backend {
         let mut rank0_capture_started = false;
         let mut rank1_capture_started = false;
         let capture_result = (|| -> Result<(RawCudaGraph, RawCudaGraph)> {
+            activate(rank0)?;
             begin_capture(rank0.stream.cu_stream(), "rank0")?;
             rank0_capture_started = true;
+            activate(rank1)?;
             begin_capture(rank1.stream.cu_stream(), "rank1")?;
             rank1_capture_started = true;
 
             self.grouped(
                 "DeepSeek-V2-Lite NCCL graph smoke all-reduce capture",
                 || {
+                    activate(rank0)?;
                     self.all_reduce_f32_raw(
                         0,
                         rank0_send_ptr,
@@ -347,6 +350,7 @@ impl NaiveNcclEp2Backend {
                         rank0.stream.cu_stream(),
                         "DeepSeek-V2-Lite NCCL graph smoke rank0 all-reduce",
                     )?;
+                    activate(rank1)?;
                     self.all_reduce_f32_raw(
                         1,
                         rank1_send_ptr,
@@ -359,12 +363,16 @@ impl NaiveNcclEp2Backend {
                 },
             )?;
 
+            activate(rank0)?;
             let captured0 = end_capture(rank0.stream.cu_stream(), "rank0")?;
             rank0_capture_started = false;
+            activate(rank1)?;
             let captured1 = end_capture(rank1.stream.cu_stream(), "rank1")?;
             rank1_capture_started = false;
             report.captured = true;
+            activate(rank0)?;
             let graph0 = captured0.instantiate("rank0")?;
+            activate(rank1)?;
             let graph1 = captured1.instantiate("rank1")?;
             Ok((graph0, graph1))
         })();
@@ -381,9 +389,11 @@ impl NaiveNcclEp2Backend {
             }
         }
 
+        activate(rank0)?;
         graph0
             .launch(rank0.stream.cu_stream(), "rank0")
             .context("launch captured rank0 NCCL CUDA Graph")?;
+        activate(rank1)?;
         graph1
             .launch(rank1.stream.cu_stream(), "rank1")
             .context("launch captured rank1 NCCL CUDA Graph")?;
@@ -572,6 +582,7 @@ impl NaiveNcclEp2Backend {
 
 fn cleanup_capture(ctx: &DeviceContext, capture_started: bool) {
     if capture_started {
+        let _ = activate(ctx);
         let _ = end_capture(ctx.stream.cu_stream(), "cleanup");
     }
 }

--- a/pegainfer-deepseek-v2-lite/src/nccl_backend.rs
+++ b/pegainfer-deepseek-v2-lite/src/nccl_backend.rs
@@ -6,12 +6,19 @@ use std::{
 
 use anyhow::{Context, Result, bail, ensure};
 use cudarc::{
-    driver::{CudaSlice, DevicePtr, DevicePtrMut, sys::CUstream},
+    driver::{
+        CudaSlice, DevicePtr, DevicePtrMut,
+        sys::{
+            CUdeviceptr, CUgraph, CUgraphExec, CUstream,
+            CUstreamCaptureMode_enum::CU_STREAM_CAPTURE_MODE_THREAD_LOCAL,
+        },
+    },
     nccl::sys::{ncclComm_t, ncclDataType_t, ncclRedOp_t, ncclResult_t},
 };
 use half::bf16;
 use libloading::Library;
 use pegainfer_core::tensor::{DeviceContext, HiddenStates};
+use serde::Serialize;
 
 use crate::device::activate;
 
@@ -35,6 +42,50 @@ type NcclGetErrorString = unsafe extern "C" fn(ncclResult_t) -> *const c_char;
 pub(crate) struct NaiveNcclEp2Backend {
     lib: Arc<RawNcclLib>,
     comms: Vec<ncclComm_t>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct NcclGraphSmokeReport {
+    attempted: bool,
+    captured: bool,
+    replayed: bool,
+    verified: bool,
+    count: usize,
+    expected_sum: f32,
+    rank0_value: Option<f32>,
+    rank1_value: Option<f32>,
+    capture_error: Option<String>,
+    replay_error: Option<String>,
+    verification_error: Option<String>,
+    capture_mode: &'static str,
+}
+
+impl NcclGraphSmokeReport {
+    pub(crate) fn coverage_status(&self) -> &'static str {
+        if self.verified {
+            "captured_replayed_verified"
+        } else if self.replayed {
+            "replayed_but_not_verified"
+        } else if self.captured {
+            "captured_but_not_replayed"
+        } else {
+            "failed"
+        }
+    }
+
+    pub(crate) fn verified(&self) -> bool {
+        self.verified
+    }
+
+    pub(crate) fn failure_summary(&self) -> String {
+        format!(
+            "status={}, capture_error={:?}, replay_error={:?}, verification_error={:?}",
+            self.coverage_status(),
+            self.capture_error,
+            self.replay_error,
+            self.verification_error
+        )
+    }
 }
 
 struct RawNcclLib {
@@ -222,6 +273,147 @@ impl NaiveNcclEp2Backend {
         Ok(())
     }
 
+    pub(crate) fn graph_smoke_all_reduce_f32(
+        &self,
+        rank0: &DeviceContext,
+        rank1: &DeviceContext,
+    ) -> NcclGraphSmokeReport {
+        let mut report = NcclGraphSmokeReport {
+            attempted: true,
+            captured: false,
+            replayed: false,
+            verified: false,
+            count: 1,
+            expected_sum: 3.0,
+            rank0_value: None,
+            rank1_value: None,
+            capture_error: None,
+            replay_error: None,
+            verification_error: None,
+            capture_mode: "thread_local",
+        };
+
+        if let Err(err) = self.graph_smoke_all_reduce_f32_inner(rank0, rank1, &mut report) {
+            let message = format!("{err:#}");
+            if report.captured {
+                report.replay_error = Some(message);
+            } else {
+                report.capture_error = Some(message);
+            }
+        }
+        report
+    }
+
+    fn graph_smoke_all_reduce_f32_inner(
+        &self,
+        rank0: &DeviceContext,
+        rank1: &DeviceContext,
+        report: &mut NcclGraphSmokeReport,
+    ) -> Result<()> {
+        activate(rank0)?;
+        let rank0_send = rank0.stream.clone_htod(&[1.0f32])?;
+        let mut rank0_recv = rank0.stream.alloc_zeros::<f32>(report.count)?;
+        activate(rank1)?;
+        let rank1_send = rank1.stream.clone_htod(&[2.0f32])?;
+        let mut rank1_recv = rank1.stream.alloc_zeros::<f32>(report.count)?;
+        rank0.sync()?;
+        rank1.sync()?;
+
+        let rank0_stream = rank0.stream.clone();
+        let rank1_stream = rank1.stream.clone();
+        let (rank0_send_ptr, rank0_send_guard) = rank0_send.device_ptr(&rank0_stream);
+        let (rank0_recv_ptr, rank0_recv_guard) = rank0_recv.device_ptr_mut(&rank0_stream);
+        let (rank1_send_ptr, rank1_send_guard) = rank1_send.device_ptr(&rank1_stream);
+        let (rank1_recv_ptr, rank1_recv_guard) = rank1_recv.device_ptr_mut(&rank1_stream);
+
+        let graph0;
+        let graph1;
+        let mut rank0_capture_started = false;
+        let mut rank1_capture_started = false;
+        let capture_result = (|| -> Result<(RawCudaGraph, RawCudaGraph)> {
+            begin_capture(rank0.stream.cu_stream(), "rank0")?;
+            rank0_capture_started = true;
+            begin_capture(rank1.stream.cu_stream(), "rank1")?;
+            rank1_capture_started = true;
+
+            self.grouped(
+                "DeepSeek-V2-Lite NCCL graph smoke all-reduce capture",
+                || {
+                    self.all_reduce_f32_raw(
+                        0,
+                        rank0_send_ptr,
+                        rank0_recv_ptr,
+                        report.count,
+                        rank0.stream.cu_stream(),
+                        "DeepSeek-V2-Lite NCCL graph smoke rank0 all-reduce",
+                    )?;
+                    self.all_reduce_f32_raw(
+                        1,
+                        rank1_send_ptr,
+                        rank1_recv_ptr,
+                        report.count,
+                        rank1.stream.cu_stream(),
+                        "DeepSeek-V2-Lite NCCL graph smoke rank1 all-reduce",
+                    )?;
+                    Ok(())
+                },
+            )?;
+
+            let captured0 = end_capture(rank0.stream.cu_stream(), "rank0")?;
+            rank0_capture_started = false;
+            let captured1 = end_capture(rank1.stream.cu_stream(), "rank1")?;
+            rank1_capture_started = false;
+            report.captured = true;
+            let graph0 = captured0.instantiate("rank0")?;
+            let graph1 = captured1.instantiate("rank1")?;
+            Ok((graph0, graph1))
+        })();
+
+        match capture_result {
+            Ok((captured0, captured1)) => {
+                graph0 = captured0;
+                graph1 = captured1;
+            }
+            Err(err) => {
+                cleanup_capture(rank0, rank0_capture_started);
+                cleanup_capture(rank1, rank1_capture_started);
+                return Err(err);
+            }
+        }
+
+        graph0
+            .launch(rank0.stream.cu_stream(), "rank0")
+            .context("launch captured rank0 NCCL CUDA Graph")?;
+        graph1
+            .launch(rank1.stream.cu_stream(), "rank1")
+            .context("launch captured rank1 NCCL CUDA Graph")?;
+        report.replayed = true;
+        rank0.sync()?;
+        rank1.sync()?;
+        drop(rank0_send_guard);
+        drop(rank0_recv_guard);
+        drop(rank1_send_guard);
+        drop(rank1_recv_guard);
+
+        activate(rank0)?;
+        let rank0_values = rank0.stream.clone_dtoh(&rank0_recv)?;
+        rank0.sync()?;
+        activate(rank1)?;
+        let rank1_values = rank1.stream.clone_dtoh(&rank1_recv)?;
+        rank1.sync()?;
+        report.rank0_value = rank0_values.first().copied();
+        report.rank1_value = rank1_values.first().copied();
+        if rank0_values == [report.expected_sum] && rank1_values == [report.expected_sum] {
+            report.verified = true;
+        } else {
+            report.verification_error = Some(format!(
+                "expected [{expected}], got rank0={rank0_values:?}, rank1={rank1_values:?}",
+                expected = report.expected_sum
+            ));
+        }
+        Ok(())
+    }
+
     fn validate_communicators(&self, expected_ordinals: &[c_int; 2]) -> Result<()> {
         for (rank, expected_ordinal) in expected_ordinals.iter().copied().enumerate() {
             let comm = self.comm(rank)?;
@@ -305,6 +497,38 @@ impl NaiveNcclEp2Backend {
         let status = unsafe {
             // SAFETY: Device pointers come from cudarc allocations and `count`
             // was checked against both buffers before enqueueing the collective.
+            self.enqueue_all_reduce_f32(rank, send_ptr, recv_ptr, count, stream)?
+        };
+        self.lib.check(status, context)
+    }
+
+    fn all_reduce_f32_raw(
+        &self,
+        rank: usize,
+        send_ptr: CUdeviceptr,
+        recv_ptr: CUdeviceptr,
+        count: usize,
+        stream: CUstream,
+        context: &str,
+    ) -> Result<()> {
+        let status = unsafe {
+            // SAFETY: The caller pre-validates that pointers come from live
+            // device allocations with at least `count` f32 elements and keeps
+            // the cudarc access guards alive until capture/enqueue completes.
+            self.enqueue_all_reduce_f32(rank, send_ptr, recv_ptr, count, stream)?
+        };
+        self.lib.check(status, context)
+    }
+
+    unsafe fn enqueue_all_reduce_f32(
+        &self,
+        rank: usize,
+        send_ptr: CUdeviceptr,
+        recv_ptr: CUdeviceptr,
+        count: usize,
+        stream: CUstream,
+    ) -> Result<ncclResult_t> {
+        Ok(unsafe {
             (self.lib.all_reduce)(
                 send_ptr as *const c_void,
                 recv_ptr as *mut c_void,
@@ -314,8 +538,7 @@ impl NaiveNcclEp2Backend {
                 self.comm(rank)?,
                 stream,
             )
-        };
-        self.lib.check(status, context)
+        })
     }
 
     fn comm(&self, rank: usize) -> Result<ncclComm_t> {
@@ -345,6 +568,114 @@ impl NaiveNcclEp2Backend {
         op_result?;
         end_result
     }
+}
+
+fn cleanup_capture(ctx: &DeviceContext, capture_started: bool) {
+    if capture_started {
+        let _ = end_capture(ctx.stream.cu_stream(), "cleanup");
+    }
+}
+
+struct CapturedCudaGraph {
+    graph: CUgraph,
+}
+
+impl CapturedCudaGraph {
+    fn instantiate(mut self, rank_label: &str) -> Result<RawCudaGraph> {
+        let mut exec = ptr::null_mut();
+        let status = unsafe {
+            // SAFETY: `graph` was returned by `cuStreamEndCapture` and is
+            // still owned by this captured graph wrapper.
+            cudarc::driver::sys::cuGraphInstantiateWithFlags(&mut exec, self.graph, 0)
+        };
+        if status != cudarc::driver::sys::CUresult::CUDA_SUCCESS || exec.is_null() {
+            bail!("instantiate CUDA Graph on {rank_label} stream failed with {status:?}");
+        }
+        let graph = self.graph;
+        self.graph = ptr::null_mut();
+        Ok(RawCudaGraph { graph, exec })
+    }
+}
+
+impl Drop for CapturedCudaGraph {
+    fn drop(&mut self) {
+        if !self.graph.is_null() {
+            let _ = unsafe {
+                // SAFETY: Best-effort destruction for an uninstantiated graph
+                // owned by the smoke helper.
+                cudarc::driver::sys::cuGraphDestroy(self.graph)
+            };
+            self.graph = ptr::null_mut();
+        }
+    }
+}
+
+struct RawCudaGraph {
+    graph: CUgraph,
+    exec: CUgraphExec,
+}
+
+impl RawCudaGraph {
+    fn launch(&self, stream: CUstream, label: &str) -> Result<()> {
+        let status = unsafe {
+            // SAFETY: `exec` is instantiated from the graph captured on this
+            // rank stream, and launch is part of the paired NCCL graph smoke.
+            cudarc::driver::sys::cuGraphLaunch(self.exec, stream)
+        };
+        ensure!(
+            status == cudarc::driver::sys::CUresult::CUDA_SUCCESS,
+            "{label}: cuGraphLaunch failed with {status:?}"
+        );
+        Ok(())
+    }
+}
+
+impl Drop for RawCudaGraph {
+    fn drop(&mut self) {
+        if !self.exec.is_null() {
+            let _ = unsafe {
+                // SAFETY: Best-effort destruction for graph exec owned by this
+                // smoke helper.
+                cudarc::driver::sys::cuGraphExecDestroy(self.exec)
+            };
+            self.exec = ptr::null_mut();
+        }
+        if !self.graph.is_null() {
+            let _ = unsafe {
+                // SAFETY: Best-effort destruction for graph owned by this
+                // smoke helper.
+                cudarc::driver::sys::cuGraphDestroy(self.graph)
+            };
+            self.graph = ptr::null_mut();
+        }
+    }
+}
+
+fn begin_capture(stream: CUstream, rank_label: &str) -> Result<()> {
+    let status = unsafe {
+        // SAFETY: `stream` is a live rank stream. This smoke intentionally
+        // avoids context rebinding inside the capture window to match
+        // nccl-tests' per-stream capture shape.
+        cudarc::driver::sys::cuStreamBeginCapture_v2(stream, CU_STREAM_CAPTURE_MODE_THREAD_LOCAL)
+    };
+    ensure!(
+        status == cudarc::driver::sys::CUresult::CUDA_SUCCESS,
+        "begin CUDA Graph capture on {rank_label} stream failed with {status:?}"
+    );
+    Ok(())
+}
+
+fn end_capture(stream: CUstream, rank_label: &str) -> Result<CapturedCudaGraph> {
+    let mut graph = ptr::null_mut();
+    let status = unsafe {
+        // SAFETY: Matches `begin_capture` on the same live rank stream.
+        cudarc::driver::sys::cuStreamEndCapture(stream, &mut graph)
+    };
+    ensure!(
+        status == cudarc::driver::sys::CUresult::CUDA_SUCCESS && !graph.is_null(),
+        "end CUDA Graph capture on {rank_label} stream failed with {status:?}"
+    );
+    Ok(CapturedCudaGraph { graph })
 }
 
 impl Drop for NaiveNcclEp2Backend {

--- a/pegainfer-deepseek-v2-lite/src/runtime.rs
+++ b/pegainfer-deepseek-v2-lite/src/runtime.rs
@@ -11,6 +11,7 @@ use pegainfer_core::{
     tensor::{DeviceVec, HiddenStates},
 };
 use pegainfer_engine::engine::{EngineLoadOptions, FinishReason};
+use serde::Serialize;
 use sha2::{Digest, Sha256};
 
 use crate::{
@@ -29,7 +30,7 @@ use crate::{
         AttentionWeights, DriverRankModel, ExpertMlp, ExpertRankModel, MlpWeights, MoeMlp,
         dense_mlp_forward, dense_mlp_forward_per_token,
     },
-    nccl_backend::NaiveNcclEp2Backend,
+    nccl_backend::{NaiveNcclEp2Backend, NcclGraphSmokeReport},
     weights::{ModelManifest, RankLoadPlan},
 };
 
@@ -75,6 +76,64 @@ pub struct BatchedGenerationResult {
     pub per_token_decode_us: Vec<u64>,
     pub total_generation_us: u64,
     pub stats: GenerationStats,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct DecodeGraphReadinessReport {
+    schema: u32,
+    backend: String,
+    batch_size: usize,
+    full_decode_capture_ready: bool,
+    status: &'static str,
+    blockers: Vec<DecodeGraphBlocker>,
+    metrics: DecodeGraphReadinessMetrics,
+    nccl_graph_smoke_requested: bool,
+    nccl_graph_smoke: Option<NcclGraphSmokeReport>,
+    claim_boundary: &'static str,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct DecodeGraphBlocker {
+    id: &'static str,
+    source: &'static str,
+    reason: &'static str,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct DecodeGraphReadinessMetrics {
+    host_dispatch_calls: usize,
+    host_combine_calls: usize,
+    host_dispatch_elements: usize,
+    host_combine_elements: usize,
+    nccl_dense_exchange_calls: usize,
+    nccl_combine_calls: usize,
+    nccl_dense_exchange_elements: usize,
+    nccl_combine_elements: usize,
+    nccl_dispatch_local_routes: usize,
+    nccl_dispatch_remote_routes: usize,
+    nccl_combine_routes: usize,
+}
+
+impl DecodeGraphReadinessReport {
+    pub fn full_decode_capture_ready(&self) -> bool {
+        self.full_decode_capture_ready
+    }
+
+    pub fn blocker_count(&self) -> usize {
+        self.blockers.len()
+    }
+
+    pub fn nccl_graph_smoke_status(&self) -> &'static str {
+        if self.backend != NCCL_BACKEND {
+            return "not_applicable";
+        }
+        if !self.nccl_graph_smoke_requested {
+            return "not_run";
+        }
+        self.nccl_graph_smoke
+            .as_ref()
+            .map_or("not_run", NcclGraphSmokeReport::coverage_status)
+    }
 }
 
 pub struct DeepSeekV2LiteEp2Generator {
@@ -278,6 +337,63 @@ impl DeepSeekV2LiteEp2Generator {
             &mut attribution,
         )?;
         Ok((result, attribution))
+    }
+
+    pub fn decode_graph_readiness_report(
+        &self,
+        stats: &GenerationStats,
+        batch_size: usize,
+        run_nccl_graph_smoke: bool,
+    ) -> Result<DecodeGraphReadinessReport> {
+        let backend = self.backend.kind();
+        ensure!(
+            stats.ep_backend == backend.as_str(),
+            "DeepSeek-V2-Lite graph readiness stats backend mismatch: stats={}, runtime={}",
+            stats.ep_backend,
+            backend.as_str()
+        );
+        let nccl_graph_smoke = if run_nccl_graph_smoke {
+            match &self.backend {
+                EpBackendRuntime::Nccl(nccl) => {
+                    let report = nccl.graph_smoke_all_reduce_f32(&self.rank0.ctx, &self.rank1.ctx);
+                    ensure!(
+                        report.verified(),
+                        "DeepSeek-V2-Lite --nccl-graph-smoke failed: {}",
+                        report.failure_summary()
+                    );
+                    Some(report)
+                }
+                EpBackendRuntime::HostStaged => bail!(
+                    "DeepSeek-V2-Lite --nccl-graph-smoke requires PEGAINFER_DSV2_LITE_EP_BACKEND=nccl"
+                ),
+            }
+        } else {
+            None
+        };
+        Ok(DecodeGraphReadinessReport {
+            schema: 1,
+            backend: stats.ep_backend.clone(),
+            batch_size,
+            full_decode_capture_ready: false,
+            status: decode_graph_readiness_status(backend),
+            blockers: decode_graph_blockers(backend),
+            metrics: DecodeGraphReadinessMetrics {
+                host_dispatch_calls: stats.host_dispatch_calls,
+                host_combine_calls: stats.host_combine_calls,
+                host_dispatch_elements: stats.host_dispatch_elements,
+                host_combine_elements: stats.host_combine_elements,
+                nccl_dense_exchange_calls: stats.nccl_dense_exchange_calls,
+                nccl_combine_calls: stats.nccl_combine_calls,
+                nccl_dense_exchange_elements: stats.nccl_dense_exchange_elements,
+                nccl_combine_elements: stats.nccl_combine_elements,
+                nccl_dispatch_local_routes: stats.nccl_dispatch_local_routes,
+                nccl_dispatch_remote_routes: stats.nccl_dispatch_remote_routes,
+                nccl_combine_routes: stats.nccl_combine_routes,
+            },
+            nccl_graph_smoke_requested: run_nccl_graph_smoke,
+            nccl_graph_smoke,
+            claim_boundary: "This is a graph-readiness diagnostic for the covered DeepSeek-V2-Lite EP2 decode attribution gate. A successful NCCL f32 smoke proves only basic preallocated collective capture/replay on this runtime; it is not full decode CUDA Graph coverage or a performance claim.",
+        })
     }
 
     fn generate_greedy_batch_same_prompt_inner(
@@ -1421,6 +1537,72 @@ impl DeepSeekV2LiteEp2Generator {
         let mut out = vec![bf16::ZERO; input.len];
         rms_norm_host(&input_host, weight, self.config.rms_norm_eps, &mut out);
         DeviceVec::from_host(&self.rank0.ctx, &out)
+    }
+}
+
+fn decode_graph_readiness_status(backend: EpBackendKind) -> &'static str {
+    match backend {
+        EpBackendKind::HostStaged => "not_applicable_host_staged_backend",
+        EpBackendKind::Nccl => "blocked_full_decode_path",
+    }
+}
+
+fn decode_graph_blockers(backend: EpBackendKind) -> Vec<DecodeGraphBlocker> {
+    match backend {
+        EpBackendKind::HostStaged => vec![
+            DecodeGraphBlocker {
+                id: "host_staged_route_and_dispatch_on_host",
+                source: "runtime.rs::moe_forward_host_staged",
+                reason: "routing, per-route expert dispatch, and contribution accumulation are intentionally host-staged",
+            },
+            DecodeGraphBlocker {
+                id: "host_staged_hidden_d2h_and_h2d",
+                source: "host_ops.rs::hidden_to_bf16 / hidden_from_f32_host",
+                reason: "the baseline path copies hidden states through host memory and synchronizes around those copies",
+            },
+        ],
+        EpBackendKind::Nccl => vec![
+            DecodeGraphBlocker {
+                id: "nccl_dense_exchange_allocates_per_call",
+                source: "nccl_backend.rs::dense_all_reduce_rank0_hidden_to_rank1",
+                reason: "rank0/rank1 receive and zero-send buffers are allocated inside each dense exchange",
+            },
+            DecodeGraphBlocker {
+                id: "nccl_dense_exchange_syncs_rank_streams",
+                source: "nccl_backend.rs::dense_all_reduce_rank0_hidden_to_rank1",
+                reason: "both rank streams are synchronized after every dense exchange",
+            },
+            DecodeGraphBlocker {
+                id: "nccl_route_iteration_on_host",
+                source: "runtime.rs::moe_forward_nccl",
+                reason: "expert routing and per-route loop decisions stay on the host",
+            },
+            DecodeGraphBlocker {
+                id: "nccl_contribution_accumulation_on_host",
+                source: "runtime.rs::moe_forward_nccl",
+                reason: "local and remote expert outputs are copied back and accumulated in host vectors",
+            },
+            DecodeGraphBlocker {
+                id: "nccl_combine_h2d_contribution_copy",
+                source: "nccl_backend.rs::combine_f32_contributions_to_rank0",
+                reason: "rank contributions are copied from host to device for each combine call",
+            },
+            DecodeGraphBlocker {
+                id: "nccl_combine_allocates_per_call",
+                source: "nccl_backend.rs::combine_f32_contributions_to_rank0",
+                reason: "send and receive buffers are allocated inside each combine call",
+            },
+            DecodeGraphBlocker {
+                id: "nccl_combine_syncs_rank_streams",
+                source: "nccl_backend.rs::combine_f32_contributions_to_rank0",
+                reason: "both rank streams are synchronized after every combine collective",
+            },
+            DecodeGraphBlocker {
+                id: "nccl_combine_d2h_result_copy",
+                source: "nccl_backend.rs::combine_f32_contributions_to_rank0",
+                reason: "the combined rank0 result is copied back to host before being uploaded again",
+            },
+        ],
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a narrow CUDA Graph readiness section to the existing DeepSeek-V2-Lite EP2 decode attribution gate.

The new `cuda_graph_readiness` JSON reports that full NCCL decode CUDA Graph capture is still blocked, lists the current blockers, and optionally runs a preallocated f32 NCCL all-reduce graph smoke with `--nccl-graph-smoke`. The smoke is fail-closed: when requested, the command exits non-zero unless capture, replay, and result verification all pass.

Related: #205, #170

## Scope

In scope:

- extend `dsv2_lite_ep2_decode_attribution` with `--nccl-graph-smoke`;
- emit `cuda_graph_readiness` in the existing attribution JSON;
- keep the current full decode CUDA Graph status as `full_decode_capture_ready=false`;
- verify a basic preallocated f32 NCCL all-reduce can be captured, replayed, and checked on the existing two rank streams;
- update the existing DeepSeek-V2-Lite status and attribution docs.

Out of scope:

- full DeepSeek-V2-Lite decode CUDA Graph capture;
- performance optimization or throughput claims;
- sparse dispatch;
- production continuous batching;
- generic EP, multi-node EP, or a new `pegainfer-comm` backend.

## Evidence

Local checks:

- `cargo fmt --check`
- `git diff --check`
- private-path / secret scan over the changed docs and source files

2x A800-SXM4-80GB validation:

- `cargo check --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite`
- `PEGAINFER_DSV2_LITE_EP_BACKEND=nccl cargo run --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite --bin dsv2_lite_ep2_decode_attribution -- --model-path models/DeepSeek-V2-Lite --batch-size 1 --nccl-graph-smoke --out <json>`

NCCL graph smoke result:

- `full_decode_cuda_graph_capture=blocked`
- `nccl_cuda_graph_smoke=captured_replayed_verified`
- `smoke_verified=true`
- `rank0_value=3.0`
- `rank1_value=3.0`
- `capture_error=null`
- `replay_error=null`
- `verification_error=null`

The same run preserved the existing A800 HF-confirmed output hashes:

- token SHA256: `d05a7b0f0ac6435fb51040582a337d8b6d72844dd61194daa1b3090fa0e16ce8`
- text SHA256: `4aaafbe4b3a46bc5b9ab5ea8d09d5fad71225006c2e234e87a928e3265b387c6`

## Claim Boundary

This PR proves only that a basic preallocated NCCL f32 all-reduce can be CUDA Graph captured, replayed, and verified in the covered DeepSeek-V2-Lite EP2 runtime.

It does not claim that the full decode path is graph-ready. The readiness report remains fail-closed and explicitly reports full decode capture as blocked.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have formatted my commit using Commitizen conventions.
- [x] I have run the relevant local and GPU validation checks.