### PR TITLE
fix(deepseek-v2-lite): widen EP2 HF correctness gate

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -63,8 +63,8 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 
 | Path | TL;DR |
 | --- | --- |
-| `models/deepseek-v2-lite/status.md` | DeepSeek-V2-Lite EP2 model status and benchmark ledger: HF/host-staged/NCCL are exact for the narrow greedy gate; direct same-prompt batch and manual vLLM snapshots are diagnostic evidence, not production serving parity. |
-| `models/deepseek-v2-lite/hf-accuracy-gate.md` | DeepSeek-V2-Lite EP2 HF accuracy gate after PR #149/#150: HF incremental greedy, host-staged EP2, and NCCL EP2 are token/text exact for `Hello`, output_len=16. |
+| `models/deepseek-v2-lite/status.md` | DeepSeek-V2-Lite EP2 model status and benchmark ledger: HF/host-staged/NCCL use a committed small correctness case set; direct same-prompt batch and manual vLLM snapshots remain diagnostic evidence, not production serving parity. |
+| `models/deepseek-v2-lite/hf-accuracy-gate.md` | DeepSeek-V2-Lite EP2 HF accuracy gate after PR #149/#150/#274: HF `generate(use_cache=true)`, host-staged EP2, and NCCL EP2 are compared across the committed small case set. |
 | `models/deepseek-v2-lite/decode-attribution-gate.md` | DeepSeek-V2-Lite EP2 decode attribution gate for `Hello`/16-token batch sizes 1/4/8: structured JSON with accuracy hashes, CPU-side timing, selected CUDA event/NVTX attribution, host-staged/NCCL EP counts, and explicit no-throughput claim boundary. |
 | `models/deepseek-v2-lite/source-layout.md` | DeepSeek-V2-Lite runtime layout refactor: `runtime.rs` split by responsibility, HF/host-staged/NCCL EP2 E2E exact on 2x RTX 5090; NCCL CUDA Graph smoke remains a diagnostic blocker on that host, independent of the passed correctness gate. |
 | `models/deepseek-v2-lite/device-resident-nccl-combine.md` | Issue #275 record: NCCL decode combine uses reusable device-resident f32 scratch; current NCCL graph-readiness blockers live in `status.md`. |

--- a/docs/models/deepseek-v2-lite/decode-attribution-gate.md
+++ b/docs/models/deepseek-v2-lite/decode-attribution-gate.md
@@ -1,6 +1,6 @@
 # DeepSeek-V2-Lite EP2 Decode Attribution Gate
 
-> **TL;DR:** DeepSeek-V2-Lite now has a narrow EP2 decode attribution report for the same correctness shape as the HF gate and the true-batch benchmark follow-up: `prompt="Hello"`, `output_len=16`, `batch-size=1/4/8`, host-staged backend, and NCCL backend. The report combines CPU-side attribution, selected CUDA event timing, optional NVTX ranges, route/transfer counts, and a fail-closed CUDA Graph readiness section; it is evidence for the next bottleneck decision, not a throughput or production EP claim.
+> **TL;DR:** DeepSeek-V2-Lite has a narrow EP2 decode attribution report for the retained diagnostic shape: `prompt="Hello"`, `output_len=16`, `batch-size=1/4/8`, host-staged backend, and NCCL backend. The wider HF accuracy gate now covers more cases, while this report stays focused on CPU-side attribution, selected CUDA event timing, optional NVTX ranges, route/transfer counts, and a fail-closed CUDA Graph readiness section. It is evidence for the next bottleneck decision, not a throughput or production EP claim.
 >
 > **Status:** Passing for the covered EP2 `Hello` / 16-token host-staged and NCCL attribution gate. The batch attribution mode is diagnostic and uses the same-prompt, fixed-length shape as the direct benchmark path.
 
@@ -11,7 +11,7 @@ This gate deliberately stays model-specific and shape-specific:
 - Model: DeepSeek-V2-Lite.
 - Shape: batch size `1`, `4`, or `8`, prompt `Hello`, prompt token ids `[17464]`, output length `16`.
 - Backends: default host-staged EP2 and `OPENINFER_DSV2_LITE_EP_BACKEND=nccl`.
-- Accuracy oracle: the same generated token/text/hash gate used by `hf-accuracy-gate.md`.
+- Accuracy oracle: the generated token/text/hash comparison from `hf-accuracy-gate.md`; attribution itself remains on the `Hello` / 16-token diagnostic shape.
 - Attribution source: `DeepSeekV2LiteEp2Generator::generate_greedy_with_attribution` for `batch-size=1`, and `DeepSeekV2LiteEp2Generator::generate_greedy_batch_same_prompt_with_attribution` for `batch-size>1`.
 - GPU attribution source: CUDA events around selected stream sections in the explicit attribution path.
 - NVTX source: set `OPENINFER_DSV2_LITE_NVTX=1` to emit matching ranges for those selected sections during a profiler run.
@@ -50,15 +50,16 @@ mkdir -p target/accuracy/dsv2-lite-ep2
 
 python tools/accuracy/hf_dump_dsv2_lite_ep2_greedy.py \
   --model-path models/DeepSeek-V2-Lite \
-  --prompt Hello \
-  --output-len 16 \
+  --case-set-json test_data/deepseek-v2-lite-ep2-cases.json \
   --out target/accuracy/dsv2-lite-ep2/hf.json
 
 OPENINFER_TEST_MODEL_PATH=models/DeepSeek-V2-Lite \
+OPENINFER_DSV2_LITE_E2E_CASE_SET=test_data/deepseek-v2-lite-ep2-cases.json \
 OPENINFER_DSV2_LITE_E2E_JSON_OUT=target/accuracy/dsv2-lite-ep2/host-staged.json \
   cargo test --release -p openinfer-deepseek-v2-lite --features deepseek-v2-lite --test e2e_ep2 -- --nocapture
 
 OPENINFER_TEST_MODEL_PATH=models/DeepSeek-V2-Lite \
+OPENINFER_DSV2_LITE_E2E_CASE_SET=test_data/deepseek-v2-lite-ep2-cases.json \
 OPENINFER_DSV2_LITE_EP_BACKEND=nccl \
 OPENINFER_DSV2_LITE_E2E_JSON_OUT=target/accuracy/dsv2-lite-ep2/nccl.json \
   cargo test --release -p openinfer-deepseek-v2-lite --features deepseek-v2-lite --test e2e_ep2 -- --nocapture

--- a/docs/models/deepseek-v2-lite/hf-accuracy-gate.md
+++ b/docs/models/deepseek-v2-lite/hf-accuracy-gate.md
@@ -1,23 +1,33 @@
 # DeepSeek-V2-Lite EP2 HF Accuracy Gate
 
-> **TL;DR:** HF comparison gate for issue #135 after PR #149 and PR #150. The remaining correctness question was not NCCL performance; it was whether the existing DeepSeek-V2-Lite EP=2 baseline matches Hugging Face `generate(use_cache=true)` greedy decode for `prompt="Hello"`, `batch=1`, `output_len=16`.
+> **TL;DR:** HF comparison gate for DeepSeek-V2-Lite EP2. The original `Hello` / 16-token shape remains covered, and issue #274 widens the same HF / host-staged / NCCL oracle to a small committed case set with multiple prompts plus diagnostic same-prompt batch sizes `4` and `8`.
 >
-> **Status:** Passing for the covered shape. The latest run is token-exact and text-exact across HF `generate(use_cache=true)` greedy, openinfer host-staged EP2, and openinfer NCCL EP2.
+> **Status:** Passing evidence must come from a same-host comparison against `test_data/deepseek-v2-lite-ep2-cases.json`. The Rust E2E may emit OpenInfer case outputs, but the HF JSON remains the accuracy oracle.
 
 ## Scope
 
 In scope:
 
 - HF truth: `AutoTokenizer` and `AutoModelForCausalLM` with `trust_remote_code=True`, `torch_dtype=torch.bfloat16`, `model.eval()`, and `torch.no_grad()`.
-- Generation shape: batch `1`, prompt `Hello`, prompt token ids `[17464]`, output length `16`, greedy argmax only.
+- Generation shapes: the committed cases in `test_data/deepseek-v2-lite-ep2-cases.json`: `Hello` at batch `1/4/8`, plus two additional batch-1 prompts, all with `output_len=16` and greedy argmax.
 - Openinfer paths: default host-staged EP2 backend and explicit `OPENINFER_DSV2_LITE_EP_BACKEND=nccl`.
-- Result comparison: generated token ids, generated text, token sha256, text sha256, and first different generated-token index.
+- Result comparison: per-case and per-row generated token ids, generated text, token sha256, text sha256, and first different generated-token index.
+
+The committed case set uses one object per case:
+
+- `id`: stable comparison key.
+- `prompt`: prompt text passed to HF and OpenInfer.
+- `output_len`: requested greedy output length.
+- `batch_size`: OpenInfer same-prompt row count for the diagnostic batch cases.
+- `ignore_eos`: when `true`, HF sets `eos_token_id=None` and OpenInfer ignores EOS so fixed-length batch rows can be compared. Batch cases must use `ignore_eos=true`; batch-1 cases may stop on EOS.
+
+The current Rust same-prompt batch helper is capped at batch size `8`, so the committed diagnostic batch cases stop at `4` and `8`.
 
 Out of scope:
 
 - Performance claims.
 - Sparse dispatch or production EP backend work.
-- Generic EP topology, multi-node support, larger prompts, or batch > 1.
+- Generic EP topology, multi-node support, serving batch, or mixed-request continuous batching.
 - Any NCCL runtime-path change when host-staged and NCCL still match each other.
 
 ## Issue #135 Coverage Map
