### PR TITLE
fix(deepseek-v2-lite): precompute NCCL MoE route plan

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 
 | Path | TL;DR |
 | --- | --- |
-| `models/deepseek-v2-lite/status.md` | DeepSeek-V2-Lite EP2 model status and benchmark ledger: HF/host-staged/NCCL use a committed small correctness case set; direct batch, HTTP pressure, and current vLLM startup failures remain diagnostic evidence, not production serving parity. |
+| `models/deepseek-v2-lite/status.md` | DeepSeek-V2-Lite EP2 model status and benchmark ledger: HF/host-staged/NCCL use a committed small correctness case set; direct batch, OpenInfer HTTP pressure, and vLLM TP2 / TP2+EP2 rows from a documented validation environment remain diagnostic evidence, not production serving parity. |
 | `models/deepseek-v2-lite/hf-accuracy-gate.md` | DeepSeek-V2-Lite EP2 HF accuracy gate after PR #149/#150/#274: HF `generate(use_cache=true)`, host-staged EP2, and NCCL EP2 are compared across the committed small case set. |
 | `models/deepseek-v2-lite/decode-attribution-gate.md` | DeepSeek-V2-Lite EP2 decode attribution gate for `Hello`/16-token batch sizes 1/4/8: structured JSON with accuracy hashes, CPU-side timing, selected CUDA event/NVTX attribution, host-staged/NCCL EP counts, and explicit no-throughput claim boundary. |
 | `models/deepseek-v2-lite/source-layout.md` | DeepSeek-V2-Lite runtime layout refactor: `runtime.rs` split by responsibility, HF/host-staged/NCCL EP2 E2E exact on 2x RTX 5090; NCCL CUDA Graph smoke remains a diagnostic blocker on that host, independent of the passed correctness gate. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 
 | Path | TL;DR |
 | --- | --- |
-| `models/deepseek-v2-lite/status.md` | DeepSeek-V2-Lite EP2 model status and benchmark ledger: HF/host-staged/NCCL use a committed small correctness case set; direct same-prompt batch and manual vLLM snapshots remain diagnostic evidence, not production serving parity. |
+| `models/deepseek-v2-lite/status.md` | DeepSeek-V2-Lite EP2 model status and benchmark ledger: HF/host-staged/NCCL use a committed small correctness case set; direct batch, HTTP pressure, and current vLLM startup failures remain diagnostic evidence, not production serving parity. |
 | `models/deepseek-v2-lite/hf-accuracy-gate.md` | DeepSeek-V2-Lite EP2 HF accuracy gate after PR #149/#150/#274: HF `generate(use_cache=true)`, host-staged EP2, and NCCL EP2 are compared across the committed small case set. |
 | `models/deepseek-v2-lite/decode-attribution-gate.md` | DeepSeek-V2-Lite EP2 decode attribution gate for `Hello`/16-token batch sizes 1/4/8: structured JSON with accuracy hashes, CPU-side timing, selected CUDA event/NVTX attribution, host-staged/NCCL EP counts, and explicit no-throughput claim boundary. |
 | `models/deepseek-v2-lite/source-layout.md` | DeepSeek-V2-Lite runtime layout refactor: `runtime.rs` split by responsibility, HF/host-staged/NCCL EP2 E2E exact on 2x RTX 5090; NCCL CUDA Graph smoke remains a diagnostic blocker on that host, independent of the passed correctness gate. |

--- a/docs/models/deepseek-v2-lite/decode-attribution-gate.md
+++ b/docs/models/deepseek-v2-lite/decode-attribution-gate.md
@@ -39,7 +39,7 @@ Out of scope:
 
 Host-staged `dispatch_calls` / `combine_calls` count MoE layer invocations in the fixed greedy run. Host-staged `dispatch_elements` / `combine_elements` count selected routed hidden vectors, so the value is route count times hidden size. NCCL `exchange` and `combine` counters count the dense all-reduce calls and elements used by the current naive NCCL gate.
 
-The GPU event rows are intentionally narrower than the CPU rows. They cover sections that enqueue device work or NCCL work on known streams, including projections, dense/shared/routed experts, NCCL dense exchange, NCCL combine clear, device contribution accumulation, and NCCL combine. They do not relabel pure host routing or host-directed route iteration as GPU work, and the mixed `attention_host_path` stays CPU-side because it includes host attention assembly as well as internal GPU projections.
+The GPU event rows are intentionally narrower than the CPU rows. They cover sections that enqueue device work or NCCL work on known streams, including projections, dense/shared/routed experts, NCCL dense exchange, NCCL combine clear, device contribution accumulation, and NCCL combine. They do not relabel host route-plan construction/replay as GPU work, and the mixed `attention_host_path` stays CPU-side because it includes host attention assembly as well as internal GPU projections.
 
 ## Commands
 
@@ -140,7 +140,7 @@ The HF oracle needs a Python environment that can load DeepSeek-V2-Lite with `tr
 
 ## Latest Validation
 
-The issue #276 refresh was rerun on 2026-06-10 with DeepSeek-V2-Lite snapshot `604d5664dddd88a0433dbae533b7fe9472482de0`, `prompt="Hello"`, `output_len=16`, and 2x RTX 5090. HF, host-staged, and NCCL were dumped from the same model directory and compared with `--require-all-exact`. The Rust path loaded NCCL `2.30.7+cuda12.9` from the Python CUDA wheel path because the system NCCL `2.25.1+cuda12.8` failed the init smoke on this Blackwell host before model-level validation.
+The issue #277 route-plan refresh was rerun on 2026-06-14 with DeepSeek-V2-Lite snapshot `604d5664dddd88a0433dbae533b7fe9472482de0`, `prompt="Hello"`, `output_len=16`, and 2x RTX 5090. HF, host-staged, and NCCL were dumped from the same model directory and compared with `--require-all-exact`. The NCCL run used a Python CUDA wheel runtime after the system NCCL runtime failed communicator initialization on this Blackwell host; this is an environment prerequisite, not a model-logic change.
 
 - HF / host-staged / NCCL comparison: `all_token_text_exact`.
 - Token SHA256: `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225`.
@@ -148,15 +148,15 @@ The issue #276 refresh was rerun on 2026-06-10 with DeepSeek-V2-Lite snapshot `6
 - Generated text: `, I am a 19 year old girl from the UK. I am`.
 - Candidate NCCL attribution: `gpu_timing.sample_count=8384`, `failure_count=0`.
 
