### PR TITLE
fix(qwen3-scheduler): route echo+logprobs requests to prefill, not unified

### DIFF
--- a/openinfer-qwen3-4b/src/scheduler/plan.rs
+++ b/openinfer-qwen3-4b/src/scheduler/plan.rs
@@ -37,7 +37,11 @@ pub(super) fn build_next_plan(
     have_active: bool,
     pending: Vec<PendingRequest>,
 ) -> Option<ExecutionPlan> {
-    if !pending.is_empty() && have_active {
+    // echo+logprobs requests need all-position logits, which the unified
+    // forward does not compute (it passes all_position_logits=None). Route
+    // them through a dedicated prefill step instead of degrading silently.
+    let needs_prompt_logprobs = pending.iter().any(|r| r.echo && r.logprobs > 0);
+    if !pending.is_empty() && have_active && !needs_prompt_logprobs {
         Some(ExecutionPlan::Unified { pending })
     } else if !pending.is_empty() {
         Some(ExecutionPlan::Prefill { pending })
@@ -201,6 +205,28 @@ mod tests {
                 Some(ExecutionPlan::Unified { pending }) if pending.len() == 1
             ),
             "active + pending fuses prefill and decode into one unified step"
+        );
+        // echo+logprobs requests need all-position logits; route to Prefill
+        // even when decodes are active so prompt logprobs are not silently lost.
+        let mut echo_req = pending();
+        echo_req.echo = true;
+        echo_req.logprobs = 5;
+        assert!(
+            matches!(
+                build_next_plan(true, vec![echo_req]),
+                Some(ExecutionPlan::Prefill { pending }) if pending.len() == 1
+            ),
+            "active + pending echo+logprobs request routes to prefill not unified"
+        );
+        // echo without logprobs (no prompt logprobs needed) can still use unified.
+        let mut echo_no_lp = pending();
+        echo_no_lp.echo = true;
+        assert!(
+            matches!(
+                build_next_plan(true, vec![echo_no_lp]),
+                Some(ExecutionPlan::Unified { pending }) if pending.len() == 1
+            ),
+            "active + pending echo-only request (no logprobs) can use unified"
         );
     }
 }


### PR DESCRIPTION
## Description

Fixes #372

The unified forward passes `all_position_logits=None` and `compute_prompt_logprobs=false`, so an `echo=true` + `logprobs>0` request scheduled while decodes are active silently received `None` for all prompt-position logprobs instead of the echoed distribution. `build_next_plan` now detects pending requests that need prompt logprobs (`echo && logprobs > 0`) and routes them to a dedicated prefill step instead of the unified path. Echo-only requests (`logprobs=0`) still use unified since they don't need all-position logits.

> Scope note: the decode-starvation concern raised in review (a sustained echo+logprobs stream selecting `Prefill` every tick) is a separate scheduling-policy issue and is left out of this PR to keep the correctness fix small. Tracked as follow-up.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project (see `docs/conventions/coding-style.md`).
- [x] I have performed a self-review of my own code.
- [x] I have formatted my commits according to Commitizen conventions.
- [x] I have run the local test suite and all tests pass (see `CLAUDE.md`).