@@ -30,7 +40,7 @@ Out of scope:
 | Unsupported backend/topology reports explicit errors. | PR #149 / #150 | Unsupported device count, duplicate devices, cuda_graph, and backend names fail closed. |
 | Minimal dispatch/combine path exists for the first correctness gate. | PR #149 | Host-staged dispatch/combine path remains the default baseline. |
 | Maintainer-requested naive NCCL backend exists before openinfer-comm/NVLink work. | PR #150 | `OPENINFER_DSV2_LITE_EP_BACKEND=nccl` path passes the same EP2 greedy E2E as host-staged. |
-| HF ground-truth accuracy comparison exists. | This gate | HF `generate(use_cache=true)` greedy, host-staged EP2, and NCCL EP2 are token/text exact for the covered shape. |
+| HF ground-truth accuracy comparison exists. | This gate | HF `generate(use_cache=true)` greedy, host-staged EP2, and NCCL EP2 are token/text exact for the covered case set. |
 
 Together with PR #149 and PR #150, this gate covers issue #135's correctness-first acceptance surface for the narrow EP=2 milestone. Follow-up work should be tracked separately for sparse/GPU dispatch, openinfer-comm/NVLink integration, performance evidence, long context, and broader prompts/batches.
 
@@ -43,15 +53,16 @@ mkdir -p target/accuracy/dsv2-lite-ep2
 
 python tools/accuracy/hf_dump_dsv2_lite_ep2_greedy.py \
   --model-path models/DeepSeek-V2-Lite \
-  --prompt Hello \
-  --output-len 16 \
+  --case-set-json test_data/deepseek-v2-lite-ep2-cases.json \
   --out target/accuracy/dsv2-lite-ep2/hf.json
 
 OPENINFER_TEST_MODEL_PATH=models/DeepSeek-V2-Lite \
+OPENINFER_DSV2_LITE_E2E_CASE_SET=test_data/deepseek-v2-lite-ep2-cases.json \
 OPENINFER_DSV2_LITE_E2E_JSON_OUT=target/accuracy/dsv2-lite-ep2/host-staged.json \
   cargo test --release -p openinfer-deepseek-v2-lite --features deepseek-v2-lite --test e2e_ep2 -- --nocapture
 
 OPENINFER_TEST_MODEL_PATH=models/DeepSeek-V2-Lite \
+OPENINFER_DSV2_LITE_E2E_CASE_SET=test_data/deepseek-v2-lite-ep2-cases.json \
 OPENINFER_DSV2_LITE_EP_BACKEND=nccl \
 OPENINFER_DSV2_LITE_E2E_JSON_OUT=target/accuracy/dsv2-lite-ep2/nccl.json \
   cargo test --release -p openinfer-deepseek-v2-lite --features deepseek-v2-lite --test e2e_ep2 -- --nocapture
@@ -71,10 +82,29 @@ On Blackwell-class GPUs, make sure the selected NCCL runtime supports the device
 ## Interpretation
 
 - `all_token_text_exact`: HF, host-staged, and NCCL agree on generated token ids and generated text.
-- `openinfer_baseline_accuracy_gap`: host-staged and NCCL match each other, but both differ from HF. Treat this as a openinfer baseline accuracy problem before touching NCCL transport.
+- `openinfer_baseline_accuracy_gap`: host-staged and NCCL match each other, but both differ from HF. Treat this as an OpenInfer baseline accuracy problem before touching NCCL transport.
 - `nccl_transport_regression`: host-staged and NCCL differ. Debug the NCCL path before drawing any HF parity conclusion.
 
+For batch cases, the HF output is the expected row output, and every host-staged / NCCL same-prompt row must match it. Host-staged and NCCL must also match each other row-by-row.
+
 ## Latest Evidence
+
+2026-06-14, single-node 2x RTX 5090 validation with `test_data/deepseek-v2-lite-ep2-cases.json` on the same `models/DeepSeek-V2-Lite` snapshot for HF, host-staged, and NCCL. The HF truth source used `AutoModelForCausalLM.generate(..., do_sample=false, use_cache=true)` with `torch==2.7.0+cu128` and `transformers==4.40.2`. The Rust gate emitted schema-2 case-set JSON for host-staged and NCCL, including row-level outputs for the same-prompt batch cases.
+
+Review artifacts from that run were written under `target/accuracy/dsv2-lite-ep2-review/`:
+
+- `target/accuracy/dsv2-lite-ep2-review/hf.json`
+- `target/accuracy/dsv2-lite-ep2-review/host-staged.json`
+- `target/accuracy/dsv2-lite-ep2-review/nccl.json`
+- `target/accuracy/dsv2-lite-ep2-review/comparison.json`
+
+Comparison result:
+
+- `case_count=5`.
+- Classification: `all_token_text_exact`.
+- Per-case classifications: `capital_16_bs1`, `code_16_bs1`, `hello_16_bs1`, `hello_16_bs4`, and `hello_16_bs8` all reported `all_token_text_exact`.
+- Warnings: none.
+- Batch rule: HF single-row output was broadcast as the expected row output; every host-staged and NCCL row for `hello_16_bs4` and `hello_16_bs8` matched HF and matched the other backend row-by-row.
 
 2026-05-30, single-node 2 GPU validation with the same `models/DeepSeek-V2-Lite` snapshot for all three outputs. The model snapshot metadata recorded commit `604d5664dddd88a0433dbae533b7fe9472482de0`. The HF truth source used `AutoModelForCausalLM.generate(..., do_sample=false, use_cache=true)` with `torch==2.7.0+cu128` and `transformers==4.40.2` on 2x A800-SXM4-80GB:
 

--- a/docs/models/deepseek-v2-lite/status.md
+++ b/docs/models/deepseek-v2-lite/status.md
@@ -1,6 +1,6 @@
 # DeepSeek-V2-Lite Status And Benchmark Ledger
 
-> **TL;DR:** DeepSeek-V2-Lite is a feature-gated EP2 correctness and attribution target. HF, host-staged, and NCCL match for the narrow greedy gate; NCCL decode combine and dense exchange now use reusable device scratch, while host-directed routing/expert accumulation still block full decode graph capture. Current batch and vLLM data remain diagnostic and do not claim production serving parity.
+> **TL;DR:** DeepSeek-V2-Lite is a feature-gated EP2 correctness and attribution target. The original `Hello` / 16 greedy gate is now widened through a committed small case set for HF / host-staged / NCCL comparison; NCCL decode combine and dense exchange use reusable device scratch, while host-directed routing/expert accumulation still block full decode graph capture. Current batch and vLLM data remain diagnostic and do not claim production serving parity.
 
 Last touched: 2026-06
 
@@ -11,6 +11,7 @@ Last touched: 2026-06
 | EP2 correctness bring-up | Available | PR #149 adds the model crate, EP2 expert ownership, rank1 expert-only loading, and the host-staged dispatch/combine baseline. |
 | Naive NCCL backend | Available | PR #150 adds a dense correctness-first NCCL path. Host-staged remains the transport oracle. |
 | HF token/text/hash gate | Available | PR #154 establishes the HF / host-staged / NCCL comparison; PR #176 refreshes it to Transformers `generate(..., use_cache=true)`. |
+| HF widened case set | Available | Issue #274 adds a committed case set that keeps the HF / host-staged / NCCL oracle strict while adding additional prompts and diagnostic batch sizes `4` and `8`; the 2026-06-14 2x RTX 5090 run classified all 5 cases as `all_token_text_exact`. |
 | Decode attribution | Available | PR #162 and PR #169 add CPU/GPU attribution, route counts, NCCL counters, CUDA event timing, and optional NVTX correlation. |
 | Direct same-prompt diagnostic batch | Available | PR #184 and PR #196 cover batch sizes `1`, `4`, and `8` for the fixed same-prompt direct path. |
 | Device-resident NCCL combine | Available | Issue #275 keeps NCCL combine contributions/results on reusable f32 device scratch and preserves the HF / host-staged / NCCL exact gate on 2x RTX 5090. |
@@ -25,13 +26,11 @@ The retained correctness gate is deliberately narrow:
 
 - model: DeepSeek-V2-Lite;
 - devices: single-node EP2 with two local GPUs;
-- prompt: `Hello`;
-- prompt token ids: `[17464]`;
-- output length: `16`;
+- committed cases: `test_data/deepseek-v2-lite-ep2-cases.json` keeps the original `Hello` / 16-token case and widens the oracle with a few additional prompts plus batch sizes `4` and `8`;
 - generation mode: greedy;
 - backends: host-staged and `OPENINFER_DSV2_LITE_EP_BACKEND=nccl`.
 
-The comparison gate must be run on the same model snapshot for HF, host-staged, and NCCL outputs. Same-host comparison remains strict: HF, host-staged, and NCCL must be token-exact and text-exact. Host-staged remains the baseline oracle for NCCL transport changes.
+The comparison gate must be run on the same model snapshot for HF, host-staged, and NCCL outputs. Same-host comparison remains strict: HF, host-staged, and NCCL must be token-exact and text-exact for every committed case and every diagnostic batch row. Host-staged remains the baseline oracle for NCCL transport changes. The latest retained evidence is the 2026-06-14 2x RTX 5090 case-set run with `case_count=5`, top-level `classification=all_token_text_exact`, and no comparison warnings.
 
 The Rust E2E accepts the known HF-confirmed RTX 5090 and A800 hash pairs for this narrow shape, because the same model snapshot has produced different exact greedy text on those hosts while still matching HF on each host. Do not use the static hash pair list as a substitute for the same-host HF comparison when changing accuracy-sensitive code.
 
@@ -101,11 +100,16 @@ Do not claim:
 
 Issue #205 records the model roadmap. Maintainer feedback there calls out NCCL plus CUDA Graph as the likely best decode direction, with host staging possibly deprecated later. Treat that as a future direction, not as current evidence.
 
