### PR TITLE
fix(kv-cache): build prefill/decode views from exact step page rows

### DIFF
--- a/openinfer-kv-cache/src/pool.rs
+++ b/openinfer-kv-cache/src/pool.rs
@@ -290,16 +290,26 @@ impl RequestKv {
     ///
     /// `prompt_len` tokens will be appended starting at `kv_position()`.
     /// The view's seq_len = kv_position + prompt_len (post-advance state
-    /// that FlashInfer attention metadata expects).
+    /// that FlashInfer attention metadata expects). The page row is exact
+    /// (`step_page_indices`), never the raw block holdings — the raw list
+    /// can carry an eagerly-allocated next block the kernel must not see.
     pub fn prefill_view(&self, prompt_len: usize) -> KvView {
         let target_seq_len = self.seq.kv_position() + prompt_len;
-        KvView::new(self.page_indices(), target_seq_len, self.seq.block_size())
+        KvView::new(
+            self.step_page_indices(prompt_len),
+            target_seq_len,
+            self.seq.block_size(),
+        )
     }
 
-    /// Build an immutable `KvView` for decode (one new token).
+    /// Build an immutable `KvView` for decode (one new token). Same exact
+    /// page-row contract as `prefill_view`.
     pub fn decode_view(&self) -> KvView {
-        let target_seq_len = self.seq.kv_position() + 1;
-        KvView::new(self.page_indices(), target_seq_len, self.seq.block_size())
+        KvView::new(
+            self.step_page_indices(1),
+            self.seq.kv_position() + 1,
+            self.seq.block_size(),
+        )
     }
 
     // ── Apply (register blocks, advance position) ──────────────────────
@@ -475,7 +485,10 @@ mod tests {
     /// raw `page_indices()` exceeds `ceil(kv_tokens / block_size)` at every
     /// block boundary. `step_page_indices` must hand the forward pass an
     /// exact page row at every step — this deadlocked Kimi DP8 on H200 when
-    /// the raw list reached the worker's exact-match page-table check.
+    /// the raw list reached the worker's exact-match page-table check, and
+    /// made qwen3's FlashInfer metadata read one garbage page past the
+    /// sequence at every block boundary (#291). `prefill_view`/`decode_view`
+    /// must carry the same exact row.
     #[test]
     fn step_page_indices_exact_at_block_boundaries() {
         let mut raw_overshoots = 0usize;
@@ -489,6 +502,11 @@ mod tests {
                 prompt_len.div_ceil(16),
                 "prefill page row P={prompt_len}"
             );
+            assert_eq!(
+                kv.prefill_view(prompt_len).num_pages(),
+                prompt_len.div_ceil(16),
+                "prefill view P={prompt_len}"
+            );
             kv.apply_prefill(1000, &pool).unwrap();
             for step in 0..23u32 {
                 kv.schedule_decode(&pool).unwrap();
@@ -497,6 +515,17 @@ mod tests {
                     kv.step_page_indices(1).len(),
                     need,
                     "decode page row P={prompt_len} step={step}"
+                );
+                let view = kv.decode_view();
+                assert_eq!(
+                    view.num_pages(),
+                    need,
+                    "decode view P={prompt_len} step={step}"
+                );
+                assert_eq!(
+                    (view.num_pages() - 1) * 16 + view.last_page_len(),
+                    kv.kv_position() + 1,
+                    "kernel-derived length P={prompt_len} step={step}"
                 );
                 raw_overshoots += usize::from(kv.page_indices().len() > need);
                 kv.apply_decode(2000 + step, &pool).unwrap();

--- a/openinfer-kv-cache/src/view.rs
+++ b/openinfer-kv-cache/src/view.rs
@@ -16,7 +16,16 @@ pub struct KvView {
 }
 
 impl KvView {
+    /// `page_indices` must cover `seq_len` exactly: attention kernels derive
+    /// the sequence length as `(num_pages - 1) * page_size + last_page_len`,
+    /// so a surplus page makes them read garbage K/V past the sequence and a
+    /// missing page makes them read out of bounds (#291).
     pub fn new(page_indices: Vec<i32>, seq_len: usize, page_size: usize) -> Self {
+        assert_eq!(
+            page_indices.len(),
+            seq_len.div_ceil(page_size),
+            "KvView pages must exactly cover seq_len={seq_len} (page_size={page_size})"
+        );
         Self {
             page_indices,
             seq_len,
@@ -43,21 +52,6 @@ impl KvView {
 
     pub fn page_indices(&self) -> &[i32] {
         &self.page_indices
-    }
-
-    /// Verify pre-allocated capacity covers the requested token count.
-    pub fn ensure_capacity(&self, token_count: usize) -> anyhow::Result<()> {
-        let needed = token_count.div_ceil(self.page_size);
-        anyhow::ensure!(
-            needed <= self.page_indices.len(),
-            "KvView: need {needed} pages but only {} allocated",
-            self.page_indices.len(),
-        );
-        Ok(())
-    }
-
-    pub fn advance(&mut self, count: usize) {
-        self.seq_len += count;
     }
 
     pub fn desc<'a>(&'a self, buffer: &'a KvBuffer) -> KvViewDesc<'a> {

--- a/openinfer-kv-cache/tests/lifecycle.rs
+++ b/openinfer-kv-cache/tests/lifecycle.rs
@@ -26,7 +26,6 @@ fn single_request_prefill_decode_release() {
     assert_eq!(view.seq_len(), 10);
     assert_eq!(view.num_pages(), 1);
     assert_eq!(view.last_page_len(), 10);
-    view.ensure_capacity(10).expect("capacity check");
 
     // Apply prefill (first generated token = 42)
     req.apply_prefill(42, mgr.pool()).expect("apply_prefill");
@@ -192,31 +191,6 @@ fn schedule_without_apply_returns_blocks_on_drop() {
     );
 }
 
-/// ensure_capacity on a view should fail if the view doesn't have
-/// enough pages for the requested token count.
-#[test]
-fn ensure_capacity_rejects_insufficient_pages() {
-    let mgr = make_manager(10);
-    let mut req = mgr.pool().new_request(vec![1; 8], 1, None);
-
-    req.schedule_prefill(8, mgr.pool())
-        .expect("schedule_prefill");
-    let view = req.prefill_view(8);
-
-    // View has 1 page (ceil(8/16)). Asking for 17 tokens needs 2 pages.
-    let err = view.ensure_capacity(17);
-    assert!(
-        err.is_err(),
-        "should reject: 17 tokens needs 2 pages but view has 1"
-    );
-
-    // 16 tokens still fits in 1 page.
-    view.ensure_capacity(16).expect("16 tokens fits 1 page");
-
-    req.apply_prefill(42, mgr.pool()).unwrap();
-    req.release().unwrap();
-}
-
 /// decode_view must produce seq_len == kv_position + 1.
 #[test]
 fn decode_view_seq_len_invariant() {
@@ -255,9 +229,6 @@ fn prefill_view_covers_target_seq_len() {
     assert_eq!(view.seq_len(), 20);
     // 20 tokens → ceil(20/16) = 2 pages
     assert_eq!(view.num_pages(), 2);
-    // ensure_capacity must agree
-    view.ensure_capacity(20)
-        .expect("20 tokens must fit in 2 pages");
 
     req.apply_prefill(42, mgr.pool()).unwrap();
     req.release().unwrap();


### PR DESCRIPTION
Closes #291.

## Problem

kvbm's `schedule_decode` eagerly allocates the next generation block when the appended token fills the current one, so raw `page_indices()` carries one surplus page at every `seq_len ≡ 0 (mod 16)` decode step. qwen3 fed that raw list into its FlashInfer CSR page table while deriving `last_page_len` from `seq_len`, so the kernel derives `seq_len + 16` and attends over one page of garbage K/V every 16 decode steps — silent on a fresh pool (zero K/V lands below bf16 tolerance), wrong logits once blocks recycle. Kimi hit the same mechanism as a hard failure and was migrated to `step_page_indices()` in #292; qwen3 never was.

## Fix

- `prefill_view()`/`decode_view()` now build from `step_page_indices()` (exact `ceil(seq_len/page_size)` rows), fixing all three qwen3 page-table constructors at once.
- The pages==`ceil(seq_len/page_size)` invariant is encoded into `KvView::new` (assert), so a future raw-list caller traps at construction instead of reading garbage.
- `KvView::advance()` and `ensure_capacity()` deleted — zero production callers, and `advance` was exactly the API to recreate #291 from the other direction.
- Boundary-sweep test extended to assert view page counts and the kernel-derived length `(num_pages−1)·16 + last_page_len == seq_len`.

`prompt_len > 0` on the prefill path is guaranteed: `match_and_add_prefix` leaves ≥1 prompt token uncached (`max_blocks = (num_input−1)/block_size`).

## Verification

`cargo test --release -p openinfer-kv-cache` (12 tests), clippy, and the HF golden gate are green. Gate A/B (main vs this branch, RTX 5090) shows the fix is numerically visible: mean/p99 logprob delta vs HF tightened in all 7 passes (e.g. sequential bs=1: mean 0.0317→0.0300, p99 0.1196→0.1080; graph cached replay: 0.0324→0.0293 / 0.1251→0.1072), while positions never touched by the surplus page are bit-identical (worst delta @ seq7 pos5 unchanged) — the garbage page was systematically inflating the softmax denominator.

## Not covered

The #291 acceptance also asks for a recycled-block determinism IT (two sequential requests, ≥32-token decode, logits identical to a fresh-pool run). The constructor invariant now guards the mechanism; the IT can land separately if still wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)