### PR TITLE
chore: polish startup logs

### DIFF
--- a/docs/conventions/coding-style.md
+++ b/docs/conventions/coding-style.md
@@ -3,3 +3,7 @@
 ## Testing
 
 Don't test for the sake of testing. Prefer integration tests over unit tests — if the E2E test catches it, a unit test is ceremony. Unit tests earn their place for silent failures: GPU kernels, tricky data-structure invariants, edge-case-rich pure logic.
+
+## Logging
+
+Log through `pegainfer-core::logging`. The text layout already prints each record's module target, so don't prefix messages with a module or model name — no `kimi-k2:`, no `Qwen3.5 `. Error messages in `anyhow!` / `bail!` keep their prefix; they surface to callers without a target.

--- a/pegainfer-core/src/weight_loader.rs
+++ b/pegainfer-core/src/weight_loader.rs
@@ -8,7 +8,6 @@ use memmap2::Mmap;
 use safetensors::SafeTensors;
 use std::collections::HashMap;
 use std::fs;
-use std::time::Instant;
 
 use crate::tensor::{DeviceContext, DeviceMatrix, DeviceVec};
 
@@ -55,7 +54,6 @@ pub fn load_shard_info(model_path: &str) -> Result<(Vec<String>, HashMap<String,
 /// let shards = deserialize_shards(&mmaps)?;
 /// ```
 pub fn mmap_shards(shard_paths: &[String]) -> Result<Vec<Mmap>> {
-    let t0 = Instant::now();
     let mmaps: Vec<Mmap> = shard_paths
         .iter()
         .map(|p| {
@@ -68,10 +66,9 @@ pub fn mmap_shards(shard_paths: &[String]) -> Result<Vec<Mmap>> {
 
     let total_bytes: usize = mmaps.iter().map(|m| m.len()).sum();
     info!(
-        "Memory-mapped {} shard(s) ({:.1} MB) in {:.0}ms",
+        "Memory-mapped {} shard(s) ({:.1} MB)",
         mmaps.len(),
-        total_bytes as f64 / 1e6,
-        t0.elapsed().as_secs_f64() * 1e3
+        total_bytes as f64 / 1e6
     );
     Ok(mmaps)
 }

--- a/pegainfer-deepseek-v4/src/direct/affinity.rs
+++ b/pegainfer-deepseek-v4/src/direct/affinity.rs
@@ -4,7 +4,7 @@ pub(super) use pegainfer_core::cpu_topology::{
 
 pub(super) fn pin_scheduler_thread(placement: &RankThreadPlacementPlan) {
     let Some(cpu) = placement.scheduler_cpu() else {
-        log::warn!("DeepSeek V4 scheduler CPU1 is not in the current affinity mask");
+        log::warn!("scheduler CPU1 is not in the current affinity mask");
         return;
     };
     pin_current_thread_to_cpu(cpu)

--- a/pegainfer-deepseek-v4/src/direct/scheduler.rs
+++ b/pegainfer-deepseek-v4/src/direct/scheduler.rs
@@ -1075,7 +1075,7 @@ pub fn start_engine(model_path: &Path, options: EngineLoadOptions) -> Result<Eng
         );
     }
     if options.enable_cuda_graph {
-        warn!("DeepSeek V4 direct engine does not use CUDA graph yet");
+        warn!("direct engine does not use CUDA graph yet");
     }
     let model_path = model_path.to_path_buf();
     let (submit_tx, mut submit_rx) = mpsc::unbounded_channel::<GenerateRequest>();
@@ -1124,7 +1124,7 @@ pub fn start_engine(model_path: &Path, options: EngineLoadOptions) -> Result<Eng
                 }
             }
             let _ = init_tx.send(Ok(()));
-            info!("DeepSeek V4 scheduler ready");
+            info!("scheduler ready");
             while let Some(req) = submit_rx.blocking_recv() {
                 let mut wave = collect_request_wave(&mut submit_rx, req);
                 if wave.len() == 1 {
@@ -1137,7 +1137,7 @@ pub fn start_engine(model_path: &Path, options: EngineLoadOptions) -> Result<Eng
                     handle_request_wave(&mut generator, wave);
                 }
             }
-            info!("DeepSeek V4 scheduler exiting");
+            info!("scheduler exiting");
         })
         .expect("failed to spawn DeepSeek V4 scheduler thread");
     init_rx

