### PR TITLE
chore(vllm): bump git deps to latest main for long-prompt 400 fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4550,7 +4550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph",
@@ -4571,7 +4571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7024,7 +7024,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 [[package]]
 name = "vllm-chat"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=5d5591d99bb7b2ba695766a992dc328ca5867a4c#5d5591d99bb7b2ba695766a992dc328ca5867a4c"
+source = "git+https://github.com/vllm-project/vllm.git?rev=a7fdfeef72323eb3db6f0620e4ea200290d0ca5a#a7fdfeef72323eb3db6f0620e4ea200290d0ca5a"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
@@ -7060,7 +7060,7 @@ dependencies = [
 [[package]]
 name = "vllm-engine-core-client"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=5d5591d99bb7b2ba695766a992dc328ca5867a4c#5d5591d99bb7b2ba695766a992dc328ca5867a4c"
+source = "git+https://github.com/vllm-project/vllm.git?rev=a7fdfeef72323eb3db6f0620e4ea200290d0ca5a#a7fdfeef72323eb3db6f0620e4ea200290d0ca5a"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -7094,11 +7094,12 @@ dependencies = [
 [[package]]
 name = "vllm-llm"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=5d5591d99bb7b2ba695766a992dc328ca5867a4c#5d5591d99bb7b2ba695766a992dc328ca5867a4c"
+source = "git+https://github.com/vllm-project/vllm.git?rev=a7fdfeef72323eb3db6f0620e4ea200290d0ca5a#a7fdfeef72323eb3db6f0620e4ea200290d0ca5a"
 dependencies = [
  "easy-ext",
  "enum-as-inner",
  "futures",
+ "parking_lot",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -7113,15 +7114,16 @@ dependencies = [
 [[package]]
 name = "vllm-metrics"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=5d5591d99bb7b2ba695766a992dc328ca5867a4c#5d5591d99bb7b2ba695766a992dc328ca5867a4c"
+source = "git+https://github.com/vllm-project/vllm.git?rev=a7fdfeef72323eb3db6f0620e4ea200290d0ca5a#a7fdfeef72323eb3db6f0620e4ea200290d0ca5a"
 dependencies = [
+ "itertools 0.14.0",
  "prometheus-client",
 ]
 
 [[package]]
 name = "vllm-reasoning-parser"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=5d5591d99bb7b2ba695766a992dc328ca5867a4c#5d5591d99bb7b2ba695766a992dc328ca5867a4c"
+source = "git+https://github.com/vllm-project/vllm.git?rev=a7fdfeef72323eb3db6f0620e4ea200290d0ca5a#a7fdfeef72323eb3db6f0620e4ea200290d0ca5a"
 dependencies = [
  "thiserror 2.0.18",
  "vllm-tokenizer",
@@ -7130,7 +7132,7 @@ dependencies = [
 [[package]]
 name = "vllm-server"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=5d5591d99bb7b2ba695766a992dc328ca5867a4c#5d5591d99bb7b2ba695766a992dc328ca5867a4c"
+source = "git+https://github.com/vllm-project/vllm.git?rev=a7fdfeef72323eb3db6f0620e4ea200290d0ca5a#a7fdfeef72323eb3db6f0620e4ea200290d0ca5a"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
@@ -7173,7 +7175,7 @@ dependencies = [
 [[package]]
 name = "vllm-text"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=5d5591d99bb7b2ba695766a992dc328ca5867a4c#5d5591d99bb7b2ba695766a992dc328ca5867a4c"
+source = "git+https://github.com/vllm-project/vllm.git?rev=a7fdfeef72323eb3db6f0620e4ea200290d0ca5a#a7fdfeef72323eb3db6f0620e4ea200290d0ca5a"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
@@ -7197,7 +7199,7 @@ dependencies = [
 [[package]]
 name = "vllm-tokenizer"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=5d5591d99bb7b2ba695766a992dc328ca5867a4c#5d5591d99bb7b2ba695766a992dc328ca5867a4c"
+source = "git+https://github.com/vllm-project/vllm.git?rev=a7fdfeef72323eb3db6f0620e4ea200290d0ca5a#a7fdfeef72323eb3db6f0620e4ea200290d0ca5a"
 dependencies = [
  "base64 0.22.1",
  "fastokens",
@@ -7216,7 +7218,7 @@ dependencies = [
 [[package]]
 name = "vllm-tool-parser"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=5d5591d99bb7b2ba695766a992dc328ca5867a4c#5d5591d99bb7b2ba695766a992dc328ca5867a4c"
+source = "git+https://github.com/vllm-project/vllm.git?rev=a7fdfeef72323eb3db6f0620e4ea200290d0ca5a#a7fdfeef72323eb3db6f0620e4ea200290d0ca5a"
 dependencies = [
  "easy-ext",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,10 +167,10 @@ url = { version = "2.5", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 validator = { version = "0.20.0", features = ["derive"] }
 velo = "0.1.0"
-vllm-engine-core-client = { git = "https://github.com/vllm-project/vllm.git", rev = "5d5591d99bb7b2ba695766a992dc328ca5867a4c" }
-vllm-server = { git = "https://github.com/vllm-project/vllm.git", rev = "5d5591d99bb7b2ba695766a992dc328ca5867a4c" }
-vllm-text = { git = "https://github.com/vllm-project/vllm.git", rev = "5d5591d99bb7b2ba695766a992dc328ca5867a4c" }
-vllm-tokenizer = { git = "https://github.com/vllm-project/vllm.git", rev = "5d5591d99bb7b2ba695766a992dc328ca5867a4c" }
+vllm-engine-core-client = { git = "https://github.com/vllm-project/vllm.git", rev = "a7fdfeef72323eb3db6f0620e4ea200290d0ca5a" }
+vllm-server = { git = "https://github.com/vllm-project/vllm.git", rev = "a7fdfeef72323eb3db6f0620e4ea200290d0ca5a" }
+vllm-text = { git = "https://github.com/vllm-project/vllm.git", rev = "a7fdfeef72323eb3db6f0620e4ea200290d0ca5a" }
+vllm-tokenizer = { git = "https://github.com/vllm-project/vllm.git", rev = "a7fdfeef72323eb3db6f0620e4ea200290d0ca5a" }
 xxhash-rust = { version = "0.8", features = ["xxh3", "const_xxh3"] }
 zeromq = { version = "0.6.0", default-features = false, features = [
     "tokio-runtime",

--- a/openinfer-vllm-frontend/src/bridge.rs
+++ b/openinfer-vllm-frontend/src/bridge.rs
@@ -59,9 +59,14 @@ impl LocalEngineBridge {
         let ready = EngineCoreReadyResponse {
             max_model_len: self.max_model_len as u64,
             num_gpu_blocks: 0,
+            // TODO(#401): report the real paged-KV block size and capacity from the
+            // openinfer scheduler once the vLLM frontend consumes ready_response KV fields.
+            block_size: 16,
             dp_stats_address: None,
             dtype: ModelDtype::BFloat16,
             vllm_version: "openinfer-local-bridge".to_string(),
+            kv_cache_size_tokens: None,
+            kv_cache_max_concurrency: None,
         };
         input
             .send(ZmqMessage::from(encode_msgpack(&ready)?))

--- a/openinfer-vllm-frontend/src/lib.rs
+++ b/openinfer-vllm-frontend/src/lib.rs
@@ -237,6 +237,7 @@ where
         chat_template: None,
         default_chat_template_kwargs: None,
         chat_template_content_format: ChatTemplateContentFormatOption::default(),
+        max_logprobs: None,
         language_model_only: true,
         api_keys: Vec::new(),
         api_server_options: ApiServerOptions {


### PR DESCRIPTION
## Summary

- Bump all four vllm git deps to upstream `main` at `a7fdfeef`, which includes [vllm#45286](https://github.com/vllm-project/vllm/pull/45286) (long prompts return HTTP 400 `invalid_request_error` instead of 500).
- Adapt `openinfer-vllm-frontend` to upstream wire-format changes (`EngineCoreReadyResponse` KV fields, `Config.max_logprobs`).
- Add a TODO on the placeholder `block_size: 16`; real KV ready metadata is tracked in #401.

Closes #364.

## Test plan

- [x] `cargo check --release -p openinfer-vllm-frontend -p openinfer-vllm-support -p openinfer-server`
- [x] `cargo test --release -p openinfer-vllm-frontend --lib`
- [ ] Manual: 41k-token prompt on `/v1/completions` → 400 `invalid_request_error` with context-length message (was 500)


Made with [Cursor](https://cursor.com)