### PR TITLE
chore(kernels): bump flashinfer to v0.6.12, make greedy top-1 deterministic

### DIFF
--- a/pegainfer-kernels/csrc/shared/flashinfer_top1.cu
+++ b/pegainfer-kernels/csrc/shared/flashinfer_top1.cu
@@ -1,5 +1,8 @@
 #include "common.cuh"
 
+#include <cstdio>
+#include <cstdlib>
+
 #include <flashinfer/sampling.cuh>
 #include <flashinfer/topk.cuh>
 
@@ -10,8 +13,19 @@ extern "C" void flashinfer_top1_cuda(const __nv_bfloat16* logits,
   auto* row_states =
       reinterpret_cast<flashinfer::sampling::RadixRowState*>(row_states_scratch);
   auto* input = const_cast<__nv_bfloat16*>(logits);
-  (void)flashinfer::sampling::TopKDispatch<__nv_bfloat16, int>(
-      input, output, top1_value_scratch, 1, 1, vocab_size, row_states, stream);
+  // deterministic=true: bf16 logits tie at the max in practice (8 mantissa
+  // bits), and the non-deterministic collect picks an arbitrary winner per
+  // run. Deterministic collect resolves ties to the smallest index (matching
+  // torch.argmax) for ~2us extra latency.
+  cudaError_t err = flashinfer::sampling::TopKDispatch<__nv_bfloat16, int>(
+      input, output, top1_value_scratch, 1, 1, vocab_size, row_states,
+      /*sorted_output=*/false, /*deterministic=*/true,
+      flashinfer::sampling::TopKTieBreak::None, stream);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "flashinfer_top1_cuda: TopKDispatch failed: %s\n",
+            cudaGetErrorString(err));
+    abort();
+  }
 }
 
 extern "C" void flashinfer_top1_batch_cuda(const __nv_bfloat16* logits,
@@ -24,8 +38,14 @@ extern "C" void flashinfer_top1_batch_cuda(const __nv_bfloat16* logits,
       reinterpret_cast<flashinfer::sampling::RadixRowState*>(row_states_scratch);
   for (int row = 0; row < num_rows; ++row) {
     auto* input = const_cast<__nv_bfloat16*>(logits + row * vocab_size);
-    (void)flashinfer::sampling::TopKDispatch<__nv_bfloat16, int>(
+    cudaError_t err = flashinfer::sampling::TopKDispatch<__nv_bfloat16, int>(
         input, output + row, top1_values + row, 1, 1, vocab_size, row_states,
-        stream);
+        /*sorted_output=*/false, /*deterministic=*/true,
+        flashinfer::sampling::TopKTieBreak::None, stream);
+    if (err != cudaSuccess) {
+      fprintf(stderr, "flashinfer_top1_batch_cuda: TopKDispatch failed: %s\n",
+              cudaGetErrorString(err));
+      abort();
+    }
   }
 }


### PR DESCRIPTION
## What

- Bump flashinfer submodule: nightly-v0.6.7 (`779c24d1`, 2026-03-29) → **v0.6.12** release tag (277 commits; nested cutlass → `b46b16d0`).
- Adapt `flashinfer_top1.cu` to the new `TopKDispatch` signature and flip `deterministic=true`.

## Why the call-site change is load-bearing

v0.6.8+ changed `TopKDispatch` arg 8 from `cudaStream_t` to `bool sorted_output`. The old positional call **compiles silently** (pointer→bool implicit conversion) and lands every launch on the default stream. Both call sites now use named-comment arguments.

## Why deterministic=true

bf16 logits (8 mantissa bits) tie at the max in practice. The non-deterministic radix collect picks an arbitrary winner per run — reproduced on an idle GPU: a planted 3-way tie returned 2 distinct argmax values over 50 runs. Deterministic collect resolves ties to the smallest index (torch.argmax convention).

Cost (sm_120, vocab 151936, bf16, 2000 iters):

| shape | det=off | det=on |
|---|---|---|
| bs=1 | 20.06μs (p99 22.0) | 22.03μs (p99 22.9) |
| bs=8 per-row | 134.9μs (p99 136.5) | 146.0μs (p99 151.9) |

+2μs vs ~12ms TPOT = noise. Routing is unchanged (bf16 1×151k stays on multi-CTA radix); det scratch (~2KB/group) fits the existing 1MB row-state buffer. Dispatch errors now crash early instead of `(void)`-discard.

## Upstream changes covered by our usage

- `sampling.cuh`: rejection-sampling binary search FP64→FP32 — pure win on 1/64-rate FP64 SMs; greedy path unaffected; `ieee_*` PTX helpers are no-ops for us (no `-use_fast_math`).
- `decode.cuh` / `norm.cuh` / `page.cuh` / `variants.cuh` / `default_*_params.cuh` / `gemm_groupwise_sm120.cuh`: byte-identical across the pins.
- `prefill.cuh` +693 lines, but the `*Dispatched` entry points we call are signature-identical.

## Validation

- Builds: default, `kimi-k2`, `deepseek-v2-lite` (release). deepseek-v4 not built locally (no TileLang toolchain); its only flashinfer header is unchanged.
- Workspace lib tests.
- Qwen3-4B `hf_golden_gate` (37.6s), Qwen3.5-4B `hf_golden_gate` (9.6s, with `PEGAINFER_TEST_MODEL_REVISION` set — it silently skips without it), Qwen3.5 `e2e_scheduler` (17.1s).
- Toxic review: approved; its one non-blocking finding (swallowed `cudaError_t`) is fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)