### PR TITLE
docs(models): add Kimi-K2, Qwen3-4B, Qwen3.5-4B roadmaps

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 
 | Path | TL;DR |
 | --- | --- |
+| `models/kimi-k2/roadmap.md` | Cross-cutting Kimi-K2 plan, verified against code 2026-06: decode beats vLLM (bs64 `1336 vs 594 tok/s`) but serving contract is broken (sampling params silently ignored, no EOS stop, 2048-token arena overrun) and no accuracy gate is clone-reproducible. Sequence: correctness + accuracy-gate-in-git → TTFT/HTTP overhead → batching/prefix-cache and PPLX-throughput chains → cleanup ledger. |
 | `models/kimi-k2/optimization.md` | Kimi-K2 model card + optimization log：61 层 MLA + Marlin WNA16 MoE，H20 ×8 当前 TP8/EP8。重点是 decode：bs4 graph TPOT `14.39ms`（≈`278 tok/s`），目标 `> 300 tok/s`；下一阶段迁到 TP1+DP8+EP8（PPLX）。Prefill 优先级低。 |
 | `models/kimi-k2/support-analysis.md` | Kimi-K2 text-only bring-up：Marlin WNA16 routed expert、MLA prompt、全 61 层 prompt forward、多 prompt vLLM top-20 gate 已过；bs4 wave decode 已接入，Marlin atomic split-K row-state bug 修复后 output16 row diff 清零，正在撤掉 decode 诊断负担并回到 bs4 性能主线。 |
 | `models/kimi-k2/operator-todo.md` | Kimi-K2 算子清单：MLA + Marlin WNA16 routed expert + NCCL RS bridge 主链；CUDA Graph 覆盖整段 decode，synthetic output64 avg `14.39ms` / p99 `14.83ms`；CUTLASS INT4 后端与 decode row-diff 诊断已下线，详见 changelog。 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 
 | Path | TL;DR |
 | --- | --- |
+| `models/qwen3/roadmap.md` | Qwen3-4B roadmap (2026-06 review): line is the maturity bar; open set is #220 RoPE OOB, per-row batch sampling, zero TP coverage, zero-adapter-only LoRA gate, dropped prefix-cache observability, stale docs. Sequenced Now/Next/Later + cleanup ledger. |
 | `models/qwen3/model-crate.md` | `pegainfer-qwen3-4b` owns Qwen3 config/weights/executor/scheduler/tests/kernel plan; root sees generic `EngineHandle`; split-K retuned to `256/64`, with 4k/64 serving TPOT p50 at `6.46ms` on RTX 5090. |
 | `models/qwen3/prefix-cache.md` | Prefix caching on by default for Qwen3-4B: full-block kvbm radix matching at the executor, suffix-only prefill. Repeated ~1900-token prompt TTFT 141.8 → 16.3ms p50 (8.7×); warm TTFT ≈ TPOT + ~5ms setup. Includes the RoPE scalar-path corruption fix and the drain-the-stream TTFT measurement pitfall. |
 | `models/qwen3/accuracy-gate.md` | Qwen3-4B instance of the logits golden gate (`tests/hf_golden_gate.rs`): 48 teacher-forced sequences / 816 positions vs a stored HF bf16 golden, replayed over bs=1 / batched eager / CUDA-graph. Strict guards: regret check + mean ≤ 0.06 + p99 ≤ 0.20; absolute max printed but not asserted (coverage-unstable). Methodology in `subsystems/correctness/`. |
@@ -35,6 +36,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 
 | Path | TL;DR |
 | --- | --- |
