### PR TITLE
fix(kimi-k2): reject non-greedy sampling at admission (#237)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -69,7 +69,8 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 
 | Path | TL;DR |
 | --- | --- |
-| `models/kimi-k2/roadmap.md` | Cross-cutting Kimi-K2 plan, verified against code 2026-06: decode beats vLLM (bs64 `1336 vs 594 tok/s`) but serving contract is broken (sampling params silently ignored, no EOS stop, 2048-token arena overrun) and no accuracy gate is clone-reproducible. Sequence: correctness + accuracy-gate-in-git → TTFT/HTTP overhead → batching/prefix-cache and PPLX-throughput chains → cleanup ledger. |
+| `models/kimi-k2/roadmap.md` | Cross-cutting Kimi-K2 plan, verified against code 2026-06: decode beats vLLM (bs64 `1336 vs 594 tok/s`) but the serving contract trails Qwen3-4B — EOS stop (#238) and sampling honor-or-reject (#237) landed; 2048-token arena overrun and accuracy-gate reproducibility still open. Sequence: correctness + accuracy-gate-in-git → TTFT/HTTP overhead → batching/prefix-cache and PPLX-throughput chains → cleanup ledger. |
+| `models/kimi-k2/serving-contract.md` | Kimi-K2 OpenAI 参数面审计(#237):greedy + EOS + ignore_eos honored;`temperature>0` 准入拒绝;其余参数逐项归属,无 silently-wrong 状态。 |
 | `models/kimi-k2/optimization.md` | Kimi-K2 model card + optimization log：61 层 MLA + Marlin WNA16 MoE，H20 ×8 当前 TP8/EP8。重点是 decode：bs4 graph TPOT `14.39ms`（≈`278 tok/s`），目标 `> 300 tok/s`；下一阶段迁到 TP1+DP8+EP8（PPLX）。Prefill 优先级低。 |
 | `models/kimi-k2/support-analysis.md` | Kimi-K2 text-only bring-up：Marlin WNA16 routed expert、MLA prompt、全 61 层 prompt forward、多 prompt vLLM top-20 gate 已过；bs4 wave decode 已接入，Marlin atomic split-K row-state bug 修复后 output16 row diff 清零，正在撤掉 decode 诊断负担并回到 bs4 性能主线。 |
 | `models/kimi-k2/operator-todo.md` | Kimi-K2 算子清单：MLA + Marlin WNA16 routed expert + NCCL RS bridge 主链；CUDA Graph 覆盖整段 decode，synthetic output64 avg `14.39ms` / p99 `14.83ms`；CUTLASS INT4 后端与 decode row-diff 诊断已下线，详见 changelog。 |

--- a/docs/models/kimi-k2/roadmap.md
+++ b/docs/models/kimi-k2/roadmap.md
@@ -1,6 +1,6 @@
 # Kimi-K2 Roadmap
 
-> **TL;DR:** Kimi-K2 decode performance is ahead of vLLM on the same H20 ×8 hardware (TP1+DP8+EP8 service bs64: output `1336 tok/s` vs vLLM `594 tok/s`, TPOT p50 `47.3ms` vs `107.2ms`), but the crate is far behind Qwen3-4B on the serving contract and correctness surface: every request runs greedy regardless of sampling params, prompts over 2048 tokens overrun the KV arena unchecked, and no accuracy gate is reproducible from a fresh clone. EOS/stop-token handling landed (issue #238): both scheduler paths stop at EOS and honor `ignore_eos`. The roadmap sequence is: serving-contract correctness + a git-versioned accuracy gate first, then the TTFT/prefill and HTTP-overhead perf gaps, then the continuous-batching→KV-lifecycle→prefix-cache chain and the PPLX/decode-throughput chain. Findings verified 2026-06-04 against `6ee9247`.
+> **TL;DR:** Kimi-K2 decode performance is ahead of vLLM on the same H20 ×8 hardware (TP1+DP8+EP8 service bs64: output `1336 tok/s` vs vLLM `594 tok/s`, TPOT p50 `47.3ms` vs `107.2ms`), but the crate still trails Qwen3-4B on the serving contract and correctness surface: prompts over 2048 tokens overrun the KV arena unchecked, and no accuracy gate is reproducible from a fresh clone. Landed: EOS/stop-token handling (#238) and sampling honor-or-reject (#237, non-greedy rejected at admission, param surface audited in [serving-contract.md](serving-contract.md)). The roadmap sequence is: serving-contract correctness + a git-versioned accuracy gate first, then the TTFT/prefill and HTTP-overhead perf gaps, then the continuous-batching→KV-lifecycle→prefix-cache chain and the PPLX/decode-throughput chain. Findings verified 2026-06-04 against `6ee9247`.
 >
 > **Last touched:** 2026-06
 
@@ -10,8 +10,8 @@ Status ledgers: [tp1-dp8-ep8-performance.md](tp1-dp8-ep8-performance.md) (active
 
 | Capability | Qwen3-4B | Kimi-K2 | Evidence |
 | --- | --- | --- | --- |
-| EOS / stop-token detection | ✓ per-step `is_stop_token` | ✓ per-step on both paths, honors `ignore_eos` (issue #238) | `config.rs::load_stop_token_ids`; checks in `runner/scheduler.rs` + `runner/scheduler/dp.rs`; e2e `scripts/e2e_eos_stop.py` |
-| Sampling params | ✓ FlashInfer greedy + non-greedy | ✗ `req.params` never read — temperature/top_k/top_p **silently ignored**, always argmax | `runner/worker/forward.rs:113` top1 only |
+| EOS / stop-token detection | ✓ per-step `is_stop_token` | ✓ per-step on both paths, honors `ignore_eos` (issue #238) | `config.rs::load_stop_token_ids`; checks in `runner/scheduler.rs` + `runner/scheduler/dp.rs`; e2e `scripts/e2e_serving_contract.py` |
+| Sampling params | ✓ FlashInfer greedy + non-greedy | ✓ honor-or-reject (#237): greedy honored, non-greedy rejected at admission; param surface audited | `runner/scheduler/lifecycle.rs::finish_unschedulable`; [serving-contract.md](serving-contract.md) |
 | Prompt-length guard | ✓ KV-budget admission rejects impossible requests | ✗ 2048-token arena cap (`worker.rs:60-61`), `append_position` unchecked → silent overrun | `runner/scheduler.rs:148-151` |
 | KV admission control | ✓ full-lifetime budget, deferral, rejection (issue #85 fix) | ✗ slot-count only on both paths | qwen3 `scheduler.rs:478-510` |
 | Continuous batching | ✓ | TP1/DP8: ✓ (`DpCoordinator` per-step admission, waiting queue); TP8/DP1: ✗ strict batch-then-drain | `runner/scheduler/dp.rs:168,189-236` vs `runner/scheduler.rs:140-207` |
@@ -47,8 +47,8 @@ PPLX graph capturability / MoE pipelining ─→ TP1+DP8 decode throughput targe
 
 The engine is fast but does not honor the OpenAI contract it serves. All items are crash-early-or-honor, none are perf work:
 
-1. **EOS/stop-token handling.** ✓ Done (issue #238): `config.rs::load_stop_token_ids` (generation_config.json with config.json fallback), per-step checks on both scheduler paths, `ignore_eos` honored end-to-end (also fixed the frontend `convert_sampling` derivation that voided it), `FinishReason::Stop` emitted. Verified on both shapes with `scripts/e2e_eos_stop.py`.
-2. **Sampling params: honor or reject.** `req.params` is never read. Either route non-greedy rows through the shared FlashInfer sampling ops, or reject non-greedy requests explicitly. Audit the full OpenAI param surface (temperature/top_k/top_p, n, seed, penalties, stop strings) — each one: honored / rejected / documented-ignored. Silent-wrong is the only forbidden state.
+1. **EOS/stop-token handling.** ✓ Done (issue #238): `config.rs::load_stop_token_ids` (generation_config.json with config.json fallback), per-step checks on both scheduler paths, `ignore_eos` honored end-to-end (also fixed the frontend `convert_sampling` derivation that voided it), `FinishReason::Stop` emitted. Verified on both shapes with `scripts/e2e_serving_contract.py`.
+2. **Sampling params: honor or reject.** ✓ Done (issue #237): non-greedy requests are rejected at scheduler admission with a clear error (the decode path is split-vocab argmax and cannot sample); the full OpenAI param surface is audited in [serving-contract.md](serving-contract.md) — every parameter is honored / rejected / documented-ignored, nothing silent. Real sampling support (full-logits gather + shared FlashInfer ops) is future feature work.
 3. **Prompt-length guard.** Reject prompts whose `prompt + max_tokens` exceeds the 2048-token per-slot arena instead of overrunning KV pages.
 4. **KV admission + abort-on-disconnect.** Port the qwen3 admission pattern (budget, deferral, rejection) to both paths; wire disconnect-abort when the server-wide #215 lands.
 5. **`tests/` directory.** Scheduler-robustness ITs (CPU-runnable: admission, coalesce, slot-lifecycle edges) so the above gets regression coverage. Kimi-K2 is the only model crate without integration tests.

--- a/docs/models/kimi-k2/serving-contract.md
+++ b/docs/models/kimi-k2/serving-contract.md
@@ -1,0 +1,30 @@
+# Kimi-K2 serving contract
+
+> **TL;DR:** Kimi-K2 经 `/v1/completions` 的 OpenAI 参数面审计(issue #237):greedy(`temperature=0`)+ EOS 停止 + `ignore_eos` 是 honored 集合;`temperature>0` 在 scheduler 准入处显式拒绝(decode 路径只有 split-vocab argmax,没有采样 kernel);其余参数按表格归属,没有 silently-wrong 状态。
+>
+> **Last touched:** 2026-06
+
+## 参数表
+
+行为分三类:**honored**(语义正确生效)、**rejected**(请求返回明确错误)、**ignored (documented)**(不生效,本表即声明)。
+
+| 参数 | 行为 | 生效层 / 依据 |
+| --- | --- | --- |
+| `temperature=0` | honored — greedy argmax decode | engine(`runner/worker/forward.rs` split-vocab top1) |
+| `temperature>0` | **rejected** — HTTP 500,无生成文本;拒绝原因见 server 日志(详见下文) | scheduler 准入(`runner/scheduler/lifecycle.rs::finish_unschedulable`),两条 shape 路径共用 |
+| `top_k` / `top_p` | `temperature=0` 时无语义;`temperature>0` 时随请求整体被拒 | — |
+| `max_tokens` | honored | engine,两条路径(#238 起 EOS 优先于 length) |
+| `ignore_eos` | honored — 跳过 EOS 检测,生成满 `max_tokens` | engine(#238;frontend 推导修复见 `pegainfer-vllm-frontend::convert_sampling`) |
+| `stop`(字符串) | honored — detokenize 后匹配,token 流在 frontend 截断 | vllm-server frontend(`text/output/decoded.rs`),engine 不参与 |
+| `stop_token_ids`(自定义) | ignored (documented) — engine 只认模型级 stop 集合(`generation_config.json`);给了自定义 stop token 时 frontend 会保持 EOS 检测开启,但不会在自定义 token 上停 | 所有 pegainfer 引擎一致,Kimi 无特例 |
+| `seed` | ignored (documented) — greedy 下无语义;wire 有字段,`convert_sampling` 不读 | pegainfer-vllm-frontend |
+| `presence_penalty` / `frequency_penalty` / `repetition_penalty` | ignored (documented) — wire 有字段,`convert_sampling` 不读。注意:penalty 在 greedy 下本应改变 argmax,这是 pegainfer 全引擎层缺口,不是 Kimi 特有 | pegainfer-vllm-frontend |
+| `min_p` / `min_tokens` / `logit_bias` / `bad_words` | ignored (documented) — 同上,frontend 层丢弃 | pegainfer-vllm-frontend |
+| `logprobs` | ignored (documented) — Kimi-K2 始终回 `logprob: None`(issue #236 跟踪) | engine |
+| `echo` | ignored (documented) — `PromptTokens` 事件未实现(issue #236 跟踪) | engine |
+
+## 拒绝行为
+
+非 greedy 请求在 prefill 之前被拒,不占用 GPU step,引擎继续服务后续请求。客户端看到的是 HTTP 500(无任何生成文本):vllm-server 的 HTTP 层把 `EngineCoreFinishReason::Error` 统一折叠成 generic `Internal server error`,引擎侧的错误文本(`StopReason::Text`)在 wire 上被丢弃——这是 pinned vllm-server crate 的限制,不是 Kimi 特有。具体拒绝原因(`Kimi-K2 decodes greedy only; ... Send temperature=0`)由 `pegainfer-vllm-frontend` 在 server 日志里打 warn,运维可见。
+
+后续如果要真正支持采样:decode 路径需要先聚合全 logits(目前 TP8 是 per-rank vocab 分片 top1 直接合并),再接 shared FlashInfer sampling ops;那是功能项,不在 #237 范围。

--- a/pegainfer-kimi-k2/src/runner/scheduler/lifecycle.rs
+++ b/pegainfer-kimi-k2/src/runner/scheduler/lifecycle.rs
@@ -50,6 +50,22 @@ fn finish_unschedulable(req: &GenerateRequest) -> bool {
         });
         return true;
     }
+    // The decode path only computes a split-vocab argmax; it cannot sample.
+    // Rejecting here keeps the API contract honest — silently returning
+    // greedy output for a temperature>0 request is the one forbidden state
+    // (issue #237).
+    if req.params.temperature > 0.0 {
+        let _ = req.token_tx.send(TokenEvent::Rejected {
+            message: format!(
+                "Kimi-K2 decodes greedy only; non-greedy sampling is not implemented \
+                 (got temperature={}, top_k={}, top_p={}). Send temperature=0",
+                req.params.temperature, req.params.top_k, req.params.top_p
+            ),
+            prompt_tokens: req.prompt_tokens.len(),
+            completion_tokens: 0,
+        });
+        return true;
+    }
     false
 }
 
@@ -58,4 +74,54 @@ fn unix_now_s() -> f64 {
         .duration_since(UNIX_EPOCH)
         .expect("system clock is before UNIX_EPOCH")
         .as_secs_f64()
+}
+
+#[cfg(test)]
+mod tests {
+    use pegainfer_core::sampler::SamplingParams;
+    use tokio::sync::mpsc;
+
+    use super::*;
+
+    fn request(params: SamplingParams) -> (GenerateRequest, mpsc::UnboundedReceiver<TokenEvent>) {
+        let (token_tx, token_rx) = mpsc::unbounded_channel();
+        (
+            GenerateRequest {
+                request_id: None,
+                queued_at_unix_s: None,
+                prompt_tokens: vec![1, 2, 3],
+                params,
+                max_tokens: 8,
+                lora_adapter: None,
+                token_tx,
+                logprobs: 0,
+                echo: false,
+            },
+            token_rx,
+        )
+    }
+
+    #[test]
+    fn greedy_request_is_schedulable() {
+        let (req, _token_rx) = request(SamplingParams::default());
+        assert!(preflight_prefill_candidate(req).is_some());
+    }
+
+    #[test]
+    fn non_greedy_request_is_rejected() {
+        let params = SamplingParams {
+            temperature: 0.8,
+            top_k: 50,
+            top_p: 0.9,
+            ignore_eos: false,
+        };
+        let (req, mut token_rx) = request(params);
+
+        assert!(preflight_prefill_candidate(req).is_none());
+        let Ok(TokenEvent::Rejected { message, .. }) = token_rx.try_recv() else {
+            panic!("expected Rejected event");
+        };
+        assert!(message.contains("greedy only"), "message: {message}");
+        assert!(message.contains("temperature=0.8"), "message: {message}");
+    }
 }

--- a/pegainfer-vllm-frontend/src/lib.rs
+++ b/pegainfer-vllm-frontend/src/lib.rs
@@ -825,6 +825,9 @@ async fn run_request_stream(
             }
             TokenEvent::Rejected { message, .. } => {
                 // Rejected means the request could not be admitted, not that it completed cleanly.
+                // The vllm-server HTTP layer collapses engine errors into a generic 500, so this
+                // log line is the only place the rejection reason is visible.
+                warn!("engine rejected request {request_id}: {message}");
                 let _ = send_terminal_output(
                     &output_tx,
                     request_id,

--- a/scripts/e2e_serving_contract.py
+++ b/scripts/e2e_serving_contract.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python3
-"""E2E check that a serving pegainfer engine stops at EOS (issue #238).
+"""E2E checks for the Kimi-K2 serving contract against a running server.
 
-Sends the same prompt twice through `/v1/completions` on an already-running
-server:
+Three checks through `/v1/completions` (issues #238, #237):
 
-1. default: the answer must end early with `finish_reason: "stop"` and fewer
+1. EOS stop: the answer must end early with `finish_reason: "stop"` and fewer
    than `max_tokens` completion tokens;
 2. `ignore_eos: true`: generation must run to `finish_reason: "length"` with
-   exactly `max_tokens` completion tokens (benchmarks rely on this).
+   exactly `max_tokens` completion tokens (benchmarks rely on this);
+3. non-greedy reject: a `temperature>0` request must fail with an HTTP error
+   and produce no completion — silently-greedy output is the one forbidden
+   state. (The vllm-server HTTP layer collapses engine rejections into a
+   generic 500; the "decodes greedy only" reason appears in the server log.)
 
 The default prompt is in Kimi-K2 chat format; pass --prompt for other models.
 
 Usage:
-    python3 scripts/e2e_eos_stop.py --base-url http://127.0.0.1:8124 --model kimi-k2.5
+    python3 scripts/e2e_serving_contract.py --base-url http://127.0.0.1:8124 --model kimi-k2.5
 """
 
 from __future__ import annotations
@@ -20,6 +23,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import urllib.error
 import urllib.request
 
 KIMI_PROMPT = (
@@ -29,23 +33,35 @@ KIMI_PROMPT = (
 )
 
 
-def request_completion(
-    base_url: str, model: str, prompt: str, max_tokens: int, ignore_eos: bool, timeout: float
-) -> dict:
-    body = {
-        "model": model,
-        "prompt": prompt,
-        "max_tokens": max_tokens,
-        "temperature": 0.0,
-        "ignore_eos": ignore_eos,
-    }
+def post_completion(base_url: str, body: dict, timeout: float) -> tuple[int, dict]:
     request = urllib.request.Request(
         f"{base_url}/v1/completions",
         data=json.dumps(body).encode(),
         headers={"Content-Type": "application/json"},
     )
-    with urllib.request.urlopen(request, timeout=timeout) as response:
-        payload = json.load(response)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.status, json.load(response)
+    except urllib.error.HTTPError as error:
+        return error.code, json.loads(error.read() or b"{}")
+
+
+def request_completion(
+    base_url: str, model: str, prompt: str, max_tokens: int, ignore_eos: bool, timeout: float
+) -> dict:
+    status, payload = post_completion(
+        base_url,
+        {
+            "model": model,
+            "prompt": prompt,
+            "max_tokens": max_tokens,
+            "temperature": 0.0,
+            "ignore_eos": ignore_eos,
+        },
+        timeout,
+    )
+    if status != 200:
+        raise RuntimeError(f"greedy request failed with HTTP {status}: {payload}")
     choice = payload["choices"][0]
     return {
         "finish_reason": choice["finish_reason"],
@@ -80,6 +96,24 @@ def main() -> int:
     )
     print(f"ignore_eos run: {length_run['finish_reason']}, {length_run['completion_tokens']} tokens")
 
+    sampling_status, sampling_payload = post_completion(
+        args.base_url,
+        {
+            "model": args.model,
+            "prompt": args.prompt,
+            "max_tokens": args.max_tokens,
+            "temperature": 0.8,
+            "top_p": 0.9,
+        },
+        args.timeout,
+    )
+    sampling_body = json.dumps(sampling_payload, ensure_ascii=False)
+    print(f"non-greedy run: HTTP {sampling_status}")
+    print(f"  body: {sampling_body[:300]}")
+    sampling_text = "".join(
+        choice.get("text") or "" for choice in sampling_payload.get("choices", [])
+    )
+
     ok = True
     ok &= check(
         "EOS stops generation",
@@ -100,6 +134,11 @@ def main() -> int:
         "ignore_eos generates max_tokens",
         length_run["completion_tokens"] == args.max_tokens,
         f"{length_run['completion_tokens']} == {args.max_tokens}",
+    )
+    ok &= check(
+        "non-greedy is explicitly rejected",
+        sampling_status != 200 and not sampling_text,
+        f"HTTP {sampling_status}, generated text: {sampling_text!r}",
     )
     return 0 if ok else 1
 


### PR DESCRIPTION
## Problem

Issue #237: Kimi-K2 silently ignores all sampling parameters — every request decodes greedy regardless of `temperature` / `top_k` / `top_p`. A client asking for `temperature=0.8` gets deterministic argmax output with a clean `finish_reason`, which is the one forbidden state: silently wrong.

## Fix

The decode path only computes a split-vocab argmax (`launch_local_top1_batch`); it cannot sample. So this PR makes the contract honest instead of pretending: **honor or reject**.

- `runner/scheduler/lifecycle.rs::finish_unschedulable` rejects `temperature>0` requests before prefill with a clear reason (`Kimi-K2 decodes greedy only; ... Send temperature=0`). Shared by both scheduler paths (TP8 batch-then-drain and TP1+DP8 lock-step); rejection happens before slot reservation, so PPLX collective semantics are untouched.
- `temperature` is the airtight signal: `convert_sampling` hard-normalizes `top_k`/`top_p` when `temperature<=0`, so any non-greedy intent reaches the engine as `temperature>0`.
- The pinned vllm-server crate collapses `EngineCoreFinishReason::Error` into a generic HTTP 500 and drops the engine's error text on the wire, so `pegainfer-vllm-frontend` now logs the rejection reason — the only place it is operator-visible.

## Param surface audit

`docs/models/kimi-k2/serving-contract.md` (new) classifies every OpenAI param as honored / rejected / documented-ignored with layer attribution — nothing silent.

## Tests

- Unit: `lifecycle.rs` — greedy schedulable, non-greedy rejected with message (both admission entry points).
- E2E: `scripts/e2e_eos_stop.py` → `scripts/e2e_serving_contract.py`, now covers EOS stop, `ignore_eos`, and non-greedy reject through `/v1/completions`.

Verified on H20 ×8, TP1+DP8+EP8 PPLX, Kimi-K2.5:

```
stop run: stop, 54 tokens
ignore_eos run: length, 256 tokens
non-greedy run: HTTP 500
[PASS] EOS stops generation: finish_reason=stop
[PASS] stop run ends early: 54 < 256
[PASS] ignore_eos runs to length: finish_reason=length
[PASS] ignore_eos generates max_tokens: 256 == 256
[PASS] non-greedy is explicitly rejected: HTTP 500, generated text: ''
```

Server log shows the reason:

```
WARN pegainfer_vllm_frontend: engine rejected request cmpl-...: Kimi-K2 decodes greedy only; non-greedy sampling is not implemented (got temperature=0.8, top_k=-1, top_p=0.9). Send temperature=0
```

Real sampling support (full-logits gather + shared FlashInfer sampling ops) is future feature work, out of scope here.

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)