### PR TITLE
fix(deps): bump cudarc to 0.19.7 to drop eager driver symbol loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1776,9 +1776,9 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.19.4"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f071cd6a7b5d51607df76aa2d426aaabc7a74bc6bdb885b8afa63a880572ad9b"
+checksum = "1cea5f10a99e025c1b44ae2354c2d8326b25ddbd0baf76bde8e55cfd4018a2cc"
 dependencies = [
  "half",
  "libloading 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,9 @@ colored = "3"
 comfy-table = "7.2"
 criterion = { version = "0.8", features = ["html_reports"] }
 crossbeam-channel = "0.5"
-cudarc = { version = "0.19.4", features = [
+# 0.19.5+ required: per-symbol lazy loading keeps the cuda-12090 binding
+# level from imposing a runtime driver floor (issue #263).
+cudarc = { version = "0.19.7", features = [
     "cuda-12090",
     "cublas",
     "f16",

--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ Measured on **RTX 5070 Ti** (16 GB), BF16, CUDA Graph enabled, single request:
 ### Prerequisites
 
 - Rust (2024 edition), CUDA Toolkit (nvcc, cuBLAS), CUDA-capable GPU
+- NVIDIA driver R535 (CUDA 12.2) or newer; driver symbols resolve lazily at call time, so the `cuda-12090` cudarc feature does not raise the driver floor
 - Python 3 + Triton (build-time only — no Python at runtime)
 - TileLang for `deepseek-v4` feature builds (build-time only)
+- `deepseek-v4` / `kimi-k2` EP paths additionally need NCCL ≥ 2.27 at runtime (`ncclAlltoAll`)
 
 ### Build & Run
 


### PR DESCRIPTION
## Problem (#263)

Any GPU run on a CUDA 12.2 (R535) driver panics at startup:

```
libcuda.so.1: undefined symbol: cuCtxCreate_v4
```

Root cause: cudarc 0.19.4's dynamic-loading mode resolves **every** symbol at the pinned feature level (`cuda-12090`) when `libcuda.so` is first opened, with `.expect()` per symbol. `cuCtxCreate_v4` enters the binding table at `cuda-12050`, so the pin imposed a driver ≥ CUDA 12.5 floor — even though no code path ever calls it.

## Fix

cudarc 0.19.5 (upstream [PR #573](https://github.com/chelsea0x3b/cudarc/pull/573)) replaced eager loading with per-symbol lazy resolution (`OnceLock` per function, resolved on first call). After that, the `cuda-XXXX` feature is only the compile-time binding level; the runtime driver only needs the symbols actually called.

Bump the manifest to `0.19.7` (latest). The floor matters: the README driver claim depends on ≥ 0.19.5 lazy-loading behavior, so it belongs in the requirement itself, not in `Cargo.lock` state — an old lock would silently reintroduce the startup panic.

## Why this is safe for every model path

Audited the full workspace against cudarc's version gates:

- Every cudarc symbol pegainfer calls is ungated (available at all binding levels): `CudaContext::new` → `cuDevicePrimaryCtxRetain`, graph capture (`cuStreamBeginCapture_v2`, `cuGraphInstantiateWithFlags`), basic mem/stream ops. The only version-dispatched constructor (`new_non_primary`, v3/v4) is never called.
- The genuinely new driver APIs (`cuMulticast*` 12.1+, `CU_MEM_HANDLE_TYPE_FABRIC` 12.3+) live in `pegainfer-comm`'s own `-sys` bindings, not cudarc — unaffected by this change and only built for EP features.
- NCCL bindings get the same lazy property: `ncclAlltoAll` (NCCL ≥ 2.27) resolves only when EP all-to-all actually runs; the default Qwen build no longer requires it at load time.
- The one breaking change in 0.19.5 (`CUmemAllocationHandleType` enum → u32) touches only cudarc's VMM types, which pegainfer doesn't use.

README prerequisites now state the driver floor (R535+) and the EP-path NCCL ≥ 2.27 requirement.

## Validation

On RTX 5070 Ti, driver 580.126.09 (CUDA 13.0), toolkit 13.3 — covers the new-driver side:

| Check | Result |
|---|---|
| `cargo test --release --workspace --lib` | 63 crates pass (one pre-existing `kvbm-config` figment flake under full-workspace parallelism; passes 3/3 standalone, identical on 0.19.4) |
| qwen3 `hf_golden_gate` (GPU) | pass, 37.8s |
| qwen35 `e2e_scheduler` (GPU) | pass, 17.4s |
| qwen35 `hf_golden_gate` | skipped by fixture (local weights lack revision metadata) — numerics covered by the qwen3 gate over shared kernels |

The old-driver side (12.2) follows analytically from lazy resolution + the symbol audit; asked the reporter to confirm on their box in #263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
