### PR TITLE
fix(deepseek-v2-lite): keep nccl combine device-resident

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -66,6 +66,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 | `models/deepseek-v2-lite/hf-accuracy-gate.md` | DeepSeek-V2-Lite EP2 HF accuracy gate after PR #149/#150: HF incremental greedy, host-staged EP2, and NCCL EP2 are token/text exact for `Hello`, output_len=16. |
 | `models/deepseek-v2-lite/decode-attribution-gate.md` | DeepSeek-V2-Lite EP2 decode attribution gate for `Hello`/16-token batch sizes 1/4/8: structured JSON with accuracy hashes, CPU-side timing, selected CUDA event/NVTX attribution, host-staged/NCCL EP counts, and explicit no-throughput claim boundary. |
 | `models/deepseek-v2-lite/source-layout.md` | DeepSeek-V2-Lite runtime layout refactor: `runtime.rs` split by responsibility, HF/host-staged/NCCL EP2 E2E exact on 2x RTX 5090; NCCL CUDA Graph smoke remains a diagnostic blocker on that host, independent of the passed correctness gate. |
+| `models/deepseek-v2-lite/device-resident-nccl-combine.md` | Issue #275 record: NCCL decode combine now uses reusable device-resident f32 scratch, HF/host-staged/NCCL exact on 2x RTX 5090, and remaining graph blockers are dense exchange plus host-directed routing. |
 
 ## models / kimi-k2
 

--- a/docs/models/deepseek-v2-lite/decode-attribution-gate.md
+++ b/docs/models/deepseek-v2-lite/decode-attribution-gate.md
@@ -39,7 +39,7 @@ Out of scope:
 
 Host-staged `dispatch_calls` / `combine_calls` count MoE layer invocations in the fixed greedy run. Host-staged `dispatch_elements` / `combine_elements` count selected routed hidden vectors, so the value is route count times hidden size. NCCL `exchange` and `combine` counters count the dense all-reduce calls and elements used by the current naive NCCL gate.
 
-The GPU event rows are intentionally narrower than the CPU rows. They cover sections that enqueue device work or NCCL work on known streams, including projections, dense/shared/routed experts, host-to-device combine, NCCL dense exchange, and NCCL combine. They do not relabel pure host routing or host accumulation as GPU work, and the mixed `attention_host_path` stays CPU-side because it includes host attention assembly as well as internal GPU projections.
+The GPU event rows are intentionally narrower than the CPU rows. They cover sections that enqueue device work or NCCL work on known streams, including projections, dense/shared/routed experts, NCCL dense exchange, NCCL combine clear, device contribution accumulation, and NCCL combine. They do not relabel pure host routing or host-directed route iteration as GPU work, and the mixed `attention_host_path` stays CPU-side because it includes host attention assembly as well as internal GPU projections.
 
 ## Commands
 
