### PR TITLE
test(qwen3): de-flake lora_golden_gate via own-distribution regret; add TP=2 pass

### DIFF
--- a/openinfer-qwen3-4b/tests/lora_golden_gate.rs
+++ b/openinfer-qwen3-4b/tests/lora_golden_gate.rs
@@ -7,6 +7,11 @@
 //! Replay framework and tolerances are copied from `hf_golden_gate.rs` (tests cannot
 //! share modules); see that header for the rationale.
 //!
+//! On a host with >=2 GPUs it also replays under TP=2 against the same reference: the
+//! adapter is sharded per rank (B row-shard for q/k/v/gate/up, A col-shard for o/down),
+//! so the col-shard deltas are summed by the same all-reduce as the base output — a path
+//! single-GPU LoRA and the TP=2 base gate never exercise.
+//!
 //! Needs a CUDA GPU and Qwen3-4B weights (`OPENINFER_TEST_MODEL_PATH`); skips cleanly
 //! otherwise.
 
@@ -500,5 +505,15 @@ fn lora_logprobs_match_peft_golden_within_bf16_tolerance() {
 
     run_suite(&golden, &model_path, &adapter_dir, &[0], "");
 
+    if cuda_device_count() >= 2 {
+        run_suite(&golden, &model_path, &adapter_dir, &[0, 1], "tp2 ");
+    } else {
+        eprintln!("skipping lora_golden_gate TP=2 pass: <2 CUDA devices visible");
+    }
+
     let _ = std::fs::remove_dir_all(&adapter_dir);
+}
+
+fn cuda_device_count() -> usize {
+    cudarc::driver::CudaContext::device_count().map_or(0, |n| n.max(0) as usize)
 }

--- a/openinfer-qwen3-4b/tests/lora_golden_gate.rs
+++ b/openinfer-qwen3-4b/tests/lora_golden_gate.rs
@@ -16,7 +16,7 @@
 //! otherwise.
 
 use std::borrow::Cow;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use openinfer_core::engine::{LoadLoraAdapterRequest, TokenLogprob};
