### PR TITLE
fix: handle f64 extraction in kvbm-config under arbitrary_precision

### DIFF
--- a/kvbm/kvbm-config/src/cache.rs
+++ b/kvbm/kvbm-config/src/cache.rs
@@ -10,8 +10,136 @@
 
 use std::path::PathBuf;
 
-use serde::{Deserialize, Serialize};
+use serde::{
+    Deserialize, Deserializer, Serialize,
+    de::{self, MapAccess, Visitor},
+};
 use validator::Validate;
+
+const SERDE_JSON_ARBITRARY_PRECISION_NUMBER: &str = "$serde_json::private::Number";
+
+fn deserialize_opt_f64<'de, D>(deserializer: D) -> Result<Option<f64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_option(OptF64Visitor)
+}
+
+struct OptF64Visitor;
+
+impl<'de> Visitor<'de> for OptF64Visitor {
+    type Value = Option<f64>;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("an optional f64")
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(None)
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(None)
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(F64Visitor).map(Some)
+    }
+}
+
+struct F64Visitor;
+
+impl<'de> Visitor<'de> for F64Visitor {
+    type Value = f64;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("an f64 or serde_json arbitrary_precision number map")
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(value)
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(value as f64)
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(value as f64)
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        parse_f64_str(value)
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let Some(key) = map.next_key::<String>()? else {
+            return Err(de::Error::custom(
+                "expected serde_json arbitrary_precision number map",
+            ));
+        };
+
+        if key != SERDE_JSON_ARBITRARY_PRECISION_NUMBER {
+            return Err(de::Error::unknown_field(
+                &key,
+                &[SERDE_JSON_ARBITRARY_PRECISION_NUMBER],
+            ));
+        }
+
+        let value = map.next_value::<String>()?;
+        if map.next_key::<de::IgnoredAny>()?.is_some() {
+            return Err(de::Error::custom(
+                "expected serde_json arbitrary_precision number map with one entry",
+            ));
+        }
+
+        parse_f64_str(&value)
+    }
+}
+
+fn parse_f64_str<E>(value: &str) -> Result<f64, E>
+where
+    E: de::Error,
+{
+    let parsed = value
+        .parse::<f64>()
+        .map_err(|_| de::Error::invalid_value(de::Unexpected::Str(value), &"an f64 string"))?;
+    // serde_json's native f64 deserializer rejects out-of-range numbers; preserve
+    // that behavior so the arbitrary_precision string path can't smuggle in
+    // non-finite values (e.g. `1e10000` -> inf) that would later cast to usize::MAX
+    // in `compute_num_blocks`.
+    if !parsed.is_finite() {
+        return Err(de::Error::invalid_value(
+            de::Unexpected::Str(value),
+            &"a finite f64",
+        ));
+    }
+    Ok(parsed)
+}
 
 /// Parallelism strategy for KV cache across workers.
 ///
