### PR TITLE
perf(server): cut Qwen3-4B warm startup-to-ready from 3.25s to 1.45s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4298,6 +4298,7 @@ dependencies = [
  "half",
  "hex",
  "log",
+ "memmap2",
  "openinfer-bench",
  "openinfer-core",
  "openinfer-cupti",
@@ -4364,6 +4365,7 @@ dependencies = [
  "serde_json",
  "tikv-jemallocator",
  "tokio",
+ "tokio-util",
  "vllm-text",
 ]
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,6 +107,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 | --- | --- |
 | `subsystems/frontend/simulated-inference-engine.md` | CPU-only simulated model crate for vLLM/OpenAI frontend and `vllm bench serve` validation without CUDA, real model weights, or real-model performance claims. |
 | `subsystems/frontend/cpu-profiling-baseline.md` | Frontend CPU profiling baseline using `openinfer-sim` with fixed TTFT=5ms/TPOT=12ms: 200 req / concurrency=16 shows ~150ms TTFT overhead (no dominant hotspot), heap allocation ~10%, stream polling ~7.5%, IPC ~1%; reproducible benchmark command and perf evidence documented. |
+| `subsystems/frontend/startup-time.md` | Qwen3-4B warm startup-to-ready 3.25s → ~1.45s: frontend tokenizer load runs concurrently with the engine load (HTTP still binds only after the engine registers), and the source safetensors mmap is kept alive to dodge ~0.4s of munmap stalling the next cudaMalloc. |
 
 ## subsystems / correctness
 

--- a/docs/subsystems/frontend/startup-time.md
+++ b/docs/subsystems/frontend/startup-time.md
@@ -1,0 +1,39 @@
+# Server startup-to-ready time
+
+**TL;DR**: Qwen3-4B warm (page-cache-hot) startup-to-HTTP-ready cut 3.25s → ~1.45s by (1) loading the engine on a blocking thread so the vLLM frontend's ~1.15s tokenizer/chat-template load runs concurrently, and (2) keeping the source safetensors mmap alive for the model's lifetime instead of paying ~0.4s of munmap page-table teardown on the critical path. Readiness semantics unchanged: HTTP binds only after the engine bridge registers.
+
+Last touched: 2026-06
+
+## Warm-start breakdown (RTX 5070 Ti, Qwen3-4B, 8GB bf16)
+
+Baseline 3.25s was three serial phases:
+
+| Phase | Cost | Fix |
+| --- | --- | --- |
+| Engine load (CUDA ctx 0.18s + H2D upload ~1.1s @ ~7GB/s pageable) | 1.3s | kept (pageable `clone_htod`; pinned staging judged not worth the complexity — see below) |
+| munmap of the 8GB touched source mmap | 0.42s | mmap now lives in `Qwen3Model::_weight_source` until model drop |
+| vLLM frontend: tokenizer (11MB tokenizer.json) + text/chat backends | 1.15s | runs concurrently with engine load |
+
+After: engine path ~1.35s and frontend path ~1.25s overlap; ready ≈ max of the two + process start ≈ 1.45s.
+
+## The munmap trap
+
+munmap of ~8GB of touched pages costs ~0.4s of kernel page-table teardown holding the process mmap lock. Dropping the mmaps "in the background" just moves the stall to whatever allocates next — cudaMalloc (KV cache), cuBLAS init on the worker thread, or first-decode graph capture all take the same lock. We measured the 0.4s gap migrating from `kv_budget` → `KvCacheManager::new` → `RankWorker::spawn` as the drop point moved. Keeping the mapping is free: the pages are clean file-backed page cache the kernel reclaims under pressure, so the only cost is RSS accounting.
+
+## Concurrent startup invariant (openinfer-vllm-frontend)
+
+`serve()` takes `impl Future<Output = Result<EngineHandle>>`. vllm-server starts immediately (loads tokenizer, then waits in `EngineCoreClient::connect` for the engine to register); a spawned task awaits the engine, sets the shared `ServableCap`, and runs the `LocalEngineBridge`. Invariant chain: `ServableCap::set` → bridge registers → vllm-server builds the router (guard included) → HTTP binds. So a reachable port still means the engine can serve, and the sampling guard never reads an unset cap (unset → loud 503, dead path by construction).
+
+Consequences to keep in mind:
+
+- The bootstrapped-transport `ready_timeout` now bounds the **whole engine load** (it used to start after load). It is 30min so multi-GPU MoE loads and cold starts fit; load *failure* cancels the server immediately via the engine task, the timeout only catches a truly hung load.
+- The graceful ctrl-c handler is installed only **after** the engine load resolves (`cancel_token_on_ctrl_c`). The blocking load can't be cancelled, so during load SIGINT keeps its default kill behavior — same as before the change. (When testing this: background jobs of non-interactive shells inherit SIGINT=SIG_IGN; use a spawner that restores default dispositions.)
+- LoRA mode stays sequential: the LoRA routes need the handle when the router is built.
+
+## Rejected: pinned-staging H2D upload
+
+Upload runs at ~7GB/s from pageable mmap memory. A pinned double-buffer pipeline would reach CPU-memcpy speed (~14GB/s, ~0.55s) but the frontend path (~1.25s, external vllm crates) is the floor — e2e gain ≲0.1s for an unsafe staging pipeline. Revisit only if the tokenizer load gets faster or engine-only load time (tests/benches) becomes the pain.
+
+## Next
+
+None active. The remaining floor is the external vllm tokenizer/backend load (~1.15s); revisit if upstream gets faster or if cold-start (bandwidth-bound, per roadmap out of scope) becomes a target.

--- a/openinfer-qwen3-4b/Cargo.toml
+++ b/openinfer-qwen3-4b/Cargo.toml
@@ -21,6 +21,7 @@ fastrace = { workspace = true }
 half = { workspace = true }
 hex = { workspace = true, optional = true }
 log = { workspace = true }
+memmap2 = { workspace = true }
 rand = { workspace = true }
 safetensors = { workspace = true }
 serde = { workspace = true }

--- a/openinfer-qwen3-4b/src/weights.rs
+++ b/openinfer-qwen3-4b/src/weights.rs
@@ -296,6 +296,13 @@ pub(crate) struct Qwen3Model {
     pub(super) packed_lora: PackedLoraRegistry,
     pub(super) max_loras: usize,
     pub(super) max_lora_rank: usize,
+    /// Source safetensors mmaps, kept for the model's lifetime. munmap of the
+    /// ~8GB touched mapping costs ~0.4s of kernel page-table teardown under
+    /// the process mmap lock, stalling whatever cudaMalloc/cuBLAS init runs
+    /// next (KV cache, decode buffers, first-decode graph capture) — while
+    /// keeping it is free: the pages are clean file-backed page cache the
+    /// kernel can reclaim under pressure.
+    _weight_source: Vec<memmap2::Mmap>,
 }
 
 // SAFETY: Each model instance is pinned to a single CUDA device and is only
@@ -533,6 +540,7 @@ impl Qwen3Model {
             "GPU model loaded in {:.0}ms",
             t_gpu.elapsed().as_secs_f64() * 1e3
         );
+        drop(shards);
 
         let num_hidden_layers = config.num_hidden_layers;
         let model = Self {
@@ -551,6 +559,7 @@ impl Qwen3Model {
             packed_lora: PackedLoraRegistry::empty(runtime.max_loras, num_hidden_layers),
             max_loras: runtime.max_loras,
             max_lora_rank: runtime.max_lora_rank,
+            _weight_source: mmaps,
         };
 
         if model.enable_cuda_graph {

--- a/openinfer-server/Cargo.toml
+++ b/openinfer-server/Cargo.toml
@@ -38,6 +38,7 @@ log = { workspace = true }
 logforth = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
+tokio-util = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 vllm-text = { workspace = true }

--- a/openinfer-server/src/main.rs
+++ b/openinfer-server/src/main.rs
@@ -7,7 +7,7 @@ use log::info;
 use openinfer::logging;
 use openinfer::server_engine::{ModelType, detect_model_type};
 use openinfer::vllm_frontend::LoraModule;
-use openinfer_core::engine::{EngineLoadOptions, EpBackend};
+use openinfer_core::engine::{EngineHandle, EngineLoadOptions, EpBackend};
 #[cfg(feature = "kimi-k2")]
 use openinfer_core::parallel::ParallelConfig;
 #[cfg(feature = "qwen3-4b")]
@@ -172,6 +172,72 @@ async fn main() -> anyhow::Result<()> {
         args.tp_size,
     );
 
+    // Engine load (weights → GPU) runs on a blocking thread so the HTTP
+    // frontend (tokenizer, chat templates) loads concurrently. The frontend
+    // binds only after the engine registers, so readiness is unchanged.
+    let model_path = args.model_path.clone();
+    let served_model_name = args.served_model_name.clone();
+    let lora_modules = args.lora_modules.clone();
+    let enable_lora = args.enable_lora;
+    let port = args.port;
+    let engine_load = tokio::task::spawn_blocking(move || -> anyhow::Result<EngineHandle> {
+        load_engine(&args, model_type, effective_cuda_graph)
+    });
+
+    if enable_lora {
+        // LoRA routes need the engine handle when the router is built, so this
+        // path stays sequential.
+        let handle = engine_load
+            .await
+            .context("engine loader thread panicked")??;
+        info!("Engine loaded: elapsed_ms={}", start.elapsed().as_millis());
+        let max_model_len =
+            openinfer::vllm_frontend::load_max_model_len(&model_path).unwrap_or(4096);
+        openinfer::vllm_frontend::serve_model_with_lora_routes(
+            handle,
+            model_path.to_string_lossy().into_owned(),
+            served_model_name.into_iter().collect(),
+            lora_modules,
+            port,
+            max_model_len,
+            openinfer::vllm_frontend::shutdown_token_from_ctrl_c(),
+        )
+        .await
+    } else {
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let engine = {
+            let shutdown = shutdown.clone();
+            async move {
+                let handle = engine_load
+                    .await
+                    .context("engine loader thread panicked")??;
+                info!("Engine loaded: elapsed_ms={}", start.elapsed().as_millis());
+                // The blocking load can't be cancelled, so SIGINT keeps its
+                // default kill behavior until the engine is up; only then
+                // switch to graceful shutdown.
+                openinfer::vllm_frontend::cancel_token_on_ctrl_c(&shutdown);
+                anyhow::Ok(handle)
+            }
+        };
+        openinfer::vllm_frontend::serve(
+            engine,
+            &model_path,
+            served_model_name.as_deref(),
+            port,
+            shutdown,
+        )
+        .await
+    }
+    .context("vLLM frontend server failed")?;
+
+    Ok(())
+}
+
+fn load_engine(
+    args: &Args,
+    model_type: ModelType,
+    effective_cuda_graph: bool,
+) -> anyhow::Result<EngineHandle> {
     let handle = match model_type {
         #[cfg(feature = "deepseek-v4")]
         ModelType::DeepSeekV4 => {
@@ -297,34 +363,7 @@ async fn main() -> anyhow::Result<()> {
         .context("failed to start Qwen3.5 engine")?,
     };
 
-    info!("Engine loaded: elapsed_ms={}", start.elapsed().as_millis());
-
-    if args.enable_lora {
-        let max_model_len =
-            openinfer::vllm_frontend::load_max_model_len(&args.model_path).unwrap_or(4096);
-        openinfer::vllm_frontend::serve_model_with_lora_routes(
-            handle,
-            args.model_path.to_string_lossy().into_owned(),
-            args.served_model_name.into_iter().collect(),
-            args.lora_modules,
-            args.port,
-            max_model_len,
-            openinfer::vllm_frontend::shutdown_token_from_ctrl_c(),
-        )
-        .await
-    } else {
-        openinfer::vllm_frontend::serve(
-            handle,
-            &args.model_path,
-            args.served_model_name.as_deref(),
-            args.port,
-            openinfer::vllm_frontend::shutdown_token_from_ctrl_c(),
-        )
-        .await
-    }
-    .context("vLLM frontend server failed")?;
-
-    Ok(())
+    Ok(handle)
 }
 
 #[cfg(feature = "kimi-k2")]

--- a/openinfer-vllm-frontend/src/lib.rs
+++ b/openinfer-vllm-frontend/src/lib.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -47,7 +48,7 @@ use openinfer_engine::engine::{
 use openinfer_engine::sampler::SamplingParams;
 
 mod sampling_guard;
-use sampling_guard::guard_generation_request;
+use sampling_guard::{ServableCap, guard_generation_request};
 
 const ENGINE_INDEX: u32 = 0;
 const LORA_ROUTE_BODY_LIMIT: usize = 128 * 1024 * 1024;
@@ -455,8 +456,12 @@ impl LocalEngineBridge {
     }
 }
 
+/// Serve while the engine is still loading: the HTTP frontend (tokenizer,
+/// chat templates) starts immediately and the engine bridge attaches once
+/// `engine` resolves. HTTP binds only after the bridge registers, so a
+/// reachable port still means the engine is ready.
 pub async fn serve(
-    handle: EngineHandle,
+    engine: impl Future<Output = Result<EngineHandle>> + Send + 'static,
     model_path: &Path,
     served_model_name: Option<&str>,
     port: u16,
@@ -471,13 +476,14 @@ pub async fn serve(
         );
         FALLBACK_MAX_MODEL_LEN
     });
-    serve_model(
-        handle,
+    serve_model_on_host(
+        engine,
         model_path.to_string_lossy().into_owned(),
         served_model_name
             .into_iter()
             .map(std::string::ToString::to_string)
             .collect(),
+        "0.0.0.0".to_string(),
         port,
         max_model_len,
         shutdown,
@@ -495,7 +501,7 @@ pub async fn serve_model(
 ) -> Result<()> {
     let model_id = model_id.into();
     serve_model_on_host(
-        handle,
+        std::future::ready(Ok(handle)),
         model_id,
         served_model_name,
         "0.0.0.0".to_string(),
@@ -523,7 +529,7 @@ pub async fn serve_model_with_lora_routes(
         .cloned()
         .unwrap_or_else(|| model_id.clone());
     serve_model_on_host_with_router_extension(
-        handle.clone(),
+        std::future::ready(Ok(handle.clone())),
         model_id,
         served_model_name.clone(),
         "0.0.0.0".to_string(),
@@ -570,7 +576,7 @@ async fn load_startup_lora_modules(
 }
 
 async fn serve_model_on_host(
-    handle: EngineHandle,
+    engine: impl Future<Output = Result<EngineHandle>> + Send + 'static,
     model_id: String,
     served_model_name: Vec<String>,
     host: String,
@@ -579,7 +585,7 @@ async fn serve_model_on_host(
     shutdown: CancellationToken,
 ) -> Result<()> {
     serve_model_on_host_with_router_extension(
-        handle,
+        engine,
         model_id,
         served_model_name,
         host,
@@ -592,7 +598,7 @@ async fn serve_model_on_host(
 }
 
 async fn serve_model_on_host_with_router_extension<F>(
-    handle: EngineHandle,
+    engine: impl Future<Output = Result<EngineHandle>> + Send + 'static,
     model_id: String,
     served_model_name: Vec<String>,
     host: String,
@@ -608,18 +614,41 @@ where
     let input_address = ipc_endpoint(&namespace, "input.sock");
     let output_address = ipc_endpoint(&namespace, "output.sock");
 
-    let servable_limit = handle.servable_len().map(|cap| max_model_len.min(cap));
-    let max_model_len = servable_limit.unwrap_or(max_model_len);
-    let bridge = LocalEngineBridge {
-        input_address: input_address.clone(),
-        output_address: output_address.clone(),
-        handle,
-        max_model_len,
-    };
+    // The HTTP server runs concurrently with the engine load: vllm-server
+    // spends ~1s loading the tokenizer and chat templates before it waits for
+    // an engine to register, so neither waits on the other. This task attaches
+    // the bridge once the engine resolves and runs it to completion; on engine
+    // failure it cancels the server so the error surfaces instead of hanging
+    // in the registration wait.
+    let servable_cap = ServableCap::default();
+    let server_shutdown = shutdown.child_token();
     let bridge_shutdown = shutdown.child_token();
-    let bridge_task = tokio::spawn(async move {
-        if let Err(error) = bridge.run(bridge_shutdown).await {
-            warn!("local vLLM engine bridge exited: {error:#}");
+    let engine_task = tokio::spawn({
+        let servable_cap = servable_cap.clone();
+        let server_shutdown = server_shutdown.clone();
+        let bridge_shutdown = bridge_shutdown.clone();
+        let input_address = input_address.clone();
+        let output_address = output_address.clone();
+        async move {
+            let handle = match engine.await {
+                Ok(handle) => handle,
+                Err(error) => {
+                    server_shutdown.cancel();
+                    return Err(error);
+                }
+            };
+            let servable_limit = handle.servable_len().map(|cap| max_model_len.min(cap));
+            servable_cap.set(servable_limit);
+            let bridge = LocalEngineBridge {
+                input_address,
+                output_address,
+                handle,
+                max_model_len: servable_limit.unwrap_or(max_model_len),
+            };
+            if let Err(error) = bridge.run(bridge_shutdown).await {
+                warn!("local vLLM engine bridge exited: {error:#}");
+            }
+            Ok(())
         }
     });
 
@@ -628,7 +657,11 @@ where
             input_address,
             output_address,
             engine_count: 1,
-            ready_timeout: Duration::from_secs(30),
+            // The in-process bridge registers once the engine future resolves,
+            // so this bounds the whole engine load (multi-GPU MoE models take
+            // minutes, cold starts longer). Load *failure* already cancels the
+            // server via the engine task; this only catches a truly hung load.
+            ready_timeout: Duration::from_mins(30),
         },
         coordinator_mode: CoordinatorMode::None,
         model: model_id,
@@ -653,10 +686,26 @@ where
     };
 
     let extend_router = move |router: Router| {
-        extend_router(router).layer(from_fn_with_state(servable_limit, guard_generation_request))
+        extend_router(router).layer(from_fn_with_state(servable_cap, guard_generation_request))
     };
-    let result = vllm_server::serve_with_router_extension(config, shutdown, extend_router).await;
-    bridge_task.abort();
+    let result =
+        vllm_server::serve_with_router_extension(config, server_shutdown, extend_router).await;
+    // Stop the bridge (no-op if the caller's shutdown already cancelled it),
+    // then collect the engine task. If the server failed while the engine is
+    // still loading, the uncancellable blocking load must finish first.
+    bridge_shutdown.cancel();
+    if result.is_err() && !engine_task.is_finished() {
+        warn!("HTTP server failed; waiting for the in-flight engine load to finish before exit");
+    }
+    let result = match engine_task.await {
+        Ok(Ok(())) => result,
+        // Engine failed: the server saw a cancel and returned Ok — the engine
+        // error is the one worth reporting.
+        Ok(Err(engine_error)) => result.and(Err(engine_error)),
+        Err(join_error) => result.and(Err(anyhow::anyhow!(
+            "engine startup task panicked: {join_error}"
+        ))),
+    };
     let _ = std::fs::remove_dir_all(namespace);
     result
 }
@@ -1203,8 +1252,11 @@ pub fn load_max_model_len(model_path: &Path) -> Option<u32> {
         .max_model_len()
 }
 
-pub fn shutdown_token_from_ctrl_c() -> CancellationToken {
-    let token = CancellationToken::new();
+/// Cancel `token` on the first CTRL+C. Installing the handler replaces the
+/// default SIGINT kill behavior — only call this once whatever the token
+/// guards can actually wind down (e.g. after an uncancellable blocking engine
+/// load has finished), otherwise CTRL+C turns into a no-op wait.
+pub fn cancel_token_on_ctrl_c(token: &CancellationToken) {
     let shutdown = token.clone();
     tokio::spawn(async move {
         if let Err(error) = tokio::signal::ctrl_c().await {
@@ -1212,6 +1264,11 @@ pub fn shutdown_token_from_ctrl_c() -> CancellationToken {
         }
         shutdown.cancel();
     });
+}
+
+pub fn shutdown_token_from_ctrl_c() -> CancellationToken {
+    let token = CancellationToken::new();
+    cancel_token_on_ctrl_c(&token);
     token
 }
 

--- a/openinfer-vllm-frontend/src/sampling_guard.rs
+++ b/openinfer-vllm-frontend/src/sampling_guard.rs
@@ -4,6 +4,8 @@
 //! covers both checks on all three generation endpoints (`/v1/completions`,
 //! `/v1/chat/completions`, `/inference/v1/generate`).
 
+use std::sync::{Arc, OnceLock};
+
 use axum::Json;
 use axum::body::{Body, to_bytes};
 use axum::extract::{Request, State};
@@ -14,6 +16,30 @@ use log::warn;
 use serde::Deserialize;
 
 use super::{COMPLETION_ROUTE_BODY_LIMIT, bad_request};
+
+/// Engine-derived cap on a request's generated tokens (`None` = no cap),
+/// shared with the guard before the engine finishes loading so the HTTP
+/// frontend can start concurrently with the engine. vllm-server builds the
+/// router (and this guard) only after the engine bridge registers, which
+/// happens after [`ServableCap::set`] — so generation requests always observe
+/// the final value. An unset read means that invariant broke; reject loudly
+/// instead of serving with a missing cap.
+#[derive(Clone, Default)]
+pub(crate) struct ServableCap(Arc<OnceLock<Option<u32>>>);
+
+impl ServableCap {
+    pub(crate) fn set(&self, cap: Option<u32>) {
+        self.0
+            .set(cap)
+            .expect("servable cap must be set exactly once");
+    }
+
+    /// Outer `None` = engine still loading; inner = the engine's cap.
+    #[allow(clippy::option_option)]
+    fn get(&self) -> Option<Option<u32>> {
+        self.0.get().copied()
+    }
+}
 
 /// OpenAI-style invalid-request error, byte-compatible with vllm-server's
 /// `ErrorDetail` wire shape (that type is not exported, so mirror it here).
@@ -225,7 +251,7 @@ struct GenerateProbe {
 /// those pass. The same parse rejects `max_tokens` over the servable cap;
 /// a too-long prompt is rejected later by the upstream tokenized-length check.
 pub(crate) async fn guard_generation_request(
-    State(servable): State<Option<u32>>,
+    State(cap): State<ServableCap>,
     request: Request,
     next: Next,
 ) -> Response {
@@ -233,6 +259,21 @@ pub(crate) async fn guard_generation_request(
         "/v1/completions" | "/v1/chat/completions" => false,
         "/inference/v1/generate" => true,
         _ => return next.run(request).await,
+    };
+    let Some(servable) = cap.get() else {
+        warn!("generation request arrived before the engine finished loading");
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "error": {
+                    "message": "the engine is still loading",
+                    "type": "service_unavailable_error",
+                    "param": null,
+                    "code": "service_unavailable_error",
+                }
+            })),
+        )
+            .into_response();
     };
     let (parts, body) = request.into_parts();
     let Ok(bytes) = to_bytes(body, COMPLETION_ROUTE_BODY_LIMIT).await else {
@@ -276,12 +317,29 @@ mod tests {
     use super::*;
 
     fn guarded_router(servable: Option<u32>) -> Router {
+        let cap = ServableCap::default();
+        cap.set(servable);
+        unset_cap_router(cap)
+    }
+
+    fn unset_cap_router(cap: ServableCap) -> Router {
         Router::new()
             .route("/v1/completions", post(|| async { "ok" }))
             .route("/v1/chat/completions", post(|| async { "ok" }))
             .route("/inference/v1/generate", post(|| async { "ok" }))
             .route("/v1/models", get(|| async { "models" }))
-            .layer(from_fn_with_state(servable, guard_generation_request))
+            .layer(from_fn_with_state(cap, guard_generation_request))
+    }
+
+    #[tokio::test]
+    async fn generation_before_engine_ready_is_rejected_not_passed_through() {
+        let (status, _) = send_json(
+            unset_cap_router(ServableCap::default()),
+            "/v1/completions",
+            r#"{"max_tokens": 1}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
     }
 
     async fn send_json(router: Router, path: &str, body: &str) -> (StatusCode, serde_json::Value) {


### PR DESCRIPTION
## What

Warm (page-cache-hot) startup-to-HTTP-ready for Qwen3-4B: **3.25s → ~1.45s** (median of 5 runs, RTX 5070 Ti). Two serial phases removed from the critical path.

### 1. Frontend loads concurrently with the engine

The vLLM frontend spends ~1.15s loading the tokenizer and chat templates before it waits for an engine to register — previously strictly after the ~1.8s engine load. Now:

- `vllm_frontend::serve()` takes `impl Future<Output = Result<EngineHandle>>`; the server binary loads the engine on `spawn_blocking`.
- vllm-server starts immediately; a spawned task awaits the engine, sets a shared `ServableCap`, and runs the `LocalEngineBridge`.
- **Readiness semantics unchanged**: invariant chain `ServableCap::set` → bridge registers → vllm-server builds the router (sampling guard included) → HTTP binds. A reachable port still means the engine can serve; an unset cap read is a loud OpenAI-shaped 503 (dead path by construction, regression-tested).
- `ready_timeout` now bounds the *whole* engine load, so it's raised 30s → 30min (multi-GPU MoE loads and cold starts fit). Load *failure* still surfaces immediately — the engine task cancels the server token; the timeout only catches a truly hung load.
- The graceful ctrl-c handler installs only after the uncancellable blocking load resolves: during load SIGINT keeps its default kill behavior, same as before this change (verified 0.21s kill-during-load, graceful drain after ready).
- LoRA mode stays sequential (LoRA routes need the handle at router-build time).

### 2. Source safetensors mmap kept for the model's lifetime

munmap of the 8GB touched mapping costs ~0.4s of mmap_lock-held kernel page-table teardown. Dropping it "in the background" just moves the stall to whatever allocates next — we measured the 0.4s gap migrating from `kv_budget` → `KvCacheManager::new` → worker-thread cuBLAS init as the drop point moved. Keeping the mapping is free: clean file-backed page cache, reclaimable under pressure. `Qwen3Model::_weight_source` now holds it until model drop.

### Rejected: pinned-staging H2D upload

Upload runs at ~7GB/s pageable; a pinned double-buffer pipeline would save ~0.6s of engine path but the frontend path (~1.25s, external vllm crates) is the floor — e2e gain ≲0.1s for an unsafe staging pipeline. Documented in `docs/subsystems/frontend/startup-time.md`.

## Verification

- Workspace lib tests pass (except the known pre-existing GDR env failure on this box)
- `openinfer-sim` frontend e2e (plain + LoRA routes) pass through the new future-based path
- `hf_golden_gate` accuracy gate passes on GPU (covers the mmap-lifetime change)
- Real serving: greedy completion correct; over-cap `max_tokens` rejected with the exact OpenAI error shape
- SIGINT: default kill during load, graceful shutdown after ready
- Startup measured 5×: 1.43–1.57s (baseline 3.25s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)