### PR TITLE
test(qwen3): pin sampling behavior for the honored params

### DIFF
--- a/openinfer-qwen3-4b/tests/sampling_behavior.rs
+++ b/openinfer-qwen3-4b/tests/sampling_behavior.rs
@@ -120,19 +120,21 @@ fn sampling_params_steer_the_sampler() {
     );
     assert_eq!(top_k_one, greedy, "top_k=1 must collapse to greedy");
 
-    // A tiny nucleus always contains exactly the top token (the largest
-    // probability alone satisfies any threshold at or below itself), so
-    // top_p -> 0 collapses to greedy as well.
+    // The nucleus is the smallest descending-probability prefix whose mass
+    // reaches top_p. The largest probability is always >= 1/vocab (~6.6e-6
+    // for Qwen3), so with top_p below that bound the nucleus is exactly the
+    // argmax for ANY distribution — the identity holds even on high-entropy
+    // steps where the top token carries little mass.
     let top_p_tiny = generate(
         &handle,
         prompt_tokens.clone(),
         SamplingParams {
             temperature: 1.0,
-            top_p: 0.01,
+            top_p: 1e-6,
             ..SamplingParams::default()
         },
     );
-    assert_eq!(top_p_tiny, greedy, "top_p=0.01 must collapse to greedy");
+    assert_eq!(top_p_tiny, greedy, "top_p=1e-6 must collapse to greedy");
 
     // Unrestricted high-temperature sampling must actually sample: four runs
     // of 32 tokens collapsing to one sequence means the params were dropped

