### PR TITLE
test(qwen3): cover TP=2 in the hf golden gate

### DIFF
--- a/openinfer-qwen3-4b/tests/hf_golden_gate.rs
+++ b/openinfer-qwen3-4b/tests/hf_golden_gate.rs
@@ -43,8 +43,13 @@
 //!     bugs) surface. Run the bucket straddles (9→16, 5→8) that maximise the
 //!     padding-slot count.
 //!
+//! On a machine with ≥2 CUDA devices the eager replays additionally run under
+//! TP=2 (`device_ordinals = [0, 1]`) against the same golden and tolerances —
+//! sharding must not move logits beyond the single-GPU bf16 noise floor.
+//!
 //! Requires a CUDA GPU and Qwen3-4B weights; skips cleanly when the model is
-//! absent (point `OPENINFER_TEST_MODEL_PATH` at the weights to run it).
+//! absent (point `OPENINFER_TEST_MODEL_PATH` at the weights to run it). The
+//! TP pass skips on single-GPU hosts.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -436,6 +441,69 @@ fn report_and_assert(label: &str, stats: &Stats) {
     let _ = max; // reported above, but not asserted: the worst single delta grows with coverage
 }
 
+/// Number of visible CUDA devices; 0 when the driver cannot be queried.
+fn cuda_device_count() -> usize {
+    cudarc::driver::CudaContext::device_count().map_or(0, |n| n.max(0) as usize)
+}
+
+/// The eager replay suite — bs=1 sequential (plus the bit-identical
+/// determinism rerun), batched eager isolation, and the prefix-cached replays
+/// — over a given device set, with `label` prefixing every report line.
+fn run_eager_suite(golden: &Golden, model_path: &str, devices: &[usize], label: &str) {
+    let all: Vec<usize> = (0..golden.num_seqs).collect();
+    let mut ex = Qwen3Executor::from_runtime(model_path, false, devices)
+        .unwrap_or_else(|e| panic!("build eager executor on {devices:?}: {e:#}"));
+    // The determinism and isolation passes need bit-replayable prefill: a
+    // prefix-cache hit shrinks the prefill GEMM to the uncached suffix,
+    // which drifts logits by bf16 ULPs. Caching gets its own pass below.
+    ex.set_prefix_cache_enabled(false);
+
+    // bs=1 sequential over *every* golden sequence — this is the breadth of
+    // the prompt/length coverage (one request's KV at a time, so it scales to
+    // long prompts cheaply). Also the determinism anchor: a second identical
+    // run must reproduce every logprob bit-for-bit. A nondeterministic kernel
+    // or uninitialised decode scratch would not.
+    let (stats, fp1) = run(golden, &mut ex, &all, false);
+    report_and_assert(&format!("{label}sequential bs=1 eager"), &stats);
+    let (_, fp2) = run(golden, &mut ex, &all, false);
+    assert_eq!(
+        fp1, fp2,
+        "{label}sequential bs=1 eager: identical inputs must reproduce identical logprobs"
+    );
+
+    // A batch advanced together (eager runs at the exact width — no padding).
+    // This is the cross-request isolation check: requests of differing
+    // lengths/page layouts share each kernel launch, so KV mixing or a
+    // per-request indexing bug corrupts a neighbour's logits. It replaces the
+    // old exact batch==sequential check, which mistook the batched decode
+    // path's benign reduction-order noise (within tolerance here) for a bug.
+    // Breadth is the bs=1 pass's job; this just needs enough concurrent reqs.
+    let n = BUCKET_STRADDLES[0];
+    let (batched, _) = run(golden, &mut ex, &all[..n], true);
+    report_and_assert(&format!("{label}batched eager ({n}, no pad)"), &batched);
+
+    // Prefix-cached replay. Every block is already registered (the runs
+    // above register blocks even with matching disabled), so these rerun
+    // with warm caches: prefill skips the cached prefix and attention spans
+    // cached KV + recomputed suffix (kv_len > q_len). Same HF tolerances —
+    // a wrong RoPE offset, mask, or stale page would blow far past them.
+    ex.set_prefix_cache_enabled(true);
+    let (cached, _) = run(golden, &mut ex, &all, false);
+    assert!(
+        cached.cached_tokens > 0,
+        "{label}cached replay matched no prefix blocks — the cache path was not exercised"
+    );
+    report_and_assert(
+        &format!("{label}sequential bs=1 eager cached replay"),
+        &cached,
+    );
+    let (cached_batched, _) = run(golden, &mut ex, &all[..n], true);
+    report_and_assert(
+        &format!("{label}batched eager cached replay ({n})"),
+        &cached_batched,
+    );
+}
+
 #[test]
 fn pega_logprobs_match_hf_golden_within_bf16_tolerance() {
     let Some(model_path) = model_path_or_skip() else {
@@ -444,58 +512,25 @@ fn pega_logprobs_match_hf_golden_within_bf16_tolerance() {
     let golden = Golden::load();
     let all: Vec<usize> = (0..golden.num_seqs).collect();
 
-    // Each executor owns its GPU memory; scope them so only one model is resident
-    // at a time (drop frees it before the next load).
-    {
-        let mut ex =
-            Qwen3Executor::from_runtime(&model_path, false, &[0]).expect("build eager executor");
-        // The determinism and isolation passes need bit-replayable prefill: a
-        // prefix-cache hit shrinks the prefill GEMM to the uncached suffix,
-        // which drifts logits by bf16 ULPs. Caching gets its own pass below.
-        ex.set_prefix_cache_enabled(false);
-
-        // bs=1 sequential over *every* golden sequence — this is the breadth of
-        // the prompt/length coverage (one request's KV at a time, so it scales to
-        // long prompts cheaply). Also the determinism anchor: a second identical
-        // run must reproduce every logprob bit-for-bit. A nondeterministic kernel
-        // or uninitialised decode scratch would not.
-        let (stats, fp1) = run(&golden, &mut ex, &all, false);
-        report_and_assert("sequential bs=1 eager", &stats);
-        let (_, fp2) = run(&golden, &mut ex, &all, false);
-        assert_eq!(
-            fp1, fp2,
-            "sequential bs=1 eager: identical inputs must reproduce identical logprobs"
-        );
-
-        // A batch advanced together (eager runs at the exact width — no padding).
-        // This is the cross-request isolation check: requests of differing
-        // lengths/page layouts share each kernel launch, so KV mixing or a
-        // per-request indexing bug corrupts a neighbour's logits. It replaces the
-        // old exact batch==sequential check, which mistook the batched decode
-        // path's benign reduction-order noise (within tolerance here) for a bug.
-        // Breadth is the bs=1 pass's job; this just needs enough concurrent reqs.
-        let n = BUCKET_STRADDLES[0];
-        let (batched, _) = run(&golden, &mut ex, &all[..n], true);
-        report_and_assert(&format!("batched eager ({n}, no pad)"), &batched);
-
-        // Prefix-cached replay. Every block is already registered (the runs
-        // above register blocks even with matching disabled), so these rerun
-        // with warm caches: prefill skips the cached prefix and attention spans
-        // cached KV + recomputed suffix (kv_len > q_len). Same HF tolerances —
-        // a wrong RoPE offset, mask, or stale page would blow far past them.
-        ex.set_prefix_cache_enabled(true);
-        let (cached, _) = run(&golden, &mut ex, &all, false);
+    // Debug knob: skip the single-GPU passes and run only the TP=2 suite.
+    // The full gate builds TP executors after single-GPU executors in the
+    // same process; running with this set isolates the TP pass from any
+    // state they leave behind.
+    if std::env::var("OPENINFER_GOLDEN_TP_ONLY").is_ok() {
+        let gpus = cuda_device_count();
         assert!(
-            cached.cached_tokens > 0,
-            "cached replay matched no prefix blocks — the cache path was not exercised"
+            gpus >= 2,
+            "OPENINFER_GOLDEN_TP_ONLY needs >=2 GPUs, have {gpus}"
         );
-        report_and_assert("sequential bs=1 eager cached replay", &cached);
-        let (cached_batched, _) = run(&golden, &mut ex, &all[..n], true);
-        report_and_assert(
-            &format!("batched eager cached replay ({n})"),
-            &cached_batched,
-        );
+        run_eager_suite(&golden, &model_path, &[0, 1], "tp2 ");
+        return;
     }
+
+    // Each executor owns its GPU memory; scope them so only one model is
+    // resident at a time (drop frees it before the next load). Everything
+    // stays in one #[test] for the same reason: two parallel tests would both
+    // budget 85% of free VRAM for KV.
+    run_eager_suite(&golden, &model_path, &[0], "");
 
     // CUDA-graph decode is captured per bucket and pads the batch up to it, so
     // this path is where padding-slot leaks (and graph pointer/buffer bugs)
@@ -520,4 +555,15 @@ fn pega_logprobs_match_hf_golden_within_bf16_tolerance() {
         );
         report_and_assert(&format!("batched cuda-graph cached replay ({n})"), &cached);
     }
+
+    // TP=2: the same eager suite sharded over two GPUs. Same golden, same
+    // tolerances — a reduction-order, shard-offset, or all-reduce bug drifts
+    // logits far past the bf16 noise floor. Eager-only: TP CUDA-graph support
+    // is deferred follow-up work (docs/models/qwen3/tp-design.md).
+    let gpus = cuda_device_count();
+    if gpus < 2 {
+        eprintln!("skipping hf_golden_gate TP=2 pass: {gpus} CUDA device(s) visible, need 2");
+        return;
+    }
+    run_eager_suite(&golden, &model_path, &[0, 1], "tp2 ");
 }


### PR DESCRIPTION
## Description

Refs #245 

Adds TP=2 coverage to the Qwen3-4B HF golden gate. The gate previously only ever ran `device_ordinals: vec![0]`. The eager replay suite (bs=1 sequential with the determinism rerun, batched isolation, both prefix-cached replays) is extracted into `run_eager_suite(golden, model_path, devices, label)` and rerun under TP=2 with the same golden and tolerances. No new golden files. The pass lives in the existing `#[test]`, so it runs in the normal local test flow on any machine with >= 2 GPUs and skips automatically below that. TP=8 is the follow-on already named in the issue.

## Test Env

- Dual-GH200 (aarch64, sm_90) node: full gate green, 7 single-GPU + 4 TP=2 passes in one process. TP=2 sits at the single-GPU noise floor (mean ~0.031, p99 ~0.12-0.13).
- Single GPU (x86_64, sm_89): existing passes green and unchanged, TP pass skips with `skipping hf_golden_gate TP=2 pass: 1 CUDA device(s) visible, need 2`.

<details>

<summary>Full gate output on the dual-GH200 (single-GPU + TP=2, one process)</summary>

```text
hf_golden_gate [sequential bs=1 eager]: 816 positions, 6528 head deltas — mean 0.0318 p50 0.0242 p99 0.1173 max 0.3124
hf_golden_gate [sequential bs=1 eager]: worst head delta 0.3124 @ seq 7 pos 5 token 68172 (pega -9.9384, HF -10.2508)
hf_golden_gate [batched eager (9, no pad)]: 153 positions, 1224 head deltas — mean 0.0325 p50 0.0240 p99 0.1558 max 0.3124
hf_golden_gate [batched eager (9, no pad)]: worst head delta 0.3124 @ seq 7 pos 5 token 239 (pega -9.0635, HF -9.3758)
hf_golden_gate [sequential bs=1 eager cached replay]: 816 positions, 6528 head deltas — mean 0.0313 p50 0.0253 p99 0.1168 max 0.3124
hf_golden_gate [sequential bs=1 eager cached replay]: worst head delta 0.3124 @ seq 7 pos 5 token 68172 (pega -9.9384, HF -10.2508)
hf_golden_gate [batched eager cached replay (9)]: 153 positions, 1224 head deltas — mean 0.0313 p50 0.0248 p99 0.1204 max 0.3124
hf_golden_gate [batched eager cached replay (9)]: worst head delta 0.3124 @ seq 7 pos 5 token 68172 (pega -9.9384, HF -10.2508)
hf_golden_gate [batched cuda-graph (9 padded)]: 153 positions, 1224 head deltas — mean 0.0325 p50 0.0240 p99 0.1558 max 0.3124
hf_golden_gate [batched cuda-graph (9 padded)]: worst head delta 0.3124 @ seq 7 pos 5 token 239 (pega -9.0635, HF -9.3758)
hf_golden_gate [batched cuda-graph (5 padded)]: 85 positions, 680 head deltas — mean 0.0311 p50 0.0248 p99 0.1271 max 0.1928
hf_golden_gate [batched cuda-graph (5 padded)]: worst head delta 0.1928 @ seq 3 pos 9 token 398 (pega -5.5985, HF -5.4057)
hf_golden_gate [batched cuda-graph cached replay (5)]: 85 positions, 680 head deltas — mean 0.0309 p50 0.0262 p99 0.1260 max 0.1816
hf_golden_gate [batched cuda-graph cached replay (5)]: worst head delta 0.1816 @ seq 4 pos 9 token 47534 (pega -5.2187, HF -5.4003)
hf_golden_gate [tp2 sequential bs=1 eager]: 816 positions, 6528 head deltas — mean 0.0311 p50 0.0245 p99 0.1189 max 0.2741
hf_golden_gate [tp2 sequential bs=1 eager]: worst head delta 0.2741 @ seq 14 pos 7 token 291 (pega -4.8874, HF -4.6133)
hf_golden_gate [tp2 batched eager (9, no pad)]: 153 positions, 1224 head deltas — mean 0.0302 p50 0.0221 p99 0.1280 max 0.3124
hf_golden_gate [tp2 batched eager (9, no pad)]: worst head delta 0.3124 @ seq 7 pos 5 token 68172 (pega -9.9384, HF -10.2508)
hf_golden_gate [tp2 sequential bs=1 eager cached replay]: 816 positions, 6528 head deltas — mean 0.0313 p50 0.0246 p99 0.1175 max 0.2741
hf_golden_gate [tp2 sequential bs=1 eager cached replay]: worst head delta 0.2741 @ seq 14 pos 7 token 291 (pega -4.8874, HF -4.6133)
hf_golden_gate [tp2 batched eager cached replay (9)]: 153 positions, 1224 head deltas — mean 0.0309 p50 0.0250 p99 0.1234 max 0.2034
hf_golden_gate [tp2 batched eager cached replay (9)]: worst head delta 0.2034 @ seq 4 pos 1 token 59941 (pega -2.3543, HF -2.5578)
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 33.68s
```

</details>

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project (see `docs/conventions/coding-style.md`).
- [x] I have performed a self-review of my own code.
- [x] I have formatted my commits according to Commitizen conventions.
- [x] I have run the local test suite and all tests pass (see `CLAUDE.md`).