+| `models/qwen35/roadmap.md` | Qwen3.5-4B roadmap (2026-06 review): fast and decode-correct, but a live long-prompt accuracy failure (GSM8K ~2% vs HF ~79%), no logits gate (#186, blocked on a teacher-forcing executor), ~640MB HND prefill staging + 20k cap, pre-#85 admission semantics. Sequenced Now/Next/Later + cleanup ledger. |
 | `models/qwen35/optimization.md` | Hybrid 24 linear + 8 full attn. At parity with vLLM: TTFT 225ms, TPOT 11.81ms (+1%). Post-accuracy-fix GDR decode kernel restore (#9). |
 | `models/qwen35/accuracy.md` | Qwen3.5-4B HF parity work: major decode-state bugs are fixed, `conv1d` now matches HF's bf16 pre-`SiLU` rounding, exact HF matches improved to 11/13, and only two small-logit-drift cases remain. |
 | `models/qwen35/model-crate.md` | `pegainfer-qwen35-4b` owns Qwen3.5 model/scheduler/recurrent ops/tests/benches; root loads it through `EngineHandle`. Build/check/clippy, root bench sanity check, Qwen3.5 e2e, and scheduler e2e pass. |

--- a/docs/models/kimi-k2/roadmap.md
+++ b/docs/models/kimi-k2/roadmap.md
@@ -1,0 +1,105 @@
+# Kimi-K2 Roadmap
+
+> **TL;DR:** Kimi-K2 decode performance is ahead of vLLM on the same H20 ×8 hardware (TP1+DP8+EP8 service bs64: output `1336 tok/s` vs vLLM `594 tok/s`, TPOT p50 `47.3ms` vs `107.2ms`), but the crate is far behind Qwen3-4B on the serving contract and correctness surface: every request runs greedy regardless of sampling params, never stops at EOS, prompts over 2048 tokens overrun the KV arena unchecked, and no accuracy gate is reproducible from a fresh clone. The roadmap sequence is: serving-contract correctness + a git-versioned accuracy gate first, then the TTFT/prefill and HTTP-overhead perf gaps, then the continuous-batching→KV-lifecycle→prefix-cache chain and the PPLX/decode-throughput chain. Findings verified 2026-06-04 against `6ee9247`.
+>
+> **Last touched:** 2026-06
+
+Status ledgers: [tp1-dp8-ep8-performance.md](tp1-dp8-ep8-performance.md) (active perf line), [optimization.md](optimization.md) (model card + TP8 history). This doc owns the cross-cutting plan: what's missing, what blocks what, and in which order.
+
+## Capability contract (Qwen3-4B as the maturity bar)
+
+| Capability | Qwen3-4B | Kimi-K2 | Evidence |
+| --- | --- | --- | --- |
+| EOS / stop-token detection | ✓ per-step `is_stop_token` | ✗ always `FinishReason::Length`, generates exactly `max_tokens` | no `eos` handling in `pegainfer-kimi-k2/src`; qwen3 `scheduler/resolve.rs:50` |
+| Sampling params | ✓ FlashInfer greedy + non-greedy | ✗ `req.params` never read — temperature/top_k/top_p **silently ignored**, always argmax | `runner/worker/forward.rs:113` top1 only |
+| Prompt-length guard | ✓ KV-budget admission rejects impossible requests | ✗ 2048-token arena cap (`worker.rs:60-61`), `append_position` unchecked → silent overrun | `runner/scheduler.rs:148-151` |
+| KV admission control | ✓ full-lifetime budget, deferral, rejection (issue #85 fix) | ✗ slot-count only on both paths | qwen3 `scheduler.rs:478-510` |
+| Continuous batching | ✓ | TP1/DP8: ✓ (`DpCoordinator` per-step admission, waiting queue); TP8/DP1: ✗ strict batch-then-drain | `runner/scheduler/dp.rs:168,189-236` vs `runner/scheduler.rs:140-207` |
+| Prefix cache | ✓ kvbm full-block matching (PR #216) | ✗ fixed per-slot arena, no block table / free pool | `runner/worker/cache.rs:391-396` |
+| Accuracy gate in git | ✓ `tests/hf_golden_gate.rs` + committed golden | ✗ no `tests/` dir (only model crate without one); fixtures + A/B harness live off-repo | see Accuracy section |
+| logprobs / echo | ✓ | ✗ `logprob: None` always, `PromptTokens` never emitted | `runner/scheduler/dp.rs:345` |
+| Bench-regression snapshot | ✓ `bench_snapshots/*/qwen3-4b.json` | ✗ no kimi snapshot, no h20 dir | `docs/conventions/bench-regression.md` |
+| CUDA Graph state | shared `pegainfer-core` type | ✓ same shared type + multi-rank synchronized capture | `runner/worker.rs:17` |
+| LoRA | ✓ | intentionally N/A, server rejects cleanly | `pegainfer-server/src/main.rs:101-103` |
+
+## Claim boundaries
+
+- **TP1+DP8+EP8 PPLX (active line):** service bs64 `256/256` success, output `1336 tok/s`, TPOT p50/p99 `47.3/47.7ms` — beats the vLLM out-of-box sustained baseline (`594 tok/s` / `107.2ms`, itself depressed by vLLM's DPLB/CUDA-graph bucket cliff; vLLM's balanced pinned capability is ~`48-50ms`). Greedy-only; token parity vs a reference trace is **not yet a gate** on this shape.
+- **TP8+EP8 NCCL (graph path):** bs4 TPOT `14.39ms` synthetic. Wave-batched, reference/history path.
+- **TTFT is the open perf gap:** HTTP decode-heavy bs4 TTFT p50 `313ms` / p99 `4240ms` vs vLLM `69.6/135.4ms` (4.5×/31× worse). Short-prompt streaming TTFT ~`2.0s`.
+- **HTTP vs in-process:** `19.13ms` vs `14.39ms` TPOT at bs4 — ~33% serving overhead, unattributed.
+- No claim of: non-greedy sampling, EOS-terminated generation, >2048-token prompts, long-context decode correctness, prefix reuse, multi-node.
+
+## Sequencing — what blocks what
+
+```
+Correctness milestone (M1) ──┬─→ any further kernel/decode opt (needs regression gate)
+Accuracy gate in git (M2) ───┘    K2.6 weight swap validation
+Lint-gate fix ───→ dead-code removal (cleanup ledger)
+TP8 continuous batching ─→ shared block table + free pool ─→ MLA physical backend
+                                ─→ nonzero-position prefill ─→ prefix cache ─→ DP prefix-affinity routing
+PPLX graph capturability / MoE pipelining ─→ TP1+DP8 decode throughput targets
+```
+
+## Roadmap
+
+### Now — M1: serving-contract correctness
+
+The engine is fast but does not honor the OpenAI contract it serves. All items are crash-early-or-honor, none are perf work:
+
+1. **EOS/stop-token handling.** Parse `eos_token_id`/`stop_token_ids` in `config.rs`, check per decode step on both scheduler paths, honor `ignore_eos`, emit `FinishReason::Stop`. Frontend mapping already exists.
+2. **Sampling params: honor or reject.** `req.params` is never read. Either route non-greedy rows through the shared FlashInfer sampling ops, or reject non-greedy requests explicitly. Audit the full OpenAI param surface (temperature/top_k/top_p, n, seed, penalties, stop strings) — each one: honored / rejected / documented-ignored. Silent-wrong is the only forbidden state.
+3. **Prompt-length guard.** Reject prompts whose `prompt + max_tokens` exceeds the 2048-token per-slot arena instead of overrunning KV pages.
+4. **KV admission + abort-on-disconnect.** Port the qwen3 admission pattern (budget, deferral, rejection) to both paths; wire disconnect-abort when the server-wide #215 lands.
+5. **`tests/` directory.** Scheduler-robustness ITs (CPU-runnable: admission, coalesce, slot-lifecycle edges) so the above gets regression coverage. Kimi-K2 is the only model crate without integration tests.
+
+### Now — M2: accuracy gate in git
+
+Today no accuracy claim is reproducible from a fresh clone: the vLLM top-20 fixture gate's reference *and* candidate fixtures live only on the H20 box, the PegaInfer-side candidate dumper was retired in PR #158, and the prefill-logits A/B harness that gated PR #204's kernel picks was never committed. The HF-loading recipe for K2.5 (trust_remote_code + vision-tower stub) is already solved in `pegainfer-kernels/tools/kimi_k2/hf_logits_reference.py`.
+
+1. Define the gate invariant per `docs/subsystems/correctness/logits-golden-gate.md`: teacher-forced per-position logprob delta vs a committed golden — not top-20 membership.
+2. Commit the reference fixture (top-K logprobs over a few sequences — small) under `test_data/`, plus a maintained candidate-dump entry point in the crate.
+3. The gate must replay **bs>1 and CUDA-graph** surfaces — every historical kimi accuracy bug was batch/row-state, exactly what one-shot bs1 runs miss.
+4. 8×H20-only model ⇒ the gate is a committed script run manually pre-release, with thresholds encoded in the script. It cannot live in CPU CI; it must still live in git.
+5. Commit the base-vs-opt prefill-logits A/B harness so future kernel picks repeat the PR #204 validation instead of re-inventing it.
+
+This milestone gates: further decode-kernel opts, the K2.6 weight swap, and any TP1/DP8 parity claim.
+
+### Next — serving performance
+
+6. **Prefill / TTFT milestone.** The largest user-visible gap vs vLLM (p50 4.5×, p99 31×). Decompose short-prompt TTFT (~2s): embedding / MLA prefill / MoE prefill / first-collective stream drain / per-layer scratch allocation; then fix the dominant term and add a TTFT gate. Target: vLLM's `69.6/135.4ms` class.
+7. **HTTP-overhead isolation.** ~33% (4.74ms/token) between in-process and HTTP at bs4. Cross-check the three causes already found on qwen3: TCP_NODELAY/Nagle on SSE, frontend bridge, zombie decode from missing abort.
+8. **TP8 continuous batching** (if TP8 stays a supported shape): running/waiting split as in dp.rs; recompute batch shape from live rows so retired rows stop paying collective width.
+9. **Bench-regression snapshot.** `bench_snapshots/h20/kimi-k2.json` via the existing `bench_serving` wiring, plugged into the convention's compare gate.
+10. **PPLX + CUDA Graph.** The EP all-to-all progresses via a host worker thread — non-capturable; graphs are hard-disabled on the PPLX path, leaving ~3ms/token of host enqueue on the table. Either device-side signaling to make a2a stream-capturable, or capture rank-local compute segments around it.
+11. **MoE layer pipelining on PPLX.** dispatch→Marlin→combine runs strictly serial per layer (~1.6ms/token structural bubble); the EpBackend already exposes the four phases separately for overlap.
+12. **DP8 routing quality.** `DpLoadBalancer::pick_rank` is greedy free-slot-count (duplicated in dp.rs); needs load- and (later) prefix-affinity-aware routing.
+
+### Later — structural
+
+13. **Prefix cache chain.** (a) shared block table + global free pool replacing the fixed per-slot arena; (b) MLA physical backend for kvbm — the logical layer (sequence hashing, block matching) is layout-agnostic and reusable, but `KvLayout`/`KvBuffer` are FullAttention-only and can't express the dual `ckv[512]+kpe[64]` segments; (c) nonzero-position suffix prefill — `configure_slot_prefill` hardcodes positions `0..seq_len`, and kpe is stored RoPE-applied, so cache-hit suffix prefill would reproduce qwen3's start-position drift bug unless positions are threaded through; gate with a cached-replay logits A/B; (d) DP8 prefix-affinity routing.
+14. **MLA split-KV decode.** `partition_kv=false`, one CTA scans the full KV serially per row — fine at 2k context, cannot saturate the GPU at long context. Prerequisite: a long-context decode harness (long-context correctness is currently not claimed at all).
+15. **TP8 cuBLASLt parity or formal demotion.** PR #204's cuBLASLt GEMM picks are shape-gated to TP1 (`local_heads==64`, `o_proj cols==8192`); TP8 silently falls back to the old GEMMs. Either add TP8-shaped plans or declare TP8 reference-only and stop maintaining two backends.
+16. **K2.6 readiness.** Same-architecture weights pending. Confirm drop-in swap (no manifest/config/kernel changes), and re-run the accuracy gate against K2.6 — impossible until M2 exists.
+17. **Multi-node DP/EP** per [dp-design.md](dp-design.md) §10.
+
+## Cleanup ledger
+
+Order matters: fix the lint gate first, or the dead code regrows.
+
+1. **Lint-gate hole.** The global clippy hook lints only `default-members` (pegainfer-server); the kimi hook is `--no-deps` scoped to `^pegainfer-kimi-k2/`. Net: `pegainfer-kernels/src/ops/kimi_k2/*`, kimi csrc, and `pegainfer-comm` are never `-D warnings` checked. Add a scoped hook for the kernels kimi slice (and comm).
+2. **Dead expert-major/CUTLASS-era cluster.** `experts.rs` (2682 lines, >1k redline) hides a retired API behind a whole-file `#![allow(dead_code, unreachable_pub)]`: 4 dead fns + dead types with zero external callers, plus 4 compiled-but-uncalled CUDA launchers in `kimi_experts.cu` and their FFI decls. Delete surgically (live Marlin kernels are interleaved in the same file), drop the file-level allow.
+3. **`weight_shape` tensor.** Loaded to GPU for 60 layers × 384 experts × 3 projections, validated to `[2]`, then never consumed by any kernel (dims come from manifest constants). Drop from the load path after the dead probe (its only consumer) is removed.
+4. **`KERNELS.md` stale rows.** References a deleted `.cu` file and two ops with zero code references.
+5. **Doc refresh.** `operator-todo.md` still asserts a `KIMI_RUNNER_MAX_BATCH = 4` hard-cap contract — code says 64 with buckets `[1..64]`; three docs still give repro commands using the removed `kimi-k2-pplx-ep` feature and `PEGAINFER_KIMI_PARALLEL` env (replaced by `--tp-size/--dp-size/--ep-backend`). `optimization.md` still headlines the TP8 bs4 path as mainline.
+6. **Doc consolidation.** Delete `dp1-tp8-ep8-performance.md` (superseded ledger) after lifting its lessons; collapse the bring-up trio (`support-analysis.md` / `changelog.md` / `operator-todo.md`) into one history doc, lifting to `docs/lessons/`: BF16 bulk all-reduce breaks greedy (keep the F32 bridge), merging shared+routed reduce breaks cold-batch greedy, and full-percentile reporting discipline.
+
+## Done criteria
+
+This roadmap is healthy when:
+
+- a temperature/top_p request is either correctly sampled or explicitly rejected — never silently greedy; generation stops at EOS;
+- a fresh clone + an 8×H20 node can re-run the accuracy gate from committed code and fixtures alone;
+- TTFT p50/p99 has a measured decomposition, a gate, and is within striking distance of the vLLM class;
+- prefix-cache work consumes the shared KV roadmap (#203 §1) rather than a kimi one-off;
+- `docs/models/kimi-k2/` describes the engine that exists, not the bring-up that happened.

--- a/docs/models/qwen3/roadmap.md
+++ b/docs/models/qwen3/roadmap.md
@@ -1,0 +1,59 @@
+# Qwen3-4B Roadmap
+
+> **TL;DR:** Qwen3-4B is the maturity bar of the project — continuous batching, TP=2, default-on prefix cache (#216), and the HF logits golden gate are all live — so its roadmap is sharpening, not bring-up. The verified open set: one real correctness bug (#220 RoPE cache 4096 vs 40960 admitted, silent OOB), per-row batch-decode sampling (O(batch) launches + syncs per step despite a production-proven batched primitive in-tree), zero TP correctness coverage, LoRA built but gated only by a zero-adapter smoke, prefix-cache observability dropped at the scheduler boundary, and a docs layer that describes deleted tooling. Findings verified 2026-06-04 against `6ee9247`.
+>
+> **Last touched:** 2026-06
+
+Tracking issue: see the `[Model] Qwen3-4B roadmap` GitHub issue. Cross-model items stay in `docs/roadmap/execution.md`; this doc owns the qwen3 line.
+
+## Where the line stands
+
+| Area | State | Evidence |
+| --- | --- | --- |
+| Batching | ✓ continuous, KV full-lifetime admission, rejection (#85 fix) | `scheduler.rs:478-510` |
+| Prefix cache | ✓ default-on full-block kvbm matching (#216); 4 cache-hit replay passes in the golden gate | `executor.rs:750-751`, `tests/hf_golden_gate.rs` |
+| Accuracy gate | ✓ HF bf16 golden, bs=1/batched/graph + cached replays; single-GPU, ≤256-token prompts | `tests/hf_golden_gate.rs:451` |
+| Long context | ✗ **#220 live**: RoPE cache built for 4096 positions, 40960 admitted, kernel reads unbounded | `weights.rs:314`, `prefill_attention.cu:75-76` |
+| Batch sampling | ✗ per-row: O(batch) launches + O(batch) D2H syncs per decode step; 1MB scratch literal | `executor.rs:159-179,212-214`, `ops/sampling.rs:7,204-208` |
+| TP correctness | ✗ zero automated coverage — every test runs `device_ordinals: vec![0]` | grep `tests/` |
+| LoRA | ⚠ load/unload/TP/request-level all built; only test uses a **zero adapter** | `lora.rs`, `tests/lora_smoke.rs:91-130` |
+| Non-greedy sampling | ✗ zero correctness coverage (all tests greedy); penalties/min_p absent from `SamplingParams` | grep `tests/` |
+| Bench snapshots | ⚠ exist but ~187 commits stale; not refreshed by #216; no mixed-load ITL profile | `bench_snapshots/` |
+| PP | greenfield (aspiration only) | — |
+
+## Roadmap
+
+### Now
+
+1. **#220 RoPE OOB fix.** Two scopes, deliberately split: (a) immediate — size the cos/sin cache from config and crash-early reject at admission past cache length; correct as a plain precompute *only because this checkpoint has `rope_scaling: null`*; (b) #8 YaRN is the prerequisite for any rope-scaled checkpoint — the precompute length must come from the scaled schedule. Add a >4096-position case to the gate once sized.
+2. **Batched greedy decode sampling.** Phase 1: route all-greedy batches through `argmax_batch_bf16_into` — one launch + one D2H per step; this primitive is production-proven in deepseek-v2-lite (`runtime.rs:1379`). `flashinfer_top1_batch_into` has *no* production caller and needs its own validation before use. Phase 2: batched random path with per-row params; source the 1MB FlashInfer row-state scratch from the kernel instead of the literal. Shared `pegainfer-core/kernels` work — covers qwen35 too. Gated by the existing golden gate.
+3. **Sampling correctness coverage.** Every test in both qwen crates is greedy. Add seed-determinism + temperature/top_k/top_p behavioral tests, and audit the frontend for silently-dropped params (penalties, min_p are absent from `SamplingParams` entirely) — the kimi-k2 silent-greedy bug (#237) shows this class is real and currently nothing would catch it here.
+4. **Prefix-cache observability.** `cached_tokens` is computed (`executor.rs:751`) and dies at the scheduler boundary; the frontend hardcodes `num_cached_tokens: 0`. Thread it through `TokenEvent::Scheduled` into usage; log hit rate. Adjacent: #78 (streaming usage discards completion_tokens) — same usage-accounting surface.
+
+### Next
+
+5. **Mixed-load ITL profile, then the chunked-prefill decision.** A long prompt admitted mid-decode runs as one unbounded prefill in the unified step (no per-step token budget exists) — the documented +38% ITL p99 tail vs vLLM. Maintainer stance on chunked prefill is *conditional* (`scheduler.md`: varied-length workloads break waves naturally); so the gate is a tracked mixed-load benchmark profile first, implementation only if the tail matters for a real workload. Refresh the stale bench snapshots in the same pass.
+6. **TP correctness pass.** Run the golden gate over `device_ordinals [0,1]` (skip when <2 GPUs) so the tolerances also guard sharding + all-reduce; TP=8 systematic pass after. A reduction-order or shard-offset bug is currently invisible to every gate.
+7. **LoRA real-adapter accuracy gate.** The last open #173 acceptance criterion: teacher-force one real PEFT adapter against an HF reference with the golden-gate tolerances. Today base==(base+zero·LoRA) is all that's proven. The salt-isolation of the prefix cache also deserves a pinning test (adapter A's blocks must not hit for adapter B).
+8. **Eviction behavioral test.** Evict-then-remiss is never exercised: register a prefix, release it, pressure the pool until eviction, assert truncated/zero match + correct recompute. kvbm-logical layer needs no GPU.
+9. **Disconnect block-pinning.** After #216, a disconnected request pins its cache blocks (strong Arcs) until the next failed send — #215 is now also a KV-budget problem. Scheduler half: proactive `token_tx.is_closed()` sweep per step; folds into the server-wide #215.
+
+### Later
+
+- **Pipeline parallelism** — greenfield, no code; revisit when a multi-node driver appears.
+- **Vocab-parallel embedding/lm_head + TP CUDA-graph** — the real open remainder of `tp-design.md`.
+
+## Cleanup ledger
+
+- **Issue hygiene:** #188 references a test target deleted in #194 — close as superseded by the golden gate. #203 §1 still claims qwen3 has no prefix reuse — stale since #216.
+- **Dead code:** `batch_decode_trace.rs` `HIDDEN_SIZE`/`INTERMEDIATE_SIZE` consts (pub, zero readers); `probe_model()`+`ModelInfo` uncalled (server inlines its own detection — same in qwen35; wire it or delete it).
+- **File size:** `executor.rs` (1435), `scheduler.rs` (1420, ~826 of them inline tests), `kernel_bench.rs` (1112) breach the 1k-line redline.
+- **Docs:** `model-crate.md` TL;DR advertises a deleted `qwen3_kernel_snapshot` bench and, with `kernels-crate.md`, uses the obsolete `crates/` layout in every command — collapse both into one slim layout doc. `tp-design.md` describes the implemented controller/worker runtime as future direction — rewrite to past tense, promote the 3 real open items. `kv-pressure-hang.md` — lift the KV-lifetime-reservation lessons to `docs/lessons/`, then delete. `execution.md` Done list predates #216.
+
+## Done criteria
+
+- No admitted request can read past the RoPE cache; long-context behavior is gated.
+- A bs=32 greedy decode step issues one sampling launch, not 32.
+- TP and LoRA paths sit under the same golden-gate tolerances as the single-GPU path.
+- Usage reporting (cached tokens, streaming completion tokens) is truthful.
+- The docs describe the crate that exists.

--- a/docs/models/qwen35/roadmap.md
+++ b/docs/models/qwen35/roadmap.md
@@ -1,0 +1,59 @@
+# Qwen3.5-4B Roadmap
+
+> **TL;DR:** Qwen3.5-4B is fast and decode-correct — GDR kernels optimized, CUDA-graph decode, TTFT/TPOT at vLLM parity, current bench snapshots — but it has a **live long-prompt accuracy failure** (GSM8K 8-shot scores ~2% vs ~79% on HF; short-prompt greedy e2e passes, so the divergence onsets with prompt length) and its only accuracy gate is the brittle exact-text e2e that #186 already indicts. The structural items behind both: no teacher-forcing executor (blocks any HF logits gate), a monolithic HND prefill staging path (~640MB transient per request, hard 20k-token cap), prompt-only admission with no rejection path, and zero CPU-testable scheduler logic. Findings verified 2026-06-04 against `6ee9247`.
+>
+> **Last touched:** 2026-06
+
+Tracking issue: see the `[Model] Qwen3.5-4B roadmap` GitHub issue. Sibling doc: `docs/models/qwen3/roadmap.md` — batched sampling and non-greedy coverage are shared items owned there.
+
+## Where the line stands
+
+| Area | State | Evidence |
+| --- | --- | --- |
+| Decode perf | ✓ GDR fused recurrent optimized; CUDA-graph decode; parity with vLLM | `docs/projects/qwen35-4b-optimization.md` |
+| Bench snapshots | ✓ current (unlike qwen3's) | `bench_snapshots/` |
+| **Long-prompt accuracy** | ✗ **GSM8K 8-shot ≈2% vs HF ≈79%** — catastrophic divergence on long prompts; short-prompt greedy exact-match passes | eval run 2026-06; `tests/e2e.rs` green |
+| Accuracy gate | ✗ exact-text e2e only (brittle, #186); no logits-level gate; `accuracy.md` describes a deleted dump toolchain (11/13 commands dead) | `tests/e2e.rs`, `docs/models/qwen35/accuracy.md` |
+| Teacher forcing | ✗ executor can only generate — no step-level forced-token path, hard prerequisite for any HF golden gate | `executor.rs` |
+| Prefill memory | ✗ monolithic HND staging ≈640MB transient per request; `MAX_SEQ = 20000` hard cap | `prefill.rs` |
+| Long context | ✗ RoPE cache 4096 positions vs `max_position_embeddings: 262144` — sibling of qwen3 #220 | `weights.rs:297` |
+| Admission | ✗ prompt-only KV sizing, no `Rejected` event, KV exhaustion mid-decode aborts the whole batch — pre-#85-fix semantics | `scheduler.rs` |
+| Scheduler tests | ✗ zero CPU-level tests; all logic behind GPU-coupled paths | — |
+| TP | ✗ absent (single GPU only) | — |
+| Prefix cache | ✗ absent; recurrent GDR state (~48MB per boundary snapshot) makes "prefix hit" itself a design question | — |
+
+## Roadmap
+
+### Now
+
+1. **Long-prompt accuracy bug.** The single most important item: bisect where the prefill diverges as prompt length grows (RoPE indexing past some boundary, GDR chunk recurrence at long T, staging-path numeric, and the 4096 RoPE cache are all candidates — the cache alone can't explain failures *below* 4096 if they exist, so first establish the onset length). Reproducible on one GPU with lm-eval against the OpenAI endpoint. The fix lands with a long-prompt case in whatever gate exists at that point.
+2. **Teacher-forcing step executor.** The executor only generates; an HF logits gate needs to force golden token IDs step by step. This is the load-bearing refactor under both the accuracy bug (bisection wants per-position logits on a fixed sequence) and #186. Design constraint: decode is graph-only here, so the gate's replay surfaces are qwen35-specific — graph decode replay and slot-compaction replay (state copied between slots) instead of qwen3's eager/graph pair.
+3. **#186 HF logits golden gate.** Port the qwen3 methodology (`docs/subsystems/correctness/logits-golden-gate.md`) once 2 exists: teacher-forced sequences, mean/p99 logprob-delta guards, replay passes for graph decode, slot compaction, and — once it exists — recurrent-state handoff. Retires the exact-text e2e and its baseline-regeneration churn. Rewrite `accuracy.md` around the new toolchain; today 11 of its 13 commands reference deleted tooling.
+4. **RoPE cache sibling fix.** Same shape as qwen3 #220: cache built for 4096, config admits 262144. Size from config + crash-early at admission. Community-friendly; coordinate with the qwen3 fix so both crates use the same pattern (and both inherit the YaRN #8 caveat for scaled checkpoints).
+
+### Next
+
+5. **Admission overhaul.** Three coupled defects, fixed together as the qwen35 analog of the #85 work: size admission on full lifetime (prompt + max_tokens), add the `Rejected` event path the engine contract already defines, and on KV exhaustion fail the offending request — not the batch. CPU-testable once 7 lands.
+6. **Prefill full-paged migration.** Replace the HND staging copy with direct paged writes: removes the ~640MB transient, the `MAX_SEQ=20000` cap, and the extra D2D pass. Chain dependency: paged-direct prefill → per-token position plumbing → (4) RoPE cache → opens the door to 8.
+7. **Scheduler logic seam.** Extract admission/eviction/slot decisions behind a GPU-free boundary and put CPU tests on them, mirroring qwen3's scheduler-test layout. Prerequisite for testing 5 without a GPU.
+8. **Prefix-cache design note.** Linear-attention layers carry recurrent state, not KV blocks — a "prefix hit" must restore both the full-attention KV *and* a recurrent-state snapshot at a block boundary (~48MB per boundary at bf16). Whether to snapshot per block, per N blocks, or only at request end is an open trade; write the design note before any code. Depends on 6.
+9. **kernel_plan port.** qwen3's `kernel_plan.rs` (runtime kernel selection + plan dump) has no qwen35 counterpart; decode kernel picks are hardwired. Mechanical port, community-friendly.
+
+### Later
+
+- **TP** — no sharding design exists for the hybrid stack (GDR state sharding is the open question). Design-first, no driver today.
+- **CUDA-graph prefill** — prefill is eager and serial; revisit after 6 changes the memory layout.
+
+## Cleanup ledger
+
+- **Dead code:** `probe_model()`+`ModelInfo` and `start_with_model()` — zero callers (the server inlines detection; same dead pair in qwen3). Wire or delete.
+- **Docs:** `accuracy.md` toolchain rewrite is covered by item 3. Several qwen35 docs still carry `Status:` enum headers (against repo convention) and `crates/` paths. Parity numbers drifted across docs (225ms/11.81ms vs the refreshed 234ms/11.77ms) — reconcile to one ledger. The e2e-gibberish debugging story should be lifted to `docs/lessons/` (it's a lesson about exact-match gates, not a qwen35 doc).
+- **Shared with qwen3 (owned there):** batched greedy decode sampling (`batch_decode.rs` has the same per-row pattern), non-greedy sampling correctness coverage, frontend usage accounting (#78).
+
+## Done criteria
+
+- GSM8K 8-shot within a few points of the HF reference, and a logits-level gate that would have caught the divergence.
+- The exact-text e2e baseline-regeneration ritual is retired (#186 closed).
+- A 30k-token prompt is either served or rejected at admission — never a crash, never a silent cap.
+- One request's KV exhaustion never kills its batch-mates.
+- Scheduler admission logic runs under `cargo test` without a GPU.


### PR DESCRIPTION
## Summary

Adds a `roadmap.md` to each of the three model lines, produced from a multi-agent review of the codebase (every finding adversarially verified against `6ee9247`):

- `docs/models/kimi-k2/roadmap.md` — tracking issue #221 (+18 sub-issues)
- `docs/models/qwen3/roadmap.md` — tracking issue #241 (+9 sub-issues)
- `docs/models/qwen35/roadmap.md` — tracking issue #249 (+10 sub-issues)

Each doc: TL;DR contract, where-the-line-stands table with code evidence, sequenced Now/Next/Later, cleanup ledger, done criteria. `docs/index.md` rows added.

The GitHub issues are the community-facing surface (PM-style: background / current state / desired outcome / acceptance boundary, no implementation plans); these docs are the maintainer-facing detail layer with file:line evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)