-The candidate readiness report still has `full_decode_capture_ready=false`. Compared with the issue #275 candidate, it removes the dense-exchange allocation/sync blockers. The remaining blockers are `nccl_route_iteration_on_host` and `nccl_expert_accumulation_host_directed`.
+The candidate readiness report still has `full_decode_capture_ready=false`. Compared with the issue #276 candidate, it removes the old per-token route-iteration and host-directed expert-accumulation blocker IDs. The remaining blockers are `nccl_route_plan_built_on_host` and `nccl_route_plan_replay_host_directed`.
 
-Current NCCL attribution for the issue #276 gate:
+Current NCCL attribution for the issue #277 gate:
 
 | Batch | GPU event samples | GPU failures | NCCL exchange/combine calls | Route counters | Readiness blockers |
 | ---: | ---: | ---: | --- | --- | --- |
-| 1 | 8384 | 0 | `416 / 416` | `local=1284`, `remote=1212`, `combine=2496` | `nccl_route_iteration_on_host`, `nccl_expert_accumulation_host_directed` |
-| 4 | 23996 | 0 | `494 / 494` | `local=5136`, `remote=4848`, `combine=9984` | `nccl_route_iteration_on_host`, `nccl_expert_accumulation_host_directed` |
-| 8 | 44812 | 0 | `598 / 598` | `local=10272`, `remote=9696`, `combine=19968` | `nccl_route_iteration_on_host`, `nccl_expert_accumulation_host_directed` |
+| 1 | 8384 | 0 | `416 / 416` | `local=1284`, `remote=1212`, `combine=2496` | `nccl_route_plan_built_on_host`, `nccl_route_plan_replay_host_directed` |
+| 4 | 23996 | 0 | `494 / 494` | `local=5136`, `remote=4848`, `combine=9984` | `nccl_route_plan_built_on_host`, `nccl_route_plan_replay_host_directed` |
+| 8 | 44812 | 0 | `598 / 598` | `local=10272`, `remote=9696`, `combine=19968` | `nccl_route_plan_built_on_host`, `nccl_route_plan_replay_host_directed` |
 
 The previous A800 strict same-host accuracy gate was rerun on 2026-06-04 with DeepSeek-V2-Lite snapshot `604d5664dddd88a0433dbae533b7fe9472482de0`, `prompt="Hello"`, `output_len=16`, and 2x A800-SXM4-80GB. The token/text oracle is confirmed by a real HF `AutoModelForCausalLM.generate(..., do_sample=false, use_cache=true)` run on the same model directory as the Rust E2E gate.
 

--- a/docs/models/deepseek-v2-lite/status.md
+++ b/docs/models/deepseek-v2-lite/status.md
@@ -1,6 +1,6 @@
 # DeepSeek-V2-Lite Status And Benchmark Ledger
 
-> **TL;DR:** DeepSeek-V2-Lite is a feature-gated EP2 correctness and attribution target. The original `Hello` / 16 greedy gate is now widened through a committed small case set for HF / host-staged / NCCL comparison; NCCL decode combine and dense exchange use reusable device scratch, and NCCL replay now uses a precomputed route plan while full decode graph capture remains blocked. Current batch, HTTP, and vLLM data remain diagnostic and do not claim production serving parity.
+> **TL;DR:** DeepSeek-V2-Lite is a feature-gated EP2 correctness and attribution target. The original `Hello` / 16 greedy gate is now widened through a committed small case set for HF / host-staged / NCCL comparison; NCCL decode combine and dense exchange use reusable device scratch, and NCCL replay now uses a precomputed route plan while full decode graph capture remains blocked. Current direct batch, OpenInfer HTTP pressure, and vLLM TP2 / TP2+EP2 data from a documented validation environment remain diagnostic and do not claim production serving parity.
 
 Last touched: 2026-06
 
@@ -19,7 +19,7 @@ Last touched: 2026-06
 | NCCL route-plan replay | Available | Issue #277 builds a token-major host route plan once after top-k routing, replays that plan for NCCL expert launches and device contribution accumulation, keeps route counters visible, and preserves HF / host-staged / NCCL exactness on 2x RTX 5090. |
 | NCCL CUDA Graph readiness | Diagnostic only | The attribution binary emits `cuda_graph_readiness`. Current NCCL full decode capture remains blocked by host route-plan construction/replay; the removed dense-exchange allocation/sync and old per-token route-iteration blockers should stay absent. |
 | Production continuous batching | Not available | The direct diagnostic batch path is not mixed-request HTTP serving. |
-| vLLM production parity | Not claimed | The vLLM startup-failure evidence below keeps the issue #170 comparison matrix honest without claiming serving parity. |
+| vLLM production parity | Not claimed | The vLLM TP2 / TP2+EP2 snapshot below is a runnable comparison from a documented validation environment, not serving parity or a stock-install claim. |
 
 ## Correctness Contract
 
@@ -74,14 +74,31 @@ OpenInfer streaming currently makes the client-side TPOT fields near-zero in thi
 | NCCL | 4 | 24/24 | 6.326 | 158.083 | 9491.680 | 10097.244 |
 | NCCL | 8 | 24/24 | 6.341 | 157.710 | 17242.941 | 20110.121 |
 
-### vLLM Startup Failures
+### vLLM Repaired-Environment Comparison
 