@@ -139,7 +139,17 @@ The HF oracle needs a Python environment that can load DeepSeek-V2-Lite with `tr
 
 ## Latest Validation
 
-The strict same-host accuracy gate was last rerun on 2026-06-04 with DeepSeek-V2-Lite snapshot `604d5664dddd88a0433dbae533b7fe9472482de0`, `prompt="Hello"`, `output_len=16`, and 2x A800-SXM4-80GB. The token/text oracle is confirmed by a real HF `AutoModelForCausalLM.generate(..., do_sample=false, use_cache=true)` run on the same model directory as the Rust E2E gate.
+The issue #275 refresh was rerun on 2026-06-08 with DeepSeek-V2-Lite snapshot `604d5664dddd88a0433dbae533b7fe9472482de0`, `prompt="Hello"`, `output_len=16`, and 2x RTX 5090. HF, host-staged, and NCCL were dumped from the same model directory and compared with `--require-all-exact`.
+
+- HF / host-staged / NCCL comparison: `all_token_text_exact`.
+- Token SHA256: `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225`.
+- Text SHA256: `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347`.
+- Generated text: `, I am a 19 year old girl from the UK. I am`.
+- Candidate NCCL attribution: `gpu_timing.sample_count=8384`, `failure_count=0`.
+
+The candidate readiness report still has `full_decode_capture_ready=false`. Compared with the same-host baseline attribution, it removed `nccl_contribution_accumulation_on_host`, `nccl_combine_h2d_contribution_copy`, `nccl_combine_allocates_per_call`, `nccl_combine_syncs_rank_streams`, and `nccl_combine_d2h_result_copy`. The remaining blockers are `nccl_dense_exchange_allocates_per_call`, `nccl_dense_exchange_syncs_rank_streams`, `nccl_route_iteration_on_host`, and `nccl_expert_accumulation_host_directed`.
+
+The previous A800 strict same-host accuracy gate was rerun on 2026-06-04 with DeepSeek-V2-Lite snapshot `604d5664dddd88a0433dbae533b7fe9472482de0`, `prompt="Hello"`, `output_len=16`, and 2x A800-SXM4-80GB. The token/text oracle is confirmed by a real HF `AutoModelForCausalLM.generate(..., do_sample=false, use_cache=true)` run on the same model directory as the Rust E2E gate.
 
 The Rust E2E accepts the known HF-confirmed RTX 5090 and A800 hash pairs for this narrow shape, but the comparison gate remains stricter: HF, host-staged, and NCCL JSON must be dumped from the same model/runtime and compared with `--require-all-exact`. This refresh does not claim a model-runtime improvement, a manual-loop root cause, or a transport issue.
 

--- a/docs/models/deepseek-v2-lite/device-resident-nccl-combine.md
+++ b/docs/models/deepseek-v2-lite/device-resident-nccl-combine.md
@@ -1,11 +1,8 @@
 # DeepSeek-V2-Lite Device-Resident NCCL Combine
 
-**Created**: 2026-06-08
-**Status**: validated on 2x RTX 5090
+> **TL;DR:** Issue #275 moves the NCCL decode combine path to reusable device-resident f32 scratch buffers. The retained `Hello` / 16-token gate stays HF / host-staged / NCCL exact, and the readiness report no longer lists the old combine H2D/D2H/allocation/sync blockers. Full decode capture is still blocked by dense exchange allocation/sync and host-directed routing.
 
-## TL;DR
-
-Issue #275 moves the NCCL decode combine path to reusable device-resident f32 scratch buffers. The retained `Hello` / 16-token gate stays HF / host-staged / NCCL exact, and the readiness report no longer lists the old combine H2D/D2H/allocation/sync blockers. Full decode capture is still blocked by dense exchange allocation/sync and host-directed routing.
+Last touched: 2026-06
 
 ## Preparation
 

--- a/docs/models/deepseek-v2-lite/device-resident-nccl-combine.md
+++ b/docs/models/deepseek-v2-lite/device-resident-nccl-combine.md
@@ -1,0 +1,113 @@
+# DeepSeek-V2-Lite Device-Resident NCCL Combine
+
+**Created**: 2026-06-08
+**Status**: validated on 2x RTX 5090
+
+## TL;DR
+
+Issue #275 moves the NCCL decode combine path to reusable device-resident f32 scratch buffers. The retained `Hello` / 16-token gate stays HF / host-staged / NCCL exact, and the readiness report no longer lists the old combine H2D/D2H/allocation/sync blockers. Full decode capture is still blocked by dense exchange allocation/sync and host-directed routing.
+
+## Preparation
+
+- **Read**:
+  - `docs/index.md` - current docs live under domain folders such as `docs/models/deepseek-v2-lite/`.
+  - `docs/models/deepseek-v2-lite/status.md` - DeepSeek-V2-Lite is still a feature-gated EP2 correctness and attribution target; host-staged remains the oracle.
+  - `docs/models/deepseek-v2-lite/decode-attribution-gate.md` - acceptance uses the `Hello` / 16-token HF / host-staged / NCCL gate plus graph-readiness blockers.
+  - `docs/models/deepseek-v2-lite/hf-accuracy-gate.md` - same-host HF, host-staged, and NCCL token/text exactness is the correctness standard.
+  - `docs/models/deepseek-v2-lite/source-layout.md` - runtime responsibilities are split, and issue #275 was intentionally left as follow-up work.
+  - `pegainfer-deepseek-v2-lite/src/runtime/moe.rs` - the pre-#275 NCCL combine path accumulated routed expert outputs in host `Vec<f32>` buffers, then copied H2D for NCCL and D2H before final H2D conversion.
+  - `pegainfer-deepseek-v2-lite/src/nccl_backend.rs` - the pre-#275 NCCL combine path allocated send/recv device buffers inside each call and synchronized both streams.
+  - `pegainfer-deepseek-v2-lite/src/runtime/readiness.rs` - the pre-#275 readiness report listed combine H2D, allocation, sync, and D2H blockers.
+  - `pegainfer-kernels/src/ops/elementwise.rs` and `pegainfer-kernels/csrc/shared/elementwise.cu` - existing device f32/bf16 conversion helpers could be reused, but there was no f32 accumulation helper for bf16 expert output.
+- **Relevant history**:
+  - `docs/models/deepseek-v2-lite/status.md` - NCCL plus CUDA Graph is the preferred direction, but the current gate must not be described as production EP.
+  - `docs/models/deepseek-v2-lite/source-layout.md` - local macOS checks are not enough for this path; remote 2-GPU validation is the real acceptance path.
+- **Implemented**:
+  1. Add a shared CUDA helper that accumulates a bf16 single-token expert output into a f32 device contribution buffer at a selected token row.
+  2. Re-export that helper through `pegainfer-core::ops`.
+  3. Add reusable NCCL combine scratch buffers inside `NaiveNcclEp2Backend`, clear the f32 send scratch per MoE call, accumulate local/remote expert outputs on the owning device, all-reduce device buffers, and cast rank0 f32 result to bf16 on device.
+  4. Update graph-readiness blockers and attribution wording so removed combine H2D/D2H/allocation/sync blockers are no longer claimed, while remaining host routing and dense-exchange blockers stay explicit.
+  5. Run formatting and local compile gates, then use the provided remote GPU host for the DeepSeek-V2-Lite EP2 exactness and attribution gates.
+- **Risks / open questions**:
+  - Device f32 accumulation must preserve the existing expert-id accumulation order before the final bf16 cast.
+  - Dense exchange and host route selection still block full decode CUDA Graph capture; `full_decode_capture_ready` should remain false unless validation proves otherwise.
+  - The provided SSH credential should stay local to the validation session and must not be echoed into docs or final output.
+
+## Execution Log
+
+Validated 2026-06-08 on the provided 2x RTX 5090 host with DeepSeek-V2-Lite snapshot `604d5664dddd88a0433dbae533b7fe9472482de0`, CUDA 12.8, Rust 1.96.0, Torch 2.7.0+cu128, Transformers 4.40.2, and NCCL from the Python CUDA wheel path.
+
+Commands run:
+
+```bash
+cargo test --offline --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite --test e2e_ep2 --no-run
+
+cargo clippy --offline --release -p pegainfer-deepseek-v2-lite \
+  --features deepseek-v2-lite --bins --tests -- \
+  -D warnings \
+  -A clippy::option_option \
+  -A clippy::manual_midpoint \
+  -A clippy::needless_range_loop
+
+python tools/accuracy/hf_dump_dsv2_lite_ep2_greedy.py \
+  --model-path models/DeepSeek-V2-Lite \
+  --prompt Hello \
+  --output-len 16 \
+  --out target/accuracy/dsv2-lite-ep2/hf.json
+
+PEGAINFER_TEST_MODEL_PATH=models/DeepSeek-V2-Lite \
+PEGAINFER_DSV2_LITE_E2E_JSON_OUT=target/accuracy/dsv2-lite-ep2/host-staged.json \
+  cargo test --offline --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite --test e2e_ep2 -- --nocapture
+
+PEGAINFER_TEST_MODEL_PATH=models/DeepSeek-V2-Lite \
+PEGAINFER_DSV2_LITE_EP_BACKEND=nccl \
+PEGAINFER_DSV2_LITE_E2E_JSON_OUT=target/accuracy/dsv2-lite-ep2/nccl-after-decouple-cleanup.json \
+  cargo test --offline --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite --test e2e_ep2 -- --nocapture
+
+python tools/accuracy/compare_dsv2_lite_ep2_outputs.py \
+  --hf target/accuracy/dsv2-lite-ep2/hf.json \
+  --host-staged target/accuracy/dsv2-lite-ep2/host-staged.json \
+  --nccl target/accuracy/dsv2-lite-ep2/nccl-after-decouple-cleanup.json \
+  --out target/accuracy/dsv2-lite-ep2/comparison-after-decouple-cleanup.json \
+  --require-all-exact
+
+PEGAINFER_DSV2_LITE_EP_BACKEND=nccl \
+  cargo run --offline --release -p pegainfer-deepseek-v2-lite \
+    --features deepseek-v2-lite \
+    --bin dsv2_lite_ep2_decode_attribution \
+    -- --model-path models/DeepSeek-V2-Lite \
+    --batch-size 1 \
+    --out target/accuracy/dsv2-lite-ep2/candidate-nccl-attribution.json
+```
+
+Results:
+
+- HF / host-staged / NCCL comparison: `all_token_text_exact`.
+- Generated text: `, I am a 19 year old girl from the UK. I am`.
+- Token SHA256: `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225`.
+- Text SHA256: `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347`.
+- Candidate NCCL attribution: `gpu_timing.sample_count=8384`, `failure_count=0`.
+- Final review cleanup gate: package `--bins --tests` clippy passed with only three explicit allows for pre-existing unrelated lints (`pegainfer-core::logging` `option_option`, and two `host_ops` test lints).
+
+Before/after readiness comparison for the same model snapshot and diagnostic shape:
+
+| Report | Readiness blockers |
+| --- | --- |
+| Baseline NCCL attribution | `nccl_dense_exchange_allocates_per_call`, `nccl_dense_exchange_syncs_rank_streams`, `nccl_route_iteration_on_host`, `nccl_contribution_accumulation_on_host`, `nccl_combine_h2d_contribution_copy`, `nccl_combine_allocates_per_call`, `nccl_combine_syncs_rank_streams`, `nccl_combine_d2h_result_copy` |
+| Candidate NCCL attribution | `nccl_dense_exchange_allocates_per_call`, `nccl_dense_exchange_syncs_rank_streams`, `nccl_route_iteration_on_host`, `nccl_expert_accumulation_host_directed` |
+
+Removed blockers:
+
+- `nccl_contribution_accumulation_on_host`
+- `nccl_combine_h2d_contribution_copy`
+- `nccl_combine_allocates_per_call`
+- `nccl_combine_syncs_rank_streams`
+- `nccl_combine_d2h_result_copy`
+
+The candidate report replaces the old `nccl_contribution_accumulate` and `nccl_combine_to_device` sections with `nccl_contribution_accumulate_device` and `nccl_combine_clear`, while keeping the final `nccl_combine` section for the f32 all-reduce plus rank0 bf16 cast.
+
+## Debrief
+
+The implementation keeps host-staged unchanged as the correctness oracle. The NCCL backend now owns reusable rank0/rank1 f32 send/recv scratch buffers behind `DeviceCombineScratch`; each MoE call clears the f32 send scratch on device, accumulates one-token expert outputs into the owning rank's send scratch with a CUDA helper, runs the f32 NCCL all-reduce, and casts rank0's f32 result back to bf16 on device.
+
+The final bf16 `HiddenStates` returned to the model is still allocated per combine call. That allocation is outside the removed NCCL contribution/result round trip, so it is not claimed as full CUDA Graph readiness. The remaining readiness blockers are still real and should drive the next slice.

--- a/docs/models/deepseek-v2-lite/device-resident-nccl-combine.md
+++ b/docs/models/deepseek-v2-lite/device-resident-nccl-combine.md
@@ -84,7 +84,18 @@ Results:
 - Token SHA256: `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225`.
 - Text SHA256: `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347`.
 - Candidate NCCL attribution: `gpu_timing.sample_count=8384`, `failure_count=0`.
-- Final review cleanup gate: package `--bins --tests` clippy passed with only three explicit allows for pre-existing unrelated lints (`pegainfer-core::logging` `option_option`, and two `host_ops` test lints).
+- Initial remote cleanup gate: package `--bins --tests` clippy passed with only three explicit allows for then-existing lints (`pegainfer-core::logging` `option_option`, and two `host_ops` test lints).
+
+Follow-up review gate on 2026-06-09 after fixing those lints:
+
+```bash
+cargo fmt --all --check
+
+cargo clippy --release -p pegainfer-deepseek-v2-lite \
+  --features deepseek-v2-lite --bins --tests -- -D warnings
+```
+
+Both commands passed on the same remote source copy after syncing the follow-up `host_ops.rs` and `logging.rs` fixes. The clippy command ran without `clippy::manual_midpoint`, `clippy::needless_range_loop`, or `clippy::option_option` allows.
 
 Before/after readiness comparison for the same model snapshot and diagnostic shape:
 

--- a/docs/models/deepseek-v2-lite/status.md
+++ b/docs/models/deepseek-v2-lite/status.md
@@ -1,6 +1,6 @@
 # DeepSeek-V2-Lite Status And Benchmark Ledger
 
-> **TL;DR:** DeepSeek-V2-Lite is a feature-gated EP2 correctness and attribution target. HF, host-staged, and NCCL match for the narrow greedy gate; current batch and vLLM data are diagnostic and do not claim production serving parity.
+> **TL;DR:** DeepSeek-V2-Lite is a feature-gated EP2 correctness and attribution target. HF, host-staged, and NCCL match for the narrow greedy gate; NCCL decode combine now uses reusable device-resident f32 scratch, while dense exchange and host-directed routing still block full decode graph capture. Current batch and vLLM data remain diagnostic and do not claim production serving parity.
 
 Last touched: 2026-06
 
@@ -13,6 +13,7 @@ Last touched: 2026-06
 | HF token/text/hash gate | Available | PR #154 establishes the HF / host-staged / NCCL comparison; PR #176 refreshes it to Transformers `generate(..., use_cache=true)`. |
 | Decode attribution | Available | PR #162 and PR #169 add CPU/GPU attribution, route counts, NCCL counters, CUDA event timing, and optional NVTX correlation. |
 | Direct same-prompt diagnostic batch | Available | PR #184 and PR #196 cover batch sizes `1`, `4`, and `8` for the fixed same-prompt direct path. |
+| Device-resident NCCL combine | Available | Issue #275 keeps NCCL combine contributions/results on reusable f32 device scratch and preserves the HF / host-staged / NCCL exact gate on 2x RTX 5090. |
 | NCCL CUDA Graph readiness | Diagnostic only | The attribution binary now emits `cuda_graph_readiness`. Current NCCL full decode capture is blocked; the optional preallocated f32 NCCL graph smoke captures, replays, and verifies. |
 | Production continuous batching | Not available | The direct diagnostic batch path is not mixed-request HTTP serving. |
 | vLLM production parity | Not claimed | The manual vLLM snapshot below is for understanding the gap requested in issue #170. |
@@ -55,7 +56,7 @@ Current retained direct snapshot from PR #184:
 | 8 | host-staged | 394.753 | 411.348 | 19.423 |
 | 8 | NCCL | 522.917 | 539.643 | 14.874 |
 
-PR #196 extends attribution for the same direct diagnostic shapes. The latest A800 attribution gate keeps `batch-size=1/4/8`, `prompt="Hello"`, `output_len=16`, host-staged, and NCCL exact against the same-host HF gate.
+PR #196 extends attribution for the same direct diagnostic shapes. The retained A800 attribution gate keeps `batch-size=1/4/8`, `prompt="Hello"`, `output_len=16`, host-staged, and NCCL exact against the same-host HF gate.
 
 ### Manual vLLM Snapshot
 
@@ -99,14 +100,15 @@ Do not claim:
 
 Issue #205 records the model roadmap. Maintainer feedback there calls out NCCL plus CUDA Graph as the likely best decode direction, with host staging possibly deprecated later. Treat that as a future direction, not as current evidence.
 
-The current graph-readiness diagnostic is intentionally fail-closed: `full_decode_capture_ready=false` for NCCL. A basic preallocated f32 NCCL all-reduce smoke now captures, replays, and verifies on the latest A800 run, but that proves only the collective smoke shape. It is not full decode CUDA Graph coverage. HF, host-staged, and NCCL remain token/text exact for the narrow greedy gate.
+The current graph-readiness diagnostic is intentionally fail-closed: `full_decode_capture_ready=false` for NCCL. Issue #275 removed the old NCCL combine H2D/D2H/allocation/sync blockers from the retained 2x RTX 5090 attribution gate, but dense exchange allocation/sync and host-directed routing remain. A basic preallocated f32 NCCL all-reduce smoke captures, replays, and verifies on the retained A800 run, but that proves only the collective smoke shape. It is not full decode CUDA Graph coverage. HF, host-staged, and NCCL remain token/text exact for the narrow greedy gate.
 
 The next implementation should be chosen from measured evidence:
 
-1. Move NCCL decode toward CUDA Graph coverage.
+1. Move the remaining NCCL decode path toward CUDA Graph coverage.
    - keep HF / host-staged / NCCL exact before and after;
    - keep host-staged as the correctness baseline while it exists;
    - preserve attribution before and after the change;
+   - attack dense exchange allocation/sync and host route iteration next;
    - avoid broad generic EP or multi-node work;
    - judge issue #170 by whether it reduces NCCL decode overhead and makes the path more graph-friendly.
 

--- a/pegainfer-core/src/logging.rs
+++ b/pegainfer-core/src/logging.rs
@@ -33,6 +33,11 @@ const DEFAULT_NOISY_MODULE_LEVELS: [(&str, &str); 5] = [
     ("tower", "warn"),
 ];
 
+enum BareGlobalLevel {
+    Off,
+    Level(Level),
+}
+
 fn apply_default_module_levels(mut filter: String) -> String {
     for (module, level) in DEFAULT_NOISY_MODULE_LEVELS {
         let module_pattern = format!("{module}=");
@@ -48,7 +53,7 @@ fn apply_default_module_levels(mut filter: String) -> String {
     filter
 }
 
-fn bare_global_level(filter: &str) -> Option<Option<Level>> {
+fn bare_global_level(filter: &str) -> Option<BareGlobalLevel> {
     let mut global_level = None;
 
     for directive in filter
@@ -61,9 +66,9 @@ fn bare_global_level(filter: &str) -> Option<Option<Level>> {
         }
 
         if directive.eq_ignore_ascii_case("off") {
-            global_level = Some(None);
+            global_level = Some(BareGlobalLevel::Off);
         } else if let Ok(level) = Level::from_str(directive) {
-            global_level = Some(Some(level));
+            global_level = Some(BareGlobalLevel::Level(level));
         }
     }
 
@@ -71,7 +76,7 @@ fn bare_global_level(filter: &str) -> Option<Option<Level>> {
 }
 
 fn should_apply_default_module_levels(filter: &str) -> bool {
-    matches!(bare_global_level(filter), Some(Some(level)) if level < Level::Warn)
+    matches!(bare_global_level(filter), Some(BareGlobalLevel::Level(level)) if level < Level::Warn)
 }
 
 fn resolved_filter_string(level: String, rust_log: Option<String>) -> String {

--- a/pegainfer-core/src/ops.rs
+++ b/pegainfer-core/src/ops.rs
@@ -15,14 +15,15 @@ pub use attention::{
 };
 pub use paged_plan::PrefillPagedPlan;
 pub use pegainfer_kernels::ops::{
-    LoraDecodeGroupedProjection, add_batch, add_batch_into, embedding_decode_into, extract_vec,
-    extract_vec_into, fused_add_rms_norm_into, gather_hidden_tokens_into, gemm, gemm_into_checked,
-    gemm_per_token, gemv, linear, lora_decode_fused_delta_group3_into,
+    LoraDecodeGroupedProjection, accumulate_bf16_token_scaled_to_f32_into, add_batch,
+    add_batch_into, bf16_hidden_to_f32_into, embedding_decode_into, extract_vec, extract_vec_into,
+    f32_to_bf16_hidden_into, fused_add_rms_norm_into, gather_hidden_tokens_into, gemm,
+    gemm_into_checked, gemm_per_token, gemv, linear, lora_decode_fused_delta_group3_into,
     lora_decode_fused_delta_into, pack_lora_b_rows_into,
     qk_norm_partial_rope_batched_decode_hd256_into, rms_norm, rms_norm_batch_offset_into,
-    rms_norm_gated_batch_into, rms_norm_into, rms_norm_offset_into, scaled_add_batch_into,
-    scaled_add_rows_indexed_into, scaled_add_rows_into, scaled_add_rows_token_range_into,
-    silu_mul_batch, silu_mul_batch_into, write_vec_into,
+    rms_norm_gated_batch_into, rms_norm_into, rms_norm_offset_into, scale_f32_in_place,
+    scaled_add_batch_into, scaled_add_rows_indexed_into, scaled_add_rows_into,
+    scaled_add_rows_token_range_into, silu_mul_batch, silu_mul_batch_into, write_vec_into,
 };
 #[cfg(not(feature = "kernel-call-trace"))]
 pub use pegainfer_kernels::ops::{

--- a/pegainfer-deepseek-v2-lite/src/bin/dsv2_lite_ep2_decode_attribution.rs
+++ b/pegainfer-deepseek-v2-lite/src/bin/dsv2_lite_ep2_decode_attribution.rs
@@ -34,7 +34,9 @@ struct Cli {
 }
 
 fn main() -> Result<()> {
-    let cli = parse_cli()?;
+    let Some(cli) = parse_cli()? else {
+        return Ok(());
+    };
     let model_path = resolve_model_path(&cli.model_path);
     ensure!(
         model_path.join("config.json").exists(),
@@ -72,9 +74,9 @@ fn main() -> Result<()> {
         single_report(
             &tokenizer,
             &prompt_tokens,
-            result,
-            attribution,
-            graph_readiness,
+            &result,
+            &attribution,
+            &graph_readiness,
         )?
     } else {
         let (result, attribution) = generator.generate_greedy_batch_same_prompt_with_attribution(
@@ -91,9 +93,9 @@ fn main() -> Result<()> {
         batch_report(
             &tokenizer,
             &prompt_tokens,
-            result,
-            attribution,
-            graph_readiness,
+            &result,
+            &attribution,
+            &graph_readiness,
         )?
     };
 
@@ -114,9 +116,9 @@ fn main() -> Result<()> {
 fn single_report(
     tokenizer: &HuggingFaceTokenizer,
     prompt_tokens: &[u32],
-    result: pegainfer_deepseek_v2_lite::GenerationResult,
-    attribution: pegainfer_deepseek_v2_lite::DecodeAttributionProfile,
-    graph_readiness: DecodeGraphReadinessReport,
+    result: &pegainfer_deepseek_v2_lite::GenerationResult,
+    attribution: &pegainfer_deepseek_v2_lite::DecodeAttributionProfile,
+    graph_readiness: &DecodeGraphReadinessReport,
 ) -> Result<Value> {
     let generated_text = tokenizer
         .decode(&result.tokens, false)
@@ -177,7 +179,7 @@ fn single_report(
             "failure_count": attribution.gpu_timing_failure_count(),
             "nvtx_enabled": attribution.nvtx_enabled(),
             "nvtx_range_count": attribution.nvtx_range_count(),
-            "scope": "selected GPU/NCCL sections only; host routing, host accumulation, and the mixed attention_host_path remain CPU-side attribution rows; GPU timing failures do not replace the token/text hash oracle; NVTX range wall time is only a profiler correlation marker and may include host/event overhead",
+            "scope": "selected GPU/NCCL sections only; host routing, host-directed route iteration, and the mixed attention_host_path remain CPU-side attribution rows; GPU timing failures do not replace the token/text hash oracle; NVTX range wall time is only a profiler correlation marker and may include host/event overhead",
         },
         "schedule_source": "fixed DeepSeek-V2-Lite EP2 greedy gate: prompt=Hello, output_len=16, cuda_graph=false, device_ordinals=[0,1]",
         "by_section": by_section,
@@ -185,7 +187,7 @@ fn single_report(
         "by_call_site": attribution.by_call_site(),
         "by_gpu_section": by_gpu_section,
         "by_gpu_call_site": by_gpu_call_site,
-        "coverage": coverage_rows(&result.stats.ep_backend, 1, &attribution, &graph_readiness),
+        "coverage": coverage_rows(&result.stats.ep_backend, 1, attribution, graph_readiness),
         "ep": ep_report(&result.stats),
         "cuda_graph_readiness": graph_readiness,
         "claim_boundary": "Attribution only for the covered EP2 Hello/16 decode gate. CPU-side section timing, selected CUDA event timing, NVTX ranges, and route/collective counts are not a throughput, sparse-dispatch, multi-node, or production EP readiness claim.",
@@ -195,9 +197,9 @@ fn single_report(
 fn batch_report(
     tokenizer: &HuggingFaceTokenizer,
     prompt_tokens: &[u32],
-    result: pegainfer_deepseek_v2_lite::BatchedGenerationResult,
-    attribution: pegainfer_deepseek_v2_lite::DecodeAttributionProfile,
-    graph_readiness: DecodeGraphReadinessReport,
+    result: &pegainfer_deepseek_v2_lite::BatchedGenerationResult,
+    attribution: &pegainfer_deepseek_v2_lite::DecodeAttributionProfile,
+    graph_readiness: &DecodeGraphReadinessReport,
 ) -> Result<Value> {
     ensure!(
         result.per_token_decode_us == attribution.per_token_decode_us(),
@@ -279,7 +281,7 @@ fn batch_report(
             "failure_count": attribution.gpu_timing_failure_count(),
             "nvtx_enabled": attribution.nvtx_enabled(),
             "nvtx_range_count": attribution.nvtx_range_count(),
-            "scope": "selected GPU/NCCL sections only; host routing, host accumulation, and the mixed attention_host_path remain CPU-side attribution rows; GPU timing failures do not replace the token/text hash oracle; NVTX range wall time is only a profiler correlation marker and may include host/event overhead",
+            "scope": "selected GPU/NCCL sections only; host routing, host-directed route iteration, and the mixed attention_host_path remain CPU-side attribution rows; GPU timing failures do not replace the token/text hash oracle; NVTX range wall time is only a profiler correlation marker and may include host/event overhead",
         },
         "schedule_source": format!(
             "fixed DeepSeek-V2-Lite EP2 greedy gate: batch_size={}, prompt=Hello, output_len=16, cuda_graph=false, device_ordinals=[0,1]",
@@ -290,14 +292,14 @@ fn batch_report(
         "by_call_site": attribution.by_call_site(),
         "by_gpu_section": by_gpu_section,
         "by_gpu_call_site": by_gpu_call_site,
-        "coverage": coverage_rows(&result.stats.ep_backend, result.tokens.len(), &attribution, &graph_readiness),
+        "coverage": coverage_rows(&result.stats.ep_backend, result.tokens.len(), attribution, graph_readiness),
         "ep": ep_report(&result.stats),
         "cuda_graph_readiness": graph_readiness,
         "claim_boundary": "Attribution only for the covered EP2 Hello/16 same-prompt batched decode gate. CPU-side section timing, selected CUDA event timing, NVTX ranges, and route/collective counts are not a throughput, sparse-dispatch, multi-node, or production EP readiness claim.",
     }))
 }
 
-fn parse_cli() -> Result<Cli> {
+fn parse_cli() -> Result<Option<Cli>> {
     let mut model_path = "models/DeepSeek-V2-Lite".to_string();
     let mut batch_size = 1;
     let mut nccl_graph_smoke = false;
@@ -333,19 +335,19 @@ fn parse_cli() -> Result<Cli> {
                 println!(
                     "DeepSeek-V2-Lite EP2 decode attribution gate\n\nUSAGE:\n  dsv2_lite_ep2_decode_attribution [--model-path PATH] [--batch-size N] [--nccl-graph-smoke] [--out PATH]\n\nThe gate is intentionally fixed to prompt=Hello, output_len=16, with batch-size in 1..=8. Select NCCL with PEGAINFER_DSV2_LITE_EP_BACKEND=nccl. Use --nccl-graph-smoke to run a preallocated f32 NCCL all-reduce CUDA Graph capture/replay smoke after attribution."
                 );
-                std::process::exit(0);
+                return Ok(None);
             }
             other => bail!(
                 "unsupported argument `{other}`; supported flags: --model-path PATH, --batch-size N, --nccl-graph-smoke, --out PATH"
             ),
         }
     }
-    Ok(Cli {
+    Ok(Some(Cli {
         model_path,
         batch_size,
         nccl_graph_smoke,
         out,
-    })
+    }))
 }
 
 fn ep_report(stats: &pegainfer_deepseek_v2_lite::GenerationStats) -> Value {

--- a/pegainfer-deepseek-v2-lite/src/host_ops.rs
+++ b/pegainfer-deepseek-v2-lite/src/host_ops.rs
@@ -458,7 +458,8 @@ mod tests {
 
         rms_norm_host(&input, &weight, eps, &mut out);
 
-        let inv_rms = ((3.0f32 * 3.0 + 4.0 * 4.0) / 2.0).sqrt().recip();
+        let mean_square = input.iter().map(|value| value * value).sum::<f32>() / input.len() as f32;
+        let inv_rms = mean_square.sqrt().recip();
         let expected0 = bf16::from_f32(bf16::from_f32(3.0 * inv_rms).to_f32() * 3.0);
         let expected1 = bf16::from_f32(bf16::from_f32(4.0 * inv_rms).to_f32() * 0.5);
         assert_eq!(out, [expected0, expected1]);
@@ -530,7 +531,7 @@ mod tests {
         let mut kv_a_decode = Vec::new();
         let mut kv_b_decode = Vec::new();
         let mut expected = Vec::new();
-        for row in 0..batch_size {
+        for (row, cache) in single_caches.iter_mut().enumerate() {
             let q_host = patterned(row + 30, config.q_proj_rows(), 0.04);
             let kv_a_host = patterned(row + 40, config.kv_a_proj_rows(), 0.05);
             let kv_b_host = patterned(row + 50, config.kv_b_proj_rows(), 0.06);
@@ -547,14 +548,10 @@ mod tests {
                 position,
                 1,
                 &mut queries,
-                &mut single_caches[row],
+                cache,
             );
             expected.extend(compute_attention_host(
-                &config,
-                &queries,
-                &single_caches[row],
-                position,
-                1,
+                &config, &queries, cache, position, 1,
             ));
         }
 

--- a/pegainfer-deepseek-v2-lite/src/nccl_backend.rs
+++ b/pegainfer-deepseek-v2-lite/src/nccl_backend.rs
@@ -1,7 +1,7 @@
 use std::{
     ffi::{CStr, c_char, c_int, c_void},
     ptr,
-    sync::Arc,
+    sync::{Arc, Mutex, MutexGuard},
 };
 
 use anyhow::{Context, Result, bail, ensure};
@@ -17,7 +17,10 @@ use cudarc::{
 };
 use half::bf16;
 use libloading::Library;
-use pegainfer_core::tensor::{DeviceContext, HiddenStates};
+use pegainfer_core::{
+    ops,
+    tensor::{DeviceContext, HiddenStates},
+};
 use serde::Serialize;
 
 use crate::device::activate;
@@ -42,8 +45,10 @@ type NcclGetErrorString = unsafe extern "C" fn(ncclResult_t) -> *const c_char;
 pub(crate) struct NaiveNcclEp2Backend {
     lib: Arc<RawNcclLib>,
     comms: Vec<ncclComm_t>,
+    combine_scratch: Mutex<DeviceCombineScratch>,
 }
 
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, Serialize)]
 pub(crate) struct NcclGraphSmokeReport {
     attempted: bool,
@@ -100,6 +105,108 @@ struct RawNcclLib {
     get_error_string: NcclGetErrorString,
 }
 
+#[derive(Default)]
+struct DeviceCombineScratch {
+    hidden_dim: usize,
+    seq_len: usize,
+    rank0_send: Option<CudaSlice<f32>>,
+    rank0_recv: Option<CudaSlice<f32>>,
+    rank1_send: Option<CudaSlice<f32>>,
+    rank1_recv: Option<CudaSlice<f32>>,
+}
+
+impl DeviceCombineScratch {
+    fn ensure(
+        &mut self,
+        rank0: &DeviceContext,
+        rank1: &DeviceContext,
+        hidden_dim: usize,
+        seq_len: usize,
+    ) -> Result<()> {
+        let elems = combine_elems(hidden_dim, seq_len)?;
+        if self.hidden_dim == hidden_dim
+            && self.seq_len == seq_len
+            && self
+                .rank0_send
+                .as_ref()
+                .is_some_and(|buf| buf.len() >= elems)
+            && self
+                .rank0_recv
+                .as_ref()
+                .is_some_and(|buf| buf.len() >= elems)
+            && self
+                .rank1_send
+                .as_ref()
+                .is_some_and(|buf| buf.len() >= elems)
+            && self
+                .rank1_recv
+                .as_ref()
+                .is_some_and(|buf| buf.len() >= elems)
+        {
+            return Ok(());
+        }
+
+        activate(rank0)?;
+        drop(self.rank0_send.take());
+        drop(self.rank0_recv.take());
+        let rank0_send = rank0.stream.alloc_zeros::<f32>(elems)?;
+        let rank0_recv = rank0.stream.alloc_zeros::<f32>(elems)?;
+        activate(rank1)?;
+        drop(self.rank1_send.take());
+        drop(self.rank1_recv.take());
+        let rank1_send = rank1.stream.alloc_zeros::<f32>(elems)?;
+        let rank1_recv = rank1.stream.alloc_zeros::<f32>(elems)?;
+
+        self.hidden_dim = hidden_dim;
+        self.seq_len = seq_len;
+        self.rank0_send = Some(rank0_send);
+        self.rank0_recv = Some(rank0_recv);
+        self.rank1_send = Some(rank1_send);
+        self.rank1_recv = Some(rank1_recv);
+        Ok(())
+    }
+
+    fn ensure_shape(&self, hidden_dim: usize, seq_len: usize) -> Result<usize> {
+        let elems = combine_elems(hidden_dim, seq_len)?;
+        ensure!(
+            self.hidden_dim == hidden_dim && self.seq_len == seq_len,
+            "DeepSeek-V2-Lite NCCL device combine scratch shape mismatch: scratch=[{}, {}], requested=[{}, {}]",
+            self.hidden_dim,
+            self.seq_len,
+            hidden_dim,
+            seq_len
+        );
+        ensure!(
+            self.rank0_send
+                .as_ref()
+                .is_some_and(|buf| buf.len() >= elems)
+                && self
+                    .rank0_recv
+                    .as_ref()
+                    .is_some_and(|buf| buf.len() >= elems)
+                && self
+                    .rank1_send
+                    .as_ref()
+                    .is_some_and(|buf| buf.len() >= elems)
+                && self
+                    .rank1_recv
+                    .as_ref()
+                    .is_some_and(|buf| buf.len() >= elems),
+            "DeepSeek-V2-Lite NCCL device combine scratch is not initialized for {elems} elements"
+        );
+        Ok(elems)
+    }
+
+    fn send_mut(&mut self, rank: usize) -> Result<&mut CudaSlice<f32>> {
+        match rank {
+            0 => self.rank0_send.as_mut(),
+            1 => self.rank1_send.as_mut(),
+            other => bail!("DeepSeek-V2-Lite NCCL device combine unsupported EP rank {other}"),
+        }
+        .context("DeepSeek-V2-Lite NCCL device combine send scratch is missing")
+    }
+}
+
 impl NaiveNcclEp2Backend {
     pub(crate) fn new(rank0: &DeviceContext, rank1: &DeviceContext) -> Result<Self> {
         ensure!(
@@ -123,7 +230,11 @@ impl NaiveNcclEp2Backend {
             comms.iter().all(|comm| !comm.is_null()),
             "DeepSeek-V2-Lite NCCL EP=2 communicator initialization returned a null communicator"
         );
-        let backend = Self { lib, comms };
+        let backend = Self {
+            lib,
+            comms,
+            combine_scratch: Mutex::new(DeviceCombineScratch::default()),
+        };
         backend.validate_communicators(&ordinals)?;
         backend.smoke_all_reduce_f32(rank0, rank1)?;
         Ok(backend)
@@ -175,57 +286,117 @@ impl NaiveNcclEp2Backend {
         Ok(rank1_recv)
     }
 
-    pub(crate) fn combine_f32_contributions_to_rank0(
+    pub(crate) fn clear_device_combine(
         &self,
         rank0: &DeviceContext,
         rank1: &DeviceContext,
-        rank0_contrib: &[f32],
-        rank1_contrib: &[f32],
-    ) -> Result<Vec<f32>> {
-        ensure!(
-            !rank0_contrib.is_empty(),
-            "DeepSeek-V2-Lite NCCL combine requires non-empty rank0 contribution"
-        );
-        ensure!(
-            rank0_contrib.len() == rank1_contrib.len(),
-            "DeepSeek-V2-Lite NCCL combine contribution length mismatch: rank0={}, rank1={}",
-            rank0_contrib.len(),
-            rank1_contrib.len()
-        );
+        hidden_dim: usize,
+        seq_len: usize,
+    ) -> Result<()> {
+        let mut scratch = self.combine_scratch()?;
+        let elems = combine_elems(hidden_dim, seq_len)?;
+        scratch.ensure(rank0, rank1, hidden_dim, seq_len)?;
         activate(rank0)?;
-        let rank0_send = rank0.stream.clone_htod(rank0_contrib)?;
-        let mut rank0_recv = rank0.stream.alloc_zeros::<f32>(rank0_contrib.len())?;
+        rank0
+            .stream
+            .memset_zeros(scratch.send_mut(0)?)
+            .context("clear DeepSeek-V2-Lite NCCL rank0 combine send scratch")?;
         activate(rank1)?;
-        let rank1_send = rank1.stream.clone_htod(rank1_contrib)?;
-        let mut rank1_recv = rank1.stream.alloc_zeros::<f32>(rank1_contrib.len())?;
+        rank1
+            .stream
+            .memset_zeros(scratch.send_mut(1)?)
+            .context("clear DeepSeek-V2-Lite NCCL rank1 combine send scratch")?;
+        scratch.ensure_shape(hidden_dim, seq_len)?;
+        ensure!(
+            elems > 0,
+            "DeepSeek-V2-Lite NCCL device combine requires non-empty scratch"
+        );
+        Ok(())
+    }
+
+    pub(crate) fn accumulate_device_contribution(
+        &self,
+        rank: usize,
+        ctx: &DeviceContext,
+        expert_output: &HiddenStates,
+        token_idx: usize,
+        seq_len: usize,
+        weight: f32,
+    ) -> Result<()> {
+        ensure!(
+            expert_output.seq_len == 1,
+            "DeepSeek-V2-Lite NCCL device combine expects one-token expert output, got seq_len={}",
+            expert_output.seq_len
+        );
+        let mut scratch = self.combine_scratch()?;
+        scratch.ensure_shape(expert_output.hidden_dim, seq_len)?;
+        activate(ctx)?;
+        ops::accumulate_bf16_token_scaled_to_f32_into(
+            ctx,
+            expert_output,
+            weight,
+            token_idx,
+            seq_len,
+            scratch.send_mut(rank)?,
+        )
+    }
+
+    pub(crate) fn combine_device_contributions_to_rank0(
+        &self,
+        rank0: &DeviceContext,
+        rank1: &DeviceContext,
+        hidden_dim: usize,
+        seq_len: usize,
+    ) -> Result<HiddenStates> {
+        let mut scratch = self.combine_scratch()?;
+        let elems = scratch.ensure_shape(hidden_dim, seq_len)?;
+
+        let DeviceCombineScratch {
+            rank0_send,
+            rank0_recv,
+            rank1_send,
+            rank1_recv,
+            ..
+        } = &mut *scratch;
+        let rank0_send = rank0_send
+            .as_ref()
+            .context("DeepSeek-V2-Lite NCCL rank0 combine send scratch is missing")?;
+        let rank0_recv = rank0_recv
+            .as_mut()
+            .context("DeepSeek-V2-Lite NCCL rank0 combine recv scratch is missing")?;
+        let rank1_send = rank1_send
+            .as_ref()
+            .context("DeepSeek-V2-Lite NCCL rank1 combine send scratch is missing")?;
+        let rank1_recv = rank1_recv
+            .as_mut()
+            .context("DeepSeek-V2-Lite NCCL rank1 combine recv scratch is missing")?;
 
         self.grouped("DeepSeek-V2-Lite NCCL combine all-reduce", || {
             activate(rank0)?;
             self.all_reduce_f32(
                 0,
-                &rank0_send,
-                &mut rank0_recv,
-                rank0_contrib.len(),
+                rank0_send,
+                rank0_recv,
+                elems,
                 rank0.stream.cu_stream(),
                 "DeepSeek-V2-Lite NCCL combine rank0 all-reduce",
             )?;
             activate(rank1)?;
             self.all_reduce_f32(
                 1,
-                &rank1_send,
-                &mut rank1_recv,
-                rank1_contrib.len(),
+                rank1_send,
+                rank1_recv,
+                elems,
                 rank1.stream.cu_stream(),
                 "DeepSeek-V2-Lite NCCL combine rank1 all-reduce",
             )?;
             Ok(())
         })?;
-        rank0.sync()?;
-        rank1.sync()?;
 
-        let combined = rank0.stream.clone_dtoh(&rank0_recv)?;
-        rank0.sync()?;
-        Ok(combined)
+        activate(rank0)?;
+        let mut routed = HiddenStates::zeros(rank0, hidden_dim, seq_len)?;
+        ops::f32_to_bf16_hidden_into(rank0, rank0_recv, &mut routed)?;
+        Ok(routed)
     }
 
     fn smoke_all_reduce_f32(&self, rank0: &DeviceContext, rank1: &DeviceContext) -> Result<()> {
@@ -562,6 +733,12 @@ impl NaiveNcclEp2Backend {
         Ok(comm)
     }
 
+    fn combine_scratch(&self) -> Result<MutexGuard<'_, DeviceCombineScratch>> {
+        self.combine_scratch
+            .lock()
+            .map_err(|_| anyhow::anyhow!("DeepSeek-V2-Lite NCCL device combine scratch poisoned"))
+    }
+
     fn grouped(&self, context: &str, f: impl FnOnce() -> Result<()>) -> Result<()> {
         let start = unsafe {
             // SAFETY: NCCL group state is process-global and entered/exited on
@@ -578,6 +755,18 @@ impl NaiveNcclEp2Backend {
         op_result?;
         end_result
     }
+}
+
+fn combine_elems(hidden_dim: usize, seq_len: usize) -> Result<usize> {
+    ensure!(
+        hidden_dim > 0 && seq_len > 0,
+        "DeepSeek-V2-Lite NCCL device combine requires non-empty shape, got hidden_dim={hidden_dim}, seq_len={seq_len}"
+    );
+    hidden_dim.checked_mul(seq_len).with_context(|| {
+        format!(
+            "DeepSeek-V2-Lite NCCL device combine shape overflow: hidden_dim={hidden_dim}, seq_len={seq_len}"
+        )
+    })
 }
 
 fn cleanup_capture(ctx: &DeviceContext, capture_started: bool) {
@@ -597,7 +786,7 @@ impl CapturedCudaGraph {
         let status = unsafe {
             // SAFETY: `graph` was returned by `cuStreamEndCapture` and is
             // still owned by this captured graph wrapper.
-            cudarc::driver::sys::cuGraphInstantiateWithFlags(&mut exec, self.graph, 0)
+            cudarc::driver::sys::cuGraphInstantiateWithFlags(&raw mut exec, self.graph, 0)
         };
         if status != cudarc::driver::sys::CUresult::CUDA_SUCCESS || exec.is_null() {
             bail!("instantiate CUDA Graph on {rank_label} stream failed with {status:?}");
@@ -680,7 +869,7 @@ fn end_capture(stream: CUstream, rank_label: &str) -> Result<CapturedCudaGraph> 
     let mut graph = ptr::null_mut();
     let status = unsafe {
         // SAFETY: Matches `begin_capture` on the same live rank stream.
-        cudarc::driver::sys::cuStreamEndCapture(stream, &mut graph)
+        cudarc::driver::sys::cuStreamEndCapture(stream, &raw mut graph)
     };
     ensure!(
         status == cudarc::driver::sys::CUresult::CUDA_SUCCESS && !graph.is_null(),
@@ -709,13 +898,12 @@ impl RawNcclLib {
         let mut tried = Vec::new();
         for candidate in ["libnccl.so.2", "libnccl.so"] {
             tried.push(candidate);
-            let library = match unsafe {
+            let Ok(library) = (unsafe {
                 // SAFETY: Loading NCCL is required to create the selected
                 // runtime backend. All symbols are validated immediately below.
                 Library::new(candidate)
-            } {
-                Ok(library) => library,
-                Err(_) => continue,
+            }) else {
+                continue;
             };
             return unsafe {
                 // SAFETY: The library is kept alive inside `RawNcclLib`; copied
@@ -766,7 +954,7 @@ impl RawNcclLib {
         let status = unsafe {
             // SAFETY: `count` is a valid out pointer and `comm` was validated
             // by the caller as a non-null communicator handle.
-            (self.comm_count)(comm, &mut count)
+            (self.comm_count)(comm, &raw mut count)
         };
         self.check(status, context)?;
         Ok(count)
@@ -777,7 +965,7 @@ impl RawNcclLib {
         let status = unsafe {
             // SAFETY: `device` is a valid out pointer and `comm` was validated
             // by the caller as a non-null communicator handle.
-            (self.comm_cu_device)(comm, &mut device)
+            (self.comm_cu_device)(comm, &raw mut device)
         };
         self.check(status, context)?;
         Ok(device)

--- a/pegainfer-deepseek-v2-lite/src/runtime/backend.rs
+++ b/pegainfer-deepseek-v2-lite/src/runtime/backend.rs
@@ -30,7 +30,7 @@ impl EpBackendKind {
 
 pub(super) enum EpBackendRuntime {
     HostStaged,
-    Nccl(NaiveNcclEp2Backend),
+    Nccl(Box<NaiveNcclEp2Backend>),
 }
 
 impl EpBackendRuntime {
@@ -41,7 +41,9 @@ impl EpBackendRuntime {
     ) -> Result<Self> {
         match kind {
             EpBackendKind::HostStaged => Ok(Self::HostStaged),
-            EpBackendKind::Nccl => Ok(Self::Nccl(NaiveNcclEp2Backend::new(rank0, rank1)?)),
+            EpBackendKind::Nccl => Ok(Self::Nccl(Box::new(NaiveNcclEp2Backend::new(
+                rank0, rank1,
+            )?))),
         }
     }
 

--- a/pegainfer-deepseek-v2-lite/src/runtime/moe.rs
+++ b/pegainfer-deepseek-v2-lite/src/runtime/moe.rs
@@ -254,6 +254,8 @@ impl DeepSeekV2LiteEp2Generator {
         )?;
         let mut local_routes = 0usize;
         let mut remote_routes = 0usize;
+        let mut live_expert_outputs =
+            Vec::with_capacity(input.seq_len * self.config.num_experts_per_token);
 
         for (token, token_routes) in routes.iter().enumerate() {
             for &(global_expert, weight) in token_routes {
@@ -312,6 +314,7 @@ impl DeepSeekV2LiteEp2Generator {
                         )
                     },
                 )?;
+                live_expert_outputs.push(out);
             }
         }
 
@@ -332,6 +335,7 @@ impl DeepSeekV2LiteEp2Generator {
                 )
             },
         )?;
+        drop(live_expert_outputs);
         activate(&self.rank0.ctx)?;
         let hidden = attribution.record_gpu_result(
             &self.rank0.ctx,

--- a/pegainfer-deepseek-v2-lite/src/runtime/moe.rs
+++ b/pegainfer-deepseek-v2-lite/src/runtime/moe.rs
@@ -225,11 +225,6 @@ impl DeepSeekV2LiteEp2Generator {
                 }
             },
         )?;
-        let mut rank0_contrib = vec![0.0f32; input.seq_len * self.config.hidden_size];
-        let mut rank1_contrib = vec![0.0f32; rank0_contrib.len()];
-        // NCCL covers only the dense hidden exchange and final contribution
-        // sum in this first gate. Route iteration and expert-output
-        // accumulation stay host-side so host-staged remains a simple oracle.
         let rank1_input = attribution.record_gpu_pair_result(
             &self.rank0.ctx,
             &self.rank1.ctx,
@@ -240,77 +235,87 @@ impl DeepSeekV2LiteEp2Generator {
             token_index,
             || nccl.dense_all_reduce_rank0_hidden_to_rank1(&self.rank0.ctx, &self.rank1.ctx, input),
         )?;
+        attribution.record_gpu_pair_result(
+            &self.rank0.ctx,
+            &self.rank1.ctx,
+            phase,
+            "nccl_combine_clear",
+            || format!("layer.{layer_idx}.nccl.combine_clear"),
+            Some(layer_idx),
+            token_index,
+            || {
+                nccl.clear_device_combine(
+                    &self.rank0.ctx,
+                    &self.rank1.ctx,
+                    input.hidden_dim,
+                    input.seq_len,
+                )
+            },
+        )?;
         let mut local_routes = 0usize;
         let mut remote_routes = 0usize;
 
         for (token, token_routes) in routes.iter().enumerate() {
             for &(global_expert, weight) in token_routes {
                 let owner_rank = self.rank0.layout.owner_rank(global_expert)?;
-                let (out, dst) = match owner_rank {
+                let out = match owner_rank {
                     0 => {
                         local_routes += 1;
                         let expert = self.rank0.routed_expert(layer_idx, global_expert)?;
-                        (
-                            attribution.record_gpu_result(
-                                &self.rank0.ctx,
-                                phase,
-                                "nccl_local_expert",
-                                || format!("layer.{layer_idx}.nccl.local_expert"),
-                                Some(layer_idx),
-                                token_index,
-                                || expert_forward_device(&self.rank0.ctx, expert, input, token),
-                            )?,
-                            &mut rank0_contrib,
-                        )
+                        attribution.record_gpu_result(
+                            &self.rank0.ctx,
+                            phase,
+                            "nccl_local_expert",
+                            || format!("layer.{layer_idx}.nccl.local_expert"),
+                            Some(layer_idx),
+                            token_index,
+                            || expert_forward_device(&self.rank0.ctx, expert, input, token),
+                        )?
                     }
                     1 => {
                         remote_routes += 1;
                         let expert = self.rank1.routed_expert(layer_idx, global_expert)?;
-                        (
-                            attribution.record_gpu_result(
-                                &self.rank1.ctx,
-                                phase,
-                                "nccl_remote_expert",
-                                || format!("layer.{layer_idx}.nccl.remote_expert"),
-                                Some(layer_idx),
-                                token_index,
-                                || {
-                                    expert_forward_device(
-                                        &self.rank1.ctx,
-                                        expert,
-                                        &rank1_input,
-                                        token,
-                                    )
-                                },
-                            )?,
-                            &mut rank1_contrib,
-                        )
+                        attribution.record_gpu_result(
+                            &self.rank1.ctx,
+                            phase,
+                            "nccl_remote_expert",
+                            || format!("layer.{layer_idx}.nccl.remote_expert"),
+                            Some(layer_idx),
+                            token_index,
+                            || expert_forward_device(&self.rank1.ctx, expert, &rank1_input, token),
+                        )?
                     }
                     other => {
                         bail!("routed expert {global_expert} maps to unsupported EP rank {other}")
                     }
                 };
-                let offset = token * self.config.hidden_size;
-                attribution.record_result(
+                let expert_ctx = if owner_rank == 0 {
+                    &self.rank0.ctx
+                } else {
+                    &self.rank1.ctx
+                };
+                attribution.record_gpu_result(
+                    expert_ctx,
                     phase,
-                    "nccl_contribution_accumulate",
-                    || format!("layer.{layer_idx}.nccl.contribution_accumulate"),
+                    "nccl_contribution_accumulate_device",
+                    || format!("layer.{layer_idx}.nccl.contribution_accumulate_device"),
                     Some(layer_idx),
                     token_index,
                     || {
-                        for (dst, value) in dst[offset..offset + self.config.hidden_size]
-                            .iter_mut()
-                            .zip(out)
-                        {
-                            *dst += weight * value;
-                        }
-                        Ok(())
+                        nccl.accumulate_device_contribution(
+                            owner_rank,
+                            expert_ctx,
+                            &out,
+                            token,
+                            input.seq_len,
+                            weight,
+                        )
                     },
                 )?;
             }
         }
 
-        let combined = attribution.record_gpu_pair_result(
+        let routed = attribution.record_gpu_pair_result(
             &self.rank0.ctx,
             &self.rank1.ctx,
             phase,
@@ -319,26 +324,10 @@ impl DeepSeekV2LiteEp2Generator {
             Some(layer_idx),
             token_index,
             || {
-                nccl.combine_f32_contributions_to_rank0(
+                nccl.combine_device_contributions_to_rank0(
                     &self.rank0.ctx,
                     &self.rank1.ctx,
-                    &rank0_contrib,
-                    &rank1_contrib,
-                )
-            },
-        )?;
-        let routed = attribution.record_gpu_result(
-            &self.rank0.ctx,
-            phase,
-            "nccl_combine_to_device",
-            || format!("layer.{layer_idx}.nccl.combine_to_device"),
-            Some(layer_idx),
-            token_index,
-            || {
-                hidden_from_f32_host(
-                    &self.rank0.ctx,
-                    &combined,
-                    self.config.hidden_size,
+                    input.hidden_dim,
                     input.seq_len,
                 )
             },
@@ -386,7 +375,7 @@ fn expert_forward_device(
     expert: &ExpertMlp,
     input: &HiddenStates,
     token_idx: usize,
-) -> Result<Vec<f32>> {
+) -> Result<HiddenStates> {
     activate(ctx)?;
     let token = ops::extract_vec(ctx, input, token_idx)?;
     let token_hidden = HiddenStates {
@@ -394,6 +383,5 @@ fn expert_forward_device(
         seq_len: 1,
         data: token.data,
     };
-    let out = dense_mlp_forward(ctx, &expert.dense, &token_hidden)?;
-    hidden_to_f32(ctx, &out)
+    dense_mlp_forward(ctx, &expert.dense, &token_hidden)
 }

--- a/pegainfer-deepseek-v2-lite/src/runtime/readiness.rs
+++ b/pegainfer-deepseek-v2-lite/src/runtime/readiness.rs
@@ -106,29 +106,9 @@ fn decode_graph_blockers(backend: EpBackendKind) -> Vec<DecodeGraphBlocker> {
                 reason: "expert routing and per-route loop decisions stay on the host",
             },
             DecodeGraphBlocker {
-                id: "nccl_contribution_accumulation_on_host",
+                id: "nccl_expert_accumulation_host_directed",
                 source: "runtime/moe.rs::moe_forward_nccl",
-                reason: "local and remote expert outputs are copied back and accumulated in host vectors",
-            },
-            DecodeGraphBlocker {
-                id: "nccl_combine_h2d_contribution_copy",
-                source: "nccl_backend.rs::combine_f32_contributions_to_rank0",
-                reason: "rank contributions are copied from host to device for each combine call",
-            },
-            DecodeGraphBlocker {
-                id: "nccl_combine_allocates_per_call",
-                source: "nccl_backend.rs::combine_f32_contributions_to_rank0",
-                reason: "send and receive buffers are allocated inside each combine call",
-            },
-            DecodeGraphBlocker {
-                id: "nccl_combine_syncs_rank_streams",
-                source: "nccl_backend.rs::combine_f32_contributions_to_rank0",
-                reason: "both rank streams are synchronized after every combine collective",
-            },
-            DecodeGraphBlocker {
-                id: "nccl_combine_d2h_result_copy",
-                source: "nccl_backend.rs::combine_f32_contributions_to_rank0",
-                reason: "the combined rank0 result is copied back to host before being uploaded again",
+                reason: "expert launches and device-side scratch accumulation are still driven by the host route loop",
             },
         ],
     }

--- a/pegainfer-kernels/KERNELS.md
+++ b/pegainfer-kernels/KERNELS.md
@@ -10,6 +10,7 @@ Use this file as the LLM entrypoint before editing kernels. Start from `op_id`, 
 | --- | --- | --- | --- | --- | --- | --- |
 | `shared.linear.gemm_per_token` | model-specific decode accuracy gates | `ops::gemm_per_token` / `ops::gemm_per_token_into_checked` | `gemm_per_token_cuda` | `csrc/shared/linear.cu` | cuBLAS | computes each row through the N=1 decode GEMM boundary; used when row-wise parity is required before performance optimization |
 | `shared.sampling.argmax_batch_bf16` | batched greedy gates | `ops::argmax_batch_bf16_into` | `argmax_batch_bf16_cuda` | `csrc/shared/argmax.cu` | CUDA | one greedy top-1 result per row over contiguous `HiddenStates` logits |
+| `shared.elementwise.accumulate_bf16_token_scaled_to_f32` | DeepSeek-V2-Lite NCCL device combine | `ops::accumulate_bf16_token_scaled_to_f32_into` | `accumulate_bf16_token_scaled_to_f32_cuda` | `csrc/shared/elementwise.cu` | CUDA | accumulates one bf16 expert-output token into a selected row of reusable f32 device scratch before the NCCL combine all-reduce |
 
 ## Qwen3-4B Dense Full-Attention Path
 

--- a/pegainfer-kernels/csrc/shared/elementwise.cu
+++ b/pegainfer-kernels/csrc/shared/elementwise.cu
@@ -126,6 +126,24 @@ __global__ void scale_f32_kernel(float *__restrict__ values, float scale, int n)
   }
 }
 
+__global__ void accumulate_bf16_token_scaled_to_f32_kernel(
+    const __nv_bfloat16 *__restrict__ token,
+    float scale,
+    float *__restrict__ out,
+    int hidden_dim,
+    int token_idx,
+    int seq_len) {
+  if (token_idx < 0 || token_idx >= seq_len) {
+    return;
+  }
+  int base = token_idx * hidden_dim;
+  for (int idx = blockIdx.x * blockDim.x + threadIdx.x;
+       idx < hidden_dim;
+       idx += gridDim.x * blockDim.x) {
+    out[base + idx] += __bfloat162float(token[idx]) * scale;
+  }
+}
+
 __global__ void repeat_f32_rows_for_reduce_scatter_kernel(
     const float *__restrict__ local,
     float *__restrict__ repeated,
@@ -336,6 +354,25 @@ CUresult scale_f32_cuda(float *values, float scale, int n, cudaStream_t stream) 
   int block = 256;
   int grid = (n + block - 1) / block;
   scale_f32_kernel<<<grid, block, 0, stream>>>(values, scale, n);
+  return (CUresult)cudaGetLastError();
+}
+
+CUresult accumulate_bf16_token_scaled_to_f32_cuda(
+    const __nv_bfloat16 *token,
+    float scale,
+    float *out,
+    int hidden_dim,
+    int token_idx,
+    int seq_len,
+    cudaStream_t stream) {
+  if (token == nullptr || out == nullptr || hidden_dim <= 0 || seq_len <= 0 ||
+      token_idx < 0 || token_idx >= seq_len) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  int block = 256;
+  int grid = (hidden_dim + block - 1) / block;
+  accumulate_bf16_token_scaled_to_f32_kernel<<<grid, block, 0, stream>>>(
+      token, scale, out, hidden_dim, token_idx, seq_len);
   return (CUresult)cudaGetLastError();
 }
 

--- a/pegainfer-kernels/src/ffi/shared.rs
+++ b/pegainfer-kernels/src/ffi/shared.rs
@@ -500,6 +500,16 @@ unsafe extern "C" {
 
     pub fn scale_f32_cuda(values: *mut f32, scale: f32, n: i32, stream: CUstream) -> CUresult;
 
+    pub fn accumulate_bf16_token_scaled_to_f32_cuda(
+        token: *const Half,
+        scale: f32,
+        out: *mut f32,
+        hidden_dim: i32,
+        token_idx: i32,
+        seq_len: i32,
+        stream: CUstream,
+    ) -> CUresult;
+
 }
 
 // Added during rebase: split argmax variant.

--- a/pegainfer-kernels/src/ops.rs
+++ b/pegainfer-kernels/src/ops.rs
@@ -22,11 +22,11 @@ pub use deepep::{
     DeepEp, DeepEpDispatchScratch, DeepEpPrefillCounts, deepep_info, deepep_unique_id,
 };
 pub use elementwise::{
-    add_batch, add_batch_into, bf16_hidden_to_f32_into, extract_vec, extract_vec_into,
-    f32_to_bf16_hidden_into, gather_hidden_tokens_into, repeat_f32_for_reduce_scatter_into,
-    scale_f32_in_place, scaled_add_batch_into, scaled_add_rows_indexed_into, scaled_add_rows_into,
-    scaled_add_rows_token_range_into, silu_mul_batch, silu_mul_batch_into,
-    silu_mul_fused_batch_into, write_vec_into,
+    accumulate_bf16_token_scaled_to_f32_into, add_batch, add_batch_into, bf16_hidden_to_f32_into,
+    extract_vec, extract_vec_into, f32_to_bf16_hidden_into, gather_hidden_tokens_into,
+    repeat_f32_for_reduce_scatter_into, scale_f32_in_place, scaled_add_batch_into,
+    scaled_add_rows_indexed_into, scaled_add_rows_into, scaled_add_rows_token_range_into,
+    silu_mul_batch, silu_mul_batch_into, silu_mul_fused_batch_into, write_vec_into,
 };
 pub use embedding::{embedding_batch, embedding_batch_vocab_shard, embedding_decode_into};
 #[cfg(feature = "kimi-k2")]

--- a/pegainfer-kernels/src/ops/elementwise.rs
+++ b/pegainfer-kernels/src/ops/elementwise.rs
@@ -316,6 +316,53 @@ pub fn scale_f32_in_place(
     Ok(())
 }
 
+pub fn accumulate_bf16_token_scaled_to_f32_into(
+    ctx: &DeviceContext,
+    token: &HiddenStates,
+    scale: f32,
+    token_idx: usize,
+    seq_len: usize,
+    out: &mut CudaSlice<f32>,
+) -> Result<()> {
+    assert!(
+        scale.is_finite(),
+        "accumulate_bf16_token_scaled_to_f32_into scale must be finite"
+    );
+    assert_eq!(
+        token.seq_len, 1,
+        "accumulate_bf16_token_scaled_to_f32_into expects one token, got seq_len={}",
+        token.seq_len
+    );
+    assert!(
+        token_idx < seq_len,
+        "accumulate token_idx {} exceeds seq_len {}",
+        token_idx,
+        seq_len
+    );
+    assert!(
+        out.len() >= token.hidden_dim * seq_len,
+        "f32 output len {} < hidden_dim {} * seq_len {}",
+        out.len(),
+        token.hidden_dim,
+        seq_len
+    );
+    let (token_ptr, _gt) = token.data.device_ptr(&ctx.stream);
+    let (out_ptr, _go) = out.device_ptr_mut(&ctx.stream);
+    let result = unsafe {
+        ffi::accumulate_bf16_token_scaled_to_f32_cuda(
+            token_ptr as *const ffi::Half,
+            scale,
+            out_ptr as *mut f32,
+            token.hidden_dim as i32,
+            token_idx as i32,
+            seq_len as i32,
+            ctx.stream.cu_stream(),
+        )
+    };
+    result.result()?;
+    Ok(())
+}
+
 pub fn repeat_f32_for_reduce_scatter_into(
     ctx: &DeviceContext,
     local: &CudaSlice<f32>,


### PR DESCRIPTION
## Summary

Fixes #275.

This moves the DeepSeek-V2-Lite NCCL decode combine path onto reusable device-resident f32 scratch buffers. Host-staged remains unchanged as the correctness oracle. The NCCL path now accumulates routed expert outputs into per-rank device scratch, runs the f32 NCCL combine all-reduce, and casts the rank0 result back to bf16 on device.

## Scope

In scope:
- add a shared CUDA helper for bf16 token output -> scaled f32 scratch accumulation
- reuse rank0/rank1 NCCL combine send/recv scratch inside `NaiveNcclEp2Backend`
- remove the old host vector NCCL combine contribution/result round trip
- update graph-readiness blockers and docs for the new device-resident combine path

Out of scope:
- full decode CUDA Graph readiness
- dense exchange allocation/sync cleanup
- host route-loop removal
- serving throughput or vLLM parity claims
- generic EP or multi-node work

## Evidence

Local:
- `cargo fmt --all --check`
- `git diff --check`

Remote 2x RTX 5090, DeepSeek-V2-Lite snapshot `604d5664dddd88a0433dbae533b7fe9472482de0`:
- `cargo clippy --offline --release -p pegainfer-deepseek-v2-lite --features deepseek-v2-lite --bins --tests -- -D warnings ...`
- HF / host-staged / NCCL comparison: `all_token_text_exact`
- generated text: `, I am a 19 year old girl from the UK. I am`
- token SHA256: `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225`
- text SHA256: `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347`
- candidate NCCL attribution: `gpu_timing.sample_count=8384`, `failure_count=0`

## Claim Boundary

This PR only claims the retained DeepSeek-V2-Lite EP2 `Hello` / 16-token gate remains HF / host-staged / NCCL exact while NCCL combine no longer uses the old per-call host/device contribution/result round trip.

`full_decode_capture_ready` remains `false`. Remaining blockers are dense exchange allocation/sync plus host-directed routing / expert accumulation.