### PR TITLE
perf(frontend): overlap startup metadata loading

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -107,6 +107,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 | --- | --- |
 | `subsystems/frontend/simulated-inference-engine.md` | CPU-only simulated model crate for vLLM/OpenAI frontend and `vllm bench serve` validation without CUDA, real model weights, or real-model performance claims. |
 | `subsystems/frontend/cpu-profiling-baseline.md` | Frontend CPU profiling baseline using `openinfer-sim` with fixed TTFT=5ms/TPOT=12ms: 200 req / concurrency=16 shows ~150ms TTFT overhead (no dominant hotspot), heap allocation ~10%, stream polling ~7.5%, IPC ~1%; reproducible benchmark command and perf evidence documented. |
+| `subsystems/frontend/startup-latency.md` | Qwen3-4B default serving overlaps vLLM tokenizer/text/chat metadata loading with engine startup; local `/v1/models` readiness improved from 3.09s external poll / 2.90s bind to about 1.9-2.1s, with completion smoke passing. |
 
 ## subsystems / correctness
 

--- a/docs/subsystems/frontend/startup-latency.md
+++ b/docs/subsystems/frontend/startup-latency.md
@@ -1,0 +1,29 @@
+# Frontend startup latency
+
+TL;DR: Qwen3-4B default serving now overlaps vLLM frontend metadata loading with engine startup; `/v1/models` readiness on the local RTX 5090 box moved from `3087 ms` external poll / `2897 ms` server bind to `1855-2082 ms` external poll, with completions smoke passing.
+
+Last touched: 2026-06
+
+## 2026-06-11 Qwen3-4B startup pass
+
+The original startup path loaded the GPU engine first, then entered `vllm_server::serve_with_router_extension`, which loaded Hugging Face tokenizer/text/chat backend metadata before binding HTTP. The measured internal timeline was:
+
+- `0.00s`: `openinfer` main starts.
+- `0.23s`: 3 safetensor shards mmaped, 8045 MB.
+- `1.30s`: GPU weights loaded.
+- `1.75s`: engine/KV/scheduler loaded.
+- `2.90s`: vLLM text/chat backend loaded and HTTP bound.
+- `3.09s`: external `/v1/models` poll observed ready.
+
+The frontend metadata load does not need an `EngineHandle`. The default non-LoRA path now starts the vLLM frontend task before synchronous engine load, and the local bridge waits on a one-shot engine handle before completing the bootstrapped engine handshake. This keeps normal request handling unchanged: `/v1/completions` and `/v1/chat/completions` still connect through the same vLLM server, IPC bridge, and scheduler after the real engine handle is available.
+
+Verified command:
+
+```bash
+LD_LIBRARY_PATH=/usr/local/cuda-13.3/lib64:${LD_LIBRARY_PATH:-} \
+  ./target/release/openinfer --model-path /data/models/Qwen3-4B --port 18080
+```
+
+Three `/v1/models` runs with 100 ms polling landed at `2082 ms`, `1952 ms`, and `1855 ms` after rebasing onto main's sampling guard changes. In server logs, tokenizer loading starts immediately after runtime options, frontend metadata finishes around `1.14-1.22s`, engine load finishes around `1.69-1.90s`, and HTTP binds immediately after the bridge handshake. A `max_tokens=1` `/v1/completions` request returned 200 after ready.
+
+LoRA startup intentionally remains sequential because startup adapter loading needs the real engine control handle before serving.

--- a/openinfer-server/src/main.rs
+++ b/openinfer-server/src/main.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::time::Instant;
 
-use anyhow::{Context, bail};
+use anyhow::{Context, anyhow, bail};
 use clap::{Parser, ValueEnum};
 use log::info;
 use openinfer::logging;
@@ -172,6 +172,28 @@ async fn main() -> anyhow::Result<()> {
         args.tp_size,
     );
 
