### PR TITLE
fix(qwen35): add __syncthreads() to close the warp_norms WAR race in GDN decode

### DIFF
--- a/openinfer-kernels/csrc/qwen35/gated_delta_rule.cu
+++ b/openinfer-kernels/csrc/qwen35/gated_delta_rule.cu
@@ -74,6 +74,11 @@ __global__ void gated_delta_rule_decode_kernel(
         smem_norm[0] = rsqrtf(total + 1e-12f);
     }
 
+    // Reused buffer: fence thread 0's q-norm read of warp_norms above before the warps
+    // overwrite it with k_sq below. Cross-warp; without this, two co-resident streams race
+    // read-vs-overwrite into a corrupted q-norm (nondeterministic decode). Do not remove.
+    __syncthreads();
+
     float k_sq = (j_slice == 0) ? k_val * k_val : 0.0f;
     k_sq = warp_reduce_sum(k_sq);
     if (lane_id == 0) warp_norms[warp_id] = k_sq;


### PR DESCRIPTION
## Description

Fixes #410 

`gated_delta_rule_decode_kernel` (`openinfer-kernels/csrc/qwen35/gated_delta_rule.cu`) reuses the `warp_norms` shared buffer for the q-norm and the k-norm, with no barrier between thread 0's read of the q partial-sums and the warps' overwrite with the k partial-sums — a write-after-read (WAR) hazard on the reused buffer. Under two co-resident CUDA streams the altered warp schedule lets the overwrite race ahead of the read → corrupted q-normalization → nondeterministic decode. Add one `__syncthreads()` to close the window.

The fix is the kernel barrier, not making the determinism test serial: the assert only fails under parallel execution, so `#[serial]` / a GPU mutex would hide the symptom and remove the only regression guard for this race. Keep `hf_golden_gate` parallel as the guard.

## Verification

Single GPU (x86_64, sm_89), real `assert_eq!`, no instrumentation: before the fix, parallel `cargo test --test hf_golden_gate` fails 12/12; after, 0/12 with the accuracy gate (logits vs HF golden) still green — the fix changes no single-stream value, only guarantees the already-correct q-norm under concurrency.

#328 (the Qwen3.5-4B single-GPU benchmark) runs one executor = one stream, so the race does not manifest there (it is latent UB that single-stream scheduling resolves correctly on the tested hardware); single-stream output is bit-identical. The added barrier is also perf-neutral, MEASURED: `vllm bench serve` (input-len 1024 / output-len 256, n=30, 3 reps each), Single GPU (x86_64, sm_89) — mean TPOT 11.27 ms (fixed: 11.21/11.29/11.31) vs 11.29 ms (unfixed: 11.27/11.30/11.31). The fixed-vs-unfixed delta (0.02 ms) is smaller than the within-config run-to-run noise (~0.1 ms).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project (see `docs/conventions/coding-style.md`).
- [x] I have performed a self-review of my own code.
- [x] I have formatted my commits according to Commitizen conventions.
- [x] I have run the local test suite and all tests pass (see `CLAUDE.md`).