### PR TITLE
fix(kernels): put flashinfer vendored CCCL on the nvcc include path

### DIFF
--- a/pegainfer-kernels/build.rs
+++ b/pegainfer-kernels/build.rs
@@ -42,6 +42,11 @@ struct FlashInferIncludes {
     cutlass: PathBuf,
     cutlass_util: PathBuf,
     spdlog: PathBuf,
+    /// Vendored CCCL (cub, libcudacxx, thrust). Must be passed as `-I` while the
+    /// CTK include dir is `-isystem`, so these override the toolkit's older CCCL
+    /// copy — FlashInfer v0.6+ uses APIs (e.g. `cuda::fast_mod_div`) that older
+    /// CTK CCCL lacks. Mirrors upstream flashinfer/jit/cpp_ext.py ordering.
+    cccl: Vec<PathBuf>,
 }
 
 fn workspace_root() -> PathBuf {
@@ -688,6 +693,18 @@ fn flashinfer_includes_from_include(include: PathBuf) -> FlashInferIncludes {
         ],
         flashinfer_root.join("spdlog/include"),
     );
+    let cccl_root = first_existing_dir(
+        &[
+            flashinfer_root.join("3rdparty/cccl"),
+            flashinfer_root.join("cccl"),
+        ],
+        flashinfer_root.join("3rdparty/cccl"),
+    );
+    let cccl = vec![
+        cccl_root.join("cub"),
+        cccl_root.join("libcudacxx/include"),
+        cccl_root.join("thrust"),
+    ];
 
     FlashInferIncludes {
         include,
@@ -695,6 +712,7 @@ fn flashinfer_includes_from_include(include: PathBuf) -> FlashInferIncludes {
         cutlass,
         cutlass_util,
         spdlog,
+        cccl,
     }
 }
 
@@ -1140,7 +1158,7 @@ fn main() {
             "-o".to_string(),
             obj_file.to_string_lossy().to_string(),
             "-O3".to_string(),
-            "-I".to_string(),
+            "-isystem".to_string(),
             cuda_include.to_string_lossy().to_string(),
             "-I".to_string(),
             csrc_dir.to_string_lossy().to_string(),
@@ -1155,6 +1173,9 @@ fn main() {
             || stem == "flashinfer_top1"
             || stem.starts_with("deepseek_")
         {
+            for dir in &flashinfer.cccl {
+                nvcc_args.extend(["-I".to_string(), dir.to_string_lossy().to_string()]);
+            }
             nvcc_args.extend([
                 "--std=c++17".to_string(),
                 "-I".to_string(),
@@ -1186,6 +1207,9 @@ fn main() {
         }
 
         if stem.starts_with("kimi_") {
+            for dir in &flashinfer.cccl {
+                nvcc_args.extend(["-I".to_string(), dir.to_string_lossy().to_string()]);
+            }
             nvcc_args.extend([
                 "--std=c++17".to_string(),
                 "--expt-relaxed-constexpr".to_string(),


### PR DESCRIPTION
## Problem

After the flashinfer v0.6.12 bump (#265), every flashinfer-dependent `.cu` fails to compile on CUDA <= 12.9 hosts:

```
include/flashinfer/fastdiv.cuh(39): error: qualified name is not allowed
  cuda::fast_mod_div<uint32_t> impl_;
```

Upstream flashinfer vendors CCCL 3.3.2 (`3rdparty/cccl`, upstream #3091) precisely because its headers now use CCCL APIs the CTK-bundled copy of older toolkits lacks — but our `build.rs` never put the vendored CCCL on the include path. CUDA 13.3 masks the bug locally because its CTK CCCL is new enough.

## Fix

Mirror upstream `flashinfer/jit/cpp_ext.py` include ordering:
- vendored `cccl/{cub,libcudacxx/include,thrust}` added as `-I` for the flashinfer-dependent translation units (`paged_attention`/`flashinfer_*`/`deepseek_*`/`kimi_*`)
- CTK include dir demoted `-I` → `-isystem` so the vendored copy wins resolution (`-isystem` is searched after all `-I`)

tilelang/cutedsl invocations are untouched — they don't include flashinfer headers.

## Verification

- CUDA 12.9 / sm_90a (8×H200): full `--features kimi-k2` release build, previously failing, now passes; Kimi-K2.6 TP1/DP8/EP8 PPLX bs64 bench runs end-to-end (TPOT p50 30.07ms)
- CUDA 13.3 / sm_120 (local): `cargo build --release -p pegainfer-kernels --features kimi-k2` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)