### PR TITLE
docs(qwen35): sync kernel-plan.md with final descriptor data (#289)

### DIFF
--- a/docs/models/qwen35/kernel-plan.md
+++ b/docs/models/qwen35/kernel-plan.md
@@ -16,9 +16,9 @@ The refactor (issue #256) adds a qwen35 counterpart: a `src/kernel_plan.rs` modu
 
 Three phases, matching the qwen3 layout:
 
-- **prefill** — embedding, full-attention prefill (Q/K/V gemm, QK-norm+RoPE, paged-kv scatter, paged prefill attention, attention gate, O proj), linear-attention prefill (5-way in-proj, conv1d, GDR chunkwise, gated RMSNorm, out-proj), shared MLP/norm/residual, final norm, LM head.
-- **decode** — embedding, RMSNorm, full-attention decode (Q/K/V gemm, QK-norm+RoPE, paged decode attention, attention gate, O proj), linear-attention decode (5-way in-proj, conv1d, GDR per-slot, gated RMSNorm, out-proj), shared MLP/norm/residual, final norm, LM head, sampling.
-- **unified** — `unified_step` (mixed prefill+decode) and per-request logit extraction.
+- **prefill** — embedding, full-attention prefill (Q/K/V gemm, QK-norm+RoPE, paged-kv scatter, paged prefill attention, attention gate, O proj), linear-attention prefill (4 GEMMs: in_proj_qkv fused q+k+v + z + b + a, conv1d, GDR chunkwise Triton AOT, gated RMSNorm, out-proj), shared MLP/norm/residual (RMSNorm via FlashInfer GemmaRMSNorm), final norm (FlashInfer), LM head.
+- **decode** — embedding, RMSNorm (FlashInfer GemmaRMSNorm), full-attention decode (Q/K/V gemm, QK-norm+RoPE, paged decode attention, attention gate, O proj), linear-attention decode (4 GEMMs: in_proj_qkv fused q+k+v + z + b + a, conv1d, GDR per-slot, gated RMSNorm, out-proj), shared MLP/norm/residual, final norm (FlashInfer), LM head, sampling (FlashInfer stochastic / CUDA argmax greedy).
+- **unified** — `unified_step` (mixed prefill+decode) and per-request logit extraction (D2D memcpy, not a kernel launch).
 
 Each `KernelOp` records the Rust call site (path through the crate), the runtime backend (CUDA, cuBLAS, FlashInfer, Triton AOT, …), and a free-form note explaining why that kernel.
 


### PR DESCRIPTION
## What

`docs/models/qwen35/kernel-plan.md` was written in commit dc9dbc3 of PR #289 but never updated after the full grep-pass correctness rewrite in f9f94f5. The prose drifted from the actual `kernel_plan.rs` data before the PR was even merged.

## Changes

Three corrections to align the doc with the authoritative `kernel_plan.rs` data:

1. **"5-way in-proj" → "4 GEMMs: in_proj_qkv fused q+k+v + z + b + a"** (prefill and decode sections). The actual call sites (`prefill.rs:402-405`, `batch_decode.rs:311-314`) issue 4 separate cuBLAS GEMMs. The `kernel_plan.rs` `linear_in_proj_*` notes already say "4 cuBLAS GEMMs".

2. **Add FlashInfer backend tags** for `rms_norm_offset` and `final_norm` (GemmaRMSNorm via `flashinfer::norm::GemmaRMSNorm`). The plan data correctly tags these as FlashInfer; the doc prose was silent on this.

3. **Clarify `extract_logits` is D2D memcpy**, not a kernel launch — matching the `kernel_plan.rs` note.

## Credit

Spotted by @CAICAIIs and @xiaguan in the #289 review thread.

## Verification

- Diff: 3 lines changed, doc-only, no code touched.
- Every claim in the updated prose matches the corresponding `KernelOp` entry in `pegainfer-qwen35-4b/src/kernel_plan.rs`.