--- a/openinfer-qwen3-4b/tests/sampling_behavior.rs
+++ b/openinfer-qwen3-4b/tests/sampling_behavior.rs
@@ -1,0 +1,153 @@
+//! Behavioral coverage for the honored sampling params (#243 Problem B).
+//!
+//! The frontend guard pins "unsupported params are rejected"; these tests pin
+//! the other half — `temperature` / `top_k` / `top_p` actually steer the
+//! sampler. The #237 failure class (request params silently falling back to
+//! greedy) is caught by the diversity assertion; the collapse identities
+//! (`top_k=1`, tiny `top_p`) catch the inverse (sampling ignoring the masks).
+//!
+//! Per-request seeds are rejected at the frontend and the legacy per-row
+//! sampler is not run-to-run deterministic (#284), so seed determinism is
+//! intentionally not asserted here.
+//!
+//! Requires a CUDA GPU and Qwen3-4B weights; skips cleanly when the model is
+//! absent (point `OPENINFER_TEST_MODEL_PATH` at the weights to run it).
+
+use std::path::Path;
+
+use openinfer_core::engine::{EngineHandle, EngineLoadOptions, GenerateRequest, TokenEvent};
+use openinfer_core::sampler::SamplingParams;
+use tokio::sync::mpsc;
+
+mod common;
+
+const MODEL_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../models/Qwen3-4B");
+const GENERATED_TOKENS: usize = 32;
+
+fn model_path_or_skip() -> Option<String> {
+    match std::env::var("OPENINFER_TEST_MODEL_PATH") {
+        Ok(path) => Some(path),
+        Err(_) if Path::new(MODEL_PATH).join("config.json").exists() => {
+            Some(MODEL_PATH.to_string())
+        }
+        Err(_) => {
+            eprintln!(
+                "skipping qwen3 sampling_behavior: {MODEL_PATH}/config.json is missing; set OPENINFER_TEST_MODEL_PATH to run it"
+            );
+            None
+        }
+    }
+}
+
+/// Submit one request and collect the generated token ids until `Finished`.
+fn generate(handle: &EngineHandle, prompt_tokens: Vec<u32>, params: SamplingParams) -> Vec<u32> {
+    let (token_tx, mut rx) = mpsc::unbounded_channel();
+    handle
+        .submit(GenerateRequest {
+            request_id: None,
+            queued_at_unix_s: None,
+            prompt_tokens,
+            params,
+            max_tokens: GENERATED_TOKENS,
+            lora_adapter: None,
+            token_tx,
+            logprobs: 0,
+            echo: false,
+        })
+        .expect("submit failed");
+
+    let mut tokens = Vec::new();
+    loop {
+        match rx.blocking_recv() {
+            Some(TokenEvent::Token { id, .. }) => tokens.push(id),
+            Some(TokenEvent::Scheduled { .. } | TokenEvent::PromptTokens { .. }) => {}
+            Some(TokenEvent::Finished { .. }) => return tokens,
+            Some(TokenEvent::Error { message, .. }) => panic!("generation failed: {message}"),
+            Some(TokenEvent::Rejected { message, .. }) => panic!("generation rejected: {message}"),
+            None => panic!("scheduler channel closed without Finished"),
+        }
+    }
+}
+
+#[test]
+fn sampling_params_steer_the_sampler() {
+    let Some(model_path) = model_path_or_skip() else {
+        return;
+    };
+
+    let handle = openinfer_qwen3_4b::start_engine(
+        Path::new(&model_path),
+        EngineLoadOptions {
+            enable_cuda_graph: true,
+            enable_prefill_profile: false,
+            device_ordinals: vec![0],
+            seed: 42,
+            ..EngineLoadOptions::default()
+        },
+    )
+    .expect("failed to start engine");
+    let tokenizer = common::load_tokenizer(&model_path);
+
+    // Branchy continuation so unrestricted sampling has real entropy to show.
+    let prompt = "Here is a short story about a dragon. Once upon a time";
+    let prompt_tokens = tokenizer.encode(prompt, false).expect("encode failed");
+
+    // Warm the prefix cache first so every measured run takes the same
+    // (cache-hit) prefill path; a cold-vs-warm comparison could flip a
+    // near-tie token through bf16 wobble and fail spuriously.
+    let _ = generate(&handle, prompt_tokens.clone(), SamplingParams::default());
+
+    // Greedy is repeatable token-for-token.
+    let greedy = generate(&handle, prompt_tokens.clone(), SamplingParams::default());
+    assert_eq!(
+        greedy.len(),
+        GENERATED_TOKENS,
+        "EOS inside a 32-token story tail is unexpected"
+    );
+    let greedy_again = generate(&handle, prompt_tokens.clone(), SamplingParams::default());
+    assert_eq!(greedy, greedy_again, "greedy decode must be deterministic");
+
+    // top_k = 1 leaves a single survivor: identical to greedy at any
+    // temperature.
+    let top_k_one = generate(
+        &handle,
+        prompt_tokens.clone(),
+        SamplingParams {
+            temperature: 0.8,
+            top_k: 1,
+            ..SamplingParams::default()
+        },
+    );
+    assert_eq!(top_k_one, greedy, "top_k=1 must collapse to greedy");
+
+    // A tiny nucleus always contains exactly the top token (the largest
+    // probability alone satisfies any threshold at or below itself), so
+    // top_p -> 0 collapses to greedy as well.
+    let top_p_tiny = generate(
+        &handle,
+        prompt_tokens.clone(),
+        SamplingParams {
+            temperature: 1.0,
+            top_p: 0.01,
+            ..SamplingParams::default()
+        },
+    );
+    assert_eq!(top_p_tiny, greedy, "top_p=0.01 must collapse to greedy");
+
+    // Unrestricted high-temperature sampling must actually sample: four runs
+    // of 32 tokens collapsing to one sequence means the params were dropped
+    // on the way to the sampler (#237's silent greedy fallback).
+    let hot = SamplingParams {
+        temperature: 1.5,
+        top_k: -1,
+        top_p: 1.0,
+        ..SamplingParams::default()
+    };
+    let runs: Vec<Vec<u32>> = (0..4)
+        .map(|_| generate(&handle, prompt_tokens.clone(), hot))
+        .collect();
+    assert!(
+        runs.iter().any(|run| *run != runs[0]),
+        "4 high-temperature runs were token-identical — sampling params are not reaching the sampler"
+    );
+}


### PR DESCRIPTION
Closes #243 (Problem B; Problem A landed in #354/#357).

## What

Single-GPU IT (`tests/sampling_behavior.rs`) pinning that `temperature`/`top_k`/`top_p` actually steer the sampler — the #237 failure class (request params silently falling back to greedy) would have passed every existing test, since the whole suite decodes greedily.

- greedy decode is repeatable token-for-token (after a prefix-cache warmup run so all measured runs share the cache-hit prefill path);
- `top_k=1` at temperature 0.8 collapses to greedy, token-exact;
- `top_p=0.01` at temperature 1.0 collapses to greedy (a tiny nucleus always contains exactly the top token);
- four unrestricted temperature-1.5 runs must diverge — this is the assertion that catches a silent greedy fallback.

## Deliberately out of scope

- Seed determinism: per-request `seed` is rejected at the frontend (#354) and the legacy per-row sampler is not run-to-run deterministic — that lands with the #284 batched-primitive migration (0.2.0).
- qwen35: same gap, same recipe; tracked by #249's tree rather than duplicated here.

## Verification

Run 3× against /data/models/Qwen3-4B on the 5090: green, ~7s each. Skips cleanly without weights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)