-The current graph-readiness diagnostic is intentionally fail-closed: `full_decode_capture_ready=false` for NCCL. Issue #275 removed the old NCCL combine H2D/D2H/allocation/sync blockers, and issue #276 removed the dense-exchange allocation/sync blockers from the retained 2x RTX 5090 attribution gate. Those removed dense-exchange blockers are absent from the current readiness report. The remaining NCCL blockers are host route iteration and host-directed expert accumulation. The optional f32 NCCL graph smoke is a separate collective-only diagnostic and is not #276 evidence. HF, host-staged, and NCCL remain token/text exact for the narrow greedy gate.
+The current graph-readiness diagnostic is intentionally fail-closed: `full_decode_capture_ready=false` for NCCL. Issue #275 removed the old NCCL combine H2D/D2H/allocation/sync blockers, and issue #276 removed the dense-exchange allocation/sync blockers from the retained 2x RTX 5090 attribution gate. Those removed dense-exchange blockers are absent from the current readiness report. The remaining NCCL blockers are host route iteration and host-directed expert accumulation. The optional f32 NCCL graph smoke is a separate collective-only diagnostic and is not #276 evidence. HF, host-staged, and NCCL remain token/text exact for the committed case set.
 
 The next implementation should be chosen from measured evidence:
 
-1. Move the remaining NCCL decode path toward CUDA Graph coverage.
+1. Keep the widened HF / host-staged / NCCL case set current.
+   - keep the committed cases and row-level comparison shape in sync with the accuracy docs;
+   - treat the widened oracle as correctness evidence only, not serving evidence;
+   - keep host-staged as the baseline oracle while it exists.
+
+2. Move the remaining NCCL decode path toward CUDA Graph coverage.
    - keep HF / host-staged / NCCL exact before and after;
    - keep host-staged as the correctness baseline while it exists;
    - preserve attribution before and after the change;
@@ -113,19 +117,19 @@ The next implementation should be chosen from measured evidence:
    - avoid broad generic EP or multi-node work;
    - judge issue #170 by whether it reduces NCCL decode overhead and makes the path more graph-friendly.
 
-2. Keep a fair serving benchmark contract around future performance work.
+3. Keep a fair serving benchmark contract around future performance work.
    - OpenInfer host-staged.
    - OpenInfer NCCL.
    - vLLM TP2.
    - vLLM TP2+EP2 when supported.
    - default vLLM configuration plus a controlled configuration with cache/flag choices recorded.
 
-3. Add real request batching / serving semantics before broader throughput claims.
+4. Add real request batching / serving semantics before broader throughput claims.
    - request admission;
    - per-request KV ownership;
    - mixed request state;
    - decode iterations that carry multiple live `/v1/completions` requests.
 
-4. Keep MoE internals readable.
+5. Keep MoE internals readable.
    - routing, dispatch, expert execution, and combine should remain distinguishable in code and attribution;
    - avoid introducing a generic EP framework before the DeepSeek-V2-Lite EP2 path has a measured reason to need it.

--- a/openinfer-deepseek-v2-lite/tests/e2e_ep2.rs
+++ b/openinfer-deepseek-v2-lite/tests/e2e_ep2.rs
@@ -6,6 +6,7 @@ use std::{
 use anyhow::{Context, Result, ensure};
 use openinfer_deepseek_v2_lite::DeepSeekV2LiteEp2Generator;
 use openinfer_engine::engine::{EngineLoadOptions, FinishReason};
+use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use vllm_text::tokenizer::{HuggingFaceTokenizer, Tokenizer};
 
@@ -25,6 +26,23 @@ const EXPECTED_OUTPUT_SHA256_PAIRS: &[(&str, &str, &str)] = &[
 const DSV2_LITE_HIDDEN_SIZE: usize = 2048;
 const DSV2_LITE_MOE_LAYERS: usize = 26;
 const E2E_JSON_OUT_ENV: &str = "OPENINFER_DSV2_LITE_E2E_JSON_OUT";
+const E2E_CASE_SET_ENV: &str = "OPENINFER_DSV2_LITE_E2E_CASE_SET";
+
+#[derive(Debug, Deserialize)]
+struct CaseSet {
+    cases: Vec<GateCase>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct GateCase {
+    id: String,
+    prompt: String,
+    output_len: usize,
+    #[serde(default = "default_batch_size")]
+    batch_size: usize,
+    #[serde(default)]
+    ignore_eos: bool,
+}
 
 #[test]
 fn test_deepseek_v2_lite_ep2_rust_generation() -> Result<()> {
@@ -65,6 +83,16 @@ fn run_rust_generation(model_path_label: &str, model_path: &Path) -> Result<()> 
             tokenizer_path.display()
         )
     })?;
+    if let Some((case_set_path, cases)) = load_case_set_from_env()? {
+        return run_case_set_generation(
+            model_path_label,
+            model_path,
+            &tokenizer,
+            &case_set_path,
+            &cases,
+        );
+    }
+
     let prompt = "Hello";
     let prompt_tokens = tokenizer
         .encode(prompt, false)
@@ -246,6 +274,429 @@ fn run_rust_generation(model_path_label: &str, model_path: &Path) -> Result<()> 
         EXPECTED_OUTPUT_SHA256_PAIRS
     );
     Ok(())
