### PR TITLE
feat(devbox): one-command Prime Intellect dev box + setup_dev.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,24 @@ flowchart TB
 
 ## Development
 
+### Fresh-box dev setup
+
+`scripts/setup_dev.sh` bootstraps a build environment on any fresh NVIDIA Ubuntu
+host: apt build deps + `protobuf-compiler`, uv, the rustup nightly pinned by
+`rust-toolchain.toml`, the vendored `flashinfer/3rdparty/cccl` submodule, then
+`cargo build --release`. CUDA is a prerequisite — it detects `nvcc` and fails
+loudly rather than installing a toolkit, so boot a CUDA image.
+
+```bash
+bash scripts/setup_dev.sh
+# on a GPU whose arch the kernels don't target (e.g. V100 sm_70), compile for another:
+OPENINFER_CUDA_SM=90 bash scripts/setup_dev.sh
+```
+
+To get the box itself, `scripts/prime_devbox.sh` provisions the cheapest match on
+[Prime Intellect](https://www.primeintellect.ai/), has the box git-clone this
+repo over HTTPS, and runs `setup_dev.sh` — see the script header for one-time setup.
+
 ### Tests
 
 ```bash

--- a/scripts/prime_devbox.sh
+++ b/scripts/prime_devbox.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# prime_devbox.sh — one command: provision a fresh Prime Intellect CUDA GPU box,
+# have it git-clone this repo over HTTPS, and run setup_dev.sh. No rsync — the
+# box pulls from GitHub itself (datacenter network, not your uplink). Only the
+# main repo is private (needs a token); its submodules are public.
+#
+# Uses the `prime` CLI directly — SkyPilot 0.12.2's Prime provisioner orphans
+# billing pods on a hardcoded 30s pod-create timeout.
+#
+# One-time prereqs:
+#   uv tool install prime              # plus `jq` and `gh` on PATH
+#   mkdir -p ~/.prime && printf '{"api_key":"%s"}\n' "$PRIME_API_KEY" > ~/.prime/config.json
+#   # The key at `prime config view` → "SSH Key Path" MUST be set as PRIMARY at
+#   # https://app.primeintellect.ai/dashboard (SSH Keys): pods inject the primary
+#   # key at boot, and it cannot be added to an already-running pod.
+#   gh auth login                      # supplies the read-only token for the clone
+#
+# Usage (env-configurable):
+#   scripts/prime_devbox.sh                                          # spot V100, compile-only (sm_90), main
+#   BRANCH=feat/x GPU=L40S_48GB SPOT=0 OPENINFER_CUDA_SM= scripts/prime_devbox.sh
+#
+# Tear down when done (id is printed at the end):  prime pods terminate <id>
+set -euo pipefail
+
+GPU="${GPU:-V100_16GB}"                  # prime availability gpu-type, e.g. L40S_48GB, A100_80GB
+SPOT="${SPOT:-1}"                        # 1 = spot (cheapest), 0 = on-demand
+IMAGE="${IMAGE:-ubuntu_22_cuda_12}"      # MUST ship nvcc; setup_dev.sh never installs CUDA
+DISK="${DISK:-100}"
+NAME="${NAME:-oi-dev}"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_rsa}"  # the key set PRIMARY on Prime (to ssh into the box)
+REMOTE_DIR="${REMOTE_DIR:-/root/openinfer}"
+REPO_SLUG="${REPO_SLUG:-openinfer-project/openinfer}"
+BRANCH="${BRANCH:-main}"
+# Compile target. V100 is sm_70, which the FlashInfer/CUDA kernels do not build
+# for, so default to sm_90 (a pure compile box). Set OPENINFER_CUDA_SM= (empty)
+# to let build.rs auto-detect the live GPU's arch (use that on L40S/A100/H100).
+CUDA_SM="${OPENINFER_CUDA_SM-90}"
+
+log(){ printf '\033[1;36m[prime_devbox]\033[0m %s\n' "$*"; }
+die(){ printf '\033[1;31m[prime_devbox] ERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+
+command -v prime >/dev/null 2>&1 || die "prime CLI not found — run: uv tool install prime"
+command -v jq    >/dev/null 2>&1 || die "jq not found — install jq"
+[ -f "$SSH_KEY" ] || die "SSH key $SSH_KEY not found (set SSH_KEY=/path/to/key)."
+
+# Read-only token for the private clone: explicit GITHUB_TOKEN, else the local gh login.
+TOKEN="${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
+[ -n "$TOKEN" ] || die "no GitHub token — export GITHUB_TOKEN=... or run 'gh auth login'."
+
+# 1. cheapest matching offer
+log "Finding $GPU (spot=$SPOT)…"
+want_spot=$([ "$SPOT" = 1 ] && echo true || echo false)
+SEL=$(prime availability list --gpu-type "$GPU" --output json 2>/dev/null \
+  | jq -r --argjson spot "$want_spot" \
+      '[.gpu_resources[] | select(.is_spot==$spot)] | sort_by(.price_value)[0].id // empty')
+[ -n "$SEL" ] || die "no $GPU (spot=$SPOT) in stock now — try SPOT=$([ "$SPOT" = 1 ] && echo 0 || echo 1) or a different GPU."
+
+# 2. create
+log "Creating pod ($GPU, $IMAGE, ${DISK}GB)…"
+POD=$(prime pods create --id "$SEL" --image "$IMAGE" --disk-size "$DISK" --name "$NAME" --yes --plain 2>&1 \
+  | grep -oE 'Successfully created pod [0-9a-f]+' | awk '{print $NF}')
+[ -n "$POD" ] || die "pod create failed — check 'prime pods list'."
+log "Pod $POD created.  (terminate with: prime pods terminate $POD)"
+
+# 3. wait for ACTIVE + SSH (tolerant of intermittent API hiccups)
+log "Waiting for ACTIVE + SSH…"
+HOSTPORT=""
+for _ in $(seq 1 90); do
+  st=$(prime pods status "$POD" --plain 2>/dev/null) || { sleep 8; continue; }
+  s=$(printf '%s\n' "$st" | awk '/^Status /{print $2}')
+  c=$(printf '%s\n' "$st" | sed -nE 's/^SSH +//p')
+  case "$s" in
+    ACTIVE|RUNNING) [ -n "$c" ] && [ "$c" != "N/A" ] && { HOSTPORT="$c"; break; } ;;
+    FAILED|TERMINATED|ERROR) die "pod entered $s. Terminate: prime pods terminate $POD" ;;
+  esac
+  sleep 8
+done
+[ -n "$HOSTPORT" ] || die "timed out waiting for SSH. Check: prime pods status $POD ; terminate: prime pods terminate $POD"
+HOST="${HOSTPORT%% -p *}"; PORT="${HOSTPORT##*-p }"; PORT="${PORT// /}"
+log "SSH up: $HOST -p $PORT"
+
+ssh_box(){ ssh -i "$SSH_KEY" -o StrictHostKeyChecking=accept-new -o ConnectTimeout=20 -o ServerAliveInterval=30 -p "$PORT" "$HOST" "$@"; }
+
+# 4. box clones the repo (token only on this short call; scrubbed right after)
+log "Cloning $REPO_SLUG@$BRANCH on the box…"
+ssh_box "set -e
+  rm -rf '$REMOTE_DIR'
+  git clone --depth 1 --branch '$BRANCH' 'https://x-access-token:${TOKEN}@github.com/${REPO_SLUG}.git' '$REMOTE_DIR' 2>&1 | tail -1
+  git -C '$REMOTE_DIR' remote set-url origin 'https://github.com/${REPO_SLUG}.git'"
+
+# 5. bootstrap + build (no token in this long-running call)
+log "Running setup_dev.sh (OPENINFER_CUDA_SM=${CUDA_SM:-auto})…"
+ssh_box "cd '$REMOTE_DIR' && OPENINFER_CUDA_SM='$CUDA_SM' bash scripts/setup_dev.sh"
+
+log "✅ Done."
+log "   SSH in:    ssh -i $SSH_KEY -p $PORT $HOST"
+log "   Terminate: prime pods terminate $POD"

--- a/scripts/setup_dev.sh
+++ b/scripts/setup_dev.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# setup_dev.sh — one-shot dev-environment bootstrap for a fresh Ubuntu GPU box.
+#
+# Goal: from a fresh CUDA GPU box to a green `cargo build --release` for the
+# default Qwen3-4B build (pure Rust + CUDA, no Python). Installs apt build deps,
+# uv, and the rustup nightly toolchain pinned by rust-toolchain.toml.
+# Idempotent — safe to re-run.
+#
+# The CUDA toolkit (nvcc + cuBLAS) is a PREREQUISITE, not something this script
+# installs: use a CUDA image (e.g. Prime Intellect's `ubuntu_22_cuda_12`) or an
+# already-provisioned toolkit. The script only detects it and fails loudly if
+# absent — it will not apt-install a toolkit onto someone's machine.
+#
+# Usage:  bash scripts/setup_dev.sh
+# Also invoked by scripts/prime_devbox.sh after it provisions a fresh box.
+set -euo pipefail
+
+log()  { printf '\033[1;32m[setup_dev]\033[0m %s\n' "$*"; }
+die()  { printf '\033[1;31m[setup_dev] ERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then command -v sudo >/dev/null && SUDO="sudo"; fi
+
+# --- 0. sanity: this must be a GPU box (build.rs reads the live arch) ----------
+command -v nvidia-smi >/dev/null 2>&1 || die "nvidia-smi not found — this script expects an NVIDIA GPU host."
+log "GPU: $(nvidia-smi --query-gpu=name,driver_version --format=csv,noheader | head -1)"
+
+# --- 1. apt build deps ---------------------------------------------------------
+if command -v apt-get >/dev/null 2>&1; then
+  log "Installing apt build deps…"
+  export DEBIAN_FRONTEND=noninteractive
+  # A freshly-booted cloud box runs cloud-init / unattended-upgrades, which hold
+  # the apt/dpkg lock for the first minute or two. DPkg::Lock::Timeout makes apt
+  # wait for the lock instead of racing it and dying with "Could not get lock".
+  APT="$SUDO apt-get -o DPkg::Lock::Timeout=300"
+  $APT update -qq
+  # protobuf-compiler: pegaflow-proto's build.rs invokes `protoc`.
+  $APT install -y -qq build-essential git curl ca-certificates pkg-config libssl-dev protobuf-compiler
+fi
+
+# --- 2. CUDA toolkit (nvcc + cuBLAS) — PREREQUISITE, detected not installed ----
+detect_cuda() {
+  local c
+  for c in "${CUDA_HOME:-}" /usr/local/cuda /usr/local/cuda-13* /usr/local/cuda-12*; do
+    [ -n "$c" ] && [ -x "$c/bin/nvcc" ] && { echo "$c"; return 0; }
+  done
+  if command -v nvcc >/dev/null 2>&1; then dirname "$(dirname "$(command -v nvcc)")"; return 0; fi
+  return 1
+}
+
+CUDA_HOME="$(detect_cuda)" || die "No CUDA toolkit (nvcc) found.
+  This script does not install CUDA — boot a CUDA image (e.g. Prime Intellect's
+  'ubuntu_22_cuda_12') or install the CUDA Toolkit (>=12.2) yourself, then re-run.
+  If it is installed at a non-standard path, export CUDA_HOME first."
+export CUDA_HOME
+export PATH="$CUDA_HOME/bin:$PATH"
+log "CUDA toolkit: $CUDA_HOME ($("$CUDA_HOME/bin/nvcc" --version | grep -oE 'release [0-9.]+' | head -1))"
+
+# --- 3. uv ---------------------------------------------------------------------
+if ! command -v uv >/dev/null 2>&1; then
+  log "Installing uv…"
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+export PATH="$HOME/.local/bin:$PATH"
+
+# --- 4. Rust (nightly channel is pinned by rust-toolchain.toml) ----------------
+if ! command -v rustup >/dev/null 2>&1; then
+  log "Installing rustup…"
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+fi
+# shellcheck disable=SC1091
+. "$HOME/.cargo/env"
+log "Provisioning toolchain pinned by rust-toolchain.toml…"
+rustup show active-toolchain >/dev/null   # triggers install of the pinned nightly + components
+
+# --- 5. vendored submodules (flashinfer headers + its pinned cccl) -------------
+# A fresh `git clone` checks out no submodules. build.rs needs the flashinfer
+# headers, and `-I`s flashinfer's pinned cccl ahead of the toolkit's own CCCL so
+# the kernels compile against a new-enough libcudacxx (<cuda/cmath>, cuda::maximum)
+# on any CUDA >=12.2. (A CUDA 13.x host ships a new-enough system CCCL and masks a
+# missing cccl; CUDA 12.x does not — so require it explicitly.) Only flashinfer +
+# cccl are inited; the heavy unused nested submodules (cutlass/nccl/nixl/spdlog)
+# and the DeepEP submodule are deliberately left untouched.
+FI=openinfer-kernels/third_party/flashinfer
+is_git() { git -C "$1" rev-parse --git-dir >/dev/null 2>&1; }
+
+if [ ! -e "$FI/include" ]; then
+  is_git . || die "flashinfer submodule not checked out and this is not a git checkout.
+  Boot from a git clone (prime_devbox.sh does this) or run: git submodule update --init $FI"
+  log "Initializing flashinfer submodule…"
+  git submodule update --init "$FI"
+fi
+
+if [ ! -e "$FI/3rdparty/cccl/libcudacxx/include/cuda/cmath" ]; then
+  is_git "$FI" || die "vendored CCCL missing and flashinfer is not a git checkout.
+  Without it the build fails on CUDA <13 with 'cuda/cmath: No such file'."
+  log "Initializing vendored CCCL submodule…"
+  git -C "$FI" submodule update --init 3rdparty/cccl
+fi
+
+# --- 6. build ------------------------------------------------------------------
+if [ -n "${OPENINFER_CUDA_SM:-}" ]; then
+  log "OPENINFER_CUDA_SM=$OPENINFER_CUDA_SM — compiling kernels for this arch instead of the live GPU."
+else
+  log "OPENINFER_CUDA_SM unset — build.rs auto-detects the arch from nvidia-smi."
+fi
+log "Building (release, default Qwen3-4B feature)… first build compiles CUDA kernels, give it a few minutes."
+cargo build --release
+
+cat <<EOF
+
+$(log "✅ Dev environment ready.")
+  CUDA_HOME : $CUDA_HOME
+  rust      : $(rustc --version)
+  next      : huggingface-cli download Qwen/Qwen3-4B --local-dir models/Qwen3-4B
+              cargo run --release -- --model-path models/Qwen3-4B
+EOF


### PR DESCRIPTION
## What

One command to go from nothing to a green `cargo build --release` on a fresh Prime Intellect GPU box.

- **`scripts/setup_dev.sh`** — on-box bootstrap, runs on any NVIDIA Ubuntu host: apt build deps + `protobuf-compiler`, uv, the rustup nightly toolchain pinned by `rust-toolchain.toml`, inits only the `flashinfer` + its pinned `3rdparty/cccl` submodules, then builds. **CUDA is a prerequisite — detected, never installed** (use a CUDA image; the script fails loudly if `nvcc` is absent).
- **`scripts/prime_devbox.sh`** — drives the `prime` CLI: pick the cheapest matching GPU, create the pod, wait for ACTIVE+SSH, then have **the box git-clone this repo over HTTPS** (read-only token from the local `gh` login — no rsync, no SSH key for git) and run `setup_dev.sh`. Env-configurable (`GPU`, `SPOT`, `IMAGE`, `BRANCH`, `OPENINFER_CUDA_SM`, …).
- **README** — a short pointer to the two scripts; the gotchas live in the script headers.

## Why the box pulls instead of rsync

The Finland-based box clones from GitHub at datacenter speed; rsync would push ~800M (incl. submodules) over the dev's uplink and needs rsync on both ends. Only the main repo is private (needs the token); flashinfer + cccl are public HTTPS submodules, so no auth there. The token rides only on the short clone call and the remote URL is scrubbed right after.

## Why not SkyPilot

SkyPilot 0.12.2 supports Prime, but its provisioner hardcodes a 30s HTTP timeout on pod creation. datacrunch answers slower, so it times out and **orphans a billing pod on every launch** (reproduced twice, cleaned up manually). The `prime` CLI path avoids this.

## Gotchas (all handled by the scripts)

1. **SSH key must be PRIMARY** — Prime injects the account's *primary* key at boot; a non-primary key gives `Permission denied (publickey)` and can't be added to a running pod.
2. **Fresh-boot apt lock** — cloud-init / unattended-upgrades hold the apt/dpkg lock for the first minute or two; `setup_dev.sh` passes `DPkg::Lock::Timeout` so apt waits instead of dying with `Could not get lock`.
3. **Vendored CCCL submodule** — `build.rs` `-I`s `flashinfer/3rdparty/cccl` so kernels find `<cuda/cmath>` / `cuda::maximum` on CUDA ≥12.2. A CUDA 13.x host's system CCCL masks a missing submodule; CUDA 12.x does not.
4. **Compile arch vs run arch** — `OPENINFER_CUDA_SM` lets a GPU whose arch the kernels don't target (e.g. V100 sm_70) compile for another arch as a pure build smoke-test; leave it empty on an A100/L40S/H100 to get a natively-runnable build.

## Verification

Full `prime_devbox.sh` run, end to end, on a `$0.45/hr` spot **A100-SXM4-40GB** (`OPENINFER_CUDA_SM=` empty → auto-detect):

```
provision → ACTIVE+SSH → HTTPS clone → init flashinfer + cccl submodules → auto-detect sm_80 →
   Compiling openinfer-server v0.1.0 (/root/openinfer/openinfer-server)
    Finished `release` profile [optimized] target(s) in 2m 00s
[setup_dev] ✅ Dev environment ready.
```

`target/release/openinfer` (59M) built for native sm_80 and runs (`--help` OK). Pod terminated after; 0 pods left billing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
