### PR TITLE
docs(readme): update Qwen3-4B performance against vLLM 0.22.1 on RTX 5090

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,53 +18,44 @@
 
 ---
 
-openinfer is a from-scratch LLM inference engine written in **~9.6K lines of Rust**, **~2.6K lines of CUDA**, and **~1.4K lines of Triton GPU kernels**. No PyTorch, no ONNX, no model framework runtime — just Rust plus CUDA, Triton AOT, and generated compatibility kernels.
+openinfer is a from-scratch LLM inference engine written in **~95K lines of Rust** and **~14K lines of CUDA**, plus Triton AOT kernels. No PyTorch, no ONNX, no model framework runtime — just Rust plus CUDA, Triton AOT, and generated compatibility kernels.
 
 The goal is to understand every layer of the inference stack by building it from the ground up, and to explore what a Rust-native inference engine can look like.
 
 ## Performance
 
-**Qwen3-4B vs vLLM 0.22.1** — measured 2026-06-10 on one **RTX 5090** (32 GB), BF16, TP1,
-both engines driven by `vllm bench serve` (random 1024-token prompts, 128-token outputs,
-Poisson arrivals, fixed seed). Full data, commands, and caveats:
-[`docs/benchmarks/qwen3-4b-serving-vllm-rtx5090.md`](docs/benchmarks/qwen3-4b-serving-vllm-rtx5090.md).
+Head-to-head with **vLLM 0.22.1** on one **RTX 5090** (32 GB) — Qwen3-4B, BF16, TP1,
+both engines measured by the same `vllm bench serve` client with identical seeds.
 
-**Warm TTFT on a GPU prefix-cache hit** (identical prompt re-sent, output = 1 token,
-20 samples per length — the agent / multi-turn-chat hot path). openinfer leads at
-every length and the gap widens with context: **3× faster at 16k tokens**.
+**On a prefix-cache hit — the multi-turn chat / agent hot path — openinfer returns
+the first token up to 3× faster, and the lead grows with context:**
 
-| Input length | openinfer p50 / p99 | vLLM p50 / p99 |
-|--------------|---------------------|----------------|
-| 256 | **9.5 / 10.5 ms** | 13.3 / 14.2 ms |
-| 512 | **9.9 / 10.1 ms** | 14.3 / 14.5 ms |
-| 1k | **10.5 / 10.7 ms** | 16.1 / 16.4 ms |
-| 2k | **11.9 / 12.4 ms** | 19.8 / 20.5 ms |
-| 4k | **14.5 / 15.1 ms** | 27.3 / 28.3 ms |
-| 8k | **24.6 / 25.6 ms** | 46.9 / 49.3 ms |
-| 16k | **30.3 / 31.4 ms** | 90.8 / 100.2 ms |
+| Cached prompt | openinfer | vLLM 0.22.1 | speedup |
+|--------------:|----------:|------------:|--------:|
+| 1k tokens | 10.5 ms | 16.1 ms | 1.5× |
+| 4k tokens | 14.5 ms | 27.3 ms | 1.9× |
+| 8k tokens | 24.6 ms | 46.9 ms | 1.9× |
+| 16k tokens | 30.3 ms | 90.8 ms | **3.0×** |
 
-**Serving load sweep** (Poisson arrivals, **openinfer** / vLLM):
+<sub>Warm TTFT, p50 of 20 samples per length. The tail behaves the same way:
+openinfer's p99 stays within ~1 ms of its p50 at every length, while vLLM's reaches
+100 ms at 16k. From 256 → 16k tokens, vLLM's warm TTFT grows ~7×; openinfer's grows ~3×.</sub>
 
-| QPS | TTFT p50 (ms) | TPOT p50 (ms) | Output tok/s |
-|-----|---------------|----------------|--------------|
-| 1 | **50.7** / 57.8 | 7.36 / **6.65** | 126 / 126 |
-| 4 | **57.3** / 61.8 | 11.09 / **8.57** | 502 / 504 |
-| 8 | 69.5 / **68.1** | 14.98 / **11.82** | 1005 / 1008 |
+Under serving load (Poisson arrivals, 1k-token prompts, 128-token outputs), openinfer
+delivers lower TTFT at low load (50.7 vs 57.8 ms p50 at QPS 1, converging by QPS 8)
+at identical output throughput, and cold prefill is at parity up to 16k context
+(1.00 vs 1.11 s). vLLM is ahead on batched decode TPOT (7.36 vs 6.65 ms at QPS 1,
+widening to 27% at QPS 8) and sustains ~12% more throughput past saturation —
+openinfer's current ceiling is its largest CUDA-graph batch bucket (64 sequences),
+which caps saturated decode at ~1.5k tok/s. Closing the batched-decode gap is active
+work.
 