+}
+
+fn run_case_set_generation(
+    model_path_label: &str,
+    model_path: &Path,
+    tokenizer: &HuggingFaceTokenizer,
+    case_set_path: &Path,
+    cases: &[GateCase],
+) -> Result<()> {
+    ensure!(
+        !cases.is_empty(),
+        "DeepSeek-V2-Lite E2E case set must contain at least one case"
+    );
+    let mut generator = DeepSeekV2LiteEp2Generator::load(
+        model_path,
+        EngineLoadOptions {
+            enable_cuda_graph: false,
+            enable_prefill_profile: false,
+            device_ordinals: vec![0, 1],
+            seed: 42,
+            ..EngineLoadOptions::default()
+        },
+    )?;
+
+    // The generator owns loaded weights and reusable backend scratch. Each
+    // generate call below builds fresh DecodeCache and GenerationStats values,
+    // so the case set can share one model load without sharing KV state.
+    let mut case_payloads = Vec::with_capacity(cases.len());
+    for case in cases {
+        case_payloads.push(run_case_set_case(tokenizer, &mut generator, case)?);
+    }
+
+    let payload = serde_json::json!({
+        "schema": 2,
+        "report_type": "deepseek-v2-lite-ep2-rust-e2e-case-set",
+        "model_path": model_path_label,
+        "case_set_json": case_set_path.display().to_string(),
+        "gpu_count": 2,
+        "ep_size": 2,
+        "ep_backend": current_backend(),
+        "devices": [0, 1],
+        "case_count": case_payloads.len(),
+        "token_sha256_algorithm": "sha256 over generated token ids encoded as little-endian u32",
+        "text_sha256_algorithm": "sha256 over UTF-8 generated text bytes",
+        "cases": case_payloads,
+    });
+    let payload_text = serde_json::to_string_pretty(&payload)?;
+    write_payload_if_requested(&payload_text)?;
+    println!("{payload_text}");
+    Ok(())
+}
+
+fn run_case_set_case(
+    tokenizer: &HuggingFaceTokenizer,
+    generator: &mut DeepSeekV2LiteEp2Generator,
+    case: &GateCase,
+) -> Result<serde_json::Value> {
+    let prompt_tokens = tokenizer
+        .encode(&case.prompt, false)
+        .map_err(|err| anyhow::anyhow!("encode prompt for case {} failed: {err:?}", case.id))?;
+    ensure!(
+        !prompt_tokens.is_empty(),
+        "tokenizer returned empty prompt for case {}",
+        case.id
+    );
+
+    if case.batch_size == 1 {
+        let result = generator.generate_greedy(&prompt_tokens, case.output_len, case.ignore_eos)?;
+        ensure!(
+            !result.tokens.is_empty(),
+            "case {} produced no tokens",
+            case.id
+        );
+        ensure!(
+            result.tokens.len() <= case.output_len,
+            "case {} generated {} tokens, expected at most {}",
+            case.id,
+            result.tokens.len(),
+            case.output_len
+        );
+        if case.ignore_eos {
+            ensure!(
+                result.tokens.len() == case.output_len,
+                "case {} uses ignore_eos=true and must generate exactly {} tokens, got {}",
+                case.id,
+                case.output_len,
+                result.tokens.len()
+            );
+        }
+        validate_generation_stats(
+            &result.stats,
+            case,
+            prompt_tokens.len(),
+            result.tokens.len(),
+        )?;
+        let generated_text = decode_tokens(tokenizer, &result.tokens, &case.id)?;
+        let text_sha256 = sha256_text(&generated_text);
+        let matched_output_oracle =
+            matched_expected_output_oracle(&result.stats.output_token_sha256, &text_sha256);
+
+        Ok(serde_json::json!({
+            "id": &case.id,
+            "prompt": &case.prompt,
+            "prompt_token_ids": &prompt_tokens,
+            "prompt_tokens": prompt_tokens.len(),
+            "batch_size": case.batch_size,
+            "output_len": case.output_len,
+            "ignore_eos": case.ignore_eos,
+            "generated_tokens": result.tokens.len(),
+            "generated_token_ids": &result.tokens,
+            "generated_text": generated_text,
+            "output_token_sha256": result.stats.output_token_sha256,
+            "output_text_sha256": text_sha256,
+            "matched_output_oracle": matched_output_oracle,
+            "finish_reason": format!("{:?}", result.finish_reason),
+            "ep": ep_payload(&result.stats),
+        }))
+    } else {
+        ensure!(
+            case.ignore_eos,
+            "batch case {} must set ignore_eos=true so each row has the requested output length",
+            case.id
+        );
+        let result = generator.generate_greedy_batch_same_prompt_with_timings(
+            &prompt_tokens,
+            case.batch_size,
+            case.output_len,
+            case.ignore_eos,
+        )?;
+        ensure!(
+            result.tokens.len() == case.batch_size,
+            "case {} returned {} rows, expected batch_size={}",
+            case.id,
+            result.tokens.len(),
+            case.batch_size
+        );
+        ensure!(
+            result
+                .tokens
+                .iter()
+                .all(|tokens| tokens.len() == case.output_len),
+            "case {} batch rows must all generate exactly {} tokens",
+            case.id,
+            case.output_len
+        );
+        validate_generation_stats(
+            &result.stats,
+            case,
+            prompt_tokens.len(),
+            result.tokens[0].len(),
+        )?;
+
+        let mut generated_text_by_row = Vec::with_capacity(result.tokens.len());
+        let mut token_sha256_by_row = Vec::with_capacity(result.tokens.len());
+        let mut text_sha256_by_row = Vec::with_capacity(result.tokens.len());
+        for row in &result.tokens {
+            let generated_text = decode_tokens(tokenizer, row, &case.id)?;
+            token_sha256_by_row.push(token_sha256(row));
+            text_sha256_by_row.push(sha256_text(&generated_text));
+            generated_text_by_row.push(generated_text);
+        }
+        ensure!(
+            token_sha256_by_row
+                .iter()
+                .all(|hash| hash == &token_sha256_by_row[0])
+                && text_sha256_by_row
+                    .iter()
+                    .all(|hash| hash == &text_sha256_by_row[0]),
+            "case {} same-prompt batch rows are not hash-identical",
+            case.id
+        );
+        let matched_output_oracle =
+            matched_expected_output_oracle(&token_sha256_by_row[0], &text_sha256_by_row[0]);
+
+        Ok(serde_json::json!({
+            "id": &case.id,
+            "prompt": &case.prompt,
+            "prompt_token_ids": &prompt_tokens,
+            "prompt_tokens": prompt_tokens.len(),
+            "batch_size": case.batch_size,
+            "output_len": case.output_len,
+            "ignore_eos": case.ignore_eos,
+            "generated_tokens": result.tokens[0].len(),
+            "generated_tokens_total": result.stats.generated_tokens,
+            "generated_token_ids": &result.tokens[0],
+            "generated_text": &generated_text_by_row[0],
+            "output_token_sha256": &token_sha256_by_row[0],
+            "output_text_sha256": &text_sha256_by_row[0],
+            "generated_token_ids_by_row": &result.tokens,
+            "generated_text_by_row": &generated_text_by_row,
+            "token_sha256_by_row": &token_sha256_by_row,
+            "text_sha256_by_row": &text_sha256_by_row,
+            "same_prompt_rows_exact": true,
+            "matched_output_oracle": matched_output_oracle,
+            "ep": ep_payload(&result.stats),
+        }))
+    }
+}
+
+fn load_case_set_from_env() -> Result<Option<(PathBuf, Vec<GateCase>)>> {
+    let Ok(raw_path) = env::var(E2E_CASE_SET_ENV) else {
+        return Ok(None);
+    };
+    if raw_path.is_empty() {
+        return Ok(None);
+    }
+    let path = resolve_workspace_path(PathBuf::from(raw_path));
+    let file = fs::File::open(&path).with_context(|| format!("open {}", path.display()))?;
+    let case_set: CaseSet =
+        serde_json::from_reader(file).with_context(|| format!("parse {}", path.display()))?;
+    ensure!(
+        !case_set.cases.is_empty(),
+        "{} must contain at least one case",
+        path.display()
+    );
+    for case in &case_set.cases {
+        validate_case(case)?;
+    }
+    Ok(Some((path, case_set.cases)))
+}
+
+fn validate_case(case: &GateCase) -> Result<()> {
+    ensure!(!case.id.is_empty(), "case id must not be empty");
+    ensure!(
+        !case.prompt.is_empty(),
+        "case {} prompt must not be empty",
+        case.id
+    );
+    ensure!(
+        case.output_len > 0,
+        "case {} output_len must be positive",
+        case.id
+    );
+    ensure!(
+        (1..=8).contains(&case.batch_size),
+        "case {} batch_size must be in 1..=8, got {}",
+        case.id,
+        case.batch_size
+    );
+    if case.batch_size > 1 {
+        ensure!(
+            case.ignore_eos,
+            "case {} batch_size={} requires ignore_eos=true",
+            case.id,
+            case.batch_size
+        );
+    }
+    Ok(())
+}
+
+fn validate_generation_stats(
+    stats: &openinfer_deepseek_v2_lite::GenerationStats,
+    case: &GateCase,
+    prompt_tokens_per_row: usize,
+    generated_tokens_per_row: usize,
+) -> Result<()> {
+    ensure!(
+        stats.ep_size == 2,
+        "case {} expected ep_size=2, got {}",
+        case.id,
+        stats.ep_size
+    );
+    ensure!(
+        stats.device_ordinals == vec![0, 1],
+        "case {} expected devices [0, 1], got {:?}",
+        case.id,
+        stats.device_ordinals
+    );
+    ensure!(
+        stats.ep_backend == current_backend(),
+        "case {} backend mismatch: got {}, expected {}",
+        case.id,
+        stats.ep_backend,
+        current_backend()
+    );
+    let expected_prompt_tokens = prompt_tokens_per_row * case.batch_size;
+    ensure!(
+        stats.prompt_tokens == expected_prompt_tokens,
+        "case {} prompt token count drift: got {}, expected {}",
+        case.id,
+        stats.prompt_tokens,
+        expected_prompt_tokens
+    );
+    let expected_generated_tokens = generated_tokens_per_row * case.batch_size;
+    ensure!(
+        stats.generated_tokens == expected_generated_tokens,
+        "case {} generated token count drift: got {}, expected {}",
+        case.id,
+        stats.generated_tokens,
+        expected_generated_tokens
+    );
+
+    match stats.ep_backend.as_str() {
+        "host-staged" => {
+            ensure!(
+                stats.host_dispatch_calls > 0
+                    && stats.host_combine_calls == stats.host_dispatch_calls
+                    && stats.host_dispatch_elements > 0
+                    && stats.host_combine_elements == stats.host_dispatch_elements,
+                "case {} host-staged EP gate did not record dispatch/combine counts",
+                case.id
+            );
+            ensure!(
+                stats.host_dispatch_remote_routes > 0,
+                "case {} host-staged EP gate did not exercise any remote routed expert",
+                case.id
+            );
+            ensure!(
+                stats.host_dispatch_local_routes > 0,
+                "case {} host-staged EP gate did not exercise any local routed expert",
+                case.id
+            );
+            ensure!(
+                stats.nccl_dense_exchange_calls == 0
+                    && stats.nccl_combine_calls == 0
+                    && stats.nccl_dense_exchange_elements == 0
+                    && stats.nccl_combine_elements == 0,
+                "case {} host-staged EP gate unexpectedly recorded NCCL collectives",
+                case.id
+            );
+        }
+        "nccl" => {
+            ensure!(
+                stats.nccl_dispatch_remote_routes > 0,
+                "case {} NCCL EP gate did not exercise any remote routed expert",
+                case.id
+            );
+            ensure!(
+                stats.nccl_dispatch_local_routes > 0,
+                "case {} NCCL EP gate did not exercise any local routed expert",
+                case.id
+            );
+            ensure!(
+                stats.nccl_combine_routes
+                    == stats.nccl_dispatch_local_routes + stats.nccl_dispatch_remote_routes,
+                "case {} NCCL combine route accounting drift",
+                case.id
+            );
+            ensure!(
+                stats.nccl_dense_exchange_calls > 0
+                    && stats.nccl_combine_calls == stats.nccl_dense_exchange_calls,
+                "case {} NCCL EP gate did not record matching dense exchange/combine calls",
+                case.id,
+                stats.nccl_dense_exchange_calls,
+                stats.nccl_combine_calls
+            );
+            ensure!(
+                stats.nccl_dense_exchange_elements > 0
+                    && stats.nccl_combine_elements == stats.nccl_dense_exchange_elements,
+                "case {} NCCL EP gate did not record matching dense exchange/combine elements",
+                case.id,
+                stats.nccl_dense_exchange_elements,
+                stats.nccl_combine_elements
+            );
+        }
+        other => anyhow::bail!(
+            "case {} unexpected DeepSeek-V2-Lite EP backend in E2E: {other}",
+            case.id
+        ),
+    }
+    Ok(())
+}
+
+fn ep_payload(stats: &openinfer_deepseek_v2_lite::GenerationStats) -> serde_json::Value {
+    serde_json::json!({
+        "host_dispatch_calls": stats.host_dispatch_calls,
+        "host_dispatch_elements": stats.host_dispatch_elements,
+        "host_combine_calls": stats.host_combine_calls,
+        "host_combine_elements": stats.host_combine_elements,
+        "host_dispatch_local_routes": stats.host_dispatch_local_routes,
+        "host_dispatch_remote_routes": stats.host_dispatch_remote_routes,
+        "nccl_dispatch_local_routes": stats.nccl_dispatch_local_routes,
+        "nccl_dispatch_remote_routes": stats.nccl_dispatch_remote_routes,
+        "nccl_combine_routes": stats.nccl_combine_routes,
+        "nccl_dense_exchange_calls": stats.nccl_dense_exchange_calls,
+        "nccl_combine_calls": stats.nccl_combine_calls,
+        "nccl_dense_exchange_elements": stats.nccl_dense_exchange_elements,
+        "nccl_combine_elements": stats.nccl_combine_elements,
+    })
+}
+
+fn decode_tokens(
+    tokenizer: &HuggingFaceTokenizer,
+    tokens: &[u32],
+    case_id: &str,
+) -> Result<String> {
+    tokenizer
+        .decode(tokens, false)
+        .map_err(|err| anyhow::anyhow!("decode output for case {case_id} failed: {err:?}"))
+}
+
+fn token_sha256(tokens: &[u32]) -> String {
+    let mut hasher = Sha256::new();
+    for token in tokens {
+        hasher.update(token.to_le_bytes());
+    }
+    hex::encode(hasher.finalize())
+}
+
+fn sha256_text(text: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(text.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+fn write_payload_if_requested(payload_text: &str) -> Result<()> {
+    if let Ok(path) = env::var(E2E_JSON_OUT_ENV) {
+        if !path.is_empty() {
+            let path = PathBuf::from(path);
+            let path = resolve_workspace_path(path);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)
+                    .with_context(|| format!("create {}", parent.display()))?;
+            }
+            fs::write(&path, format!("{payload_text}\n"))
+                .with_context(|| format!("write {}", path.display()))?;
+        }
+    }
+    Ok(())
+}
+
+fn default_batch_size() -> usize {
+    1
 }
 
 fn matched_expected_output_oracle(token_sha256: &str, text_sha256: &str) -> Option<&'static str> {

