### PR TITLE
feat(qwen3): extend decode CUDA-graph buckets to 256 + bound prefill tokens per step

### DIFF
--- a/openinfer-qwen3-4b/src/batch_decode_buffers.rs
+++ b/openinfer-qwen3-4b/src/batch_decode_buffers.rs
@@ -9,7 +9,13 @@ use openinfer_core::tensor::{DeviceContext, HiddenStates};
 use openinfer_kv_cache::KvView;
 
 /// Bucket sizes for CUDA Graph capture. Actual batch is padded to the nearest bucket.
-pub(crate) const BATCH_BUCKETS: &[usize] = &[1, 2, 4, 8, 16, 32, 64];
+/// Mirrors vLLM's cudagraph capture list ([1,2,4,8] then every 8) up to 256; graphs
+/// are captured lazily per bucket, and activation buffers are shared (sized once at
+/// the largest bucket), so extra buckets cost capture time on first hit, not memory.
+pub(crate) const BATCH_BUCKETS: &[usize] = &[
+    1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160,
+    168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256,
+];
 const DECODE_ATTENTION_PATH_COUNT: usize = 2;
 const SPLIT_KV_CHUNK_TOKENS: usize = 256;
 const SPLIT_KV_MAX_CHUNKS_PER_REQUEST: usize = 64;

--- a/openinfer-qwen3-4b/src/lib.rs
+++ b/openinfer-qwen3-4b/src/lib.rs
@@ -19,6 +19,7 @@ use anyhow::Result;
 use openinfer_core::engine::{EngineHandle, EngineLoadOptions, ModelInfo};
 
 pub use kernel_plan::kernel_plan;
