### PR TITLE
refactor(scheduler): collapse per-request output fan-out into one channel + demux

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -102,6 +102,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 | Path | TL;DR |
 | --- | --- |
 | `subsystems/scheduler/scheduler.md` | Single dedicated thread owns GPU; FCFS prefill-priority, paged KV, bucket CUDA Graphs, unified forward for mixed prefill+decode. Qwen3-4B at QPS=2 is within 2% of vLLM throughput while winning TTFT (-16%), TPOT (-3%), and latency stability. Open: ITL p99 tail, Qwen3.5 full-paged prefill, batched per-row sampling redesign. |
+| `subsystems/scheduler/output-dispatch.md` | GPU bubble study + token-dispatch redesign (**landed 2026-06**). Single-thread CPU↔GPU(sync) alternation idles the GPU through scheduling; bubble ≈3µs×batch (bs=128 → ~380µs, 2% of an 18ms step on 5070 Ti), dominated by N per-request `token_tx.send` wakeups. Fix shipped: `token_tx` is a `TokenSink` drop-in over one request-tagged channel + one bridge demux loop (N→1 wakeups/tasks/ZMQ msgs); cancellation rides an `Arc<AtomicBool>` flag, not a separate channel. Bubble target ~150µs (exec_cpu floor). Trigger: fast GPUs (→10–15%) or N≫128. |
 
 ## subsystems / frontend
 

