### PR TITLE
fix(core): use c_char for the aarch64-incompatible PCI bus id FFI buffer

### DIFF
--- a/openinfer-core/src/cpu_topology.rs
+++ b/openinfer-core/src/cpu_topology.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
-    ffi::CStr,
+    ffi::{CStr, c_char},
 };
 
 use anyhow::{Context, Result, ensure};
@@ -146,7 +146,7 @@ pub fn pin_current_thread_to_cpu(cpu: CpuId) -> Result<()> {
 }
 
 pub fn cuda_device_pci_bus_id(device_ordinal: usize) -> Result<String> {
-    let mut buf = [0i8; 32];
+    let mut buf = [c_char::default(); 32];
     cuda_driver_result::init().map_err(|err| anyhow::anyhow!("{err:?}"))?;
     let device = cuda_driver_result::device::get(device_ordinal as i32)
         .map_err(|err| anyhow::anyhow!("{err:?}"))?;


### PR DESCRIPTION
## Description

Refs #320 

`cpu_topology.rs` built the PCI-bus-id buffer as `[0i8; 32]`, which only type-checks where `c_char = i8` (x86_64). On aarch64 (`c_char = u8`) `openinfer-core` fails to compile (E0308 at the `cuDeviceGetPCIBusId` / `CStr::from_ptr` call sites). Switch the buffer to `[c_char::default(); 32]`.

Validated on an aarch64 node: `openinfer-core` compiles. x86_64 also compiles. A workspace-wide audit found no other `i8`-as-`c_char` assumptions.



## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project (see `docs/conventions/coding-style.md`).
- [x] I have performed a self-review of my own code.
- [x] I have formatted my commits according to Commitizen conventions.
- [x] I have run the local test suite and all tests pass (see `CLAUDE.md`).