+pub use scheduler::DEFAULT_MAX_PREFILL_TOKENS;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Qwen3LoraOptions {
@@ -138,7 +139,13 @@ pub fn probe_model(model_path: &Path) -> Result<Option<ModelInfo>> {
 }
 
 pub fn start_engine(model_path: &Path, options: EngineLoadOptions) -> Result<EngineHandle> {
-    start_engine_with_offload(model_path, options, Qwen3OffloadOptions::disabled(), false)
+    start_engine_with_offload(
+        model_path,
+        options,
+        Qwen3OffloadOptions::disabled(),
+        false,
+        DEFAULT_MAX_PREFILL_TOKENS,
+    )
 }
 
 /// Like [`start_engine`] but with pegaflow KV offload (single-GPU only). The
@@ -150,11 +157,15 @@ pub fn start_engine(model_path: &Path, options: EngineLoadOptions) -> Result<Eng
 /// without offload it disables prefix matching outright; with offload it keeps
 /// the host tier but stops cross-request HBM reuse, so every prefix is served
 /// from L2 — the pure-L2 benchmark mode.
+///
+/// `max_prefill_tokens` caps the total prompt tokens batch-prefilled in one
+/// scheduler step (see [`DEFAULT_MAX_PREFILL_TOKENS`]).
 pub fn start_engine_with_offload(
     model_path: &Path,
     options: EngineLoadOptions,
     offload_options: Qwen3OffloadOptions,
     no_prefix_cache: bool,
+    max_prefill_tokens: usize,
 ) -> Result<EngineHandle> {
     let EngineLoadOptions {
         enable_cuda_graph,
@@ -172,6 +183,7 @@ pub fn start_engine_with_offload(
         seed,
         offload_options,
         no_prefix_cache,
+        max_prefill_tokens,
     )
 }
 
@@ -181,6 +193,7 @@ pub fn start_engine_with_lora_control(
     lora_options: Qwen3LoraOptions,
     offload_options: Qwen3OffloadOptions,
     no_prefix_cache: bool,
+    max_prefill_tokens: usize,
 ) -> Result<EngineHandle> {
     let EngineLoadOptions {
         enable_cuda_graph,
@@ -199,5 +212,6 @@ pub fn start_engine_with_lora_control(
         lora_options.validate()?,
         offload_options,
         no_prefix_cache,
+        max_prefill_tokens,
     )
 }

--- a/openinfer-qwen3-4b/src/scheduler.rs
+++ b/openinfer-qwen3-4b/src/scheduler.rs
@@ -672,6 +672,14 @@ fn active_future_blocks(active: &[ActiveRequestState], block_size: usize) -> usi
         .sum()
 }
 
+/// Prefill tokens admitted into a single step. Prefill activation scratch
+/// scales with the step's total prompt tokens (~22 KB/token measured on
+/// Qwen3-4B), so an unbounded prefill batch can eat the post-KV-pool VRAM
+/// headroom and OOM mid-serving under a request burst. A single request is
+/// always admitted regardless of its prompt length — only batching beyond one
+/// request is capped.
+const PREFILL_STEP_TOKEN_BUDGET: usize = 8192;
+
 fn admit_deferred_requests(
     deferred: Vec<PendingRequest>,
     active: &[ActiveRequestState],
@@ -688,6 +696,7 @@ fn admit_deferred_requests(
 ) -> AdmissionOutcome {
     let mut budget = available_blocks.saturating_sub(active_future_blocks(active, block_size));
     let mut decode_slots = max_decode_batch_size.saturating_sub(active.len());
+    let mut step_prefill_tokens = 0usize;
     let mut pending = Vec::new();
     let mut still_deferred = Vec::new();
     let mut rejected = Vec::new();
@@ -715,9 +724,13 @@ fn admit_deferred_requests(
         // …but only the blocks not already held by this request's prefetch must
         // come from the free-pool budget.
         let fresh_needed = footprint.saturating_sub(prefetch_credit(req.request_id));
-        if fresh_needed <= budget && decode_slots > 0 {
+        let prompt_len = req.prompt_tokens.len();
+        let within_token_budget =
+            pending.is_empty() || step_prefill_tokens + prompt_len <= PREFILL_STEP_TOKEN_BUDGET;
+        if fresh_needed <= budget && decode_slots > 0 && within_token_budget {
             budget -= fresh_needed;
             decode_slots -= 1;
+            step_prefill_tokens += prompt_len;
             pending.push(req);
         } else {
             still_deferred.push(req);

--- a/openinfer-qwen3-4b/src/scheduler.rs
+++ b/openinfer-qwen3-4b/src/scheduler.rs
@@ -85,6 +85,7 @@ pub(crate) fn start_qwen3(
     seed: u64,
     offload_options: Qwen3OffloadOptions,
     no_prefix_cache: bool,
+    max_prefill_tokens: usize,
 ) -> Result<EngineHandle> {
     let mut executor = Qwen3Executor::from_runtime_with_lora_options(
         model_path,
@@ -94,7 +95,7 @@ pub(crate) fn start_qwen3(
         offload_options,
     )?;
     executor.set_no_prefix_cache(no_prefix_cache);
-    Ok(start_with_executor(executor, seed))
+    Ok(start_with_executor(executor, seed, max_prefill_tokens))
 }
 
 pub(crate) fn start_qwen3_with_lora_control(
@@ -105,6 +106,7 @@ pub(crate) fn start_qwen3_with_lora_control(
     lora_options: Qwen3LoraOptions,
     offload_options: Qwen3OffloadOptions,
     no_prefix_cache: bool,
+    max_prefill_tokens: usize,
 ) -> Result<EngineHandle> {
     let mut executor = Qwen3Executor::from_runtime_with_lora_options(
         model_path,
@@ -114,7 +116,11 @@ pub(crate) fn start_qwen3_with_lora_control(
         offload_options,
     )?;
     executor.set_no_prefix_cache(no_prefix_cache);
-    Ok(start_with_executor_with_lora_control(executor, seed))
+    Ok(start_with_executor_with_lora_control(
+        executor,
+        seed,
+        max_prefill_tokens,
+    ))
 }
 
 fn servable_len(max_context: usize, max_blocks: usize, block_size: usize) -> u32 {
@@ -124,7 +130,11 @@ fn servable_len(max_context: usize, max_blocks: usize, block_size: usize) -> u32
         .unwrap_or(u32::MAX)
 }
 
-pub(crate) fn start_with_executor<E>(executor: E, seed: u64) -> EngineHandle
+pub(crate) fn start_with_executor<E>(
+    executor: E,
+    seed: u64,
+    max_prefill_tokens: usize,
+) -> EngineHandle
 where
     E: ModelExecutor + 'static,
 {
@@ -138,14 +148,18 @@ where
     thread::Builder::new()
         .name("scheduler".into())
         .spawn(move || {
-            scheduler_loop(executor, submit_rx, seed);
+            scheduler_loop(executor, submit_rx, seed, max_prefill_tokens);
         })
         .expect("failed to spawn scheduler thread");
 
     EngineHandle::new(submit_tx).with_servable_len(servable)
 }
 
-pub(crate) fn start_with_executor_with_lora_control<E>(executor: E, seed: u64) -> EngineHandle
+pub(crate) fn start_with_executor_with_lora_control<E>(
+    executor: E,
+    seed: u64,
+    max_prefill_tokens: usize,
+) -> EngineHandle
 where
     E: ModelExecutor + 'static,
 {
@@ -159,7 +173,7 @@ where
     thread::Builder::new()
         .name("scheduler".into())
         .spawn(move || {
-            scheduler_loop_with_lora_control(executor, command_rx, seed);
+            scheduler_loop_with_lora_control(executor, command_rx, seed, max_prefill_tokens);
         })
         .expect("failed to spawn scheduler thread");
 
@@ -256,6 +270,7 @@ fn scheduler_loop<E>(
     mut executor: E,
     mut submit_rx: mpsc::UnboundedReceiver<GenerateRequest>,
     seed: u64,
+    max_prefill_tokens: usize,
 ) where
     E: ModelExecutor,
 {
@@ -326,6 +341,7 @@ fn scheduler_loop<E>(
             executor.max_request_blocks(),
             executor.max_context_tokens(),
             executor.max_decode_batch_size(),
+            max_prefill_tokens,
             |id| executor.prefetched_blocks(id),
         );
         for (rejected, reason) in &admission.rejected {
@@ -356,6 +372,7 @@ fn scheduler_loop_with_lora_control<E>(
     mut executor: E,
     mut command_rx: mpsc::UnboundedReceiver<EngineCommand>,
     seed: u64,
+    max_prefill_tokens: usize,
 ) where
     E: ModelExecutor,
 {
@@ -449,6 +466,7 @@ fn scheduler_loop_with_lora_control<E>(
             executor.max_request_blocks(),
             executor.max_context_tokens(),
             executor.max_decode_batch_size(),
+            max_prefill_tokens,
             |id| executor.prefetched_blocks(id),
         );
         for (rejected, reason) in &admission.rejected {
@@ -672,13 +690,13 @@ fn active_future_blocks(active: &[ActiveRequestState], block_size: usize) -> usi
         .sum()
 }
 
-/// Prefill tokens admitted into a single step. Prefill activation scratch
-/// scales with the step's total prompt tokens (~22 KB/token measured on
-/// Qwen3-4B), so an unbounded prefill batch can eat the post-KV-pool VRAM
-/// headroom and OOM mid-serving under a request burst. A single request is
-/// always admitted regardless of its prompt length — only batching beyond one
-/// request is capped.
-const PREFILL_STEP_TOKEN_BUDGET: usize = 8192;
+/// Default for `max_prefill_tokens`: prefill tokens admitted into a single
+/// step. Prefill activation scratch scales with the step's total prompt tokens
+/// (~22 KB/token measured on Qwen3-4B), so an unbounded prefill batch can eat
+/// the post-KV-pool VRAM headroom and OOM mid-serving under a request burst. A
+/// single request is always admitted regardless of its prompt length — only
+/// batching beyond one request is capped.
+pub const DEFAULT_MAX_PREFILL_TOKENS: usize = 8192;
 
 fn admit_deferred_requests(
     deferred: Vec<PendingRequest>,
@@ -688,6 +706,7 @@ fn admit_deferred_requests(
     max_request_blocks: usize,
     max_context_tokens: usize,
     max_decode_batch_size: usize,
+    max_prefill_tokens: usize,
     // Blocks a request already holds from a settled prefetch. These are already
     // out of `available_blocks`, so they must be credited against the request's
     // need or admission double-counts them and can wedge a near-budget CPU-hit
@@ -726,7 +745,7 @@ fn admit_deferred_requests(
         let fresh_needed = footprint.saturating_sub(prefetch_credit(req.request_id));
         let prompt_len = req.prompt_tokens.len();
         let within_token_budget =
-            pending.is_empty() || step_prefill_tokens + prompt_len <= PREFILL_STEP_TOKEN_BUDGET;
+            pending.is_empty() || step_prefill_tokens + prompt_len <= max_prefill_tokens;
         if fresh_needed <= budget && decode_slots > 0 && within_token_budget {
             budget -= fresh_needed;
             decode_slots -= 1;
@@ -1221,7 +1240,17 @@ mod tests {
         ];
 
         // available 4 blocks - 2 reserved for active growth = budget of 2.
-        let outcome = admit_deferred_requests(deferred, &active, 16, 4, 4, usize::MAX, 64, |_| 0);
+        let outcome = admit_deferred_requests(
+            deferred,
+            &active,
+            16,
+            4,
+            4,
+            usize::MAX,
+            64,
+            DEFAULT_MAX_PREFILL_TOKENS,
+            |_| 0,
+        );
 
         let ids =
             |reqs: &[PendingRequest]| reqs.iter().map(|r| r.request_id.get()).collect::<Vec<_>>();
@@ -1260,7 +1289,17 @@ mod tests {
             mk(3, 40, 1), // request 3: 40 prompt + 1 max = 41 total: overflows by 9 tokens → rejected
         ];
 
-        let outcome = admit_deferred_requests(deferred, &active, 16, 1000, 1000, 32, 64, |_| 0);
+        let outcome = admit_deferred_requests(
+            deferred,
+            &active,
+            16,
+            1000,
+            1000,
+            32,
+            64,
+            DEFAULT_MAX_PREFILL_TOKENS,
+            |_| 0,
+        );
 
         let pending_ids = outcome
             .pending
@@ -1314,6 +1353,7 @@ mod tests {
             1024,
             usize::MAX,
             64,
+            DEFAULT_MAX_PREFILL_TOKENS,
             |_| 0,
         );
 
@@ -1330,10 +1370,59 @@ mod tests {
     }
 
     #[test]
+    fn prefill_token_budget_caps_batching_but_never_starves_one_request() {
+        let active: [ActiveRequestState; 0] = [];
+        let mk = |id: u64, prompt_len, max_tokens| {
+            PendingRequest::from_scheduler_request(RequestId(id), request(prompt_len, max_tokens).0)
+        };
+
+        // A first request larger than the whole budget is still admitted alone —
+        // otherwise it would be deferred forever.
+        let oversized = admit_deferred_requests(
+            vec![mk(1, 64, 1), mk(2, 16, 1)],
+            &active,
+            16,
+            1024,
+            1024,
+            usize::MAX,
+            64,
+            32,
+            |_| 0,
+        );
+        assert_eq!(oversized.pending.len(), 1);
+        assert_eq!(
+            oversized.deferred[0].request_id,
+            RequestId(2),
+            "follow-up waits for the next step once the budget is blown"
+        );
+
+        // Requests batch until the budget is filled exactly; overflow defers,
+        // never rejects.
+        let batched = admit_deferred_requests(
+            vec![mk(3, 16, 1), mk(4, 16, 1), mk(5, 16, 1)],
+            &active,
+            16,
+            1024,
+            1024,
+            usize::MAX,
+            64,
+            32,
+            |_| 0,
+        );
+        assert_eq!(
+            batched.pending.len(),
+            2,
+            "16 + 16 fills the 32-token budget"
+        );
+        assert_eq!(batched.deferred[0].request_id, RequestId(5));
+        assert!(batched.rejected.is_empty());
+    }
+
+    #[test]
     fn one_token_completion_on_page_boundary_fits_one_page() {
         let dropped = Arc::new(Mutex::new(Vec::new()));
         let executor = FakeExecutor::new(1, Arc::clone(&dropped));
-        let handle = start_with_executor(executor, 42);
+        let handle = start_with_executor(executor, 42, DEFAULT_MAX_PREFILL_TOKENS);
 
         let (fits_exactly, mut rx) = request(16, 1);
         handle.submit(fits_exactly).expect("submit fits_exactly");
@@ -1366,6 +1455,7 @@ mod tests {
             2,
             usize::MAX,
             64,
+            DEFAULT_MAX_PREFILL_TOKENS,
             |_| 0,
         );
         assert!(
@@ -1386,6 +1476,7 @@ mod tests {
             3,
             usize::MAX,
             64,
+            DEFAULT_MAX_PREFILL_TOKENS,
             |_| 0,
         );
         assert_eq!(
@@ -1480,7 +1571,7 @@ mod tests {
     fn request_waits_for_full_kv_budget_before_prefill() {
         let dropped = Arc::new(Mutex::new(Vec::new()));
         let executor = FakeExecutor::new(4, Arc::clone(&dropped));
-        let handle = start_with_executor(executor, 42);
+        let handle = start_with_executor(executor, 42, DEFAULT_MAX_PREFILL_TOKENS);
 
         let (long_running, mut long_rx) = request(16, 18);
         handle.submit(long_running).expect("submit long_running");
@@ -1595,7 +1686,7 @@ mod tests {
     fn impossible_request_is_rejected_without_blocking_later_work() {
         let dropped = Arc::new(Mutex::new(Vec::new()));
         let executor = FakeExecutor::new(2, Arc::clone(&dropped));
-        let handle = start_with_executor(executor, 42);
+        let handle = start_with_executor(executor, 42, DEFAULT_MAX_PREFILL_TOKENS);
 
         let (too_large, mut too_large_rx) = request(16, 34);
         handle.submit(too_large).expect("submit too_large");
@@ -1631,7 +1722,7 @@ mod tests {
         let dropped = Arc::new(Mutex::new(Vec::new()));
         // max_positional_encoding_tokens = 32
         let executor = FakeExecutor::new(1000, Arc::clone(&dropped)).with_max_context_tokens(32);
-        let handle = start_with_executor(executor, 42);
+        let handle = start_with_executor(executor, 42, DEFAULT_MAX_PREFILL_TOKENS);
 
         // prompt=16, max_new=100
         let (too_long, mut too_long_rx) = request(16, 100);
@@ -1738,7 +1829,7 @@ mod tests {
     fn unknown_lora_request_is_rejected_without_blocking_base_request() {
         let dropped = Arc::new(Mutex::new(Vec::new()));
         let executor = FakeExecutor::new(4, Arc::clone(&dropped));
-        let handle = start_with_executor(executor, 42);
+        let handle = start_with_executor(executor, 42, DEFAULT_MAX_PREFILL_TOKENS);
 
         let (unknown, mut unknown_rx) = request_with_lora(16, 1, Some("missing-adapter"));
         let (base, mut base_rx) = request_with_lora(16, 1, None);
@@ -1775,7 +1866,7 @@ mod tests {
     fn decode_error_drops_request_state_and_scheduler_recovers() {
         let dropped = Arc::new(Mutex::new(Vec::new()));
         let executor = FakeExecutor::new(4, Arc::clone(&dropped)).with_decode_failure();
-        let handle = start_with_executor(executor, 42);
+        let handle = start_with_executor(executor, 42, DEFAULT_MAX_PREFILL_TOKENS);
 
         let (will_fail, mut fail_rx) = request(16, 2);
         handle.submit(will_fail).expect("submit will_fail");
@@ -1825,7 +1916,7 @@ mod tests {
     fn active_receiver_drop_releases_request_state() {
         let dropped = Arc::new(Mutex::new(Vec::new()));
         let executor = FakeExecutor::new(4, Arc::clone(&dropped));
-        let handle = start_with_executor(executor, 42);
+        let handle = start_with_executor(executor, 42, DEFAULT_MAX_PREFILL_TOKENS);
 
         let (will_disconnect, mut token_rx) = request(16, 3);
         handle
@@ -1918,7 +2009,8 @@ mod tests {
     fn lora_control_reports_unimplemented_when_idle() {
         let dropped = Arc::new(Mutex::new(Vec::new()));
         let executor = FakeExecutor::new(4, Arc::clone(&dropped));
-        let handle = start_with_executor_with_lora_control(executor, 42);
+        let handle =
+            start_with_executor_with_lora_control(executor, 42, DEFAULT_MAX_PREFILL_TOKENS);
 
         let error = tokio::runtime::Builder::new_current_thread()
             .build()
@@ -1944,7 +2036,8 @@ mod tests {
         let dropped = Arc::new(Mutex::new(Vec::new()));
         let executor =
             FakeExecutor::new(4, Arc::clone(&dropped)).with_lora_adapters(&["adapter-a"]);
-        let handle = start_with_executor_with_lora_control(executor, 42);
+        let handle =
+            start_with_executor_with_lora_control(executor, 42, DEFAULT_MAX_PREFILL_TOKENS);
 
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
@@ -1968,7 +2061,8 @@ mod tests {
         let dropped = Arc::new(Mutex::new(Vec::new()));
         let executor =
             FakeExecutor::new(4, Arc::clone(&dropped)).with_decode_delay(Duration::from_millis(80));
-        let handle = start_with_executor_with_lora_control(executor, 42);
+        let handle =
+            start_with_executor_with_lora_control(executor, 42, DEFAULT_MAX_PREFILL_TOKENS);
 
         let (long_running, mut token_rx) = request(16, 3);
         handle.submit(long_running).expect("submit long_running");

--- a/openinfer-qwen3-4b/tests/lora_smoke.rs
+++ b/openinfer-qwen3-4b/tests/lora_smoke.rs
@@ -230,6 +230,7 @@ fn qwen3_lora_loads_rank_and_generates(rank: usize, adapter_name: &str) {
         openinfer_qwen3_4b::Qwen3LoraOptions::default(),
         openinfer_qwen3_4b::Qwen3OffloadOptions::disabled(),
         false,
+        openinfer_qwen3_4b::DEFAULT_MAX_PREFILL_TOKENS,
     )
     .expect("start LoRA-capable Qwen3 engine");
 

--- a/openinfer-server/src/main.rs
+++ b/openinfer-server/src/main.rs
@@ -93,6 +93,13 @@ struct Args {
     /// prefix is restored from the host tier — for measuring the L2 TTFT win.
     #[arg(long, default_value_t = false)]
     no_prefix_cache: bool,
+
+    /// Cap on total prompt tokens batch-prefilled in one Qwen3 scheduler step.
+    /// Prefill activation scratch scales with the step's prompt tokens, so this
+    /// bounds peak VRAM under request bursts. A single request longer than the
+    /// cap is still admitted alone.
+    #[arg(long, default_value_t = openinfer_qwen3_4b::DEFAULT_MAX_PREFILL_TOKENS)]
+    max_prefill_tokens: usize,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -250,6 +257,7 @@ async fn main() -> anyhow::Result<()> {
                     lora_options,
                     offload,
                     args.no_prefix_cache,
+                    args.max_prefill_tokens,
                 )
             } else {
                 openinfer_qwen3_4b::start_engine_with_offload(
@@ -257,6 +265,7 @@ async fn main() -> anyhow::Result<()> {
                     options,
                     offload,
                     args.no_prefix_cache,
+                    args.max_prefill_tokens,
                 )
             }
             .context("failed to start Qwen3 engine")?;


### PR DESCRIPTION
Follow-up to #338, which pinned openinfer's saturated throughput on the bs=64 decode cap (implied decode concurrency sat at exactly 62 in every overloaded run while vLLM grew past 128).

## Changes

1. **`BATCH_BUCKETS` extended to 256** with vLLM's capture granularity (`[1,2,4,8]` then every 8). The largest bucket is also the scheduler's decode-batch cap, so this raises max decode concurrency 64 → 256. Graphs capture lazily and activation buffers are shared (sized once at the largest bucket), so the cost is first-hit capture latency per bucket — measured ~50 MiB total VRAM growth through bucket 128, no startup-time change.
2. **Per-step prefill token budget, exposed as `--max-prefill-tokens` (default 8192)**. Found while validating: the scheduler batch-prefills *every* pending request in one forward pass, and prefill activation scratch scales with the step's total prompt tokens (~22 KB/token measured). The old 64-cap incidentally bounded this; at cap 256 a 300-request burst admits ~126 × 1024-token prefills in one step (~3 GB transient) and **OOMs mid-serving** (every in-flight request fails). Same class of bug qwen35 fixed in #333. With the budget, the burst that previously failed 300/300 now completes 300/300 with VRAM steady at 29.1 GB. A single request is always admitted regardless of prompt length — only batching beyond one request is capped, so the budget defers, never rejects.

## Validation (RTX 5090, TP1, Qwen3-4B, same harness as #338: `vllm bench serve`, random 1024/128, seed 42)

- `hf_golden_gate` green (bs=1 / batched eager / CUDA-graph replay).
- Warm prefix-cache-hit TTFT unchanged (spot check 1k: 10.5 ms, 16k: 30.5 ms vs 30.3 baseline).
- QPS 1–10: identical to the bucket-64 baseline within noise.
- Admission budget covered by unit tests (caps batching, admits a single oversized request alone, defers instead of rejecting).

Overload region (out tok/s, TPOT p50):

| Load | bucket-64 (main) | this PR | vLLM 0.22.1 |
|------|------------------|---------|-------------|
| QPS 12 | 1415, 44.2 ms | **1325, 89.8 ms (regression)** | 1501, 19.4 ms |
| QPS 16 | 1511, 41.1 ms | 1465, 80.1 ms | 1690, 76.2 ms |
| QPS 20 | — (capped) | 1647, 69.6 ms | — |
| inf burst ×300 | ~1520 ceiling | **1805** | 1750 |

**Honest reading**: the cap removal raises the hard throughput ceiling past vLLM (+3% at inf burst, 1805 vs 1750) and fixes a crash, but the moderate-overload band regresses — the decode step does not scale past bs≈64 (44 ms @ 64 → 90 ms @ ~126, ~2× step time for ~2× batch ⇒ flat aggregate). Per-stream TPOT in deep overload is now in vLLM's ballpark (69–80 ms vs 76 ms at similar concurrency); the remaining gap is queue drain policy.

## Follow-ups

- #345 tracks the decode-step scaling wall (nsys diff at fixed batch sizes) and the overload admission policy question.

Raw JSONs on the 5090 host under `/data/xingming/bench/20260611-qwen3-b256/` (sweep, burst ×2 engines, warm-TTFT spot check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
