### PR TITLE
fix(kimi-k2): advertise the real 2048 context window and guard admission (#239)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -69,8 +69,8 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 
 | Path | TL;DR |
 | --- | --- |
-| `models/kimi-k2/roadmap.md` | Cross-cutting Kimi-K2 plan, verified against code 2026-06: decode beats vLLM (bs64 `1336 vs 594 tok/s`) but the serving contract trails Qwen3-4B — EOS stop (#238) and sampling honor-or-reject (#237) landed; 2048-token arena overrun and accuracy-gate reproducibility still open. Sequence: correctness + accuracy-gate-in-git → TTFT/HTTP overhead → batching/prefix-cache and PPLX-throughput chains → cleanup ledger. |
-| `models/kimi-k2/serving-contract.md` | Kimi-K2 OpenAI 参数面审计(#237):greedy + EOS + ignore_eos honored;`temperature>0` 准入拒绝;其余参数逐项归属,无 silently-wrong 状态。 |
+| `models/kimi-k2/roadmap.md` | Cross-cutting Kimi-K2 plan, verified against code 2026-06: decode beats vLLM (bs64 `1336 vs 594 tok/s`) but the serving contract trails Qwen3-4B — EOS stop (#238), sampling honor-or-reject (#237), and the 2048-window guard (#239 first half) landed; accuracy-gate reproducibility still open. Sequence: correctness + accuracy-gate-in-git → TTFT/HTTP overhead → batching/prefix-cache and PPLX-throughput chains → cleanup ledger. |
+| `models/kimi-k2/serving-contract.md` | Kimi-K2 OpenAI 参数面审计(#237/#239):greedy + EOS + ignore_eos honored;`temperature>0` 准入拒绝;context window 按真实 2048 KV 窗口公告(超长拒绝、`max_tokens` clamp);其余参数逐项归属,无 silently-wrong 状态。 |
 | `models/kimi-k2/optimization.md` | Kimi-K2 model card + optimization log：61 层 MLA + Marlin WNA16 MoE，H20 ×8 当前 TP8/EP8。重点是 decode：bs4 graph TPOT `14.39ms`（≈`278 tok/s`），目标 `> 300 tok/s`；下一阶段迁到 TP1+DP8+EP8（PPLX）。Prefill 优先级低。 |
 | `models/kimi-k2/support-analysis.md` | Kimi-K2 text-only bring-up：Marlin WNA16 routed expert、MLA prompt、全 61 层 prompt forward、多 prompt vLLM top-20 gate 已过；bs4 wave decode 已接入，Marlin atomic split-K row-state bug 修复后 output16 row diff 清零，正在撤掉 decode 诊断负担并回到 bs4 性能主线。 |
 | `models/kimi-k2/operator-todo.md` | Kimi-K2 算子清单：MLA + Marlin WNA16 routed expert + NCCL RS bridge 主链；CUDA Graph 覆盖整段 decode，synthetic output64 avg `14.39ms` / p99 `14.83ms`；CUTLASS INT4 后端与 decode row-diff 诊断已下线，详见 changelog。 |

--- a/docs/models/kimi-k2/roadmap.md
+++ b/docs/models/kimi-k2/roadmap.md
@@ -1,6 +1,6 @@
 # Kimi-K2 Roadmap
 
-> **TL;DR:** Kimi-K2 decode performance is ahead of vLLM on the same H20 ×8 hardware (TP1+DP8+EP8 service bs64: output `1336 tok/s` vs vLLM `594 tok/s`, TPOT p50 `47.3ms` vs `107.2ms`), but the crate still trails Qwen3-4B on the serving contract and correctness surface: prompts over 2048 tokens overrun the KV arena unchecked, and no accuracy gate is reproducible from a fresh clone. Landed: EOS/stop-token handling (#238) and sampling honor-or-reject (#237, non-greedy rejected at admission, param surface audited in [serving-contract.md](serving-contract.md)). The roadmap sequence is: serving-contract correctness + a git-versioned accuracy gate first, then the TTFT/prefill and HTTP-overhead perf gaps, then the continuous-batching→KV-lifecycle→prefix-cache chain and the PPLX/decode-throughput chain. Findings verified 2026-06-04 against `6ee9247`.
+> **TL;DR:** Kimi-K2 decode performance is ahead of vLLM on the same H20 ×8 hardware (TP1+DP8+EP8 service bs64: output `1336 tok/s` vs vLLM `594 tok/s`, TPOT p50 `47.3ms` vs `107.2ms`), but the crate still trails Qwen3-4B on the serving contract and correctness surface: no accuracy gate is reproducible from a fresh clone. Landed: EOS/stop-token handling (#238), sampling honor-or-reject (#237), and the context-window guard (#239 first half: `max_model_len` advertised as the real 2048 KV window, over-long prompts refused, `max_tokens` clamped) — param surface audited in [serving-contract.md](serving-contract.md). The roadmap sequence is: serving-contract correctness + a git-versioned accuracy gate first, then the TTFT/prefill and HTTP-overhead perf gaps, then the continuous-batching→KV-lifecycle→prefix-cache chain and the PPLX/decode-throughput chain. Findings verified 2026-06-04 against `6ee9247`.
 >
 > **Last touched:** 2026-06
 
@@ -12,7 +12,7 @@ Status ledgers: [tp1-dp8-ep8-performance.md](tp1-dp8-ep8-performance.md) (active
 | --- | --- | --- | --- |
 | EOS / stop-token detection | ✓ per-step `is_stop_token` | ✓ per-step on both paths, honors `ignore_eos` (issue #238) | `config.rs::load_stop_token_ids`; checks in `runner/scheduler.rs` + `runner/scheduler/dp.rs`; e2e `scripts/e2e_serving_contract.py` |
 | Sampling params | ✓ FlashInfer greedy + non-greedy | ✓ honor-or-reject (#237): greedy honored, non-greedy rejected at admission; param surface audited | `runner/scheduler/lifecycle.rs::finish_unschedulable`; [serving-contract.md](serving-contract.md) |
-| Prompt-length guard | ✓ KV-budget admission rejects impossible requests | ✗ 2048-token arena cap (`worker.rs:60-61`), `append_position` unchecked → silent overrun | `runner/scheduler.rs:148-151` |
+| Prompt-length guard | ✓ KV-budget admission rejects impossible requests | ✓ `max_model_len` advertised as the real 2048 window: HTTP refuses over-long prompts, clamps `max_tokens`; admission guard backstops direct submitters (#239) | `config.rs::KIMI_K2_SERVING_CONTEXT_TOKENS`; `lifecycle.rs::finish_unschedulable`; e2e `scripts/e2e_serving_contract.py` |
 | KV admission control | ✓ full-lifetime budget, deferral, rejection (issue #85 fix) | ✗ slot-count only on both paths | qwen3 `scheduler.rs:478-510` |
 | Continuous batching | ✓ | TP1/DP8: ✓ (`DpCoordinator` per-step admission, waiting queue); TP8/DP1: ✗ strict batch-then-drain | `runner/scheduler/dp.rs:168,189-236` vs `runner/scheduler.rs:140-207` |
 | Prefix cache | ✓ kvbm full-block matching (PR #216) | ✗ fixed per-slot arena, no block table / free pool | `runner/worker/cache.rs:391-396` |
@@ -28,7 +28,7 @@ Status ledgers: [tp1-dp8-ep8-performance.md](tp1-dp8-ep8-performance.md) (active
 - **TP8+EP8 NCCL (graph path):** bs4 TPOT `14.39ms` synthetic. Wave-batched, reference/history path.
 - **TTFT is the open perf gap:** HTTP decode-heavy bs4 TTFT p50 `313ms` / p99 `4240ms` vs vLLM `69.6/135.4ms` (4.5×/31× worse). Short-prompt streaming TTFT ~`2.0s`.
 - **HTTP vs in-process:** `19.13ms` vs `14.39ms` TPOT at bs4 — ~33% serving overhead, unattributed.
-- No claim of: non-greedy sampling, >2048-token prompts, long-context decode correctness, prefix reuse, multi-node.
+- No claim of: non-greedy sampling, >2048-token prompts (now refused at the HTTP layer instead of accepted-and-corrupted), long-context decode correctness, prefix reuse, multi-node.
 
 ## Sequencing — what blocks what
 
@@ -49,8 +49,8 @@ The engine is fast but does not honor the OpenAI contract it serves. All items a
 
 1. **EOS/stop-token handling.** ✓ Done (issue #238): `config.rs::load_stop_token_ids` (generation_config.json with config.json fallback), per-step checks on both scheduler paths, `ignore_eos` honored end-to-end (also fixed the frontend `convert_sampling` derivation that voided it), `FinishReason::Stop` emitted. Verified on both shapes with `scripts/e2e_serving_contract.py`.
 2. **Sampling params: honor or reject.** ✓ Done (issue #237): non-greedy requests are rejected at scheduler admission with a clear error (the decode path is split-vocab argmax and cannot sample); the full OpenAI param surface is audited in [serving-contract.md](serving-contract.md) — every parameter is honored / rejected / documented-ignored, nothing silent. Real sampling support (full-logits gather + shared FlashInfer ops) is future feature work.
-3. **Prompt-length guard.** Reject prompts whose `prompt + max_tokens` exceeds the 2048-token per-slot arena instead of overrunning KV pages.
-4. **KV admission + abort-on-disconnect.** Port the qwen3 admission pattern (budget, deferral, rejection) to both paths; wire disconnect-abort when the server-wide #215 lands.
+3. **Prompt-length guard.** ✓ Done (issue #239 first half): `max_model_len` is now advertised as the engine's real per-request KV window (`KIMI_K2_SERVING_CONTEXT_TOKENS` = 2048, which also derives the decode page-table geometry), so the HTTP layer refuses over-long prompts with a clear message and clamps `max_tokens` to the remaining window; scheduler admission carries the same guard for direct engine submitters — previously an over-capacity request errored mid-batch, taking every co-scheduled request down with it. Verified with `scripts/e2e_serving_contract.py` (over-long refusal + exact window-saturating clamp).
+4. **KV admission + abort-on-disconnect.** (#239 second half) Port the qwen3 admission pattern (budget, deferral, rejection) to both paths; wire disconnect-abort when the server-wide #215 lands.
 5. **`tests/` directory.** Scheduler-robustness ITs (CPU-runnable: admission, coalesce, slot-lifecycle edges) so the above gets regression coverage. Kimi-K2 is the only model crate without integration tests.
 
 ### Now — M2: accuracy gate in git

--- a/docs/models/kimi-k2/serving-contract.md
+++ b/docs/models/kimi-k2/serving-contract.md
@@ -1,6 +1,6 @@
 # Kimi-K2 serving contract
 
-> **TL;DR:** Kimi-K2 经 `/v1/completions` 的 OpenAI 参数面审计(issue #237):greedy(`temperature=0`)+ EOS 停止 + `ignore_eos` 是 honored 集合;`temperature>0` 在 scheduler 准入处显式拒绝(decode 路径只有 split-vocab argmax,没有采样 kernel);其余参数按表格归属,没有 silently-wrong 状态。
+> **TL;DR:** Kimi-K2 经 `/v1/completions` 的 OpenAI 参数面审计(issue #237/#239):greedy(`temperature=0`)+ EOS 停止 + `ignore_eos` 是 honored 集合;`temperature>0` 在 scheduler 准入处显式拒绝(decode 路径只有 split-vocab argmax,没有采样 kernel);context window 按引擎真实 KV 容量(2048)对外公告,超长 prompt 在 HTTP 层拒绝、`max_tokens` 被 clamp 到剩余窗口;其余参数按表格归属,没有 silently-wrong 状态。
 >
 > **Last touched:** 2026-06
 
@@ -13,7 +13,8 @@
 | `temperature=0` | honored — greedy argmax decode | engine(`runner/worker/forward.rs` split-vocab top1) |
 | `temperature>0` | **rejected** — HTTP 500,无生成文本;拒绝原因见 server 日志(详见下文) | scheduler 准入(`runner/scheduler/lifecycle.rs::finish_unschedulable`),两条 shape 路径共用 |
 | `top_k` / `top_p` | `temperature=0` 时无语义;`temperature>0` 时随请求整体被拒 | — |
-| `max_tokens` | honored | engine,两条路径(#238 起 EOS 优先于 length) |
+| `max_tokens` | honored — 超出剩余窗口时 clamp 到 `2048 - prompt_tokens`(vLLM 同语义) | HTTP 层(`resolve_max_tokens`)+ engine 两条路径(#238 起 EOS 优先于 length) |
+| prompt 长度 | honored — 超过 2048 的 prompt 在 HTTP 层拒绝,错误消息含 "maximum context length" | `max_model_len` 按引擎真实 KV 窗口公告(#239,`KIMI_K2_SERVING_CONTEXT_TOKENS`);scheduler 准入有同款兜底 guard |
 | `ignore_eos` | honored — 跳过 EOS 检测,生成满 `max_tokens` | engine(#238;frontend 推导修复见 `pegainfer-vllm-frontend::convert_sampling`) |
 | `stop`(字符串) | honored — detokenize 后匹配,token 流在 frontend 截断 | vllm-server frontend(`text/output/decoded.rs`),engine 不参与 |
 | `stop_token_ids`(自定义) | ignored (documented) — engine 只认模型级 stop 集合(`generation_config.json`);给了自定义 stop token 时 frontend 会保持 EOS 检测开启,但不会在自定义 token 上停 | 所有 pegainfer 引擎一致,Kimi 无特例 |
@@ -23,8 +24,18 @@
 | `logprobs` | ignored (documented) — Kimi-K2 始终回 `logprob: None`(issue #236 跟踪) | engine |
 | `echo` | ignored (documented) — `PromptTokens` 事件未实现(issue #236 跟踪) | engine |
 
+## Context window(#239)
+
+引擎对外公告的 `max_model_len` 是每请求 KV arena 的真实容量 2048(`KIMI_K2_SERVING_CONTEXT_TOKENS`,decode 页表几何由它推导),不是模型训练上下文 262144。效果:
+
+- 超长 prompt 在 HTTP 层被拒,消息明确(`this model's maximum context length is 2048 tokens, but the prompt contains N input tokens`)。pinned vllm-server 把 lowering 错误映射为 HTTP 500 而非 vLLM Python 的 400,但消息完整。
+- `prompt + max_tokens` 超窗时 `max_tokens` 被 clamp 到剩余窗口,跑满后以 `length` 结束——与 vLLM `get_max_tokens()` 同语义,KV 永不越界。HTTP 层拒绝 `prompt >= 2048`(比引擎 arena 严一个 token):HTTP 进来的请求永远满足引擎 guard。
+- scheduler 准入处有同一常量的兜底 guard(`prompt + max_tokens - 1 > 2048` 拒绝),保护不走 HTTP 的直接 `EngineHandle` 提交方:在 TP8 路径上,一个超容请求若进到 decode 中途才报错,会把整个 co-scheduled batch 一起带崩。
+
+每请求 KV 需求是 `prompt + max_tokens - 1`:最后一个生成 token 直接发出,不回填 KV。
+
 ## 拒绝行为
 
-非 greedy 请求在 prefill 之前被拒,不占用 GPU step,引擎继续服务后续请求。客户端看到的是 HTTP 500(无任何生成文本):vllm-server 的 HTTP 层把 `EngineCoreFinishReason::Error` 统一折叠成 generic `Internal server error`,引擎侧的错误文本(`StopReason::Text`)在 wire 上被丢弃——这是 pinned vllm-server crate 的限制,不是 Kimi 特有。具体拒绝原因(`Kimi-K2 decodes greedy only; ... Send temperature=0`)由 `pegainfer-vllm-frontend` 在 server 日志里打 warn,运维可见。
+非 greedy / 超容请求在 prefill 之前被拒,不占用 GPU step,引擎继续服务后续请求。引擎侧拒绝(`TokenEvent::Rejected`)到客户端是 HTTP 500(无任何生成文本):vllm-server 的 HTTP 层把 `EngineCoreFinishReason::Error` 统一折叠成 generic `Internal server error`,引擎侧的错误文本(`StopReason::Text`)在 wire 上被丢弃——这是 pinned vllm-server crate 的限制,不是 Kimi 特有。具体拒绝原因(`Kimi-K2 decodes greedy only; ... Send temperature=0`)由 `pegainfer-vllm-frontend` 在 server 日志里打 warn,运维可见。
 
 后续如果要真正支持采样:decode 路径需要先聚合全 logits(目前 TP8 是 per-rank vocab 分片 top1 直接合并),再接 shared FlashInfer sampling ops;那是功能项,不在 #237 范围。

--- a/pegainfer-kimi-k2/src/config.rs
+++ b/pegainfer-kimi-k2/src/config.rs
@@ -12,6 +12,14 @@ pub(crate) const KIMI_K2_DENSE_LAYERS: usize = 1;
 pub(crate) const KIMI_K2_MOE_LAYERS: usize = 60;
 const KIMI_K2_MAX_CONTEXT: usize = 262_144;
 
+/// The serving window the engine can actually hold per request: each decode
+/// slot owns a fixed KV page range sized from this value (`runner/worker.rs`).
+/// The model's trained context is [`KIMI_K2_MAX_CONTEXT`]; advertising that
+/// would admit prompts the KV arena cannot store. The server reports this as
+/// `max_model_len` so over-long prompts are refused at the HTTP layer and
+/// `max_tokens` is clamped to the remaining window.
+pub const KIMI_K2_SERVING_CONTEXT_TOKENS: usize = 2048;
+
 pub(crate) const KIMI_K2_HEADS: usize = 64;
 pub(crate) const KIMI_K2_Q_LORA_RANK: usize = 1536;
 const KIMI_K2_KV_LORA_RANK: usize = 512;

--- a/pegainfer-kimi-k2/src/lib.rs
+++ b/pegainfer-kimi-k2/src/lib.rs
@@ -28,7 +28,7 @@ mod typed_scratch;
 #[cfg(feature = "kimi-k2")]
 mod weights;
 
-pub use config::{KIMI_K2_LAYERS, probe_config_json};
+pub use config::{KIMI_K2_LAYERS, KIMI_K2_SERVING_CONTEXT_TOKENS, probe_config_json};
 
 #[cfg(feature = "kimi-k2")]
 #[allow(clippy::needless_pass_by_value)]

--- a/pegainfer-kimi-k2/src/runner/scheduler/lifecycle.rs
+++ b/pegainfer-kimi-k2/src/runner/scheduler/lifecycle.rs
@@ -2,6 +2,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use pegainfer_core::engine::{FinishReason, GenerateRequest, TokenEvent};
 
+use crate::config::KIMI_K2_SERVING_CONTEXT_TOKENS;
+
 pub(in crate::runner) fn schedule_prefill_candidate(
     req: GenerateRequest,
 ) -> Option<GenerateRequest> {
@@ -66,6 +68,25 @@ fn finish_unschedulable(req: &GenerateRequest) -> bool {
         });
         return true;
     }
+    // Per-request KV demand: the prompt plus every generated token except the
+    // last, which is emitted without being fed back. The HTTP layer already
+    // clamps to the advertised `max_model_len`, so this only fires for direct
+    // engine submitters — rejecting here beats erroring mid-batch, where a
+    // forward failure takes down every co-scheduled request (issue #239).
+    let kv_demand = req.prompt_tokens.len() + req.max_tokens - 1;
+    if kv_demand > KIMI_K2_SERVING_CONTEXT_TOKENS {
+        let _ = req.token_tx.send(TokenEvent::Rejected {
+            message: format!(
+                "Kimi-K2 serving context is {KIMI_K2_SERVING_CONTEXT_TOKENS} tokens; \
+                 prompt ({}) + max_tokens ({}) needs {kv_demand} KV positions",
+                req.prompt_tokens.len(),
+                req.max_tokens
+            ),
+            prompt_tokens: req.prompt_tokens.len(),
+            completion_tokens: 0,
+        });
+        return true;
+    }
     false
 }
 
@@ -83,15 +104,19 @@ mod tests {
 
     use super::*;
 
-    fn request(params: SamplingParams) -> (GenerateRequest, mpsc::UnboundedReceiver<TokenEvent>) {
+    fn request(
+        prompt_len: usize,
+        max_tokens: usize,
+        params: SamplingParams,
+    ) -> (GenerateRequest, mpsc::UnboundedReceiver<TokenEvent>) {
         let (token_tx, token_rx) = mpsc::unbounded_channel();
         (
             GenerateRequest {
                 request_id: None,
                 queued_at_unix_s: None,
-                prompt_tokens: vec![1, 2, 3],
+                prompt_tokens: vec![1; prompt_len],
                 params,
-                max_tokens: 8,
+                max_tokens,
                 lora_adapter: None,
                 token_tx,
                 logprobs: 0,
@@ -101,9 +126,16 @@ mod tests {
         )
     }
 
+    fn rejection_message(token_rx: &mut mpsc::UnboundedReceiver<TokenEvent>) -> String {
+        let Ok(TokenEvent::Rejected { message, .. }) = token_rx.try_recv() else {
+            panic!("expected Rejected event");
+        };
+        message
+    }
+
     #[test]
     fn greedy_request_is_schedulable() {
-        let (req, _token_rx) = request(SamplingParams::default());
+        let (req, _token_rx) = request(3, 8, SamplingParams::default());
         assert!(preflight_prefill_candidate(req).is_some());
     }
 
@@ -115,13 +147,45 @@ mod tests {
             top_p: 0.9,
             ignore_eos: false,
         };
-        let (req, mut token_rx) = request(params);
+        let (req, mut token_rx) = request(3, 8, params);
 
         assert!(preflight_prefill_candidate(req).is_none());
-        let Ok(TokenEvent::Rejected { message, .. }) = token_rx.try_recv() else {
-            panic!("expected Rejected event");
-        };
+        let message = rejection_message(&mut token_rx);
         assert!(message.contains("greedy only"), "message: {message}");
         assert!(message.contains("temperature=0.8"), "message: {message}");
+    }
+
+    #[test]
+    fn request_filling_the_context_exactly_is_schedulable() {
+        // KV demand is prompt + max_tokens - 1: the last generated token is
+        // emitted without being appended.
+        let max_tokens = 8;
+        let prompt_len = KIMI_K2_SERVING_CONTEXT_TOKENS + 1 - max_tokens;
+        let (req, _token_rx) = request(prompt_len, max_tokens, SamplingParams::default());
+        assert!(preflight_prefill_candidate(req).is_some());
+    }
+
+    #[test]
+    fn request_one_token_over_the_context_is_rejected() {
+        let max_tokens = 8;
+        let prompt_len = KIMI_K2_SERVING_CONTEXT_TOKENS + 2 - max_tokens;
+        let (req, mut token_rx) = request(prompt_len, max_tokens, SamplingParams::default());
+
+        assert!(preflight_prefill_candidate(req).is_none());
+        let message = rejection_message(&mut token_rx);
+        assert!(message.contains("serving context"), "message: {message}");
+    }
+
+    #[test]
+    fn over_long_prompt_is_rejected() {
+        let (req, mut token_rx) = request(
+            KIMI_K2_SERVING_CONTEXT_TOKENS + 1,
+            1,
+            SamplingParams::default(),
+        );
+
+        assert!(preflight_prefill_candidate(req).is_none());
+        let message = rejection_message(&mut token_rx);
+        assert!(message.contains("serving context"), "message: {message}");
     }
 }

--- a/pegainfer-kimi-k2/src/runner/worker.rs
+++ b/pegainfer-kimi-k2/src/runner/worker.rs
@@ -57,7 +57,11 @@ const KIMI_MARLIN_MAX_BLOCK_SIZE: usize = 64;
 const KIMI_DECODE_MAX_BATCH: usize = 64;
 const KIMI_DECODE_BATCH_BUCKETS: [usize; 7] = [1, 2, 4, 8, 16, 32, KIMI_DECODE_MAX_BATCH];
 const KIMI_DECODE_PAGE_SIZE: usize = 16;
-const KIMI_DECODE_PAGES_PER_REQUEST: usize = 128;
+// Per-slot page count covers the advertised serving window exactly; the
+// scheduler admission guard and `max_model_len` both derive from the same
+// constant, so an admitted request can never overrun its page range.
+const KIMI_DECODE_PAGES_PER_REQUEST: usize =
+    crate::config::KIMI_K2_SERVING_CONTEXT_TOKENS.div_ceil(KIMI_DECODE_PAGE_SIZE);
 const KIMI_DECODE_ROPE_CACHE_TOKENS: usize = KIMI_DECODE_PAGE_SIZE * KIMI_DECODE_PAGES_PER_REQUEST;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/pegainfer-server/src/main.rs
+++ b/pegainfer-server/src/main.rs
@@ -231,9 +231,24 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
+    let config_model_len =
+        pegainfer::vllm_frontend::load_max_model_len(&args.model_path).unwrap_or(4096);
+    let max_model_len = match model_type {
+        // Advertise the engine's real per-request KV window, not the model's
+        // trained context: the HTTP layer rejects over-long prompts and clamps
+        // max_tokens against this value (issue #239).
+        #[cfg(feature = "kimi-k2")]
+        ModelType::KimiK2 => {
+            config_model_len.min(pegainfer_kimi_k2::KIMI_K2_SERVING_CONTEXT_TOKENS as u32)
+        }
+        #[cfg(feature = "deepseek-v2-lite")]
+        ModelType::DeepSeekV2Lite => config_model_len,
+        #[cfg(feature = "deepseek-v4")]
+        ModelType::DeepSeekV4 => config_model_len,
+        ModelType::Qwen3 | ModelType::Qwen35 => config_model_len,
+    };
+
     if args.enable_lora {
-        let max_model_len =
-            pegainfer::vllm_frontend::load_max_model_len(&args.model_path).unwrap_or(4096);
         pegainfer::vllm_frontend::serve_model_with_lora_routes(
             handle,
             args.model_path.to_string_lossy().into_owned(),
@@ -245,11 +260,12 @@ async fn main() -> anyhow::Result<()> {
         )
         .await
     } else {
-        pegainfer::vllm_frontend::serve(
+        pegainfer::vllm_frontend::serve_model(
             handle,
-            &args.model_path,
-            args.served_model_name.as_deref(),
+            args.model_path.to_string_lossy().into_owned(),
+            args.served_model_name.into_iter().collect(),
             args.port,
+            max_model_len,
             pegainfer::vllm_frontend::shutdown_token_from_ctrl_c(),
         )
         .await

--- a/pegainfer-vllm-frontend/src/lib.rs
+++ b/pegainfer-vllm-frontend/src/lib.rs
@@ -434,28 +434,6 @@ impl LocalEngineBridge {
     }
 }
 
-pub async fn serve(
-    handle: EngineHandle,
-    model_path: &Path,
-    served_model_name: Option<&str>,
-    port: u16,
-    shutdown: CancellationToken,
-) -> Result<()> {
-    let max_model_len = load_max_model_len(model_path).unwrap_or(4096);
-    serve_model(
-        handle,
-        model_path.to_string_lossy().into_owned(),
-        served_model_name
-            .into_iter()
-            .map(|name| name.to_string())
-            .collect(),
-        port,
-        max_model_len,
-        shutdown,
-    )
-    .await
-}
-
 pub async fn serve_model(
     handle: EngineHandle,
     model_id: impl Into<String>,

--- a/scripts/e2e_serving_contract.py
+++ b/scripts/e2e_serving_contract.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """E2E checks for the Kimi-K2 serving contract against a running server.
 
-Three checks through `/v1/completions` (issues #238, #237):
+Five checks through `/v1/completions` (issues #238, #237, #239):
 
 1. EOS stop: the answer must end early with `finish_reason: "stop"` and fewer
    than `max_tokens` completion tokens;
@@ -11,6 +11,11 @@ Three checks through `/v1/completions` (issues #238, #237):
    and produce no completion — silently-greedy output is the one forbidden
    state. (The vllm-server HTTP layer collapses engine rejections into a
    generic 500; the "decodes greedy only" reason appears in the server log.)
+4. over-long prompt: a prompt beyond the advertised context window must be
+   refused with a "maximum context length" error, not overrun the KV arena;
+5. max_tokens clamp: a request asking for more tokens than the window holds
+   must be clamped to `window - prompt_tokens` and run to `length` — proving
+   generation saturates the window without overrunning it.
 
 The default prompt is in Kimi-K2 chat format; pass --prompt for other models.
 
@@ -82,6 +87,7 @@ def main() -> int:
     parser.add_argument("--model", required=True)
     parser.add_argument("--prompt", default=KIMI_PROMPT)
     parser.add_argument("--max-tokens", type=int, default=256)
+    parser.add_argument("--context-window", type=int, default=2048)
     parser.add_argument("--timeout", type=float, default=300.0)
     args = parser.parse_args()
 
@@ -114,6 +120,49 @@ def main() -> int:
         choice.get("text") or "" for choice in sampling_payload.get("choices", [])
     )
 
+    # One word per token is a safe lower bound for simple repeats, so 2x the
+    # window in words is comfortably over it.
+    over_long_prompt = " hello" * (args.context_window * 2)
+    over_long_status, over_long_payload = post_completion(
+        args.base_url,
+        {
+            "model": args.model,
+            "prompt": over_long_prompt,
+            "max_tokens": 8,
+            "temperature": 0.0,
+        },
+        args.timeout,
+    )
+    over_long_body = json.dumps(over_long_payload, ensure_ascii=False)
+    print(f"over-long prompt run: HTTP {over_long_status}")
+    print(f"  body: {over_long_body[:300]}")
+
+    # ~93% of the window in words: repeated " hello" tokenizes to ~1 token/word
+    # for the Kimi tokenizer, and the clamp assertion below self-corrects via
+    # the server-reported prompt_tokens anyway. max_tokens=window forces the
+    # clamp to kick in.
+    near_window_prompt = " hello" * (args.context_window * 15 // 16)
+    clamp_status, clamp_payload = post_completion(
+        args.base_url,
+        {
+            "model": args.model,
+            "prompt": near_window_prompt,
+            "max_tokens": args.context_window,
+            "temperature": 0.0,
+            "ignore_eos": True,
+        },
+        args.timeout,
+    )
+    if clamp_status != 200:
+        raise RuntimeError(f"clamp request failed with HTTP {clamp_status}: {clamp_payload}")
+    clamp_finish = clamp_payload["choices"][0]["finish_reason"]
+    clamp_prompt_tokens = clamp_payload["usage"]["prompt_tokens"]
+    clamp_completion_tokens = clamp_payload["usage"]["completion_tokens"]
+    print(
+        f"clamp run: {clamp_finish}, {clamp_prompt_tokens} prompt + "
+        f"{clamp_completion_tokens} completion tokens"
+    )
+
     ok = True
     ok &= check(
         "EOS stops generation",
@@ -139,6 +188,18 @@ def main() -> int:
         "non-greedy is explicitly rejected",
         sampling_status != 200 and not sampling_text,
         f"HTTP {sampling_status}, generated text: {sampling_text!r}",
+    )
+    ok &= check(
+        "over-long prompt is refused",
+        over_long_status != 200 and "maximum context length" in over_long_body,
+        f"HTTP {over_long_status}",
+    )
+    ok &= check(
+        "max_tokens is clamped to the window",
+        clamp_finish == "length"
+        and clamp_completion_tokens == args.context_window - clamp_prompt_tokens,
+        f"finish_reason={clamp_finish}, {clamp_completion_tokens} == "
+        f"{args.context_window} - {clamp_prompt_tokens}",
     )
     return 0 if ok else 1
 


### PR DESCRIPTION
> Stacked on #261 (base branch `fix/kimi-k2-sampling-params-237`); will rebase onto main once #261 merges.

## Problem

Issue #239 (first half — roadmap M1 item 3): the engine advertised `max_model_len=262144` (the trained context from `config.json`) while each request owns a fixed 2048-token KV page range. An over-capacity request passed admission and errored mid-batch in the worker `ensure!`s — on the TP8 path a `forward_decode_batch` failure takes down **every co-scheduled request**, not just the offender.

## Fix

Three legs, one constant:

- **`KIMI_K2_SERVING_CONTEXT_TOKENS` (2048)** in `config.rs` is the single source of truth: the decode page-table geometry (`KIMI_DECODE_PAGES_PER_REQUEST`) now derives from it, so the advertised window and the arena can never disagree.
- **`pegainfer-server` advertises `min(config len, serving window)`** for Kimi-K2. The pinned vllm-server HTTP layer then does the right thing on its own: over-long prompts get a clear refusal (`this model's maximum context length is 2048 tokens, but the prompt contains N input tokens`) and `max_tokens` is clamped to the remaining window — same semantics as vLLM `get_max_tokens()`. The single-caller `serve()` wrapper was folded into `main.rs`.
- **Scheduler admission guard** for direct engine submitters: reject `prompt + max_tokens - 1 > 2048` (the last generated token is emitted without being appended to KV). Through HTTP this never fires — the HTTP layer is strictly one token stricter — it protects in-process `EngineHandle` users from the mid-batch crash.

## Tests

- Unit (`lifecycle.rs`): exact-fit boundary admitted, one-token-over rejected, over-long prompt rejected. 22/22 kimi-k2 lib tests, 16/16 frontend lib tests.
- E2E (`scripts/e2e_serving_contract.py`, now 7 checks) on H20 ×8, TP1+DP8+EP8 PPLX, Kimi-K2.5:

```
stop run: stop, 54 tokens
ignore_eos run: length, 256 tokens
non-greedy run: HTTP 500
over-long prompt run: HTTP 500
  body: ...maximum context length is 2048 tokens, but the prompt contains 4096 input tokens...
clamp run: length, 1920 prompt + 128 completion tokens
[PASS] EOS stops generation / stop run ends early / ignore_eos runs to length /
       ignore_eos generates max_tokens / non-greedy is explicitly rejected
[PASS] over-long prompt is refused: HTTP 500
[PASS] max_tokens is clamped to the window: finish_reason=length, 128 == 2048 - 1920
```

Startup log confirms `max_model_len=2048`. The clamp run saturates the window exactly (1920 + 128 = 2048) and doubles as the engine-keeps-serving proof after the refusal.

The off-by-one chain was traced end-to-end (admission guard ↔ decode `append_positions` ↔ worker page-table `ensure!`): the guard bound is tight, including the `prompt=2048, max_tokens=1` zero-decode-step edge on both scheduler paths.

## Out of scope

Second half of #239: KV budget/deferral admission (qwen3 #85 pattern) and abort-on-disconnect (#215). [serving-contract.md](https://github.com/xiaguan/pegainfer/blob/fix/kimi-k2-context-window-239/docs/models/kimi-k2/serving-contract.md) documents the full context-window behavior.

Refs #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)