--- a/openinfer-kernels/build.rs
+++ b/openinfer-kernels/build.rs
@@ -284,29 +284,32 @@ fn collect_files_recursively(dir: &Path, out: &mut Vec<PathBuf>) {
 }
 
 fn is_deepseek_v4_source(csrc_dir: &Path, path: &Path) -> bool {
-    path.strip_prefix(csrc_dir).ok().is_some_and(|relative| {
-        relative
+    match path.strip_prefix(csrc_dir) {
+        Ok(relative) => relative
             .components()
-            .any(|part| part.as_os_str() == "deepseek_v4")
-    })
+            .any(|part| part.as_os_str() == "deepseek_v4"),
+        Err(_) => false,
+    }
 }
 
 fn is_kimi_k2_source(csrc_dir: &Path, path: &Path) -> bool {
-    path.strip_prefix(csrc_dir).ok().is_some_and(|relative| {
-        relative
+    match path.strip_prefix(csrc_dir) {
+        Ok(relative) => relative
             .components()
-            .any(|part| part.as_os_str() == "kimi_k2")
-    })
+            .any(|part| part.as_os_str() == "kimi_k2"),
+        Err(_) => false,
+    }
 }
 
 /// DeepEP elastic shim (csrc/deepep/): Kimi-K2's EP all-to-all backend.
 /// Compiled only with the `kimi-k2` feature; needs NCCL >= 2.30.4 headers/lib.
 fn is_deepep_source(csrc_dir: &Path, path: &Path) -> bool {
-    path.strip_prefix(csrc_dir).ok().is_some_and(|relative| {
-        relative
+    match path.strip_prefix(csrc_dir) {
+        Ok(relative) => relative
             .components()
-            .any(|part| part.as_os_str() == "deepep")
-    })
+            .any(|part| part.as_os_str() == "deepep"),
+        Err(_) => false,
+    }
 }
 
 /// NCCL >= 2.30.4 root (include/nccl.h + lib/libnccl.so.2) for the DeepEP

--- a/test_data/deepseek-v2-lite-ep2-cases.json
+++ b/test_data/deepseek-v2-lite-ep2-cases.json
@@ -1,0 +1,41 @@
+{
+  "schema": 1,
+  "description": "Small DeepSeek-V2-Lite EP2 HF / host-staged / NCCL correctness case set for issue #274.",
+  "cases": [
+    {
+      "id": "hello_16_bs1",
+      "prompt": "Hello",
+      "output_len": 16,
+      "batch_size": 1,
+      "ignore_eos": false
+    },
+    {
+      "id": "hello_16_bs4",
+      "prompt": "Hello",
+      "output_len": 16,
+      "batch_size": 4,
+      "ignore_eos": true
+    },
+    {
+      "id": "hello_16_bs8",
+      "prompt": "Hello",
+      "output_len": 16,
+      "batch_size": 8,
+      "ignore_eos": true
+    },
+    {
+      "id": "capital_16_bs1",
+      "prompt": "The capital of France is",
+      "output_len": 16,
+      "batch_size": 1,
+      "ignore_eos": false
+    },
+    {
+      "id": "code_16_bs1",
+      "prompt": "def quicksort",
+      "output_len": 16,
+      "batch_size": 1,
+      "ignore_eos": false
+    }
+  ]
+}

--- a/tools/accuracy/compare_dsv2_lite_ep2_outputs.py
+++ b/tools/accuracy/compare_dsv2_lite_ep2_outputs.py
@@ -447,6 +447,33 @@ def output_summary(output: Output) -> dict[str, Any]:
     }
 
 
+def legacy_output_summary(output: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "model_path": output["model_path"],
+        "backend": output["backend"],
+        "prompt": output["prompt"],
+        "prompt_token_ids": output["prompt_token_ids"],
+        "generated_token_ids": output["generated_token_ids"],
+        "generated_text": output["generated_text"],
+        "token_sha256": output["token_sha256"],
+        "text_sha256": output["text_sha256"],
+        "reported_token_sha256": output["reported_token_sha256"],
+        "reported_text_sha256": output["reported_text_sha256"],
+    }
+
+
+def legacy_pair_summary(pair: dict[str, Any]) -> dict[str, Any]:
+    first_diff = pair["first_different_token"]
+    if isinstance(first_diff, dict):
+        first_diff = dict(first_diff)
+        first_diff.pop("row_index", None)
+    return {
+        "token_exact": pair["token_exact"],
+        "text_exact": pair["text_exact"],
+        "first_different_token": first_diff,
+    }
+
+
 def compare_cases(
     hf_cases: dict[str, list[Output]],
     host_cases: dict[str, list[Output]],
@@ -525,10 +552,17 @@ def main() -> int:
         public_case.pop("_outputs_for_table", None)
         result_cases.append(public_case)
     if len(result_cases) == 1 and result_cases[0]["id"] == "default":
+        default_case = result_cases[0]
         result = {
             "classification": classification,
-            "outputs": result_cases[0]["outputs"],
-            "pairs": result_cases[0]["pairs"],
+            "outputs": {
+                name: legacy_output_summary(outputs[0]) if outputs else {}
+                for name, outputs in default_case["outputs"].items()
+            },
+            "pairs": {
+                name: legacy_pair_summary(pair)
+                for name, pair in default_case["pairs"].items()
+            },
             "warnings": warnings,
         }
     else:
@@ -546,7 +580,9 @@ def main() -> int:
         out_path.write_text(json.dumps(result, indent=2, ensure_ascii=False) + "\n")
         print(f"wrote {out_path}")
 
-    if args.require_all_exact and classification != "all_token_text_exact":
+    if args.require_all_exact and (
+        classification != "all_token_text_exact" or warnings
+    ):
         return 1
     return 0
 

--- a/tools/accuracy/compare_dsv2_lite_ep2_outputs.py
+++ b/tools/accuracy/compare_dsv2_lite_ep2_outputs.py
@@ -40,13 +40,39 @@ def load_json_or_stdout(path: Path) -> dict[str, Any]:
         raise
 
 
+def list_of_ints(raw: Any) -> list[int]:
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise ValueError(f"expected a list of token ids, got {type(raw)!r}")
+    return [int(value) for value in raw]
+
+
+def list_of_token_rows(raw: Any) -> list[list[int]] | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, list):
+        raise ValueError(f"expected generated_token_ids_by_row to be a list, got {type(raw)!r}")
+    rows: list[list[int]] = []
+    for index, item in enumerate(raw):
+        if not isinstance(item, list):
+            raise ValueError(f"generated row {index} must be a list")
+        rows.append([int(value) for value in item])
+    return rows
+
+
 @dataclass
 class Output:
     name: str
+    case_id: str
+    row_index: int
     model_path: str | None
     backend: str | None
     prompt: str | None
     prompt_token_ids: list[int]
+    batch_size: int | None
+    output_len: int | None
+    generation_mode: str | None
     generated_token_ids: list[int]
     generated_text: str
     reported_token_sha256: str | None
@@ -56,46 +82,141 @@ class Output:
     raw: dict[str, Any]
 
 
-def normalize(name: str, payload: dict[str, Any]) -> Output:
-    token_ids = payload.get("generated_token_ids")
-    if token_ids is None:
-        token_ids = payload.get("output_tokens")
-    if token_ids is None:
-        token_ids = payload.get("tokens")
-    if token_ids is None:
-        token_ids = []
-
-    generated_text = payload.get("generated_text")
-    if generated_text is None:
-        generated_text = payload.get("output_text")
-    if generated_text is None:
-        generated_text = payload.get("output")
-    if generated_text is None:
-        generated_text = ""
-
-    reported_token_hash = payload.get("token_sha256")
-    if reported_token_hash is None:
-        reported_token_hash = payload.get("output_token_sha256")
-    reported_text_hash = payload.get("text_sha256")
-    if reported_text_hash is None:
-        reported_text_hash = payload.get("output_text_sha256")
-
+def normalize_output(
+    name: str,
+    case_id: str,
+    payload: dict[str, Any],
+    *,
+    row_index: int,
+    token_ids: list[int],
+    generated_text: str,
+    reported_token_sha256: str | None,
+    reported_text_sha256: str | None,
+    fallback_model_path: str | None = None,
+    fallback_backend: str | None = None,
+    fallback_generation_mode: str | None = None,
+) -> Output:
     prompt_token_ids = payload.get("prompt_token_ids") or []
-
     return Output(
         name=name,
-        model_path=payload.get("model_path"),
-        backend=payload.get("ep_backend") or payload.get("backend"),
+        case_id=case_id,
+        row_index=row_index,
+        model_path=payload.get("model_path") or fallback_model_path,
+        backend=payload.get("ep_backend") or payload.get("backend") or fallback_backend,
         prompt=payload.get("prompt"),
         prompt_token_ids=[int(value) for value in prompt_token_ids],
-        generated_token_ids=[int(value) for value in token_ids],
-        generated_text=str(generated_text),
-        reported_token_sha256=reported_token_hash,
-        reported_text_sha256=reported_text_hash,
-        token_sha256=sha256_u32_le([int(value) for value in token_ids]),
-        text_sha256=sha256_text(str(generated_text)),
+        batch_size=payload.get("batch_size"),
+        output_len=payload.get("output_len") or payload.get("max_new_tokens"),
+        generation_mode=payload.get("generation_mode") or fallback_generation_mode,
+        generated_token_ids=token_ids,
+        generated_text=generated_text,
+        reported_token_sha256=reported_token_sha256,
+        reported_text_sha256=reported_text_sha256,
+        token_sha256=sha256_u32_le(token_ids),
+        text_sha256=sha256_text(generated_text),
         raw=payload,
     )