--- a/pegainfer-kimi-k2/src/config.rs
+++ b/pegainfer-kimi-k2/src/config.rs
@@ -250,7 +250,7 @@ pub fn probe_config_json(json: &Value) -> Result<()> {
 /// of letting every request silently run to `max_tokens`.
 pub(crate) fn load_stop_token_ids(model_path: &Path) -> Result<Vec<u32>> {
     let stop_token_ids = read_stop_token_ids(model_path)?;
-    log::info!("kimi-k2: stop tokens: {stop_token_ids:?}");
+    log::info!("stop tokens: {stop_token_ids:?}");
     Ok(stop_token_ids)
 }
 

--- a/pegainfer-kimi-k2/src/runner/bringup.rs
+++ b/pegainfer-kimi-k2/src/runner/bringup.rs
@@ -42,7 +42,7 @@ const KIMI_DP_KV_POOL_PAGES_PER_RANK: usize = 1024;
 pub(crate) fn start_engine(model_path: &Path, options: &EngineLoadOptions) -> Result<EngineHandle> {
     let parallel = resolve_parallel_config(options);
     info!(
-        "kimi-k2: resolving engine startup: model_path={}, tp_size={}, dp_size={}, ep_size={}, ep_backend={:?}, devices={:?}",
+        "resolving engine startup: model_path={}, tp_size={}, dp_size={}, ep_size={}, ep_backend={:?}, devices={:?}",
         model_path.display(),
         parallel.tp_world(),
         parallel.dp_world(),
@@ -83,7 +83,7 @@ fn build_runner_config(
     kv_pool_pages: usize,
 ) -> Result<KimiK2RunnerConfig> {
     let started = Instant::now();
-    info!("kimi-k2: start build runner config");
+    info!("start build runner config");
     let mut weight_manifest = ensure_text_only_model_index(model_path)?;
     weight_manifest = weight_manifest.with_parallel_shape(shape)?;
     let placements = build_placements(&options.device_ordinals)?;
@@ -108,12 +108,12 @@ fn build_runner_config(
         kv_pool_pages,
     };
     info!(
-        "kimi-k2: build runner config cost {:.2}s: ranks={}",
+        "build runner config cost {:.2}s: ranks={}",
         started.elapsed().as_secs_f64(),
         config.placements.len()
     );
     debug!(
-        "kimi-k2: runner config detail: tensors_per_rank={:?}",
+        "runner config detail: tensors_per_rank={:?}",
         config
             .rank_sliced_load_plans
             .iter()
@@ -128,7 +128,7 @@ fn start_engine_tp8_dp1(
     options: &EngineLoadOptions,
     parallel: ParallelConfig,
 ) -> Result<EngineHandle> {
-    info!("kimi-k2: starting TP8/DP1 engine");
+    info!("starting TP8/DP1 engine");
     ensure!(
         options.ep_backend == EpBackend::Nccl,
         "Kimi-K2 TP8/DP1 routes MoE through the NCCL backend; --ep-backend={:?} has no TP8 path",
@@ -176,7 +176,7 @@ fn start_engine_tp1_dp8(
     options: &EngineLoadOptions,
     parallel: ParallelConfig,
 ) -> Result<EngineHandle> {
-    info!("kimi-k2: starting TP1/DP8 engine");
+    info!("starting TP1/DP8 engine");
     ensure!(
         options.ep_backend == EpBackend::DeepEp,
         "Kimi-K2 TP1/DP8 requires --ep-backend=deepep"
@@ -210,13 +210,13 @@ fn start_engine_tp1_dp8(
         .recv()
         .map_err(|err| anyhow::anyhow!("Kimi-K2 DP coordinator init failed: {err}"))??;
 
-    info!("kimi-k2: TP1 DP{dp_world} coordinated engine started");
+    info!("TP1 DP{dp_world} coordinated engine started");
     Ok(EngineHandle::new_with_join_handle(submit_tx, coord_handle))
 }
 
 fn build_tp8_dp1_executor(config: &KimiK2RunnerConfig) -> Result<Box<dyn ForwardExecutor + Send>> {
     let started = Instant::now();
-    info!("kimi-k2: start build TP8/DP1 executor");
+    info!("start build TP8/DP1 executor");
     let workers = spawn_workers(config)?;
     let weight_reports =
         maybe_load_rank_weights(&config.model_path, &config.rank_sliced_load_plans, &workers)?;
@@ -226,7 +226,7 @@ fn build_tp8_dp1_executor(config: &KimiK2RunnerConfig) -> Result<Box<dyn Forward
         weight_reports,
     });
     info!(
-        "kimi-k2: build TP8/DP1 executor cost {:.2}s",
+        "build TP8/DP1 executor cost {:.2}s",
         started.elapsed().as_secs_f64()
     );
     Ok(executor)
@@ -236,7 +236,7 @@ fn build_tp1_dp8_executors(
     config: &KimiK2RunnerConfig,
 ) -> Result<Vec<Box<dyn ForwardExecutor + Send>>> {
     let started = Instant::now();
-    info!("kimi-k2: start build TP1/DP8 executors");
+    info!("start build TP1/DP8 executors");
     let workers = spawn_workers(config)?;
     let weight_reports =
         maybe_load_rank_weights(&config.model_path, &config.rank_sliced_load_plans, &workers)?;
@@ -251,7 +251,7 @@ fn build_tp1_dp8_executors(
         }));
     }
     info!(
-        "kimi-k2: build TP1/DP8 executors cost {:.2}s",
+        "build TP1/DP8 executors cost {:.2}s",
         started.elapsed().as_secs_f64()
     );
     Ok(executors)
@@ -263,7 +263,7 @@ fn maybe_load_rank_weights(
     workers: &[KimiRankWorker],
 ) -> Result<Vec<KimiRankWeightLoadReport>> {
     let started = Instant::now();
-    info!("kimi-k2: start load rank weights: ranks={}", workers.len());
+    info!("start load rank weights: ranks={}", workers.len());
     ensure_weight_payload_available(model_path, load_plans)?;
     let receivers = workers
         .iter()
@@ -287,7 +287,7 @@ fn maybe_load_rank_weights(
                 )
             })?;
         debug!(
-            "kimi-k2: rank {rank} weights loaded: tensors={}, bytes={}, expert_layers={}",
+            "rank {rank} weights loaded: tensors={}, bytes={}, expert_layers={}",
             report.tensor_count,
             ByteSize(report.total_bytes as u64),
             report.expert_kernel_layers
@@ -295,7 +295,7 @@ fn maybe_load_rank_weights(
         reports.push(report);
     }
     info!(
-        "kimi-k2: load rank weights cost {:.2}s: ranks={}",
+        "load rank weights cost {:.2}s: ranks={}",
         started.elapsed().as_secs_f64(),
         reports.len()
     );
@@ -305,7 +305,7 @@ fn maybe_load_rank_weights(
 fn spawn_workers(config: &KimiK2RunnerConfig) -> Result<Vec<KimiRankWorker>> {
     let started = Instant::now();
     let n = config.placements.len();
-    info!("kimi-k2: start spawn rank workers: ranks={n}");
+    info!("start spawn rank workers: ranks={n}");
     ensure!(
         config.rank_weight_names.len() == n && config.rank_sliced_load_plans.len() == n,
         "Kimi-K2 names/sliced counts must match {} placements",
@@ -341,7 +341,7 @@ fn spawn_workers(config: &KimiK2RunnerConfig) -> Result<Vec<KimiRankWorker>> {
         workers.push(worker);
     }
     info!(
-        "kimi-k2: spawn rank workers cost {:.2}s: ranks={}",
+        "spawn rank workers cost {:.2}s: ranks={}",
         started.elapsed().as_secs_f64(),
         workers.len()
     );
@@ -350,7 +350,7 @@ fn spawn_workers(config: &KimiK2RunnerConfig) -> Result<Vec<KimiRankWorker>> {
 
 fn init_tp_nccl(workers: &[KimiRankWorker]) -> Result<()> {
     let started = Instant::now();
-    info!("kimi-k2: start TP NCCL init: ranks={}", workers.len());
+    info!("start TP NCCL init: ranks={}", workers.len());
     let nccl_id = cudarc::nccl::safe::Id::new()
         .map_err(|err| anyhow::anyhow!("Kimi TP NCCL unique id creation failed: {err:?}"))?;
     let comm_receivers = workers
@@ -364,7 +364,7 @@ fn init_tp_nccl(workers: &[KimiRankWorker]) -> Result<()> {
             .with_context(|| format!("Kimi rank {rank} TP comm init"))?;
     }
     info!(
-        "kimi-k2: TP NCCL init cost {:.2}s: ranks={}",
+        "TP NCCL init cost {:.2}s: ranks={}",
         started.elapsed().as_secs_f64(),
         workers.len()
     );
@@ -377,10 +377,7 @@ fn init_tp_nccl(workers: &[KimiRankWorker]) -> Result<()> {
 /// blocks inside the collective until the last rank joins.
 fn install_deepep_backends(workers: &[KimiRankWorker]) -> Result<()> {
     let started = Instant::now();
-    info!(
-        "kimi-k2: start install DeepEP EP backend: ranks={}",
-        workers.len()
-    );
+    info!("start install DeepEP EP backend: ranks={}", workers.len());
     let unique_id = pegainfer_kernels::ops::deepep_unique_id()?;
     let receivers = workers
         .iter()
@@ -393,7 +390,7 @@ fn install_deepep_backends(workers: &[KimiRankWorker]) -> Result<()> {
             .with_context(|| format!("Kimi rank {rank} DeepEP enable"))?;
     }
     info!(
-        "kimi-k2: DeepEP EP backend install cost {:.2}s: ranks={}",
+        "DeepEP EP backend install cost {:.2}s: ranks={}",
         started.elapsed().as_secs_f64(),
         workers.len()
     );

--- a/pegainfer-kimi-k2/src/runner/scheduler.rs
+++ b/pegainfer-kimi-k2/src/runner/scheduler.rs
@@ -197,7 +197,7 @@ impl KimiK2Scheduler {
                 self.executor.gpu_weight_ready_count(),
                 self.executor.worker_count()
             );
-            error!("kimi-k2: {message}");
+            error!("{message}");
             for req in prefill_reqs {
                 let _ = req.token_tx.send(TokenEvent::Error {
                     message: message.clone(),
@@ -265,7 +265,7 @@ impl KimiK2Scheduler {
                 let message = format!(
                     "Kimi-K2 decode KV block accounting violated full-lifetime reservation: {err}"
                 );
-                error!("kimi-k2: {message}");
+                error!("{message}");
                 for req in active.drain(..) {
                     let _ = req.token_tx.send(TokenEvent::Error {
                         message: message.clone(),
@@ -292,7 +292,7 @@ impl KimiK2Scheduler {
                         self.executor.gpu_weight_ready_count(),
                         self.executor.worker_count()
                     );
-                    error!("kimi-k2: {message}");
+                    error!("{message}");
                     for req in active.drain(..) {
                         let _ = req.token_tx.send(TokenEvent::Error {
                             message: message.clone(),
@@ -310,7 +310,7 @@ impl KimiK2Scheduler {
                 req.completion_tokens += 1;
                 if let Err(err) = req.kv.apply_decode(token_id, &self.pool) {
                     let message = format!("Kimi-K2 decode KV bookkeeping failed: {err:#}");
-                    error!("kimi-k2: {message}");
+                    error!("{message}");
                     let _ = req.token_tx.send(TokenEvent::Error {
                         message,
                         prompt_tokens: req.prompt_len,
@@ -372,7 +372,7 @@ impl KimiK2Scheduler {
             Ok(cached) => cached,
             Err(err) => {
                 let message = format!("Kimi-K2 prefix cache matching failed: {err:#}");
-                error!("kimi-k2: {message}");
+                error!("{message}");
                 let _ = req.token_tx.send(TokenEvent::Error {
                     message,
                     prompt_tokens: req.prompt_tokens.len(),
@@ -386,7 +386,7 @@ impl KimiK2Scheduler {
             let message = format!(
                 "Kimi-K2 prefill KV block accounting violated full-lifetime reservation: {err}"
             );
-            error!("kimi-k2: {message}");
+            error!("{message}");
             let _ = req.token_tx.send(TokenEvent::Error {
                 message,
                 prompt_tokens: req.prompt_tokens.len(),
@@ -424,7 +424,7 @@ impl KimiK2Scheduler {
                 let token_id = report.local_next_token_global_id;
                 if let Err(err) = kv.apply_prefill(token_id, &self.pool) {
                     let message = format!("Kimi-K2 prefill KV bookkeeping failed: {err:#}");
-                    error!("kimi-k2: {message}");
+                    error!("{message}");
                     let _ = req.token_tx.send(TokenEvent::Error {
                         message,
                         prompt_tokens: req.prompt_tokens.len(),
@@ -544,7 +544,7 @@ impl KimiK2Scheduler {
                     self.executor.gpu_weight_ready_count(),
                     self.executor.worker_count()
                 );
-                error!("kimi-k2: {message}");
+                error!("{message}");
                 for (_, req, _) in group_kv {
                     let _ = req.token_tx.send(TokenEvent::Error {
                         message: message.clone(),
@@ -559,7 +559,7 @@ impl KimiK2Scheduler {
             let token_id = report.local_next_token_global_id;
             if let Err(err) = kv.apply_prefill(token_id, &self.pool) {
                 let message = format!("Kimi-K2 admission KV bookkeeping failed: {err:#}");
-                error!("kimi-k2: {message}");
+                error!("{message}");
                 let _ = req.token_tx.send(TokenEvent::Error {
                     message,
                     prompt_tokens: req.prompt_tokens.len(),

--- a/pegainfer-kimi-k2/src/runner/scheduler/dp.rs
+++ b/pegainfer-kimi-k2/src/runner/scheduler/dp.rs
@@ -340,7 +340,7 @@ impl DpCoordinator {
                     let message = format!(
                         "Kimi-K2 admission KV block accounting violated full-lifetime reservation: {err}"
                     );
-                    error!("kimi-k2: {message}");
+                    error!("{message}");
                     send_scheduled(&req);
                     let _ = req.token_tx.send(TokenEvent::Error {
                         message,
@@ -428,7 +428,7 @@ impl DpCoordinator {
             Ok(cached) => cached,
             Err(err) => {
                 let message = format!("Kimi-K2 prefix cache matching failed: {err:#}");
-                error!("kimi-k2: {message}");
+                error!("{message}");
                 let _ = req.token_tx.send(TokenEvent::Error {
                     message,
                     prompt_tokens: req.prompt_tokens.len(),
@@ -442,7 +442,7 @@ impl DpCoordinator {
             let message = format!(
                 "Kimi-K2 prefill KV block accounting violated full-lifetime reservation: {err}"
             );
-            error!("kimi-k2: {message}");
+            error!("{message}");
             let _ = req.token_tx.send(TokenEvent::Error {
                 message,
                 prompt_tokens: req.prompt_tokens.len(),
@@ -496,7 +496,7 @@ impl DpCoordinator {
         let last_token = owner_report.local_next_token_global_id;
         if let Err(err) = kv.apply_prefill(last_token, &self.pools[dp_rank]) {
             let message = format!("Kimi-K2 prefill KV bookkeeping failed: {err:#}");
-            error!("kimi-k2: {message}");
+            error!("{message}");
             let _ = req.token_tx.send(TokenEvent::Error {
                 message,
                 prompt_tokens: prompt_len,
@@ -631,7 +631,7 @@ impl DpCoordinator {
         let token_id = report.local_next_token_global_id;
         if let Err(err) = kv.apply_prefill(token_id, &self.pools[dp_rank]) {
             let message = format!("Kimi-K2 admission KV bookkeeping failed: {err:#}");
-            error!("kimi-k2: {message}");
+            error!("{message}");
             let _ = req.token_tx.send(TokenEvent::Error {
                 message,
                 prompt_tokens: req.prompt_tokens.len(),
@@ -832,7 +832,7 @@ impl DpRankState {
                 let message = format!(
                     "Kimi-K2 decode KV block accounting violated full-lifetime reservation: {err}"
                 );
-                error!("kimi-k2: {message}");
+                error!("{message}");
                 let _ = state.token_tx.send(TokenEvent::Error {
                     message,
                     prompt_tokens: state.prompt_len,
@@ -890,7 +890,7 @@ impl DpRankState {
 
         if let Err(err) = req.kv.apply_decode(token_id, pool) {
             let message = format!("Kimi-K2 decode KV bookkeeping failed: {err:#}");
-            error!("kimi-k2: {message}");
+            error!("{message}");
             let _ = req.token_tx.send(TokenEvent::Error {
                 message,
                 prompt_tokens: req.prompt_len,
@@ -1005,13 +1005,13 @@ fn build_decode_command_from_inputs(
 
 fn send_step_command(tx: &Sender<StepCommand>, dp_rank: usize, phase: &str, command: StepCommand) {
     if tx.send(command).is_err() {
-        error!("kimi-k2: fatal: DP rank {dp_rank} forward thread dropped before {phase}");
+        error!("fatal: DP rank {dp_rank} forward thread dropped before {phase}");
         std::process::abort();
     }
 }
 
 fn abort_dropped_result_channel(dp_rank: usize, phase: &str) -> ! {
-    error!("kimi-k2: fatal: DP rank {dp_rank} forward thread dropped during {phase}");
+    error!("fatal: DP rank {dp_rank} forward thread dropped during {phase}");
     std::process::abort();
 }
 

--- a/pegainfer-kimi-k2/src/runner/worker/state.rs
+++ b/pegainfer-kimi-k2/src/runner/worker/state.rs
@@ -52,7 +52,7 @@ impl KimiRankThreadState {
     ) -> Result<KimiRankWeightLoadReport> {
         let started = Instant::now();
         let rank = self.sliced_load_plan.rank;
-        debug!("kimi-k2: rank {rank} start rank weight init");
+        debug!("rank {rank} start rank weight init");
         let load_output = load_rank_sliced_weights_to_gpu(
             &self.ctx,
             model_path,
@@ -69,7 +69,7 @@ impl KimiRankThreadState {
         let expert_kernel_weights = load_output.expert_kernel_weights;
         let tensor_count = load_output.loaded_tensor_count;
         let total_bytes = load_output.loaded_total_bytes;
-        debug!("kimi-k2: rank {rank} start one-token forward cache build");
+        debug!("rank {rank} start one-token forward cache build");
         let cache_started = Instant::now();
         let one_token_cache =
             KimiOneTokenForwardCache::from_gpu_weights(&self.ctx, &weights, &self.weight_names)
@@ -80,7 +80,7 @@ impl KimiRankThreadState {
                     )
                 })?;
         debug!(
-            "kimi-k2: rank {rank} one-token forward cache build cost {:.2}s",
+            "rank {rank} one-token forward cache build cost {:.2}s",
             cache_started.elapsed().as_secs_f64()
         );
         // Allocate the shared KV pool eagerly: an OOM should kill bringup,
@@ -98,7 +98,7 @@ impl KimiRankThreadState {
             )
         })?;
         debug!(
-            "kimi-k2: rank {rank} KV pool ({} pages, {} tokens) alloc cost {:.2}s",
+            "rank {rank} KV pool ({} pages, {} tokens) alloc cost {:.2}s",
             self.kv_pool_pages,
             self.kv_pool_pages * KIMI_KV_PAGE_SIZE,
             kv_pool_started.elapsed().as_secs_f64()
@@ -134,7 +134,7 @@ impl KimiRankThreadState {
         );
         self.loaded = Some(loaded);
         debug!(
-            "kimi-k2: rank {rank} rank weight init cost {:.2}s: tensors={}, bytes={}, expert_layers={}",
+            "rank {rank} rank weight init cost {:.2}s: tensors={}, bytes={}, expert_layers={}",
             started.elapsed().as_secs_f64(),
             tensor_count,
             ByteSize(total_bytes as u64),

--- a/pegainfer-kimi-k2/src/weights/load.rs
+++ b/pegainfer-kimi-k2/src/weights/load.rs
@@ -96,7 +96,7 @@ pub(crate) fn load_rank_sliced_weights_to_gpu(
     let mut expert_layers = Vec::with_capacity(KIMI_K2_MOE_LAYERS);
     let load_started = Instant::now();
     debug!(
-        "kimi-k2: rank {} start weight load: tensors={}, shards={}",
+        "rank {} start weight load: tensors={}, shards={}",
         load_plan.rank,
         load_plan.tensor_count,
         load_plan.shards.len()
@@ -176,7 +176,7 @@ pub(crate) fn load_rank_sliced_weights_to_gpu(
         layers: expert_layers,
         total_bytes: expert_kernel_total_bytes,
     };
-    debug!("kimi-k2: rank {} start weight copy sync", load_plan.rank);
+    debug!("rank {} start weight copy sync", load_plan.rank);
     let sync_started = Instant::now();
     ctx.sync().with_context(|| {
         format!(
@@ -185,13 +185,13 @@ pub(crate) fn load_rank_sliced_weights_to_gpu(
         )
     })?;
     debug!(
-        "kimi-k2: rank {} weight copy sync cost {:.2}s",
+        "rank {} weight copy sync cost {:.2}s",
         load_plan.rank,
         sync_started.elapsed().as_secs_f64()
     );
     let (slowest_shard, slowest_secs) = slowest_shard.unwrap_or_else(|| ("none".to_owned(), 0.0));
     debug!(
-        "kimi-k2: rank {} weight load cost {:.2}s: loaded_tensors={}, loaded_bytes={}, resident_raw_bytes={}, expert_package_bytes={}, packed_moe_layers={}, slowest_shard={} {:.2}s",
+        "rank {} weight load cost {:.2}s: loaded_tensors={}, loaded_bytes={}, resident_raw_bytes={}, expert_package_bytes={}, packed_moe_layers={}, slowest_shard={} {:.2}s",
         load_plan.rank,
         load_started.elapsed().as_secs_f64(),
         loaded_tensor_count,

--- a/pegainfer-qwen3-4b/src/weights.rs
+++ b/pegainfer-qwen3-4b/src/weights.rs
@@ -530,10 +530,9 @@ impl Qwen3Model {
 
         ctx.sync()?;
         info!(
-            "GPU transfer complete in {:.0}ms",
+            "GPU model loaded in {:.0}ms",
             t_gpu.elapsed().as_secs_f64() * 1e3
         );
-        info!("GPU model loaded successfully");
 
         let num_hidden_layers = config.num_hidden_layers;
         let model = Self {

--- a/pegainfer-qwen35-4b/src/scheduler.rs
+++ b/pegainfer-qwen35-4b/src/scheduler.rs
@@ -159,7 +159,7 @@ fn scheduler_loop(
     let mut deferred: Vec<SchedulerRequest> = Vec::new();
     let max_batch = graph_state.slot_states.len();
 
-    info!("Qwen3.5 scheduler ready (max_batch={})", max_batch);
+    info!("scheduler ready (max_batch={})", max_batch);
 
     loop {
         // 1. Drain all pending requests (deferred from last iteration + channel)
@@ -173,7 +173,7 @@ fn scheduler_loop(
             if let Some(req) = submit_rx.blocking_recv() {
                 pending.push(req);
             } else {
-                info!("Qwen3.5 scheduler: all handles dropped, exiting");
+                info!("scheduler: all handles dropped, exiting");
                 return;
             }
             while let Ok(req) = submit_rx.try_recv() {
@@ -268,7 +268,7 @@ fn prefill_batch(
     let logits_vec = match model.batch_prefill(&prompts, &mut kv_states, &mut rec_refs) {
         Ok(v) => v,
         Err(e) => {
-            warn!("Qwen3.5 batch prefill failed: {e}");
+            warn!("batch prefill failed: {e}");
             let message = e.to_string();
             for req in pending {
                 let _ = req.token_tx.send(TokenEvent::Error {
@@ -399,7 +399,7 @@ fn unified_step_sched(
     ) {
         Ok(v) => v,
         Err(e) => {
-            warn!("Qwen3.5 unified step failed: {e}");
+            warn!("unified step failed: {e}");
             let message = e.to_string();
             // Notify all pending requests
             for req in pending {
@@ -519,7 +519,7 @@ fn decode_step(
     let mut kv_refs: Vec<&mut KvState> = active.iter_mut().map(|r| &mut r.kv).collect();
 
     if let Err(e) = model.batch_decode_graph(&token_ids, &mut kv_refs, graph_state) {
-        warn!("Qwen3.5 batch_decode_graph error: {e}");
+        warn!("batch_decode_graph error: {e}");
         let message = e.to_string();
         for req in active.drain(..) {
             let _ = req.token_tx.send(TokenEvent::Error {
@@ -554,7 +554,7 @@ fn decode_step(
     {
         Ok(t) => t,
         Err(e) => {
-            warn!("Qwen3.5 sampling error: {e}");
+            warn!("sampling error: {e}");
             let message = e.to_string();
             for req in active.drain(..) {
                 let _ = req.token_tx.send(TokenEvent::Error {

--- a/pegainfer-qwen35-4b/src/weights.rs
+++ b/pegainfer-qwen35-4b/src/weights.rs
@@ -303,10 +303,9 @@ impl Qwen35Model {
 
         ctx.sync()?;
         info!(
-            "GPU transfer complete in {:.0}ms",
+            "GPU model loaded in {:.0}ms",
             t_gpu.elapsed().as_secs_f64() * 1e3
         );
-        info!("Qwen3.5 GPU model loaded successfully");
         if enable_cuda_graph {
             debug!("Decode path CUDA Graph is enabled");
         } else {

--- a/pegainfer-qwen35-4b/tests/e2e_scheduler.rs
+++ b/pegainfer-qwen35-4b/tests/e2e_scheduler.rs
@@ -133,7 +133,7 @@ fn test_e2e_qwen35_scheduler() {
     // Use reduced batch capacity (8) to fit on 16GB GPUs alongside the model.
     let handle = pegainfer_qwen35_4b::runtime::start_with_capacity(model, 42, 8)
         .expect("Failed to start Qwen3.5 scheduler");
-    info!("Qwen3.5 scheduler loaded in {:.2?}", start.elapsed());
+    info!("scheduler loaded in {:.2?}", start.elapsed());
 
     // ── 1. Sequential scheduler requests ────────────────────────────────
     info!("=== Phase 1: Qwen3.5 sequential scheduler requests ===");

--- a/pegainfer-server/src/main.rs
+++ b/pegainfer-server/src/main.rs
@@ -121,11 +121,11 @@ async fn main() -> anyhow::Result<()> {
         ModelType::Qwen3 | ModelType::Qwen35 => args.cuda_graph,
     };
 
-    info!("=== Rust LLM Server - {} (GPU) ===", model_type);
+    info!("=== pegainfer - {} (GPU) ===", model_type);
     info!("Loading engine...");
     let start = Instant::now();
     info!(
-        "Runtime options: model_path={}, requested_cuda_graph={}, effective_cuda_graph={}, enable_lora={}, max_loras={}, max_lora_rank={}, device_ordinal={}, tp_size={}, dp_size={}, ep_backend={:?}",
+        "Runtime options: model_path={}, requested_cuda_graph={}, effective_cuda_graph={}, enable_lora={}, max_loras={}, max_lora_rank={}, device_ordinal={}, tp_size={}",
         args.model_path.display(),
         args.cuda_graph,
         effective_cuda_graph,
@@ -134,8 +134,6 @@ async fn main() -> anyhow::Result<()> {
         args.max_lora_rank,
         args.device_ordinal,
         args.tp_size,
-        args.dp_size,
-        args.ep_backend
     );
 
     let handle = match model_type {
@@ -154,8 +152,6 @@ async fn main() -> anyhow::Result<()> {
             )
             .context("failed to start DeepSeek V4 engine")?;
 
-            info!("Engine loaded: elapsed_ms={}", start.elapsed().as_millis());
-
             handle
         }
         #[cfg(feature = "deepseek-v2-lite")]
@@ -172,13 +168,15 @@ async fn main() -> anyhow::Result<()> {
                 },
             )?;
 
-            info!("Engine loaded: elapsed_ms={}", start.elapsed().as_millis());
-
             handle
         }
         #[cfg(feature = "kimi-k2")]
         ModelType::KimiK2 => {
             let parallel = kimi_parallel_config(args.tp_size, args.dp_size)?;
+            info!(
+                "EP options: dp_size={}, ep_backend={:?}",
+                args.dp_size, args.ep_backend
+            );
             let handle = pegainfer_kimi_k2::start_engine(
                 &args.model_path,
                 EngineLoadOptions {
@@ -191,8 +189,6 @@ async fn main() -> anyhow::Result<()> {
                 },
             )
             .context("failed to start Kimi-K2.6 text engine")?;
-
-            info!("Engine loaded: elapsed_ms={}", start.elapsed().as_millis());
 
             handle
         }
@@ -229,8 +225,6 @@ async fn main() -> anyhow::Result<()> {
             }
             .context("failed to start Qwen3 engine")?;
 
-            info!("Engine loaded: elapsed_ms={}", start.elapsed().as_millis());
-
             handle
         }
         ModelType::Qwen35 => {
@@ -247,11 +241,11 @@ async fn main() -> anyhow::Result<()> {
             )
             .context("failed to start Qwen3.5 engine")?;
 
-            info!("Engine loaded: elapsed_ms={}", start.elapsed().as_millis());
-
             handle
         }
     };
+
+    info!("Engine loaded: elapsed_ms={}", start.elapsed().as_millis());
 
     if args.enable_lora {
         let max_model_len =


### PR DESCRIPTION
## Description

Closes #214.

Before

```text
  === Rust LLM Server - Qwen3 (GPU) ===
  Loading engine...
  Runtime options: …, device_ordinal=0, tp_size=1, dp_size=8, ep_backend=DeepEp
  Memory-mapped 3 shard(s) (8045.0 MB) in 0ms
  GPU transfer complete in 1365ms
  GPU model loaded successfully
  …
  Engine loaded: elapsed_ms=1839
```
After

```text
  === pegainfer - Qwen3 (GPU) ===
  Loading engine...
  Runtime options: …, device_ordinal=0, tp_size=1
  Memory-mapped 3 shard(s) (8045.0 MB)
  GPU model loaded in 1354ms
  …
  Engine loaded: elapsed_ms=1823
```

* === Rust LLM Server - … === -> === pegainfer - … ===
* dp_size=…, ep_backend=… line now prints inside the Kimi-K2 arm only
* Memory-mapped … in 0ms -> Drop the timing
* 2 GPU line merges into one.
* Engine loaded: … duplicated in all 5 model -> single after match
* Message-prefix convention is inconsistent -> remove prefix

## Type of Change
- [x] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project (see `docs/conventions/coding-style.md`).
- [x] I have performed a self-review of my own code.
- [x] I have formatted my commits according to Commitizen conventions.
- [ ] I have run the local test suite and all tests pass (see CLAUDE.md). 
This is a log change, `cargo test` passes on this crate.
