### PR TITLE
fix(kimi-k2): stop generation at EOS on both scheduler paths

### DIFF
--- a/docs/models/kimi-k2/roadmap.md
+++ b/docs/models/kimi-k2/roadmap.md
@@ -1,6 +1,6 @@
 # Kimi-K2 Roadmap
 
-> **TL;DR:** Kimi-K2 decode performance is ahead of vLLM on the same H20 ×8 hardware (TP1+DP8+EP8 service bs64: output `1336 tok/s` vs vLLM `594 tok/s`, TPOT p50 `47.3ms` vs `107.2ms`), but the crate is far behind Qwen3-4B on the serving contract and correctness surface: every request runs greedy regardless of sampling params, never stops at EOS, prompts over 2048 tokens overrun the KV arena unchecked, and no accuracy gate is reproducible from a fresh clone. The roadmap sequence is: serving-contract correctness + a git-versioned accuracy gate first, then the TTFT/prefill and HTTP-overhead perf gaps, then the continuous-batching→KV-lifecycle→prefix-cache chain and the PPLX/decode-throughput chain. Findings verified 2026-06-04 against `6ee9247`.
+> **TL;DR:** Kimi-K2 decode performance is ahead of vLLM on the same H20 ×8 hardware (TP1+DP8+EP8 service bs64: output `1336 tok/s` vs vLLM `594 tok/s`, TPOT p50 `47.3ms` vs `107.2ms`), but the crate is far behind Qwen3-4B on the serving contract and correctness surface: every request runs greedy regardless of sampling params, prompts over 2048 tokens overrun the KV arena unchecked, and no accuracy gate is reproducible from a fresh clone. EOS/stop-token handling landed (issue #238): both scheduler paths stop at EOS and honor `ignore_eos`. The roadmap sequence is: serving-contract correctness + a git-versioned accuracy gate first, then the TTFT/prefill and HTTP-overhead perf gaps, then the continuous-batching→KV-lifecycle→prefix-cache chain and the PPLX/decode-throughput chain. Findings verified 2026-06-04 against `6ee9247`.
 >
 > **Last touched:** 2026-06
 
@@ -10,7 +10,7 @@ Status ledgers: [tp1-dp8-ep8-performance.md](tp1-dp8-ep8-performance.md) (active
 
 | Capability | Qwen3-4B | Kimi-K2 | Evidence |
 | --- | --- | --- | --- |
-| EOS / stop-token detection | ✓ per-step `is_stop_token` | ✗ always `FinishReason::Length`, generates exactly `max_tokens` | no `eos` handling in `pegainfer-kimi-k2/src`; qwen3 `scheduler/resolve.rs:50` |
+| EOS / stop-token detection | ✓ per-step `is_stop_token` | ✓ per-step on both paths, honors `ignore_eos` (issue #238) | `config.rs::load_stop_token_ids`; checks in `runner/scheduler.rs` + `runner/scheduler/dp.rs`; e2e `scripts/e2e_eos_stop.py` |
 | Sampling params | ✓ FlashInfer greedy + non-greedy | ✗ `req.params` never read — temperature/top_k/top_p **silently ignored**, always argmax | `runner/worker/forward.rs:113` top1 only |
 | Prompt-length guard | ✓ KV-budget admission rejects impossible requests | ✗ 2048-token arena cap (`worker.rs:60-61`), `append_position` unchecked → silent overrun | `runner/scheduler.rs:148-151` |
 | KV admission control | ✓ full-lifetime budget, deferral, rejection (issue #85 fix) | ✗ slot-count only on both paths | qwen3 `scheduler.rs:478-510` |
@@ -28,7 +28,7 @@ Status ledgers: [tp1-dp8-ep8-performance.md](tp1-dp8-ep8-performance.md) (active
 - **TP8+EP8 NCCL (graph path):** bs4 TPOT `14.39ms` synthetic. Wave-batched, reference/history path.
 - **TTFT is the open perf gap:** HTTP decode-heavy bs4 TTFT p50 `313ms` / p99 `4240ms` vs vLLM `69.6/135.4ms` (4.5×/31× worse). Short-prompt streaming TTFT ~`2.0s`.
 - **HTTP vs in-process:** `19.13ms` vs `14.39ms` TPOT at bs4 — ~33% serving overhead, unattributed.
-- No claim of: non-greedy sampling, EOS-terminated generation, >2048-token prompts, long-context decode correctness, prefix reuse, multi-node.
+- No claim of: non-greedy sampling, >2048-token prompts, long-context decode correctness, prefix reuse, multi-node.
 
 ## Sequencing — what blocks what
 
@@ -47,7 +47,7 @@ PPLX graph capturability / MoE pipelining ─→ TP1+DP8 decode throughput targe
 
 The engine is fast but does not honor the OpenAI contract it serves. All items are crash-early-or-honor, none are perf work:
 
-1. **EOS/stop-token handling.** Parse `eos_token_id`/`stop_token_ids` in `config.rs`, check per decode step on both scheduler paths, honor `ignore_eos`, emit `FinishReason::Stop`. Frontend mapping already exists.
+1. **EOS/stop-token handling.** ✓ Done (issue #238): `config.rs::load_stop_token_ids` (generation_config.json with config.json fallback), per-step checks on both scheduler paths, `ignore_eos` honored end-to-end (also fixed the frontend `convert_sampling` derivation that voided it), `FinishReason::Stop` emitted. Verified on both shapes with `scripts/e2e_eos_stop.py`.
 2. **Sampling params: honor or reject.** `req.params` is never read. Either route non-greedy rows through the shared FlashInfer sampling ops, or reject non-greedy requests explicitly. Audit the full OpenAI param surface (temperature/top_k/top_p, n, seed, penalties, stop strings) — each one: honored / rejected / documented-ignored. Silent-wrong is the only forbidden state.
 3. **Prompt-length guard.** Reject prompts whose `prompt + max_tokens` exceeds the 2048-token per-slot arena instead of overrunning KV pages.
 4. **KV admission + abort-on-disconnect.** Port the qwen3 admission pattern (budget, deferral, rejection) to both paths; wire disconnect-abort when the server-wide #215 lands.

--- a/pegainfer-kimi-k2/src/config.rs
+++ b/pegainfer-kimi-k2/src/config.rs
@@ -1,5 +1,7 @@
 //! Kimi-K2.6 text-only constants, config probing, and derived shapes.
 
+use std::{fs, path::Path};
+
 use anyhow::{Context, Result, bail, ensure};
 use serde_json::Value;
 
@@ -242,6 +244,58 @@ pub fn probe_config_json(json: &Value) -> Result<()> {
     Ok(())
 }
 
+/// Stop-token IDs for EOS detection. `generation_config.json` is authoritative
+/// (it may list several); `config.json`'s `eos_token_id` is the fallback. A
+/// chat model without either cannot signal end-of-turn, so this fails instead
+/// of letting every request silently run to `max_tokens`.
+pub(crate) fn load_stop_token_ids(model_path: &Path) -> Result<Vec<u32>> {
+    let stop_token_ids = read_stop_token_ids(model_path)?;
+    log::info!("kimi-k2: stop tokens: {stop_token_ids:?}");
+    Ok(stop_token_ids)
+}
+
+fn read_stop_token_ids(model_path: &Path) -> Result<Vec<u32>> {
+    let generation_config_path = model_path.join("generation_config.json");
+    match fs::read_to_string(&generation_config_path) {
+        Ok(content) => {
+            let json: Value = serde_json::from_str(&content)
+                .with_context(|| format!("parse {}", generation_config_path.display()))?;
+            eos_token_ids(&json).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "{} has no usable eos_token_id",
+                    generation_config_path.display()
+                )
+            })
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            let config_path = model_path.join("config.json");
+            let content = fs::read_to_string(&config_path)
+                .with_context(|| format!("read {}", config_path.display()))?;
+            let json: Value = serde_json::from_str(&content)
+                .with_context(|| format!("parse {}", config_path.display()))?;
+            // kimi_k25 wraps the text model config in text_config.
+            eos_token_ids(&json)
+                .or_else(|| json.get("text_config").and_then(eos_token_ids))
+                .ok_or_else(|| {
+                    anyhow::anyhow!("{} has no usable eos_token_id", config_path.display())
+                })
+        }
+        Err(err) => Err(err).with_context(|| format!("read {}", generation_config_path.display())),
+    }
+}
+
+fn eos_token_ids(json: &Value) -> Option<Vec<u32>> {
+    let to_u32 = |value: &Value| value.as_u64().and_then(|id| u32::try_from(id).ok());
+    match json.get("eos_token_id")? {
+        Value::Array(ids) => {
+            let mut ids = ids.iter().map(to_u32).collect::<Option<Vec<_>>>()?;
+            ids.dedup();
+            (!ids.is_empty()).then_some(ids)
+        }
+        id => to_u32(id).map(|id| vec![id]),
+    }
+}
+
 fn string_field(json: &Value, key: &str) -> Result<String> {
     json.get(key)
         .and_then(Value::as_str)
@@ -349,5 +403,32 @@ impl KimiK2ParallelShape {
     #[must_use]
     pub(crate) fn parallel_config(&self) -> pegainfer_core::parallel::ParallelConfig {
         pegainfer_core::parallel::ParallelConfig::new(self.tp_world, self.dp_world)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::eos_token_ids;
+
+    #[test]
+    fn eos_token_ids_accepts_single_and_array() {
+        assert_eq!(
+            eos_token_ids(&json!({"eos_token_id": 163_586})),
+            Some(vec![163_586])
+        );
+        assert_eq!(
+            eos_token_ids(&json!({"eos_token_id": [163_585, 163_586, 163_586]})),
+            Some(vec![163_585, 163_586])
+        );
+    }
+
+    #[test]
+    fn eos_token_ids_rejects_missing_or_malformed() {
+        assert_eq!(eos_token_ids(&json!({})), None);
+        assert_eq!(eos_token_ids(&json!({"eos_token_id": []})), None);
+        assert_eq!(eos_token_ids(&json!({"eos_token_id": "eos"})), None);
+        assert_eq!(eos_token_ids(&json!({"eos_token_id": [163_585, -1]})), None);
     }
 }

--- a/pegainfer-kimi-k2/src/runner/bringup.rs
+++ b/pegainfer-kimi-k2/src/runner/bringup.rs
@@ -17,7 +17,7 @@ use pegainfer_core::{
 use tokio::sync::mpsc;
 
 use crate::{
-    config::KimiK2ParallelShape,
+    config::{KimiK2ParallelShape, load_stop_token_ids},
     runner::{
         affinity::pin_scheduler_thread,
         config::KimiK2RunnerConfig,
@@ -128,6 +128,7 @@ fn start_engine_tp8_dp1(
         parallel,
         KimiK2ParallelShape::tp8_ep8(),
     )?;
+    let stop_token_ids = load_stop_token_ids(model_path)?;
     let executor = build_tp8_dp1_executor(&config)?;
 
     let (submit_tx, submit_rx) = mpsc::unbounded_channel::<GenerateRequest>();
@@ -136,7 +137,7 @@ fn start_engine_tp8_dp1(
         .name("kimi-k2-scheduler".into())
         .spawn(move || {
             pin_scheduler_thread(&config.thread_placement);
-            let mut scheduler = match KimiK2Scheduler::new(executor) {
+            let mut scheduler = match KimiK2Scheduler::new(executor, stop_token_ids) {
                 Ok(scheduler) => scheduler,
                 Err(err) => {
                     let _ = init_tx.send(Err(err));
@@ -173,8 +174,9 @@ fn start_engine_tp1_dp8(
         parallel,
         KimiK2ParallelShape::tp1_dp8(),
     )?;
+    let stop_token_ids = load_stop_token_ids(model_path)?;
     let executors = build_tp1_dp8_executors(&config)?;
-    let coordinator = DpCoordinator::new(executors);
+    let coordinator = DpCoordinator::new(executors, stop_token_ids);
     let lb = DpLoadBalancer::new(dp_world);
 
     let (submit_tx, submit_rx) = mpsc::unbounded_channel::<GenerateRequest>();

--- a/pegainfer-kimi-k2/src/runner/scheduler.rs
+++ b/pegainfer-kimi-k2/src/runner/scheduler.rs
@@ -24,6 +24,7 @@ const KIMI_PREFILL_BATCH_POLL: Duration = Duration::from_micros(50);
 
 pub(super) struct KimiK2Scheduler {
     executor: Box<dyn ForwardExecutor + Send>,
+    stop_token_ids: Vec<u32>,
 }
 
 struct ActiveKimiRequest {
@@ -31,13 +32,17 @@ struct ActiveKimiRequest {
     prompt_len: usize,
     completion_tokens: usize,
     max_tokens: usize,
+    ignore_eos: bool,
     last_token: u32,
     slot: usize,
     decode_batch_size: usize,
 }
 
 impl KimiK2Scheduler {
-    pub(super) fn new(executor: Box<dyn ForwardExecutor + Send>) -> Result<Self> {
+    pub(super) fn new(
+        executor: Box<dyn ForwardExecutor + Send>,
+        stop_token_ids: Vec<u32>,
+    ) -> Result<Self> {
         executor
             .ensure_decode_batch(KIMI_RUNNER_MAX_BATCH)
             .with_context(|| {
@@ -52,7 +57,10 @@ impl KimiK2Scheduler {
             .with_context(|| {
                 format!("Kimi-K2 warm prompt_len1 bs{KIMI_RUNNER_MAX_BATCH} before serving")
             })?;
-        Ok(Self { executor })
+        Ok(Self {
+            executor,
+            stop_token_ids,
+        })
     }
 
     pub(in crate::runner) fn run(
@@ -179,6 +187,17 @@ impl KimiK2Scheduler {
                 let req = &mut active[idx];
                 let token_id = report.local_next_token_global_id;
                 req.completion_tokens += 1;
+                // EOS outranks the length limit; the stop token itself is not
+                // emitted (same contract as the Qwen schedulers).
+                if !req.ignore_eos && self.stop_token_ids.contains(&token_id) {
+                    let _ = req.token_tx.send(TokenEvent::Finished {
+                        finish_reason: FinishReason::Stop,
+                        prompt_tokens: req.prompt_len,
+                        completion_tokens: req.completion_tokens,
+                    });
+                    retire.push(idx);
+                    continue;
+                }
                 if req
                     .token_tx
                     .send(TokenEvent::Token {
@@ -222,6 +241,14 @@ impl KimiK2Scheduler {
         ) {
             Ok(report) => {
                 let token_id = report.local_next_token_global_id;
+                if !req.params.ignore_eos && self.stop_token_ids.contains(&token_id) {
+                    let _ = req.token_tx.send(TokenEvent::Finished {
+                        finish_reason: FinishReason::Stop,
+                        prompt_tokens: req.prompt_tokens.len(),
+                        completion_tokens: 0,
+                    });
+                    return None;
+                }
                 if req
                     .token_tx
                     .send(TokenEvent::Token {
@@ -262,6 +289,7 @@ impl KimiK2Scheduler {
             prompt_len: req.prompt_tokens.len(),
             completion_tokens,
             max_tokens: req.max_tokens,
+            ignore_eos: req.params.ignore_eos,
             last_token,
             slot,
             decode_batch_size,
@@ -327,6 +355,14 @@ impl KimiK2Scheduler {
         };
         for ((slot, req), report) in group.into_iter().zip(reports) {
             let token_id = report.local_next_token_global_id;
+            if !req.params.ignore_eos && self.stop_token_ids.contains(&token_id) {
+                let _ = req.token_tx.send(TokenEvent::Finished {
+                    finish_reason: FinishReason::Stop,
+                    prompt_tokens: req.prompt_tokens.len(),
+                    completion_tokens: 0,
+                });
+                continue;
+            }
             if req
                 .token_tx
                 .send(TokenEvent::Token {
@@ -351,6 +387,7 @@ impl KimiK2Scheduler {
                 prompt_len: req.prompt_tokens.len(),
                 completion_tokens,
                 max_tokens: req.max_tokens,
+                ignore_eos: req.params.ignore_eos,
                 last_token: token_id,
                 slot,
                 decode_batch_size,

--- a/pegainfer-kimi-k2/src/runner/scheduler/dp.rs
+++ b/pegainfer-kimi-k2/src/runner/scheduler/dp.rs
@@ -27,6 +27,7 @@ pub(in crate::runner) struct DpCoordinator {
     executors: Vec<Box<dyn ForwardExecutor + Send>>,
     step_txs: Vec<Sender<StepCommand>>,
     result_rxs: Vec<Receiver<StepResult>>,
+    stop_token_ids: Vec<u32>,
 }
 
 pub(in crate::runner) struct DpRankState {
@@ -38,6 +39,7 @@ struct RequestState {
     prompt_len: usize,
     completion_tokens: usize,
     max_tokens: usize,
+    ignore_eos: bool,
     last_token: u32,
 }
 
@@ -103,7 +105,10 @@ enum StepResult {
 }
 
 impl DpCoordinator {
-    pub(in crate::runner) fn new(executors: Vec<Box<dyn ForwardExecutor + Send>>) -> Self {
+    pub(in crate::runner) fn new(
+        executors: Vec<Box<dyn ForwardExecutor + Send>>,
+        stop_token_ids: Vec<u32>,
+    ) -> Self {
         let dp_world = executors.len();
         let mut ranks = Vec::with_capacity(dp_world);
         for _ in 0..dp_world {
@@ -118,6 +123,7 @@ impl DpCoordinator {
             executors,
             step_txs: Vec::new(),
             result_rxs: Vec::new(),
+            stop_token_ids,
         }
     }
 
@@ -338,6 +344,14 @@ impl DpCoordinator {
         }
 
         let last_token = owner_report.local_next_token_global_id;
+        if !req.params.ignore_eos && self.stop_token_ids.contains(&last_token) {
+            let _ = req.token_tx.send(TokenEvent::Finished {
+                finish_reason: FinishReason::Stop,
+                prompt_tokens: prompt_len,
+                completion_tokens: 0,
+            });
+            return;
+        }
         if req
             .token_tx
             .send(TokenEvent::Token {
@@ -364,6 +378,7 @@ impl DpCoordinator {
             prompt_len,
             completion_tokens,
             max_tokens: req.max_tokens,
+            ignore_eos: req.params.ignore_eos,
             last_token,
         });
     }
@@ -433,7 +448,11 @@ impl DpCoordinator {
             for (row, report) in rows.into_iter().zip(reports) {
                 match row {
                     PromptLen1DecodeRow::Active(input) => {
-                        self.ranks[dp_rank].process_decode_report(input.slot, &report);
+                        self.ranks[dp_rank].process_decode_report(
+                            input.slot,
+                            &report,
+                            &self.stop_token_ids,
+                        );
                     }
                     PromptLen1DecodeRow::Admission(admission) => {
                         self.install_prompt_len1_decode_result(dp_rank, admission, &report);
@@ -450,6 +469,14 @@ impl DpCoordinator {
         report: &KimiOneTokenForwardReport,
     ) {
         let token_id = report.local_next_token_global_id;
+        if !admission.req.params.ignore_eos && self.stop_token_ids.contains(&token_id) {
+            let _ = admission.req.token_tx.send(TokenEvent::Finished {
+                finish_reason: FinishReason::Stop,
+                prompt_tokens: admission.req.prompt_tokens.len(),
+                completion_tokens: 0,
+            });
+            return;
+        }
         if admission
             .req
             .token_tx
@@ -477,6 +504,7 @@ impl DpCoordinator {
             prompt_len: admission.req.prompt_tokens.len(),
             completion_tokens,
             max_tokens: admission.req.max_tokens,
+            ignore_eos: admission.req.params.ignore_eos,
             last_token: token_id,
         });
     }
@@ -569,7 +597,7 @@ impl DpCoordinator {
                 Err(_) => abort_dropped_result_channel(dp_rank, "decode"),
             };
 
-            self.ranks[dp_rank].process_decode_results(result);
+            self.ranks[dp_rank].process_decode_results(result, &self.stop_token_ids);
         }
     }
 }
@@ -622,7 +650,11 @@ impl DpRankState {
             .collect()
     }
 
-    fn process_decode_results(&mut self, reports: Vec<KimiOneTokenForwardReport>) {
+    fn process_decode_results(
+        &mut self,
+        reports: Vec<KimiOneTokenForwardReport>,
+        stop_token_ids: &[u32],
+    ) {
         let active_slots: Vec<usize> = self
             .slots
             .iter()
@@ -635,17 +667,34 @@ impl DpRankState {
         }
 
         for (slot_idx, report) in active_slots.into_iter().zip(reports) {
-            self.process_decode_report(slot_idx, &report);
+            self.process_decode_report(slot_idx, &report, stop_token_ids);
         }
     }
 
-    fn process_decode_report(&mut self, slot_idx: usize, report: &KimiOneTokenForwardReport) {
+    fn process_decode_report(
+        &mut self,
+        slot_idx: usize,
+        report: &KimiOneTokenForwardReport,
+        stop_token_ids: &[u32],
+    ) {
         let Some(req) = self.slots[slot_idx].as_mut() else {
             return;
         };
 
         let token_id = report.local_next_token_global_id;
         req.completion_tokens += 1;
+
+        // EOS outranks the length limit; the stop token itself is not emitted
+        // (same contract as the Qwen schedulers).
+        if !req.ignore_eos && stop_token_ids.contains(&token_id) {
+            let _ = req.token_tx.send(TokenEvent::Finished {
+                finish_reason: FinishReason::Stop,
+                prompt_tokens: req.prompt_len,
+                completion_tokens: req.completion_tokens,
+            });
+            self.slots[slot_idx] = None;
+            return;
+        }
 
         if req
             .token_tx
@@ -805,7 +854,23 @@ mod tests {
             prompt_len,
             completion_tokens,
             max_tokens: 16,
+            ignore_eos: false,
             last_token,
+        }
+    }
+
+    fn dummy_report(token_id: u32) -> KimiOneTokenForwardReport {
+        KimiOneTokenForwardReport {
+            rank: 0,
+            batch_slot: 0,
+            input_token_id: 0,
+            local_next_token_id: token_id,
+            local_next_token_global_id: token_id,
+            local_top_logit_f32: 0.0,
+            vocab_start: 0,
+            vocab_rows: 0,
+            dense_layers_executed: 0,
+            moe_layers_executed: 0,
         }
     }
 
@@ -820,6 +885,7 @@ mod tests {
             executors: Vec::new(),
             step_txs: Vec::new(),
             result_rxs: Vec::new(),
+            stop_token_ids: Vec::new(),
         }
     }
 
@@ -892,6 +958,62 @@ mod tests {
         assert_eq!(token_ids, vec![0]);
         assert_eq!(positions, vec![0]);
         assert_eq!(slots, vec![0]);
+    }
+
+    #[test]
+    fn decode_report_finishes_with_stop_at_eos() {
+        let mut rank = DpRankState {
+            slots: (0..MAX_BATCH_PER_DP).map(|_| None).collect(),
+        };
+        let (token_tx, mut token_rx) = mpsc::unbounded_channel();
+        rank.slots[0] = Some(RequestState {
+            token_tx,
+            prompt_len: 4,
+            completion_tokens: 1,
+            max_tokens: 16,
+            ignore_eos: false,
+            last_token: 7,
+        });
+
+        rank.process_decode_report(0, &dummy_report(163_586), &[163_586]);
+
+        assert!(rank.slots[0].is_none());
+        let Ok(TokenEvent::Finished {
+            finish_reason,
+            completion_tokens,
+            ..
+        }) = token_rx.try_recv()
+        else {
+            panic!("expected Finished event");
+        };
+        assert_eq!(finish_reason, FinishReason::Stop);
+        assert_eq!(completion_tokens, 2);
+        // The stop token itself is not emitted.
+        assert!(token_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn decode_report_honors_ignore_eos() {
+        let mut rank = DpRankState {
+            slots: (0..MAX_BATCH_PER_DP).map(|_| None).collect(),
+        };
+        let (token_tx, mut token_rx) = mpsc::unbounded_channel();
+        rank.slots[0] = Some(RequestState {
+            token_tx,
+            prompt_len: 4,
+            completion_tokens: 1,
+            max_tokens: 16,
+            ignore_eos: true,
+            last_token: 7,
+        });
+
+        rank.process_decode_report(0, &dummy_report(163_586), &[163_586]);
+
+        assert!(rank.slots[0].is_some());
+        let Ok(TokenEvent::Token { id, .. }) = token_rx.try_recv() else {
+            panic!("expected Token event");
+        };
+        assert_eq!(id, 163_586);
     }
 
     #[test]

--- a/pegainfer-vllm-frontend/src/lib.rs
+++ b/pegainfer-vllm-frontend/src/lib.rs
@@ -1046,12 +1046,19 @@ fn to_wire_position_logprobs(
 }
 
 fn convert_sampling(params: &EngineCoreSamplingParams) -> SamplingParams {
+    // The vLLM frontend lowers a client `ignore_eos=true` to `_eos_token_id:
+    // None`, but `_all_stop_token_ids` always carries the model EOS set (it
+    // exists for min_tokens masking, not stop detection). Deriving ignore_eos
+    // from all_stop_token_ids would therefore void every ignore_eos request on
+    // models with a real EOS. Only `_eos_token_id` and the client's explicit
+    // `stop_token_ids` express a stop intent.
+    let ignore_eos = params.eos_token_id.is_none() && params.stop_token_ids.is_empty();
     if params.temperature <= 0.0 {
         return SamplingParams {
             temperature: 0.0,
             top_k: -1,
             top_p: 1.0,
-            ignore_eos: params.eos_token_id.is_none() && params.all_stop_token_ids.is_empty(),
+            ignore_eos,
         };
     }
 
@@ -1063,7 +1070,7 @@ fn convert_sampling(params: &EngineCoreSamplingParams) -> SamplingParams {
             i32::try_from(params.top_k).unwrap_or(i32::MAX)
         },
         top_p: params.top_p,
-        ignore_eos: params.eos_token_id.is_none() && params.all_stop_token_ids.is_empty(),
+        ignore_eos,
     }
 }
 
@@ -1329,6 +1336,25 @@ mod tests {
             .map(|entry| entry["id"].as_str().expect("id string"))
             .collect::<Vec<_>>();
         assert_eq!(ids, vec!["adapter-a", "adapter-b", "served-base"]);
+    }
+
+    #[test]
+    fn convert_sampling_honors_ignore_eos_lowering() {
+        // ignore_eos=true lowering: _eos_token_id=None while
+        // _all_stop_token_ids still carries the model EOS set.
+        let mut params = EngineCoreSamplingParams::for_test();
+        params.all_stop_token_ids = BTreeSet::from([163586]);
+        assert!(convert_sampling(&params).ignore_eos);
+
+        // Normal request: _eos_token_id present.
+        params.eos_token_id = Some(163586);
+        assert!(!convert_sampling(&params).ignore_eos);
+
+        // Explicit client stop tokens keep EOS detection on even when the
+        // frontend dropped _eos_token_id.
+        params.eos_token_id = None;
+        params.stop_token_ids = vec![42];
+        assert!(!convert_sampling(&params).ignore_eos);
     }
 
     #[test]

--- a/scripts/e2e_eos_stop.py
+++ b/scripts/e2e_eos_stop.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""E2E check that a serving pegainfer engine stops at EOS (issue #238).
+
+Sends the same prompt twice through `/v1/completions` on an already-running
+server:
+
+1. default: the answer must end early with `finish_reason: "stop"` and fewer
+   than `max_tokens` completion tokens;
+2. `ignore_eos: true`: generation must run to `finish_reason: "length"` with
+   exactly `max_tokens` completion tokens (benchmarks rely on this).
+
+The default prompt is in Kimi-K2 chat format; pass --prompt for other models.
+
+Usage:
+    python3 scripts/e2e_eos_stop.py --base-url http://127.0.0.1:8124 --model kimi-k2.5
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.request
+
+KIMI_PROMPT = (
+    "<|im_system|>system<|im_middle|>You are a helpful assistant.<|im_end|>"
+    "<|im_user|>user<|im_middle|>What is 2+2? Reply with just the number.<|im_end|>"
+    "<|im_assistant|>assistant<|im_middle|>"
+)
+
+
+def request_completion(
+    base_url: str, model: str, prompt: str, max_tokens: int, ignore_eos: bool, timeout: float
+) -> dict:
+    body = {
+        "model": model,
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+        "ignore_eos": ignore_eos,
+    }
+    request = urllib.request.Request(
+        f"{base_url}/v1/completions",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        payload = json.load(response)
+    choice = payload["choices"][0]
+    return {
+        "finish_reason": choice["finish_reason"],
+        "completion_tokens": payload["usage"]["completion_tokens"],
+        "text": choice["text"],
+    }
+
+
+def check(label: str, condition: bool, detail: str) -> bool:
+    status = "PASS" if condition else "FAIL"
+    print(f"[{status}] {label}: {detail}")
+    return condition
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:8124")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--prompt", default=KIMI_PROMPT)
+    parser.add_argument("--max-tokens", type=int, default=256)
+    parser.add_argument("--timeout", type=float, default=300.0)
+    args = parser.parse_args()
+
+    stop_run = request_completion(
+        args.base_url, args.model, args.prompt, args.max_tokens, ignore_eos=False, timeout=args.timeout
+    )
+    print(f"stop run: {stop_run['finish_reason']}, {stop_run['completion_tokens']} tokens")
+    print(f"  text: {stop_run['text']!r}")
+
+    length_run = request_completion(
+        args.base_url, args.model, args.prompt, args.max_tokens, ignore_eos=True, timeout=args.timeout
+    )
+    print(f"ignore_eos run: {length_run['finish_reason']}, {length_run['completion_tokens']} tokens")
+
+    ok = True
+    ok &= check(
+        "EOS stops generation",
+        stop_run["finish_reason"] == "stop",
+        f"finish_reason={stop_run['finish_reason']}",
+    )
+    ok &= check(
+        "stop run ends early",
+        stop_run["completion_tokens"] < args.max_tokens,
+        f"{stop_run['completion_tokens']} < {args.max_tokens}",
+    )
+    ok &= check(
+        "ignore_eos runs to length",
+        length_run["finish_reason"] == "length",
+        f"finish_reason={length_run['finish_reason']}",
+    )
+    ok &= check(
+        "ignore_eos generates max_tokens",
+        length_run["completion_tokens"] == args.max_tokens,
+        f"{length_run['completion_tokens']} == {args.max_tokens}",
+    )
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #238

## 改动

**kimi-k2 EOS/stop-token 检测**(此前两条 scheduler 路径都只会发 `FinishReason::Length`,每个请求都生成满 `max_tokens`):

- `config.rs::load_stop_token_ids`:`generation_config.json` 优先(单值/数组都支持),fallback 到 `config.json` 的 `eos_token_id`(处理 `kimi_k25` 的 `text_config` wrapper)。两处都没有则启动时报错,不静默退化。
- TP8+EP8(`runner/scheduler.rs`)与 TP1+DP8+EP8(`runner/scheduler/dp.rs`)各三处 next-token 消费点(decode loop / prefill 首 token / prompt_len1 microbatch)全部加 EOS 检测。契约与 Qwen scheduler 一致:EOS 优先于 length,stop token 本身不发出,`ignore_eos` 跳过检测。
- DP 路径的 retire 都发生在 forward 之后的结果处理阶段,不影响 PPLX lock-step/padding 约定。

**vllm-frontend `ignore_eos` 推导修复**(独立 commit):`convert_sampling` 此前用 `_all_stop_token_ids.is_empty()` 参与推导,但该字段是 min_tokens masking 用的、永远含模型 EOS,导致带真实 EOS 的模型上所有 `ignore_eos:true` 请求被架空。改为只看 `_eos_token_id` 与 client 显式 `stop_token_ids`。

**`scripts/e2e_eos_stop.py`**:对已起服务一条命令断言 stop/length/ignore_eos 三种行为。

## 验证(h20, 8×H20, Kimi-K2.5)

两个 shape 都跑了 `scripts/e2e_eos_stop.py`(`max_tokens=256`,问 2+2):

| Shape | 自然回答 | ignore_eos=true |
|---|---|---|
| TP1+DP8+EP8 (pplx) | 54 tokens, `finish_reason=stop` | 256 tokens, `finish_reason=length` |
| TP8+EP8 (nccl) | 61 tokens, `finish_reason=stop` | 256 tokens, `finish_reason=length` |

- 启动日志确认 loader 行为:`kimi-k2: stop tokens: [163586]`(K2.5 的 generation_config 与 config.json 不一致,163586 vs 163585,generation_config 优先)。
- 单测:`cargo test -p pegainfer-kimi-k2 --features kimi-k2 --lib` 17 passed、`-p pegainfer-vllm-frontend --lib` 16 passed(新增 DP 路径 EOS retire/ignore_eos 行为测试、config 解析测试、convert_sampling 推导测试)。
- pre-commit 全过(fmt、workspace clippy、clippy-kimi-k2 -D warnings)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)