### PR TITLE
fix(kv-cache): route the lifecycle test through the pool() accessors

### DIFF
--- a/openinfer-kv-cache/tests/lifecycle.rs
+++ b/openinfer-kv-cache/tests/lifecycle.rs
@@ -11,16 +11,17 @@ fn make_manager(num_blocks: usize) -> KvCacheManager {
 fn single_request_prefill_decode_release() {
     let mgr = make_manager(32);
     // 1 block reserved for padding
-    assert_eq!(mgr.total_blocks(), 32);
-    let initial_avail = mgr.available_blocks();
+    assert_eq!(mgr.pool().total_blocks(), 32);
+    let initial_avail = mgr.pool().available_blocks();
     assert_eq!(initial_avail, 31); // 32 - 1 padding
 
     // New request: 10-token prompt, up to 6 output tokens
-    let mut req = mgr.new_request(vec![1; 10], 6, None);
+    let mut req = mgr.pool().new_request(vec![1; 10], 6, None);
     assert_eq!(req.kv_position(), 0);
 
     // Schedule prefill for 10 tokens → needs 1 block (ceil(10/16))
-    req.schedule_prefill(10, &mgr).expect("schedule_prefill");
+    req.schedule_prefill(10, mgr.pool())
+        .expect("schedule_prefill");
     let view = req.prefill_view(10);
     assert_eq!(view.seq_len(), 10);
     assert_eq!(view.num_pages(), 1);
@@ -28,16 +29,16 @@ fn single_request_prefill_decode_release() {
     view.ensure_capacity(10).expect("capacity check");
 
     // Apply prefill (first generated token = 42)
-    req.apply_prefill(42, &mgr).expect("apply_prefill");
+    req.apply_prefill(42, mgr.pool()).expect("apply_prefill");
     assert_eq!(req.kv_position(), 10);
     assert_eq!(req.generated_tokens(), 1);
 
     // Decode loop: 5 more tokens (total 6 output = max)
     for i in 0..5 {
-        req.schedule_decode(&mgr).expect("schedule_decode");
+        req.schedule_decode(mgr.pool()).expect("schedule_decode");
         let view = req.decode_view();
         assert_eq!(view.seq_len(), 10 + 1 + i); // prompt + generated so far + 1 new
-        req.apply_decode(100 + i as u32, &mgr)
+        req.apply_decode(100 + i as u32, mgr.pool())
             .expect("apply_decode");
     }
 
@@ -46,34 +47,36 @@ fn single_request_prefill_decode_release() {
 
     // Release → blocks return to pool
     req.release().expect("release");
-    assert_eq!(mgr.available_blocks(), initial_avail);
+    assert_eq!(mgr.pool().available_blocks(), initial_avail);
 }
 
 #[test]
 fn multiple_requests_share_capacity() {
     let mgr = make_manager(10); // 10 blocks, 1 padding → 9 usable
-    assert_eq!(mgr.available_blocks(), 9);
+    assert_eq!(mgr.pool().available_blocks(), 9);
 
     // Request A: 16 tokens prompt → 1 block, max 16 output → needs ceil(31/16)=2 blocks total
-    let mut a = mgr.new_request(vec![1; 16], 16, None);
-    a.schedule_prefill(16, &mgr).expect("a prefill schedule");
-    a.apply_prefill(42, &mgr).expect("a prefill apply");
+    let mut a = mgr.pool().new_request(vec![1; 16], 16, None);
+    a.schedule_prefill(16, mgr.pool())
+        .expect("a prefill schedule");
+    a.apply_prefill(42, mgr.pool()).expect("a prefill apply");
 
-    let after_a = mgr.available_blocks();
+    let after_a = mgr.pool().available_blocks();
     assert!(after_a < 9);
 
     // Request B: 16 tokens prompt → 1 block
-    let mut b = mgr.new_request(vec![2; 16], 1, None);
-    b.schedule_prefill(16, &mgr).expect("b prefill schedule");
-    b.apply_prefill(43, &mgr).expect("b prefill apply");
+    let mut b = mgr.pool().new_request(vec![2; 16], 1, None);
+    b.schedule_prefill(16, mgr.pool())
+        .expect("b prefill schedule");
+    b.apply_prefill(43, mgr.pool()).expect("b prefill apply");
 
-    let after_b = mgr.available_blocks();
+    let after_b = mgr.pool().available_blocks();
     assert!(after_b < after_a);
 
     // Release both → all blocks back
     a.release().expect("a release");
     b.release().expect("b release");
-    assert_eq!(mgr.available_blocks(), 9);
+    assert_eq!(mgr.pool().available_blocks(), 9);
 }
 
 #[test]
@@ -82,33 +85,35 @@ fn page_boundary_crossing() {
 
     // Prompt exactly 16 tokens (fills block 0 exactly), then decode
     // 1 token which should cross into block 1.
-    let mut req = mgr.new_request(vec![1; 16], 2, None);
-    req.schedule_prefill(16, &mgr).expect("schedule_prefill");
+    let mut req = mgr.pool().new_request(vec![1; 16], 2, None);
+    req.schedule_prefill(16, mgr.pool())
+        .expect("schedule_prefill");
 
     let view = req.prefill_view(16);
     assert_eq!(view.num_pages(), 1);
     assert_eq!(view.last_page_len(), 16); // full page
 
-    req.apply_prefill(42, &mgr).expect("apply_prefill");
+    req.apply_prefill(42, mgr.pool()).expect("apply_prefill");
 
     // First decode: token 42 is "dangling" (not yet in KV). schedule_decode
     // will allocate a new block for it.
-    req.schedule_decode(&mgr).expect("schedule_decode");
+    req.schedule_decode(mgr.pool()).expect("schedule_decode");
     let view = req.decode_view();
     assert_eq!(view.seq_len(), 17); // 16 prompt + 1 decode
     assert_eq!(view.num_pages(), 2); // crossed page boundary
     assert_eq!(view.last_page_len(), 1); // 1 token in new page
 
-    req.apply_decode(43, &mgr).expect("apply_decode");
+    req.apply_decode(43, mgr.pool()).expect("apply_decode");
     req.release().expect("release");
 }
 
 #[test]
 fn kv_view_desc_has_correct_layout() {
     let mgr = make_manager(10);
-    let mut req = mgr.new_request(vec![1; 5], 1, None);
+    let mut req = mgr.pool().new_request(vec![1; 5], 1, None);
 
-    req.schedule_prefill(5, &mgr).expect("schedule_prefill");
+    req.schedule_prefill(5, mgr.pool())
+        .expect("schedule_prefill");
     let view = req.prefill_view(5);
     let desc = view.desc(mgr.buffer());
 
@@ -120,21 +125,21 @@ fn kv_view_desc_has_correct_layout() {
     assert!(!desc.buffer().is_empty());
     assert_eq!(desc.page_indices().len(), 1);
 
-    req.apply_prefill(42, &mgr).expect("apply_prefill");
+    req.apply_prefill(42, mgr.pool()).expect("apply_prefill");
     req.release().expect("release");
 }
 
 #[test]
 fn padding_block_id_is_stable() {
     let mgr = make_manager(10);
-    let pid = mgr.padding_block_id();
+    let pid = mgr.pool().padding_block_id();
     assert!(pid >= 0);
     // Allocate and release — padding ID must not change.
-    let mut req = mgr.new_request(vec![1; 8], 1, None);
-    req.schedule_prefill(8, &mgr).unwrap();
-    req.apply_prefill(1, &mgr).unwrap();
+    let mut req = mgr.pool().new_request(vec![1; 8], 1, None);
+    req.schedule_prefill(8, mgr.pool()).unwrap();
+    req.apply_prefill(1, mgr.pool()).unwrap();
     req.release().unwrap();
-    assert_eq!(mgr.padding_block_id(), pid);
+    assert_eq!(mgr.pool().padding_block_id(), pid);
 }
 
 #[test]
@@ -144,24 +149,24 @@ fn exhaust_capacity_returns_error() {
     // Each request with 16-token prompt needs 1 block.
     let mut reqs: Vec<_> = (0..3)
         .map(|_| {
-            let mut r = mgr.new_request(vec![1; 16], 1, None);
-            r.schedule_prefill(16, &mgr).expect("schedule");
-            r.apply_prefill(42, &mgr).expect("apply");
+            let mut r = mgr.pool().new_request(vec![1; 16], 1, None);
+            r.schedule_prefill(16, mgr.pool()).expect("schedule");
+            r.apply_prefill(42, mgr.pool()).expect("apply");
             r
         })
         .collect();
 
-    assert_eq!(mgr.available_blocks(), 0);
+    assert_eq!(mgr.pool().available_blocks(), 0);
 
     // Next request should fail to schedule.
-    let mut overflow = mgr.new_request(vec![1; 16], 1, None);
-    let result = overflow.schedule_prefill(16, &mgr);
+    let mut overflow = mgr.pool().new_request(vec![1; 16], 1, None);
+    let result = overflow.schedule_prefill(16, mgr.pool());
     assert!(result.is_err(), "should fail when no blocks available");
 
     for r in &mut reqs {
         r.release().unwrap();
     }
-    assert_eq!(mgr.available_blocks(), 3);
+    assert_eq!(mgr.pool().available_blocks(), 3);
 }
 
 /// Schedule allocates blocks, but if we never apply (e.g. forward
@@ -169,17 +174,22 @@ fn exhaust_capacity_returns_error() {
 #[test]
 fn schedule_without_apply_returns_blocks_on_drop() {
     let mgr = make_manager(10); // 9 usable
-    let before = mgr.available_blocks();
+    let before = mgr.pool().available_blocks();
 
     {
-        let mut req = mgr.new_request(vec![1; 32], 1, None);
+        let mut req = mgr.pool().new_request(vec![1; 32], 1, None);
         // 32 tokens → ceil(32/16) = 2 blocks scheduled
-        req.schedule_prefill(32, &mgr).expect("schedule_prefill");
-        assert!(mgr.available_blocks() < before);
+        req.schedule_prefill(32, mgr.pool())
+            .expect("schedule_prefill");
+        assert!(mgr.pool().available_blocks() < before);
         // No apply_prefill — simulate forward failure. Drop req here.
     }
 
-    assert_eq!(mgr.available_blocks(), before, "blocks must return on drop");
+    assert_eq!(
+        mgr.pool().available_blocks(),
+        before,
+        "blocks must return on drop"
+    );
 }
 
 /// ensure_capacity on a view should fail if the view doesn't have
@@ -187,9 +197,10 @@ fn schedule_without_apply_returns_blocks_on_drop() {
 #[test]
 fn ensure_capacity_rejects_insufficient_pages() {
     let mgr = make_manager(10);
-    let mut req = mgr.new_request(vec![1; 8], 1, None);
+    let mut req = mgr.pool().new_request(vec![1; 8], 1, None);
 
-    req.schedule_prefill(8, &mgr).expect("schedule_prefill");
+    req.schedule_prefill(8, mgr.pool())
+        .expect("schedule_prefill");
     let view = req.prefill_view(8);
 
     // View has 1 page (ceil(8/16)). Asking for 17 tokens needs 2 pages.
@@ -202,7 +213,7 @@ fn ensure_capacity_rejects_insufficient_pages() {
     // 16 tokens still fits in 1 page.
     view.ensure_capacity(16).expect("16 tokens fits 1 page");
 
-    req.apply_prefill(42, &mgr).unwrap();
+    req.apply_prefill(42, mgr.pool()).unwrap();
     req.release().unwrap();
 }
 
@@ -210,21 +221,21 @@ fn ensure_capacity_rejects_insufficient_pages() {
 #[test]
 fn decode_view_seq_len_invariant() {
     let mgr = make_manager(10);
-    let mut req = mgr.new_request(vec![1; 10], 4, None);
+    let mut req = mgr.pool().new_request(vec![1; 10], 4, None);
 
-    req.schedule_prefill(10, &mgr).unwrap();
-    req.apply_prefill(42, &mgr).unwrap();
+    req.schedule_prefill(10, mgr.pool()).unwrap();
+    req.apply_prefill(42, mgr.pool()).unwrap();
     assert_eq!(req.kv_position(), 10);
 
     for i in 0..3 {
-        req.schedule_decode(&mgr).unwrap();
+        req.schedule_decode(mgr.pool()).unwrap();
         let view = req.decode_view();
         assert_eq!(
             view.seq_len(),
             req.kv_position() + 1,
             "decode_view seq_len must be kv_position + 1 (iteration {i})"
         );
-        req.apply_decode(100 + i, &mgr).unwrap();
+        req.apply_decode(100 + i, mgr.pool()).unwrap();
     }
 
     req.release().unwrap();
@@ -235,9 +246,9 @@ fn decode_view_seq_len_invariant() {
 #[test]
 fn prefill_view_covers_target_seq_len() {
     let mgr = make_manager(10);
-    let mut req = mgr.new_request(vec![1; 20], 1, None);
+    let mut req = mgr.pool().new_request(vec![1; 20], 1, None);
 
-    req.schedule_prefill(20, &mgr).unwrap();
+    req.schedule_prefill(20, mgr.pool()).unwrap();
     let view = req.prefill_view(20);
 
     // seq_len = 0 (initial kv_position) + 20
@@ -248,7 +259,7 @@ fn prefill_view_covers_target_seq_len() {
     view.ensure_capacity(20)
         .expect("20 tokens must fit in 2 pages");
 
-    req.apply_prefill(42, &mgr).unwrap();
+    req.apply_prefill(42, mgr.pool()).unwrap();
     req.release().unwrap();
 }
 
@@ -259,29 +270,30 @@ fn lora_salt_isolates_prefix_cache() {
 
     // Register the prompt's blocks under adapter "a"; release leaves them
     // in the inactive pool, still matchable.
-    let mut a = mgr.new_request(prompt.clone(), 4, Some("a"));
-    a.schedule_prefill(48, &mgr).expect("a prefill schedule");
-    a.apply_prefill(42, &mgr).expect("a prefill apply");
+    let mut a = mgr.pool().new_request(prompt.clone(), 4, Some("a"));
+    a.schedule_prefill(48, mgr.pool())
+        .expect("a prefill schedule");
+    a.apply_prefill(42, mgr.pool()).expect("a prefill apply");
     a.release().expect("a release");
 
     // Base model (no adapter): same tokens, different salt — zero hits.
-    let mut base = mgr.new_request(prompt.clone(), 4, None);
+    let mut base = mgr.pool().new_request(prompt.clone(), 4, None);
     assert_eq!(
-        base.match_and_add_prefix(&mgr).expect("base match"),
+        base.match_and_add_prefix(mgr.pool()).expect("base match"),
         0,
         "base request must not reuse KV computed under adapter 'a'"
     );
 
     // Different adapter: same tokens — zero hits.
-    let mut b = mgr.new_request(prompt.clone(), 4, Some("b"));
+    let mut b = mgr.pool().new_request(prompt.clone(), 4, Some("b"));
     assert_eq!(
-        b.match_and_add_prefix(&mgr).expect("b match"),
+        b.match_and_add_prefix(mgr.pool()).expect("b match"),
         0,
         "adapter 'b' must not reuse KV computed under adapter 'a'"
     );
 
     // Same adapter: hits, capped to leave the last block for prefill
     // ((48-1)/16 = 2 blocks = 32 tokens).
-    let mut a2 = mgr.new_request(prompt, 4, Some("a"));
-    assert_eq!(a2.match_and_add_prefix(&mgr).expect("a2 match"), 32);
+    let mut a2 = mgr.pool().new_request(prompt, 4, Some("a"));
+    assert_eq!(a2.match_and_add_prefix(mgr.pool()).expect("a2 match"), 32);
 }


### PR DESCRIPTION
## Description

`tests/lifecycle.rs` still calls the block accessors on `KvCacheManager` directly (`mgr.total_blocks()`, `mgr.new_request(...)`, `req.schedule_prefill(.., &mgr)`), but since #292 these live on `KvPool` behind the `pool()` accessor — a typo-class drift: every production call site already uses `mgr.pool().xxx()`. The test target fails to compile (30x E0599).

## Before

Repro:

```bash
cargo check -p openinfer-kv-cache --tests
```

<details>

<summary>Error log</summary>

```text
error[E0599]: no method named `total_blocks` found for struct `KvCacheManager` in the current scope
  --> openinfer-kv-cache/tests/lifecycle.rs:14:20
   |
14 |     assert_eq!(mgr.total_blocks(), 32);
   |                    ^^^^^^^^^^^^ method not found in `KvCacheManager`

error[E0599]: no method named `new_request` found for struct `KvCacheManager` in the current scope
  --> openinfer-kv-cache/tests/lifecycle.rs:19:23
   |
19 |     let mut req = mgr.new_request(vec![1; 10], 6, None);
   |                       ^^^^^^^^^^^ method not found in `KvCacheManager`

......

```

</details>

## After

- `cargo check -p openinfer-kv-cache --tests` compiles clean.
- `cargo test -p openinfer-kv-cache --test lifecycle` test result: ok. 11 passed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project (see `docs/conventions/coding-style.md`).
- [x] I have performed a self-review of my own code.
- [x] I have formatted my commits according to Commitizen conventions.
- [x] I have run the local test suite and all tests pass (see `CLAUDE.md`).
