### PR TITLE
feat(qwen3): report prefix-cache hits as cached_tokens in usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,6 +1620,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8072bec12b909b65aec01fa6518f387cfbf3427d4475409ad622898cd347522c"
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,6 +1671,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0359ee92f81184d7985519e474bda2a5738476334edd3746c9b1265c067afe70"
 dependencies = [
  "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4976,7 +5008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -4997,7 +5029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7551,13 +7583,14 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 [[package]]
 name = "vllm-chat"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=4aaed4ca225a3745aa1e18864dad0599d3ac7626#4aaed4ca225a3745aa1e18864dad0599d3ac7626"
+source = "git+https://github.com/vllm-project/vllm.git?rev=5d5591d99bb7b2ba695766a992dc328ca5867a4c#5d5591d99bb7b2ba695766a992dc328ca5867a4c"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
  "easy-ext",
  "futures",
  "half",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "llm-multimodal",
  "minijinja",
@@ -7586,7 +7619,7 @@ dependencies = [
 [[package]]
 name = "vllm-engine-core-client"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=4aaed4ca225a3745aa1e18864dad0599d3ac7626#4aaed4ca225a3745aa1e18864dad0599d3ac7626"
+source = "git+https://github.com/vllm-project/vllm.git?rev=5d5591d99bb7b2ba695766a992dc328ca5867a4c#5d5591d99bb7b2ba695766a992dc328ca5867a4c"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -7620,7 +7653,7 @@ dependencies = [
 [[package]]
 name = "vllm-llm"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=4aaed4ca225a3745aa1e18864dad0599d3ac7626#4aaed4ca225a3745aa1e18864dad0599d3ac7626"
+source = "git+https://github.com/vllm-project/vllm.git?rev=5d5591d99bb7b2ba695766a992dc328ca5867a4c#5d5591d99bb7b2ba695766a992dc328ca5867a4c"
 dependencies = [
  "easy-ext",
  "enum-as-inner",
@@ -7639,7 +7672,7 @@ dependencies = [
 [[package]]
 name = "vllm-metrics"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=4aaed4ca225a3745aa1e18864dad0599d3ac7626#4aaed4ca225a3745aa1e18864dad0599d3ac7626"
+source = "git+https://github.com/vllm-project/vllm.git?rev=5d5591d99bb7b2ba695766a992dc328ca5867a4c#5d5591d99bb7b2ba695766a992dc328ca5867a4c"
 dependencies = [
  "prometheus-client",
 ]
@@ -7647,7 +7680,7 @@ dependencies = [
 [[package]]
 name = "vllm-reasoning-parser"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=4aaed4ca225a3745aa1e18864dad0599d3ac7626#4aaed4ca225a3745aa1e18864dad0599d3ac7626"
+source = "git+https://github.com/vllm-project/vllm.git?rev=5d5591d99bb7b2ba695766a992dc328ca5867a4c#5d5591d99bb7b2ba695766a992dc328ca5867a4c"
 dependencies = [
  "thiserror 2.0.18",
  "vllm-tokenizer",
@@ -7656,11 +7689,12 @@ dependencies = [
 [[package]]
 name = "vllm-server"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=4aaed4ca225a3745aa1e18864dad0599d3ac7626#4aaed4ca225a3745aa1e18864dad0599d3ac7626"
+source = "git+https://github.com/vllm-project/vllm.git?rev=5d5591d99bb7b2ba695766a992dc328ca5867a4c#5d5591d99bb7b2ba695766a992dc328ca5867a4c"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
  "axum",
+ "educe",
  "futures",
  "http-body",
  "itertools 0.14.0",
@@ -7672,7 +7706,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "sha2 0.10.9",
  "socket2",
+ "subtle",
  "thiserror-ext",
  "tokio",
  "tokio-stream",
@@ -7696,7 +7732,7 @@ dependencies = [
 [[package]]
 name = "vllm-text"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=4aaed4ca225a3745aa1e18864dad0599d3ac7626#4aaed4ca225a3745aa1e18864dad0599d3ac7626"
+source = "git+https://github.com/vllm-project/vllm.git?rev=5d5591d99bb7b2ba695766a992dc328ca5867a4c#5d5591d99bb7b2ba695766a992dc328ca5867a4c"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
@@ -7720,7 +7756,7 @@ dependencies = [
 [[package]]
 name = "vllm-tokenizer"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=4aaed4ca225a3745aa1e18864dad0599d3ac7626#4aaed4ca225a3745aa1e18864dad0599d3ac7626"
+source = "git+https://github.com/vllm-project/vllm.git?rev=5d5591d99bb7b2ba695766a992dc328ca5867a4c#5d5591d99bb7b2ba695766a992dc328ca5867a4c"
 dependencies = [
  "base64 0.22.1",
  "fastokens",
@@ -7739,7 +7775,7 @@ dependencies = [
 [[package]]
 name = "vllm-tool-parser"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=4aaed4ca225a3745aa1e18864dad0599d3ac7626#4aaed4ca225a3745aa1e18864dad0599d3ac7626"
+source = "git+https://github.com/vllm-project/vllm.git?rev=5d5591d99bb7b2ba695766a992dc328ca5867a4c#5d5591d99bb7b2ba695766a992dc328ca5867a4c"
 dependencies = [
  "easy-ext",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,10 +173,10 @@ url = { version = "2.5", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 validator = { version = "0.20.0", features = ["derive"] }
 velo = "0.1.0"
-vllm-engine-core-client = { git = "https://github.com/vllm-project/vllm.git", rev = "4aaed4ca225a3745aa1e18864dad0599d3ac7626" }
-vllm-server = { git = "https://github.com/vllm-project/vllm.git", rev = "4aaed4ca225a3745aa1e18864dad0599d3ac7626" }
-vllm-text = { git = "https://github.com/vllm-project/vllm.git", rev = "4aaed4ca225a3745aa1e18864dad0599d3ac7626" }
-vllm-tokenizer = { git = "https://github.com/vllm-project/vllm.git", rev = "4aaed4ca225a3745aa1e18864dad0599d3ac7626" }
+vllm-engine-core-client = { git = "https://github.com/vllm-project/vllm.git", rev = "5d5591d99bb7b2ba695766a992dc328ca5867a4c" }
+vllm-server = { git = "https://github.com/vllm-project/vllm.git", rev = "5d5591d99bb7b2ba695766a992dc328ca5867a4c" }
+vllm-text = { git = "https://github.com/vllm-project/vllm.git", rev = "5d5591d99bb7b2ba695766a992dc328ca5867a4c" }
+vllm-tokenizer = { git = "https://github.com/vllm-project/vllm.git", rev = "5d5591d99bb7b2ba695766a992dc328ca5867a4c" }
 xxhash-rust = { version = "0.8", features = ["xxh3", "const_xxh3"] }
 zeromq = { version = "0.6.0", default-features = false, features = [
     "tokio-runtime",

--- a/openinfer-deepseek-v2-lite/src/engine.rs
+++ b/openinfer-deepseek-v2-lite/src/engine.rs
@@ -34,6 +34,7 @@ fn handle_request(generator: &mut DeepSeekV2LiteEp2Generator, req: &GenerateRequ
         queued_at_unix_s: req.queued_at_unix_s.unwrap_or(now),
         scheduled_at_unix_s: now,
         prompt_tokens,
+        cached_tokens: 0,
     });
     if req.echo {
         let _ = req.token_tx.send(TokenEvent::PromptTokens {

--- a/openinfer-deepseek-v4/src/direct/scheduler.rs
+++ b/openinfer-deepseek-v4/src/direct/scheduler.rs
@@ -1179,6 +1179,7 @@ fn handle_request(generator: &mut DeepSeekV4DirectGenerator, req: GenerateReques
         queued_at_unix_s,
         scheduled_at_unix_s,
         prompt_tokens: prompt_len,
+        cached_tokens: 0,
     });
     if req.echo {
         let _ = req.token_tx.send(TokenEvent::PromptTokens {
@@ -1356,6 +1357,7 @@ fn handle_request_wave(generator: &mut DeepSeekV4DirectGenerator, requests: Vec<
             queued_at_unix_s,
             scheduled_at_unix_s,
             prompt_tokens: prompt_len,
+            cached_tokens: 0,
         });
         if req.echo {
             let _ = req.token_tx.send(TokenEvent::PromptTokens {

--- a/openinfer-engine/src/engine.rs
+++ b/openinfer-engine/src/engine.rs
@@ -134,6 +134,9 @@ pub enum TokenEvent {
         queued_at_unix_s: f64,
         scheduled_at_unix_s: f64,
         prompt_tokens: usize,
+        /// Prompt tokens served from the prefix cache (0 when the engine has
+        /// no prefix cache or the value is not known at emit time).
+        cached_tokens: usize,
     },
     Token {
         id: u32,
@@ -158,6 +161,15 @@ pub enum TokenEvent {
         prompt_tokens: usize,
         completion_tokens: usize,
     },
+}
+
+/// Seconds since `UNIX_EPOCH` as `f64` — the clock base for `TokenEvent`
+/// timestamps.
+pub fn unix_now_s() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock is before UNIX_EPOCH")
+        .as_secs_f64()
 }
 
 #[derive(Clone)]

--- a/openinfer-kimi-k2/src/runner/scheduler/lifecycle.rs
+++ b/openinfer-kimi-k2/src/runner/scheduler/lifecycle.rs
@@ -1,6 +1,4 @@
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use openinfer_core::engine::{FinishReason, GenerateRequest, TokenEvent};
+use openinfer_core::engine::{FinishReason, GenerateRequest, TokenEvent, unix_now_s};
 
 use crate::runner::worker::KIMI_MAX_REQUEST_TOKENS;
 
@@ -95,6 +93,10 @@ pub(in crate::runner) fn send_scheduled(req: &GenerateRequest) {
         queued_at_unix_s: req.queued_at_unix_s.unwrap_or(scheduled_at),
         scheduled_at_unix_s: scheduled_at,
         prompt_tokens: req.prompt_tokens.len(),
+        // Emitted at admission, before the KV prefix match runs — the real
+        // hit count is not known yet (kimi prefix-cache usage reporting is a
+        // follow-up).
+        cached_tokens: 0,
     });
 }
 
@@ -149,11 +151,4 @@ fn validate_sampling_params(req: &GenerateRequest) -> Result<(), String> {
         ));
     }
     Ok(())
-}
-
-fn unix_now_s() -> f64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system clock is before UNIX_EPOCH")
-        .as_secs_f64()
 }

--- a/openinfer-qwen3-4b/src/scheduler.rs
+++ b/openinfer-qwen3-4b/src/scheduler.rs
@@ -54,6 +54,7 @@ pub(super) struct PendingRequest {
     pub(super) token_tx: mpsc::UnboundedSender<TokenEvent>,
     pub(super) logprobs: usize,
     pub(super) echo: bool,
+    pub(super) queued_at_unix_s: Option<f64>,
     /// Whether this request has already been offered to async KV prefetch.
     /// Offered at most once; a no-hit offer leaves the request in the normal
     /// admission flow with this set so it isn't re-probed every tick.
@@ -71,6 +72,7 @@ impl PendingRequest {
             token_tx: req.token_tx,
             logprobs: req.logprobs,
             echo: req.echo,
+            queued_at_unix_s: req.queued_at_unix_s,
             prefetch_offered: false,
         }
     }
@@ -874,6 +876,7 @@ mod tests {
 
     struct FakeExecutor {
         block_size: usize,
+        cached_tokens: usize,
         max_request_blocks: usize,
         max_context_tokens: usize,
         available_blocks: usize,
@@ -893,6 +896,7 @@ mod tests {
         fn new(max_request_blocks: usize, dropped: Arc<Mutex<Vec<u64>>>) -> Self {
             Self {
                 block_size: 16,
+                cached_tokens: 0,
                 max_request_blocks,
                 max_context_tokens: usize::MAX,
                 available_blocks: max_request_blocks,
@@ -907,6 +911,11 @@ mod tests {
                 prefill_lora_batches: Arc::new(Mutex::new(Vec::new())),
                 decode_lora_batches: Arc::new(Mutex::new(Vec::new())),
             }
+        }
+
+        fn with_cached_tokens(mut self, cached_tokens: usize) -> Self {
+            self.cached_tokens = cached_tokens;
+            self
         }
 
         fn with_decode_failure(mut self) -> Self {
@@ -1050,7 +1059,7 @@ mod tests {
                         first_token: 100 + req.request_id.get() as u32,
                         first_token_logprob: None,
                         prompt_logprobs: None,
-                        cached_tokens: 0,
+                        cached_tokens: self.cached_tokens,
                     })
                     .collect(),
             })
@@ -1148,7 +1157,7 @@ mod tests {
                         first_token: 100 + req.request_id.get() as u32,
                         first_token_logprob: None,
                         prompt_logprobs: None,
-                        cached_tokens: 0,
+                        cached_tokens: self.cached_tokens,
                     })
                     .collect(),
                 decode_requests: plan
@@ -1427,17 +1436,61 @@ mod tests {
         let (fits_exactly, mut rx) = request(16, 1);
         handle.submit(fits_exactly).expect("submit fits_exactly");
         assert!(
-            matches!(rx.blocking_recv(), Some(TokenEvent::Token { id: 100, .. })),
+            matches!(
+                recv_skipping_scheduled(&mut rx),
+                Some(TokenEvent::Token { id: 100, .. })
+            ),
             "prefill should emit the sampled token"
         );
         assert!(
-            matches!(rx.blocking_recv(), Some(TokenEvent::Finished { .. })),
+            matches!(
+                recv_skipping_scheduled(&mut rx),
+                Some(TokenEvent::Finished { .. })
+            ),
             "one-token completion should finish without a decode KV page"
         );
         assert!(
             dropped.lock().unwrap().contains(&0),
             "finished request should release its one prompt page"
         );
+    }
+
+    /// The engine stream opens with exactly one `Scheduled` event carrying
+    /// the executor-reported prefix-cache hit count (#246) — before any
+    /// token, and never again.
+    #[test]
+    fn scheduled_event_reports_cached_tokens_exactly_once() {
+        let dropped = Arc::new(Mutex::new(Vec::new()));
+        let executor = FakeExecutor::new(4, Arc::clone(&dropped)).with_cached_tokens(7);
+        let handle = start_with_executor(executor, 42, DEFAULT_MAX_PREFILL_TOKENS);
+
+        let (req, mut rx) = request(32, 2);
+        handle.submit(req).expect("submit");
+
+        match rx.blocking_recv() {
+            Some(TokenEvent::Scheduled {
+                prompt_tokens,
+                cached_tokens,
+                queued_at_unix_s,
+                scheduled_at_unix_s,
+            }) => {
+                assert_eq!(prompt_tokens, 32);
+                assert_eq!(cached_tokens, 7);
+                assert!(queued_at_unix_s <= scheduled_at_unix_s);
+            }
+            _ => panic!("first event must be Scheduled"),
+        }
+
+        loop {
+            match rx.blocking_recv() {
+                Some(TokenEvent::Scheduled { .. }) => {
+                    panic!("Scheduled must be emitted exactly once")
+                }
+                Some(TokenEvent::Finished { .. }) => break,
+                Some(_) => {}
+                None => panic!("stream closed without Finished"),
+            }
+        }
     }
 
     #[test]
@@ -1577,7 +1630,7 @@ mod tests {
         handle.submit(long_running).expect("submit long_running");
         assert!(
             matches!(
-                long_rx.blocking_recv(),
+                recv_skipping_scheduled(&mut long_rx),
                 Some(TokenEvent::Token { id: 100, .. })
             ),
             "first request should prefill"
@@ -1588,7 +1641,7 @@ mod tests {
 
         assert!(
             matches!(
-                wait_rx.blocking_recv(),
+                recv_skipping_scheduled(&mut wait_rx),
                 Some(TokenEvent::Token { id: 101, .. })
             ),
             "waiting request should start once the active request releases its full KV budget"
@@ -1598,9 +1651,23 @@ mod tests {
             "second request was admitted before the first request released KV"
         );
         assert!(
-            matches!(wait_rx.blocking_recv(), Some(TokenEvent::Finished { .. })),
+            matches!(
+                recv_skipping_scheduled(&mut wait_rx),
+                Some(TokenEvent::Finished { .. })
+            ),
             "waiting request should finish after admission"
         );
+    }
+
+    /// Engine streams now open with `TokenEvent::Scheduled` (#246); these
+    /// tests assert on the token/terminal events, so skip past it.
+    fn recv_skipping_scheduled(rx: &mut mpsc::UnboundedReceiver<TokenEvent>) -> Option<TokenEvent> {
+        loop {
+            match rx.blocking_recv() {
+                Some(TokenEvent::Scheduled { .. }) => {}
+                other => return other,
+            }
+        }
     }
 
     fn pending(request_id: u64, echo: bool) -> PendingRequest {
@@ -1614,6 +1681,7 @@ mod tests {
             token_tx,
             logprobs: 0,
             echo,
+            queued_at_unix_s: None,
             prefetch_offered: false,
         }
     }
@@ -1705,12 +1773,15 @@ mod tests {
 
         let (fits, mut fits_rx) = request(16, 1);
         handle.submit(fits).expect("submit fits");
-        match fits_rx.blocking_recv() {
+        match recv_skipping_scheduled(&mut fits_rx) {
             Some(TokenEvent::Token { id, .. }) => assert_eq!(id, 101),
             _ => panic!("later fitting request should emit a token"),
         }
         assert!(
-            matches!(fits_rx.blocking_recv(), Some(TokenEvent::Finished { .. })),
+            matches!(
+                recv_skipping_scheduled(&mut fits_rx),
+                Some(TokenEvent::Finished { .. })
+            ),
             "later fitting request should finish"
         );
     }
@@ -1747,11 +1818,17 @@ mod tests {
         let (fits, mut fits_rx) = request(16, 1);
         handle.submit(fits).expect("submit fits");
         assert!(
-            matches!(fits_rx.blocking_recv(), Some(TokenEvent::Token { .. })),
+            matches!(
+                recv_skipping_scheduled(&mut fits_rx),
+                Some(TokenEvent::Token { .. })
+            ),
             "later fitting request should emit a token"
         );
         assert!(
-            matches!(fits_rx.blocking_recv(), Some(TokenEvent::Finished { .. })),
+            matches!(
+                recv_skipping_scheduled(&mut fits_rx),
+                Some(TokenEvent::Finished { .. })
+            ),
             "later fitting request should finish"
         );
     }
@@ -1851,13 +1928,16 @@ mod tests {
 
         assert!(
             matches!(
-                base_rx.blocking_recv(),
+                recv_skipping_scheduled(&mut base_rx),
                 Some(TokenEvent::Token { id: 101, .. })
             ),
             "base request should still run after unknown adapter rejection"
         );
         assert!(
-            matches!(base_rx.blocking_recv(), Some(TokenEvent::Finished { .. })),
+            matches!(
+                recv_skipping_scheduled(&mut base_rx),
+                Some(TokenEvent::Finished { .. })
+            ),
             "base request should finish"
         );
     }
@@ -1872,12 +1952,12 @@ mod tests {
         handle.submit(will_fail).expect("submit will_fail");
         assert!(
             matches!(
-                fail_rx.blocking_recv(),
+                recv_skipping_scheduled(&mut fail_rx),
                 Some(TokenEvent::Token { id: 100, .. })
             ),
             "first token should be emitted before decode failure"
         );
-        match fail_rx.blocking_recv() {
+        match recv_skipping_scheduled(&mut fail_rx) {
             Some(TokenEvent::Error {
                 message,
                 prompt_tokens,
@@ -1901,13 +1981,16 @@ mod tests {
         handle.submit(after_failure).expect("submit after_failure");
         assert!(
             matches!(
-                after_rx.blocking_recv(),
+                recv_skipping_scheduled(&mut after_rx),
                 Some(TokenEvent::Token { id: 101, .. })
             ),
             "scheduler should accept new work after a decode error"
         );
         assert!(
-            matches!(after_rx.blocking_recv(), Some(TokenEvent::Finished { .. })),
+            matches!(
+                recv_skipping_scheduled(&mut after_rx),
+                Some(TokenEvent::Finished { .. })
+            ),
             "request after failure should finish"
         );
     }
@@ -1924,7 +2007,7 @@ mod tests {
             .expect("submit will_disconnect");
         assert!(
             matches!(
-                token_rx.blocking_recv(),
+                recv_skipping_scheduled(&mut token_rx),
                 Some(TokenEvent::Token { id: 100, .. })
             ),
             "prefill should emit the first token"
@@ -1968,6 +2051,7 @@ mod tests {
             &mut executor,
             &mut active,
             effects::StepEffects {
+                scheduled: Vec::new(),
                 prompt_echoes: Vec::new(),
                 pending: Vec::new(),
                 decode: vec![
@@ -2068,7 +2152,7 @@ mod tests {
         handle.submit(long_running).expect("submit long_running");
         assert!(
             matches!(
-                token_rx.blocking_recv(),
+                recv_skipping_scheduled(&mut token_rx),
                 Some(TokenEvent::Token { id: 100, .. })
             ),
             "first token should be emitted before decode"
@@ -2096,7 +2180,10 @@ mod tests {
             "load_lora_adapter should wait while generation is active"
         );
 
-        while !matches!(token_rx.blocking_recv(), Some(TokenEvent::Finished { .. })) {}
+        while !matches!(
+            recv_skipping_scheduled(&mut token_rx),
+            Some(TokenEvent::Finished { .. })
+        ) {}
 
         let error = load_thread
             .join()

--- a/openinfer-qwen3-4b/src/scheduler/effects.rs
+++ b/openinfer-qwen3-4b/src/scheduler/effects.rs
@@ -11,6 +11,18 @@ pub(super) struct PromptEchoEffect {
     pub(super) logprobs: Vec<Option<TokenLogprob>>,
 }
 
+/// Emitted once per request when its prefill result lands — carries the
+/// prefix-cache hit count the frontend reports in usage (#246). The
+/// scheduled timestamp was stamped when the batch was formed, not when the
+/// event is sent, so queue-time metrics exclude prefill execution.
+pub(super) struct ScheduledEffect {
+    pub(super) token_tx: mpsc::UnboundedSender<TokenEvent>,
+    pub(super) queued_at_unix_s: Option<f64>,
+    pub(super) scheduled_at_unix_s: f64,
+    pub(super) prompt_tokens: usize,
+    pub(super) cached_tokens: usize,
+}
+
 pub(super) enum PendingEffect {
     Finish {
         request_id: RequestId,
@@ -57,6 +69,7 @@ pub(super) enum DecodeEffect {
 }
 
 pub(super) struct StepEffects {
+    pub(super) scheduled: Vec<ScheduledEffect>,
     pub(super) prompt_echoes: Vec<PromptEchoEffect>,
     pub(super) pending: Vec<PendingEffect>,
     pub(super) decode: Vec<DecodeEffect>,
@@ -65,6 +78,7 @@ pub(super) struct StepEffects {
 impl StepEffects {
     pub(super) fn empty() -> Self {
         Self {
+            scheduled: Vec::new(),
             prompt_echoes: Vec::new(),
             pending: Vec::new(),
             decode: Vec::new(),
@@ -77,6 +91,17 @@ pub(super) fn apply_effects(
     active: &mut Vec<ActiveRequestState>,
     effects: StepEffects,
 ) {
+    for scheduled in effects.scheduled {
+        let _ = scheduled.token_tx.send(TokenEvent::Scheduled {
+            queued_at_unix_s: scheduled
+                .queued_at_unix_s
+                .unwrap_or(scheduled.scheduled_at_unix_s),
+            scheduled_at_unix_s: scheduled.scheduled_at_unix_s,
+            prompt_tokens: scheduled.prompt_tokens,
+            cached_tokens: scheduled.cached_tokens,
+        });
+    }
+
     for echo in effects.prompt_echoes {
         let _ = echo.token_tx.send(TokenEvent::PromptTokens {
             ids: echo.ids,

--- a/openinfer-qwen3-4b/src/scheduler/plan.rs
+++ b/openinfer-qwen3-4b/src/scheduler/plan.rs
@@ -18,6 +18,10 @@ pub(super) enum ExecutionArtifacts {
     Prefill {
         pending: Vec<PendingRequest>,
         result: PrefillResult,
+        /// Stamped before the forward pass ran — downstream metrics split
+        /// queue time (queued→scheduled) from prefill time (scheduled→first
+        /// token), so stamping after execution would fold prefill into queue.
+        scheduled_at_unix_s: f64,
     },
     Decode {
         result: DecodeResult,
@@ -25,6 +29,7 @@ pub(super) enum ExecutionArtifacts {
     Unified {
         pending: Vec<PendingRequest>,
         result: UnifiedResult,
+        scheduled_at_unix_s: f64,
     },
 }
 
@@ -51,6 +56,7 @@ pub(super) fn execute_plan(
 ) -> Result<ExecutionArtifacts> {
     match plan {
         ExecutionPlan::Prefill { pending } => {
+            let scheduled_at_unix_s = openinfer_core::engine::unix_now_s();
             let indices: Vec<usize> = (0..pending.len()).collect();
             let requests = build_prefill_items(&pending, &indices, rng);
             let any_echo = pending.iter().any(|req| req.echo);
@@ -59,7 +65,11 @@ pub(super) fn execute_plan(
                 echo: any_echo,
             })?;
             sort_prefill_results(&mut result.requests);
-            Ok(ExecutionArtifacts::Prefill { pending, result })
+            Ok(ExecutionArtifacts::Prefill {
+                pending,
+                result,
+                scheduled_at_unix_s,
+            })
         }
         ExecutionPlan::Decode => {
             let indices: Vec<usize> = (0..active.len()).collect();
@@ -71,6 +81,7 @@ pub(super) fn execute_plan(
             Ok(ExecutionArtifacts::Decode { result })
         }
         ExecutionPlan::Unified { pending } => {
+            let scheduled_at_unix_s = openinfer_core::engine::unix_now_s();
             let pending_indices: Vec<usize> = (0..pending.len()).collect();
             let active_indices: Vec<usize> = (0..active.len()).collect();
             let prefill_requests = build_prefill_items(&pending, &pending_indices, rng);
@@ -81,7 +92,11 @@ pub(super) fn execute_plan(
             })?;
             sort_prefill_results(&mut result.prefill_requests);
             sort_decode_results(&mut result.decode_requests);
-            Ok(ExecutionArtifacts::Unified { pending, result })
+            Ok(ExecutionArtifacts::Unified {
+                pending,
+                result,
+                scheduled_at_unix_s,
+            })
         }
     }
 }
@@ -156,6 +171,7 @@ mod tests {
             token_tx,
             logprobs: 0,
             echo: false,
+            queued_at_unix_s: None,
             prefetch_offered: false,
         }
     }

--- a/openinfer-qwen3-4b/src/scheduler/resolve.rs
+++ b/openinfer-qwen3-4b/src/scheduler/resolve.rs
@@ -1,7 +1,7 @@
 use crate::executor::{DecodeRequestResult, ModelExecutor, PrefillRequestResult};
 use openinfer_core::engine::FinishReason;
 
-use super::effects::{DecodeEffect, PendingEffect, PromptEchoEffect, StepEffects};
+use super::effects::{DecodeEffect, PendingEffect, PromptEchoEffect, ScheduledEffect, StepEffects};
 use super::plan::ExecutionArtifacts;
 use super::{ActiveRequestState, PendingRequest};
 
@@ -11,16 +11,28 @@ pub(super) fn resolve_step(
     artifacts: ExecutionArtifacts,
 ) -> StepEffects {
     match artifacts {
-        ExecutionArtifacts::Prefill { pending, result } => {
-            resolve_prefill_outputs(executor, pending, result.requests)
-        }
+        ExecutionArtifacts::Prefill {
+            pending,
+            result,
+            scheduled_at_unix_s,
+        } => resolve_prefill_outputs(executor, pending, result.requests, scheduled_at_unix_s),
         ExecutionArtifacts::Decode { result } => StepEffects {
+            scheduled: Vec::new(),
             prompt_echoes: Vec::new(),
             pending: Vec::new(),
             decode: resolve_decode_outputs(executor, active, &result.requests),
         },
-        ExecutionArtifacts::Unified { pending, result } => {
-            let mut effects = resolve_prefill_outputs(executor, pending, result.prefill_requests);
+        ExecutionArtifacts::Unified {
+            pending,
+            result,
+            scheduled_at_unix_s,
+        } => {
+            let mut effects = resolve_prefill_outputs(
+                executor,
+                pending,
+                result.prefill_requests,
+                scheduled_at_unix_s,
+            );
             effects.decode = resolve_decode_outputs(executor, active, &result.decode_requests);
             effects
         }
@@ -31,11 +43,20 @@ fn resolve_prefill_outputs(
     executor: &impl ModelExecutor,
     pending: Vec<PendingRequest>,
     request_results: Vec<PrefillRequestResult>,
+    scheduled_at_unix_s: f64,
 ) -> StepEffects {
     let mut effects = StepEffects::empty();
     for (req, result) in pending.into_iter().zip(request_results) {
         debug_assert_eq!(req.request_id, result.request_id);
         let prompt_len = req.prompt_tokens.len();
+
+        effects.scheduled.push(ScheduledEffect {
+            token_tx: req.token_tx.clone(),
+            queued_at_unix_s: req.queued_at_unix_s,
+            scheduled_at_unix_s,
+            prompt_tokens: prompt_len,
+            cached_tokens: result.cached_tokens,
+        });
 
         if req.echo {
             effects.prompt_echoes.push(PromptEchoEffect {

--- a/openinfer-qwen3-4b/tests/cached_tokens_usage.rs
+++ b/openinfer-qwen3-4b/tests/cached_tokens_usage.rs
@@ -1,0 +1,123 @@
+//! Prefix-cache observability IT for Qwen3-4B (#246).
+//!
+//! The frontend reports `usage.prompt_tokens_details.cached_tokens` from
+//! `TokenEvent::Scheduled`. This test pins the engine half of that contract:
+//! a cold prompt reports zero cached tokens, a warm repeat of the same prompt
+//! reports a nonzero full-block count, and the count never claims the whole
+//! prompt (the last token is always recomputed).
+//!
+//! Requires a CUDA GPU and Qwen3-4B weights; skips cleanly when the model is
+//! absent (point `OPENINFER_TEST_MODEL_PATH` at the weights to run it).
+
+use std::path::Path;
+
+use openinfer_core::engine::{EngineHandle, EngineLoadOptions, GenerateRequest, TokenEvent};
+use openinfer_core::sampler::SamplingParams;
+use tokio::sync::mpsc;
+
+mod common;
+
+const MODEL_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../models/Qwen3-4B");
+const KV_BLOCK_SIZE: usize = 16;
+
+fn model_path_or_skip() -> Option<String> {
+    match std::env::var("OPENINFER_TEST_MODEL_PATH") {
+        Ok(path) => Some(path),
+        Err(_) if Path::new(MODEL_PATH).join("config.json").exists() => {
+            Some(MODEL_PATH.to_string())
+        }
+        Err(_) => {
+            eprintln!(
+                "skipping qwen3 cached_tokens_usage: {MODEL_PATH}/config.json is missing; set OPENINFER_TEST_MODEL_PATH to run it"
+            );
+            None
+        }
+    }
+}
+
+/// Submit `prompt_tokens`, drain the stream to `Finished`, and return the
+/// `cached_tokens` carried by the `Scheduled` event.
+fn run_and_capture_cached(handle: &EngineHandle, prompt_tokens: Vec<u32>) -> usize {
+    let (token_tx, mut rx) = mpsc::unbounded_channel();
+    handle
+        .submit(GenerateRequest {
+            request_id: None,
+            queued_at_unix_s: None,
+            prompt_tokens,
+            params: SamplingParams::default(),
+            max_tokens: 4,
+            lora_adapter: None,
+            token_tx,
+            logprobs: 0,
+            echo: false,
+        })
+        .expect("submit failed");
+
+    let mut cached = None;
+    loop {
+        match rx.blocking_recv() {
+            Some(TokenEvent::Scheduled { cached_tokens, .. }) => {
+                assert!(
+                    cached.replace(cached_tokens).is_none(),
+                    "Scheduled must be emitted exactly once per request"
+                );
+            }
+            Some(TokenEvent::Token { .. } | TokenEvent::PromptTokens { .. }) => {}
+            Some(TokenEvent::Finished { .. }) => break,
+            Some(TokenEvent::Error { message, .. }) => panic!("generation failed: {message}"),
+            Some(TokenEvent::Rejected { message, .. }) => panic!("generation rejected: {message}"),
+            None => panic!("scheduler channel closed without Finished"),
+        }
+    }
+    cached.expect("Scheduled event must precede Finished")
+}
+
+#[test]
+fn warm_repeat_reports_cached_tokens() {
+    let Some(model_path) = model_path_or_skip() else {
+        return;
+    };
+
+    let handle = openinfer_qwen3_4b::start_engine(
+        Path::new(&model_path),
+        EngineLoadOptions {
+            enable_cuda_graph: true,
+            enable_prefill_profile: false,
+            device_ordinals: vec![0],
+            seed: 42,
+            ..EngineLoadOptions::default()
+        },
+    )
+    .expect("failed to start engine");
+    let tokenizer = common::load_tokenizer(&model_path);
+
+    let prompt = "The kv cache stores attention keys and values for every \
+        generated token so the model never recomputes earlier positions. "
+        .repeat(8);
+    let prompt_tokens = tokenizer.encode(&prompt, false).expect("encode failed");
+    let prompt_len = prompt_tokens.len();
+    assert!(
+        prompt_len > 2 * KV_BLOCK_SIZE,
+        "prompt must span multiple KV blocks for a meaningful hit"
+    );
+
+    let cold = run_and_capture_cached(&handle, prompt_tokens.clone());
+    assert_eq!(cold, 0, "cold run must report zero cached tokens");
+
+    let warm = run_and_capture_cached(&handle, prompt_tokens);
+    assert!(warm > 0, "warm repeat must report a prefix-cache hit");
+    assert!(
+        warm < prompt_len,
+        "at least the last prompt token is always recomputed (warm={warm}, prompt={prompt_len})"
+    );
+    assert_eq!(
+        warm % KV_BLOCK_SIZE,
+        0,
+        "hits are matched in full blocks (warm={warm})"
+    );
+    assert_eq!(
+        warm,
+        (prompt_len - 1) / KV_BLOCK_SIZE * KV_BLOCK_SIZE,
+        "warm hit must cover every cacheable full block (prompt={prompt_len})"
+    );
+}

--- a/openinfer-sim/src/lib.rs
+++ b/openinfer-sim/src/lib.rs
@@ -83,6 +83,7 @@ async fn run_simulated_request(req: GenerateRequest, config: SimulatedEngineConf
             queued_at_unix_s,
             scheduled_at_unix_s: now_secs_f64(),
             prompt_tokens: prompt_len,
+            cached_tokens: 0,
         })
         .is_err()
     {

--- a/openinfer-vllm-frontend/src/lib.rs
+++ b/openinfer-vllm-frontend/src/lib.rs
@@ -33,8 +33,8 @@ use vllm_engine_core_client::protocol::{
 };
 use vllm_engine_core_client::{EngineId, TransportMode};
 use vllm_server::{
-    ChatTemplateContentFormatOption, Config, CoordinatorMode, HttpListenerMode, ParserSelection,
-    RendererSelection,
+    ApiServerOptions, ChatTemplateContentFormatOption, Config, CoordinatorMode, HttpListenerMode,
+    ParserSelection, RendererSelection,
 };
 use zeromq::prelude::{Socket, SocketRecv, SocketSend};
 use zeromq::util::PeerIdentity;
@@ -429,12 +429,26 @@ impl LocalEngineBridge {
         } = request;
         let Some(prompt_tokens) = prompt_token_ids else {
             warn!("request {request_id} dropped: missing prompt_token_ids");
-            send_terminal_output(output_tx, request_id, EngineCoreFinishReason::Error, None)?;
+            send_terminal_output(
+                output_tx,
+                request_id,
+                EngineCoreFinishReason::Error,
+                None,
+                None,
+                None,
+            )?;
             return Ok(());
         };
         let Some(sampling_params) = sampling_params else {
             warn!("request {request_id} dropped: missing sampling_params");
-            send_terminal_output(output_tx, request_id, EngineCoreFinishReason::Error, None)?;
+            send_terminal_output(
+                output_tx,
+                request_id,
+                EngineCoreFinishReason::Error,
+                None,
+                None,
+                None,
+            )?;
             return Ok(());
         };
 
@@ -651,8 +665,13 @@ where
         chat_template: None,
         default_chat_template_kwargs: None,
         chat_template_content_format: ChatTemplateContentFormatOption::default(),
-        enable_log_requests: true,
-        enable_request_id_headers: false,
+        language_model_only: true,
+        api_keys: Vec::new(),
+        api_server_options: ApiServerOptions {
+            enable_log_requests: true,
+            enable_prompt_tokens_details: true,
+            enable_request_id_headers: false,
+        },
         disable_log_stats: true,
         grpc_port: None,
         shutdown_timeout: Duration::from_secs(10),
@@ -807,6 +826,7 @@ async fn run_request_stream(
                 queued_at_unix_s,
                 scheduled_at_unix_s,
                 prompt_tokens,
+                cached_tokens,
             } => {
                 first_token_events = Some(vec![
                     EngineCoreEvent {
@@ -818,11 +838,14 @@ async fn run_request_stream(
                         timestamp: scheduled_at_unix_s,
                     },
                 ]);
+                // Upstream invariant: computed (actual prefill work) +
+                // cached (prefix-cache hit) == prompt; double-counting skews
+                // the per-source prompt token metrics.
                 first_token_prefill_stats = Some(PrefillStats {
                     num_prompt_tokens: prompt_tokens as u32,
-                    num_computed_tokens: prompt_tokens as u32,
-                    num_cached_tokens: 0,
-                    num_local_cached_tokens: 0,
+                    num_computed_tokens: prompt_tokens.saturating_sub(cached_tokens) as u32,
+                    num_cached_tokens: cached_tokens as u32,
+                    num_local_cached_tokens: cached_tokens as u32,
                     num_external_cached_tokens: 0,
                 });
             }
@@ -855,11 +878,16 @@ async fn run_request_stream(
                 // Prompt logprobs are intentionally deferred for this bridge.
             }
             TokenEvent::Finished { finish_reason, .. } => {
+                // A request can finish without emitting a token (EOS sampled
+                // on prefill) — flush the pending scheduled events and prefill
+                // stats with the terminal output or they are lost.
                 let _ = send_terminal_output(
                     &output_tx,
                     request_id,
                     convert_finish_reason(finish_reason),
                     None,
+                    first_token_events.take(),
+                    first_token_prefill_stats.take(),
                 );
                 return;
             }
@@ -870,6 +898,8 @@ async fn run_request_stream(
                     request_id,
                     EngineCoreFinishReason::Error,
                     Some(StopReason::Text(message)),
+                    None,
+                    None,
                 );
                 return;
             }
@@ -881,6 +911,8 @@ async fn run_request_stream(
                     request_id,
                     EngineCoreFinishReason::Error,
                     Some(StopReason::Text(message)),
+                    None,
+                    None,
                 );
                 return;
             }
@@ -933,6 +965,8 @@ fn send_terminal_output(
     request_id: String,
     finish_reason: EngineCoreFinishReason,
     stop_reason: Option<StopReason>,
+    events: Option<Vec<EngineCoreEvent>>,
+    prefill_stats: Option<PrefillStats>,
 ) -> Result<()> {
     send_outputs(
         output_tx,
@@ -944,8 +978,8 @@ fn send_terminal_output(
                 None,
                 Some(finish_reason),
                 stop_reason,
-                None,
-                None,
+                events,
+                prefill_stats,
             )],
             finished_requests: Some(BTreeSet::from([request_id])),
             timestamp: now_secs_f64(),
@@ -960,7 +994,7 @@ fn send_utility_response(
     method_name: &str,
 ) -> Result<()> {
     let result = match method_name {
-        "is_sleeping" | "reset_prefix_cache" => rmpv::ext::to_value(false)?,
+        "is_sleeping" | "is_paused" | "reset_prefix_cache" => rmpv::ext::to_value(false)?,
         "sleep" | "wake_up" | "reset_mm_cache" | "reset_encoder_cache" | "collective_rpc" => {
             rmpv::Value::Nil
         }
@@ -1469,6 +1503,7 @@ mod tests {
                 queued_at_unix_s: 1.0,
                 scheduled_at_unix_s: 2.0,
                 prompt_tokens: 16,
+                cached_tokens: 0,
             })
             .expect("send scheduled");
         token_tx
@@ -1544,6 +1579,7 @@ mod tests {
                 queued_at_unix_s: 1.0,
                 scheduled_at_unix_s: 2.0,
                 prompt_tokens: 8,
+                cached_tokens: 5,
             })
             .expect("send scheduled");
         token_tx
@@ -1573,9 +1609,62 @@ mod tests {
         assert_eq!(first_batch.outputs[0].new_token_ids, vec![1]);
         assert_eq!(second_batch.outputs[0].new_token_ids, vec![2]);
         assert!(first_batch.outputs[0].events.is_some());
-        assert!(first_batch.outputs[0].prefill_stats.is_some());
+        let stats = first_batch.outputs[0]
+            .prefill_stats
+            .as_ref()
+            .expect("first batch carries prefill stats");
+        assert_eq!(stats.num_prompt_tokens, 8);
+        assert_eq!(stats.num_cached_tokens, 5);
+        assert_eq!(stats.num_local_cached_tokens, 5);
+        assert_eq!(
+            stats.num_computed_tokens, 3,
+            "computed must be prompt minus cached, not the full prompt"
+        );
         assert!(second_batch.outputs[0].events.is_none());
         assert!(second_batch.outputs[0].prefill_stats.is_none());
+        assert!(output_rx.recv().await.is_none());
+    }
+
+    /// A request that stops on its first sampled token never emits `Token`
+    /// — the terminal output must still deliver the scheduled events and
+    /// prefill stats or cached_tokens silently vanishes from usage.
+    #[tokio::test]
+    async fn stop_on_prefill_terminal_output_carries_prefill_stats() {
+        let (token_tx, token_rx) = mpsc::unbounded_channel();
+        let (output_tx, mut output_rx) = mpsc::unbounded_channel();
+
+        token_tx
+            .send(TokenEvent::Scheduled {
+                queued_at_unix_s: 1.0,
+                scheduled_at_unix_s: 2.0,
+                prompt_tokens: 16,
+                cached_tokens: 4,
+            })
+            .expect("send scheduled");
+        token_tx
+            .send(TokenEvent::Finished {
+                finish_reason: FinishReason::Stop,
+                prompt_tokens: 16,
+                completion_tokens: 0,
+            })
+            .expect("send finished");
+        drop(token_tx);
+
+        run_request_stream("req-stop".to_string(), token_rx, output_tx).await;
+
+        let terminal = output_rx.recv().await.expect("terminal output");
+        let output = &terminal.outputs[0];
+        assert_eq!(output.finish_reason, Some(EngineCoreFinishReason::Stop));
+        assert!(
+            output.events.is_some(),
+            "queued/scheduled events must flush"
+        );
+        let stats = output
+            .prefill_stats
+            .as_ref()
+            .expect("terminal output must flush prefill stats");
+        assert_eq!(stats.num_cached_tokens, 4);
+        assert_eq!(stats.num_computed_tokens, 12);
         assert!(output_rx.recv().await.is_none());
     }
 


### PR DESCRIPTION
Closes #246.

First, thanks to @jackyYang6 — #299 identified this exact gap and pushed it forward; it's what got the missing upstream half filed as vllm#44824 and fixed there. This PR lands the same outcome now that the upstream piece exists, so #299 can close in its favor.

## What was broken

The qwen3 executor has computed per-request `cached_tokens` since #216, but it died at the scheduler boundary — qwen3 never emitted `TokenEvent::Scheduled` at all — and the frontend hardcoded `num_cached_tokens: 0`. Prefix-cache hits were invisible to clients, benchmarks, and operators.

## Engine side

- `TokenEvent::Scheduled` gains `cached_tokens`.
- qwen3's scheduler now produces a `ScheduledEffect` when the prefill result lands (`scheduler/resolve.rs`), sent before the first token — exactly once per request; reject/error paths emit none.
- The scheduled timestamp is stamped at batch formation (`scheduler/plan.rs`), **before** the forward pass, so downstream queue-time vs prefill-time metrics split honestly.
- Other engines send 0. Kimi's real value needs its `Scheduled` emit moved past the prefix match — filed as #351.
- `unix_now_s()` unified into `openinfer-engine` (qwen3/kimi copies removed).

## Frontend side (vllm crates bump 4aaed4c → 5d5591d)

- Picks up vllm#44887 (`cached_token_count` → `usage.prompt_tokens_details` plumbing — thanks @BugenZhao), 8 days of upstream churn audited: `EngineCoreOutput`/`PrefillStats`/msgpack unchanged.
- Adapts to the `ApiServerOptions` config split; `enable_prompt_tokens_details` on.
- `num_computed_tokens` now reports `prompt − cached` per the upstream per-source invariant (was double-counting on warm hits).
- Terminal outputs flush pending scheduled events/prefill stats for requests that stop on prefill (EOS on first sampled token) — previously dropped.
- New `/is_paused` utility (introduced by the bump) answers `false` instead of `Nil`.

## Verification

- New GPU IT `cached_tokens_usage.rs`: cold == 0, warm == `(prompt−1)/16·16`, `Scheduled` exactly once.
- New CPU unit tests: scheduler exactly-once contract on a FakeExecutor (`cached_tokens: 7`); frontend field mapping (`computed = prompt − cached`) and the stop-on-prefill terminal flush. Rejection tests assert the raw first event so a `Scheduled` leaking onto the reject path fails.
- HF golden gate green; lib tests green across qwen3/frontend/sim/engine/kimi.
- Real-server HTTP: cold run reports no `prompt_tokens_details`; warm repeat of a 177-token prompt reports `cached_tokens: 176`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)