@@ -108,24 +108,25 @@ fn check_position(
     reference: &[(u32, f32)],
 ) {
     stats.positions += 1;
-    let ref_top = reference[0].1;
-    let pega_argmax = pega[0].0;
-    let ref_map: HashMap<u32, f32> = reference.iter().copied().collect();
 
-    match ref_map.get(&pega_argmax) {
+    // Regret in our own distribution, not the reference's: a benign bf16 tie is not a wrong token.
+    let pega_top = pega[0].1;
+    let ref_argmax = reference[0].0;
+    match pega.iter().find(|&&(tok, _)| tok == ref_argmax) {
         None => stats.argmax_violations.push(format!(
-            "seq {seq} pos {pos}: openinfer's argmax {pega_argmax} is absent from the reference top-{}",
-            reference.len()
+            "seq {seq} pos {pos}: reference argmax {ref_argmax} is absent from openinfer's top-{}",
+            pega.len()
         )),
-        Some(&rlp) if ref_top - rlp > MARGIN_TOL => stats.argmax_violations.push(format!(
-            "seq {seq} pos {pos}: openinfer chose {pega_argmax}, which the reference scores {:.4} nat below its own argmax (> {MARGIN_TOL})",
-            ref_top - rlp
+        Some(&(_, plp)) if pega_top - plp > MARGIN_TOL => stats.argmax_violations.push(format!(
+            "seq {seq} pos {pos}: openinfer ranks {} over the reference argmax {ref_argmax} by {:.4} nat (> {MARGIN_TOL})",
+            pega[0].0,
+            pega_top - plp
         )),
         Some(_) => {}
     }
 
     for &(token, plp) in pega.iter().take(HEAD_K) {
-        if let Some(&rlp) = ref_map.get(&token) {
+        if let Some(&(_, rlp)) = reference.iter().find(|&&(t, _)| t == token) {
             let delta = (plp - rlp).abs();
             stats.head_deltas.push(delta);
             if stats.worst.is_none_or(|(w, ..)| delta > w) {
@@ -168,7 +169,7 @@ fn report_and_assert(label: &str, stats: &Stats) {
     }
     assert!(
         stats.argmax_violations.is_empty(),
-        "[{label}] openinfer picked a token the reference does not rank near its best:\n  {}",
+        "[{label}] openinfer's argmax disagrees with the reference beyond tolerance:\n  {}",
         stats.argmax_violations.join("\n  ")
     );
     assert!(


### PR DESCRIPTION
## Description

Follow-up to #369. Closes #384 

#369's `lora_golden_gate` measured the argmax/regret check in the reference (PEFT) distribution, which false-positives on benign bf16 near-ties whenever the tie-break differs across allocations. On Dual-GH200 the gate is flaky — 5/20 allocations FAIL at seq 12 / pos 16, where openinfer scores tokens 243 and 105 as an exact bf16 tie (−2.047943). #369's CI host (sm_89) never exercised it — an over-strictness exposed by an untested arch, not a model or LoRA-math error (head-delta mean ~0.03 everywhere).

This judges regret in openinfer's own distribution: flag only when openinfer *confidently* (> `MARGIN_TOL` = 0.20, unchanged) ranks its pick above the reference's argmax, or the reference's argmax is absent from openinfer's top-K. A benign tie openinfer scores within `MARGIN_TOL` is no longer a violation; a confidently-wrong token still is, backstopped by the unchanged mean / p99 / top-K-overlap guards. Also adds a TP=2 replay pass (sharded adapter) gated on `cuda_device_count() >= 2`.

The fix only changes which distribution regret is measured against; MARGIN_TOL and the mean / p99 top-K-overlap guards are unchanged.

## Reproduce

Needs a CUDA GPU + Qwen3-4B weights. The flake shows across separate Dual-GH200 allocations (~5/20); a fixed single GPU resolves the near-tie deterministically and will not reproduce it.

```bash
OPENINFER_TEST_MODEL_PATH=models/Qwen3-4B cargo test --release -p openinfer-qwen3-4b --test lora_golden_gate
```


## Dual-GH200, sm_90 Result

> The [DEBUG-tie] lines are throwaway local-only instrumentation, not in the committed gate.

### Before

<details>
<summary>buggy FAIL log</summary>

```
[DEBUG-tie] seq 12 pos 16 pega-top5 [(243, -2.047943), (105, -2.047943), (109, -2.172943), (121, -2.297943), (254, -2.422943)] ref-top5 [(105, -1.9747112), (109, -2.0997112), (121, -2.2247112), (243, -2.2247112), (98, -2.5997112)]
[mixed lora/base batch] openinfer picked a token the reference does not rank near its best:
  seq 12 pos 16: openinfer chose 243, which the reference scores 0.2500 nat below its own argmax (> 0.2)
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.53s
```
</details>

### Fixed

same tie, same flip to 243, passes (allocations 3 and 18 hit the identical flip). openinfer scores 243 and the reference's argmax 105 identically (gap 0.0000 < `MARGIN_TOL`) → benign tie → pass.

<details>
<summary>fixed log (same flip, passes)</summary>

```
[DEBUG-tie] seq 12 pos 16 pega-top5 [(243, -2.047943), (105, -2.047943), (109, -2.172943), (121, -2.297943), (254, -2.422943)] ref-top5 [(105, -1.9747112), (109, -2.0997112), (121, -2.2247112), (243, -2.2247112), (98, -2.5997112)]
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 19.56s
```
</details>

## Single GPU (sm_89, x86_64) cross-check

Both binaries rebuilt on a fixed single GPU (forward/decode path byte-identical to this branch), each run 20× as separate launches: buggy 20/20 PASS, fixed 20/20 PASS. The flake-site argmax (mixed pass, the third value) is **109 in all 40 launches — never 243**; one fixed GPU has one reduction order, so the near-tie resolves deterministically to the safe side. A second benign jitter — 98 for 109 in the *base* pass (2/40, 0.125 nat < `MARGIN_TOL`) — trips neither gate.

<details>
<summary>sm_89 launches</summary>

```
buggy launch 1 rc=0 PASS seq12pos16_argmax=[109 105 109 ]
buggy launch 10 rc=0 PASS seq12pos16_argmax=[98 105 109 ]
fixed launch 13 rc=0 PASS seq12pos16_argmax=[98 105 109 ]
```
</details>




## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] My code follows the style guidelines of this project (see `docs/conventions/coding-style.md`).
- [x] I have performed a self-review of my own code.
- [x] I have formatted my commits according to Commitizen conventions.
- [x] I have run the local test suite and all tests pass (see `CLAUDE.md`).

