### PR TITLE
fix(qwen3): give model-report decode trace a 2-token budget

### DIFF
--- a/openinfer-qwen3-4b/src/batch_decode_trace.rs
+++ b/openinfer-qwen3-4b/src/batch_decode_trace.rs
@@ -55,13 +55,18 @@ pub fn trace_decode_kernel_calls(
         budget.block_size,
     );
 
-    // Build dummy RequestKvs with the target kv_len
+    // Build dummy RequestKvs with the target kv_len.
+    //
+    // max_output_tokens must be at least 2: `apply_prefill` emits the first
+    // generated token (counted as 1 toward the budget), and tracing a decode
+    // step needs one more. With max_output_tokens = 1 the sequence is already
+    // complete after prefill, so `schedule_decode` fails with GenerationComplete.
     let dummy_prompt_len = if kv_len > 1 { kv_len - 1 } else { 1 };
     let mut rkvs = (0..batch_size)
         .map(|_| {
             let mut rkv = kv_mgr
                 .pool()
-                .new_request(vec![0; dummy_prompt_len], 1, None);
+                .new_request(vec![0; dummy_prompt_len], 2, None);
             rkv.schedule_prefill(dummy_prompt_len, kv_mgr.pool())
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
             rkv.apply_prefill(0, kv_mgr.pool())?;

--- a/openinfer-qwen3-4b/src/batch_decode_trace.rs
+++ b/openinfer-qwen3-4b/src/batch_decode_trace.rs
@@ -62,7 +62,7 @@ pub fn trace_decode_kernel_calls(
     // step needs one more. With max_output_tokens = 1 the sequence is already
     // complete after prefill, so `schedule_decode` fails with GenerationComplete.
     let dummy_prompt_len = if kv_len > 1 { kv_len - 1 } else { 1 };
-    let mut rkvs = (0..batch_size)
+    let rkvs = (0..batch_size)
         .map(|_| {
             let mut rkv = kv_mgr
                 .pool()


### PR DESCRIPTION
## Summary

`qwen3_model_report decode` aborts before producing any output with `Error: generation complete: 1 >= 1`, so the model-level operator report cannot trace a decode step. This fixes the trace harness so the report runs.

## Root cause

`trace_decode_kernel_calls` (in `openinfer-qwen3-4b/src/batch_decode_trace.rs`) builds its dummy request with `max_output_tokens = 1`:

    let mut rkv = kv_mgr.pool().new_request(vec![0; dummy_prompt_len], 1, None);
    rkv.schedule_prefill(dummy_prompt_len, kv_mgr.pool())?;
    rkv.apply_prefill(0, kv_mgr.pool())?;   // emits the first generated token
    rkv.schedule_decode(kv_mgr.pool())?;    // <-- fails here

Under the kvbm `SchedulableSequence` lifecycle, the token emitted by `apply_prefill` counts toward `max_output_tokens`. With a budget of 1 the sequence is already complete after prefill (generated == max_output == 1), so the following `schedule_decode` hits `require_not_complete()` and returns `ScheduleError::GenerationComplete { generated: 1, max_output: 1 }`.

The harness only ever needs a single decode step, so the minimum correct budget is 2: one token for the prefill-emitted token, one for the decode step being traced.

## Fix

Bump the dummy request's `max_output_tokens` from 1 to 2 and document why.

## Verification

    cargo run -p openinfer-qwen3-4b --features kernel-report \
      --bin qwen3_model_report -- decode --batch-size 1 --kv-len 1024

Now runs to completion and prints the per-op rollup + schedule preview (e.g. paged_decode_attention ~27.5us x36, lm_head gemm ~843us, MLP gemms ~66us x36) on RTX 4090 / Qwen3-4B.