-In response to issue #170's request for a vLLM TP2+EP2 or pure TP2 comparison, keep vLLM in the matrix when the selected validation environment can bring the server to readiness. The 2026-06-15 attempts on the same 2x RTX 5090 host failed before `/v1/models` readiness for both the older retained vLLM environment and a freshly installed current vLLM environment. Earlier manual vLLM rows should not be mixed with this current branch/hardware snapshot; they only show that vLLM may be viable in other environments.
+In response to issue #170's request for a vLLM TP2+EP2 or pure TP2 comparison, the 2026-06-15 2x RTX 5090 run now has a successful vLLM baseline for the same DeepSeek-V2-Lite model/tokenizer snapshot and short HTTP benchmark shape as the OpenInfer table above.
+
+This is a validation environment with documented package/toolchain fixes, not a stock vLLM install claim. The working run used vLLM `0.22.1`, Torch `2.11.0+cu130`, Transformers `5.12.0`, FlashInfer `0.6.12`, `FLASHINFER_CUDA_ARCH_LIST=12.0f`, CUDA 13.3-aligned Python CUDA packages, and FastAPI `0.115.14` / Starlette `0.46.2` / `prometheus-fastapi-instrumentator` `7.1.0`. Those fixes were needed after earlier SM120 FlashInfer JIT/linking and HTTP middleware failures.
+
+The server was launched eager bf16 with `--max-model-len 512`, `--gpu-memory-utilization 0.70`, `--tensor-parallel-size 2`; TP2+EP2 additionally used `--enable-expert-parallel`, and the server log confirmed expert parallelism with `32/64` local/global experts.
+
+Client shape: `vllm bench serve --backend openai --endpoint /v1/completions --model DeepSeek-V2-Lite --tokenizer models/DeepSeek-V2-Lite --dataset-name random --random-input-len 2 --random-output-len 16 --num-prompts 24 --temperature 0 --ignore-eos`, run separately with `--max-concurrency 1`, `4`, and `8`.
+
+| Runtime | conc | completed | output tok/s | mean TTFT ms | median TTFT ms | mean TPOT ms | median TPOT ms | mean ITL ms | median ITL ms |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| vLLM TP2 | 1 | 24/24 | 19.140 | 217.484 | 48.451 | 41.193 | 41.193 | 41.193 | 40.312 |
+| vLLM TP2 | 4 | 24/24 | 84.790 | 125.694 | 125.623 | 41.678 | 41.635 | 41.678 | 41.247 |
+| vLLM TP2 | 8 | 24/24 | 167.600 | 129.826 | 125.069 | 41.933 | 41.810 | 41.933 | 41.033 |
+| vLLM TP2+EP2 | 1 | 24/24 | 23.834 | 62.245 | 46.911 | 40.576 | 40.596 | 40.576 | 40.502 |
+| vLLM TP2+EP2 | 4 | 24/24 | 87.078 | 121.439 | 121.553 | 40.641 | 40.409 | 40.641 | 40.253 |
+| vLLM TP2+EP2 | 8 | 24/24 | 174.097 | 125.144 | 119.399 | 40.348 | 40.272 | 40.348 | 40.117 |
+
+Earlier failed vLLM attempts are still useful as environment-discovery evidence:
 
 | Environment | Modes tried | Result |
 | --- | --- | --- |
 | vLLM `0.9.2`, Torch `2.7.0+cu128`, Transformers `4.53.3` | TP2, TP2+EP2, V1/V0, default/eager fallback, plus one low-memory smoke | server never reached readiness; failures were `CUBLAS_STATUS_NOT_INITIALIZED` during worker profile plus one low-memory illegal-memory-access smoke |
-| vLLM `0.22.1`, Torch `2.11.0+cu130`, Transformers `5.12.0` | TP2 and TP2+EP2 default/eager fallback | server never reached readiness; failures were FlashInfer / SM12x backend selection errors (`No supported CUDA architectures found for major versions [12]`, `FlashInfer requires GPUs with sm75 or higher`) |
+| vLLM `0.22.1`, Torch `2.11.0+cu130`, Transformers `5.12.0` | TP2 and TP2+EP2 default/eager fallback | server never reached readiness until FlashInfer SM120f, CUDA 13.3 headers/libs, unversioned CUDA linker names, and FastAPI middleware compatibility were repaired |
 | vLLM `0.22.1` controlled backend fallback | TP2 and TP2+EP2 with `--attention-backend TRITON_ATTN --moe-backend triton` | server never reached readiness; `TRITON_ATTN` is not valid for DeepSeek-V2 MLA (`MLA not supported`) |
 
 Interpretation:
@@ -89,7 +106,9 @@ Interpretation:
 - direct same-prompt diagnostics show NCCL is still much slower than host-staged, although aggregate decode throughput improves with larger diagnostic batch size;
 - NCCL remains a correctness-first backend and is still significantly slower than host-staged;
 - OpenInfer HTTP throughput did not scale with concurrency in this snapshot, so serving batching remains open;
-- vLLM comparison rows should remain failed/missing for this environment until a selected vLLM build reaches server readiness; standalone Torch bf16 GEMM passed on both GPUs in both tested vLLM environments, so the retained failure is specific to the vLLM DeepSeek-V2 server/model startup path rather than a blanket CUDA outage.
+- vLLM TP2 and TP2+EP2 both show higher aggregate output tok/s under this short HTTP pressure shape than the current OpenInfer HTTP pressure rows;
+- TP2+EP2 is slightly ahead of TP2 in this short snapshot, but this is one workload and one documented validation environment;
+- standalone Torch bf16 GEMM passed on both GPUs in the failed and repaired vLLM environments, so the earlier failures were specific to the vLLM DeepSeek-V2 server/model startup and Python package/toolchain path rather than a blanket CUDA outage.
 
 ## Claim Boundaries
 
@@ -100,6 +119,7 @@ Use these labels consistently:
 | `direct single-row` | In-process batch `1` decode. | HTTP serving throughput. |
 | `direct same-prompt diagnostic batch` | Fixed same-prompt direct batch sizes `1/4/8`. | Production continuous batching or mixed-request scheduling. |
 | `HTTP concurrency pressure` | `vllm bench serve --max-concurrency N` against an HTTP endpoint. | True OpenInfer batch size unless the engine path proves it. |
+| `vLLM comparison from documented environment` | vLLM TP2 / TP2+EP2 after target-environment package/toolchain fixes. | Stock vLLM install support, OpenInfer serving parity, or production readiness. |
 
 Do not claim:
 

--- a/docs/models/deepseek-v2-lite/status.md
+++ b/docs/models/deepseek-v2-lite/status.md
@@ -1,6 +1,6 @@
 # DeepSeek-V2-Lite Status And Benchmark Ledger
 
-> **TL;DR:** DeepSeek-V2-Lite is a feature-gated EP2 correctness and attribution target. The original `Hello` / 16 greedy gate is now widened through a committed small case set for HF / host-staged / NCCL comparison; NCCL decode combine and dense exchange use reusable device scratch, and NCCL replay now uses a precomputed route plan while full decode graph capture remains blocked. Current batch and vLLM data remain diagnostic and do not claim production serving parity.
+> **TL;DR:** DeepSeek-V2-Lite is a feature-gated EP2 correctness and attribution target. The original `Hello` / 16 greedy gate is now widened through a committed small case set for HF / host-staged / NCCL comparison; NCCL decode combine and dense exchange use reusable device scratch, and NCCL replay now uses a precomputed route plan while full decode graph capture remains blocked. Current batch, HTTP, and vLLM data remain diagnostic and do not claim production serving parity.
 
 Last touched: 2026-06
 