--- a/docs/subsystems/scheduler/output-dispatch.md
+++ b/docs/subsystems/scheduler/output-dispatch.md
@@ -1,0 +1,87 @@
+# Scheduler output dispatch — GPU bubble & redesign
+
+> **TL;DR:** The scheduler is a single thread that strictly alternates CPU(schedule) → GPU(forward+sample+`ctx.sync()`) → CPU(dispatch), so the GPU sits idle through every non-`run_step` CPU phase. Measured on RTX 5070 Ti / Qwen3-4B (greedy): the bubble was **≈3µs × batch** (bs=128 → ~380µs, 2.0% of an 18ms step), dominated by **`apply_effects` per-request token dispatch (~250µs at bs=128)** — N individual `token_tx.send()` waking N distinct frontend tasks. **Landed (2026-06):** the per-request output fan-out (N channels + N consumer tasks) is collapsed into one request-tagged channel + one demux loop. `GenerateRequest.token_tx` is now a `TokenSink` (engine.rs) — a drop-in over a shared `UnboundedSender<(Arc<str>, TokenEvent)>` + an `Arc<AtomicBool>` cancel flag — so scheduler call sites are unchanged; the bridge runs one `dispatch_burst` demux that buckets a ready burst by request and ships **one** `EngineCoreOutputs` per burst (N→1 wakeups, tasks, ZMQ msgs). Cancellation is the flag, not a new channel: abort flips it + drops the bridge stream entry, the scheduler retires the request on its next emit. Measured A/B vs `main` on this GPU is throughput-neutral-to-slightly-positive (within run-to-run noise at c≤128, a consistent +0.9% at c=192) — exactly the predicted noise-floor win here; the payoff is fast decode GPUs (H20/H100, bubble → 10–15%) or N≫128. (The A/B also caught that the migration had left the `bench_serving` server bins uncompiled — fixed.)
+>
+> **Last touched:** 2026-06.
+
+## What "GPU bubble" means here
+
+Each scheduler step ends in `select_batch_tokens_into` → `ctx.sync()` (`openinfer-core/src/ops/sampling.rs`), a full stream sync after sampling. So the worker thread blocks until the GPU finishes the whole forward+sample, and the GPU then goes idle until the *next* step's kernels are enqueued. Everything the scheduler thread does between two `run_step` calls — admission, batch formation, result resolution, token dispatch — runs with the GPU idle. Bubble = per-step CPU time outside the GPU forward.
+
+DB analogy: a single-threaded transaction loop that blocks on each disk I/O (the GPU step) and does all bookkeeping serially around it; the disk (GPU) is idle during the bookkeeping.
+
+## Measurement (how to reproduce)
+
+Temporary instrumentation (reverted from the tree — re-add to re-measure):
+1. In `Qwen3Executor::run_step` (executor.rs), bracket the worker round trip with `Instant` and accumulate to a global ns counter (this is "GPU busy" — the step ends in a sync, so this ≈ forward+sample).
+2. In `scheduler_loop` (scheduler.rs), bracket per step: `pre` (top-of-loop → before `execute_plan`), `exec` (`execute_plan`), `resolve` (`resolve_step`), `apply` (`apply_effects`). Capture decode batch = `active.len()` before the step. Flush an `info!` summary every ~2s.
+
+Drive load over HTTP: `scripts/bench_http_serving.py --concurrency 128 --num-requests 384 --prompt-words 32 --max-tokens 256 --temperature 0`.
+
+`bubble = pre + exec_cpu + resolve + apply`, where `exec_cpu = exec − run_step(global)`.
+
+## Measured decomposition (RTX 5070 Ti, Qwen3-4B, greedy)
+
+| decode batch | period/step | GPU busy | bubble | bubble % | exec_cpu / resolve / apply |
+|---:|---:|---:|---:|---:|---|
+| 1   | 10.6 ms | 99.8% | 19 µs  | 0.2% | 7 / 1 / 9 µs |
+| 32  | 12.0 ms | 99.3% | 83 µs  | 0.7% | 34 / 3 / 43 µs |
+| 64  | 13.1 ms | 98.8% | 157 µs | 1.2% | 58 / 5 / 88 µs |
+| 128 | 17.8 ms | 98.0% | 380 µs | 2.0% | 110 / 13 / **254** µs |
+| 140 | 20.5 ms | 97.9% | 440 µs | 2.1% | 125 / 14 / **300** µs |
+
+- Bubble ≈ **3µs × batch**, grows ~linearly with concurrency.
+- `apply` (apply_effects) dominates: ~250µs of ~380µs at bs=128. Decomposes into ~240µs of N `token_tx.send()` (each wakes one frontend task, ~1.9µs) + ~14µs of the O(N²) `active.iter().position` scan and state writes. The O(N²) scans (`resolve` + `apply`) are negligible now (~14µs total) but quadratic — they bite at bs≳256.
+- `exec_cpu` (~0.9µs/req): per-request `schedule_decode`/`apply_decode`/kv_views in the executor.
+- **Bubble % is small *here* only because the decode step is huge** (bs=1 = 10.6ms ⇒ memory-bandwidth-bound, 7.67GB weights / ~0.75TB/s). The ~380µs absolute cost is fixed; on a ~4TB/s GPU (bs=128 decode ≈ 3ms) it is ~12%.
+- Greedy only. `temperature>0` takes the per-row `gpu_sample_into` path (O(bs) launch+sync), which would inflate `exec_cpu` far beyond these numbers — a separate bubble source (see scheduler.md "Batch decode per-row sampling").
+
+## Why pipelining is *not* the cheap answer (and what it actually costs)
+
+The decode dependency is real: step N+1's forward input token = step N's sampled token. But the dependency does **not** create the bubble — two dependent GPU ops can be back-to-back on the stream with zero gap. The bubble comes from routing the dependency **through the host**: `d2h+sync → CPU decide → h2d`. Async/pipelined scheduling (keep the sampled token on-GPU, feed it to the next step's embedding gather; run host bookkeeping one step behind, overlapped) removes the host from the critical path. Costs: EOS-by-value can't gate the launch, so an EOS'ing request runs ≤1 extra (discarded) decode step (length-stop is count-based and still gates cleanly); sampler must stay on-device; bubble → residual launch gap, and only fully hidden when CPU/step < GPU/step. Real but heavyweight; not justified by a 2% bubble.
+
+## Recommended architecture: single request-tagged output channel + one demux loop
+
+Three facts (investigated 2026-06) reframe the dispatch fix:
+
+1. **Explicit abort already exists.** `EngineCoreRequestType::Abort` → `bridge.rs:143` → `task.abort()` → `token_rx` drop → scheduler notices on its *next* send. Today's "consumer-drop is the cancellation signal" is a lazy 3-hop chain whose last leg is the per-request channel closure. Removing per-request channels means routing abort *directly* to the scheduler (1 hop) — more responsive, not a regression.
+2. **The consumer/wire side is already batch-shaped.** `EngineCoreOutputs.outputs` is a `Vec<EngineCoreOutput>`, each already carrying `request_id: String`; everything funnels through one shared `output_tx` → one `output_loop` → one ZMQ socket. The N `run_request_stream` tasks' isolation is real for per-request state, **illusory for throughput** (single downstream socket). The per-request fan-out is vestigial.
+3. **The 240µs is N distinct sleeping consumers = N wakeups.** tokio mpsc only wakes its receiver on the empty→non-empty transition. Collapsing N channels into one ⇒ ~1 wake + N cheap pushes — **even if the producer still emits one event at a time.** The lever is "one consumer," not "batch the producer API"; that makes per-model migration mechanical.
+
+### Target shape
+
+```
+now:   scheduler ──N× token_tx──> N× run_request_stream task ──> 1 output_tx ──> 1 socket
+                  (N wakeups=240µs)    (N tasks, vestigial)       (already single point)
+
+target: scheduler ──1× (RequestId,TokenEvent)──> 1 demux loop ──> 1 socket
+                   (1 wake + N pushes)   HashMap<id, RequestState>   coalesce into 1 EngineCoreOutputs
+```
+
+- **Producer (engine + each scheduler):** drop `GenerateRequest.token_tx`; carry the external `request_id`. Engine owns one `UnboundedSender<(RequestId, TokenEvent)>`. qwen3's `StepEffects`/`apply_effects` already aggregates per step — change "send each" to "push into the shared sender" (single-emit is enough; per-step batch-send is an optional P3 micro-opt). Keep the external id in `PendingRequest`/`ActiveRequestState` for tagging + cancel lookup.
+- **Consumer (bridge):** one demux loop replacing N tasks, holding `HashMap<RequestId, RequestState>` (the existing `first_token_events` / `prefill_stats` / `has_sent_token_output` / `pending` fields). `recv` one + `try_recv`-drain the ready burst → one `EngineCoreOutputs { outputs: Vec<…> }` → one socket send (ZMQ msgs N→1/step). Remove the HashMap entry on terminal event + on abort — **the one place that must be leak-tight.**
+- **Cancellation (as shipped):** *not* a new channel — a shared `Arc<AtomicBool>` per request, held by both the bridge stream entry and the request's `TokenSink`. Abort flips the flag (`Release`) and drops the bridge stream entry; the scheduler's next `TokenSink::send`/`is_closed` reads it (`Acquire`) and retires the request — the same reactive retirement the old consumer-drop gave, with no scheduler-side cancel drain and no external→internal id registry. A token already in flight for an aborted id finds no stream entry in the demux and is dropped. Organic disconnect already arrives as an explicit Abort from the in-process vLLM server, which also drops the request from its own tracking, so no post-abort terminal is required (matching the old `task.abort()` behavior).
+
+### Why this over a dispatch thread (Option A)
+
+A dispatch thread that keeps the N per-request channels only **relocates** the N wakeups off the critical path; it keeps N tasks, keeps N ZMQ msgs/step, and is thrown away the moment the real fix lands. The consumer already wants the batch shape, so go straight to it. Both land bubble ≈150µs (floored by `exec_cpu` ~110µs), but the single-channel design also removes ~N−1 wakeups of *total* work.
+
+## Numbers and cost
+
+- bs=128 bubble **380 → ~150µs** (`apply` 254 → ~22), new floor `exec_cpu` ~110µs (batch the KV bookkeeping next). Fast GPU (3ms step): 11% → ~5%.
+- Blast radius: 86 `token_tx.send` sites, 5 crates, 12 files, ~400–500 LOC, no shared dispatch abstraction. Mostly mechanical; the only redesign is qwen3 `effects.rs` (~50%) and kimi `dp.rs` (`RequestState` carries `token_tx`, needs request_id tracking). ~1–2 weeks incl. tests.
+- Risk: centralized demux concentrates both performance and failure (a per-request task isolates bugs); the `streams` HashMap cleanup must be airtight — entries are removed on the terminal event (demux) and on abort (`streams.remove`), and a request that only ever emits `Scheduled` is held until one of those fires. Cancellation needed no new channel or id registry — the shared `Arc<AtomicBool>` flag carries it.
+
+## Staging — what landed
+
+- **P1 (done):** `TokenSink` contract in `openinfer-engine/src/engine.rs` + the bridge `dispatch_burst` demux + cancel-flag; qwen3 migrated as the reference. Bridge unit tests cover burst coalescing, token+finish in one burst vs. across bursts, first-token metadata flush-once, lone-Scheduled deferral, multi-request N→1 batching, and aborted-request late-token drop. End-to-end on RTX 5070 Ti / Qwen3-4B: single + streaming + concurrency-32 (0 errors) + mid-stream client disconnect (server stays healthy).
+- **Build-fix caught during A/B (done):** the migration originally missed the two `openinfer-server` `bench_serving` bins (`decode.rs`, `exec.rs`) — the `--lib` test runs never compiled the server binaries, so the default `cargo run --release` build was broken on the branch until those two call sites were swapped to `TokenSink::standalone()` and `openinfer::scheduler` re-exported `TokenSink`. Lesson: gate on `cargo build --release` (bins), not just `--workspace --lib`.
+- **A/B throughput (done, RTX 5070 Ti / Qwen3-4B, greedy, 32-word prompt):** branch vs. stashed `main`, identical KV pool (2473 blocks ≈ 39.5K tokens). End-to-end output tok/s, 3 runs each: c=96/out256 **5594 vs 5551** (+0.8%, within noise); c=128/out128 **7517 vs 7502** (+0.2%, within noise); c=192/out128 **7764 vs 7698** (+0.9%, *non-overlapping* ranges — small but consistent, and growing with concurrency as predicted). 0 failures on both. Note: c=128/out256 over-subscribes this box's 6.5 GB-free KV pool and errors ~245 tokens in **identically on branch and main** (pre-existing admission behavior, not a regression). Takeaway: throughput-neutral-to-slightly-positive on this memory-bound GPU, exactly the predicted ~1–2%-at-the-noise-floor; the payoff regime (fast decode GPU / N≫128) isn't reachable on this hardware.
+- **P2 (done):** mechanically migrated qwen35, deepseek-v4, deepseek-v2-lite, kimi-k2, and the sim. deepseek-v4's scheduler keeps the whole `GenerateRequest`, so its sends were already drop-in (no field change). Compiler-verified here: engine, vllm-frontend, qwen3, deepseek-v2-lite, sim. The Triton/TileLang/NCCL-gated crates (qwen35, deepseek-v4, kimi-k2) couldn't link in this env (missing toolchains); their migration is the same uniform type-swap.
+- **P3 (optional, not done):** per-step batch send (shaves the N pushes, ~6µs, marginal); attack the new `exec_cpu` floor (batch `schedule_decode`/`apply_decode`).
+
+## Next
+
+- End-to-end throughput A/B is done (see Staging — within noise to +0.9%, growing with concurrency). Still open: the *per-phase* bubble re-measurement (instrument as in "Measurement") to confirm `apply` 254 → ~22µs directly — the low-noise mechanism proof that end-to-end tok/s can't resolve on this memory-bound GPU.
+- Build/verify qwen35, deepseek-v4, kimi-k2 once their toolchains are available (Triton venv / TileLang / `OPENINFER_NCCL_ROOT`).
+- Adjacent: O(N²) `active.iter().position/find` in resolve/apply → `HashMap<RequestId, usize>` index (cheap hygiene, prevents bs≳256 blowup); per-row sampling redesign for `temperature>0` (separate `exec_cpu` source).

--- a/docs/subsystems/scheduler/scheduler.md
+++ b/docs/subsystems/scheduler/scheduler.md
@@ -21,7 +21,7 @@ token_rx.recv()  ←──────────────  token_tx.send(to
 tokenizer.decode() + SSE
 ```
 
-The scheduler thread owns the model, `BatchDecodeBuffers`, and `KvPool` exclusively. No `Mutex` — single-threaded GPU ownership. HTTP handlers and scheduler talk over channels only. Consumer drop (`token_tx.send` returns `Err`) is the cancellation signal.
+The scheduler thread owns the model, `BatchDecodeBuffers`, and `KvPool` exclusively. No `Mutex` — single-threaded GPU ownership. HTTP handlers and scheduler talk over channels only. `token_tx` is now a `TokenSink` over one shared request-tagged channel (see `output-dispatch.md`); `token_tx.send` returns `Err` when the request's cancel flag is flipped (abort) or the engine shuts down, which is the cancellation signal the scheduler retires on.
 
 ## Paged KV cache
 
@@ -95,6 +95,7 @@ Related: FlashInfer's f32 fused RoPE rounds differently from a precomputed bf16 
 
 - **ITL p99 tail (291 vs vLLM 211ms).** Large prefills block in-flight decode. Chunked prefill would fix it. Low priority — varied-length workloads break the waves naturally, and fixed-length ITL p99 already beats vLLM.
 - **9 failures at QPS=2.** Needs root-cause — likely KV pressure or empty-prompt rejection from the random dataset.
+- **Worker-panic wedge at high concurrency (RTX 5070 Ti, verified 2026-06).** Under sustained high load (c≈128–192, mixed prefill+decode), the GPU worker thread `qwen3-tp-rank-0` panics in a cudarc copy: `assertion failed: dst.len() >= src.len()` (`cudarc .../driver/safe/core.rs:1607`) — a pre-allocated buffer is too small for some batch/shape the step produces. Two distinct faults compound: (1) the undersized buffer (proximate crash); (2) **blast radius + no recovery** — `fail_touched_requests` clears the *entire* active batch on any step `Err`, the worker thread is never restarted, so every subsequent step returns "worker step channel closed" and **all** in-flight and future requests fail. `/health` still returns 200 (separate layer), so it reads as a silent permanent wedge until process restart. Not KV admission: a 160-request single burst defers cleanly with 0 errors, so full-lifetime admission works. Independent of the output-dispatch change (the panic is in the executor copy path; `main` fails identically). Next: `RUST_BACKTRACE=1` to capture the call site — prime suspects are the prefill/unified or batched step-tail logits/sampling readback (not the decode token H2D, which is sized to the 256 bucket).
 - **Batch decode per-row sampling.** `(0..bs).map(gpu_sample_into)` regresses to O(bs) launches; scheduler still hot-pathes through this. See memory entry on FlashInfer sampling for the redesign target (batched per-request sampling metadata, mini-sglang/vLLM style).
 - **Qwen3.5 partial paged migration.** Decode is fully paged via the scheduler. Prefill still scatters from contiguous HND staging into paged KV before attention. Migration mirrors Qwen3's step 2 with HD256 + partial RoPE (rotary_dim=64 of head_dim=256) wrinkles.
 
@@ -104,3 +105,4 @@ Related: FlashInfer's f32 fused RoPE rounds differently from a precomputed bf16 
 - Batch sampling redesign with per-request metadata
 - Chunked prefill — only if ITL p99 becomes a hard requirement
 - Preemption / priority queuing — deferred, no current pain
+- **Output-dispatch redesign — landed 2026-06** (see `output-dispatch.md`): the per-request `token_tx` fan-out (N channels + N tasks, N wakeups/step ≈ 3µs×batch GPU bubble) is collapsed to one request-tagged channel + one demux loop; `token_tx` is a `TokenSink` drop-in and cancellation rides an `Arc<AtomicBool>` flag (no separate cancel channel). Remaining: re-measure the bubble on the migrated path; small win on this GPU, material on fast decode GPUs (H20/H100) or N≫128.

--- a/openinfer-deepseek-v2-lite/src/engine.rs
+++ b/openinfer-deepseek-v2-lite/src/engine.rs
@@ -5,7 +5,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use openinfer_engine::engine::{
-    EngineHandle, EngineLoadOptions, FinishReason, GenerateRequest, TokenEvent,
+    EngineHandle, EngineLoadOptions, FinishReason, GenerateRequest, TokenEvent, TokenSink,
 };
 use tokio::sync::mpsc;
 
@@ -92,11 +92,7 @@ fn reject_request(req: &GenerateRequest, prompt_tokens: usize, message: String) 
     });
 }
 
-fn emit_generation_result(
-    token_tx: &mpsc::UnboundedSender<TokenEvent>,
-    prompt_tokens: usize,
-    result: &GenerationResult,
-) {
+fn emit_generation_result(token_tx: &TokenSink, prompt_tokens: usize, result: &GenerationResult) {
     for token in &result.tokens {
         let _ = token_tx.send(TokenEvent::Token {
             id: *token,
@@ -123,7 +119,7 @@ mod tests {
 
     #[test]
     fn stop_generation_streams_tokens_and_stop_finish() {
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (tx, mut rx) = TokenSink::standalone();
 
         emit_generation_result(
             &tx,
@@ -136,15 +132,15 @@ mod tests {
         );
         drop(tx);
 
-        match rx.try_recv().expect("expected first token") {
+        match rx.try_recv().expect("expected first token").1 {
             TokenEvent::Token { id, .. } => assert_eq!(id, 10),
             _ => panic!("expected first token event"),
         }
-        match rx.try_recv().expect("expected second token") {
+        match rx.try_recv().expect("expected second token").1 {
             TokenEvent::Token { id, .. } => assert_eq!(id, 11),
             _ => panic!("expected second token event"),
         }
-        match rx.try_recv().expect("expected finished event") {
+        match rx.try_recv().expect("expected finished event").1 {
             TokenEvent::Finished {
                 finish_reason,
                 prompt_tokens,

--- a/openinfer-deepseek-v4/src/e2e_runner.rs
+++ b/openinfer-deepseek-v4/src/e2e_runner.rs
@@ -4,10 +4,11 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
 use log::info;
-use openinfer_core::engine::{EngineHandle, EngineLoadOptions, GenerateRequest, TokenEvent};
+use openinfer_core::engine::{
+    EngineHandle, EngineLoadOptions, GenerateRequest, TokenEvent, TokenSink, TokenStreamReceiver,
+};
 use openinfer_core::sampler::SamplingParams;
 use serde::Deserialize;
-use tokio::sync::mpsc;
 use vllm_text::tokenizer::{HuggingFaceTokenizer, Tokenizer};
 
 pub const DEFAULT_MODEL_PATH: &str = "models/DeepSeek-V4-Flash";
@@ -201,7 +202,7 @@ fn generate_text(
         .encode(prompt, false)
         .map_err(|err| anyhow::anyhow!("encode failed: {err:?}"))?;
     let prompt_token_count = prompt_tokens.len();
-    let (token_tx, mut token_rx) = mpsc::unbounded_channel();
+    let (token_tx, mut token_rx) = TokenSink::standalone();
     let started = Instant::now();
 
     handle
@@ -228,7 +229,7 @@ fn generate_text(
 }
 
 fn collect_generation_events(
-    token_rx: &mut mpsc::UnboundedReceiver<TokenEvent>,
+    token_rx: &mut TokenStreamReceiver,
     tokenizer: &HuggingFaceTokenizer,
     expected: &str,
     started: Instant,
@@ -237,7 +238,7 @@ fn collect_generation_events(
     let mut out = Vec::new();
     let mut ttft = None;
     loop {
-        match token_rx.blocking_recv() {
+        match token_rx.blocking_recv().map(|(_, event)| event) {
             Some(TokenEvent::Token { id, .. }) => {
                 ttft.get_or_insert_with(|| started.elapsed());
                 out.push(id);

--- a/openinfer-engine/src/engine.rs
+++ b/openinfer-engine/src/engine.rs
@@ -2,7 +2,10 @@ use std::{
     error::Error,
     fmt,
     path::PathBuf,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     thread::{self, JoinHandle},
 };
 
@@ -69,7 +72,10 @@ pub struct GenerateRequest {
     pub params: SamplingParams,
     pub max_tokens: usize,
     pub lora_adapter: Option<String>,
-    pub token_tx: mpsc::UnboundedSender<TokenEvent>,
+    /// Where the scheduler emits this request's `TokenEvent`s. All requests on
+    /// one engine share a single tagged output channel behind this sink (see
+    /// [`TokenSink`]); the frontend demuxes by tag.
+    pub token_tx: TokenSink,
     pub logprobs: usize,
     pub echo: bool,
 }
@@ -161,6 +167,83 @@ pub enum TokenEvent {
         prompt_tokens: usize,
         completion_tokens: usize,
     },
+}
+
+/// The tag that routes a [`TokenEvent`] back to its request on the shared
+/// output channel — the external request id (vLLM's `request_id`). `Arc<str>`
+/// keeps per-event tagging to a refcount bump instead of a string copy.
+pub type RequestTag = Arc<str>;
+
+/// The single output channel an engine dispatches *all* requests' token events
+/// into, each tagged with its [`RequestTag`]. One receiver (the frontend demux
+/// loop) drains it, replacing the former per-request fan-out of N channels and
+/// N consumer tasks — N distinct sleeping consumers cost N wakeups per step,
+/// one shared consumer costs ~1.
+pub type TokenStreamSender = mpsc::UnboundedSender<(RequestTag, TokenEvent)>;
+pub type TokenStreamReceiver = mpsc::UnboundedReceiver<(RequestTag, TokenEvent)>;
+
+/// Per-request handle the scheduler holds to emit [`TokenEvent`]s.
+///
+/// Drop-in for the former `UnboundedSender<TokenEvent>`: it keeps the same
+/// `send` / `is_closed` / `Clone` surface, so scheduler call sites are
+/// unchanged. Internally each event is tagged with the request's
+/// [`RequestTag`] and pushed onto one shared [`TokenStreamSender`].
+///
+/// Cancellation moved from "drop the per-request receiver" to a shared
+/// `cancelled` flag: the frontend aborts a *single* request by flipping its
+/// flag without closing the channel the other requests still use. `send` and
+/// `is_closed` then report that request as gone, so the scheduler retires it on
+/// its next emit — the same *reactive* retirement the old consumer-drop gave,
+/// reached through the flag rather than channel closure. `tx.is_closed()` is
+/// the engine-wide signal (the whole demux is gone); the per-request signal is
+/// the flag. The flag is set with `Release` and read with `Acquire` so the
+/// abort is ordered against the frontend dropping the request's stream state.
+#[derive(Clone)]
+pub struct TokenSink {
+    tag: RequestTag,
+    tx: TokenStreamSender,
+    cancelled: Arc<AtomicBool>,
+}
+
+impl TokenSink {
+    pub fn new(tag: RequestTag, tx: TokenStreamSender, cancelled: Arc<AtomicBool>) -> Self {
+        Self { tag, tx, cancelled }
+    }
+
+    /// Emit one event for this request. Returns `Err` (handing the event back)
+    /// when the request was cancelled or the shared receiver is gone — both of
+    /// which the scheduler reads as "consumer dropped, retire the request",
+    /// the same contract as the old per-request channel.
+    #[allow(clippy::result_large_err)]
+    pub fn send(&self, event: TokenEvent) -> Result<(), mpsc::error::SendError<TokenEvent>> {
+        if self.cancelled.load(Ordering::Acquire) {
+            return Err(mpsc::error::SendError(event));
+        }
+        self.tx.send((self.tag.clone(), event)).map_err(|err| {
+            let (_, event) = err.0;
+            mpsc::error::SendError(event)
+        })
+    }
+
+    /// `true` once the request is cancelled or the shared receiver is gone.
+    pub fn is_closed(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire) || self.tx.is_closed()
+    }
+
+    /// The request id this sink tags its events with.
+    pub fn tag(&self) -> &RequestTag {
+        &self.tag
+    }
+
+    /// A sink backed by its own private channel, for direct drivers
+    /// (benchmarks, integration tests, the simulator) that consume one
+    /// request's events without the shared frontend demux. The returned
+    /// receiver yields the tagged events; the cancel flag is never tripped.
+    pub fn standalone() -> (Self, TokenStreamReceiver) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let sink = Self::new(Arc::from("local"), tx, Arc::new(AtomicBool::new(false)));
+        (sink, rx)
+    }
 }
 
 /// Seconds since `UNIX_EPOCH` as `f64` — the clock base for `TokenEvent`

--- a/openinfer-kimi-k2/src/batch_decode_trace.rs
+++ b/openinfer-kimi-k2/src/batch_decode_trace.rs
@@ -1,7 +1,7 @@
 use anyhow::{Result, ensure};
 #[cfg(feature = "kernel-call-trace")]
 use openinfer_core::{
-    engine::{EngineLoadOptions, GenerateRequest, TokenEvent},
+    engine::{EngineLoadOptions, GenerateRequest, TokenEvent, TokenSink},
     ops::call_trace,
     sampler::SamplingParams,
 };
@@ -9,8 +9,6 @@ use openinfer_kernels::tensor::{
     AxisSpec, Bf16, Contiguous1D, F32, HiddenStatesLayout, I32, KernelCall, RowMajor2D, TensorSpec,
     U32,
 };
-#[cfg(feature = "kernel-call-trace")]
-use tokio::sync::mpsc;
 
 use crate::config::{
     KIMI_K2_DENSE_INTERMEDIATE, KIMI_K2_HIDDEN, KIMI_K2_LAYERS, KIMI_K2_MOE_LAYERS,
@@ -119,7 +117,7 @@ pub fn trace_runtime_decode_kernel_calls(
     let ((), calls) = call_trace::collect_result(|| {
         let mut receivers = Vec::with_capacity(batch_size);
         for request_idx in 0..batch_size {
-            let (token_tx, mut token_rx) = mpsc::unbounded_channel();
+            let (token_tx, mut token_rx) = TokenSink::standalone();
             engine.submit(GenerateRequest {
                 request_id: Some(format!("kimi-trace-{request_idx}")),
                 queued_at_unix_s: None,
@@ -137,7 +135,7 @@ pub fn trace_runtime_decode_kernel_calls(
                 echo: false,
             })?;
             receivers.push(std::thread::spawn(move || -> Result<()> {
-                while let Some(event) = token_rx.blocking_recv() {
+                while let Some((_, event)) = token_rx.blocking_recv() {
                     match event {
                         TokenEvent::Scheduled { .. }
                         | TokenEvent::Token { .. }

--- a/openinfer-kimi-k2/src/runner/scheduler.rs
+++ b/openinfer-kimi-k2/src/runner/scheduler.rs
@@ -12,7 +12,7 @@ use crate::runner::worker::{KimiKvStepPages, KimiRowOptions};
 use anyhow::{Context, Result};
 use lifecycle::{preflight_prefill_candidate, send_scheduled, validate_kv_capacity};
 use log::error;
-use openinfer_core::engine::{FinishReason, GenerateRequest, TokenEvent};
+use openinfer_core::engine::{FinishReason, GenerateRequest, TokenEvent, TokenSink};
 use openinfer_kv_cache::{BlockPool, RequestKv};
 use tokio::sync::mpsc;
 
@@ -35,7 +35,7 @@ fn row_options(req: &GenerateRequest) -> KimiRowOptions {
 }
 
 struct ActiveKimiRequest {
-    token_tx: mpsc::UnboundedSender<TokenEvent>,
+    token_tx: TokenSink,
     prompt_len: usize,
     completion_tokens: usize,
     max_tokens: usize,
@@ -754,8 +754,8 @@ mod tests {
     fn request_with_channel(
         prompt_tokens: Vec<u32>,
         max_tokens: usize,
-    ) -> (GenerateRequest, mpsc::UnboundedReceiver<TokenEvent>) {
-        let (token_tx, token_rx) = mpsc::unbounded_channel();
+    ) -> (GenerateRequest, openinfer_core::engine::TokenStreamReceiver) {
+        let (token_tx, token_rx) = TokenSink::standalone();
         let req = GenerateRequest {
             request_id: None,
             queued_at_unix_s: None,
@@ -831,10 +831,10 @@ mod tests {
             "a rejected sampling request must not reach the executor"
         );
         // Scheduled event precedes the rejection.
-        let Ok(TokenEvent::Scheduled { .. }) = token_rx.try_recv() else {
+        let Ok((_, TokenEvent::Scheduled { .. })) = token_rx.try_recv() else {
             panic!("expected Scheduled event");
         };
-        let Ok(TokenEvent::Rejected { message, .. }) = token_rx.try_recv() else {
+        let Ok((_, TokenEvent::Rejected { message, .. })) = token_rx.try_recv() else {
             panic!("expected Rejected event");
         };
         assert!(
@@ -857,10 +857,10 @@ mod tests {
             calls.lock().unwrap().is_empty(),
             "a rejected echo request must not reach the executor"
         );
-        let Ok(TokenEvent::Scheduled { .. }) = token_rx.try_recv() else {
+        let Ok((_, TokenEvent::Scheduled { .. })) = token_rx.try_recv() else {
             panic!("expected Scheduled event");
         };
-        let Ok(TokenEvent::Rejected { message, .. }) = token_rx.try_recv() else {
+        let Ok((_, TokenEvent::Rejected { message, .. })) = token_rx.try_recv() else {
             panic!("expected Rejected event");
         };
         assert!(
@@ -889,10 +889,10 @@ mod tests {
             calls.lock().unwrap().is_empty(),
             "a rejected over-cap request must not reach the executor"
         );
-        let Ok(TokenEvent::Scheduled { .. }) = token_rx.try_recv() else {
+        let Ok((_, TokenEvent::Scheduled { .. })) = token_rx.try_recv() else {
             panic!("expected Scheduled event");
         };
-        let Ok(TokenEvent::Rejected { message, .. }) = token_rx.try_recv() else {
+        let Ok((_, TokenEvent::Rejected { message, .. })) = token_rx.try_recv() else {
             panic!("expected Rejected event");
         };
         assert!(

--- a/openinfer-kimi-k2/src/runner/scheduler/dp.rs
+++ b/openinfer-kimi-k2/src/runner/scheduler/dp.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use crossbeam_channel::{Receiver, Sender, bounded};
 use log::error;
-use openinfer_core::engine::{FinishReason, GenerateRequest, TokenEvent};
+use openinfer_core::engine::{FinishReason, GenerateRequest, TokenEvent, TokenSink};
 use openinfer_kv_cache::{BlockPool, RequestKv};
 use rand::rngs::StdRng;
 use tokio::sync::mpsc;
@@ -49,7 +49,7 @@ pub(in crate::runner) struct DpRankState {
 }
 
 struct RequestState {
-    token_tx: mpsc::UnboundedSender<TokenEvent>,
+    token_tx: TokenSink,
     prompt_len: usize,
     completion_tokens: usize,
     max_tokens: usize,
@@ -1092,7 +1092,7 @@ mod tests {
     use super::*;
 
     fn dummy_request(prompt_tokens: Vec<u32>, max_tokens: usize) -> GenerateRequest {
-        let (token_tx, _token_rx) = mpsc::unbounded_channel();
+        let (token_tx, _token_rx) = TokenSink::standalone();
         GenerateRequest {
             request_id: None,
             queued_at_unix_s: None,
@@ -1141,7 +1141,7 @@ mod tests {
         max_tokens: usize,
         last_token: u32,
     ) -> RequestState {
-        let (token_tx, _token_rx) = mpsc::unbounded_channel();
+        let (token_tx, _token_rx) = TokenSink::standalone();
         RequestState {
             token_tx,
             prompt_len,
@@ -1307,7 +1307,7 @@ mod tests {
         let mut rank = DpRankState {
             slots: (0..MAX_BATCH_PER_DP).map(|_| None).collect(),
         };
-        let (token_tx, mut token_rx) = mpsc::unbounded_channel();
+        let (token_tx, mut token_rx) = TokenSink::standalone();
         let mut kv = dummy_kv(&pool, 4, 1, 16, 7);
         kv.schedule_decode(&pool).expect("decode block");
         rank.slots[0] = Some(RequestState {
@@ -1323,11 +1323,14 @@ mod tests {
         rank.process_decode_report(0, &dummy_report(163_586), &[163_586], &pool);
 
         assert!(rank.slots[0].is_none());
-        let Ok(TokenEvent::Finished {
-            finish_reason,
-            completion_tokens,
-            ..
-        }) = token_rx.try_recv()
+        let Ok((
+            _,
+            TokenEvent::Finished {
+                finish_reason,
+                completion_tokens,
+                ..
+            },
+        )) = token_rx.try_recv()
         else {
             panic!("expected Finished event");
         };
@@ -1343,7 +1346,7 @@ mod tests {
         let mut rank = DpRankState {
             slots: (0..MAX_BATCH_PER_DP).map(|_| None).collect(),
         };
-        let (token_tx, mut token_rx) = mpsc::unbounded_channel();
+        let (token_tx, mut token_rx) = TokenSink::standalone();
         let mut kv = dummy_kv(&pool, 4, 1, 16, 7);
         kv.schedule_decode(&pool).expect("decode block");
         rank.slots[0] = Some(RequestState {
@@ -1365,7 +1368,7 @@ mod tests {
         rank.process_decode_report(0, &dummy_report(163_586), &[163_586], &pool);
 
         assert!(rank.slots[0].is_some());
-        let Ok(TokenEvent::Token { id, .. }) = token_rx.try_recv() else {
+        let Ok((_, TokenEvent::Token { id, .. })) = token_rx.try_recv() else {
             panic!("expected Token event");
         };
         assert_eq!(id, 163_586);

--- a/openinfer-kimi-k2/tests/vllm_golden_gate.rs
+++ b/openinfer-kimi-k2/tests/vllm_golden_gate.rs
@@ -55,7 +55,8 @@ use std::path::Path;
 use std::time::{Duration, Instant};
 
 use openinfer_core::engine::{
-    EngineHandle, EngineLoadOptions, EpBackend, TokenEvent, TokenLogprob,
+    EngineHandle, EngineLoadOptions, EpBackend, TokenEvent, TokenLogprob, TokenSink,
+    TokenStreamReceiver,
 };
 use openinfer_core::parallel::ParallelConfig;
 use openinfer_core::sampler::SamplingParams;
@@ -310,7 +311,7 @@ fn start_engine(path: &str) -> EngineHandle {
 
 struct PendingRequest {
     label: String,
-    rx: tokio::sync::mpsc::UnboundedReceiver<TokenEvent>,
+    rx: TokenStreamReceiver,
 }
 
 fn submit(
@@ -320,7 +321,7 @@ fn submit(
     max_tokens: usize,
     logprobs: usize,
 ) -> PendingRequest {
-    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let (tx, rx) = TokenSink::standalone();
     engine
         .submit(openinfer_core::engine::GenerateRequest {
             request_id: Some(label.clone()),
@@ -351,7 +352,7 @@ impl PendingRequest {
         let mut tokens = Vec::new();
         let deadline = Instant::now() + RECV_TIMEOUT;
         loop {
-            match self.rx.try_recv() {
+            match self.rx.try_recv().map(|(_, event)| event) {
                 Ok(TokenEvent::Token { id, logprob }) => {
                     let logprob = logprob.unwrap_or_else(|| {
                         panic!(

--- a/openinfer-qwen3-4b/src/scheduler.rs
+++ b/openinfer-qwen3-4b/src/scheduler.rs
@@ -22,6 +22,7 @@ use crate::executor::{ModelExecutor, Qwen3Executor, RequestId};
 use crate::{Qwen3LoraOptions, Qwen3OffloadOptions};
 use openinfer_core::engine::{
     EngineCommand, EngineControlRequest, EngineHandle, GenerateRequest, KvCapacity, TokenEvent,
+    TokenSink,
 };
 use openinfer_core::sampler::SamplingParams;
 
@@ -35,7 +36,7 @@ use self::resolve::resolve_step;
 pub(super) struct ActiveRequestState {
     pub(super) request_id: RequestId,
     pub(super) lora_adapter: Option<String>,
-    pub(super) token_tx: mpsc::UnboundedSender<TokenEvent>,
+    pub(super) token_tx: TokenSink,
     pub(super) last_token: u32,
     pub(super) generated_count: usize,
     pub(super) max_tokens: usize,
@@ -51,7 +52,7 @@ pub(super) struct PendingRequest {
     pub(super) prompt_tokens: Vec<u32>,
     pub(super) params: SamplingParams,
     pub(super) max_tokens: usize,
-    pub(super) token_tx: mpsc::UnboundedSender<TokenEvent>,
+    pub(super) token_tx: TokenSink,
     pub(super) logprobs: usize,
     pub(super) echo: bool,
     pub(super) queued_at_unix_s: Option<f64>,
@@ -676,7 +677,7 @@ fn handle_control_request(executor: &mut impl ModelExecutor, control: EngineCont
 #[derive(Clone)]
 struct RequestFailureTarget {
     request_id: RequestId,
-    token_tx: mpsc::UnboundedSender<TokenEvent>,
+    token_tx: TokenSink,
     prompt_tokens: usize,
     completion_tokens: usize,
 }
@@ -1351,7 +1352,7 @@ mod tests {
         assert_eq!(blocks_needed(max_request_tokens(&pending), 16), 2);
         assert_eq!(pending_lifetime_blocks(&pending, 16), 3);
 
-        let (token_tx, _token_rx) = mpsc::unbounded_channel();
+        let (token_tx, _token_rx) = TokenSink::standalone();
         let after_prefill = ActiveRequestState {
             request_id: RequestId(8),
             lora_adapter: None,
@@ -1367,7 +1368,7 @@ mod tests {
         assert_eq!(max_active_tokens(&after_prefill), 32);
         assert_eq!(active_lifetime_blocks(&after_prefill, 16), 3);
 
-        let (token_tx, _token_rx) = mpsc::unbounded_channel();
+        let (token_tx, _token_rx) = TokenSink::standalone();
         let after_one_decode = ActiveRequestState {
             request_id: RequestId(9),
             lora_adapter: None,
@@ -1389,7 +1390,7 @@ mod tests {
         // block_size 16, per-request cap 4 blocks (max 64 tokens). One active
         // request is mid-flight and will grow into 2 more blocks, so it
         // pre-reserves them out of the budget.
-        let (token_tx, _rx) = mpsc::unbounded_channel();
+        let (token_tx, _rx) = TokenSink::standalone();
         let active = [ActiveRequestState {
             request_id: RequestId(0),
             lora_adapter: None,
@@ -1485,7 +1486,7 @@ mod tests {
     fn admission_respects_decode_batch_capacity() {
         let mut active = Vec::new();
         for id in 0..64 {
-            let (token_tx, _rx) = mpsc::unbounded_channel();
+            let (token_tx, _rx) = TokenSink::standalone();
             active.push(ActiveRequestState {
                 request_id: RequestId(id),
                 lora_adapter: None,
@@ -1616,7 +1617,7 @@ mod tests {
         let (req, mut rx) = request(32, 2);
         handle.submit(req).expect("submit chunked request");
         match rx.blocking_recv() {
-            Some(TokenEvent::Scheduled { prompt_tokens, .. }) => {
+            Some((_, TokenEvent::Scheduled { prompt_tokens, .. })) => {
                 assert_eq!(
                     prompt_tokens, 32,
                     "Scheduled fires once, on the first chunk"
@@ -1625,16 +1626,22 @@ mod tests {
             _ => panic!("stream opens with Scheduled"),
         }
         assert!(
-            matches!(rx.blocking_recv(), Some(TokenEvent::Token { id: 100, .. })),
+            matches!(
+                rx.blocking_recv(),
+                Some((_, TokenEvent::Token { id: 100, .. }))
+            ),
             "first token arrives only after the final chunk, with no duplicate Scheduled"
         );
         assert!(
-            matches!(rx.blocking_recv(), Some(TokenEvent::Token { id: 200, .. })),
+            matches!(
+                rx.blocking_recv(),
+                Some((_, TokenEvent::Token { id: 200, .. }))
+            ),
             "decode continues normally after promotion"
         );
         assert!(matches!(
             rx.blocking_recv(),
-            Some(TokenEvent::Finished { .. })
+            Some((_, TokenEvent::Finished { .. }))
         ));
 
         let batches = prefill_batches.lock().unwrap();
@@ -1710,12 +1717,15 @@ mod tests {
         handle.submit(req).expect("submit");
 
         match rx.blocking_recv() {
-            Some(TokenEvent::Scheduled {
-                prompt_tokens,
-                cached_tokens,
-                queued_at_unix_s,
-                scheduled_at_unix_s,
-            }) => {
+            Some((
+                _,
+                TokenEvent::Scheduled {
+                    prompt_tokens,
+                    cached_tokens,
+                    queued_at_unix_s,
+                    scheduled_at_unix_s,
+                },
+            )) => {
                 assert_eq!(prompt_tokens, 32);
                 assert_eq!(cached_tokens, 7);
                 assert!(queued_at_unix_s <= scheduled_at_unix_s);
@@ -1725,10 +1735,10 @@ mod tests {
 
         loop {
             match rx.blocking_recv() {
-                Some(TokenEvent::Scheduled { .. }) => {
+                Some((_, TokenEvent::Scheduled { .. })) => {
                     panic!("Scheduled must be emitted exactly once")
                 }
-                Some(TokenEvent::Finished { .. }) => break,
+                Some((_, TokenEvent::Finished { .. })) => break,
                 Some(_) => {}
                 None => panic!("stream closed without Finished"),
             }
@@ -1903,17 +1913,20 @@ mod tests {
 
     /// Engine streams now open with `TokenEvent::Scheduled` (#246); these
     /// tests assert on the token/terminal events, so skip past it.
-    fn recv_skipping_scheduled(rx: &mut mpsc::UnboundedReceiver<TokenEvent>) -> Option<TokenEvent> {
+    fn recv_skipping_scheduled(
+        rx: &mut openinfer_core::engine::TokenStreamReceiver,
+    ) -> Option<TokenEvent> {
         loop {
             match rx.blocking_recv() {
-                Some(TokenEvent::Scheduled { .. }) => {}
-                other => return other,
+                Some((_, TokenEvent::Scheduled { .. })) => {}
+                Some((_, event)) => return Some(event),
+                None => return None,
             }
         }
     }
 
     fn pending(request_id: u64, echo: bool) -> PendingRequest {
-        let (token_tx, _token_rx) = mpsc::unbounded_channel();
+        let (token_tx, _token_rx) = TokenSink::standalone();
         PendingRequest {
             request_id: RequestId::new(request_id),
             lora_adapter: None,
@@ -1956,8 +1969,8 @@ mod tests {
     fn request(
         prompt_len: usize,
         max_tokens: usize,
-    ) -> (GenerateRequest, mpsc::UnboundedReceiver<TokenEvent>) {
-        let (token_tx, token_rx) = mpsc::unbounded_channel();
+    ) -> (GenerateRequest, openinfer_core::engine::TokenStreamReceiver) {
+        let (token_tx, token_rx) = TokenSink::standalone();
         (
             GenerateRequest {
                 request_id: None,
@@ -1978,7 +1991,7 @@ mod tests {
         prompt_len: usize,
         max_tokens: usize,
         lora_adapter: Option<&str>,
-    ) -> (GenerateRequest, mpsc::UnboundedReceiver<TokenEvent>) {
+    ) -> (GenerateRequest, openinfer_core::engine::TokenStreamReceiver) {
         let (mut request, token_rx) = request(prompt_len, max_tokens);
         request.lora_adapter = lora_adapter.map(ToString::to_string);
         (request, token_rx)
@@ -2004,11 +2017,14 @@ mod tests {
         let (too_large, mut too_large_rx) = request(16, 34);
         handle.submit(too_large).expect("submit too_large");
         match too_large_rx.blocking_recv() {
-            Some(TokenEvent::Rejected {
-                prompt_tokens,
-                completion_tokens,
-                message,
-            }) => {
+            Some((
+                _,
+                TokenEvent::Rejected {
+                    prompt_tokens,
+                    completion_tokens,
+                    message,
+                },
+            )) => {
                 assert_eq!(prompt_tokens, 16);
                 assert_eq!(completion_tokens, 0);
                 assert!(message.contains("requires more KV blocks"));
@@ -2044,11 +2060,14 @@ mod tests {
         let (too_long, mut too_long_rx) = request(16, 100);
         handle.submit(too_long).expect("submit too_long");
         match too_long_rx.blocking_recv() {
-            Some(TokenEvent::Rejected {
-                prompt_tokens,
-                completion_tokens,
-                message,
-            }) => {
+            Some((
+                _,
+                TokenEvent::Rejected {
+                    prompt_tokens,
+                    completion_tokens,
+                    message,
+                },
+            )) => {
                 assert_eq!(prompt_tokens, 16);
                 assert_eq!(completion_tokens, 0);
                 assert!(
@@ -2159,11 +2178,14 @@ mod tests {
         handle.submit(base).expect("submit base");
 
         match unknown_rx.blocking_recv() {
-            Some(TokenEvent::Rejected {
-                message,
-                prompt_tokens,
-                completion_tokens,
-            }) => {
+            Some((
+                _,
+                TokenEvent::Rejected {
+                    message,
+                    prompt_tokens,
+                    completion_tokens,
+                },
+            )) => {
                 assert!(message.contains("LoRA adapter is not loaded: missing-adapter"));
                 assert_eq!(prompt_tokens, 16);
                 assert_eq!(completion_tokens, 0);
@@ -2275,7 +2297,7 @@ mod tests {
         let mut active = Vec::new();
 
         for request_id in [RequestId(10), RequestId(1), RequestId(7)] {
-            let (token_tx, _token_rx) = mpsc::unbounded_channel();
+            let (token_tx, _token_rx) = TokenSink::standalone();
             active.push(ActiveRequestState {
                 request_id,
                 lora_adapter: None,

--- a/openinfer-qwen3-4b/src/scheduler/effects.rs
+++ b/openinfer-qwen3-4b/src/scheduler/effects.rs
@@ -1,14 +1,12 @@
-use tokio::sync::mpsc;
-
 use log::debug;
 
 use crate::executor::RequestId;
-use openinfer_core::engine::{FinishReason, TokenLogprob};
+use openinfer_core::engine::{FinishReason, TokenLogprob, TokenSink};
 
 use super::{ActiveRequestState, PendingRequest, TokenEvent};
 
 pub(super) struct PromptEchoEffect {
-    pub(super) token_tx: mpsc::UnboundedSender<TokenEvent>,
+    pub(super) token_tx: TokenSink,
     pub(super) ids: Vec<u32>,
     pub(super) logprobs: Vec<Option<TokenLogprob>>,
 }
@@ -18,7 +16,7 @@ pub(super) struct PromptEchoEffect {
 /// scheduled timestamp was stamped when the batch was formed, not when the
 /// event is sent, so queue-time metrics exclude prefill execution.
 pub(super) struct ScheduledEffect {
-    pub(super) token_tx: mpsc::UnboundedSender<TokenEvent>,
+    pub(super) token_tx: TokenSink,
     pub(super) queued_at_unix_s: Option<f64>,
     pub(super) scheduled_at_unix_s: f64,
     pub(super) prompt_tokens: usize,
@@ -28,14 +26,14 @@ pub(super) struct ScheduledEffect {
 pub(super) enum PendingEffect {
     Finish {
         request_id: RequestId,
-        token_tx: mpsc::UnboundedSender<TokenEvent>,
+        token_tx: TokenSink,
         finish_reason: FinishReason,
         prompt_tokens: usize,
         completion_tokens: usize,
     },
     EmitAndFinish {
         request_id: RequestId,
-        token_tx: mpsc::UnboundedSender<TokenEvent>,
+        token_tx: TokenSink,
         token: u32,
         logprob: Option<TokenLogprob>,
         finish_reason: FinishReason,

--- a/openinfer-qwen3-4b/src/scheduler/plan.rs
+++ b/openinfer-qwen3-4b/src/scheduler/plan.rs
@@ -164,7 +164,7 @@ mod tests {
     use openinfer_core::sampler::SamplingParams;
 
     fn pending() -> PendingRequest {
-        let (token_tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let (token_tx, _rx) = openinfer_core::engine::TokenSink::standalone();
         PendingRequest {
             request_id: RequestId::new(0),
             lora_adapter: None,

--- a/openinfer-qwen3-4b/tests/cached_tokens_usage.rs
+++ b/openinfer-qwen3-4b/tests/cached_tokens_usage.rs
@@ -11,9 +11,10 @@
 
 use std::path::Path;
 
-use openinfer_core::engine::{EngineHandle, EngineLoadOptions, GenerateRequest, TokenEvent};
+use openinfer_core::engine::{
+    EngineHandle, EngineLoadOptions, GenerateRequest, TokenEvent, TokenSink,
+};
 use openinfer_core::sampler::SamplingParams;
-use tokio::sync::mpsc;
 
 mod common;
 
@@ -38,7 +39,7 @@ fn model_path_or_skip() -> Option<String> {
 /// Submit `prompt_tokens`, drain the stream to `Finished`, and return the
 /// `cached_tokens` carried by the `Scheduled` event.
 fn run_and_capture_cached(handle: &EngineHandle, prompt_tokens: Vec<u32>) -> usize {
-    let (token_tx, mut rx) = mpsc::unbounded_channel();
+    let (token_tx, mut rx) = TokenSink::standalone();
     handle
         .submit(GenerateRequest {
             request_id: None,
@@ -55,7 +56,7 @@ fn run_and_capture_cached(handle: &EngineHandle, prompt_tokens: Vec<u32>) -> usi
 
     let mut cached = None;
     loop {
-        match rx.blocking_recv() {
+        match rx.blocking_recv().map(|(_, event)| event) {
             Some(TokenEvent::Scheduled { cached_tokens, .. }) => {
                 assert!(
                     cached.replace(cached_tokens).is_none(),

--- a/openinfer-qwen3-4b/tests/context_window.rs
+++ b/openinfer-qwen3-4b/tests/context_window.rs
@@ -17,9 +17,10 @@
 
 use std::path::Path;
 
-use openinfer_core::engine::{EngineHandle, EngineLoadOptions, GenerateRequest, TokenEvent};
+use openinfer_core::engine::{
+    EngineHandle, EngineLoadOptions, GenerateRequest, TokenEvent, TokenSink,
+};
 use openinfer_core::sampler::SamplingParams;
-use tokio::sync::mpsc;
 use vllm_text::tokenizer::DynTokenizer;
 
 mod common;
@@ -49,7 +50,7 @@ fn generate_text(
     max_tokens: usize,
 ) -> String {
     let prompt_tokens = tokenizer.encode(prompt, false).expect("encode failed");
-    let (token_tx, mut rx) = mpsc::unbounded_channel();
+    let (token_tx, mut rx) = TokenSink::standalone();
     handle
         .submit(GenerateRequest {
             request_id: None,
@@ -66,7 +67,7 @@ fn generate_text(
 
     let mut tokens = Vec::new();
     loop {
-        match rx.blocking_recv() {
+        match rx.blocking_recv().map(|(_, event)| event) {
             Some(TokenEvent::Token { id, .. }) => tokens.push(id),
             Some(TokenEvent::PromptTokens { .. } | TokenEvent::Scheduled { .. }) => {}
             Some(TokenEvent::Finished { .. }) => break,
@@ -99,7 +100,7 @@ fn oversized_prompt_is_rejected_with_context_length_error() {
     // Qwen3-4B's max_position_embeddings is 40960; 60k tokens overflows it outright.
     // Token id is irrelevant — the request is rejected before any embedding lookup.
     let prompt_tokens = vec![1u32; 60_000];
-    let (token_tx, mut rx) = mpsc::unbounded_channel();
+    let (token_tx, mut rx) = TokenSink::standalone();
     handle
         .submit(GenerateRequest {
             request_id: None,
@@ -114,7 +115,7 @@ fn oversized_prompt_is_rejected_with_context_length_error() {
         })
         .expect("submit failed");
 
-    match rx.blocking_recv() {
+    match rx.blocking_recv().map(|(_, event)| event) {
         Some(TokenEvent::Rejected { message, .. }) => {
             assert!(
                 message.contains("context length"),

--- a/openinfer-qwen3-4b/tests/context_window_in_window.rs
+++ b/openinfer-qwen3-4b/tests/context_window_in_window.rs
@@ -22,9 +22,8 @@
 
 use std::path::Path;
 
-use openinfer_core::engine::{EngineLoadOptions, GenerateRequest, TokenEvent};
+use openinfer_core::engine::{EngineLoadOptions, GenerateRequest, TokenEvent, TokenSink};
 use openinfer_core::sampler::SamplingParams;
-use tokio::sync::mpsc;
 
 const MODEL_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../models/Qwen3-4B");
 
@@ -66,7 +65,7 @@ fn in_window_prompt_past_old_rope_table_is_served() {
     // Token id 1 is a valid vocab id — a forward pass actually runs here (unlike
     // the rejection test, which never reaches prefill).
     let prompt_tokens = vec![1u32; 4097];
-    let (token_tx, mut rx) = mpsc::unbounded_channel();
+    let (token_tx, mut rx) = TokenSink::standalone();
     handle
         .submit(GenerateRequest {
             request_id: None,
@@ -83,7 +82,7 @@ fn in_window_prompt_past_old_rope_table_is_served() {
 
     let mut generated = 0usize;
     loop {
-        match rx.blocking_recv() {
+        match rx.blocking_recv().map(|(_, event)| event) {
             Some(TokenEvent::Token { .. }) => generated += 1,
             Some(TokenEvent::PromptTokens { .. } | TokenEvent::Scheduled { .. }) => {}
             Some(TokenEvent::Finished { .. }) => break,

--- a/openinfer-qwen3-4b/tests/lora_smoke.rs
+++ b/openinfer-qwen3-4b/tests/lora_smoke.rs
@@ -7,13 +7,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use half::bf16;
 use openinfer_core::engine::{
     EngineHandle, EngineLoadOptions, FinishReason, GenerateRequest, LoadLoraAdapterRequest,
-    TokenEvent,
+    TokenEvent, TokenSink,
 };
 use openinfer_core::sampler::SamplingParams;
 use safetensors::Dtype;
 use safetensors::tensor::View;
 use serde::Deserialize;
-use tokio::sync::mpsc;
 use vllm_text::tokenizer::DynTokenizer;
 
 mod common;
@@ -166,7 +165,7 @@ fn generate_tokens(
     lora_adapter: Option<String>,
 ) -> (Vec<u32>, FinishReason) {
     let prompt_tokens = tokenizer.encode(prompt, false).expect("encode failed");
-    let (token_tx, mut token_rx) = mpsc::unbounded_channel();
+    let (token_tx, mut token_rx) = TokenSink::standalone();
 
     handle
         .submit(GenerateRequest {
@@ -184,7 +183,7 @@ fn generate_tokens(
 
     let mut tokens = Vec::new();
     loop {
-        match token_rx.blocking_recv() {
+        match token_rx.blocking_recv().map(|(_, event)| event) {
             Some(TokenEvent::Token { id, .. }) => tokens.push(id),
             Some(TokenEvent::PromptTokens { .. } | TokenEvent::Scheduled { .. }) => {}
             Some(TokenEvent::Finished { finish_reason, .. }) => return (tokens, finish_reason),

--- a/openinfer-qwen3-4b/tests/sampling_behavior.rs
+++ b/openinfer-qwen3-4b/tests/sampling_behavior.rs
@@ -15,9 +15,10 @@
 
 use std::path::Path;
 
-use openinfer_core::engine::{EngineHandle, EngineLoadOptions, GenerateRequest, TokenEvent};
+use openinfer_core::engine::{
+    EngineHandle, EngineLoadOptions, GenerateRequest, TokenEvent, TokenSink,
+};
 use openinfer_core::sampler::SamplingParams;
-use tokio::sync::mpsc;
 
 mod common;
 
@@ -41,7 +42,7 @@ fn model_path_or_skip() -> Option<String> {
 
 /// Submit one request and collect the generated token ids until `Finished`.
 fn generate(handle: &EngineHandle, prompt_tokens: Vec<u32>, params: SamplingParams) -> Vec<u32> {
-    let (token_tx, mut rx) = mpsc::unbounded_channel();
+    let (token_tx, mut rx) = TokenSink::standalone();
     handle
         .submit(GenerateRequest {
             request_id: None,
@@ -58,7 +59,7 @@ fn generate(handle: &EngineHandle, prompt_tokens: Vec<u32>, params: SamplingPara
 
     let mut tokens = Vec::new();
     loop {
-        match rx.blocking_recv() {
+        match rx.blocking_recv().map(|(_, event)| event) {
             Some(TokenEvent::Token { id, .. }) => tokens.push(id),
             Some(TokenEvent::Scheduled { .. } | TokenEvent::PromptTokens { .. }) => {}
             Some(TokenEvent::Finished { .. }) => return tokens,

--- a/openinfer-qwen3-4b/tests/scheduler_robustness.rs
+++ b/openinfer-qwen3-4b/tests/scheduler_robustness.rs
@@ -14,9 +14,10 @@
 use std::path::Path;
 use std::time::Duration;
 
-use openinfer_core::engine::{EngineHandle, EngineLoadOptions, GenerateRequest, TokenEvent};
+use openinfer_core::engine::{
+    EngineHandle, EngineLoadOptions, GenerateRequest, TokenEvent, TokenSink,
+};
 use openinfer_core::sampler::SamplingParams;
-use tokio::sync::mpsc;
 use vllm_text::tokenizer::DynTokenizer;
 
 mod common;
@@ -46,7 +47,7 @@ fn generate_text(
     max_tokens: usize,
 ) -> String {
     let prompt_tokens = tokenizer.encode(prompt, false).expect("encode failed");
-    let (token_tx, mut rx) = mpsc::unbounded_channel();
+    let (token_tx, mut rx) = TokenSink::standalone();
     handle
         .submit(GenerateRequest {
             request_id: None,
@@ -63,7 +64,7 @@ fn generate_text(
 
     let mut tokens = Vec::new();
     loop {
-        match rx.blocking_recv() {
+        match rx.blocking_recv().map(|(_, event)| event) {
             Some(TokenEvent::Token { id, .. }) => tokens.push(id),
             Some(TokenEvent::PromptTokens { .. } | TokenEvent::Scheduled { .. }) => {}
             Some(TokenEvent::Finished { .. }) => break,
@@ -100,7 +101,7 @@ fn scheduler_survives_consumer_drop() {
     // Submit, then drop the receiver immediately — the scheduler should notice
     // the send failures and retire the request rather than spinning on it.
     let prompt_tokens = tokenizer.encode("Hello", false).expect("encode failed");
-    let (token_tx, rx) = mpsc::unbounded_channel();
+    let (token_tx, rx) = TokenSink::standalone();
     drop(rx);
     handle
         .submit(GenerateRequest {

--- a/openinfer-qwen35-4b/src/scheduler.rs
+++ b/openinfer-qwen35-4b/src/scheduler.rs
@@ -24,7 +24,7 @@ use crate::recurrent_state::RecurrentState;
 use crate::weights::Qwen35Model;
 use openinfer_core::engine::{
     EngineHandle as SchedulerHandle, FinishReason, GenerateRequest as SchedulerRequest, TokenEvent,
-    TokenLogprob,
+    TokenLogprob, TokenSink,
 };
 use openinfer_core::kv_pool::KvState;
 use openinfer_core::sampler::SamplingParams;
@@ -41,7 +41,7 @@ use self::plan::{
 /// `BatchDecodeGraphState` at `graph_slot_idx` — NOT owned here.
 struct ActiveRequest35 {
     request_id: Option<String>,
-    token_tx: mpsc::UnboundedSender<TokenEvent>,
+    token_tx: TokenSink,
     kv: KvState,
     /// Index into `BatchDecodeGraphState.slot_states`.
     graph_slot_idx: usize,

--- a/openinfer-qwen35-4b/src/scheduler/tests.rs
+++ b/openinfer-qwen35-4b/src/scheduler/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 fn send_rejection_reports_kv_lifetime_request_tokens() {
-    let (token_tx, mut token_rx) = mpsc::unbounded_channel();
+    let (token_tx, mut token_rx) = TokenSink::standalone();
     let req = SchedulerRequest {
         request_id: Some("too-large".to_string()),
         queued_at_unix_s: None,
@@ -17,7 +17,7 @@ fn send_rejection_reports_kv_lifetime_request_tokens() {
 
     send_rejection(&req, RejectReason::KvBudget);
 
-    match token_rx.blocking_recv() {
+    match token_rx.blocking_recv().map(|(_, event)| event) {
         Some(TokenEvent::Rejected {
             message,
             prompt_tokens,
@@ -36,7 +36,7 @@ fn send_rejection_reports_kv_lifetime_request_tokens() {
 
 #[test]
 fn send_rejection_reports_context_window_limit() {
-    let (token_tx, mut token_rx) = mpsc::unbounded_channel();
+    let (token_tx, mut token_rx) = TokenSink::standalone();
     let req = SchedulerRequest {
         request_id: Some("too-long".to_string()),
         queued_at_unix_s: None,
@@ -51,7 +51,7 @@ fn send_rejection_reports_context_window_limit() {
 
     send_rejection(&req, RejectReason::ContextLength { limit: 32 });
 
-    match token_rx.blocking_recv() {
+    match token_rx.blocking_recv().map(|(_, event)| event) {
         Some(TokenEvent::Rejected {
             message,
             prompt_tokens,

--- a/openinfer-qwen35-4b/tests/e2e_scheduler.rs
+++ b/openinfer-qwen35-4b/tests/e2e_scheduler.rs
@@ -5,10 +5,11 @@
 use std::time::Instant;
 
 use log::info;
-use tokio::sync::mpsc;
 
 use openinfer_core::engine::FinishReason;
-use openinfer_core::engine::{EngineHandle, GenerateRequest, TokenEvent, TokenLogprob};
+use openinfer_core::engine::{
+    EngineHandle, GenerateRequest, TokenEvent, TokenLogprob, TokenSink, TokenStreamReceiver,
+};
 use openinfer_core::sampler::SamplingParams;
 use vllm_text::tokenizer::DynTokenizer;
 
@@ -117,7 +118,7 @@ fn generate_tokens_with_logprobs(
     logprobs: usize,
 ) -> GenerationResult {
     let prompt_tokens = tokenizer.encode(prompt, false).expect("encode failed");
-    let (token_tx, mut token_rx) = mpsc::unbounded_channel();
+    let (token_tx, mut token_rx) = TokenSink::standalone();
 
     handle
         .submit(GenerateRequest {
@@ -137,14 +138,14 @@ fn generate_tokens_with_logprobs(
 }
 
 fn collect_generation(
-    token_rx: &mut mpsc::UnboundedReceiver<TokenEvent>,
+    token_rx: &mut TokenStreamReceiver,
     name: &str,
     logprobs: usize,
 ) -> GenerationResult {
     let mut tokens = Vec::new();
     let mut token_logprobs = Vec::new();
     loop {
-        match token_rx.blocking_recv() {
+        match token_rx.blocking_recv().map(|(_, event)| event) {
             Some(TokenEvent::Token { id, logprob }) => {
                 if logprobs == 0 {
                     assert!(
@@ -193,7 +194,7 @@ fn collect_generation(
 }
 
 fn expect_context_window_rejection(handle: &EngineHandle, max_context_tokens: usize) {
-    let (token_tx, mut token_rx) = mpsc::unbounded_channel();
+    let (token_tx, mut token_rx) = TokenSink::standalone();
 
     handle
         .submit(GenerateRequest {
@@ -209,7 +210,7 @@ fn expect_context_window_rejection(handle: &EngineHandle, max_context_tokens: us
         })
         .expect("submit over-context request");
 
-    match token_rx.blocking_recv() {
+    match token_rx.blocking_recv().map(|(_, event)| event) {
         Some(TokenEvent::Rejected {
             message,
             prompt_tokens,
@@ -333,12 +334,12 @@ fn test_e2e_qwen35_scheduler() {
     // ── 4. Concurrent requests ──────────────────────────────────────────
     info!("=== Phase 4: Concurrent requests ===");
     {
-        let mut receivers: Vec<(String, usize, mpsc::UnboundedReceiver<TokenEvent>)> = Vec::new();
+        let mut receivers: Vec<(String, usize, TokenStreamReceiver)> = Vec::new();
 
         // Submit all cases concurrently
         for case in CASES {
             let prompt_tokens = tokenizer.encode(case.prompt, false).expect("encode failed");
-            let (token_tx, token_rx) = mpsc::unbounded_channel();
+            let (token_tx, token_rx) = TokenSink::standalone();
             handle
                 .submit(GenerateRequest {
                     request_id: None,
@@ -373,11 +374,11 @@ fn test_e2e_qwen35_scheduler() {
             ("mixed_no_logprobs", CASES[0].prompt, 0usize),
             ("mixed_with_logprobs", CASES[1].prompt, 1usize),
         ];
-        let mut receivers: Vec<(&str, usize, mpsc::UnboundedReceiver<TokenEvent>)> = Vec::new();
+        let mut receivers: Vec<(&str, usize, TokenStreamReceiver)> = Vec::new();
 
         for (name, prompt, logprobs) in mixed {
             let prompt_tokens = tokenizer.encode(prompt, false).expect("encode failed");
-            let (token_tx, token_rx) = mpsc::unbounded_channel();
+            let (token_tx, token_rx) = TokenSink::standalone();
             handle
                 .submit(GenerateRequest {
                     request_id: Some(name.to_string()),
@@ -416,7 +417,7 @@ fn test_e2e_qwen35_scheduler() {
     info!("=== Phase 5: Consumer drop ===");
     {
         let prompt_tokens = tokenizer.encode("Hello", false).expect("encode failed");
-        let (token_tx, rx) = mpsc::unbounded_channel();
+        let (token_tx, rx) = TokenSink::standalone();
         drop(rx);
         handle
             .submit(GenerateRequest {

--- a/openinfer-server/src/bin/bench_serving/decode.rs
+++ b/openinfer-server/src/bin/bench_serving/decode.rs
@@ -22,9 +22,8 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result, anyhow, bail, ensure};
 use log::{info, warn};
 use openinfer::sampler::SamplingParams;
-use openinfer::scheduler::{KvCapacity, SchedulerHandle, SchedulerRequest, TokenEvent};
+use openinfer::scheduler::{KvCapacity, SchedulerHandle, SchedulerRequest, TokenEvent, TokenSink};
 use openinfer::server_engine::ModelType;
-use tokio::sync::mpsc;
 
 use crate::cli::{Cli, DecodeArgs};
 use crate::exec::{BenchModel, run_scheduler_stream};
@@ -276,7 +275,7 @@ fn measure_decode_stream(
     params: SamplingParams,
     max_tokens: usize,
 ) -> Result<StreamResult> {
-    let (token_tx, mut token_rx) = mpsc::unbounded_channel();
+    let (token_tx, mut token_rx) = TokenSink::standalone();
     handle
         .submit(SchedulerRequest {
             request_id: Some(request_id),
@@ -297,7 +296,7 @@ fn measure_decode_stream(
     let mut first_at: Option<Instant> = None;
     let mut prev_at: Option<Instant> = None;
     loop {
-        match token_rx.blocking_recv() {
+        match token_rx.blocking_recv().map(|(_, event)| event) {
             Some(TokenEvent::Scheduled {
                 cached_tokens: cached,
                 ..

--- a/openinfer-server/src/bin/bench_serving/exec.rs
+++ b/openinfer-server/src/bin/bench_serving/exec.rs
@@ -6,10 +6,9 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Result, ensure};
 use rand::rngs::StdRng;
-use tokio::sync::mpsc;
 
 use openinfer::sampler::SamplingParams;
-use openinfer::scheduler::{SchedulerHandle, SchedulerRequest, TokenEvent};
+use openinfer::scheduler::{SchedulerHandle, SchedulerRequest, TokenEvent, TokenSink};
 
 pub(crate) struct GenTimings {
     pub(crate) ttft: Duration,
@@ -121,7 +120,7 @@ pub(crate) fn run_scheduler_stream(
     max_tokens: usize,
     mut on_token: impl FnMut(u32) -> bool,
 ) -> Result<StreamOutcome> {
-    let (token_tx, mut token_rx) = mpsc::unbounded_channel();
+    let (token_tx, mut token_rx) = TokenSink::standalone();
     handle
         .submit(SchedulerRequest {
             request_id,
@@ -137,7 +136,7 @@ pub(crate) fn run_scheduler_stream(
         .map_err(|e| anyhow::anyhow!("scheduler submit failed: {e}"))?;
 
     loop {
-        match token_rx.blocking_recv() {
+        match token_rx.blocking_recv().map(|(_, event)| event) {
             Some(TokenEvent::Token { id, .. }) => {
                 if !on_token(id) {
                     return Ok(StreamOutcome { finished: false });

--- a/openinfer-server/src/scheduler.rs
+++ b/openinfer-server/src/scheduler.rs
@@ -1,3 +1,4 @@
 pub use openinfer_core::engine::{
     EngineHandle as SchedulerHandle, GenerateRequest as SchedulerRequest, KvCapacity, TokenEvent,
+    TokenSink,
 };

--- a/openinfer-sim/src/lib.rs
+++ b/openinfer-sim/src/lib.rs
@@ -155,6 +155,7 @@ fn now_secs_f64() -> f64 {
 
 #[cfg(test)]
 mod tests {
+    use openinfer_engine::engine::TokenSink;
     use openinfer_engine::sampler::SamplingParams;
 
     use super::*;
@@ -180,7 +181,7 @@ mod tests {
     #[tokio::test]
     async fn simulated_request_emits_scheduled_tokens_and_finished() {
         let config = SimulatedEngineConfig::new(0.0, 100.0, 0.0, 42).unwrap();
-        let (token_tx, mut token_rx) = mpsc::unbounded_channel();
+        let (token_tx, mut token_rx) = TokenSink::standalone();
 
         run_simulated_request(
             GenerateRequest {
@@ -199,35 +200,35 @@ mod tests {
         .await;
 
         assert!(matches!(
-            token_rx.recv().await,
+            token_rx.recv().await.map(|(_, event)| event),
             Some(TokenEvent::Scheduled {
                 prompt_tokens: 2,
                 ..
             })
         ));
         assert!(matches!(
-            token_rx.recv().await,
+            token_rx.recv().await.map(|(_, event)| event),
             Some(TokenEvent::Token {
                 id: 7,
                 logprob: Some(_)
             })
         ));
         assert!(matches!(
-            token_rx.recv().await,
+            token_rx.recv().await.map(|(_, event)| event),
             Some(TokenEvent::Token {
                 id: 9,
                 logprob: Some(_)
             })
         ));
         assert!(matches!(
-            token_rx.recv().await,
+            token_rx.recv().await.map(|(_, event)| event),
             Some(TokenEvent::Token {
                 id: 7,
                 logprob: Some(_)
             })
         ));
         assert!(matches!(
-            token_rx.recv().await,
+            token_rx.recv().await.map(|(_, event)| event),
             Some(TokenEvent::Finished {
                 finish_reason: FinishReason::Length,
                 prompt_tokens: 2,

--- a/openinfer-vllm-frontend/src/bridge.rs
+++ b/openinfer-vllm-frontend/src/bridge.rs
@@ -1,12 +1,12 @@
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
 use log::{info, warn};
 use tokio::sync::mpsc;
-use tokio::sync::mpsc::error::TryRecvError;
-use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use vllm_engine_core_client::EngineId;
 use vllm_engine_core_client::protocol::handshake::EngineCoreReadyResponse;
@@ -23,7 +23,9 @@ use zeromq::prelude::{Socket, SocketRecv, SocketSend};
 use zeromq::util::PeerIdentity;
 use zeromq::{DealerSocket, PushSocket, SocketOptions, ZmqMessage};
 
-use openinfer_engine::engine::{EngineHandle, GenerateRequest, TokenEvent, TokenLogprob};
+use openinfer_engine::engine::{
+    EngineHandle, GenerateRequest, RequestTag, TokenEvent, TokenSink, TokenStreamReceiver,
+};
 
 use crate::wire::{
     convert_finish_reason, convert_sampling, lora_adapter_from_sampling_params, requested_logprobs,
@@ -87,8 +89,12 @@ impl LocalEngineBridge {
         let (output_tx, output_rx) = mpsc::unbounded_channel();
         let output_task = tokio::spawn(output_loop(output, output_rx));
 
-        let (done_tx, mut done_rx) = mpsc::unbounded_channel::<String>();
-        let mut active: HashMap<String, JoinHandle<()>> = HashMap::new();
+        // One shared channel carries every request's token events, tagged by
+        // request id; this loop is the sole consumer. Per-request state lives
+        // in `streams`, keyed by the same tag, and holds the cancel flag the
+        // scheduler observes (via `TokenSink`) when an abort flips it.
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let mut streams: HashMap<RequestTag, RequestStreamState> = HashMap::new();
 
         info!(
             "local vLLM engine bridge connected: input={}, output={}, max_model_len={}",
@@ -98,16 +104,20 @@ impl LocalEngineBridge {
         loop {
             tokio::select! {
                 () = shutdown.cancelled() => break,
-                Some(request_id) = done_rx.recv() => {
-                    active.remove(&request_id);
+                Some(first) = event_rx.recv() => {
+                    if let Err(error) =
+                        dispatch_burst(first, &mut event_rx, &mut streams, &output_tx)
+                    {
+                        warn!("local engine bridge output failed: {error:#}");
+                    }
                 }
                 recv = input.recv() => {
                     let message = recv.context("failed to receive local engine request")?;
                     if let Err(error) = self.handle_message(
                         message,
+                        &event_tx,
                         &output_tx,
-                        &done_tx,
-                        &mut active,
+                        &mut streams,
                     ) {
                         warn!("local engine bridge request failed: {error:#}");
                     }
@@ -115,8 +125,10 @@ impl LocalEngineBridge {
             }
         }
 
-        for (_, task) in active {
-            task.abort();
+        // Cancel every in-flight request so the scheduler retires them on its
+        // next emit instead of pushing into a channel no one drains.
+        for state in streams.values() {
+            state.cancelled.store(true, Ordering::Release);
         }
         drop(output_tx);
         output_task.abort();
@@ -127,9 +139,9 @@ impl LocalEngineBridge {
     fn handle_message(
         &self,
         message: ZmqMessage,
+        event_tx: &mpsc::UnboundedSender<(RequestTag, TokenEvent)>,
         output_tx: &mpsc::UnboundedSender<EngineCoreOutputs>,
-        done_tx: &mpsc::UnboundedSender<String>,
-        active: &mut HashMap<String, JoinHandle<()>>,
+        streams: &mut HashMap<RequestTag, RequestStreamState>,
     ) -> Result<()> {
         let frames = message.into_vec();
         if frames.len() != 2 {
@@ -143,14 +155,20 @@ impl LocalEngineBridge {
             ty if ty == EngineCoreRequestType::Add.to_frame().as_ref() => {
                 let request: EngineCoreRequest =
                     vllm_engine_core_client::protocol::decode_msgpack(&frames[1])?;
-                self.start_request(request, output_tx, done_tx, active)
+                self.start_request(request, event_tx, output_tx, streams)
             }
             ty if ty == EngineCoreRequestType::Abort.to_frame().as_ref() => {
                 let request_ids: Vec<String> =
                     vllm_engine_core_client::protocol::decode_msgpack(&frames[1])?;
                 for request_id in request_ids {
-                    if let Some(task) = active.remove(&request_id) {
-                        task.abort();
+                    // Drop our state first, then flip the cancel flag (so the
+                    // scheduler's next emit fails and retires the request). The
+                    // `Release` store orders the `streams.remove` before the
+                    // flag the scheduler reads with `Acquire`; any token already
+                    // in flight for this id is discarded by the demux when it
+                    // finds no stream entry.
+                    if let Some(state) = streams.remove(request_id.as_str()) {
+                        state.cancelled.store(true, Ordering::Release);
                     }
                 }
                 Ok(())
@@ -171,9 +189,9 @@ impl LocalEngineBridge {
     fn start_request(
         &self,
         request: EngineCoreRequest,
+        event_tx: &mpsc::UnboundedSender<(RequestTag, TokenEvent)>,
         output_tx: &mpsc::UnboundedSender<EngineCoreOutputs>,
-        done_tx: &mpsc::UnboundedSender<String>,
-        active: &mut HashMap<String, JoinHandle<()>>,
+        streams: &mut HashMap<RequestTag, RequestStreamState>,
     ) -> Result<()> {
         let EngineCoreRequest {
             request_id,
@@ -206,10 +224,12 @@ impl LocalEngineBridge {
             return Ok(());
         };
 
-        let (token_tx, token_rx) = mpsc::unbounded_channel();
+        let tag: RequestTag = Arc::from(request_id.as_str());
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let token_tx = TokenSink::new(tag.clone(), event_tx.clone(), Arc::clone(&cancelled));
         self.handle
             .submit(GenerateRequest {
-                request_id: Some(request_id.clone()),
+                request_id: Some(request_id),
                 queued_at_unix_s: Some(request.arrival_time),
                 prompt_tokens,
                 params: convert_sampling(&sampling_params),
@@ -221,36 +241,113 @@ impl LocalEngineBridge {
             })
             .context("failed to submit request to scheduler")?;
 
-        let output_tx = output_tx.clone();
-        let done_tx = done_tx.clone();
-        let task_request_id = request_id.clone();
-        let task = tokio::spawn(async move {
-            run_request_stream(task_request_id.clone(), token_rx, output_tx).await;
-            let _ = done_tx.send(task_request_id);
-        });
-        active.insert(request_id, task);
-
+        streams.insert(tag, RequestStreamState::new(cancelled));
         Ok(())
     }
 }
 
-async fn run_request_stream(
-    request_id: String,
-    mut token_rx: mpsc::UnboundedReceiver<TokenEvent>,
-    output_tx: mpsc::UnboundedSender<EngineCoreOutputs>,
-) {
-    let mut first_token_events = None;
-    let mut first_token_prefill_stats = None;
-    let mut has_sent_token_output = false;
-    let mut pending_event = None;
-    loop {
-        let event = match pending_event.take() {
-            Some(event) => event,
-            None => match token_rx.recv().await {
-                Some(event) => event,
-                None => return,
-            },
+/// Per-request demux state held by the bridge loop, keyed by [`RequestTag`].
+/// Replaces the former per-request task's locals; `first_token_*` flush onto
+/// the request's first output, `cancelled` is the flag the scheduler's
+/// [`TokenSink`] checks so an abort retires the request without closing the
+/// shared channel.
+struct RequestStreamState {
+    first_token_events: Option<Vec<EngineCoreEvent>>,
+    first_token_prefill_stats: Option<PrefillStats>,
+    cancelled: Arc<AtomicBool>,
+}
+
+impl RequestStreamState {
+    fn new(cancelled: Arc<AtomicBool>) -> Self {
+        Self {
+            first_token_events: None,
+            first_token_prefill_stats: None,
+            cancelled,
+        }
+    }
+}
+
+/// Drain the ready burst from the shared token channel (the `first` event plus
+/// everything already queued), bucket it per request preserving event order,
+/// fold each request's events into at most one `EngineCoreOutput`, and ship the
+/// whole burst as a single `EngineCoreOutputs` — collapsing what used to be N
+/// per-request ZMQ messages per step into one.
+fn dispatch_burst(
+    first: (RequestTag, TokenEvent),
+    event_rx: &mut TokenStreamReceiver,
+    streams: &mut HashMap<RequestTag, RequestStreamState>,
+    output_tx: &mpsc::UnboundedSender<EngineCoreOutputs>,
+) -> Result<()> {
+    // Bucket the burst by request, keeping first-seen order so outputs are
+    // deterministic and each request's events stay in arrival order.
+    let mut order: Vec<RequestTag> = Vec::new();
+    let mut buckets: HashMap<RequestTag, Vec<TokenEvent>> = HashMap::new();
+    let mut bucket = |tag: RequestTag, event: TokenEvent| {
+        if let Some(events) = buckets.get_mut(&tag) {
+            events.push(event);
+        } else {
+            order.push(Arc::clone(&tag));
+            buckets.insert(tag, vec![event]);
+        }
+    };
+    bucket(first.0, first.1);
+    while let Ok((tag, event)) = event_rx.try_recv() {
+        bucket(tag, event);
+    }
+
+    let mut outputs: Vec<EngineCoreOutput> = Vec::with_capacity(order.len());
+    let mut finished_requests: BTreeSet<String> = BTreeSet::new();
+    for tag in order {
+        let events = buckets.remove(&tag).expect("bucket for ordered tag");
+        // No stream entry means the request was aborted or already finished;
+        // its late events are dropped.
+        let Some(state) = streams.get_mut(&tag) else {
+            continue;
         };
+        let (output, terminated) = reduce_request(&tag, state, events);
+        if let Some(output) = output {
+            outputs.push(output);
+        }
+        if terminated {
+            streams.remove(&tag);
+            finished_requests.insert(tag.to_string());
+        }
+    }
+
+    if outputs.is_empty() {
+        return Ok(());
+    }
+    send_outputs(
+        output_tx,
+        EngineCoreOutputs {
+            engine_index: ENGINE_INDEX,
+            outputs,
+            finished_requests: (!finished_requests.is_empty()).then_some(finished_requests),
+            timestamp: now_secs_f64(),
+            ..Default::default()
+        },
+    )
+}
+
+/// Fold one request's events from a single burst into at most one output.
+/// Tokens coalesce, and a trailing terminal rides the same output carrying its
+/// finish reason; `first_token_events`/`prefill_stats` flush onto whichever
+/// output goes first. A lone `Scheduled` (no token, no terminal) yields no
+/// output — its metadata waits in `state` for the first real output. Returns
+/// `(output, terminated)`.
+fn reduce_request(
+    request_id: &str,
+    state: &mut RequestStreamState,
+    events: Vec<TokenEvent>,
+) -> (Option<EngineCoreOutput>, bool) {
+    let mut token_ids: Vec<u32> = Vec::new();
+    let mut positions: Vec<PositionLogprobs> = Vec::new();
+    let mut has_logprobs = false;
+    let mut finish_reason: Option<EngineCoreFinishReason> = None;
+    let mut stop_reason: Option<StopReason> = None;
+    let mut terminated = false;
+
+    for event in events {
         match event {
             TokenEvent::Scheduled {
                 queued_at_unix_s,
@@ -258,7 +355,7 @@ async fn run_request_stream(
                 prompt_tokens,
                 cached_tokens,
             } => {
-                first_token_events = Some(vec![
+                state.first_token_events = Some(vec![
                     EngineCoreEvent {
                         r#type: EngineCoreEventType::Queued,
                         timestamp: queued_at_unix_s,
@@ -271,7 +368,7 @@ async fn run_request_stream(
                 // Upstream invariant: computed (actual prefill work) +
                 // cached (prefix-cache hit) == prompt; double-counting skews
                 // the per-source prompt token metrics.
-                first_token_prefill_stats = Some(PrefillStats {
+                state.first_token_prefill_stats = Some(PrefillStats {
                     num_prompt_tokens: prompt_tokens as u32,
                     num_computed_tokens: prompt_tokens.saturating_sub(cached_tokens) as u32,
                     num_cached_tokens: cached_tokens as u32,
@@ -280,74 +377,55 @@ async fn run_request_stream(
                 });
             }
             TokenEvent::Token { id, logprob } => {
-                // Keep the first streamed token on the direct path so TTFT
-                // does not pay an extra scheduler turn. Later decode bursts
-                // still benefit from one-turn coalescing before draining the
-                // ready queue into one bridge output.
-                if has_sent_token_output {
-                    tokio::task::yield_now().await;
+                token_ids.push(id);
+                if let Some(position) = to_wire_position_logprobs(id, logprob) {
+                    has_logprobs = true;
+                    positions.push(position);
+                } else {
+                    positions.push(PositionLogprobs {
+                        entries: Vec::new(),
+                    });
                 }
-                let (token_ids, batched_logprobs, next_event) =
-                    collect_ready_token_batch(id, logprob, &mut token_rx);
-                pending_event = next_event;
-                if send_token_output(
-                    &output_tx,
-                    &request_id,
-                    token_ids,
-                    batched_logprobs,
-                    first_token_events.take(),
-                    first_token_prefill_stats.take(),
-                )
-                .is_err()
-                {
-                    return;
-                }
-                has_sent_token_output = true;
             }
             TokenEvent::PromptTokens { .. } => {
                 // Prompt logprobs are intentionally deferred for this bridge.
             }
-            TokenEvent::Finished { finish_reason, .. } => {
-                // A request can finish without emitting a token (EOS sampled
-                // on prefill) — flush the pending scheduled events and prefill
-                // stats with the terminal output or they are lost.
-                let _ = send_terminal_output(
-                    &output_tx,
-                    request_id,
-                    convert_finish_reason(finish_reason),
-                    None,
-                    first_token_events.take(),
-                    first_token_prefill_stats.take(),
-                );
-                return;
+            TokenEvent::Finished { finish_reason: fr, .. } => {
+                finish_reason = Some(convert_finish_reason(fr));
+                terminated = true;
             }
             TokenEvent::Error { message, .. } => {
                 warn!("request {request_id} failed: {message}");
-                let _ = send_terminal_output(
-                    &output_tx,
-                    request_id,
-                    EngineCoreFinishReason::Error,
-                    Some(StopReason::Text(message)),
-                    None,
-                    None,
-                );
-                return;
+                finish_reason = Some(EngineCoreFinishReason::Error);
+                stop_reason = Some(StopReason::Text(message));
+                terminated = true;
             }
             TokenEvent::Rejected { message, .. } => {
-                // Rejected means the request could not be admitted, not that it completed cleanly.
+                // Rejected means the request could not be admitted, not that it
+                // completed cleanly.
                 warn!("request {request_id} rejected: {message}");
-                let _ = send_terminal_output(
-                    &output_tx,
-                    request_id,
-                    EngineCoreFinishReason::Error,
-                    Some(StopReason::Text(message)),
-                    None,
-                    None,
-                );
-                return;
+                finish_reason = Some(EngineCoreFinishReason::Error);
+                stop_reason = Some(StopReason::Text(message));
+                terminated = true;
             }
         }
     }
+
+    if token_ids.is_empty() && !terminated {
+        return (None, false);
+    }
+
+    let logprobs = has_logprobs.then_some(MaybeWireLogprobs::Direct(Logprobs { positions }));
+    let output = engine_output(
+        request_id.to_string(),
+        token_ids,
+        logprobs,
+        finish_reason,
+        stop_reason,
+        state.first_token_events.take(),
+        state.first_token_prefill_stats.take(),
+    );
+    (Some(output), terminated)
 }
 
 async fn output_loop(
@@ -361,33 +439,6 @@ async fn output_loop(
             .context("failed to send local engine output")?;
     }
     Ok(())
-}
-
-fn send_token_output(
-    output_tx: &mpsc::UnboundedSender<EngineCoreOutputs>,
-    request_id: &str,
-    token_ids: Vec<u32>,
-    logprobs: Option<MaybeWireLogprobs>,
-    events: Option<Vec<EngineCoreEvent>>,
-    prefill_stats: Option<PrefillStats>,
-) -> Result<()> {
-    send_outputs(
-        output_tx,
-        EngineCoreOutputs {
-            engine_index: ENGINE_INDEX,
-            outputs: vec![engine_output(
-                request_id.to_string(),
-                token_ids,
-                logprobs,
-                None,
-                None,
-                events,
-                prefill_stats,
-            )],
-            timestamp: now_secs_f64(),
-            ..Default::default()
-        },
-    )
 }
 
 fn send_terminal_output(
@@ -481,49 +532,6 @@ fn engine_output(
     }
 }
 
-fn collect_ready_token_batch(
-    first_id: u32,
-    first_logprob: Option<TokenLogprob>,
-    token_rx: &mut mpsc::UnboundedReceiver<TokenEvent>,
-) -> (Vec<u32>, Option<MaybeWireLogprobs>, Option<TokenEvent>) {
-    let mut token_ids = Vec::with_capacity(4);
-    let mut positions = Vec::with_capacity(4);
-    let mut has_logprobs = false;
-
-    let mut push_token = |token_id: u32, logprob: Option<TokenLogprob>| {
-        token_ids.push(token_id);
-        if let Some(position) = to_wire_position_logprobs(token_id, logprob) {
-            has_logprobs = true;
-            positions.push(position);
-        } else {
-            positions.push(PositionLogprobs {
-                entries: Vec::new(),
-            });
-        }
-    };
-    push_token(first_id, first_logprob);
-
-    loop {
-        match token_rx.try_recv() {
-            Ok(TokenEvent::Token { id, logprob }) => push_token(id, logprob),
-            Ok(other) => {
-                return (
-                    token_ids,
-                    has_logprobs.then_some(MaybeWireLogprobs::Direct(Logprobs { positions })),
-                    Some(other),
-                );
-            }
-            Err(TryRecvError::Empty | TryRecvError::Disconnected) => {
-                return (
-                    token_ids,
-                    has_logprobs.then_some(MaybeWireLogprobs::Direct(Logprobs { positions })),
-                    None,
-                );
-            }
-        }
-    }
-}
-
 fn now_secs_f64() -> f64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -563,27 +571,82 @@ async fn wait_for_ipc_endpoint(address: &str, shutdown: &CancellationToken) -> R
 
 #[cfg(test)]
 mod tests {
-    use openinfer_engine::engine::FinishReason;
+    use openinfer_engine::engine::{FinishReason, TokenLogprob};
 
     use super::*;
 
-    #[tokio::test]
-    async fn rejected_request_is_reported_as_error() {
-        let (token_tx, token_rx) = mpsc::unbounded_channel();
-        let (output_tx, mut output_rx) = mpsc::unbounded_channel();
+    /// Test harness that exercises the bridge's demux path directly: register
+    /// requests, emit tagged events onto the shared channel, drain one ready
+    /// burst at a time, and inspect the coalesced outputs — the same flow the
+    /// `run` loop drives, minus the sockets.
+    struct Demux {
+        event_tx: mpsc::UnboundedSender<(RequestTag, TokenEvent)>,
+        event_rx: TokenStreamReceiver,
+        streams: HashMap<RequestTag, RequestStreamState>,
+        output_tx: mpsc::UnboundedSender<EngineCoreOutputs>,
+        output_rx: mpsc::UnboundedReceiver<EngineCoreOutputs>,
+    }
 
-        token_tx
-            .send(TokenEvent::Rejected {
+    impl Demux {
+        fn new() -> Self {
+            let (event_tx, event_rx) = mpsc::unbounded_channel();
+            let (output_tx, output_rx) = mpsc::unbounded_channel();
+            Self {
+                event_tx,
+                event_rx,
+                streams: HashMap::new(),
+                output_tx,
+                output_rx,
+            }
+        }
+
+        /// Register a request as `start_request` does and return its cancel flag.
+        fn add(&mut self, id: &str) -> Arc<AtomicBool> {
+            let tag: RequestTag = Arc::from(id);
+            let cancelled = Arc::new(AtomicBool::new(false));
+            self.streams
+                .insert(Arc::clone(&tag), RequestStreamState::new(Arc::clone(&cancelled)));
+            cancelled
+        }
+
+        fn emit(&self, id: &str, event: TokenEvent) {
+            self.event_tx
+                .send((Arc::from(id), event))
+                .expect("emit token event");
+        }
+
+        /// Process one ready burst. Returns false if nothing was queued.
+        fn drain(&mut self) -> bool {
+            match self.event_rx.try_recv() {
+                Ok(first) => {
+                    dispatch_burst(first, &mut self.event_rx, &mut self.streams, &self.output_tx)
+                        .expect("dispatch burst");
+                    true
+                }
+                Err(_) => false,
+            }
+        }
+
+        fn next_output(&mut self) -> Option<EngineCoreOutputs> {
+            self.output_rx.try_recv().ok()
+        }
+    }
+
+    #[test]
+    fn rejected_request_is_reported_as_error() {
+        let mut d = Demux::new();
+        d.add("req-1");
+        d.emit(
+            "req-1",
+            TokenEvent::Rejected {
                 message: "request is too large for KV cache".to_string(),
                 prompt_tokens: 16,
                 completion_tokens: 0,
-            })
-            .expect("send rejected event");
-        drop(token_tx);
+            },
+        );
+        assert!(d.drain());
 
-        run_request_stream("req-1".to_string(), token_rx, output_tx).await;
-
-        let outputs = output_rx.recv().await.expect("terminal output");
+        let outputs = d.next_output().expect("terminal output");
         assert!(
             outputs
                 .finished_requests
@@ -600,63 +663,72 @@ mod tests {
                 "request is too large for KV cache".to_string()
             ))
         );
+        assert!(d.next_output().is_none());
+        assert!(!d.streams.contains_key("req-1"), "finished stream is removed");
     }
 
-    #[tokio::test]
-    async fn consecutive_tokens_are_batched_into_one_output() {
-        let (token_tx, token_rx) = mpsc::unbounded_channel();
-        let (output_tx, mut output_rx) = mpsc::unbounded_channel();
-
-        token_tx
-            .send(TokenEvent::Scheduled {
+    /// Token(s) and the terminal arriving in one burst (EmitAndFinish) coalesce
+    /// into a single output carrying both the tokens and the finish reason —
+    /// the canonical vLLM shape, one wire message instead of two.
+    #[test]
+    fn token_and_finish_in_one_burst_coalesce() {
+        let mut d = Demux::new();
+        d.add("req-1");
+        d.emit(
+            "req-1",
+            TokenEvent::Scheduled {
                 queued_at_unix_s: 1.0,
                 scheduled_at_unix_s: 2.0,
                 prompt_tokens: 16,
                 cached_tokens: 0,
-            })
-            .expect("send scheduled");
-        token_tx
-            .send(TokenEvent::Token {
+            },
+        );
+        d.emit(
+            "req-1",
+            TokenEvent::Token {
                 id: 11,
                 logprob: Some(TokenLogprob {
                     logprob: -0.1,
                     top_logprobs: vec![(11, -0.1), (12, -0.5)],
                 }),
-            })
-            .expect("send token 1");
-        token_tx
-            .send(TokenEvent::Token {
+            },
+        );
+        d.emit(
+            "req-1",
+            TokenEvent::Token {
                 id: 21,
                 logprob: Some(TokenLogprob {
                     logprob: -0.2,
                     top_logprobs: vec![(21, -0.2), (22, -0.6)],
                 }),
-            })
-            .expect("send token 2");
-        token_tx
-            .send(TokenEvent::Finished {
+            },
+        );
+        d.emit(
+            "req-1",
+            TokenEvent::Finished {
                 finish_reason: FinishReason::Length,
                 prompt_tokens: 16,
                 completion_tokens: 2,
-            })
-            .expect("send finished");
-        drop(token_tx);
+            },
+        );
+        assert!(d.drain());
 
-        run_request_stream("req-1".to_string(), token_rx, output_tx).await;
+        let outputs = d.next_output().expect("coalesced output");
+        assert_eq!(outputs.outputs.len(), 1);
+        let output = &outputs.outputs[0];
+        assert_eq!(output.request_id, "req-1");
+        assert_eq!(output.new_token_ids, vec![11, 21]);
+        assert_eq!(output.finish_reason, Some(EngineCoreFinishReason::Length));
+        assert!(output.events.is_some());
+        assert!(output.prefill_stats.is_some());
+        assert!(
+            outputs
+                .finished_requests
+                .as_ref()
+                .is_some_and(|requests| requests.contains("req-1"))
+        );
 
-        let token_outputs = output_rx.recv().await.expect("token output");
-        assert_eq!(token_outputs.outputs.len(), 1);
-        assert_eq!(token_outputs.outputs[0].request_id, "req-1");
-        assert_eq!(token_outputs.outputs[0].new_token_ids, vec![11, 21]);
-        assert!(token_outputs.outputs[0].finish_reason.is_none());
-        assert!(token_outputs.outputs[0].events.is_some());
-        assert!(token_outputs.outputs[0].prefill_stats.is_some());
-
-        let direct = match token_outputs.outputs[0]
-            .new_logprobs
-            .as_ref()
-            .expect("batched logprobs")
-        {
+        let direct = match output.new_logprobs.as_ref().expect("batched logprobs") {
             MaybeWireLogprobs::Direct(direct) => direct,
             MaybeWireLogprobs::Wire(_) => panic!("expected direct batched logprobs"),
         };
@@ -664,7 +736,47 @@ mod tests {
         assert_eq!(direct.positions[0].entries[0].token_id, 11);
         assert_eq!(direct.positions[1].entries[0].token_id, 21);
 
-        let terminal = output_rx.recv().await.expect("terminal output");
+        assert!(d.next_output().is_none());
+    }
+
+    /// Tokens that stream over several steps and a finish that lands later
+    /// arrive in separate bursts: a token output first, a terminal output once
+    /// the finish shows up.
+    #[test]
+    fn tokens_then_finish_in_separate_bursts() {
+        let mut d = Demux::new();
+        d.add("req-1");
+        d.emit(
+            "req-1",
+            TokenEvent::Token {
+                id: 11,
+                logprob: None,
+            },
+        );
+        d.emit(
+            "req-1",
+            TokenEvent::Token {
+                id: 21,
+                logprob: None,
+            },
+        );
+        assert!(d.drain());
+        let token_out = d.next_output().expect("token output");
+        assert_eq!(token_out.outputs[0].new_token_ids, vec![11, 21]);
+        assert!(token_out.outputs[0].finish_reason.is_none());
+        assert!(token_out.finished_requests.is_none());
+
+        d.emit(
+            "req-1",
+            TokenEvent::Finished {
+                finish_reason: FinishReason::Length,
+                prompt_tokens: 16,
+                completion_tokens: 2,
+            },
+        );
+        assert!(d.drain());
+        let terminal = d.next_output().expect("terminal output");
+        assert!(terminal.outputs[0].new_token_ids.is_empty());
         assert_eq!(
             terminal.outputs[0].finish_reason,
             Some(EngineCoreFinishReason::Length)
@@ -675,46 +787,49 @@ mod tests {
                 .as_ref()
                 .is_some_and(|requests| requests.contains("req-1"))
         );
-        assert!(output_rx.recv().await.is_none());
+        assert!(d.next_output().is_none());
     }
 
-    #[tokio::test]
-    async fn first_token_metadata_is_only_sent_with_first_batch() {
-        let (token_tx, token_rx) = mpsc::unbounded_channel();
-        let (output_tx, mut output_rx) = mpsc::unbounded_channel();
-
-        token_tx
-            .send(TokenEvent::Scheduled {
+    #[test]
+    fn first_token_metadata_is_only_sent_with_first_output() {
+        let mut d = Demux::new();
+        d.add("req-2");
+        d.emit(
+            "req-2",
+            TokenEvent::Scheduled {
                 queued_at_unix_s: 1.0,
                 scheduled_at_unix_s: 2.0,
                 prompt_tokens: 8,
                 cached_tokens: 5,
-            })
-            .expect("send scheduled");
-        token_tx
-            .send(TokenEvent::Token {
+            },
+        );
+        d.emit(
+            "req-2",
+            TokenEvent::Token {
                 id: 1,
                 logprob: None,
-            })
-            .expect("send first token");
-        token_tx
-            .send(TokenEvent::PromptTokens {
+            },
+        );
+        assert!(d.drain());
+
+        d.emit(
+            "req-2",
+            TokenEvent::PromptTokens {
                 ids: vec![9],
                 logprobs: vec![None],
-            })
-            .expect("send prompt token metadata");
-        token_tx
-            .send(TokenEvent::Token {
+            },
+        );
+        d.emit(
+            "req-2",
+            TokenEvent::Token {
                 id: 2,
                 logprob: None,
-            })
-            .expect("send second token");
-        drop(token_tx);
+            },
+        );
+        assert!(d.drain());
 
-        run_request_stream("req-2".to_string(), token_rx, output_tx).await;
-
-        let first_batch = output_rx.recv().await.expect("first batch");
-        let second_batch = output_rx.recv().await.expect("second batch");
+        let first_batch = d.next_output().expect("first batch");
+        let second_batch = d.next_output().expect("second batch");
         assert_eq!(first_batch.outputs[0].new_token_ids, vec![1]);
         assert_eq!(second_batch.outputs[0].new_token_ids, vec![2]);
         assert!(first_batch.outputs[0].events.is_some());
@@ -731,37 +846,71 @@ mod tests {
         );
         assert!(second_batch.outputs[0].events.is_none());
         assert!(second_batch.outputs[0].prefill_stats.is_none());
-        assert!(output_rx.recv().await.is_none());
+        assert!(d.next_output().is_none());
+    }
+
+    /// A lone `Scheduled` (no token yet) emits nothing; its metadata waits in
+    /// the stream state and flushes onto the first real output.
+    #[test]
+    fn lone_scheduled_defers_until_first_token() {
+        let mut d = Demux::new();
+        d.add("req-defer");
+        d.emit(
+            "req-defer",
+            TokenEvent::Scheduled {
+                queued_at_unix_s: 1.0,
+                scheduled_at_unix_s: 2.0,
+                prompt_tokens: 4,
+                cached_tokens: 0,
+            },
+        );
+        assert!(d.drain());
+        assert!(d.next_output().is_none(), "scheduled alone emits nothing");
+        assert!(d.streams.contains_key("req-defer"), "stream is retained");
+
+        d.emit(
+            "req-defer",
+            TokenEvent::Token {
+                id: 7,
+                logprob: None,
+            },
+        );
+        assert!(d.drain());
+        let output = d.next_output().expect("first token output");
+        assert_eq!(output.outputs[0].new_token_ids, vec![7]);
+        assert!(
+            output.outputs[0].events.is_some(),
+            "deferred scheduled events flush onto the first token"
+        );
     }
 
     /// A request that stops on its first sampled token never emits `Token`
     /// — the terminal output must still deliver the scheduled events and
     /// prefill stats or cached_tokens silently vanishes from usage.
-    #[tokio::test]
-    async fn stop_on_prefill_terminal_output_carries_prefill_stats() {
-        let (token_tx, token_rx) = mpsc::unbounded_channel();
-        let (output_tx, mut output_rx) = mpsc::unbounded_channel();
-
-        token_tx
-            .send(TokenEvent::Scheduled {
+    #[test]
+    fn stop_on_prefill_terminal_output_carries_prefill_stats() {
+        let mut d = Demux::new();
+        d.add("req-stop");
+        d.emit(
+            "req-stop",
+            TokenEvent::Scheduled {
                 queued_at_unix_s: 1.0,
                 scheduled_at_unix_s: 2.0,
                 prompt_tokens: 16,
                 cached_tokens: 4,
-            })
-            .expect("send scheduled");
-        token_tx
-            .send(TokenEvent::Finished {
+            },
+        );
+        d.emit(
+            "req-stop",
+            TokenEvent::Finished {
                 finish_reason: FinishReason::Stop,
                 prompt_tokens: 16,
                 completion_tokens: 0,
-            })
-            .expect("send finished");
-        drop(token_tx);
+            },
+        );
+        assert!(d.drain());
 
-        run_request_stream("req-stop".to_string(), token_rx, output_tx).await;
-
-        let terminal = output_rx.recv().await.expect("terminal output");
+        let terminal = d.next_output().expect("terminal output");
         let output = &terminal.outputs[0];
         assert_eq!(output.finish_reason, Some(EngineCoreFinishReason::Stop));
         assert!(
@@ -774,34 +923,33 @@ mod tests {
             .expect("terminal output must flush prefill stats");
         assert_eq!(stats.num_cached_tokens, 4);
         assert_eq!(stats.num_computed_tokens, 12);
-        assert!(output_rx.recv().await.is_none());
+        assert!(d.next_output().is_none());
     }
 
-    #[tokio::test]
-    async fn mixed_logprob_batch_keeps_token_alignment() {
-        let (token_tx, token_rx) = mpsc::unbounded_channel();
-        let (output_tx, mut output_rx) = mpsc::unbounded_channel();
-
-        token_tx
-            .send(TokenEvent::Token {
+    #[test]
+    fn mixed_logprob_batch_keeps_token_alignment() {
+        let mut d = Demux::new();
+        d.add("req-3");
+        d.emit(
+            "req-3",
+            TokenEvent::Token {
                 id: 31,
                 logprob: None,
-            })
-            .expect("send token without logprob");
-        token_tx
-            .send(TokenEvent::Token {
+            },
+        );
+        d.emit(
+            "req-3",
+            TokenEvent::Token {
                 id: 32,
                 logprob: Some(TokenLogprob {
                     logprob: -0.3,
                     top_logprobs: vec![(32, -0.3), (33, -0.7)],
                 }),
-            })
-            .expect("send token with logprob");
-        drop(token_tx);
+            },
+        );
+        assert!(d.drain());
 
-        run_request_stream("req-3".to_string(), token_rx, output_tx).await;
-
-        let batch = output_rx.recv().await.expect("batched output");
+        let batch = d.next_output().expect("batched output");
         let direct = match batch.outputs[0]
             .new_logprobs
             .as_ref()
@@ -815,7 +963,73 @@ mod tests {
         assert_eq!(direct.positions.len(), 2);
         assert!(direct.positions[0].entries.is_empty());
         assert_eq!(direct.positions[1].entries[0].token_id, 32);
-        assert!(output_rx.recv().await.is_none());
+        assert!(d.next_output().is_none());
+    }
+
+    /// Many requests' tokens in one burst coalesce into a single
+    /// `EngineCoreOutputs` with one `EngineCoreOutput` each — the N→1 wire
+    /// collapse that motivated the demux.
+    #[test]
+    fn burst_batches_multiple_requests_into_one_message() {
+        let mut d = Demux::new();
+        d.add("req-a");
+        d.add("req-b");
+        d.emit(
+            "req-a",
+            TokenEvent::Token {
+                id: 1,
+                logprob: None,
+            },
+        );
+        d.emit(
+            "req-b",
+            TokenEvent::Token {
+                id: 2,
+                logprob: None,
+            },
+        );
+        assert!(d.drain());
+
+        let outputs = d.next_output().expect("one coalesced message");
+        assert_eq!(outputs.outputs.len(), 2);
+        let a = outputs
+            .outputs
+            .iter()
+            .find(|o| o.request_id == "req-a")
+            .expect("req-a output");
+        let b = outputs
+            .outputs
+            .iter()
+            .find(|o| o.request_id == "req-b")
+            .expect("req-b output");
+        assert_eq!(a.new_token_ids, vec![1]);
+        assert_eq!(b.new_token_ids, vec![2]);
+        assert!(d.next_output().is_none(), "exactly one wire message");
+    }
+
+    /// After an abort removes the stream entry, a token already in flight for
+    /// that request is dropped instead of producing a stray output.
+    #[test]
+    fn aborted_request_drops_late_tokens() {
+        let mut d = Demux::new();
+        let cancelled = d.add("req-abort");
+
+        // Replicate the Abort handler: flip the cancel flag, drop the stream.
+        cancelled.store(true, Ordering::Relaxed);
+        d.streams.remove("req-abort");
+
+        d.emit(
+            "req-abort",
+            TokenEvent::Token {
+                id: 99,
+                logprob: None,
+            },
+        );
+        assert!(d.drain(), "the late event is consumed");
+        assert!(
+            d.next_output().is_none(),
+            "no output is produced for an aborted request"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Collapses the frontend's per-request output fan-out into **one request-tagged channel + one bridge demux loop**.

Before, each in-flight request got its own `mpsc` channel and its own `run_request_stream` consumer task. At high concurrency `apply_effects` woke N distinct frontend tasks per scheduler step (~250µs of the ~380µs GPU bubble at bs=128), even though the consumer/wire side already funnels everything through a single `output_tx` → one ZMQ socket. The per-request fan-out was vestigial.

## How

- **Contract** (`openinfer-engine`): `GenerateRequest.token_tx` is now a `TokenSink` — a drop-in wrapper over a shared `UnboundedSender<(Arc<str>, TokenEvent)>` + an `Arc<AtomicBool>` cancel flag. It keeps `.send()/.is_closed()/.clone()`, so **every scheduler call site is unchanged**.
- **Demux** (`openinfer-vllm-frontend`): one loop replaces the N tasks. It `recv`s one tagged event, `try_recv`-drains the ready burst, buckets by request id (order-preserving), folds each request's events into ≤1 `EngineCoreOutput`, and ships **one** `EngineCoreOutputs` per burst → N→1 wakeups, tasks, and ZMQ messages per step. Token + finish landing in the same burst coalesce into the canonical single vLLM message.
- **Cancellation** is the flag, not a channel: abort flips it (`Release`) + drops the bridge stream entry; the scheduler reads it (`Acquire`) on its next emit and retires the request — same reactive retirement consumer-drop gave, with no cancel drain and no external→internal id registry.

`qwen3` is the reference migration; `qwen35`, `deepseek-v4`, `deepseek-v2-lite`, `kimi-k2`, and the sim follow by uniform type-swap (`deepseek-v4` keeps the whole `GenerateRequest`, so it was already drop-in). Also migrates the two `openinfer-server` `bench_serving` bins — the `--lib` test runs never compiled the server binaries, so that gap was invisible until a `cargo build --release`.

## Testing

- `cargo build --release` green; `cargo test --release --workspace --lib` green for every touched non-gated crate (engine 6, vllm-frontend 29, qwen3 43, sim 3). Bridge tests cover burst coalescing, token+finish in one burst vs. across bursts, first-token-metadata flush-once, lone-`Scheduled` deferral, multi-request N→1 batching, and aborted-late-token drop.
- **GPU end-to-end** (RTX 5070 Ti / Qwen3-4B): single + streaming + concurrency-32 (0 errors) + mid-stream client disconnect (server stays healthy).
- **A/B throughput vs `main`** (same machine, identical KV pool), output tok/s, 3 runs each:

  | workload | this branch | main | delta |
  |---|---|---|---|
  | c=96, out=256 | 5594 | 5551 | +0.8% (within noise) |
  | c=128, out=128 | 7517 | 7502 | +0.2% (within noise) |
  | c=192, out=128 | 7764 | 7698 | +0.9% (non-overlapping ranges) |

  Throughput-neutral-to-slightly-positive on this memory-bound GPU — exactly the predicted noise-floor win here. The payoff regime is fast decode GPUs (H20/H100, bubble → 10–15%) or N≫128.

The feature-gated crates (`qwen35`, `deepseek-v4`, `kimi-k2`) can't link in this env (Triton/TileLang/NCCL toolchains absent); their migration is the same uniform type-swap and is compile-verified structurally.

## Notes

- Rebased on `main` (`6b7c201`, includes #404).
- The docs commit also records a **pre-existing, out-of-scope** bug found while benchmarking: under sustained high concurrency the GPU worker panics in a cudarc copy and the engine wedges permanently while `/health` stays 200. It reproduces on `main` independently of this change — filed as #403. Included here only as a Known-issue doc note.

Design write-up: `docs/subsystems/scheduler/output-dispatch.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