-openinfer wins single-stream and low-load TTFT; vLLM wins batched decode TPOT and
-holds higher load before saturating (knee ~QPS 12 vs ~QPS 10 on this GPU — the full
-sweep through overload is in the snapshot doc). Qwen3.5-4B single-stream numbers are
-at parity with vLLM — see
+Full tables (p50/p99 at every QPS level, the saturation sweep, exact commands, and
+caveats) are in
+[`docs/benchmarks/qwen3-4b-serving-vllm-rtx5090.md`](docs/benchmarks/qwen3-4b-serving-vllm-rtx5090.md)
+(measured 2026-06-10, openinfer `6901965`, vLLM 0.22.1 from PyPI). Qwen3.5-4B
+single-stream latency is at parity with vLLM — see
 [`docs/models/qwen35/optimization.md`](docs/models/qwen35/optimization.md).
-
-<details>
-<summary>What do these metrics mean?</summary>
-
-- **TTFT** (Time To First Token): latency from receiving the prompt to generating the first output token. Includes tokenization, embedding, and the full prefill pass.
-- **TPOT** (Time Per Output Token): average time to generate each subsequent token during the decode phase.
-- **Warm TTFT**: TTFT when the prompt's KV is already resident in the GPU prefix cache, so only cache lookup + suffix prefill + sampling remain.
-
-</details>
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -24,20 +24,39 @@ The goal is to understand every layer of the inference stack by building it from
 
 ## Performance
 
-Measured on **RTX 5070 Ti** (16 GB), BF16, CUDA Graph enabled, single request:
+**Qwen3-4B vs vLLM 0.22.1** — measured 2026-06-10 on one **RTX 5090** (32 GB), BF16, TP1,
+both engines driven by `vllm bench serve` (random 1024-token prompts, 128-token outputs,
+Poisson arrivals, fixed seed). Full data, commands, and caveats:
+[`docs/benchmarks/qwen3-4b-serving-vllm-rtx5090.md`](docs/benchmarks/qwen3-4b-serving-vllm-rtx5090.md).
 
-| Metric | Qwen3-4B | Qwen3.5-4B |
-|--------|----------|-------------|
-| TTFT (short prompt) | ~14 ms | ~22 ms |
-| TPOT (decode) | ~11 ms/tok | ~11.8 ms/tok |
-| Throughput | **~91 tok/s** | **~85 tok/s** |
+Serving load sweep (**openinfer** / vLLM):
+
+| QPS | TTFT p50 (ms) | TPOT p50 (ms) | Output tok/s |
+|-----|---------------|----------------|--------------|
+| 1 | **50.7** / 57.8 | 7.36 / **6.65** | 126 / 126 |
+| 4 | **57.3** / 61.8 | 11.09 / **8.57** | 502 / 504 |
+| 8 | 69.5 / **68.1** | 14.98 / **11.82** | 1005 / 1008 |
+| 12 (overload) | 1754 / **120** | 44.2 / **19.4** | 1415 / 1501 |
+
+Warm TTFT with a GPU prefix-cache hit (identical prompt re-sent, output = 1 token):
+
+| Input length | openinfer warm p50 | vLLM warm p50 |
+|--------------|--------------------|---------------|
+| 1k tokens | **10.5 ms** | 16.1 ms |
+| 4k tokens | **14.5 ms** | 27.3 ms |
+| 16k tokens | **30.3 ms** | 90.8 ms |
+
+openinfer wins single-stream TTFT and prefix-cache-hit TTFT (3× at 16k tokens);
+vLLM wins batched decode TPOT and saturates later (knee ~QPS 12 vs ~QPS 10).
+Qwen3.5-4B single-stream numbers are at parity with vLLM — see
+[`docs/models/qwen35/optimization.md`](docs/models/qwen35/optimization.md).
 
 <details>
 <summary>What do these metrics mean?</summary>
 
 - **TTFT** (Time To First Token): latency from receiving the prompt to generating the first output token. Includes tokenization, embedding, and the full prefill pass.
 - **TPOT** (Time Per Output Token): average time to generate each subsequent token during the decode phase.