@@ -19,7 +19,7 @@ Last touched: 2026-06
 | NCCL route-plan replay | Available | Issue #277 builds a token-major host route plan once after top-k routing, replays that plan for NCCL expert launches and device contribution accumulation, keeps route counters visible, and preserves HF / host-staged / NCCL exactness on 2x RTX 5090. |
 | NCCL CUDA Graph readiness | Diagnostic only | The attribution binary emits `cuda_graph_readiness`. Current NCCL full decode capture remains blocked by host route-plan construction/replay; the removed dense-exchange allocation/sync and old per-token route-iteration blockers should stay absent. |
 | Production continuous batching | Not available | The direct diagnostic batch path is not mixed-request HTTP serving. |
-| vLLM production parity | Not claimed | The manual vLLM snapshot below is for understanding the gap requested in issue #170. |
+| vLLM production parity | Not claimed | The vLLM startup-failure evidence below keeps the issue #170 comparison matrix honest without claiming serving parity. |
 
 ## Correctness Contract
 
@@ -46,38 +46,50 @@ This path is useful for attribution and for avoiding the earlier row-loop TPOT m
 - the direct benchmark path is not `/v1/completions` serving;
 - it does not prove request admission, per-request KV ownership, fairness, or mixed-request scheduling.
 
-Current retained direct snapshot from PR #184:
+Current retained direct snapshot from the issue #277 branch (`2f52ed6`, 2026-06-15, 2x RTX 5090 / SYS interconnect). Shape: `prompt="Hello"`, `output_len=16`, `warmup=5`, `iters=20`; every row produced token trace hash `ed0eab52473991fc`. `decode tok/s` is the benchmark report's aggregate `metrics.decode_tok_s`. This refresh replaces the older PR #184 row values for the current branch ledger, but it should not be read as an isolated route-plan speedup because the retained snapshot was rerun on a different validation environment.
 
 | Batch | Backend | steady TPOT p50 ms | steady TPOT avg ms | decode tok/s |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | host-staged | 58.558 | 62.009 | 16.144 |
-| 1 | NCCL | 193.650 | 201.276 | 4.982 |
-| 4 | host-staged | 202.186 | 210.409 | 19.124 |
-| 4 | NCCL | 333.321 | 344.764 | 11.528 |
-| 8 | host-staged | 394.753 | 411.348 | 19.423 |
-| 8 | NCCL | 522.917 | 539.643 | 14.874 |
+| 1 | host-staged | 55.727 | 57.313 | 17.486 |
+| 1 | NCCL | 181.795 | 188.420 | 5.321 |
+| 4 | host-staged | 193.954 | 198.905 | 20.106 |
+| 4 | NCCL | 303.389 | 311.621 | 12.821 |
+| 8 | host-staged | 385.013 | 394.908 | 20.270 |
+| 8 | NCCL | 472.045 | 483.538 | 16.517 |
 
 PR #196 extends attribution for the same direct diagnostic shapes. The retained A800 attribution gate keeps `batch-size=1/4/8`, `prompt="Hello"`, `output_len=16`, host-staged, and NCCL exact against the same-host HF gate.
 
-### Manual vLLM Snapshot
+### HTTP Concurrency Pressure
 
-In response to issue #170's request for a vLLM TP2+EP2 or pure TP2 comparison, a manual same-model snapshot was collected with `vllm bench serve` concurrency pressure `1`, `4`, and `8`.
+The issue #277 branch was also run through `/v1/completions` with `vllm bench serve` used only as the common HTTP client. Shape: random input length `2`, output length `16`, `24` prompts, `temperature=0`, `ignore_eos`, `--max-concurrency 1/4/8`, OpenInfer `--cuda-graph=false`.
 
-This table is retained only to document the current gap. It is not evidence of a complete, fair production-serving parity comparison, and `--max-concurrency` should be read as concurrent request pressure, not as proof of true internal OpenInfer batch size.
+OpenInfer streaming currently makes the client-side TPOT fields near-zero in this shape, so this table reports output throughput and throughput-derived milliseconds per output token computed as `duration / total_output_tokens`. `--max-concurrency` should be read as concurrent request pressure, not as proof of true internal OpenInfer batch size.
 
-| Engine | Mode | conc=1 TPOT ms | conc=4 TPOT ms | conc=8 TPOT ms | Output tok/s at 1/4/8 |
-| --- | --- | ---: | ---: | ---: | --- |
-| OpenInfer | host-staged | 49.95 | 51.30 | 51.22 | 19.84 / 19.53 / 19.56 |
-| OpenInfer | NCCL | 178.31 | 173.22 | 174.46 | 5.59 / 5.77 / 5.73 |
-| vLLM | TP2 default | 35.61 | 36.43 | 36.37 | 27.54 / 97.72 / 195.28 |
-| vLLM | TP2+EP2 default | 34.15 | 34.97 | 34.88 | 28.87 / 101.52 / 204.08 |
+| Backend | conc | completed | output tok/s | throughput-derived ms/output token | mean TTFT ms | median TTFT ms |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| host-staged | 1 | 24/24 | 20.912 | 47.820 | 764.471 | 740.296 |
+| host-staged | 4 | 24/24 | 21.030 | 47.552 | 2838.390 | 3036.649 |
+| host-staged | 8 | 24/24 | 20.964 | 47.700 | 5198.935 | 5991.506 |
+| NCCL | 1 | 24/24 | 6.302 | 158.689 | 2538.216 | 2553.374 |
+| NCCL | 4 | 24/24 | 6.326 | 158.083 | 9491.680 | 10097.244 |
+| NCCL | 8 | 24/24 | 6.341 | 157.710 | 17242.941 | 20110.121 |
+
+### vLLM Startup Failures
+
+In response to issue #170's request for a vLLM TP2+EP2 or pure TP2 comparison, keep vLLM in the matrix when the selected validation environment can bring the server to readiness. The 2026-06-15 attempts on the same 2x RTX 5090 host failed before `/v1/models` readiness for both the older retained vLLM environment and a freshly installed current vLLM environment. Earlier manual vLLM rows should not be mixed with this current branch/hardware snapshot; they only show that vLLM may be viable in other environments.
+
+| Environment | Modes tried | Result |
+| --- | --- | --- |
+| vLLM `0.9.2`, Torch `2.7.0+cu128`, Transformers `4.53.3` | TP2, TP2+EP2, V1/V0, default/eager fallback, plus one low-memory smoke | server never reached readiness; failures were `CUBLAS_STATUS_NOT_INITIALIZED` during worker profile plus one low-memory illegal-memory-access smoke |
+| vLLM `0.22.1`, Torch `2.11.0+cu130`, Transformers `5.12.0` | TP2 and TP2+EP2 default/eager fallback | server never reached readiness; failures were FlashInfer / SM12x backend selection errors (`No supported CUDA architectures found for major versions [12]`, `FlashInfer requires GPUs with sm75 or higher`) |
+| vLLM `0.22.1` controlled backend fallback | TP2 and TP2+EP2 with `--attention-backend TRITON_ATTN --moe-backend triton` | server never reached readiness; `TRITON_ATTN` is not valid for DeepSeek-V2 MLA (`MLA not supported`) |
 
 Interpretation:
 
