### PR TITLE
fix(frontend): log rejected and errored requests instead of swallowin…

### DIFF
--- a/pegainfer-vllm-frontend/src/lib.rs
+++ b/pegainfer-vllm-frontend/src/lib.rs
@@ -398,10 +398,12 @@ impl LocalEngineBridge {
             ..
         } = request;
         let Some(prompt_tokens) = prompt_token_ids else {
+            warn!("request {request_id} dropped: missing prompt_token_ids");
             send_terminal_output(output_tx, request_id, EngineCoreFinishReason::Error, None)?;
             return Ok(());
         };
         let Some(sampling_params) = sampling_params else {
+            warn!("request {request_id} dropped: missing sampling_params");
             send_terminal_output(output_tx, request_id, EngineCoreFinishReason::Error, None)?;
             return Ok(());
         };
@@ -815,6 +817,7 @@ async fn run_request_stream(
                 return;
             }
             TokenEvent::Error { message, .. } => {
+                warn!("request {request_id} failed: {message}");
                 let _ = send_terminal_output(
                     &output_tx,
                     request_id,
@@ -825,6 +828,7 @@ async fn run_request_stream(
             }
             TokenEvent::Rejected { message, .. } => {
                 // Rejected means the request could not be admitted, not that it completed cleanly.
+                warn!("request {request_id} rejected: {message}");
                 let _ = send_terminal_output(
                     &output_tx,
                     request_id,


### PR DESCRIPTION
…g them

## Description

This adds the missing `warn!`s in `run_request_stream` (Rejected/Error arms) and the two silent guards in `start_request`.

Fixes #209 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

- [ ] Documentation update



## Checklist

- [x] My code follows the style guidelines of this project (see `docs/areas/coding-style.md`).

- [x] I have performed a self-review of my own code.

- [x] I have formatted my commits according to Commitizen conventions.

- [ ] I have run the local test suite and all tests pass (see `CLAUDE.md`).
This is a log change, `cargo test` passes on this crate. `--workspace --lib` needs RDMA deps absent on my work dev.