### PR TITLE
fix(ci): restore green CI — sim fixture vocab_size + rustfmt

### DIFF
--- a/openinfer-kimi-k2/src/lib.rs
+++ b/openinfer-kimi-k2/src/lib.rs
@@ -14,9 +14,9 @@
 use std::path::Path;
 
 use anyhow::Result;
-use openinfer_core::engine::{EngineHandle, EngineLoadOptions};
 #[cfg(feature = "kimi-k2")]
 use openinfer_core::engine::EpBackend;
+use openinfer_core::engine::{EngineHandle, EngineLoadOptions};
 
 #[cfg(feature = "kimi-k2")]
 pub mod batch_decode_trace;

--- a/openinfer-server/src/main.rs
+++ b/openinfer-server/src/main.rs
@@ -111,13 +111,17 @@ async fn main() -> anyhow::Result<()> {
 fn load_engine(args: &Args, model_type: ModelType) -> anyhow::Result<EngineHandle> {
     let handle = match model_type {
         #[cfg(feature = "deepseek-v4")]
-        ModelType::DeepSeekV4 => {
-            openinfer_deepseek_v4::launch(&args.model_path, args.cuda_graph, args.deepseek_prefill_profile)
-                .context("failed to start DeepSeek V4 engine")?
-        }
+        ModelType::DeepSeekV4 => openinfer_deepseek_v4::launch(
+            &args.model_path,
+            args.cuda_graph,
+            args.deepseek_prefill_profile,
+        )
+        .context("failed to start DeepSeek V4 engine")?,
         #[cfg(feature = "deepseek-v2-lite")]
-        ModelType::DeepSeekV2Lite => openinfer_deepseek_v2_lite::launch(&args.model_path, args.cuda_graph)
-            .context("failed to start DeepSeek V2 Lite engine")?,
+        ModelType::DeepSeekV2Lite => {
+            openinfer_deepseek_v2_lite::launch(&args.model_path, args.cuda_graph)
+                .context("failed to start DeepSeek V2 Lite engine")?
+        }
         #[cfg(feature = "kimi-k2")]
         ModelType::KimiK2 => openinfer_kimi_k2::launch(
             &args.model_path,

--- a/openinfer-sim/tests/frontend_e2e.rs
+++ b/openinfer-sim/tests/frontend_e2e.rs
@@ -427,5 +427,6 @@ const TINY_TOKENIZER_CONFIG_JSON: &str = r#"{
 
 const TINY_CONFIG_JSON: &str = r#"{
   "model_type": "openinfer_sim",
-  "max_position_embeddings": 128
+  "max_position_embeddings": 128,
+  "vocab_size": 3
 }"#;

--- a/openinfer-vllm-frontend/src/bridge.rs
+++ b/openinfer-vllm-frontend/src/bridge.rs
@@ -390,7 +390,9 @@ fn reduce_request(
             TokenEvent::PromptTokens { .. } => {
                 // Prompt logprobs are intentionally deferred for this bridge.
             }
-            TokenEvent::Finished { finish_reason: fr, .. } => {
+            TokenEvent::Finished {
+                finish_reason: fr, ..
+            } => {
                 finish_reason = Some(convert_finish_reason(fr));
                 terminated = true;
             }
@@ -604,8 +606,10 @@ mod tests {
         fn add(&mut self, id: &str) -> Arc<AtomicBool> {
             let tag: RequestTag = Arc::from(id);
             let cancelled = Arc::new(AtomicBool::new(false));
-            self.streams
-                .insert(Arc::clone(&tag), RequestStreamState::new(Arc::clone(&cancelled)));
+            self.streams.insert(
+                Arc::clone(&tag),
+                RequestStreamState::new(Arc::clone(&cancelled)),
+            );
             cancelled
         }
 
@@ -619,8 +623,13 @@ mod tests {
         fn drain(&mut self) -> bool {
             match self.event_rx.try_recv() {
                 Ok(first) => {
-                    dispatch_burst(first, &mut self.event_rx, &mut self.streams, &self.output_tx)
-                        .expect("dispatch burst");
+                    dispatch_burst(
+                        first,
+                        &mut self.event_rx,
+                        &mut self.streams,
+                        &self.output_tx,
+                    )
+                    .expect("dispatch burst");
                     true
                 }
                 Err(_) => false,
@@ -664,7 +673,10 @@ mod tests {
             ))
         );
         assert!(d.next_output().is_none());
-        assert!(!d.streams.contains_key("req-1"), "finished stream is removed");
+        assert!(
+            !d.streams.contains_key("req-1"),
+            "finished stream is removed"
+        );
     }
 
     /// Token(s) and the terminal arriving in one burst (EmitAndFinish) coalesce

--- a/openinfer-vllm-frontend/src/lora.rs
+++ b/openinfer-vllm-frontend/src/lora.rs
@@ -78,7 +78,10 @@ struct ModelCardBody {
     owned_by: &'static str,
 }
 
-pub(crate) fn lora_routes(handle: EngineHandle, adapter_names: Arc<RwLock<HashSet<String>>>) -> Router {
+pub(crate) fn lora_routes(
+    handle: EngineHandle,
+    adapter_names: Arc<RwLock<HashSet<String>>>,
+) -> Router {
     Router::new()
         .route("/v1/load_lora_adapter", post(load_lora_adapter))
         .route("/v1/unload_lora_adapter", post(unload_lora_adapter))


### PR DESCRIPTION
## 背景

`main` 从两个独立的改动开始一直挂 CI：

| commit | CI 表现 |
|--------|---------|
| #402 `chore(vllm): bump git deps` | `frontend_e2e` 测试全挂(跑了 6min 到 e2e 步骤才失败) |
| #404 `refactor(server)` | `cargo fmt --all --check` 早期失败,根本没跑到 e2e |

两个问题叠在一起,所以单看最新 run 只会看到 fmt 失败,fmt 修好后 e2e 失败还会冒出来。本 PR 一并修。

## 问题 1 — sim fixture 缺 `vocab_size`

vllm git 依赖 bump 后,Rust text backend 在创建时要求 model config 必须能解析出 `vocab_size`(`rust/src/text/src/backend/hf/mod.rs` 里 `model_config.vocab_size()?`)。`openinfer-sim` 的 e2e 用临时目录里的 `TINY_CONFIG_JSON` 当模型 metadata,这个 fixture 没有 `vocab_size`,于是:

\`\`\`
failed to create chat/text backends
  caused by: tokenizer error: the model config does not define \`vocab_size\`
\`\`\`

修复:给 fixture 加 `"vocab_size": 3`,和那个 3-token 的 tiny tokenizer(`<unk>`=0, alpha=1, beta=2)对齐。有效词表取 `max(tokenizer_vocab, model_vocab)`,测试请求用的 `prompt: [1, 2]` 在范围内。

## 问题 2 — #404 带进来的 rustfmt 违规

#404 合并时带了 4 个文件的格式违规(import 顺序、函数签名/match arm 换行),`cargo fmt --all --check` 直接失败。本 PR `cargo fmt --all` 修掉,涉及 `kimi-k2`、`server`、`vllm-frontend`,纯格式无逻辑改动。

## 验证

本地复现并通过 CI 的三个步骤:

- ✅ `cargo fmt --all --check`
- ✅ `cargo metadata --locked --no-deps --format-version 1`
- ✅ `cargo test --release -p openinfer-sim --test frontend_e2e` (5/5 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)