-- at single-concurrency TPOT, host-staged is closer to vLLM than the current NCCL backend;
+- direct same-prompt diagnostics show NCCL is still much slower than host-staged, although aggregate decode throughput improves with larger diagnostic batch size;
 - NCCL remains a correctness-first backend and is still significantly slower than host-staged;
 - OpenInfer HTTP throughput did not scale with concurrency in this snapshot, so serving batching remains open;
-- vLLM TP2+EP2 worked in this environment and should stay in future comparison matrices.
+- vLLM comparison rows should remain failed/missing for this environment until a selected vLLM build reaches server readiness; standalone Torch bf16 GEMM passed on both GPUs in both tested vLLM environments, so the retained failure is specific to the vLLM DeepSeek-V2 server/model startup path rather than a blanket CUDA outage.
 
 ## Claim Boundaries
 

--- a/docs/models/deepseek-v2-lite/status.md
+++ b/docs/models/deepseek-v2-lite/status.md
@@ -1,6 +1,6 @@
 # DeepSeek-V2-Lite Status And Benchmark Ledger
 
-> **TL;DR:** DeepSeek-V2-Lite is a feature-gated EP2 correctness and attribution target. The original `Hello` / 16 greedy gate is now widened through a committed small case set for HF / host-staged / NCCL comparison; NCCL decode combine and dense exchange use reusable device scratch, while host-directed routing/expert accumulation still block full decode graph capture. Current batch and vLLM data remain diagnostic and do not claim production serving parity.
+> **TL;DR:** DeepSeek-V2-Lite is a feature-gated EP2 correctness and attribution target. The original `Hello` / 16 greedy gate is now widened through a committed small case set for HF / host-staged / NCCL comparison; NCCL decode combine and dense exchange use reusable device scratch, and NCCL replay now uses a precomputed route plan while full decode graph capture remains blocked. Current batch and vLLM data remain diagnostic and do not claim production serving parity.
 
 Last touched: 2026-06
 
@@ -16,7 +16,8 @@ Last touched: 2026-06
 | Direct same-prompt diagnostic batch | Available | PR #184 and PR #196 cover batch sizes `1`, `4`, and `8` for the fixed same-prompt direct path. |
 | Device-resident NCCL combine | Available | Issue #275 keeps NCCL combine contributions/results on reusable f32 device scratch and preserves the HF / host-staged / NCCL exact gate on 2x RTX 5090. |
 | Device-resident NCCL dense exchange | Available | Issue #276 reuses backend-owned bf16 dense-exchange scratch, clears rank1 zero-send every exchange, removes dense-exchange stream sync from the backend call, and preserves HF / host-staged / NCCL exactness on 2x RTX 5090. |
-| NCCL CUDA Graph readiness | Diagnostic only | The attribution binary emits `cuda_graph_readiness`. Current NCCL full decode capture remains blocked by host route iteration and host-directed expert accumulation; the removed dense-exchange allocation/sync blockers should stay absent. |
+| NCCL route-plan replay | Available | Issue #277 builds a token-major host route plan once after top-k routing, replays that plan for NCCL expert launches and device contribution accumulation, keeps route counters visible, and preserves HF / host-staged / NCCL exactness on 2x RTX 5090. |
+| NCCL CUDA Graph readiness | Diagnostic only | The attribution binary emits `cuda_graph_readiness`. Current NCCL full decode capture remains blocked by host route-plan construction/replay; the removed dense-exchange allocation/sync and old per-token route-iteration blockers should stay absent. |
 | Production continuous batching | Not available | The direct diagnostic batch path is not mixed-request HTTP serving. |
 | vLLM production parity | Not claimed | The manual vLLM snapshot below is for understanding the gap requested in issue #170. |
 
@@ -100,7 +101,7 @@ Do not claim:
 
 Issue #205 records the model roadmap. Maintainer feedback there calls out NCCL plus CUDA Graph as the likely best decode direction, with host staging possibly deprecated later. Treat that as a future direction, not as current evidence.
 
-The current graph-readiness diagnostic is intentionally fail-closed: `full_decode_capture_ready=false` for NCCL. Issue #275 removed the old NCCL combine H2D/D2H/allocation/sync blockers, and issue #276 removed the dense-exchange allocation/sync blockers from the retained 2x RTX 5090 attribution gate. Those removed dense-exchange blockers are absent from the current readiness report. The remaining NCCL blockers are host route iteration and host-directed expert accumulation. The optional f32 NCCL graph smoke is a separate collective-only diagnostic and is not #276 evidence. HF, host-staged, and NCCL remain token/text exact for the committed case set.
+The current graph-readiness diagnostic is intentionally fail-closed: `full_decode_capture_ready=false` for NCCL. Issue #275 removed the old NCCL combine H2D/D2H/allocation/sync blockers, issue #276 removed the dense-exchange allocation/sync blockers, and issue #277 narrows the remaining NCCL route work into a precomputed host route plan plus host-directed replay. The old per-token route-iteration and host-directed expert-accumulation blocker IDs should stay absent from the current readiness report. The optional f32 NCCL graph smoke is a separate collective-only diagnostic and is not #276/#277 evidence. HF, host-staged, and NCCL remain token/text exact for the committed case set.
 
 The next implementation should be chosen from measured evidence:
 
@@ -113,7 +114,7 @@ The next implementation should be chosen from measured evidence:
    - keep HF / host-staged / NCCL exact before and after;
    - keep host-staged as the correctness baseline while it exists;
    - preserve attribution before and after the change;