-- **Throughput**: 1000 / TPOT, i.e. tokens generated per second during decode.
+- **Warm TTFT**: TTFT when the prompt's KV is already resident in the GPU prefix cache, so only cache lookup + suffix prefill + sampling remain.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -29,26 +29,32 @@ both engines driven by `vllm bench serve` (random 1024-token prompts, 128-token 
 Poisson arrivals, fixed seed). Full data, commands, and caveats:
 [`docs/benchmarks/qwen3-4b-serving-vllm-rtx5090.md`](docs/benchmarks/qwen3-4b-serving-vllm-rtx5090.md).
 
-Serving load sweep (**openinfer** / vLLM):
+**Warm TTFT on a GPU prefix-cache hit** (identical prompt re-sent, output = 1 token,
+20 samples per length — the agent / multi-turn-chat hot path). openinfer leads at
+every length and the gap widens with context: **3× faster at 16k tokens**.
+
+| Input length | openinfer p50 / p99 | vLLM p50 / p99 |
+|--------------|---------------------|----------------|
+| 256 | **9.5 / 10.5 ms** | 13.3 / 14.2 ms |
+| 512 | **9.9 / 10.1 ms** | 14.3 / 14.5 ms |
+| 1k | **10.5 / 10.7 ms** | 16.1 / 16.4 ms |
+| 2k | **11.9 / 12.4 ms** | 19.8 / 20.5 ms |
+| 4k | **14.5 / 15.1 ms** | 27.3 / 28.3 ms |
+| 8k | **24.6 / 25.6 ms** | 46.9 / 49.3 ms |
+| 16k | **30.3 / 31.4 ms** | 90.8 / 100.2 ms |
+
+**Serving load sweep** (Poisson arrivals, **openinfer** / vLLM):
 
 | QPS | TTFT p50 (ms) | TPOT p50 (ms) | Output tok/s |
 |-----|---------------|----------------|--------------|
 | 1 | **50.7** / 57.8 | 7.36 / **6.65** | 126 / 126 |
 | 4 | **57.3** / 61.8 | 11.09 / **8.57** | 502 / 504 |
 | 8 | 69.5 / **68.1** | 14.98 / **11.82** | 1005 / 1008 |
-| 12 (overload) | 1754 / **120** | 44.2 / **19.4** | 1415 / 1501 |
 
-Warm TTFT with a GPU prefix-cache hit (identical prompt re-sent, output = 1 token):
-
-| Input length | openinfer warm p50 | vLLM warm p50 |
-|--------------|--------------------|---------------|
-| 1k tokens | **10.5 ms** | 16.1 ms |
-| 4k tokens | **14.5 ms** | 27.3 ms |
-| 16k tokens | **30.3 ms** | 90.8 ms |
-
-openinfer wins single-stream TTFT and prefix-cache-hit TTFT (3× at 16k tokens);
-vLLM wins batched decode TPOT and saturates later (knee ~QPS 12 vs ~QPS 10).
-Qwen3.5-4B single-stream numbers are at parity with vLLM — see
+openinfer wins single-stream and low-load TTFT; vLLM wins batched decode TPOT and
+holds higher load before saturating (knee ~QPS 12 vs ~QPS 10 on this GPU — the full
+sweep through overload is in the snapshot doc). Qwen3.5-4B single-stream numbers are
+at parity with vLLM — see
 [`docs/models/qwen35/optimization.md`](docs/models/qwen35/optimization.md).
 
 <details>

