### PR TITLE
chore(vllm-support): remove unused load_tokenizer_async

### DIFF
--- a/openinfer-vllm-support/src/lib.rs
+++ b/openinfer-vllm-support/src/lib.rs
@@ -11,18 +11,13 @@ static TOKENIZER_RESOLVER_RUNTIME: OnceCell<Mutex<Runtime>> = OnceCell::new();
 pub fn load_tokenizer(model_id: &str) -> Result<DynTokenizer> {
     if tokio::runtime::Handle::try_current().is_ok() {
         return Err(Error::Tokenizer(
-            "openinfer_vllm_support::load_tokenizer is synchronous and cannot be called from \
-             inside an active Tokio runtime; use load_tokenizer_async instead"
+            "openinfer_vllm_support::load_tokenizer cannot be called from inside an active \
+             Tokio runtime"
                 .to_string(),
         ));
     }
 
     let files = resolve_model_files(model_id)?;
-    tokenizer_from_source(&files.tokenizer)
-}
-
-pub async fn load_tokenizer_async(model_id: &str) -> Result<DynTokenizer> {
-    let files = ResolvedModelFiles::new(model_id).await?;
     tokenizer_from_source(&files.tokenizer)
 }
 
@@ -72,7 +67,7 @@ mod tests {
         });
 
         assert!(
-            err.to_string().contains("load_tokenizer_async"),
+            err.to_string().contains("active Tokio runtime"),
             "unexpected error: {err}"
         );
     }


### PR DESCRIPTION
## Summary
- Remove `load_tokenizer_async` from `openinfer-vllm-support`; it had zero callers across the workspace.
- Simplify the sync loader error message and update the runtime-guard unit test accordingly.

HTTP serving continues to load tokenizers via `vllm-server`; tests/bench use the sync `load_tokenizer` outside Tokio.

## Test plan
- [x] `cargo test --release -p openinfer-vllm-support --lib`

Made with [Cursor](https://cursor.com)