-   - attack host route iteration and host-directed expert accumulation next;
+   - keep narrowing host route-plan construction/replay before claiming full decode capture;
    - avoid broad generic EP or multi-node work;
    - judge issue #170 by whether it reduces NCCL decode overhead and makes the path more graph-friendly.
 

--- a/openinfer-deepseek-v2-lite/src/bin/dsv2_lite_ep2_decode_attribution.rs
+++ b/openinfer-deepseek-v2-lite/src/bin/dsv2_lite_ep2_decode_attribution.rs
@@ -179,7 +179,7 @@ fn single_report(
             "failure_count": attribution.gpu_timing_failure_count(),
             "nvtx_enabled": attribution.nvtx_enabled(),
             "nvtx_range_count": attribution.nvtx_range_count(),
-            "scope": "selected GPU/NCCL sections only; host routing, host-directed route iteration, and the mixed attention_host_path remain CPU-side attribution rows; GPU timing failures do not replace the token/text hash oracle; NVTX range wall time is only a profiler correlation marker and may include host/event overhead",
+            "scope": "selected GPU/NCCL sections only; host route-plan construction/replay and the mixed attention_host_path remain CPU-side attribution rows; GPU timing failures do not replace the token/text hash oracle; NVTX range wall time is only a profiler correlation marker and may include host/event overhead",
         },
         "schedule_source": "fixed DeepSeek-V2-Lite EP2 greedy gate: prompt=Hello, output_len=16, cuda_graph=false, device_ordinals=[0,1]",
         "by_section": by_section,
