### PR TITLE
test(qwen35): add CPU coverage for scheduler decisions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 
 | Path | TL;DR |
 | --- | --- |
-| `models/qwen35/roadmap.md` | Qwen3.5-4B roadmap (2026-06 review): fast and decode-correct, #186 adds the teacher-forced HF logits gate, and #250 covers the old 4096 RoPE boundary with a 4097/8192-token HF logits replay plus a recovered GSM8K 8-shot score; ~640MB HND prefill staging remains, with the 20k cap now fail-closed and pre-#85 admission semantics still open. |
+| `models/qwen35/roadmap.md` | Qwen3.5-4B roadmap (2026-06 review): fast and decode-correct, #186 adds the teacher-forced HF logits gate, and #250 covers the old 4096 RoPE boundary with a 4097/8192-token HF logits replay plus a recovered GSM8K 8-shot score; ~640MB HND prefill staging remains, pre-#85 admission semantics still open, and current scheduler admission/slot/compaction policy is now CPU-tested. |
 | `models/qwen35/optimization.md` | Hybrid 24 linear + 8 full attn. At parity with vLLM: TTFT 225ms, TPOT 11.81ms (+1%). Post-accuracy-fix GDR decode kernel restore (#9). |
 | `models/qwen35/accuracy.md` | Qwen3.5-4B HF bf16 logits goldens through `past_key_values`: short replay covers sequential graph, bucket-straddling batched graph, and slot-compaction; long replay covers 4097/8192-token prompts; full GSM8K 8-shot now matches the HF baseline within 0.15 percentage points. |
 | `models/qwen35/model-crate.md` | `pegainfer-qwen35-4b` owns Qwen3.5 model/scheduler/recurrent ops/tests/benches; root loads it through `EngineHandle`. Build/check/clippy, root bench sanity check, historical Qwen3.5 e2e, and scheduler e2e records live here. |

--- a/docs/models/qwen35/roadmap.md
+++ b/docs/models/qwen35/roadmap.md
@@ -1,6 +1,6 @@
 # Qwen3.5-4B Roadmap
 
-> **TL;DR:** Qwen3.5-4B is fast and decode-correct — GDR kernels optimized, CUDA-graph decode, TTFT/TPOT at vLLM parity, current bench snapshots — and now has a long-prompt logits gate over the old 4096-position RoPE cache boundary. The current #250 slice fixes the Qwen3.5 RoPE cache to use `max_position_embeddings`, adds fail-closed cache coverage checks, verifies 4097/8192-token HF bf16 logits replay, and recovers full GSM8K 8-shot within 0.15 percentage points of the HF baseline (`strict-match` 79.38%, `flexible-extract` 79.30% vs HF 79.45%). Remaining structural items: monolithic HND prefill staging (~640MB transient per request, now fail-closed at the hard 20k-token cap), prompt-only admission with no `Rejected` event path, and zero CPU-testable scheduler logic. Findings originally verified 2026-06-04 against `6ee9247`; #186 gate status updated 2026-06-05, #250 long-prompt and GSM8K status updated 2026-06-05.
+> **TL;DR:** Qwen3.5-4B is fast and decode-correct — GDR kernels optimized, CUDA-graph decode, TTFT/TPOT at vLLM parity, current bench snapshots — and now has a long-prompt logits gate over the old 4096-position RoPE cache boundary. The current #250 slice fixes the Qwen3.5 RoPE cache to use `max_position_embeddings`, adds fail-closed cache coverage checks, verifies 4097/8192-token HF bf16 logits replay, and recovers full GSM8K 8-shot within 0.15 percentage points of the HF baseline (`strict-match` 79.38%, `flexible-extract` 79.30% vs HF 79.45%). Remaining structural items: monolithic HND prefill staging (~640MB transient per request, now fail-closed at the hard 20k-token cap) and prompt-only admission with no `Rejected` event path; the current admission/slot/compaction scheduler decisions are now covered by CPU-level lib tests. Findings originally verified 2026-06-04 against `6ee9247`; #186 gate status updated 2026-06-05, #250 long-prompt and GSM8K status updated 2026-06-05, #255 scheduler seam updated 2026-06-06.
 >
 > **Last touched:** 2026-06
 
@@ -18,7 +18,7 @@ Tracking issue: see the `[Model] Qwen3.5-4B roadmap` GitHub issue. Sibling doc: 
 | Prefill memory | ✗ monolithic HND staging ≈640MB transient per request; `MAX_SEQ = 20000` hard cap | `prefill.rs` |
 | Long context | Partial: current #250 slice sizes the RoPE cache from `max_position_embeddings`; decode checks the cache before use, and prefill now fails closed at the active `MAX_SEQ = 20000` HND staging cap | `config.rs`, `weights.rs`, `prefill.rs`, `batch_decode.rs` |
 | Admission | ✗ prompt-only KV sizing, no `Rejected` event, KV exhaustion mid-decode aborts the whole batch — pre-#85-fix semantics | `scheduler.rs` |
-| Scheduler tests | ✗ zero CPU-level tests; all logic behind GPU-coupled paths | — |
+| Scheduler tests | Partial: current plan selection, prompt-only admission, slot assignment, and slot-compaction decisions are CPU-tested; GPU execution remains coupled to the production scheduler | `src/scheduler/plan.rs` |
 | TP | ✗ absent (single GPU only) | — |
 | Prefix cache | ✗ absent; recurrent GDR state (~48MB per boundary snapshot) makes "prefix hit" itself a design question | — |
 
@@ -32,9 +32,9 @@ Tracking issue: see the `[Model] Qwen3.5-4B roadmap` GitHub issue. Sibling doc: 
 
 ### Next
 
-4. **Admission overhaul.** Three coupled defects, fixed together as the qwen35 analog of the #85 work: size admission on full lifetime (prompt + max_tokens), add the `Rejected` event path the engine contract already defines, and on KV exhaustion fail the offending request — not the batch. CPU-testable once 6 lands.
+4. **Admission overhaul.** Three coupled defects, fixed together as the qwen35 analog of the #85 work: size admission on full lifetime (prompt + max_tokens), add the `Rejected` event path the engine contract already defines, and on KV exhaustion fail the offending request — not the batch. The #255 scheduler seam gives this work a CPU-testable policy surface.
 5. **Prefill full-paged migration.** Replace the HND staging copy with direct paged writes: removes the ~640MB transient, the `MAX_SEQ=20000` cap, and the extra D2D pass. Chain dependency: paged-direct prefill → per-token position plumbing → (3) RoPE cache → opens the door to 7.
-6. **Scheduler logic seam.** Extract admission/eviction/slot decisions behind a GPU-free boundary and put CPU tests on them, mirroring qwen3's scheduler-test layout. Prerequisite for testing 4 without a GPU.
+6. **Scheduler logic seam follow-through.** The current admission/slot/compaction decisions have a CPU-tested seam. When 4 lands, keep the new lifetime-admission and rejection behavior in that seam instead of re-embedding it in GPU execution.
 7. **Prefix-cache design note.** Linear-attention layers carry recurrent state, not KV blocks — a "prefix hit" must restore both the full-attention KV *and* a recurrent-state snapshot at a block boundary (~48MB per boundary at bf16). Whether to snapshot per block, per N blocks, or only at request end is an open trade; write the design note before any code. Depends on 5.
 8. **kernel_plan port.** qwen3's `kernel_plan.rs` (runtime kernel selection + plan dump) has no qwen35 counterpart; decode kernel picks are hardwired. Mechanical port, community-friendly.
 

--- a/pegainfer-qwen35-4b/src/scheduler.rs
+++ b/pegainfer-qwen35-4b/src/scheduler.rs
@@ -7,6 +7,8 @@
 //! Prefill allocates temporary `RecurrentState`s, then D2D-copies them into
 //! graph slots. On request retirement, swap-remove compaction keeps slots dense.
 
+mod plan;
+
 use std::sync::mpsc as std_mpsc;
 use std::thread;
 
@@ -26,6 +28,10 @@ use pegainfer_core::engine::{
 use pegainfer_core::kv_pool::KvState;
 use pegainfer_core::sampler::SamplingParams;
 use pegainfer_core::tensor::DeviceVec;
+
+use self::plan::{
+    ExecutionPlan, admit_pending_requests, compaction_after_retire, slot_for_new_request,
+};
 
 // ── Internal types ──────────────────────────────────────────────────────
 
@@ -186,60 +192,38 @@ fn scheduler_loop(
             }
         }
 
-        // Admission control: cap by slot capacity AND KV page budget.
-        // Reserve one page per active decode request for its next step.
-        let page_size = model.kv_pool().layout().page_size;
-        let decode_reserve = active.len();
-        let mut page_budget = model
-            .kv_pool()
-            .available_pages()
-            .saturating_sub(decode_reserve);
-        let slot_budget = max_batch.saturating_sub(active.len());
-        let mut admitted = 0;
-        for req in &pending {
-            if admitted >= slot_budget {
-                break;
-            }
-            let needed = req.prompt_tokens.len().div_ceil(page_size);
-            if needed > page_budget {
-                break;
-            }
-            page_budget -= needed;
-            admitted += 1;
-        }
-        if admitted < pending.len() {
-            deferred = pending.split_off(admitted);
-        }
+        let admission = admit_pending_requests(
+            pending,
+            active.len(),
+            graph_state.slot_states.len(),
+            model.kv_pool().layout().page_size,
+            model.kv_pool().available_pages(),
+            |req| req.prompt_tokens.len(),
+        );
+        let pending = admission.pending;
+        deferred = admission.deferred;
 
-        let have_pending = !pending.is_empty();
-
-        if have_pending && !active.is_empty() {
-            unified_step_sched(
+        match plan::build_next_plan(!active.is_empty(), pending) {
+            Some(ExecutionPlan::Unified { pending }) => unified_step_sched(
                 &model,
                 &mut active,
                 pending,
                 &mut graph_state,
                 &mut sample_scratch,
                 &mut rng,
-            );
-        } else if have_pending {
-            prefill_batch(
+            ),
+            Some(ExecutionPlan::Prefill { pending }) => prefill_batch(
                 &model,
                 &mut active,
                 pending,
                 &mut graph_state,
                 &mut sample_scratch,
                 &mut rng,
-            );
-        }
-
-        if active.is_empty() {
-            continue;
-        }
-
-        // Pure decode step — only when no pending arrived (unified_step already did one decode).
-        if !have_pending {
-            decode_step(&model, &mut active, &mut graph_state, &mut rng);
+            ),
+            Some(ExecutionPlan::Decode) => {
+                decode_step(&model, &mut active, &mut graph_state, &mut rng)
+            }
+            None => {}
         }
     }
 }