+    let shutdown = openinfer::vllm_frontend::shutdown_token_from_ctrl_c();
+    let frontend = if args.enable_lora {
+        None
+    } else {
+        let (handle_tx, handle_rx) = tokio::sync::oneshot::channel();
+        let model_path = args.model_path.clone();
+        let served_model_name = args.served_model_name.clone();
+        let port = args.port;
+        let frontend_shutdown = shutdown.clone();
+        let task = tokio::spawn(async move {
+            openinfer::vllm_frontend::serve_with_deferred_handle(
+                handle_rx,
+                model_path,
+                served_model_name,
+                port,
+                frontend_shutdown,
+            )
+            .await
+        });
+        Some((handle_tx, task))
+    };
+
     let handle = match model_type {
         #[cfg(feature = "deepseek-v4")]
         ModelType::DeepSeekV4 => {
@@ -309,18 +331,19 @@ async fn main() -> anyhow::Result<()> {
             args.lora_modules,
             args.port,
             max_model_len,
-            openinfer::vllm_frontend::shutdown_token_from_ctrl_c(),
+            shutdown,
         )
         .await
     } else {
-        openinfer::vllm_frontend::serve(
-            handle,
-            &args.model_path,
-            args.served_model_name.as_deref(),
-            args.port,
-            openinfer::vllm_frontend::shutdown_token_from_ctrl_c(),
-        )
-        .await
+        let Some((handle_tx, frontend_task)) = frontend else {
+            unreachable!("non-LoRA frontend task should be started before engine load");
+        };
+        handle_tx
+            .send(handle)
+            .map_err(|_| anyhow!("vLLM frontend exited before engine was ready"))?;
+        frontend_task
+            .await
+            .context("vLLM frontend task failed to join")?
     }
     .context("vLLM frontend server failed")?;
 

--- a/openinfer-vllm-frontend/src/lib.rs
+++ b/openinfer-vllm-frontend/src/lib.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
@@ -15,7 +15,7 @@ use axum::routing::{get, post};
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::error::TryRecvError;
-use tokio::sync::{RwLock, mpsc};
+use tokio::sync::{RwLock, mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tower::ServiceExt;
@@ -265,6 +265,25 @@ struct LocalEngineBridge {
     max_model_len: u32,
 }
 
+enum EngineHandleSource {
+    Ready(EngineHandle),
+    Deferred(oneshot::Receiver<EngineHandle>),
+}
+
+impl EngineHandleSource {
+    async fn recv(self, shutdown: &CancellationToken) -> Result<Option<EngineHandle>> {
+        match self {
+            Self::Ready(handle) => Ok(Some(handle)),
+            Self::Deferred(handle_rx) => tokio::select! {
+                result = handle_rx => result
+                    .map(Some)
+                    .context("engine handle sender dropped before local vLLM bridge startup"),
+                () = shutdown.cancelled() => Ok(None),
+            },
+        }
+    }
+}
+
 impl LocalEngineBridge {
     async fn run(self, shutdown: CancellationToken) -> Result<()> {
         wait_for_ipc_endpoint(&self.input_address, &shutdown).await?;
@@ -455,14 +474,8 @@ impl LocalEngineBridge {
     }
 }
 
-pub async fn serve(
-    handle: EngineHandle,
-    model_path: &Path,
-    served_model_name: Option<&str>,
-    port: u16,
-    shutdown: CancellationToken,
-) -> Result<()> {
-    let max_model_len = load_max_model_len(model_path).unwrap_or_else(|| {
+fn load_max_model_len_or_fallback(model_path: &Path) -> u32 {
+    load_max_model_len(model_path).unwrap_or_else(|| {
         const FALLBACK_MAX_MODEL_LEN: u32 = 4096;
         warn!(
             "max_position_embeddings not found in {}/config.json; capping max_model_len at {FALLBACK_MAX_MODEL_LEN}. \
@@ -470,7 +483,17 @@ pub async fn serve(
             model_path.display()
         );
         FALLBACK_MAX_MODEL_LEN
-    });
+    })
+}
+
+pub async fn serve(
+    handle: EngineHandle,
+    model_path: &Path,
+    served_model_name: Option<&str>,
+    port: u16,
+    shutdown: CancellationToken,
+) -> Result<()> {
+    let max_model_len = load_max_model_len_or_fallback(model_path);
     serve_model(
         handle,
         model_path.to_string_lossy().into_owned(),
@@ -478,6 +501,25 @@ pub async fn serve(
             .into_iter()
             .map(std::string::ToString::to_string)
             .collect(),
+        port,
+        max_model_len,
+        shutdown,
+    )
+    .await
+}
+
+pub async fn serve_with_deferred_handle(
+    handle_rx: oneshot::Receiver<EngineHandle>,
+    model_path: PathBuf,
+    served_model_name: Option<String>,
+    port: u16,
+    shutdown: CancellationToken,
+) -> Result<()> {
+    let max_model_len = load_max_model_len_or_fallback(&model_path);
+    serve_model_with_deferred_handle(
+        handle_rx,
+        model_path.to_string_lossy().into_owned(),
+        served_model_name.into_iter().collect(),
         port,
         max_model_len,
         shutdown,
@@ -502,6 +544,28 @@ pub async fn serve_model(
         port,
         max_model_len,
         shutdown,
+    )
+    .await
+}
+
+pub async fn serve_model_with_deferred_handle(
+    handle_rx: oneshot::Receiver<EngineHandle>,
+    model_id: impl Into<String>,
+    served_model_name: Vec<String>,
+    port: u16,
+    max_model_len: u32,
+    shutdown: CancellationToken,
+) -> Result<()> {
+    let model_id = model_id.into();
+    serve_model_on_host_with_handle_source_and_router_extension(
+        EngineHandleSource::Deferred(handle_rx),
+        model_id,
+        served_model_name,
+        "0.0.0.0".to_string(),
+        port,
+        max_model_len,
+        shutdown,
+        |router| router,
     )
     .await
 }
@@ -604,23 +668,58 @@ async fn serve_model_on_host_with_router_extension<F>(
 where
     F: FnOnce(Router) -> Router,
 {
+    serve_model_on_host_with_handle_source_and_router_extension(
+        EngineHandleSource::Ready(handle),
+        model_id,
+        served_model_name,
+        host,
+        port,
+        max_model_len,
+        shutdown,
+        extend_router,
+    )
+    .await
+}
+
+async fn serve_model_on_host_with_handle_source_and_router_extension<F>(
+    handle_source: EngineHandleSource,
+    model_id: String,
+    served_model_name: Vec<String>,
+    host: String,
+    port: u16,
+    max_model_len: u32,
+    shutdown: CancellationToken,
+    extend_router: F,
+) -> Result<()>
+where
+    F: FnOnce(Router) -> Router,
+{
     let namespace = local_ipc_namespace()?;
     let input_address = ipc_endpoint(&namespace, "input.sock");
     let output_address = ipc_endpoint(&namespace, "output.sock");
 
-    let servable_limit = handle.servable_len().map(|cap| max_model_len.min(cap));
-    let max_model_len = servable_limit.unwrap_or(max_model_len);
-    let bridge = LocalEngineBridge {
-        input_address: input_address.clone(),
-        output_address: output_address.clone(),
-        handle,
-        max_model_len,
-    };
+    let servable_limit = Arc::new(OnceLock::new());
     let bridge_shutdown = shutdown.child_token();
+    let bridge_servable_limit = Arc::clone(&servable_limit);
+    let bridge_input_address = input_address.clone();
+    let bridge_output_address = output_address.clone();
     let bridge_task = tokio::spawn(async move {
+        let Some(handle) = handle_source.recv(&bridge_shutdown).await? else {
+            return Ok::<(), anyhow::Error>(());
+        };
+        let effective_servable_limit = handle.servable_len().map(|cap| max_model_len.min(cap));
+        let bridge_max_model_len = effective_servable_limit.unwrap_or(max_model_len);
+        let _ = bridge_servable_limit.set(effective_servable_limit);
+        let bridge = LocalEngineBridge {
+            input_address: bridge_input_address,
+            output_address: bridge_output_address,
+            handle,
+            max_model_len: bridge_max_model_len,
+        };
         if let Err(error) = bridge.run(bridge_shutdown).await {
             warn!("local vLLM engine bridge exited: {error:#}");
         }
+        Ok(())
     });
 
     let config = Config {
@@ -653,7 +752,11 @@ where
     };
 
     let extend_router = move |router: Router| {
-        extend_router(router).layer(from_fn_with_state(servable_limit, guard_generation_request))
+        let router = extend_router(router);
+        let servable_limit = *servable_limit
+            .get()
+            .expect("local vLLM bridge must publish servable limit before router setup");
+        router.layer(from_fn_with_state(servable_limit, guard_generation_request))
     };
     let result = vllm_server::serve_with_router_extension(config, shutdown, extend_router).await;
     bridge_task.abort();


### PR DESCRIPTION
## Summary

- start the default non-LoRA vLLM frontend task before synchronous engine loading
- defer the local bridge's `EngineHandle` through a one-shot so the bootstrapped handshake still completes only after the real engine is ready
- keep LoRA startup sequential because startup adapter loading needs the real engine control handle
- record the Qwen3-4B startup measurement in `docs/subsystems/frontend/startup-latency.md`

## Measurements

Baseline on local RTX 5090 Qwen3-4B:

- external `/v1/models` poll ready: `3087 ms`
- server bind from log timestamps: `2897 ms`
- engine loaded: `1752 ms`

After this branch, rebased on current `main`:

- `/v1/models` poll ready, 3 runs: `2082 ms`, `1952 ms`, `1855 ms`
- `/v1/completions` smoke with `max_tokens=1`: 200 OK

## Code Quality Notes

- merged with main's new `sampling_guard` middleware instead of stacking a second capacity middleware
- shared the existing max-model-len fallback through a private helper rather than duplicating warning/fallback logic
- the bridge writes the servable cap before sending engine ready, so router setup reads a startup invariant established by the bootstrapped connect path

## Verification

- `cargo fmt --all -- --check`
- `cargo test --release -p openinfer-vllm-frontend sampling_guard --lib`
- `cargo check --release -p openinfer-server --bin openinfer`
- `cargo build --release -p openinfer-server --bin openinfer`
- `cargo clippy --release -p openinfer-server --bin openinfer --no-deps -- -D warnings`