@@ -281,7 +281,7 @@ fn batch_report(
             "failure_count": attribution.gpu_timing_failure_count(),
             "nvtx_enabled": attribution.nvtx_enabled(),
             "nvtx_range_count": attribution.nvtx_range_count(),
-            "scope": "selected GPU/NCCL sections only; host routing, host-directed route iteration, and the mixed attention_host_path remain CPU-side attribution rows; GPU timing failures do not replace the token/text hash oracle; NVTX range wall time is only a profiler correlation marker and may include host/event overhead",
+            "scope": "selected GPU/NCCL sections only; host route-plan construction/replay and the mixed attention_host_path remain CPU-side attribution rows; GPU timing failures do not replace the token/text hash oracle; NVTX range wall time is only a profiler correlation marker and may include host/event overhead",
         },
         "schedule_source": format!(
             "fixed DeepSeek-V2-Lite EP2 greedy gate: batch_size={}, prompt=Hello, output_len=16, cuda_graph=false, device_ordinals=[0,1]",

--- a/openinfer-deepseek-v2-lite/src/runtime.rs
+++ b/openinfer-deepseek-v2-lite/src/runtime.rs
@@ -6,6 +6,7 @@ mod helpers;
 mod layers;
 mod moe;
 mod readiness;
+mod routing;
 #[cfg(test)]
 mod tests;
 mod types;

--- a/openinfer-deepseek-v2-lite/src/runtime/moe.rs
+++ b/openinfer-deepseek-v2-lite/src/runtime/moe.rs
@@ -5,7 +5,11 @@ use openinfer_core::{
     tensor::{HiddenStates, HiddenStatesRef},
 };
 
-use super::{DeepSeekV2LiteEp2Generator, backend::EpBackendRuntime};
+use super::{
+    DeepSeekV2LiteEp2Generator,
+    backend::EpBackendRuntime,
+    routing::{MoeRouteEntry, MoeRoutePlan},
+};
 use crate::{
     attribution::DecodeAttributionProfile,
     device::activate,
@@ -196,7 +200,7 @@ impl DeepSeekV2LiteEp2Generator {
         shared_per_token_gemm: bool,
     ) -> Result<(HiddenStates, usize, usize)> {
         activate(&self.rank0.ctx)?;
-        let routes = attribution.record_result(
+        let route_plan = attribution.record_result(
             phase,
             "ep_route_host",
             || format!("layer.{layer_idx}.nccl.route"),
@@ -205,11 +209,8 @@ impl DeepSeekV2LiteEp2Generator {
             || {
                 let input_host = hidden_to_bf16(&self.rank0.ctx, input)?;
                 let route_logits_host = gate_logits_host(&self.config, &input_host, &moe.gate_host);
-                Ok(topk_softmax_routes(
-                    &self.config,
-                    &route_logits_host,
-                    input.seq_len,
-                ))
+                let routes = topk_softmax_routes(&self.config, &route_logits_host, input.seq_len);
+                MoeRoutePlan::from_topk_routes(&routes, &self.rank0.layout)
             },
         )?;
 
@@ -256,78 +257,16 @@ impl DeepSeekV2LiteEp2Generator {
                 )
             },
         )?;
-        let mut local_routes = 0usize;
-        let mut remote_routes = 0usize;
-        let mut live_expert_outputs =
-            Vec::with_capacity(input.seq_len * self.config.num_experts_per_token);
-
-        for (token, token_routes) in routes.iter().enumerate() {
-            for &(global_expert, weight) in token_routes {
-                let owner_rank = self.rank0.layout.owner_rank(global_expert)?;
-                let out = match owner_rank {
-                    0 => {
-                        local_routes += 1;
-                        let expert = self.rank0.routed_expert(layer_idx, global_expert)?;
-                        attribution.record_gpu_result(
-                            &self.rank0.ctx,
-                            phase,
-                            "nccl_local_expert",
-                            || format!("layer.{layer_idx}.nccl.local_expert"),
-                            Some(layer_idx),
-                            token_index,
-                            || {
-                                expert_forward_device(
-                                    &self.rank0.ctx,
-                                    expert,
-                                    input.as_ref(),
-                                    token,
-                                )
-                            },
-                        )?
-                    }
-                    1 => {
-                        remote_routes += 1;
-                        let expert = self.rank1.routed_expert(layer_idx, global_expert)?;
-                        attribution.record_gpu_result(
-                            &self.rank1.ctx,
-                            phase,
-                            "nccl_remote_expert",
-                            || format!("layer.{layer_idx}.nccl.remote_expert"),
-                            Some(layer_idx),
-                            token_index,
-                            || expert_forward_device(&self.rank1.ctx, expert, rank1_hidden, token),
-                        )?
-                    }
-                    other => {
-                        bail!("routed expert {global_expert} maps to unsupported EP rank {other}")
-                    }
-                };
-                let expert_ctx = if owner_rank == 0 {
-                    &self.rank0.ctx
-                } else {
-                    &self.rank1.ctx
-                };
-                attribution.record_gpu_result(
-                    expert_ctx,
-                    phase,
-                    "nccl_contribution_accumulate_device",
-                    || format!("layer.{layer_idx}.nccl.contribution_accumulate_device"),
-                    Some(layer_idx),
-                    token_index,
-                    || {
-                        nccl.accumulate_device_contribution(
-                            owner_rank,
-                            expert_ctx,
-                            &out,
-                            token,
-                            input.seq_len,
-                            weight,
-                        )
-                    },
-                )?;
-                live_expert_outputs.push(out);
-            }
-        }
+        let live_expert_outputs = self.replay_nccl_route_plan(
+            nccl,
+            layer_idx,
+            input,
+            rank1_hidden,
+            &route_plan,
+            attribution,
+            phase,
+            token_index,
+        )?;
 
         let routed = attribution.record_gpu_pair_result(
             &self.rank0.ctx,
@@ -357,7 +296,11 @@ impl DeepSeekV2LiteEp2Generator {
             token_index,
             || ops::add_batch(&self.rank0.ctx, &routed, &shared),
         )?;
-        Ok((hidden, local_routes, remote_routes))
+        Ok((
+            hidden,
+            route_plan.local_routes(),
+            route_plan.remote_routes(),
+        ))
     }
 
     fn expert_forward_host(
@@ -382,6 +325,101 @@ impl DeepSeekV2LiteEp2Generator {
         let input = hidden_from_bf16_host(ctx, token_input, self.config.hidden_size, 1)?;
         let out = dense_mlp_forward(ctx, &expert.dense, &input)?;
         Ok((hidden_to_f32(ctx, &out)?, owner_rank != 0))
+    }
+
+    fn replay_nccl_route_plan(
+        &self,
+        nccl: &NaiveNcclEp2Backend,
+        layer_idx: usize,
+        input: &HiddenStates,
+        rank1_hidden: HiddenStatesRef<'_>,
+        route_plan: &MoeRoutePlan,
+        attribution: &mut DecodeAttributionProfile,
+        phase: &'static str,
+        token_index: Option<usize>,
+    ) -> Result<Vec<HiddenStates>> {
+        let mut live_expert_outputs = Vec::with_capacity(route_plan.route_count());
+        for route in route_plan.entries() {
+            let out = self.forward_nccl_route(
+                layer_idx,
+                input.as_ref(),
+                rank1_hidden,
+                route,
+                attribution,
+                phase,
+                token_index,
+            )?;
+            let expert_ctx = match route.owner_rank {
+                0 => &self.rank0.ctx,
+                1 => &self.rank1.ctx,
+                other => bail!(
+                    "routed expert {} maps to unsupported EP rank {other}",
+                    route.global_expert
+                ),
+            };
+            attribution.record_gpu_result(
+                expert_ctx,
+                phase,
+                "nccl_contribution_accumulate_device",
+                || format!("layer.{layer_idx}.nccl.contribution_accumulate_device"),
+                Some(layer_idx),
+                token_index,
+                || {
+                    nccl.accumulate_device_contribution(
+                        route.owner_rank,
+                        expert_ctx,
+                        &out,
+                        route.token,
+                        input.seq_len,
+                        route.weight,
+                    )
+                },
+            )?;
+            live_expert_outputs.push(out);
+        }
+        Ok(live_expert_outputs)
+    }
+
+    fn forward_nccl_route(
+        &self,
+        layer_idx: usize,
+        rank0_hidden: HiddenStatesRef<'_>,
+        rank1_hidden: HiddenStatesRef<'_>,
+        route: &MoeRouteEntry,
+        attribution: &mut DecodeAttributionProfile,
+        phase: &'static str,
+        token_index: Option<usize>,
+    ) -> Result<HiddenStates> {
+        match route.owner_rank {
+            0 => {
+                let expert = self.rank0.routed_expert(layer_idx, route.global_expert)?;
+                attribution.record_gpu_result(
+                    &self.rank0.ctx,
+                    phase,
+                    "nccl_local_expert",
+                    || format!("layer.{layer_idx}.nccl.local_expert"),
+                    Some(layer_idx),
+                    token_index,
+                    || expert_forward_device(&self.rank0.ctx, expert, rank0_hidden, route.token),
+                )
+            }
+            1 => {
+                let expert = self.rank1.routed_expert(layer_idx, route.global_expert)?;
+                attribution.record_gpu_result(
+                    &self.rank1.ctx,
+                    phase,
+                    "nccl_remote_expert",
+                    || format!("layer.{layer_idx}.nccl.remote_expert"),
+                    Some(layer_idx),
+                    token_index,
+                    || expert_forward_device(&self.rank1.ctx, expert, rank1_hidden, route.token),
+                )
+            }
+            other => bail!(
+                "routed expert {} maps to unsupported EP rank {other}",
+                route.global_expert
+            ),
+        }
     }
 }
 

--- a/openinfer-deepseek-v2-lite/src/runtime/readiness.rs
+++ b/openinfer-deepseek-v2-lite/src/runtime/readiness.rs
@@ -94,14 +94,14 @@ fn decode_graph_blockers(backend: EpBackendKind) -> Vec<DecodeGraphBlocker> {
         ],
         EpBackendKind::Nccl => vec![
             DecodeGraphBlocker {
-                id: "nccl_route_iteration_on_host",
-                source: "runtime/moe.rs::moe_forward_nccl",
-                reason: "expert routing and per-route loop decisions stay on the host",
+                id: "nccl_route_plan_built_on_host",
+                source: "runtime/routing.rs::MoeRoutePlan::from_topk_routes",
+                reason: "the NCCL path still builds the routed-expert replay plan from host-side top-k routing",
             },
             DecodeGraphBlocker {
-                id: "nccl_expert_accumulation_host_directed",
-                source: "runtime/moe.rs::moe_forward_nccl",
-                reason: "expert launches and device-side scratch accumulation are still driven by the host route loop",
+                id: "nccl_route_plan_replay_host_directed",
+                source: "runtime/moe.rs::replay_nccl_route_plan",
+                reason: "expert launches and device scratch accumulation now replay a precomputed plan, but replay is still host-directed",
             },
         ],
     }

--- a/openinfer-deepseek-v2-lite/src/runtime/readiness/tests.rs
+++ b/openinfer-deepseek-v2-lite/src/runtime/readiness/tests.rs
@@ -8,8 +8,8 @@ fn nccl_readiness_reports_only_remaining_graph_blockers() {
     assert_eq!(
         ids,
         vec![
-            "nccl_route_iteration_on_host",
-            "nccl_expert_accumulation_host_directed",
+            "nccl_route_plan_built_on_host",
+            "nccl_route_plan_replay_host_directed",
         ]
     );
 }

--- a/openinfer-deepseek-v2-lite/src/runtime/routing.rs
+++ b/openinfer-deepseek-v2-lite/src/runtime/routing.rs
@@ -1,0 +1,122 @@
+use anyhow::Result;
+
+use crate::ep::ExpertParallelLayout;
+
+#[derive(Clone, Debug)]
+pub(super) struct MoeRouteEntry {
+    pub(super) token: usize,
+    pub(super) global_expert: usize,
+    pub(super) owner_rank: usize,
+    pub(super) weight: f32,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct MoeRoutePlan {
+    entries: Vec<MoeRouteEntry>,
+    // Counts are relative to the rank carried by the layout used to build the plan.
+    local_routes: usize,
+    remote_routes: usize,
+}
+
+impl MoeRoutePlan {
+    pub(super) fn from_topk_routes(
+        routes: &[Vec<(usize, f32)>],
+        layout: &ExpertParallelLayout,
+    ) -> Result<Self> {
+        let route_count = routes.iter().map(Vec::len).sum();
+        let mut entries = Vec::with_capacity(route_count);
+        let mut local_routes = 0usize;
+        let mut remote_routes = 0usize;
+
+        for (token, token_routes) in routes.iter().enumerate() {
+            for &(global_expert, weight) in token_routes {
+                let owner_rank = layout.owner_rank(global_expert)?;
+                if owner_rank == layout.rank() {
+                    local_routes += 1;
+                } else {
+                    remote_routes += 1;
+                }
+                entries.push(MoeRouteEntry {
+                    token,
+                    global_expert,
+                    owner_rank,
+                    weight,
+                });
+            }
+        }
+
+        Ok(Self {
+            entries,
+            local_routes,
+            remote_routes,
+        })
+    }
+
+    pub(super) fn entries(&self) -> &[MoeRouteEntry] {
+        &self.entries
+    }
+
+    pub(super) fn route_count(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub(super) fn local_routes(&self) -> usize {
+        self.local_routes
+    }
+
+    pub(super) fn remote_routes(&self) -> usize {
+        self.remote_routes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{config::test_lite_config, ep::ExpertParallelConfig};
+
+    #[test]
+    fn route_plan_preserves_token_major_expert_order() {
+        let config = test_lite_config();
+        let layout = ExpertParallelConfig::ep2(0).validate_for(&config).unwrap();
+        let routes = vec![vec![(7, 0.7), (33, 0.3)], vec![(2, 0.4), (41, 0.6)]];
+
+        let plan = MoeRoutePlan::from_topk_routes(&routes, &layout).unwrap();
+        let entries: Vec<_> = plan
+            .entries()
+            .iter()
+            .map(|entry| {
+                (
+                    entry.token,
+                    entry.global_expert,
+                    entry.owner_rank,
+                    entry.weight,
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            entries,
+            vec![
+                (0, 7, 0, 0.7),
+                (0, 33, 1, 0.3),
+                (1, 2, 0, 0.4),
+                (1, 41, 1, 0.6)
+            ]
+        );
+        assert_eq!(plan.route_count(), 4);
+        assert_eq!(plan.local_routes(), 2);
+        assert_eq!(plan.remote_routes(), 2);
+    }
+
+    #[test]
+    fn route_plan_rejects_out_of_range_experts() {
+        let config = test_lite_config();
+        let layout = ExpertParallelConfig::ep2(0).validate_for(&config).unwrap();
+        let err = MoeRoutePlan::from_topk_routes(&[vec![(64, 1.0)]], &layout).unwrap_err();
+
+        assert!(
+            err.to_string().contains("out of range"),
+            "unexpected error: {err:#}"
+        );
+    }
+}

--- a/openinfer-deepseek-v2-lite/tests/e2e_ep2.rs
+++ b/openinfer-deepseek-v2-lite/tests/e2e_ep2.rs
@@ -615,7 +615,7 @@ fn validate_generation_stats(
             ensure!(
                 stats.nccl_dense_exchange_calls > 0
                     && stats.nccl_combine_calls == stats.nccl_dense_exchange_calls,
-                "case {} NCCL EP gate did not record matching dense exchange/combine calls",
+                "case {} NCCL EP gate did not record matching dense exchange/combine calls: exchange={}, combine={}",
                 case.id,
                 stats.nccl_dense_exchange_calls,
                 stats.nccl_combine_calls
@@ -623,7 +623,7 @@ fn validate_generation_stats(
             ensure!(
                 stats.nccl_dense_exchange_elements > 0
                     && stats.nccl_combine_elements == stats.nccl_dense_exchange_elements,
-                "case {} NCCL EP gate did not record matching dense exchange/combine elements",
+                "case {} NCCL EP gate did not record matching dense exchange/combine elements: exchange={}, combine={}",
                 case.id,
                 stats.nccl_dense_exchange_elements,
                 stats.nccl_combine_elements


### PR DESCRIPTION
## Summary

- Add a model-local `MoeRoutePlan` that flattens host top-k routes into token-major, owner-annotated entries.
- Replay the precomputed plan for NCCL expert launches and device contribution accumulation, while keeping host-staged as the correctness oracle.
- Keep route counters visible and narrow NCCL graph-readiness blockers to host route-plan construction/replay.
- Update the DeepSeek-V2-Lite status and attribution docs without claiming sparse dispatch, generic EP, multi-node support, vLLM parity, or full decode CUDA Graph coverage.

Fixes #277.
Refs #205, #170.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy --release -p openinfer-deepseek-v2-lite --features deepseek-v2-lite --bins --tests -- -D warnings`
- `cargo test --release -p openinfer-deepseek-v2-lite --features deepseek-v2-lite route_plan --lib -- --nocapture`
- readiness blocker ID unit test
- HF / host-staged / NCCL EP2 JSON comparison with `--require-all-exact`: `all_token_text_exact`
- NCCL attribution batch `1/4/8`: route counters remain visible; old blocker IDs are absent; current blockers are `nccl_route_plan_built_on_host` and `nccl_route_plan_replay_host_directed`