--- a/docs/benchmarks/qwen3-4b-serving-vllm-rtx5090.md
+++ b/docs/benchmarks/qwen3-4b-serving-vllm-rtx5090.md
@@ -1,0 +1,153 @@
+# Qwen3-4B serving: openinfer vs vLLM on RTX 5090
+
+**Created**: 2026-06-10
+**TL;DR**: TP1 Qwen3-4B on one RTX 5090, both engines driven by `vllm bench serve`
+(Poisson arrivals, seed 42). Low load (QPS ≤ 8): openinfer wins TTFT p50 by ~10%,
+vLLM wins TPOT at every level (gap grows +11% → +27% with batch size). Saturation:
+openinfer knees at ~QPS 10, vLLM at ~QPS 12–14; vLLM's overloaded peak throughput is
+~12% higher (1690 vs 1511 out tok/s). Warm prefix-cache-hit TTFT: openinfer leads at
+every input length, 3× at 16k tokens (30.3 ms vs 90.8 ms p50).
+
+Source benchmark for the README performance section (issue #327).
+
+## Setup
+
+| Item | Value |
+| --- | --- |
+| GPU | 1× NVIDIA GeForce RTX 5090 (32 GB), driver 590.48.01, same GPU for both engines (sequential runs) |
+| Model | Qwen3-4B, BF16 safetensors (7.6 GB), TP1 |
+| openinfer | commit `6901965` (main, 2026-06-10), release build, CUDA Graph on (default) |
+| vLLM | 0.22.1 (PyPI), torch 2.11.0+cu130, Python 3.12, default engine config |
+| Client | `vllm bench serve` 0.22.1 on localhost (same host) |
+
+Server commands:
+
+```bash
+# vLLM (test 1: prefix cache off for random-prompt fairness)
+CUDA_VISIBLE_DEVICES=1 vllm serve /data/Qwen3-4B --port 8100 \
+  --max-model-len 8192 --gpu-memory-utilization 0.9 --no-enable-prefix-caching
+
+# vLLM (test 2: prefix cache on — the default; longer context for the sweep)
+CUDA_VISIBLE_DEVICES=1 vllm serve /data/Qwen3-4B --port 8100 --max-model-len 20480
+
+# openinfer (test 1: prefix cache off)
+CUDA_VISIBLE_DEVICES=1 target/release/openinfer --model-path /data/Qwen3-4B \
+  --port 8100 --no-prefix-cache
+
+# openinfer (test 2: prefix cache on — the default)
+CUDA_VISIBLE_DEVICES=1 target/release/openinfer --model-path /data/Qwen3-4B --port 8100
+```
+
+Both engines got an unrecorded 8-request warmup (`--num-prompts 8 --request-rate inf --seed 7`)
+before measurement, so vLLM torch.compile cold-start does not pollute the sweep.
+
+## Test 1 — QPS sweep, Poisson arrivals
+
+`tools/bench/qps_sweep.sh`: random dataset, `input_len=1024`, `output_len=128`,
+`--ignore-eos --temperature 0`, Poisson arrivals (`--burstiness 1.0`), `--seed 42`,
+`num_prompts = 60 × QPS` (≈60 s of arrivals per level).
+
+```bash
+MODEL=/data/Qwen3-4B PORT=8100 ENGINE=<openinfer|vllm> \
+RESULT_DIR=<dir> QPS_LIST="1 2 4 8 10 12 16" INPUT_LEN=1024 OUTPUT_LEN=128 SEED=42 \
+VLLM=.venv/bin/vllm tools/bench/qps_sweep.sh
+```
+
+### openinfer
+
+| QPS | req/s | out tok/s | TTFT p50 (ms) | TTFT p99 | TPOT p50 | TPOT p99 | ITL p99 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | 0.98 | 126 | 50.7 | 69.2 | 7.36 | 9.34 | 9.5 |
+| 2 | 1.97 | 252 | 52.9 | 98.8 | 8.95 | 11.04 | 49.1 |
+| 4 | 3.92 | 502 | 57.3 | 139.2 | 11.09 | 13.34 | 52.9 |
+| 8 | 7.85 | 1005 | 69.5 | 211.6 | 14.98 | 23.65 | 97.7 |
+| 10 | 9.77 | 1251 | 109.4 | 432.2 | 22.98 | 42.99 | 148.2 |
+| 12 | 11.05 | 1415 | 1753.8 | 4199.6 | 44.17 | 44.65 | 171.0 |
+| 16 | 11.80 | 1511 | 8898.4 | 19716.1 | 41.12 | 42.01 | 252.0 |
+
+### vLLM 0.22.1
+
+| QPS | req/s | out tok/s | TTFT p50 (ms) | TTFT p99 | TPOT p50 | TPOT p99 | ITL p99 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | 0.99 | 126 | 57.8 | 73.2 | 6.65 | 7.77 | 12.8 |
+| 2 | 1.97 | 252 | 58.8 | 103.7 | 7.17 | 8.92 | 35.3 |
+| 4 | 3.93 | 504 | 61.8 | 115.8 | 8.57 | 10.60 | 38.2 |
+| 8 | 7.88 | 1008 | 68.1 | 192.4 | 11.82 | 15.80 | 46.7 |
+| 10 | 9.80 | 1254 | 75.7 | 243.3 | 13.99 | 20.90 | 80.0 |
+| 12 | 11.72 | 1501 | 119.5 | 409.3 | 19.41 | 49.21 | 102.5 |
+| 16 | 13.20 | 1690 | 3933.9 | 10684.2 | 76.21 | 80.17 | 118.5 |
+
+### Reading
+
+- **Low load (QPS ≤ 8): TTFT favors openinfer (~10% lower p50), TPOT favors vLLM.**
+  The TPOT gap grows with concurrency: +11% at QPS 1 (7.36 vs 6.65 ms) to +27% at
+  QPS 8 (14.98 vs 11.82 ms). openinfer's batched decode is the known weak spot
+  (per-row sampling, `models/qwen3/roadmap.md`).
+- **Saturation: openinfer knees at ~QPS 10, vLLM holds to ~QPS 12.** At QPS 12
+  openinfer's queue diverges (TTFT p50 1.75 s) while vLLM still serves at 119.5 ms.
+  Both are overloaded at QPS 16; vLLM's saturated throughput is ~12% higher
+  (1690 vs 1511 out tok/s).
+- ITL p99 is consistently worse for openinfer under load (97.7 vs 46.7 ms at QPS 8) —
+  scheduling jitter, same tail issue noted in `subsystems/scheduler/scheduler.md`.
+
+## Test 2 — warm (prefix-cache-hit) TTFT vs input length
+
+`tools/bench/warm_ttft_sweep.py`: one fixed random-token prompt per length
+(seed 42), sent once cold to populate the GPU prefix cache, then 20 warm samples
+of the identical prompt with `max_tokens=1`. Every sample drains the SSE stream
+to `[DONE]` before the next request. Prefix cache ON for both engines.
+
+```bash
+.venv/bin/python tools/bench/warm_ttft_sweep.py \
+  --base-url http://localhost:8100 --model /data/Qwen3-4B \
+  --tokenizer /data/Qwen3-4B --lengths 256,512,1024,2048,4096,8192,16384 \
+  --samples 20 --seed 42 --output <out>.json
+```
+
+### openinfer
+
+| Input len | Cold TTFT (ms) | Warm p50 | Warm p99 |
+| --- | --- | --- | --- |
+| 256 | 34.4 | 9.5 | 10.5 |
+| 512 | 23.7 | 9.9 | 10.1 |
+| 1024 | 44.8 | 10.5 | 10.7 |
+| 2048 | 88.4 | 11.9 | 12.4 |
+| 4096 | 199.1 | 14.5 | 15.1 |
+| 8192 | 415.0 | 24.6 | 25.6 |
+| 16384 | 1003.0 | 30.3 | 31.4 |
+
+### vLLM 0.22.1
+
+| Input len | Cold TTFT (ms) | Warm p50 | Warm p99 |
+| --- | --- | --- | --- |
+| 256 | 41.5 | 13.3 | 14.2 |
+| 512 | 28.5 | 14.3 | 14.5 |
+| 1024 | 50.3 | 16.1 | 16.4 |
+| 2048 | 95.2 | 19.8 | 20.5 |
+| 4096 | 197.9 | 27.3 | 28.3 |
+| 8192 | 449.6 | 46.9 | 49.3 |
+| 16384 | 1106.8 | 90.8 | 100.2 |
+
+### Reading
+
+- **openinfer wins warm TTFT at every length, and the gap widens with length:
+  1.4× at 256 tokens (9.5 vs 13.3 ms), 3× at 16k (30.3 vs 90.8 ms).** vLLM's warm
+  TTFT grows ~7× from 256 → 16k while openinfer grows ~3×.
+- Cold TTFT (full prefill) is near parity, openinfer slightly ahead at most
+  lengths (16k: 1003 vs 1107 ms).
+- p99 stays tight on both engines (single client, no contention) — the warm p99
+  column shows jitter, not load.
+
+## Caveats
+
+- `vllm bench serve` is the unified client for test 1; both engines see identical
+  request streams (same seed → same prompts and same Poisson arrival schedule).
+- The historical openinfer caveat about overreported streaming
+  `usage.completion_tokens` (see `playbooks/bench-vs-vllm.md`) did **not** reproduce:
+  every openinfer run has `total_output_tokens == completed × 128` exactly, so the
+  `output_throughput` field is trusted as-is.
+- QPS levels past the knee (12, 16) measure overload behavior, not steady state:
+  `req/s < QPS` means the arrival window stretched and TTFT includes queue time.
+- Raw result JSONs (one per engine × QPS level, plus the two TTFT sweeps) live on
+  the 5090 host under `/data/xingming/bench/20260610-qwen3-5090/`; the tables
+  above are transcribed from them.

--- a/docs/benchmarks/qwen3-4b-serving-vllm-rtx5090.md
+++ b/docs/benchmarks/qwen3-4b-serving-vllm-rtx5090.md
@@ -88,6 +88,13 @@ VLLM=.venv/bin/vllm tools/bench/qps_sweep.sh
   openinfer's queue diverges (TTFT p50 1.75 s) while vLLM still serves at 119.5 ms.
   Both are overloaded at QPS 16; vLLM's saturated throughput is ~12% higher
   (1690 vs 1511 out tok/s).
+- **openinfer's saturated throughput is pinned by the bs=64 decode cap** (largest
+  CUDA-graph bucket, `BATCH_BUCKETS` ends at 64). Implied decode concurrency
+  (`out_tok/s × TPOT`) sits at 62 in both overloaded openinfer runs — exactly the
+  cap — giving a hard ceiling of `64 / TPOT(bs64) ≈ 64/42 ms ≈ 1520 tok/s`, which
+  matches the measured 1511. vLLM keeps admitting past 64 (implied concurrency ~129
+  at QPS 16) and converts that into its +12%. The low-load TPOT gap is unrelated to
+  the cap (implied concurrency ≤ 16 at QPS ≤ 8).
 - ITL p99 is consistently worse for openinfer under load (97.7 vs 46.7 ms at QPS 8) —
   scheduling jitter, same tail issue noted in `subsystems/scheduler/scheduler.md`.
 

