### PR TITLE
fix(build): explicitly enable tracing log bridge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,9 @@ rand = "0.10"
 smallvec = { version = "1.15.1", features = ["serde", "union"] }
 syscalls = "0.7.0"
 thiserror = "2.0.17"
-tracing = "0.1.41"
+# logforth consumes the `log` facade only; the `log` feature bridges tracing
+# events into log so they reach logforth instead of vanishing silently.
+tracing = { version = "0.1.41", features = ["log"] }
 tracing-core = "0.1.34"
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "json"] }


### PR DESCRIPTION
## Summary
- Explicitly enable `tracing` feature `log` at the workspace level in `Cargo.toml`.
- Add an inline comment documenting why this bridge is required (`logforth` consumes the `log` facade; tracing events must be bridged).
- This hardens logging behavior against transitive feature drift (e.g. if `tower` defaults change).

Fixes #212.

## Test plan
- [x] `cargo tree -e features -i tracing | rg -n -C 1 'feature "log"'`
  - Verified `tracing feature "log"` is now enabled via workspace dependency users (e.g. `kvbm-logical`) in addition to transitive `tower`.
- [x] `cargo check -p openinfer-sim`
  - Passed.
- [x] `cargo test -p openinfer-sim --test frontend_e2e`
  - Passed (`5 passed; 0 failed`).

## Validation notes
- The change does not alter runtime logging behavior today; it makes the existing bridge explicit and stable.
- Model inference was not required for this acceptance path; the tested frontend/sim path exercises the same tracing-to-log bridge used by server components.

Made with [Cursor](https://cursor.com)