### PR TITLE
feat(scheduler): add engine-side request lifecycle logs (admitted/fin…

### DIFF
--- a/openinfer-qwen3-4b/src/scheduler.rs
+++ b/openinfer-qwen3-4b/src/scheduler.rs
@@ -13,7 +13,7 @@ use std::collections::{HashSet, VecDeque};
 use std::thread;
 
 use anyhow::Result;
-use log::{info, warn};
+use log::{debug, info, warn};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use tokio::sync::mpsc;
@@ -888,6 +888,12 @@ fn admit_deferred_requests(
         if fresh_needed <= budget && decode_slots > 0 {
             budget -= fresh_needed;
             decode_slots -= 1;
+            debug!(
+                "request admitted: request_id={:?} prompt_len={} max_tokens={}",
+                req.request_id,
+                req.prompt_tokens.len(),
+                req.max_tokens
+            );
             pending.push(req);
         } else {
             still_deferred.push(req);

--- a/openinfer-qwen3-4b/src/scheduler/effects.rs
+++ b/openinfer-qwen3-4b/src/scheduler/effects.rs
@@ -1,5 +1,7 @@
 use tokio::sync::mpsc;
 
+use log::debug;
+
 use crate::executor::RequestId;
 use openinfer_core::engine::{FinishReason, TokenLogprob};
 
@@ -125,6 +127,10 @@ pub(super) fn apply_effects(
                     continue;
                 };
                 let req = &active[index];
+                debug!(
+                    "request finished: request_id={:?} prompt_tokens={} completion_tokens={} finish_reason={:?}",
+                    request_id, req.prompt_len, completion_tokens, finish_reason
+                );
                 let _ = req.token_tx.send(TokenEvent::Finished {
                     finish_reason,
                     prompt_tokens: req.prompt_len,
@@ -144,6 +150,10 @@ pub(super) fn apply_effects(
                     continue;
                 };
                 let req = &active[index];
+                debug!(
+                    "request finished: request_id={:?} prompt_tokens={} completion_tokens={} finish_reason={:?}",
+                    request_id, req.prompt_len, completion_tokens, finish_reason
+                );
                 if req
                     .token_tx
                     .send(TokenEvent::Token { id: token, logprob })
@@ -173,6 +183,10 @@ pub(super) fn apply_effects(
                     .send(TokenEvent::Token { id: token, logprob })
                     .is_err()
                 {
+                    debug!(
+                        "request dropped: client disconnected: request_id={:?} tokens_generated={}",
+                        request_id, completion_tokens
+                    );
                     let _ = executor.drop_request(request_id);
                     to_retire.push(index);
                 } else {
@@ -209,6 +223,10 @@ pub(super) fn apply_effects(
                 prompt_tokens,
                 completion_tokens,
             } => {
+                debug!(
+                    "request finished: request_id={:?} prompt_tokens={} completion_tokens={} finish_reason={:?}",
+                    request_id, prompt_tokens, completion_tokens, finish_reason
+                );
                 let _ = token_tx.send(TokenEvent::Finished {
                     finish_reason,
                     prompt_tokens,
@@ -225,6 +243,10 @@ pub(super) fn apply_effects(
                 prompt_tokens,
                 completion_tokens,
             } => {
+                debug!(
+                    "request finished: request_id={:?} prompt_tokens={} completion_tokens={} finish_reason={:?}",
+                    request_id, prompt_tokens, completion_tokens, finish_reason
+                );
                 if token_tx
                     .send(TokenEvent::Token { id: token, logprob })
                     .is_ok()

--- a/openinfer-qwen35-4b/src/scheduler.rs
+++ b/openinfer-qwen35-4b/src/scheduler.rs
@@ -349,7 +349,10 @@ fn prefill_batch(
         if !req.params.ignore_eos && model.is_stop_token(first_token) {
             debug!(
                 "request finished: request_id={:?} prompt_tokens={} completion_tokens={} finish_reason={:?}",
-                req.request_id, prompt_len, 0, FinishReason::Stop
+                req.request_id,
+                prompt_len,
+                0,
+                FinishReason::Stop
             );
             let _ = req.token_tx.send(TokenEvent::Finished {
                 finish_reason: FinishReason::Stop,
@@ -377,7 +380,10 @@ fn prefill_batch(
         if req.max_tokens <= 1 {
             debug!(
                 "request finished: request_id={:?} prompt_tokens={} completion_tokens={} finish_reason={:?}",
-                req.request_id, prompt_len, 1, FinishReason::Length
+                req.request_id,
+                prompt_len,
+                1,
+                FinishReason::Length
             );
             let _ = req.token_tx.send(TokenEvent::Finished {
                 finish_reason: FinishReason::Length,
@@ -506,7 +512,10 @@ fn unified_step_sched(
         if !req.params.ignore_eos && model.is_stop_token(first_token) {
             debug!(
                 "request finished: request_id={:?} prompt_tokens={} completion_tokens={} finish_reason={:?}",
-                req.request_id, prompt_len, 0, FinishReason::Stop
+                req.request_id,
+                prompt_len,
+                0,
+                FinishReason::Stop
             );
             let _ = req.token_tx.send(TokenEvent::Finished {
                 finish_reason: FinishReason::Stop,
@@ -534,7 +543,10 @@ fn unified_step_sched(
         if req.max_tokens <= 1 {
             debug!(
                 "request finished: request_id={:?} prompt_tokens={} completion_tokens={} finish_reason={:?}",
-                req.request_id, prompt_len, 1, FinishReason::Length
+                req.request_id,
+                prompt_len,
+                1,
+                FinishReason::Length
             );
             let _ = req.token_tx.send(TokenEvent::Finished {
                 finish_reason: FinishReason::Length,
@@ -706,7 +718,10 @@ fn dispatch_decode_tokens(
         if is_eos {
             debug!(
                 "request finished: request_id={:?} prompt_tokens={} completion_tokens={} finish_reason={:?}",
-                req.request_id, req.prompt_len, req.generated_count, FinishReason::Stop
+                req.request_id,
+                req.prompt_len,
+                req.generated_count,
+                FinishReason::Stop
             );
             let _ = req.token_tx.send(TokenEvent::Finished {
                 finish_reason: FinishReason::Stop,
@@ -717,7 +732,10 @@ fn dispatch_decode_tokens(
         } else if at_limit {
             debug!(
                 "request finished: request_id={:?} prompt_tokens={} completion_tokens={} finish_reason={:?}",
-                req.request_id, req.prompt_len, req.generated_count, FinishReason::Length
+                req.request_id,
+                req.prompt_len,
+                req.generated_count,
+                FinishReason::Length
             );
             let _ = req.token_tx.send(TokenEvent::Token { id: token, logprob });
             let _ = req.token_tx.send(TokenEvent::Finished {

--- a/openinfer-qwen35-4b/src/scheduler.rs
+++ b/openinfer-qwen35-4b/src/scheduler.rs
@@ -13,7 +13,7 @@ use std::sync::mpsc as std_mpsc;
 use std::thread;
 
 use anyhow::Result;
-use log::{info, warn};
+use log::{debug, info, warn};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use tokio::sync::mpsc;
@@ -39,6 +39,7 @@ use self::plan::{
 /// An in-flight request being decoded. Recurrent state lives in the
 /// `BatchDecodeGraphState` at `graph_slot_idx` — NOT owned here.
 struct ActiveRequest35 {
+    request_id: Option<String>,
     token_tx: mpsc::UnboundedSender<TokenEvent>,
     kv: KvState,
     /// Index into `BatchDecodeGraphState.slot_states`.
@@ -220,6 +221,14 @@ fn scheduler_loop(
             send_rejection(rejected, *reason);
         }
         let pending = admission.pending;
+        for req in &pending {
+            debug!(
+                "request admitted: request_id={:?} prompt_len={} max_tokens={}",
+                req.request_id,
+                req.prompt_tokens.len(),
+                req.max_tokens
+            );
+        }
         deferred = admission.deferred;
 
         if let Some(plan) = plan::build_next_plan(!active.is_empty(), pending) {
@@ -338,6 +347,10 @@ fn prefill_batch(
         }
 
         if !req.params.ignore_eos && model.is_stop_token(first_token) {
+            debug!(
+                "request finished: request_id={:?} prompt_tokens={} completion_tokens={} finish_reason={:?}",
+                req.request_id, prompt_len, 0, FinishReason::Stop
+            );
             let _ = req.token_tx.send(TokenEvent::Finished {
                 finish_reason: FinishReason::Stop,
                 prompt_tokens: prompt_len,
@@ -354,10 +367,18 @@ fn prefill_batch(
             })
             .is_err()
         {
+            debug!(
+                "request dropped: client disconnected: request_id={:?} tokens_generated={}",
+                req.request_id, 0
+            );
             continue;
         }
 
         if req.max_tokens <= 1 {
+            debug!(
+                "request finished: request_id={:?} prompt_tokens={} completion_tokens={} finish_reason={:?}",
+                req.request_id, prompt_len, 1, FinishReason::Length
+            );
             let _ = req.token_tx.send(TokenEvent::Finished {
                 finish_reason: FinishReason::Length,
                 prompt_tokens: prompt_len,
@@ -375,6 +396,7 @@ fn prefill_batch(
 
         let kv = std::mem::replace(&mut kv_states[i], model.alloc_kv());
         active.push(ActiveRequest35 {
+            request_id: req.request_id,
             token_tx: req.token_tx,
             kv,
             graph_slot_idx: slot_idx,
@@ -482,6 +504,10 @@ fn unified_step_sched(
         }
 
         if !req.params.ignore_eos && model.is_stop_token(first_token) {
+            debug!(
+                "request finished: request_id={:?} prompt_tokens={} completion_tokens={} finish_reason={:?}",
+                req.request_id, prompt_len, 0, FinishReason::Stop
+            );
             let _ = req.token_tx.send(TokenEvent::Finished {
                 finish_reason: FinishReason::Stop,
                 prompt_tokens: prompt_len,
@@ -498,10 +524,18 @@ fn unified_step_sched(
             })
             .is_err()
         {
+            debug!(
+                "request dropped: client disconnected: request_id={:?} tokens_generated={}",
+                req.request_id, 0
+            );
             continue;
         }
 
         if req.max_tokens <= 1 {
+            debug!(
+                "request finished: request_id={:?} prompt_tokens={} completion_tokens={} finish_reason={:?}",
+                req.request_id, prompt_len, 1, FinishReason::Length
+            );
             let _ = req.token_tx.send(TokenEvent::Finished {
                 finish_reason: FinishReason::Length,
                 prompt_tokens: prompt_len,
@@ -519,6 +553,7 @@ fn unified_step_sched(
 
         let kv = std::mem::replace(&mut prefill_kv_states[i], model.alloc_kv());
         active.push(ActiveRequest35 {
+            request_id: req.request_id,
             token_tx: req.token_tx,
             kv,
             graph_slot_idx: slot_idx,
@@ -669,6 +704,10 @@ fn dispatch_decode_tokens(
         let at_limit = req.generated_count >= req.max_tokens;
 
         if is_eos {
+            debug!(
+                "request finished: request_id={:?} prompt_tokens={} completion_tokens={} finish_reason={:?}",
+                req.request_id, req.prompt_len, req.generated_count, FinishReason::Stop
+            );
             let _ = req.token_tx.send(TokenEvent::Finished {
                 finish_reason: FinishReason::Stop,
                 prompt_tokens: req.prompt_len,
@@ -676,6 +715,10 @@ fn dispatch_decode_tokens(
             });
             to_retire.push(i);
         } else if at_limit {
+            debug!(
+                "request finished: request_id={:?} prompt_tokens={} completion_tokens={} finish_reason={:?}",
+                req.request_id, req.prompt_len, req.generated_count, FinishReason::Length
+            );
             let _ = req.token_tx.send(TokenEvent::Token { id: token, logprob });
             let _ = req.token_tx.send(TokenEvent::Finished {
                 finish_reason: FinishReason::Length,
@@ -688,6 +731,10 @@ fn dispatch_decode_tokens(
             .send(TokenEvent::Token { id: token, logprob })
             .is_err()
         {
+            debug!(
+                "request dropped: client disconnected: request_id={:?} tokens_generated={}",
+                req.request_id, req.generated_count
+            );
             to_retire.push(i);
         } else {
             req.last_token = token;


### PR DESCRIPTION
## Summary

Adds engine-side request lifecycle logging in **both** `openinfer-qwen3-4b` and
`openinfer-qwen35-4b` schedulers so a request can be traced through admission
→ completion → client-abort from engine logs alone, addressing #210.

Today the engine emits no per-request lines: all per-request logging comes
from the external vllm-* crates, whose finish line carries no request_id
(the id lives in a tracing span and is lost across the tracing→log bridge),
and client disconnects are dropped silently.

## Changes

All at `debug!` level via the existing `log` facade — one line per lifecycle
event, not per token.

**`openinfer-qwen3-4b`**
- **Admitted** — `admit_deferred_requests` in `scheduler.rs`: `request_id`, `prompt_len`, `max_tokens`.
- **Finished** — `effects.rs`, at every arm sending `TokenEvent::Finished` (both decode and pending paths): `request_id`, `prompt_tokens`, `completion_tokens`, `finish_reason`.
- **Dropped** — `effects.rs`, the `DecodeEffect::EmitAndContinue` arm where `token_tx.send` fails: `request_id`, `tokens_generated`.

**`openinfer-qwen35-4b`** — same three events mirrored at the equivalent sites:
- Admitted: in the scheduler loop, after `admit_pending_requests`.
- Finished: 6 sites — 2 in `prefill_batch`, 2 in `unified_step_sched`, 2 in `dispatch_decode_tokens`.
- Dropped: 3 `.is_err()` arms where `token_tx.send` returns failure (prefill, unified-step, decode dispatch).
- Adds a `request_id: Option<String>` field to `ActiveRequest35` so the decode-path log can correlate.

## Expected behavior

With `RUST_LOG=openinfer_qwen3_4b=debug,openinfer_qwen35_4b=debug` and two
concurrent requests:

```
[DEBUG ...] request admitted: request_id=Some("cmpl-A") prompt_len=5 max_tokens=64
[DEBUG ...] request admitted: request_id=Some("cmpl-B") prompt_len=7 max_tokens=64
[DEBUG ...] request finished: request_id=Some("cmpl-A") prompt_tokens=5 completion_tokens=64 finish_reason=Length
[DEBUG ...] request finished: request_id=Some("cmpl-B") prompt_tokens=7 completion_tokens=64 finish_reason=Length
```

Mid-stream client abort:

```
[DEBUG ...] request dropped: client disconnected: request_id=Some("cmpl-C") tokens_generated=12
```

Each lifecycle event fires exactly once per request and the `request_id` is
carried through admission → completion → drop, so concurrent requests are
correlatable from engine-side lines alone.

## Local verification

- ✅ `cargo fmt --all --check` — clean.
- ❌ Runtime acceptance (`RUST_LOG=debug` + two concurrent requests + mid-stream abort) — **no local GPU**; relying on review + CI.

Happy to (a) paste live log samples if you can point me at a small test box, or
(b) follow up in a separate PR if you'd like to verify on your side first.

## Note on CI

This is my first contribution to the repo, so the CI runs are currently
queued in `action_required` waiting for maintainer approval. Once approved,
the only paid job is the CPU `cpu-checks` workflow (rustfmt + cargo metadata
+ sim e2e), which I expect to pass.

Closes #210