@@ -51,6 +179,7 @@ pub enum ParallelismMode {
 pub struct HostCacheConfig {
     /// Cache size in gigabytes.
     /// Used to compute num_blocks if not explicitly set.
+    #[serde(default, deserialize_with = "deserialize_opt_f64")]
     pub cache_size_gb: Option<f64>,
 
     /// Explicit number of blocks for the host cache.
@@ -96,6 +225,7 @@ impl HostCacheConfig {
 pub struct DiskCacheConfig {
     /// Cache size in gigabytes.
     /// Used to compute num_blocks if not explicitly set.
+    #[serde(default, deserialize_with = "deserialize_opt_f64")]
     pub cache_size_gb: Option<f64>,
 
     /// Explicit number of blocks for the disk cache.
@@ -206,6 +336,42 @@ mod tests {
         let bytes_per_block = 1_000_000;
         assert_eq!(config.compute_num_blocks(bytes_per_block), Some(10_000));
         assert!(config.is_enabled());
+    }
+
+    #[test]
+    fn test_cache_size_gb_arbitrary_precision_map() {
+        let config: HostCacheConfig =
+            serde_json::from_str(r#"{"cache_size_gb": {"$serde_json::private::Number": "2.0"}}"#)
+                .unwrap();
+        assert_eq!(config.cache_size_gb, Some(2.0));
+
+        let config: DiskCacheConfig =
+            serde_json::from_str(r#"{"cache_size_gb": {"$serde_json::private::Number": "2.0"}}"#)
+                .unwrap();
+        assert_eq!(config.cache_size_gb, Some(2.0));
+
+        let config: HostCacheConfig = serde_json::from_str(r#"{"cache_size_gb": 4}"#).unwrap();
+        assert_eq!(config.cache_size_gb, Some(4.0));
+
+        let config: HostCacheConfig = serde_json::from_str(r#"{"cache_size_gb": 1.5}"#).unwrap();
+        assert_eq!(config.cache_size_gb, Some(1.5));
+
+        let config: HostCacheConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(config.cache_size_gb, None);
+    }
+
+    #[test]
+    fn test_cache_size_gb_rejects_non_finite() {
+        // Out-of-range numbers arriving through the arbitrary_precision string path
+        // must be rejected, matching serde_json's native f64 deserializer behavior,
+        // rather than silently becoming Some(inf).
+        let result: Result<HostCacheConfig, _> = serde_json::from_str(
+            r#"{"cache_size_gb": {"$serde_json::private::Number": "1e10000"}}"#,
+        );
+        assert!(
+            result.is_err(),
+            "non-finite cache_size_gb should be rejected, got {result:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`kvbm-config`'s `cache_size_gb: Option<f64>` fields now deserialize correctly whether figment hands them a native JSON number or the `serde_json` `arbitrary_precision` "number map" form. This unblocks the documented workspace test command `cargo test --release --workspace --lib`, which was failing on `main`.

## Why this matters

Per #296, `test_profile_with_defaults_and_overlay` panics with `InvalidType(Map, "f64") at path ["cache", "host", "cache_size_gb"]`. The crate is green in isolation but red when co-compiled with `pegainfer-server`: `vllm-chat` (a transitive git dep) enables `serde_json/arbitrary_precision`, and Cargo feature unification turns that feature on for every `serde_json` user in the workspace. Under `arbitrary_precision`, JSON numbers deserialize as an internal map `{"$serde_json::private::Number": "2.0"}`, so figment's `Json` source hands `kvbm-config` a `Map` where a plain `f64` is expected.

Pinning or stripping the feature isn't viable: it's owned by a git dependency and would regress on the next bump. The robust, behavior-preserving fix is to make the float fields tolerant of either representation, so the config-load path stays correct no matter which workspace features get unified on.

## Changes

A small, self-contained `deserialize_opt_f64` serde helper was added in `cache.rs` and applied to `cache_size_gb` on both `HostCacheConfig` and `DiskCacheConfig`. It accepts a native JSON number, the `arbitrary_precision` single-entry map form, or an omitted/null value (yielding `None`). The helper uses only `serde`, so there is no dependency change and `serde_json` stays a dev-dependency.

It also rejects non-finite parses (such as `1e10000` overflowing to `inf`), matching what `serde_json`'s native f64 deserializer already does. Without this guard, a malformed config could smuggle in an infinite cache size that later casts to `usize::MAX` in `compute_num_blocks`.

## Testing

`cargo fmt --check` and `cargo clippy --all-targets` are both clean for the crate, and `cargo test --release -p kvbm-config --lib` passes 65 tests (up from 63). To confirm the fix targets the exact feature-unification path, I forced `serde_json/arbitrary_precision` on the crate's dev `serde_json`: on `main` this reproduces the failure (`test_profile_with_defaults_and_overlay` FAILED), and with this change it passes.

Two new tests cover the behavior. `test_cache_size_gb_arbitrary_precision_map` asserts the map form, a plain integer (`4` -> `4.0`), and a fractional value all extract correctly and that an omitted field yields `None`. `test_cache_size_gb_rejects_non_finite` asserts that an out-of-range value is rejected rather than becoming `Some(inf)`.

Fixes #296