--- a/docs/benchmarks/qwen3-4b-serving-vllm-rtx5090.md
+++ b/docs/benchmarks/qwen3-4b-serving-vllm-rtx5090.md
@@ -81,8 +81,9 @@ VLLM=.venv/bin/vllm tools/bench/qps_sweep.sh
 
 - **Low load (QPS ≤ 8): TTFT favors openinfer (~10% lower p50), TPOT favors vLLM.**
   The TPOT gap grows with concurrency: +11% at QPS 1 (7.36 vs 6.65 ms) to +27% at
-  QPS 8 (14.98 vs 11.82 ms). openinfer's batched decode is the known weak spot
-  (per-row sampling, `models/qwen3/roadmap.md`).
+  QPS 8 (14.98 vs 11.82 ms). The growth pattern points at batched decode step cost,
+  not sampling — greedy token selection is already batched (#307, in this build);
+  isolating the kernel-level cause needs an nsys diff at fixed batch size.
 - **Saturation: openinfer knees at ~QPS 10, vLLM holds to ~QPS 12.** At QPS 12
   openinfer's queue diverges (TTFT p50 1.75 s) while vLLM still serves at 119.5 ms.
   Both are overloaded at QPS 16; vLLM's saturated throughput is ~12% higher

--- a/docs/index.md
+++ b/docs/index.md
@@ -147,6 +147,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 
 | Path | TL;DR |
 | --- | --- |
+| `benchmarks/qwen3-4b-serving-vllm-rtx5090.md` | Qwen3-4B TP1 vs vLLM 0.22.1 on RTX 5090, README source (#327): Poisson QPS sweep (openinfer wins low-load TTFT, vLLM wins TPOT +11→27% and knees later, ~QPS 12 vs ~10) + warm prefix-cache-hit TTFT sweep (openinfer leads all lengths, 3× at 16k: 30.3 vs 90.8 ms). Seeded, reproducible via `tools/bench/`. |
 | `benchmarks/bs1-4k64-vllm-openinfer.md` | RTX 5090 single-concurrency probe: `input_len=4096`, `output_len=64`, no vLLM prefix cache. OpenInfer TTFT median `177ms` vs vLLM `198ms`; TPOT median `6.47ms` vs `6.36ms`; corrected output throughput `+6%` for OpenInfer. |
 | `benchmarks/accuracy-eval-results.md` | Phase 1 GSM8K: Qwen3-4B PASS (openinfer 85.37% vs HF 85.82%, delta -0.45 pp). Qwen3.5-4B historical FAIL recovered by #250 (strict 79.38%, flexible 79.30% vs HF 79.45%). |
 | `benchmarks/pplx-ep-a2a-h20-nvlink.md` | pplx EP all-to-all latency on 8× H20 NV18 NVLink: DSV4 & Kimi-K2 shapes, tok=1..256. tok=1 p50 ~82μs, tok=256 p50 ~204/303μs. |

--- a/tools/bench/qps_sweep.sh
+++ b/tools/bench/qps_sweep.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# QPS sweep with Poisson arrivals against an already-running OpenAI-compatible
+# server. Drives `vllm bench serve` (random dataset, fixed seed) once per QPS
+# value and saves one JSON per run.
+#
+# Usage:
+#   MODEL=/data/Qwen3-4B PORT=8000 ENGINE=openinfer RESULT_DIR=/data/bench \
+#   QPS_LIST="1 2 4 8 16" INPUT_LEN=1024 OUTPUT_LEN=128 SEED=42 \
+#   VLLM=.venv/bin/vllm tools/bench/qps_sweep.sh
+set -euo pipefail
+
+MODEL=${MODEL:?model path}
+PORT=${PORT:-8000}
+ENGINE=${ENGINE:?engine label for result filenames}
+RESULT_DIR=${RESULT_DIR:?result dir}
+QPS_LIST=${QPS_LIST:-"1 2 4 8 16"}
+INPUT_LEN=${INPUT_LEN:-1024}
+OUTPUT_LEN=${OUTPUT_LEN:-128}
+SEED=${SEED:-42}
+SECONDS_PER_RUN=${SECONDS_PER_RUN:-60}
+VLLM=${VLLM:-.venv/bin/vllm}
+
+mkdir -p "$RESULT_DIR"
+
+for QPS in $QPS_LIST; do
+  NUM_PROMPTS=$(python3 -c "print(int($QPS * $SECONDS_PER_RUN))")
+  echo "=== $ENGINE qps=$QPS num_prompts=$NUM_PROMPTS in=$INPUT_LEN out=$OUTPUT_LEN seed=$SEED ==="
+  "$VLLM" bench serve \
+    --backend openai --model "$MODEL" --port "$PORT" \
+    --dataset-name random \
+    --random-input-len "$INPUT_LEN" --random-output-len "$OUTPUT_LEN" \
+    --num-prompts "$NUM_PROMPTS" \
+    --request-rate "$QPS" --burstiness 1.0 \
+    --seed "$SEED" \
+    --ignore-eos --temperature 0 \
+    --tokenizer "$MODEL" \
+    --percentile-metrics ttft,tpot,itl,e2el \
+    --save-result --result-dir "$RESULT_DIR" \
+    --result-filename "${ENGINE}-in${INPUT_LEN}-out${OUTPUT_LEN}-qps${QPS}-seed${SEED}.json"
+done

--- a/tools/bench/summarize_qps_sweep.py
+++ b/tools/bench/summarize_qps_sweep.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Print one summary line per `vllm bench serve` result JSON given on argv."""
+
+import json
+import re
+import sys
+
+for path in sorted(
+    sys.argv[1:],
+    key=lambda p: (
+        p.split("/")[-1].split("-qps")[0],
+        float(re.search(r"qps([0-9.]+)", p).group(1)),
+    ),
+):
+    d = json.load(open(path))
+    qps = re.search(r"qps([0-9.]+)", path).group(1)
+    name = path.split("/")[-1].split("-")[0]
+    print(
+        f"{name:>9} qps={qps:>4} dur={d['duration']:6.1f}s "
+        f"completed={d['completed']} req/s={d['request_throughput']:.2f} "
+        f"out_tok/s={d['output_throughput']:7.1f} "
+        f"ttft p50={d['median_ttft_ms']:7.1f} p99={d['p99_ttft_ms']:8.1f} "
+        f"tpot p50={d['median_tpot_ms']:6.2f} p99={d['p99_tpot_ms']:7.2f} "
+        f"itl p99={d['p99_itl_ms']:7.2f}"
+    )

--- a/tools/bench/warm_ttft_sweep.py
+++ b/tools/bench/warm_ttft_sweep.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Warm (prefix-cache-hit) TTFT sweep over input lengths.
+
+For each input length L: build one fixed random-token prompt (seeded), send it
+once cold to populate the GPU prefix cache, then re-send the identical prompt N
+times and measure TTFT for each warm sample. Output is 1 token, so warm TTFT
+isolates cache lookup + suffix prefill + first-token sampling.
+
+Every sample fully drains the SSE stream to [DONE] before the next request —
+an early disconnect can leave the previous request decoding and inflate the
+next sample's TTFT.
+
+Usage:
+  python tools/bench/warm_ttft_sweep.py \
+      --base-url http://localhost:8000 --model /data/Qwen3-4B \
+      --tokenizer /data/Qwen3-4B --lengths 256,512,1024,2048,4096,8192,16384 \
+      --samples 20 --seed 42 --output results.json
+"""
+
+import argparse
+import json
+import time
+
+import numpy as np
+import requests
+from transformers import AutoTokenizer
+
+
+def build_prompt(tokenizer, length: int, rng: np.random.Generator) -> tuple[str, int]:
+    """Build a prompt that re-encodes to exactly `length` tokens (best effort)."""
+    vocab_size = tokenizer.vocab_size
+    ids = rng.integers(0, vocab_size, size=length * 2).tolist()
+    text = tokenizer.decode(ids, skip_special_tokens=True)
+    for _ in range(8):
+        reencoded = tokenizer.encode(text, add_special_tokens=False)
+        if len(reencoded) == length:
+            break
+        text = tokenizer.decode(reencoded[:length], skip_special_tokens=True)
+    actual = len(tokenizer.encode(text, add_special_tokens=False))
+    return text, actual
+
+
+def measure_ttft(session: requests.Session, base_url: str, model: str, prompt: str) -> float:
+    """Send one streaming completion (max_tokens=1), return TTFT in seconds."""
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "max_tokens": 1,
+        "temperature": 0.0,
+        "stream": True,
+    }
+    start = time.perf_counter()
+    ttft = None
+    with session.post(
+        f"{base_url}/v1/completions", json=payload, stream=True, timeout=600
+    ) as resp:
+        resp.raise_for_status()
+        for line in resp.iter_lines():
+            if not line:
+                continue
+            if ttft is None and line.startswith(b"data:") and b"[DONE]" not in line:
+                ttft = time.perf_counter() - start
+            # keep draining to [DONE]
+    if ttft is None:
+        raise RuntimeError("stream ended without a data chunk")
+    return ttft
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://localhost:8000")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--tokenizer", required=True)
+    parser.add_argument("--lengths", default="256,512,1024,2048,4096,8192,16384")
+    parser.add_argument("--samples", type=int, default=20)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer)
+    lengths = [int(x) for x in args.lengths.split(",")]
+    session = requests.Session()
+
+    results = []
+    for length in lengths:
+        # Fresh RNG per length so the prompt set is independent of sweep order.
+        rng = np.random.default_rng(args.seed + length)
+        prompt, actual = build_prompt(tokenizer, length, rng)
+        cold = measure_ttft(session, args.base_url, args.model, prompt)
+        warm = [
+            measure_ttft(session, args.base_url, args.model, prompt)
+            for _ in range(args.samples)
+        ]
+        warm_ms = sorted(w * 1000 for w in warm)
+        entry = {
+            "target_len": length,
+            "actual_len": actual,
+            "cold_ttft_ms": round(cold * 1000, 2),
+            "warm_ttft_ms": {
+                "p50": round(float(np.percentile(warm_ms, 50)), 2),
+                "p90": round(float(np.percentile(warm_ms, 90)), 2),
+                "p99": round(float(np.percentile(warm_ms, 99)), 2),
+                "samples": [round(w, 2) for w in warm_ms],
+            },
+        }
+        results.append(entry)
+        print(
+            f"len={length} (actual {actual}): cold {entry['cold_ttft_ms']}ms, "
+            f"warm p50 {entry['warm_ttft_ms']['p50']}ms p99 {entry['warm_ttft_ms']['p99']}ms",
+            flush=True,
+        )
+
+    with open(args.output, "w") as f:
+        json.dump(
+            {
+                "base_url": args.base_url,
+                "model": args.model,
+                "seed": args.seed,
+                "samples_per_length": args.samples,
+                "results": results,
+            },
+            f,
+            indent=2,
+        )
+    print(f"wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #327.

## What

Replaces the stale RTX 5070 Ti single-request table in the README with current Qwen3-4B numbers against vLLM 0.22.1, backed by a new benchmark snapshot doc so every number is traceable.

## Method

Both engines on the same RTX 5090 (32 GB, TP1, BF16), sequentially, driven by the same `vllm bench serve` client. openinfer at main `6901965`, vLLM 0.22.1 from PyPI. All commands seeded (`--seed 42`) and recorded in the doc; drivers committed under `tools/bench/`.

1. **Poisson QPS sweep** — random dataset 1024 in / 128 out, `--burstiness 1.0`, ~60 s of arrivals per level, prefix cache off on both. openinfer wins low-load TTFT p50 (~10%); vLLM wins TPOT at every level (+11% → +27% as load grows) and saturates later (knee ~QPS 12 vs ~QPS 10).
2. **Warm prefix-cache-hit TTFT sweep** — identical prompt re-sent with `max_tokens=1`, lengths 256→16384, prefix cache on on both, SSE fully drained between samples. openinfer leads at every length, 3× at 16k (30.3 vs 90.8 ms p50).

A historical caveat did not reproduce: openinfer streaming usage accounting through the vLLM frontend is now exact (`total_output_tokens == completed × output_len` in every run).

## Files

- `docs/benchmarks/qwen3-4b-serving-vllm-rtx5090.md` — full tables, commands, readings, caveats
- `README.md` — Performance section rewritten, links to the snapshot
- `tools/bench/{qps_sweep.sh,warm_ttft_sweep.py,summarize_qps_sweep.py}` — reproducible drivers
- `docs/index.md` — routing row

🤖 Generated with [Claude Code](https://claude.com/claude-code)