### PR TITLE
docs: refresh README architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,19 +175,68 @@ Sampling and logprob support is model-dependent. Qwen models support the samplin
 
 ## Architecture
 
-```
-HTTP / vLLM frontend → EngineHandle → per-model engine crate
-                                  │
-          ┌───────────────────────┼───────────────────────┐
-          │                       │                       │
-openinfer-qwen3-4b      openinfer-qwen35-4b     openinfer-deepseek-v4
-  (full attention)      (24 linear + 8 full)    (MP8 MoE + sparse attn)
-          │                       │                       │
-          └───────────────────────┼───────────────────────┘
-                                  │
-                  openinfer-core runtime + openinfer-kernels
-                                  │
-                  CUDA / cuBLAS / Triton / TileLang / FlashInfer
+```mermaid
+flowchart TB
+    api["HTTP / OpenAI-compatible /v1/completions"]
+    frontend["openinfer-server<br/>openinfer-vllm-frontend"]
+    runtime["EngineHandle<br/>openinfer-core shared runtime"]
+
+    api --> frontend
+    frontend --> runtime
+
+    subgraph engines["Per-model engine crates"]
+        direction LR
+        qwen3["openinfer-qwen3-4b<br/>full attention"]
+        qwen35["openinfer-qwen35-4b<br/>24 linear + 8 full attention"]
+        dsv2["openinfer-deepseek-v2-lite<br/>MoE + EP"]
+        dsv4["openinfer-deepseek-v4<br/>MoE + compressor + indexer"]
+        kimi["openinfer-kimi-k2<br/>MLA + MoE + Marlin INT4"]
+    end
+
+    runtime --> qwen3
+    runtime --> qwen35
+    runtime --> dsv2
+    runtime --> dsv4
+    runtime --> kimi
+
+    subgraph shared["Shared kernels and KV management"]
+        direction LR
+        kernels["openinfer-kernels"]
+        kvbm["kvbm/*<br/>dynamo-memory / kvbm-logical / kvbm-kernels"]
+    end
+
+    qwen3 --> kernels
+    qwen35 --> kernels
+    dsv2 --> kernels
+    dsv4 --> kernels
+    kimi --> kernels
+
+    qwen3 --> kvbm
+    qwen35 --> kvbm
+    dsv2 --> kvbm
+    dsv4 --> kvbm
+    kimi --> kvbm
+
+    subgraph backends["Backend libraries and communication"]
+        direction LR
+        cuda["CUDA"]
+        cublas["cuBLAS"]
+        triton["Triton AOT"]
+        tilelang["TileLang"]
+        flashinfer["FlashInfer"]
+        nccl["NCCL"]
+        comm["openinfer-comm<br/>PPLX all-to-all"]
+    end
+
+    kernels --> cuda
+    kernels --> cublas
+    kernels --> triton
+    kernels --> tilelang
+    kernels --> flashinfer
+    dsv2 --> comm
+    dsv4 --> comm
+    kimi --> comm
+    comm --> nccl
 ```
 
 **Key design decisions:**

--- a/README.md
+++ b/README.md
@@ -212,9 +212,6 @@ flowchart TB
     kimi --> kernels
 
     qwen3 --> kvbm
-    qwen35 --> kvbm
-    dsv2 --> kvbm
-    dsv4 --> kvbm
     kimi --> kvbm
 
     subgraph backends["Backend libraries and communication"]
@@ -225,7 +222,8 @@ flowchart TB
         tilelang["TileLang"]
         flashinfer["FlashInfer"]
         nccl["NCCL"]
-        comm["openinfer-comm<br/>PPLX all-to-all"]
+        deepep["DeepEP shim<br/>NCCL"]
+        comm["openinfer-comm<br/>optional pplx-ep PPLX all-to-all"]
     end
 
     kernels --> cuda
@@ -233,9 +231,11 @@ flowchart TB
     kernels --> triton
     kernels --> tilelang
     kernels --> flashinfer
-    dsv2 --> comm
-    dsv4 --> comm
-    kimi --> comm
+    dsv2 --> nccl
+    dsv4 --> nccl
+    kimi --> deepep
+    deepep --> nccl
+    dsv4 -.-> comm
     comm --> nccl
 ```
 


### PR DESCRIPTION
## Summary

Replaces the README "Architecture" ASCII diagram with a Mermaid diagram covering the current workspace: the OpenAI/vLLM HTTP frontend, the `EngineHandle`/`openinfer-core` shared runtime, all five model engine crates (`qwen3-4b`, `qwen35-4b`, `deepseek-v2-lite`, `deepseek-v4`, `kimi-k2`), the shared `openinfer-kernels` + kvbm KV-management layer, and the backend row (CUDA, cuBLAS, Triton AOT, TileLang, FlashInfer, NCCL/DeepEP, optional `openinfer-comm`/PPLX).

## Why this matters

#331 (split from the README rework tracker #122) asks for a refreshed architecture diagram so new users get a clear view of the system. The current ASCII diagram shows only three engines and omits Kimi-K2, DeepSeek-V2-Lite, the kvbm layer, and the EP communication backends that now exist in the workspace. Mermaid renders natively on GitHub, diffs cleanly, and avoids adding binary image assets.

Edges follow actual crate dependencies: only the engines that depend on `openinfer-kv-cache`/kvbm get the kvbm edge (Qwen3.5 has its own paged KV; the DeepSeek crates do not depend on it), and the comm node separates the default NCCL/DeepEP paths from the optional `pplx-ep` feature so readers do not install the wrong communication backend.

## Testing

Docs-only change. The Mermaid block parses and renders on GitHub's Markdown preview; layer names are byte-consistent with the workspace `Cargo.toml` members and the README Source Layout section.

Fixes #331
