### PR TITLE
fix(qwen35): align GDN chunk_state AOT pointers :16 to fix sm_90 crash

### DIFF
--- a/openinfer-kernels/build.rs
+++ b/openinfer-kernels/build.rs
@@ -1035,7 +1035,8 @@ fn compile_triton_aot_kernels(cuda_include: &Path, out_dir: &Path, sm_targets: &
             artifact_dir: "gated_delta_rule_chunk_state",
             kernel_path: "tools/triton/gated_delta_rule_chunkwise_kernels.py",
             kernel_name: "gdr_chunk_state_qwen35_kernel",
-            signature: "*bf16,*bf16,*bf16,*fp32,*fp32,*fp32,*bf16,*fp32,i32,i32,32,64,128,128,64",
+            // `g` (pos 4) stays bare — not a contiguous block-ptr load, so `:16` would be untrue.
+            signature: "*bf16:16,*bf16:16,*bf16:16,*fp32,*fp32:16,*fp32:16,*bf16:16,*fp32:16,i32,i32,32,64,128,128,64",
             grid: "4,num_value_heads,1",
             out_name: "triton_gated_delta_rule_chunk_state",
             num_warps: 4,

--- a/openinfer-qwen35-4b/src/config.rs
+++ b/openinfer-qwen35-4b/src/config.rs
@@ -73,6 +73,11 @@ pub(crate) struct Config35 {
     pub(crate) layer_types: Vec<LayerType>,
 }
 
+/// GDN dims the Triton-AOT kernels are built for; a mismatched model is rejected at load.
+const GDN_AOT_KEY_HEAD_DIM: usize = 128;
+const GDN_AOT_VALUE_HEAD_DIM: usize = 128;
+const GDN_AOT_NUM_VALUE_HEADS: usize = 32;
+
 impl Config35 {
     pub(crate) fn from_file(model_path: &str) -> Result<Self> {
         let config_path = format!("{}/config.json", model_path);
@@ -107,6 +112,20 @@ impl Config35 {
         anyhow::ensure!(
             max_position_embeddings > 0,
             "Qwen3.5 max_position_embeddings must be positive"
+        );
+
+        anyhow::ensure!(
+            t.linear_key_head_dim == GDN_AOT_KEY_HEAD_DIM
+                && t.linear_value_head_dim == GDN_AOT_VALUE_HEAD_DIM
+                && t.linear_num_value_heads == GDN_AOT_NUM_VALUE_HEADS,
+            "Qwen3.5 GDN Triton-AOT kernels are baked for key/value head dim {}/{}, \
+             {} value heads; config has {}/{}, {}. Rebuild openinfer-kernels to match.",
+            GDN_AOT_KEY_HEAD_DIM,
+            GDN_AOT_VALUE_HEAD_DIM,
+            GDN_AOT_NUM_VALUE_HEADS,
+            t.linear_key_head_dim,
+            t.linear_value_head_dim,
+            t.linear_num_value_heads,
         );
 
         Ok(Self {


### PR DESCRIPTION

## Description

Fixes #389 

Marks the 7 tile pointers `:16` in the `triton_gated_delta_rule_chunk_state` AOT signature so Triton emits the aligned (async) load path on sm_90; `g` stays bare (strided gather, not a block-ptr tile, so `:16` would be untrue). Adds a config-load guard so a model whose GDN head dims differ from the baked kernels fails fast. Prefill-only — decode never reads this kernel.

## Verification

- Dual-GH200 (aarch64, sm_90): crashed on the first GDN prefill → `hf_golden_gate` runs green.
- Single GPU (x86_64, sm_89): unaffected; builds + accuracy gate pass.

<details>

<summary>logs</summary>

```text
== Dual-GH200 (aarch64, sm_90), main + this PR ==
hf_golden_gate (--features qwen35-4b): test result: ok. 2 passed; 0 failed; finished in 16.11s

== Single GPU (x86_64, sm_89), main + this PR ==
hf_golden_gate (--features qwen35-4b): test result: ok. 2 passed; 0 failed; finished in 13.78s
```

</details>

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project (see `docs/conventions/coding-style.md`).
- [x] I have performed a self-review of my own code.
- [x] I have formatted my commits according to Commitizen conventions.
- [x] I have run the local test suite and all tests pass (see `CLAUDE.md`).