+
+
+def normalize_singleton(
+    name: str,
+    payload: dict[str, Any],
+    *,
+    case_id: str = "default",
+    fallback_model_path: str | None = None,
+    fallback_backend: str | None = None,
+    fallback_generation_mode: str | None = None,
+) -> list[Output]:
+    rows = list_of_token_rows(payload.get("generated_token_ids_by_row"))
+    texts_by_row = payload.get("generated_text_by_row")
+    token_hashes_by_row = payload.get("token_sha256_by_row")
+    text_hashes_by_row = payload.get("text_sha256_by_row")
+
+    if rows is None:
+        token_ids = payload.get("generated_token_ids")
+        if token_ids is None:
+            token_ids = payload.get("output_tokens")
+        if token_ids is None:
+            token_ids = payload.get("tokens")
+        generated_text = payload.get("generated_text")
+        if generated_text is None:
+            generated_text = payload.get("output_text")
+        if generated_text is None:
+            generated_text = payload.get("output")
+        return [
+            normalize_output(
+                name,
+                case_id,
+                payload,
+                row_index=0,
+                token_ids=list_of_ints(token_ids),
+                generated_text=str(generated_text or ""),
+                reported_token_sha256=payload.get("token_sha256")
+                or payload.get("output_token_sha256"),
+                reported_text_sha256=payload.get("text_sha256")
+                or payload.get("output_text_sha256"),
+                fallback_model_path=fallback_model_path,
+                fallback_backend=fallback_backend,
+                fallback_generation_mode=fallback_generation_mode,
+            )
+        ]
+
+    outputs = []
+    for row_index, token_ids in enumerate(rows):
+        if isinstance(texts_by_row, list) and row_index < len(texts_by_row):
+            generated_text = str(texts_by_row[row_index])
+        else:
+            generated_text = str(payload.get("generated_text") or payload.get("output_text") or "")
+        reported_token_hash = (
+            token_hashes_by_row[row_index]
+            if isinstance(token_hashes_by_row, list) and row_index < len(token_hashes_by_row)
+            else None
+        )
+        reported_text_hash = (
+            text_hashes_by_row[row_index]
+            if isinstance(text_hashes_by_row, list) and row_index < len(text_hashes_by_row)
+            else None
+        )
+        outputs.append(
+            normalize_output(
+                name,
+                case_id,
+                payload,
+                row_index=row_index,
+                token_ids=token_ids,
+                generated_text=generated_text,
+                reported_token_sha256=reported_token_hash,
+                reported_text_sha256=reported_text_hash,
+                fallback_model_path=fallback_model_path,
+                fallback_backend=fallback_backend,
+                fallback_generation_mode=fallback_generation_mode,
+            )
+        )
+    return outputs
+
+
+def normalize_cases(name: str, payload: dict[str, Any]) -> dict[str, list[Output]]:
+    if payload.get("schema") == 2 and isinstance(payload.get("cases"), list):
+        cases: dict[str, list[Output]] = {}
+        fallback_model_path = payload.get("model_path")
+        fallback_backend = payload.get("ep_backend") or payload.get("backend")
+        fallback_generation_mode = payload.get("generation_mode")
+        for index, item in enumerate(payload["cases"]):
+            if not isinstance(item, dict):
+                raise ValueError(f"{name} case {index} must be an object")
+            case_id = str(item.get("id") or item.get("case_id") or f"case_{index:03d}")
+            if case_id in cases:
+                raise ValueError(f"{name} contains duplicate case id {case_id!r}")
+            cases[case_id] = normalize_singleton(
+                name,
+                item,
+                case_id=case_id,
+                fallback_model_path=fallback_model_path,
+                fallback_backend=fallback_backend,
+                fallback_generation_mode=fallback_generation_mode,
+            )
+        return cases
+    return {"default": normalize_singleton(name, payload)}
 
 
 def first_token_diff(left: Output, right: Output) -> dict[str, Any] | None:
