### PR TITLE
fix(docs): correct broken doc-link paths in CONTRIBUTING and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ Fixes # (issue number)
 
 \## Checklist
 
-\- \[ ] My code follows the style guidelines of this project (see `docs/areas/coding-style.md`).
+\- \[ ] My code follows the style guidelines of this project (see `docs/conventions/coding-style.md`).
 
 \- \[ ] I have performed a self-review of my own code.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,11 +15,11 @@ If you have questions, need help, or want to discuss a feature, please reach out
 
 We keep our detailed technical documentation close to the code. Please refer to these guides:
 
-\* \*\*First-time Setup:\*\* See \[Developer Onboarding](docs/resources/developer-onboarding.md) to set up your toolchain.
+\* \*\*First-time Setup:\*\* See \[Developer Onboarding](docs/playbooks/developer-onboarding.md) to set up your toolchain.
 
 \* \*\*Building \& Running Tests:\*\* Check \[CLAUDE.md](./CLAUDE.md) for quick commands on building and running the test suite.
 
-\* \*\*Coding Style \& Principles:\*\* Read our \[Coding Style Guide](docs/areas/coding-style.md).
+\* \*\*Coding Style \& Principles:\*\* Read our \[Coding Style Guide](docs/conventions/coding-style.md).
 
 
 


### PR DESCRIPTION
## Description

correct broken doc-link paths in CONTRIBUTING and PR template.

## Type of Change

- [x] Documentation update



## Checklist

- [x] My code follows the style guidelines of this project (see `docs/conventions/coding-style.md`).
- [x] I have performed a self-review of my own code.
- [x] I have formatted my commits according to Commitizen conventions.
- [x] This is a log change. no code or tests affected.