@@ -334,7 +318,8 @@ fn prefill_batch(
         }
 
         // Assign a graph slot and copy recurrent state into it
-        let slot_idx = active.len();
+        let slot_idx = slot_for_new_request(active.len(), graph_state.slot_states.len())
+            .expect("admission must reserve a graph slot");
         graph_state
             .copy_state_to_slot(model.device_ctx(), &rec_states[i], slot_idx)
             .expect("copy recurrent state to slot failed");
@@ -471,7 +456,8 @@ fn unified_step_sched(
         }
 
         // Assign graph slot and copy recurrent state
-        let slot_idx = active.len();
+        let slot_idx = slot_for_new_request(active.len(), graph_state.slot_states.len())
+            .expect("admission must reserve a graph slot");
         graph_state
             .copy_state_to_slot(model.device_ctx(), &rec_states[i], slot_idx)
             .expect("copy recurrent state to slot failed");
@@ -667,26 +653,26 @@ fn compact_slot(
     graph_state: &mut BatchDecodeGraphState,
     idx: usize,
 ) {
-    let last = active.len() - 1;
+    let compaction = compaction_after_retire(active.len(), idx);
     active.swap_remove(idx);
 
-    if idx < active.len() {
+    if let Some(compaction) = compaction {
         // The element that was at `last` is now at `idx`.
         // Copy its recurrent state from slot `last` to slot `idx`.
         let src_slot = active[idx].graph_slot_idx;
-        debug_assert_eq!(src_slot, last);
+        debug_assert_eq!(src_slot, compaction.moved_from);
 
-        // D2D copy: graph_state.slot_states[last] → graph_state.slot_states[idx]
+        // D2D copy: graph_state.slot_states[src] -> graph_state.slot_states[dst]
         // We can't borrow two slots mutably at once, so use raw index copy.
         let ctx = model.device_ctx();
-        let src = &graph_state.slot_states[last];
+        let src = &graph_state.slot_states[compaction.moved_from];
         // Copy layer by layer using the public fields
         for layer_idx in 0..src.layers.len() {
-            let (src_part, dst_part) = if idx < last {
-                let (left, right) = graph_state.slot_states.split_at_mut(last);
+            let (src_part, dst_part) = if compaction.moved_to < compaction.moved_from {
+                let (left, right) = graph_state.slot_states.split_at_mut(compaction.moved_from);
                 (
                     &right[0].layers[layer_idx],
-                    &mut left[idx].layers[layer_idx],
+                    &mut left[compaction.moved_to].layers[layer_idx],
                 )
             } else {
                 unreachable!("idx < active.len() <= last");
@@ -699,9 +685,10 @@ fn compact_slot(
                 .memcpy_dtod(&src_part.conv_state.data, &mut dst_part.conv_state.data)
                 .expect("compact slot conv_state copy failed");
         }
-        graph_state.slot_states[idx].seq_len = graph_state.slot_states[last].seq_len;
+        graph_state.slot_states[compaction.moved_to].seq_len =
+            graph_state.slot_states[compaction.moved_from].seq_len;
 
-        active[idx].graph_slot_idx = idx;
+        active[compaction.moved_to].graph_slot_idx = compaction.moved_to;
     }
 }
 

--- a/pegainfer-qwen35-4b/src/scheduler/plan.rs
+++ b/pegainfer-qwen35-4b/src/scheduler/plan.rs
@@ -1,0 +1,277 @@
+pub(super) enum ExecutionPlan<T> {
+    Prefill { pending: Vec<T> },
+    Decode,
+    Unified { pending: Vec<T> },
+}
+
+pub(super) struct AdmissionOutcome<T> {
+    pub(super) pending: Vec<T>,
+    pub(super) deferred: Vec<T>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct SlotCompaction {
+    pub(super) moved_from: usize,
+    pub(super) moved_to: usize,
+}
+
+pub(super) fn build_next_plan<T>(have_active: bool, pending: Vec<T>) -> Option<ExecutionPlan<T>> {
+    if !pending.is_empty() && have_active {
+        Some(ExecutionPlan::Unified { pending })
+    } else if !pending.is_empty() {
+        Some(ExecutionPlan::Prefill { pending })
+    } else if have_active {
+        Some(ExecutionPlan::Decode)
+    } else {
+        None
+    }
+}
+
+pub(super) fn admit_pending_requests<T>(
+    mut pending: Vec<T>,
+    active_count: usize,
+    max_batch: usize,
+    page_size: usize,
+    available_pages: usize,
+    mut prompt_len: impl FnMut(&T) -> usize,
+) -> AdmissionOutcome<T> {
+    assert!(page_size > 0, "Qwen3.5 KV page size must be non-zero");
+
+    // Preserve the current Qwen3.5 scheduler contract exactly: each active
+    // decode request reserves one page for the next token, and pending requests
+    // are admitted FCFS on prompt-only page demand.
+    let mut page_budget = available_pages.saturating_sub(active_count);
+    let slot_budget = max_batch.saturating_sub(active_count);
+    let mut admitted = 0;
+
+    for req in &pending {
+        if admitted >= slot_budget {
+            break;
+        }
+
+        let needed_pages = prompt_len(req).div_ceil(page_size);
+        if needed_pages > page_budget {
+            break;
+        }
+
+        page_budget -= needed_pages;
+        admitted += 1;
+    }
+
+    let deferred = if admitted < pending.len() {
+        pending.split_off(admitted)
+    } else {
+        Vec::new()
+    };
+
+    AdmissionOutcome { pending, deferred }
+}
+
+pub(super) fn slot_for_new_request(active_count: usize, max_batch: usize) -> Option<usize> {
+    (active_count < max_batch).then_some(active_count)
+}
+
+pub(super) fn compaction_after_retire(
+    active_len_before: usize,
+    retired_idx: usize,
+) -> Option<SlotCompaction> {
+    assert!(
+        retired_idx < active_len_before,
+        "retired Qwen3.5 slot index must be active"
+    );
+
+    let last = active_len_before - 1;
+    (retired_idx < last).then_some(SlotCompaction {
+        moved_from: last,
+        moved_to: retired_idx,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Debug)]
+    struct Pending {
+        id: u32,
+        prompt_len: usize,
+    }
+
+    fn pending(id: u32, prompt_len: usize) -> Pending {
+        Pending { id, prompt_len }
+    }
+
+    fn ids(reqs: &[Pending]) -> Vec<u32> {
+        reqs.iter().map(|req| req.id).collect()
+    }
+
+    #[test]
+    fn plan_selection_follows_active_and_pending_state() {
+        assert!(
+            build_next_plan::<Pending>(false, vec![]).is_none(),
+            "idle scheduler produces no execution plan"
+        );
+        assert!(
+            matches!(
+                build_next_plan::<Pending>(true, vec![]),
+                Some(ExecutionPlan::Decode)
+            ),
+            "active-only scheduler tick decodes the active batch"
+        );
+        assert!(
+            matches!(
+                build_next_plan(false, vec![pending(1, 8)]),
+                Some(ExecutionPlan::Prefill { pending }) if ids(&pending) == vec![1]
+            ),
+            "pending-only scheduler tick prefills new requests"
+        );
+        assert!(
+            matches!(
+                build_next_plan(true, vec![pending(1, 8)]),
+                Some(ExecutionPlan::Unified { pending }) if ids(&pending) == vec![1]
+            ),
+            "active + pending scheduler tick runs the unified path"
+        );
+    }
+
+    #[test]
+    fn admission_respects_slot_capacity_and_active_decode_reserve() {
+        let outcome = admit_pending_requests(
+            vec![pending(1, 16), pending(2, 16), pending(3, 16)],
+            2,
+            4,
+            16,
+            4,
+            |req| req.prompt_len,
+        );
+
+        assert_eq!(
+            ids(&outcome.pending),
+            vec![1, 2],
+            "two active decode requests reserve two pages, leaving two prompt pages"
+        );
+        assert_eq!(
+            ids(&outcome.deferred),
+            vec![3],
+            "requests beyond the remaining slot/page budget stay deferred"
+        );
+    }
+
+    #[test]
+    fn admission_is_fcfs_and_keeps_later_requests_deferred_after_first_miss() {
+        let outcome = admit_pending_requests(
+            vec![pending(1, 16), pending(2, 33), pending(3, 16)],
+            0,
+            8,
+            16,
+            3,
+            |req| req.prompt_len,
+        );
+
+        assert_eq!(ids(&outcome.pending), vec![1]);
+        assert_eq!(
+            ids(&outcome.deferred),
+            vec![2, 3],
+            "a later smaller request must not jump ahead of an earlier budget miss"
+        );
+    }
+
+    #[test]
+    fn admission_keeps_order_when_first_pending_request_misses_budget() {
+        let outcome =
+            admit_pending_requests(vec![pending(1, 33), pending(2, 16)], 0, 8, 16, 2, |req| {
+                req.prompt_len
+            });
+
+        assert!(outcome.pending.is_empty());
+        assert_eq!(
+            ids(&outcome.deferred),
+            vec![1, 2],
+            "a later smaller request must not bypass the first deferred request"
+        );
+    }
+
+    #[test]
+    fn admission_uses_ceil_div_at_page_boundaries() {
+        let outcome = admit_pending_requests(
+            vec![pending(1, 15), pending(2, 16), pending(3, 17)],
+            0,
+            8,
+            16,
+            3,
+            |req| req.prompt_len,
+        );
+
+        assert_eq!(
+            ids(&outcome.pending),
+            vec![1, 2],
+            "15 and 16 tokens each use one page"
+        );
+        assert_eq!(
+            ids(&outcome.deferred),
+            vec![3],
+            "17 tokens needs two pages and waits when only one page remains"
+        );
+    }
+
+    #[test]
+    fn admission_returns_all_pending_when_active_batch_is_at_slot_capacity() {
+        let outcome =
+            admit_pending_requests(vec![pending(1, 1), pending(2, 1)], 4, 4, 16, 10, |req| {
+                req.prompt_len
+            });
+
+        assert!(outcome.pending.is_empty());
+        assert_eq!(ids(&outcome.deferred), vec![1, 2]);
+    }
+
+    #[test]
+    fn active_scheduler_decodes_when_no_pending_request_is_admitted() {
+        let outcome =
+            admit_pending_requests(vec![pending(1, 16)], 1, 4, 16, 1, |req| req.prompt_len);
+
+        assert!(outcome.pending.is_empty());
+        assert_eq!(ids(&outcome.deferred), vec![1]);
+        assert!(
+            matches!(
+                build_next_plan(true, outcome.pending),
+                Some(ExecutionPlan::Decode)
+            ),
+            "active requests should keep decoding when pending requests are all deferred"
+        );
+    }
+
+    #[test]
+    fn graph_slot_assignment_stays_dense_after_retirement() {
+        assert_eq!(slot_for_new_request(0, 4), Some(0));
+        assert_eq!(slot_for_new_request(3, 4), Some(3));
+        assert_eq!(slot_for_new_request(4, 4), None);
+
+        assert_eq!(
+            compaction_after_retire(4, 1),
+            Some(SlotCompaction {
+                moved_from: 3,
+                moved_to: 1
+            }),
+            "retiring a middle slot moves the last dense slot into the hole"
+        );
+        assert_eq!(
+            compaction_after_retire(4, 0),
+            Some(SlotCompaction {
+                moved_from: 3,
+                moved_to: 0
+            }),
+            "retiring the first slot also moves the last dense slot into the hole"
+        );
+        assert_eq!(
+            compaction_after_retire(4, 3),
+            None,
+            "retiring the last slot does not need a recurrent-state copy"
+        );
+        assert_eq!(
+            slot_for_new_request(3, 4),
+            Some(3),
+            "after compaction, the next request reuses the next dense slot"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #255.

Extract the Qwen3.5 scheduler's GPU-independent decision logic into `pegainfer-qwen35-4b/src/scheduler/plan.rs`: next-step planning, FCFS admission under slot/page budgets, dense slot assignment, and swap-remove slot compaction. `scheduler.rs` now calls those helpers while keeping prefill/decode execution and recurrent-state D2D copies in the existing GPU path.

## Scope

In scope:
- CPU-level unit tests for plan selection, admission ordering, page-budget ceil-div boundaries, active decode reserve, full slot capacity, decode fallback when pending is deferred, and dense slot compaction.
- `pub(super)` scheduler helpers only; no cross-crate API.
- Qwen3.5 roadmap/docs index updated to record the new CPU-tested policy surface.

Out of scope:
- No admission semantic overhaul: prompt-only sizing and missing `Rejected` event path remain follow-up work.
- No GPU executor or recurrent-state copy refactor.
- No serving throughput or performance claim.

## Evidence

Local:
- `cargo fmt --check`
- `git diff --check`

Remote RTX 5090 / CUDA 12.8:
- `cargo test --release -p pegainfer-qwen35-4b --lib scheduler::plan -- --nocapture` — 8 passed
- `cargo test --release -p pegainfer-qwen35-4b --lib -- --nocapture` — 13 passed
- `cargo test --release -p pegainfer-qwen35-4b --test e2e_scheduler -- --nocapture` — 1 passed
- `cargo test --release -p pegainfer-qwen35-4b --test hf_golden_gate -- --nocapture` — 2 passed

## Claim Boundary

This adds CPU-testable coverage for the current Qwen3.5 scheduler policy decisions and keeps the exercised serving path behavior unchanged. The package still follows the existing CUDA build pipeline; this PR does not make the whole model crate buildable without the current CUDA toolchain.