@@ -105,6 +226,7 @@ def first_token_diff(left: Output, right: Output) -> dict[str, Any] | None:
         right_token = right.generated_token_ids[index]
         if left_token != right_token:
             return {
+                "row_index": right.row_index,
                 "index": index,
                 left.name: left_token,
                 right.name: right_token,
@@ -112,6 +234,7 @@ def first_token_diff(left: Output, right: Output) -> dict[str, Any] | None:
             }
     if len(left.generated_token_ids) != len(right.generated_token_ids):
         return {
+            "row_index": right.row_index,
             "index": limit,
             left.name: left.generated_token_ids[limit]
             if len(left.generated_token_ids) > limit
@@ -124,13 +247,53 @@ def first_token_diff(left: Output, right: Output) -> dict[str, Any] | None:
     return None
 
 
-def pair_summary(left: Output, right: Output) -> dict[str, Any]:
-    token_exact = left.generated_token_ids == right.generated_token_ids
-    text_exact = left.generated_text == right.generated_text
+def pair_summary(
+    left_rows: list[Output],
+    right_rows: list[Output],
+    *,
+    broadcast_single: bool,
+) -> dict[str, Any]:
+    if not left_rows or not right_rows:
+        return {
+            "token_exact": False,
+            "text_exact": False,
+            "first_different_token": {"reason": "missing_outputs"},
+        }
+    if len(left_rows) == len(right_rows):
+        pairs = list(zip(left_rows, right_rows, strict=True))
+    elif broadcast_single and len(left_rows) == 1:
+        # HF case-set dumps one expected row; OpenInfer emits every same-prompt
+        # batch row, so only the left/HF side is allowed to broadcast.
+        pairs = [(left_rows[0], right) for right in right_rows]
+    else:
+        return {
+            "token_exact": False,
+            "text_exact": False,
+            "first_different_token": {
+                "reason": "row_count_mismatch",
+                left_rows[0].name: len(left_rows),
+                right_rows[0].name: len(right_rows),
+            },
+        }
+
+    token_exact = True
+    text_exact = True
+    first_diff = None
+    for left, right in pairs:
+        row_token_exact = left.generated_token_ids == right.generated_token_ids
+        row_text_exact = left.generated_text == right.generated_text
+        token_exact = token_exact and row_token_exact
+        text_exact = text_exact and row_text_exact
+        if first_diff is None and not row_token_exact:
+            first_diff = first_token_diff(left, right)
+        if first_diff is None and row_token_exact and not row_text_exact:
+            first_diff = {"row_index": right.row_index, "reason": "text_mismatch"}
+
     return {
         "token_exact": token_exact,
         "text_exact": text_exact,
-        "first_different_token": None if token_exact else first_token_diff(left, right),
+        "first_different_token": first_diff,
+        "row_comparisons": len(pairs),
     }
 
 
@@ -151,6 +314,15 @@ def classify(pairs: dict[str, dict[str, Any]]) -> str:
     return "openinfer_baseline_accuracy_gap"
 
 
+def overall_classification(case_results: list[dict[str, Any]]) -> str:
+    labels = {case["classification"] for case in case_results}
+    if labels == {"all_token_text_exact"}:
+        return "all_token_text_exact"
+    if "nccl_transport_regression" in labels:
+        return "nccl_transport_regression"
+    return "openinfer_baseline_accuracy_gap"
+
+
 def short(text: str, width: int = 72) -> str:
     one_line = text.replace("\n", "\\n")
     if len(one_line) <= width:
@@ -158,51 +330,55 @@ def short(text: str, width: int = 72) -> str:
     return one_line[: width - 3] + "..."
 
 
-def table(outputs: list[Output]) -> str:
+def table(case_results: list[dict[str, Any]]) -> str:
     rows = [
-        "| Source | Backend | Tokens | Token SHA256 | Text SHA256 | Text |",
-        "| --- | --- | ---: | --- | --- | --- |",
+        "| Case | Source | Row | Backend | Tokens | Token SHA256 | Text SHA256 | Text |",
+        "| --- | --- | ---: | --- | ---: | --- | --- | --- |",
     ]
-    for output in outputs:
-        rows.append(
-            "| {name} | {backend} | {tokens} | `{token_hash}` | `{text_hash}` | `{text}` |".format(
-                name=output.name,
-                backend=output.backend or "-",
-                tokens=len(output.generated_token_ids),
-                token_hash=output.token_sha256,
-                text_hash=output.text_sha256,
-                text=short(output.generated_text),
+    for case in case_results:
+        for output in case["_outputs_for_table"]:
+            rows.append(
+                "| {case_id} | {name} | {row} | {backend} | {tokens} | `{token_hash}` | `{text_hash}` | `{text}` |".format(
+                    case_id=case["id"],
+                    name=output.name,
+                    row=output.row_index,
+                    backend=output.backend or "-",
+                    tokens=len(output.generated_token_ids),
+                    token_hash=output.token_sha256,
+                    text_hash=output.text_sha256,
+                    text=short(output.generated_text),
+                )
             )
-        )
     return "\n".join(rows)
 
 
 def hash_warnings(outputs: list[Output]) -> list[str]:
     warnings = []
     for output in outputs:
+        label = f"{output.name}:{output.case_id}:row{output.row_index}"
         if (
             output.reported_token_sha256
             and output.reported_token_sha256 != output.token_sha256
         ):
             warnings.append(
-                f"{output.name}: reported token hash {output.reported_token_sha256} "
+                f"{label}: reported token hash {output.reported_token_sha256} "
                 f"does not match recomputed {output.token_sha256}"
             )
         if output.reported_text_sha256 and output.reported_text_sha256 != output.text_sha256:
             warnings.append(
-                f"{output.name}: reported text hash {output.reported_text_sha256} "
+                f"{label}: reported text hash {output.reported_text_sha256} "
                 f"does not match recomputed {output.text_sha256}"
             )
     return warnings
 
 
-def context_warnings(hf: Output, host: Output, nccl: Output) -> list[str]:
+def context_warnings(case_id: str, hf: list[Output], host: list[Output], nccl: list[Output]) -> list[str]:
     warnings = []
-    outputs = [hf, host, nccl]
+    outputs = hf + host + nccl
 
     prompts = {output.prompt for output in outputs if output.prompt is not None}
     if len(prompts) > 1:
-        warnings.append(f"prompt mismatch across outputs: {sorted(prompts)!r}")
+        warnings.append(f"{case_id}: prompt mismatch across outputs: {sorted(prompts)!r}")
 
     prompt_token_ids = {
         tuple(output.prompt_token_ids)
@@ -210,44 +386,102 @@ def context_warnings(hf: Output, host: Output, nccl: Output) -> list[str]:
         if output.prompt_token_ids
     }
     if len(prompt_token_ids) > 1:
-        warnings.append("prompt_token_ids mismatch across outputs")
+        warnings.append(f"{case_id}: prompt_token_ids mismatch across outputs")
 
     model_paths = {output.model_path for output in outputs if output.model_path is not None}
     if len(model_paths) > 1:
         warnings.append(
-            "model_path labels differ; verify all outputs use the same snapshot: "
+            f"{case_id}: model_path labels differ; verify all outputs use the same snapshot: "
             f"{sorted(model_paths)!r}"
         )
 
-    hf_output_len = hf.raw.get("output_len")
-    peg_output_lens = {
-        output.raw.get("max_new_tokens")
-        for output in [host, nccl]
-        if output.raw.get("max_new_tokens") is not None
-    }
-    output_lens = set()
-    if hf_output_len is not None:
-        output_lens.add(hf_output_len)
-    output_lens.update(peg_output_lens)
+    output_lens = {output.output_len for output in outputs if output.output_len is not None}
     if len(output_lens) > 1:
-        warnings.append(f"output length labels differ across outputs: {sorted(output_lens)!r}")
+        warnings.append(f"{case_id}: output length labels differ: {sorted(output_lens)!r}")
 
-    hf_generation_mode = hf.raw.get("generation_mode")
-    if hf_generation_mode not in (
-        None,
-        "incremental_past_key_values",
-        "transformers_generate_use_cache",
-    ):
-        warnings.append(
-            "HF output generation_mode is not a recognized HF generation mode: "
-            f"{hf_generation_mode}"
-        )
-    if host.backend not in (None, "host-staged"):
-        warnings.append(f"host-staged file reports backend {host.backend!r}")
-    if nccl.backend not in (None, "nccl"):
-        warnings.append(f"NCCL file reports backend {nccl.backend!r}")
+    batch_sizes = {output.batch_size for output in outputs if output.batch_size is not None}
+    if len(batch_sizes) > 1:
+        warnings.append(f"{case_id}: batch_size labels differ: {sorted(batch_sizes)!r}")
+    expected_rows = max(batch_sizes) if batch_sizes else None
+    if expected_rows is not None:
+        if len(host) != expected_rows:
+            warnings.append(f"{case_id}: host-staged row count {len(host)} != batch_size {expected_rows}")
+        if len(nccl) != expected_rows:
+            warnings.append(f"{case_id}: NCCL row count {len(nccl)} != batch_size {expected_rows}")
+
+    hf_generation_modes = {
+        output.generation_mode
+        for output in hf
+        if output.generation_mode is not None
+    }
+    allowed_hf_modes = {"incremental_past_key_values", "transformers_generate_use_cache"}
+    for mode in hf_generation_modes:
+        if mode not in allowed_hf_modes:
+            warnings.append(
+                f"{case_id}: HF output generation_mode is not recognized: {mode}"
+            )
+    if any(output.backend not in (None, "host-staged") for output in host):
+        warnings.append(f"{case_id}: host-staged file reports a non-host backend")
+    if any(output.backend not in (None, "nccl") for output in nccl):
+        warnings.append(f"{case_id}: NCCL file reports a non-NCCL backend")
 
     return warnings
+
+
+def output_summary(output: Output) -> dict[str, Any]:
+    return {
+        "row_index": output.row_index,
+        "model_path": output.model_path,
+        "backend": output.backend,
+        "prompt": output.prompt,
+        "prompt_token_ids": output.prompt_token_ids,
+        "batch_size": output.batch_size,
+        "output_len": output.output_len,
+        "generation_mode": output.generation_mode,
+        "generated_token_ids": output.generated_token_ids,
+        "generated_text": output.generated_text,
+        "token_sha256": output.token_sha256,
+        "text_sha256": output.text_sha256,
+        "reported_token_sha256": output.reported_token_sha256,
+        "reported_text_sha256": output.reported_text_sha256,
+    }
+
+
+def compare_cases(
+    hf_cases: dict[str, list[Output]],
+    host_cases: dict[str, list[Output]],
+    nccl_cases: dict[str, list[Output]],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    case_ids = sorted(set(hf_cases) | set(host_cases) | set(nccl_cases))
+    case_results: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    for case_id in case_ids:
+        hf = hf_cases.get(case_id, [])
+        host = host_cases.get(case_id, [])
+        nccl = nccl_cases.get(case_id, [])
+        pairs = {
+            "hf_vs_host_staged": pair_summary(hf, host, broadcast_single=True),
+            "hf_vs_nccl": pair_summary(hf, nccl, broadcast_single=True),
+            "host_staged_vs_nccl": pair_summary(host, nccl, broadcast_single=False),
+        }
+        classification = classify(pairs)
+        all_outputs = hf + host + nccl
+        warnings.extend(hash_warnings(all_outputs))
+        warnings.extend(context_warnings(case_id, hf, host, nccl))
+        case_results.append(
+            {
+                "id": case_id,
+                "classification": classification,
+                "outputs": {
+                    "hf": [output_summary(output) for output in hf],
+                    "host_staged": [output_summary(output) for output in host],
+                    "nccl": [output_summary(output) for output in nccl],
+                },
+                "pairs": pairs,
+                "_outputs_for_table": all_outputs,
+            }
+        )
+    return case_results, warnings
 
 
 def main() -> int:
@@ -259,47 +493,52 @@ def main() -> int:
     parser.add_argument(
         "--require-all-exact",
         action="store_true",
-        help="Exit nonzero unless HF, host-staged, and NCCL are token/text exact",
+        help="Exit nonzero unless every case is token/text exact across HF, host-staged, and NCCL",
     )
     args = parser.parse_args()
 
-    hf = normalize("hf", load_json_or_stdout(Path(args.hf)))
-    host = normalize("host_staged", load_json_or_stdout(Path(args.host_staged)))
-    nccl = normalize("nccl", load_json_or_stdout(Path(args.nccl)))
-    outputs = [hf, host, nccl]
+    hf_cases = normalize_cases("hf", load_json_or_stdout(Path(args.hf)))
+    host_cases = normalize_cases("host_staged", load_json_or_stdout(Path(args.host_staged)))
+    nccl_cases = normalize_cases("nccl", load_json_or_stdout(Path(args.nccl)))
+    case_results, warnings = compare_cases(hf_cases, host_cases, nccl_cases)
+    classification = overall_classification(case_results)
 
-    pairs = {
-        "hf_vs_host_staged": pair_summary(hf, host),
-        "hf_vs_nccl": pair_summary(hf, nccl),
-        "host_staged_vs_nccl": pair_summary(host, nccl),
-    }
-    classification = classify(pairs)
-    warnings = hash_warnings(outputs) + context_warnings(hf, host, nccl)
-    result = {
-        "classification": classification,
-        "outputs": {
-            output.name: {
-                "model_path": output.model_path,
-                "backend": output.backend,
-                "prompt": output.prompt,
-                "prompt_token_ids": output.prompt_token_ids,
-                "generated_token_ids": output.generated_token_ids,
-                "generated_text": output.generated_text,
-                "token_sha256": output.token_sha256,
-                "text_sha256": output.text_sha256,
-                "reported_token_sha256": output.reported_token_sha256,
-                "reported_text_sha256": output.reported_text_sha256,
-            }
-            for output in outputs
-        },
-        "pairs": pairs,
-        "warnings": warnings,
-    }
-
-    print(table(outputs))
+    print(table(case_results))
     print()
     print(f"Classification: {classification}")
-    print(json.dumps({"pairs": pairs, "warnings": warnings}, indent=2, ensure_ascii=False))
+    print(
+        json.dumps(
+            {
+                "case_classifications": {
+                    case["id"]: case["classification"] for case in case_results
+                },
+                "warnings": warnings,
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+    )
+
+    result_cases = []
+    for case in case_results:
+        public_case = dict(case)
+        public_case.pop("_outputs_for_table", None)
+        result_cases.append(public_case)
+    if len(result_cases) == 1 and result_cases[0]["id"] == "default":
+        result = {
+            "classification": classification,
+            "outputs": result_cases[0]["outputs"],
+            "pairs": result_cases[0]["pairs"],
+            "warnings": warnings,
+        }
+    else:
+        result = {
+            "schema": 2,
+            "classification": classification,
+            "case_count": len(result_cases),
+            "cases": result_cases,
+            "warnings": warnings,
+        }
 
     if args.out:
         out_path = Path(args.out)

--- a/tools/accuracy/hf_dump_dsv2_lite_ep2_greedy.py
+++ b/tools/accuracy/hf_dump_dsv2_lite_ep2_greedy.py
@@ -142,9 +142,13 @@ def load_case_set(path: Path) -> list[dict[str, Any]]:
         if output_len <= 0:
             raise ValueError(f"case {case_id!r} output_len must be positive")
         batch_size = int(item.get("batch_size", 1))
-        if batch_size <= 0:
-            raise ValueError(f"case {case_id!r} batch_size must be positive")
         ignore_eos = bool(item.get("ignore_eos", False))
+        if not 1 <= batch_size <= 8:
+            raise ValueError(f"case {case_id!r} batch_size must be in 1..=8")
+        if batch_size > 1 and not ignore_eos:
+            raise ValueError(
+                f"case {case_id!r} batch_size={batch_size} requires ignore_eos=true"
+            )
 
         cases.append(
             {

--- a/tools/accuracy/hf_dump_dsv2_lite_ep2_greedy.py
+++ b/tools/accuracy/hf_dump_dsv2_lite_ep2_greedy.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 import torch
 import transformers.dynamic_module_utils as dynamic_module_utils
@@ -99,6 +100,8 @@ def generate_with_transformers(
 
     input_len = inputs["input_ids"].shape[1]
     generated_token_ids = output_ids[0, input_len:].tolist()
+    if not generated_token_ids:
+        raise RuntimeError(f"HF generated no tokens for prompt {prompt!r}")
     finish_reason = "length" if len(generated_token_ids) >= output_len else "eos"
     generated_text = tokenizer.decode(
         generated_token_ids,
@@ -115,6 +118,84 @@ def generate_with_transformers(
     }
 
 
+def load_case_set(path: Path) -> list[dict[str, Any]]:
+    with path.open("r", encoding="utf-8") as f:
+        raw = json.load(f)
+    raw_cases = raw.get("cases") if isinstance(raw, dict) else raw
+    if not isinstance(raw_cases, list) or not raw_cases:
+        raise ValueError("case set must contain a non-empty cases list")
+
+    cases: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, item in enumerate(raw_cases):
+        if not isinstance(item, dict):
+            raise ValueError(f"case {index} must be an object")
+        case_id = str(item.get("id") or item.get("case_id") or f"case_{index:03d}")
+        if case_id in seen or case_id in {"", ".", ".."} or "/" in case_id or "\\" in case_id:
+            raise ValueError(f"invalid or duplicate case id {case_id!r}")
+        seen.add(case_id)
+
+        prompt = item.get("prompt")
+        if not isinstance(prompt, str) or not prompt:
+            raise ValueError(f"case {case_id!r} must provide a non-empty prompt")
+        output_len = int(item.get("output_len", item.get("max_new_tokens", 16)))
+        if output_len <= 0:
+            raise ValueError(f"case {case_id!r} output_len must be positive")
+        batch_size = int(item.get("batch_size", 1))
+        if batch_size <= 0:
+            raise ValueError(f"case {case_id!r} batch_size must be positive")
+        ignore_eos = bool(item.get("ignore_eos", False))
+
+        cases.append(
+            {
+                "id": case_id,
+                "prompt": prompt,
+                "output_len": output_len,
+                "batch_size": batch_size,
+                "ignore_eos": ignore_eos,
+            }
+        )
+    return cases
+
+
+def base_payload(args, model) -> dict[str, Any]:
+    return {
+        "model_path": args.model_path,
+        "model_type": getattr(getattr(model, "config", None), "model_type", None),
+        "torch_version": torch.__version__,
+        "transformers_version": __import__("transformers").__version__,
+        "compat_patches": [
+            "dynamic_module_utils.check_imports ignores missing optional flash_attn import"
+        ],
+        "device_map": args.device_map,
+        "device": args.device,
+        "dtype": "torch.bfloat16",
+        "generation_mode": "transformers_generate_use_cache",
+    }
+
+
+def case_payload(case: dict[str, Any], result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": case["id"],
+        "prompt": case["prompt"],
+        "output_len": case["output_len"],
+        "batch_size": case["batch_size"],
+        "ignore_eos": case["ignore_eos"],
+        "prompt_token_ids": result["prompt_token_ids"],
+        "generated_token_ids": result["generated_token_ids"],
+        "generated_text": result["generated_text"],
+        "token_sha256": result["token_sha256"],
+        "text_sha256": result["text_sha256"],
+        "finish_reason": result["finish_reason"],
+        "generation": {
+            "do_sample": False,
+            "max_new_tokens": case["output_len"],
+            "use_cache": True,
+            "ignore_eos": case["ignore_eos"],
+        },
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
@@ -122,6 +203,11 @@ def main() -> int:
     parser.add_argument("--model-path", required=True, help="HF model path or id")
     parser.add_argument("--prompt", default="Hello", help="Prompt text")
     parser.add_argument("--output-len", type=int, default=16, help="Greedy output length")
+    parser.add_argument(
+        "--case-set-json",
+        type=Path,
+        help="Optional JSON case set; emits schema=2 with one HF row per case",
+    )
     parser.add_argument(
         "--device-map",
         default="auto",
@@ -151,42 +237,58 @@ def main() -> int:
         trust_remote_code=True,
     )
     model = load_model(args.model_path, args.device_map, args.device)
-    result = generate_with_transformers(
-        model,
-        tokenizer,
-        args.prompt,
-        args.output_len,
-        args.device,
-        args.ignore_eos,
-    )
 
-    payload = {
-        "model_path": args.model_path,
-        "model_type": getattr(getattr(model, "config", None), "model_type", None),
-        "torch_version": torch.__version__,
-        "transformers_version": __import__("transformers").__version__,
-        "compat_patches": [
-            "dynamic_module_utils.check_imports ignores missing optional flash_attn import"
-        ],
-        "device_map": args.device_map,
-        "device": args.device,
-        "dtype": "torch.bfloat16",
-        "prompt": args.prompt,
-        "output_len": args.output_len,
-        "prompt_token_ids": result["prompt_token_ids"],
-        "generated_token_ids": result["generated_token_ids"],
-        "generated_text": result["generated_text"],
-        "token_sha256": result["token_sha256"],
-        "text_sha256": result["text_sha256"],
-        "finish_reason": result["finish_reason"],
-        "generation_mode": "transformers_generate_use_cache",
-        "generation": {
-            "do_sample": False,
-            "max_new_tokens": args.output_len,
-            "use_cache": True,
-            "ignore_eos": args.ignore_eos,
-        },
-    }
+    if args.case_set_json is None:
+        result = generate_with_transformers(
+            model,
+            tokenizer,
+            args.prompt,
+            args.output_len,
+            args.device,
+            args.ignore_eos,
+        )
+        payload = base_payload(args, model)
+        payload.update(
+            {
+                "prompt": args.prompt,
+                "output_len": args.output_len,
+                "prompt_token_ids": result["prompt_token_ids"],
+                "generated_token_ids": result["generated_token_ids"],
+                "generated_text": result["generated_text"],
+                "token_sha256": result["token_sha256"],
+                "text_sha256": result["text_sha256"],
+                "finish_reason": result["finish_reason"],
+                "generation": {
+                    "do_sample": False,
+                    "max_new_tokens": args.output_len,
+                    "use_cache": True,
+                    "ignore_eos": args.ignore_eos,
+                },
+            }
+        )
+    else:
+        cases = load_case_set(args.case_set_json)
+        case_results = []
+        for case in cases:
+            result = generate_with_transformers(
+                model,
+                tokenizer,
+                case["prompt"],
+                case["output_len"],
+                args.device,
+                case["ignore_eos"],
+            )
+            case_results.append(case_payload(case, result))
+        payload = base_payload(args, model)
+        payload.update(
+            {
+                "schema": 2,
+                "report_type": "deepseek-v2-lite-ep2-hf-greedy-case-set",
+                "case_set_json": str(args.case_set_json),
+                "case_count": len(case_results),
+                "cases": case_results,
+            }
+        )
     text = json.dumps(payload, indent=2, ensure_ascii=False)
 
     if args.out == "-":


### PR DESCRIPTION
## Summary

Fixes #274.

This widens the DeepSeek-V2-Lite EP2 correctness gate from the original
`Hello` / 16-token singleton shape to a small committed case set while keeping
the existing HF / host-staged / NCCL oracle strict.

Changes included:

- add `test_data/deepseek-v2-lite-ep2-cases.json`
- extend the HF greedy dumper with optional `--case-set-json`
- extend the Rust EP2 E2E test with `OPENINFER_DSV2_LITE_E2E_CASE_SET`
- emit schema-2 `cases[]` JSON for case-set runs while preserving the old singleton path
- extend the compare script to handle both legacy singleton JSON and schema-2 case sets
- preserve the existing classification labels:
  - `all_token_text_exact`
  - `openinfer_baseline_accuracy_gap`
  - `nccl_transport_regression`
- update DeepSeek-V2-Lite docs to describe the widened correctness gate and claim boundary

## Claim Boundary

This PR is correctness-only.

It does not claim:

- performance improvement
- production serving readiness
- sparse EP readiness
- CUDA Graph readiness
- mixed-request or continuous batching

The batch cases are same-prompt diagnostic rows. They only widen the correctness
oracle and do not imply production batching semantics.

## Validation

Local/static checks:

```bash
python -m py_compile tools/accuracy/hf_dump_dsv2_lite_ep2_greedy.py tools/accuracy/compare_dsv2_lite_ep2_outputs.py
python -m json.tool test_data/deepseek-v2-lite-ep2-cases.json
cargo metadata --locked --no-deps --format-version 1
cargo +nightly fmt --all --check
git diff --check
```

Synthetic compare smoke covered:

- legacy singleton exact match
- schema-2 batch exact match
- OpenInfer baseline accuracy gap
- NCCL transport regression
- batch row mismatch

Remote GPU correctness gate on a single-node 2-GPU setup:

- HF case dump with `--case-set-json`
- host-staged EP2 E2E case-set run
- NCCL EP2 E2E case-set run
- HF / host-staged / NCCL comparison with `--require-all-exact`

Result:

```text
classification=all_token_text_exact
case_count=5
warnings=[]
```

All five committed cases reported `all_token_text_exact`.