### PR TITLE
fix(qwen3): opt-in GEMM-N reduction-order pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3809,6 +3809,7 @@ dependencies = [
  "cc",
  "cudarc",
  "half",
+ "log",
  "openinfer-build",
  "serde",
  "tvm-ffi",

--- a/openinfer-kernels/Cargo.toml
+++ b/openinfer-kernels/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 anyhow = { workspace = true }
 cudarc = { workspace = true }
 half = { workspace = true }
+log = { workspace = true }
 serde = { workspace = true }
 tvm-ffi = { version = "0.1.0-alpha.0", optional = true }
 

--- a/openinfer-kernels/csrc/shared/linear.cu
+++ b/openinfer-kernels/csrc/shared/linear.cu
@@ -41,10 +41,28 @@ thread_local cublasLtHandle_t g_lt_handle = nullptr;
 thread_local void *g_lt_workspace = nullptr;
 thread_local std::map<std::array<int, 3>, LtGemmPlan> g_lt_plans;
 static const size_t LT_WORKSPACE_SIZE = 32 * 1024 * 1024; // 32MB
+
+// Pin-path workspace, separate from the 32MB default. Arch-dependent, with 128MB kept as margin
+// for the tested decode buckets. Allocated lazily on first Pin use.
+thread_local void *g_lt_pin_workspace = nullptr;
+static const size_t LT_PIN_WORKSPACE_SIZE = 128 * 1024 * 1024;
+// Tuner pref kept smaller than the buffer: cuBLASLt picks a larger-workspace algo given a larger
+// budget, so 64MB pref forces a small-workspace algo and the 128MB buffer stays margin.
+static const size_t LT_PIN_TUNER_PREF = 64 * 1024 * 1024;
 // gemm_lt_cuda returns this when the calling thread has no tuned plan for the
 // shape; callers fall back to the cublasGemmEx paths so untuned models keep
 // their existing kernel selection and capture behavior.
 static constexpr int GEMM_LT_UNTUNED = -1;
+
+// Keyed on {M,K} only (g_lt_plans uses {M,N,K}): one cublasLt algo chosen at rep_n, reused for every N.
+static constexpr int GEMM_LT_PIN_UNTUNED = -1;     // no pinned plan for {M,K}
+static constexpr int GEMM_LT_PIN_UNSUPPORTED = -2; // pinned algo cannot serve this N
+struct LtPinPlan {
+  cublasLtMatmulDesc_t op = nullptr;
+  cublasLtMatrixLayout_t a = nullptr; // [K, M], independent of N
+  cublasLtMatmulAlgo_t algo{};
+};
+thread_local std::map<std::array<int, 2>, LtPinPlan> g_lt_pin_plans;
 
 static void lt_plan_destroy(LtGemmPlan &plan) {
   if (plan.c != nullptr) {
@@ -60,6 +78,67 @@ static void lt_plan_destroy(LtGemmPlan &plan) {
     cublasLtMatmulDescDestroy(plan.op);
   }
   plan = LtGemmPlan{};
+}
+
+static void lt_pin_destroy(LtPinPlan &plan) {
+  if (plan.a != nullptr) {
+    cublasLtMatrixLayoutDestroy(plan.a);
+  }
+  if (plan.op != nullptr) {
+    cublasLtMatmulDescDestroy(plan.op);
+  }
+  plan = LtPinPlan{};
+}
+
+// Lazily create this thread's cublasLt handle + 32MB workspace (shared by tuner and pin paths).
+static int ensure_lt_resources() {
+  if (g_lt_handle == nullptr) {
+    cublasStatus_t status = cublasLtCreate(&g_lt_handle);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+      g_lt_handle = nullptr;
+      return cublas_status_to_error(status);
+    }
+  }
+  if (g_lt_workspace == nullptr) {
+    cudaError_t status = cudaMalloc(&g_lt_workspace, LT_WORKSPACE_SIZE);
+    if (status != cudaSuccess) {
+      g_lt_workspace = nullptr;
+      return static_cast<int>(status);
+    }
+  }
+  return static_cast<int>(cudaSuccess);
+}
+
+static int ensure_lt_pin_workspace() {
+  if (g_lt_pin_workspace == nullptr) {
+    cudaError_t status = cudaMalloc(&g_lt_pin_workspace, LT_PIN_WORKSPACE_SIZE);
+    if (status != cudaSuccess) {
+      g_lt_pin_workspace = nullptr;
+      return static_cast<int>(status);
+    }
+  }
+  return static_cast<int>(cudaSuccess);
+}
+
+// Op descriptor + A layout [K,M] for the pinned path; B/C rebuilt per call from N.
+static cublasStatus_t lt_pin_desc_create(LtPinPlan &plan, int M, int K) {
+  cublasStatus_t status = cublasLtMatmulDescCreate(&plan.op, CUBLAS_COMPUTE_32F, CUDA_R_32F);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    return status;
+  }
+  const cublasOperation_t transa = CUBLAS_OP_T;
+  const cublasOperation_t transb = CUBLAS_OP_N;
+  status = cublasLtMatmulDescSetAttribute(plan.op, CUBLASLT_MATMUL_DESC_TRANSA, &transa,
+                                          sizeof(transa));
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    return status;
+  }
+  status = cublasLtMatmulDescSetAttribute(plan.op, CUBLASLT_MATMUL_DESC_TRANSB, &transb,
+                                          sizeof(transb));
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    return status;
+  }
+  return cublasLtMatrixLayoutCreate(&plan.a, CUDA_R_16BF, K, M, K);
 }
 
 // Same math as gemm_cuda: Y[M,N] = W[M,K]^T-layout @ X[K,N], all bf16/FP32 compute.
@@ -194,6 +273,10 @@ void cublas_destroy() {
     lt_plan_destroy(entry.second);
   }
   g_lt_plans.clear();
+  for (auto &entry : g_lt_pin_plans) {
+    lt_pin_destroy(entry.second);
+  }
+  g_lt_pin_plans.clear();
   if (g_lt_handle != nullptr) {
     cublasLtDestroy(g_lt_handle);
     g_lt_handle = nullptr;
@@ -201,6 +284,10 @@ void cublas_destroy() {
   if (g_lt_workspace != nullptr) {
     cudaFree(g_lt_workspace);
     g_lt_workspace = nullptr;
+  }
+  if (g_lt_pin_workspace != nullptr) {
+    cudaFree(g_lt_pin_workspace);
+    g_lt_pin_workspace = nullptr;
   }
 }
 
@@ -301,19 +388,9 @@ int gemm_lt_tune_cuda(const __nv_bfloat16 *const *Ws, int num_ws, int M, int N, 
   }
   // Lt resources are created here rather than in cublas_init so only threads
   // that actually tune (model executor threads) pay the 32MB workspace.
-  if (g_lt_handle == nullptr) {
-    cublasStatus_t create_status = cublasLtCreate(&g_lt_handle);
-    if (create_status != CUBLAS_STATUS_SUCCESS) {
-      g_lt_handle = nullptr;
-      return cublas_status_to_error(create_status);
-    }
-  }
-  if (g_lt_workspace == nullptr) {
-    cudaError_t alloc_status = cudaMalloc(&g_lt_workspace, LT_WORKSPACE_SIZE);
-    if (alloc_status != cudaSuccess) {
-      g_lt_workspace = nullptr;
-      return static_cast<int>(alloc_status);
-    }
+  int lt_rc = ensure_lt_resources();
+  if (lt_rc != static_cast<int>(cudaSuccess)) {
+    return lt_rc;
   }
 
   const std::array<int, 3> key{M, N, K};
@@ -413,6 +490,127 @@ int gemm_lt_tune_cuda(const __nv_bfloat16 *const *Ws, int num_ws, int M, int N, 
   }
   plan.algo = results[best].algo;
   g_lt_plans.emplace(key, plan);
+  return static_cast<int>(cudaSuccess);
+}
+
+// Pin one cublasLt algo for (M,K) at rep_n (heuristic top, no timing → deterministic), keyed {M,K}.
+int gemm_lt_pin_tune_cuda(int M, int rep_n, int K) {
+  if (M <= 0 || rep_n <= 0 || K <= 0) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+  int rc = ensure_lt_resources();
+  if (rc == static_cast<int>(cudaSuccess)) {
+    rc = ensure_lt_pin_workspace();
+  }
+  if (rc != static_cast<int>(cudaSuccess)) {
+    return rc;
+  }
+
+  LtPinPlan plan;
+  cublasStatus_t status = lt_pin_desc_create(plan, M, K);
+  cublasLtMatrixLayout_t b = nullptr, c = nullptr;
+  cublasLtMatmulPreference_t pref = nullptr;
+  cublasLtMatmulHeuristicResult_t results[16];
+  int returned = 0;
+  size_t ws = LT_PIN_TUNER_PREF;
+  if (status == CUBLAS_STATUS_SUCCESS)
+    status = cublasLtMatrixLayoutCreate(&b, CUDA_R_16BF, K, rep_n, K);
+  if (status == CUBLAS_STATUS_SUCCESS)
+    status = cublasLtMatrixLayoutCreate(&c, CUDA_R_16BF, M, rep_n, M);
+  if (status == CUBLAS_STATUS_SUCCESS)
+    status = cublasLtMatmulPreferenceCreate(&pref);
+  if (status == CUBLAS_STATUS_SUCCESS)
+    status = cublasLtMatmulPreferenceSetAttribute(
+        pref, CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &ws, sizeof(ws));
+  if (status == CUBLAS_STATUS_SUCCESS)
+    status = cublasLtMatmulAlgoGetHeuristic(g_lt_handle, plan.op, plan.a, b, c, c, pref, 16, results,
+                                            &returned);
+  if (pref != nullptr) cublasLtMatmulPreferenceDestroy(pref);
+  if (status == CUBLAS_STATUS_SUCCESS && returned == 0) status = CUBLAS_STATUS_NOT_SUPPORTED;
+  if (c != nullptr) cublasLtMatrixLayoutDestroy(c);
+  if (b != nullptr) cublasLtMatrixLayoutDestroy(b);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    lt_pin_destroy(plan);
+    return cublas_status_to_error(status);
+  }
+
+  plan.algo = results[0].algo;
+  const std::array<int, 2> key{M, K};
+  auto existing = g_lt_pin_plans.find(key);
+  if (existing != g_lt_pin_plans.end()) {
+    lt_pin_destroy(existing->second);
+    g_lt_pin_plans.erase(existing);
+  }
+  g_lt_pin_plans.emplace(key, plan);
+  return static_cast<int>(cudaSuccess);
+}
+
+// Run the pinned (M,K) algo at an arbitrary N (rebuilds only B/C). Returns PIN_UNTUNED (no plan)
+// or PIN_UNSUPPORTED (algo can't serve this N; caller falls back).
+int gemm_lt_pin_cuda(const __nv_bfloat16 *W, const __nv_bfloat16 *X, __nv_bfloat16 *Y, int M, int N,
+                     int K, cudaStream_t stream) {
+  if (g_lt_handle == nullptr || g_lt_pin_workspace == nullptr) {
+    return GEMM_LT_PIN_UNTUNED;
+  }
+  auto it = g_lt_pin_plans.find(std::array<int, 2>{M, K});
+  if (it == g_lt_pin_plans.end()) {
+    return GEMM_LT_PIN_UNTUNED;
+  }
+  LtPinPlan &plan = it->second;
+
+  cublasLtMatrixLayout_t b = nullptr, c = nullptr;
+  cublasStatus_t status = cublasLtMatrixLayoutCreate(&b, CUDA_R_16BF, K, N, K);
+  if (status == CUBLAS_STATUS_SUCCESS) {
+    status = cublasLtMatrixLayoutCreate(&c, CUDA_R_16BF, M, N, M);
+  }
+  int result;
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    result = cublas_status_to_error(status);
+  } else {
+    cublasLtMatmulHeuristicResult_t check{};
+    cublasStatus_t check_status =
+        cublasLtMatmulAlgoCheck(g_lt_handle, plan.op, plan.a, b, c, c, &plan.algo, &check);
+    if (check_status != CUBLAS_STATUS_SUCCESS) {
+      result = GEMM_LT_PIN_UNSUPPORTED;
+    } else if (check.workspaceSize > LT_PIN_WORKSPACE_SIZE) {
+      result = GEMM_LT_PIN_UNSUPPORTED;
+    } else {
+      const float h_alpha = 1.0f;
+      const float h_beta = 0.0f;
+      cublasStatus_t mm =
+          cublasLtMatmul(g_lt_handle, plan.op, &h_alpha, W, plan.a, X, b, &h_beta, Y, c, Y, c,
+                         &plan.algo, g_lt_pin_workspace, LT_PIN_WORKSPACE_SIZE, stream);
+      result = (mm == CUBLAS_STATUS_SUCCESS) ? static_cast<int>(cudaPeekAtLastError())
+                                             : cublas_status_to_error(mm);
+    }
+  }
+  if (c != nullptr) cublasLtMatrixLayoutDestroy(c);
+  if (b != nullptr) cublasLtMatrixLayoutDestroy(b);
+  return result;
+}
+
+// Diagnostics: write [tile_id, stages_id, splitk_num, reduction_scheme] for (M,K) into out4;
+// GEMM_LT_PIN_UNTUNED if no pinned plan.
+int gemm_lt_pin_inspect_cuda(int M, int K, int *out4) {
+  if (out4 == nullptr) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+  auto it = g_lt_pin_plans.find(std::array<int, 2>{M, K});
+  if (it == g_lt_pin_plans.end()) {
+    return GEMM_LT_PIN_UNTUNED;
+  }
+  cublasLtMatmulAlgo_t &algo = it->second.algo;
+  int tile = -1, stages = -1, splitk = -1, reduction = -1;
+  size_t written = 0;
+  cublasLtMatmulAlgoConfigGetAttribute(&algo, CUBLASLT_ALGO_CONFIG_TILE_ID, &tile, sizeof(tile),
+                                       &written);
+  cublasLtMatmulAlgoConfigGetAttribute(&algo, CUBLASLT_ALGO_CONFIG_STAGES_ID, &stages,
+                                       sizeof(stages), &written);
+  cublasLtMatmulAlgoConfigGetAttribute(&algo, CUBLASLT_ALGO_CONFIG_SPLITK_NUM, &splitk,
+                                       sizeof(splitk), &written);
+  cublasLtMatmulAlgoConfigGetAttribute(&algo, CUBLASLT_ALGO_CONFIG_REDUCTION_SCHEME, &reduction,
+                                       sizeof(reduction), &written);
+  out4[0] = tile, out4[1] = stages, out4[2] = splitk, out4[3] = reduction;
   return static_cast<int>(cudaSuccess);
 }
 

--- a/openinfer-kernels/csrc/shared/linear.cu
+++ b/openinfer-kernels/csrc/shared/linear.cu
@@ -648,4 +648,14 @@ int gemm_per_token_cuda(const __nv_bfloat16 *W, const __nv_bfloat16 *X,
   return static_cast<int>(cudaPeekAtLastError());
 }
 
+// 1 if `stream` is mid graph-capture, 0 if not, <0 (negated cudaError_t) on query failure.
+int stream_is_capturing_cuda(cudaStream_t stream) {
+  cudaStreamCaptureStatus capture_status;
+  cudaError_t err = cudaStreamIsCapturing(stream, &capture_status);
+  if (err != cudaSuccess) {
+    return -static_cast<int>(err);
+  }
+  return capture_status == cudaStreamCaptureStatusNone ? 0 : 1;
+}
+
 } // extern "C"

--- a/openinfer-kernels/src/ffi/shared.rs
+++ b/openinfer-kernels/src/ffi/shared.rs
@@ -151,6 +151,21 @@ unsafe extern "C" {
         stream: CUstream,
     ) -> i32;
 
+    // Batch-invariant pinned-algo path (csrc/shared/linear.cu).
+    pub fn gemm_lt_pin_tune_cuda(M: i32, rep_n: i32, K: i32) -> i32;
+
+    pub fn gemm_lt_pin_cuda(
+        W: *const Half,
+        X: *const Half,
+        Y: *mut Half,
+        M: i32,
+        N: i32,
+        K: i32,
+        stream: CUstream,
+    ) -> i32;
+
+    pub fn gemm_lt_pin_inspect_cuda(M: i32, K: i32, out4: *mut i32) -> i32;
+
     // Embedding lookup reading token_id from decode_meta[0] (CUDA Graph safe)
     pub fn embedding_decode_cuda(
         embed: *const Half,

--- a/openinfer-kernels/src/ffi/shared.rs
+++ b/openinfer-kernels/src/ffi/shared.rs
@@ -154,6 +154,8 @@ unsafe extern "C" {
     // Batch-invariant pinned-algo path (csrc/shared/linear.cu).
     pub fn gemm_lt_pin_tune_cuda(M: i32, rep_n: i32, K: i32) -> i32;
 
+    pub fn stream_is_capturing_cuda(stream: CUstream) -> i32;
+
     pub fn gemm_lt_pin_cuda(
         W: *const Half,
         X: *const Half,

--- a/openinfer-kernels/src/ops.rs
+++ b/openinfer-kernels/src/ops.rs
@@ -39,7 +39,7 @@ pub use kimi_k2::*;
 pub use linear::{
     GEMM_LT_MAX_N, NumericPolicy, gemm, gemm_graphsafe_into_checked,
     gemm_graphsafe_ref_into_checked, gemm_into, gemm_into_checked, gemm_lt_pin_inspect,
-    gemm_lt_pin_into_checked, gemm_lt_pin_tune, gemm_lt_tune, gemm_per_token,
+    gemm_lt_pin_into_checked, gemm_lt_pin_tune, gemm_lt_pin_warmup, gemm_lt_tune, gemm_per_token,
     gemm_per_token_into_checked, gemm_rows_into, gemm_rows_into_checked,
     gemm_token_range_into_checked, gemv, linear, numeric_policy, pin_counters, pin_fallback_shapes,
     reset_pin_counters, set_numeric_policy,

--- a/openinfer-kernels/src/ops.rs
+++ b/openinfer-kernels/src/ops.rs
@@ -37,9 +37,10 @@ pub use embedding::{embedding_batch, embedding_batch_vocab_shard, embedding_deco
 #[cfg(feature = "kimi-k2")]
 pub use kimi_k2::*;
 pub use linear::{
-    GEMM_LT_MAX_N, NumericPolicy, gemm, gemm_graphsafe_into_checked, gemm_graphsafe_ref_into_checked,
-    gemm_into, gemm_into_checked, gemm_lt_pin_inspect, gemm_lt_pin_into_checked, gemm_lt_pin_tune,
-    gemm_lt_tune, gemm_per_token, gemm_per_token_into_checked, gemm_rows_into, gemm_rows_into_checked,
+    GEMM_LT_MAX_N, NumericPolicy, gemm, gemm_graphsafe_into_checked,
+    gemm_graphsafe_ref_into_checked, gemm_into, gemm_into_checked, gemm_lt_pin_inspect,
+    gemm_lt_pin_into_checked, gemm_lt_pin_tune, gemm_lt_tune, gemm_per_token,
+    gemm_per_token_into_checked, gemm_rows_into, gemm_rows_into_checked,
     gemm_token_range_into_checked, gemv, linear, numeric_policy, pin_counters, pin_fallback_shapes,
     reset_pin_counters, set_numeric_policy,
 };

--- a/openinfer-kernels/src/ops.rs
+++ b/openinfer-kernels/src/ops.rs
@@ -37,9 +37,11 @@ pub use embedding::{embedding_batch, embedding_batch_vocab_shard, embedding_deco
 #[cfg(feature = "kimi-k2")]
 pub use kimi_k2::*;
 pub use linear::{
-    GEMM_LT_MAX_N, gemm, gemm_graphsafe_into_checked, gemm_graphsafe_ref_into_checked, gemm_into,
-    gemm_into_checked, gemm_lt_tune, gemm_per_token, gemm_per_token_into_checked, gemm_rows_into,
-    gemm_rows_into_checked, gemm_token_range_into_checked, gemv, linear,
+    GEMM_LT_MAX_N, NumericPolicy, gemm, gemm_graphsafe_into_checked, gemm_graphsafe_ref_into_checked,
+    gemm_into, gemm_into_checked, gemm_lt_pin_inspect, gemm_lt_pin_into_checked, gemm_lt_pin_tune,
+    gemm_lt_tune, gemm_per_token, gemm_per_token_into_checked, gemm_rows_into, gemm_rows_into_checked,
+    gemm_token_range_into_checked, gemv, linear, numeric_policy, pin_counters, pin_fallback_shapes,
+    reset_pin_counters, set_numeric_policy,
 };
 pub use lora::{
     LoraDecodeGroupedProjection, lora_decode_fused_delta_group3_into, lora_decode_fused_delta_into,

--- a/openinfer-kernels/src/ops/linear.rs
+++ b/openinfer-kernels/src/ops/linear.rs
@@ -1,3 +1,7 @@
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+
 use anyhow::{Result, bail};
 use cudarc::driver::{DevicePtr, DevicePtrMut};
 
@@ -62,6 +66,99 @@ pub fn gemm_lt_tune(
         );
     }
     Ok(())
+}
+
+/// Mirrors the GEMM_LT_PIN_* sentinels in csrc/shared/linear.cu.
+const GEMM_LT_PIN_UNTUNED: i32 = -1;
+const GEMM_LT_PIN_UNSUPPORTED: i32 = -2;
+
+/// Pin one cublasLt algo for `(num_rows, cols)`, selected by the heuristic at `rep_n` (shape-only),
+/// reused for every N. Run on the GEMM-issuing thread (the plan cache is thread-local).
+pub fn gemm_lt_pin_tune(num_rows: usize, rep_n: usize, cols: usize) -> Result<()> {
+    let status = unsafe { ffi::gemm_lt_pin_tune_cuda(num_rows as i32, rep_n as i32, cols as i32) };
+    if status != 0 {
+        bail!(
+            "cublasLt pin tuning failed: status={}, m={}, rep_n={}, k={}",
+            status,
+            num_rows,
+            rep_n,
+            cols
+        );
+    }
+    Ok(())
+}
+
+/// Run the pinned `(rows, cols)` algo at this N. `Ok(false)` = algo can't serve this N (caller
+/// falls back); bails if never pinned.
+pub fn gemm_lt_pin_into_checked(
+    ctx: &DeviceContext,
+    weight: &DeviceMatrix,
+    x: &HiddenStates,
+    out: &mut HiddenStates,
+) -> Result<bool> {
+    assert_eq!(
+        weight.cols, x.hidden_dim,
+        "weight cols {} != hidden_dim {}",
+        weight.cols, x.hidden_dim
+    );
+    assert_eq!(
+        out.hidden_dim, weight.rows,
+        "out hidden_dim {} != weight rows {}",
+        out.hidden_dim, weight.rows
+    );
+    assert_eq!(
+        out.seq_len, x.seq_len,
+        "out seq_len {} != x seq_len {}",
+        out.seq_len, x.seq_len
+    );
+
+    let (w_ptr, _gw) = weight.data.device_ptr(&ctx.stream);
+    let (x_ptr, _gx) = x.data.device_ptr(&ctx.stream);
+    let (y_ptr, _gy) = out.data.device_ptr_mut(&ctx.stream);
+
+    let status = unsafe {
+        ffi::gemm_lt_pin_cuda(
+            w_ptr as *const ffi::Half,
+            x_ptr as *const ffi::Half,
+            y_ptr as *mut ffi::Half,
+            weight.rows as i32,
+            x.seq_len as i32,
+            weight.cols as i32,
+            crate::tensor::active_cu_stream(ctx),
+        )
+    };
+    match status {
+        0 => Ok(true),
+        GEMM_LT_PIN_UNSUPPORTED => Ok(false),
+        GEMM_LT_PIN_UNTUNED => bail!(
+            "gemm_lt_pin_into_checked: (m={}, k={}) was never pinned — call gemm_lt_pin_tune first",
+            weight.rows,
+            weight.cols
+        ),
+        s if s >= 100_000 => bail!(
+            "cublasLt pin GEMM failed: cublas_status={}, m={}, n={}, k={}",
+            s - 100_000,
+            weight.rows,
+            x.seq_len,
+            weight.cols
+        ),
+        s => bail!(
+            "cublasLt pin GEMM launch failed: cuda_status={}, m={}, n={}, k={}",
+            s,
+            weight.rows,
+            x.seq_len,
+            weight.cols
+        ),
+    }
+}
+
+/// Diagnostics: the pinned algo's `[tile_id, stages_id, splitk_num, reduction_scheme]` for
+/// `(rows, cols)`, or `None` if never pinned.
+pub fn gemm_lt_pin_inspect(rows: usize, cols: usize) -> Option<[i32; 4]> {
+    let mut out = [0i32; 4];
+    let status =
+        unsafe { ffi::gemm_lt_pin_inspect_cuda(rows as i32, cols as i32, out.as_mut_ptr()) };
+    if status == 0 { Some(out) } else { None }
 }
 
 /// GEMM on a row sub-range of a weight matrix: Y = W[row_offset..row_offset+M, :] @ X
@@ -352,6 +449,204 @@ fn gemm_ref_into_with_policy(
     )
 }
 
+/// Process-global numeric policy for projection GEMMs (atomics, not thread-local: the probe sets it
+/// from the main thread, the model reads it on a worker thread). `Tuned` (default) = production
+/// path; `Pin` = batch-invariant pinned algo (per-token fallback when it can't run); `PerToken` =
+/// N=1 oracle. `OPENINFER_NUMERIC_POLICY=pin|pertoken` sets the initial value.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(u8)]
+pub enum NumericPolicy {
+    Tuned = 0,
+    Pin = 1,
+    PerToken = 2,
+}
+
+impl NumericPolicy {
+    fn from_env() -> Self {
+        match std::env::var("OPENINFER_NUMERIC_POLICY").as_deref() {
+            Ok("pin") => NumericPolicy::Pin,
+            Ok("pertoken") => NumericPolicy::PerToken,
+            _ => NumericPolicy::Tuned,
+        }
+    }
+}
+
+const POLICY_UNINIT: u8 = u8::MAX;
+static NUMERIC_POLICY: AtomicU8 = AtomicU8::new(POLICY_UNINIT);
+static PIN_SERVED: AtomicU64 = AtomicU64::new(0);
+static PIN_FALLBACK: AtomicU64 = AtomicU64::new(0);
+type FallbackShapeMap = Mutex<BTreeMap<(usize, usize, usize), u64>>;
+/// Per-(m, n, k) fallback tally; only the fallback branch touches it (served path stays lock-free).
+static PIN_FALLBACK_SHAPES: OnceLock<FallbackShapeMap> = OnceLock::new();
+
+fn pin_fallback_shapes_map() -> &'static FallbackShapeMap {
+    PIN_FALLBACK_SHAPES.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+/// Override the cached policy in-process — to drive baseline/pin/per-token in one run, vs the
+/// `OPENINFER_NUMERIC_POLICY` env var that `numeric_policy()` lazy-reads.
+pub fn set_numeric_policy(p: NumericPolicy) {
+    NUMERIC_POLICY.store(p as u8, Ordering::Release);
+}
+
+pub fn numeric_policy() -> NumericPolicy {
+    let mut v = NUMERIC_POLICY.load(Ordering::Acquire);
+    if v == POLICY_UNINIT {
+        // Only win the lazy-init race while still uninit, so a concurrent
+        // set_numeric_policy() is never clobbered by the env default.
+        let env = NumericPolicy::from_env() as u8;
+        v = match NUMERIC_POLICY.compare_exchange(
+            POLICY_UNINIT,
+            env,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => env,
+            Err(actual) => actual,
+        };
+    }
+    match v {
+        1 => NumericPolicy::Pin,
+        2 => NumericPolicy::PerToken,
+        _ => NumericPolicy::Tuned,
+    }
+}
+
+/// `(pin_served, pin_fallback)` projection-GEMM counts. Guards the experiment
+/// against a maxΔ=0 that is actually all per-token fallback (already known
+/// invariant), not the pin.
+pub fn pin_counters() -> (u64, u64) {
+    (
+        PIN_SERVED.load(Ordering::Relaxed),
+        PIN_FALLBACK.load(Ordering::Relaxed),
+    )
+}
+
+pub fn reset_pin_counters() {
+    PIN_SERVED.store(0, Ordering::Relaxed);
+    PIN_FALLBACK.store(0, Ordering::Relaxed);
+    pin_fallback_shapes_map().lock().unwrap().clear();
+}
+
+/// `((m, n, k), count)` per shape that fell back to per-token; empty iff `pin_fallback` is 0.
+pub fn pin_fallback_shapes() -> Vec<((usize, usize, usize), u64)> {
+    pin_fallback_shapes_map()
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|(&shape, &count)| (shape, count))
+        .collect()
+}
+
+/// Fixed representative N at which every (M,K) pin is resolved — one algo for ALL
+/// N (NOT first-call-N, which would make the pinned algo call-order-dependent).
+const PIN_REP_N: i32 = 32;
+
+/// `Pin` policy: lazily pin (m,k) at PIN_REP_N, run at live N, per-token fallback if it can't serve N.
+fn launch_gemm_pin(
+    w_ptr: *const ffi::Half,
+    x_ptr: *const ffi::Half,
+    y_ptr: *mut ffi::Half,
+    m: usize,
+    n: usize,
+    k: usize,
+    ctx: &DeviceContext,
+) -> Result<()> {
+    // cuBLASLt (gemm_lt_pin) risks Xid 31 under a stream override — see launch_gemm; use per-token.
+    if crate::tensor::has_stream_override() {
+        PIN_FALLBACK.fetch_add(1, Ordering::Relaxed);
+        *pin_fallback_shapes_map()
+            .lock()
+            .unwrap()
+            .entry((m, n, k))
+            .or_insert(0) += 1;
+        return launch_gemm_pertoken(w_ptr, x_ptr, y_ptr, m, n, k, ctx);
+    }
+    // Lazy-pin (m,k); a no-op during decode graph capture, since prefill pins all shapes
+    // first (the tune's cudaMalloc would otherwise invalidate the capture).
+    if gemm_lt_pin_inspect(m, k).is_none() {
+        gemm_lt_pin_tune(m, PIN_REP_N as usize, k)?;
+    }
+    unsafe {
+        let status = ffi::gemm_lt_pin_cuda(
+            w_ptr,
+            x_ptr,
+            y_ptr,
+            m as i32,
+            n as i32,
+            k as i32,
+            crate::tensor::active_cu_stream(ctx),
+        );
+        match status {
+            0 => {
+                PIN_SERVED.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+            GEMM_LT_PIN_UNSUPPORTED | GEMM_LT_PIN_UNTUNED => {
+                PIN_FALLBACK.fetch_add(1, Ordering::Relaxed);
+                *pin_fallback_shapes_map()
+                    .lock()
+                    .unwrap()
+                    .entry((m, n, k))
+                    .or_insert(0) += 1;
+                let st = ffi::gemm_per_token_cuda(
+                    w_ptr,
+                    x_ptr,
+                    y_ptr,
+                    m as i32,
+                    n as i32,
+                    k as i32,
+                    crate::tensor::active_cu_stream(ctx),
+                );
+                if st != 0 {
+                    bail!("pin per-token fallback failed: status={st}, m={m}, n={n}, k={k}");
+                }
+                Ok(())
+            }
+            s if s >= 100_000 => {
+                bail!(
+                    "cuBLAS pin GEMM failed: cublas_status={}, m={m}, n={n}, k={k}",
+                    s - 100_000
+                )
+            }
+            s => bail!("CUDA pin GEMM launch failed: cuda_status={s}, m={m}, n={n}, k={k}"),
+        }
+    }
+}
+
+/// `PerToken` policy: the N=1-per-column oracle (invariant by construction).
+fn launch_gemm_pertoken(
+    w_ptr: *const ffi::Half,
+    x_ptr: *const ffi::Half,
+    y_ptr: *mut ffi::Half,
+    m: usize,
+    n: usize,
+    k: usize,
+    ctx: &DeviceContext,
+) -> Result<()> {
+    unsafe {
+        let status = ffi::gemm_per_token_cuda(
+            w_ptr,
+            x_ptr,
+            y_ptr,
+            m as i32,
+            n as i32,
+            k as i32,
+            crate::tensor::active_cu_stream(ctx),
+        );
+        if status != 0 {
+            if status >= 100_000 {
+                bail!(
+                    "cuBLAS per-token GEMM failed: cublas_status={}, m={m}, n={n}, k={k}",
+                    status - 100_000
+                );
+            }
+            bail!("CUDA per-token GEMM launch failed: cuda_status={status}, m={m}, n={n}, k={k}");
+        }
+    }
+    Ok(())
+}
+
 fn launch_gemm(
     w_ptr: *const ffi::Half,
     x_ptr: *const ffi::Half,
@@ -362,6 +657,12 @@ fn launch_gemm(
     graphsafe: bool,
     ctx: &DeviceContext,
 ) -> Result<()> {
+    // Non-Tuned policies route every N through the pinned/per-token path; Tuned falls through.
+    match numeric_policy() {
+        NumericPolicy::Pin => return launch_gemm_pin(w_ptr, x_ptr, y_ptr, m, n, k, ctx),
+        NumericPolicy::PerToken => return launch_gemm_pertoken(w_ptr, x_ptr, y_ptr, m, n, k, ctx),
+        NumericPolicy::Tuned => {}
+    }
     unsafe {
         // Small-N projections run the cublasLt algo selected by gemm_lt_tune.
         // Shapes this thread never tuned report GEMM_LT_UNTUNED and keep their

--- a/openinfer-kernels/src/ops/linear.rs
+++ b/openinfer-kernels/src/ops/linear.rs
@@ -529,6 +529,11 @@ fn record_pin_fallback(m: usize, n: usize, k: usize, reason: &str) {
 /// N (NOT first-call-N, which would make the pinned algo call-order-dependent).
 const PIN_REP_N: i32 = 32;
 
+/// Pin one `(num_rows, cols)` algo at the canonical `PIN_REP_N`, reused for all N.
+pub fn gemm_lt_pin_warmup(num_rows: usize, cols: usize) -> Result<()> {
+    gemm_lt_pin_tune(num_rows, PIN_REP_N as usize, cols)
+}
+
 /// `Pin` policy: lazily pin (m,k) at PIN_REP_N, run at live N, per-token fallback if it can't serve N.
 fn launch_gemm_pin(
     w_ptr: *const ffi::Half,
@@ -549,10 +554,19 @@ fn launch_gemm_pin(
         );
         return launch_gemm_pertoken(w_ptr, x_ptr, y_ptr, m, n, k, ctx);
     }
-    // Lazy-pin (m,k). In the Qwen3 served path, non-overlap prefill should have pinned every decode
-    // projection shape before decode graph capture; tuning a new shape here may allocate.
+    // The eager warmup (gemm_lt_pin_warmup in tune_decode_gemm_algos) pins every decode shape before
+    // capture; a lazy tune here allocates, illegal mid-capture — so refuse under capture, don't 900.
     if gemm_lt_pin_inspect(m, k).is_none() {
-        gemm_lt_pin_tune(m, PIN_REP_N as usize, k)?;
+        match unsafe { ffi::stream_is_capturing_cuda(crate::tensor::active_cu_stream(ctx)) } {
+            0 => gemm_lt_pin_tune(m, PIN_REP_N as usize, k)?,
+            s if s < 0 => bail!(
+                "cudaStreamIsCapturing query failed: status={}, m={m}, k={k}",
+                -s
+            ),
+            _ => bail!(
+                "batch-invariant pin: ({m},{k}) reached graph capture unpinned — the decode pin warmup must run before capture"
+            ),
+        }
     }
     unsafe {
         let status = ffi::gemm_lt_pin_cuda(

--- a/openinfer-kernels/src/ops/linear.rs
+++ b/openinfer-kernels/src/ops/linear.rs
@@ -449,10 +449,11 @@ fn gemm_ref_into_with_policy(
     )
 }
 
-/// Process-global numeric policy for projection GEMMs (atomics, not thread-local: the probe sets it
-/// from the main thread, the model reads it on a worker thread). `Tuned` (default) = production
-/// path; `Pin` = batch-invariant pinned algo (per-token fallback when it can't run); `PerToken` =
-/// N=1 oracle. `OPENINFER_NUMERIC_POLICY=pin|pertoken` sets the initial value.
+/// Process-global numeric policy for projection GEMMs (atomics, not thread-local: set on the main
+/// thread before worker construction, read on the worker). `Tuned` (default) = production path;
+/// `Pin` = batch-invariant pinned algo (per-token fallback when it can't serve an N, or under a
+/// stream override); `PerToken` = N=1 oracle. Set via `set_numeric_policy` before executor
+/// construction / graph capture.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[repr(u8)]
 pub enum NumericPolicy {
@@ -461,18 +462,7 @@ pub enum NumericPolicy {
     PerToken = 2,
 }
 
-impl NumericPolicy {
-    fn from_env() -> Self {
-        match std::env::var("OPENINFER_NUMERIC_POLICY").as_deref() {
-            Ok("pin") => NumericPolicy::Pin,
-            Ok("pertoken") => NumericPolicy::PerToken,
-            _ => NumericPolicy::Tuned,
-        }
-    }
-}
-
-const POLICY_UNINIT: u8 = u8::MAX;
-static NUMERIC_POLICY: AtomicU8 = AtomicU8::new(POLICY_UNINIT);
+static NUMERIC_POLICY: AtomicU8 = AtomicU8::new(NumericPolicy::Tuned as u8);
 static PIN_SERVED: AtomicU64 = AtomicU64::new(0);
 static PIN_FALLBACK: AtomicU64 = AtomicU64::new(0);
 type FallbackShapeMap = Mutex<BTreeMap<(usize, usize, usize), u64>>;
@@ -483,38 +473,23 @@ fn pin_fallback_shapes_map() -> &'static FallbackShapeMap {
     PIN_FALLBACK_SHAPES.get_or_init(|| Mutex::new(BTreeMap::new()))
 }
 
-/// Override the cached policy in-process — to drive baseline/pin/per-token in one run, vs the
-/// `OPENINFER_NUMERIC_POLICY` env var that `numeric_policy()` lazy-reads.
+/// Set the process-global policy. Must run before executor construction / graph capture (the
+/// captured algo is the one live at capture). Tests drive baseline/pin/per-token through it.
 pub fn set_numeric_policy(p: NumericPolicy) {
     NUMERIC_POLICY.store(p as u8, Ordering::Release);
 }
 
 pub fn numeric_policy() -> NumericPolicy {
-    let mut v = NUMERIC_POLICY.load(Ordering::Acquire);
-    if v == POLICY_UNINIT {
-        // Only win the lazy-init race while still uninit, so a concurrent
-        // set_numeric_policy() is never clobbered by the env default.
-        let env = NumericPolicy::from_env() as u8;
-        v = match NUMERIC_POLICY.compare_exchange(
-            POLICY_UNINIT,
-            env,
-            Ordering::AcqRel,
-            Ordering::Acquire,
-        ) {
-            Ok(_) => env,
-            Err(actual) => actual,
-        };
-    }
-    match v {
+    match NUMERIC_POLICY.load(Ordering::Acquire) {
         1 => NumericPolicy::Pin,
         2 => NumericPolicy::PerToken,
         _ => NumericPolicy::Tuned,
     }
 }
 
-/// `(pin_served, pin_fallback)` projection-GEMM counts. Guards the experiment
-/// against a maxΔ=0 that is actually all per-token fallback (already known
-/// invariant), not the pin.
+/// `(pin_served, pin_fallback)` projection-GEMM counts: process-global, mixed across prefill +
+/// decode + unified and across TP ranks (not decode-specific). Decode counts the graph capture,
+/// not replays; read quiesced.
 pub fn pin_counters() -> (u64, u64) {
     (
         PIN_SERVED.load(Ordering::Relaxed),
@@ -528,7 +503,9 @@ pub fn reset_pin_counters() {
     pin_fallback_shapes_map().lock().unwrap().clear();
 }
 
-/// `((m, n, k), count)` per shape that fell back to per-token; empty iff `pin_fallback` is 0.
+/// `((m, n, k), count)` per shape that fell back to per-token. Quiesced and single-threaded, an
+/// empty list means no recorded fallback; under TP/concurrency the map and counter can momentarily
+/// disagree.
 pub fn pin_fallback_shapes() -> Vec<((usize, usize, usize), u64)> {
     pin_fallback_shapes_map()
         .lock()
@@ -536,6 +513,16 @@ pub fn pin_fallback_shapes() -> Vec<((usize, usize, usize), u64)> {
         .iter()
         .map(|(&shape, &count)| (shape, count))
         .collect()
+}
+
+fn record_pin_fallback(m: usize, n: usize, k: usize, reason: &str) {
+    PIN_FALLBACK.fetch_add(1, Ordering::Relaxed);
+    let mut shapes = pin_fallback_shapes_map().lock().unwrap();
+    let count = shapes.entry((m, n, k)).or_insert(0);
+    if *count == 0 {
+        log::warn!("batch-invariant pin fell back to per-token at (m={m}, n={n}, k={k}): {reason}");
+    }
+    *count += 1;
 }
 
 /// Fixed representative N at which every (M,K) pin is resolved — one algo for ALL
@@ -552,18 +539,18 @@ fn launch_gemm_pin(
     k: usize,
     ctx: &DeviceContext,
 ) -> Result<()> {
-    // cuBLASLt (gemm_lt_pin) risks Xid 31 under a stream override — see launch_gemm; use per-token.
+    // cuBLASLt (gemm_lt_pin) risks Xid 31 under a stream override; fall back to per-token.
     if crate::tensor::has_stream_override() {
-        PIN_FALLBACK.fetch_add(1, Ordering::Relaxed);
-        *pin_fallback_shapes_map()
-            .lock()
-            .unwrap()
-            .entry((m, n, k))
-            .or_insert(0) += 1;
+        record_pin_fallback(
+            m,
+            n,
+            k,
+            "stream override active (cuBLASLt would risk Xid 31)",
+        );
         return launch_gemm_pertoken(w_ptr, x_ptr, y_ptr, m, n, k, ctx);
     }
-    // Lazy-pin (m,k); a no-op during decode graph capture, since prefill pins all shapes
-    // first (the tune's cudaMalloc would otherwise invalidate the capture).
+    // Lazy-pin (m,k). In the Qwen3 served path, non-overlap prefill should have pinned every decode
+    // projection shape before decode graph capture; tuning a new shape here may allocate.
     if gemm_lt_pin_inspect(m, k).is_none() {
         gemm_lt_pin_tune(m, PIN_REP_N as usize, k)?;
     }
@@ -583,12 +570,7 @@ fn launch_gemm_pin(
                 Ok(())
             }
             GEMM_LT_PIN_UNSUPPORTED | GEMM_LT_PIN_UNTUNED => {
-                PIN_FALLBACK.fetch_add(1, Ordering::Relaxed);
-                *pin_fallback_shapes_map()
-                    .lock()
-                    .unwrap()
-                    .entry((m, n, k))
-                    .or_insert(0) += 1;
+                record_pin_fallback(m, n, k, "pinned algo cannot serve this N");
                 let st = ffi::gemm_per_token_cuda(
                     w_ptr,
                     x_ptr,

--- a/openinfer-kernels/src/tensor.rs
+++ b/openinfer-kernels/src/tensor.rs
@@ -477,6 +477,35 @@ impl HiddenStates {
             seq_len,
         })
     }
+
+    /// Create from host data: `hidden_dim * seq_len` bf16, token `i` at `i * hidden_dim`.
+    pub fn from_host(
+        ctx: &DeviceContext,
+        data: &[bf16],
+        hidden_dim: usize,
+        seq_len: usize,
+    ) -> Result<Self> {
+        assert_eq!(data.len(), hidden_dim * seq_len);
+        let gpu_data = ctx
+            .stream
+            .clone_htod(data)
+            .map_err(|e| anyhow!("H2D copy failed: {}", e))?;
+        Ok(Self {
+            data: gpu_data,
+            hidden_dim,
+            seq_len,
+        })
+    }
+
+    /// Copy to host as f32. bf16 → f32 is lossless, so f32 equality is bitwise.
+    pub fn to_host(&self, ctx: &DeviceContext) -> Result<Vec<f32>> {
+        let host = ctx
+            .stream
+            .clone_dtoh(&self.data)
+            .map_err(|e| anyhow!("D2H copy failed: {}", e))?;
+        ctx.sync()?;
+        Ok(host.iter().map(|x| x.to_f32()).collect())
+    }
 }
 
 // ── Typed tensor layer ───────────────────────────────────────────────

--- a/openinfer-kernels/tests/batch_invariance_gemm.rs
+++ b/openinfer-kernels/tests/batch_invariance_gemm.rs
@@ -1,0 +1,180 @@
+//! Batch-invariance gate at the GEMM seam.
+//!
+//! A projection GEMM Y = W·X runs at N = total batched tokens; cuBLAS picks its tile/split-K by N,
+//! so a fixed token's bf16 output changes with the batch it rides in. Column 0 is held identical
+//! across an N-sweep, run three ways: baseline (drifts = the bug), pin (one cublasLt algo for all
+//! N = the fix), per_token (N=1 oracle). bf16→f32 is lossless, so the comparison is bitwise.
+//!
+//!   OPENINFER_BI_REPS=8 cargo test --release -p openinfer-kernels \
+//!     --test batch_invariance_gemm -- --nocapture --test-threads=1
+
+use half::bf16;
+use openinfer_kernels::ops::{
+    GEMM_LT_MAX_N, gemm_into_checked, gemm_lt_pin_into_checked, gemm_lt_pin_tune, gemm_per_token,
+};
+use openinfer_kernels::tensor::{DeviceContext, DeviceMatrix, HiddenStates};
+
+/// (label, M = out rows, K = in cols). down_proj is the shape whose winning
+/// split-K varied across N in the original repro — the strongest drift.
+const SHAPES: &[(&str, usize, usize)] = &[
+    ("down_proj", 2560, 9728),
+    ("o_proj", 2560, 2560),
+    ("qkv_wide", 4096, 2560),
+];
+
+/// N sweep straddling the cublasLt/GemmEx boundary (GEMM_LT_MAX_N).
+const NS: &[usize] = &[1, 2, 4, 8, 16, 24, 32, 48, 64];
+
+const REP_N: usize = 32;
+
+fn reps() -> usize {
+    std::env::var("OPENINFER_BI_REPS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(1)
+        .max(1)
+}
+
+/// Deterministic value in [-1, 1) from (seed, a, b), independent of N.
+fn g(seed: u64, a: usize, b: usize) -> f32 {
+    let mut h = seed
+        ^ (a as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15)
+        ^ (b as u64).wrapping_mul(0xC2B2_AE3D_27D4_EB4F);
+    h ^= h >> 29;
+    h = h.wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    h ^= h >> 32;
+    ((h >> 40) as f32 / (1u64 << 24) as f32) * 2.0 - 1.0
+}
+
+/// Row-major weight [rows, cols]: element (m, k) at m*cols + k.
+fn w_data(seed: u64, rows: usize, cols: usize) -> Vec<bf16> {
+    (0..rows * cols)
+        .map(|i| bf16::from_f32(g(seed, i / cols, i % cols)))
+        .collect()
+}
+
+/// Column-major activations [k, n]: element (col c, row r) at c*k + r.
+fn x_data(seed: u64, k: usize, n: usize) -> Vec<bf16> {
+    let mut v = Vec::with_capacity(k * n);
+    for c in 0..n {
+        for r in 0..k {
+            v.push(bf16::from_f32(g(seed, c, r)));
+        }
+    }
+    v
+}
+
+#[derive(Clone, Copy)]
+enum Arm {
+    Baseline,
+    Pin,
+    PerToken,
+}
+
+/// Token-0 output for `arm` at this N, or `None` if the pinned algo cannot serve
+/// this N (pin arm only).
+fn col0(
+    ctx: &DeviceContext,
+    arm: Arm,
+    w: &DeviceMatrix,
+    x: &HiddenStates,
+    m: usize,
+) -> Option<Vec<f32>> {
+    match arm {
+        Arm::Baseline => {
+            let mut out = HiddenStates::zeros(ctx, m, x.seq_len).expect("out");
+            gemm_into_checked(ctx, w, x, &mut out).expect("baseline gemm");
+            Some(out.to_host(ctx).expect("d2h")[..m].to_vec())
+        }
+        Arm::Pin => {
+            let mut out = HiddenStates::zeros(ctx, m, x.seq_len).expect("out");
+            if gemm_lt_pin_into_checked(ctx, w, x, &mut out).expect("pin gemm") {
+                Some(out.to_host(ctx).expect("d2h")[..m].to_vec())
+            } else {
+                None
+            }
+        }
+        Arm::PerToken => {
+            let out = gemm_per_token(ctx, w, x).expect("per-token gemm");
+            Some(out.to_host(ctx).expect("d2h")[..m].to_vec())
+        }
+    }
+}
+
+/// Run one arm across the N-sweep; return (maxΔ across N, samples that ran).
+#[allow(clippy::many_single_char_names)]
+fn run_arm(
+    ctx: &DeviceContext,
+    arm: Arm,
+    w: &DeviceMatrix,
+    xseed: u64,
+    m: usize,
+    k: usize,
+) -> (f32, usize) {
+    let mut reference: Option<Vec<f32>> = None;
+    let mut maxd = 0.0f32;
+    let mut ran = 0usize;
+    for &n in NS {
+        let x = HiddenStates::from_host(ctx, &x_data(xseed, k, n), k, n).expect("X h2d");
+        if let Some(c0) = col0(ctx, arm, w, &x, m) {
+            ran += 1;
+            match &reference {
+                None => reference = Some(c0),
+                Some(r) => {
+                    maxd = c0
+                        .iter()
+                        .zip(r)
+                        .map(|(x, y)| (x - y).abs())
+                        .fold(maxd, f32::max);
+                }
+            }
+        }
+    }
+    (maxd, ran)
+}
+
+#[allow(clippy::float_cmp)]
+#[test]
+fn batch_invariance_gemm_gate() {
+    let Ok(ctx) = DeviceContext::new() else {
+        eprintln!("skipping batch_invariance_gemm: no CUDA device — gate inconclusive");
+        return;
+    };
+    let reps = reps();
+    for _rep in 0..reps {
+        let mut any_baseline_drift = false;
+
+        for (i, &(name, m, k)) in SHAPES.iter().enumerate() {
+            let wseed = 0x5717_0000 ^ i as u64;
+            let xseed = 0x0414_A000 ^ i as u64;
+            let w = DeviceMatrix::from_host(&ctx, &w_data(wseed, m, k), m, k).expect("W h2d");
+
+            gemm_lt_pin_tune(m, REP_N, k).expect("pin tune");
+            let (base_d, _) = run_arm(&ctx, Arm::Baseline, &w, xseed, m, k);
+            let (pin_d, pin_ran) = run_arm(&ctx, Arm::Pin, &w, xseed, m, k);
+            let (ora_d, _) = run_arm(&ctx, Arm::PerToken, &w, xseed, m, k);
+
+            if base_d > 0.0 {
+                any_baseline_drift = true;
+            }
+            assert_eq!(
+                ora_d, 0.0,
+                "shape {name}: per-token ORACLE drifted (maxΔ={ora_d:.2e}) — harness bug, not a fix result"
+            );
+            assert_eq!(
+                pin_d, 0.0,
+                "shape {name}: PIN is NOT batch-invariant (maxΔ={pin_d:.2e}) — fix candidate FAILED"
+            );
+            let decode_ns = NS.iter().filter(|&&n| n <= GEMM_LT_MAX_N).count();
+            assert!(
+                pin_ran >= decode_ns,
+                "shape {name}: pin served only {pin_ran} of the sweep, < {decode_ns} decode buckets (N<={GEMM_LT_MAX_N}) — invariance not exercised"
+            );
+        }
+
+        assert!(
+            any_baseline_drift,
+            "no baseline drift on any shape this rep — was not reproduced here, so the pin pass is vacuous"
+        );
+    }
+}

--- a/openinfer-qwen3-4b/src/executor.rs
+++ b/openinfer-qwen3-4b/src/executor.rs
@@ -493,11 +493,10 @@ fn bind_model_thread(model: &Qwen3Model) -> Result<()> {
     Ok(())
 }
 
-/// Pick the fastest cublasLt algo for every decode GEMM shape (buckets up to
-/// `GEMM_LT_MAX_N`) before the first step, so CUDA-Graph capture bakes in the
-/// tuned kernels; adds a few seconds of startup per model thread. Every
-/// layer's weights enter the timing rotation to keep the loop L2-cold, the
-/// regime steady-state decode runs in.
+/// Prepare decode GEMM algos before capture, per the active numeric policy: under `Pin`, eagerly pin
+/// one algo per projection {M,K} (reused for all N); otherwise tune the fastest cublasLt algo per
+/// decode shape (buckets up to `GEMM_LT_MAX_N`, every layer's weights in the L2-cold timing rotation).
+/// Adds a few seconds of startup per model thread.
 fn tune_decode_gemm_algos(model: &Qwen3Model) -> Result<()> {
     let ctx = model.device_ctx();
     let hidden = model.config().hidden_size;
@@ -505,6 +504,19 @@ fn tune_decode_gemm_algos(model: &Qwen3Model) -> Result<()> {
     let q_dim = model.local_q_dim();
     let kv_dim = model.local_kv_dim();
     let intermediate = model.local_intermediate_size();
+
+    use openinfer_kernels::ops::{NumericPolicy, gemm_lt_pin_warmup, numeric_policy};
+    if numeric_policy() == NumericPolicy::Pin {
+        // Eager pin before capture: the lazy pin-workspace alloc is illegal mid-capture.
+        gemm_lt_pin_warmup(q_dim, hidden)?;
+        gemm_lt_pin_warmup(kv_dim, hidden)?;
+        gemm_lt_pin_warmup(hidden, q_dim)?;
+        gemm_lt_pin_warmup(intermediate, hidden)?;
+        gemm_lt_pin_warmup(hidden, intermediate)?;
+        gemm_lt_pin_warmup(vocab, hidden)?;
+        return Ok(());
+    }
+
     let layers = &model.layers;
 
     let q_samples: Vec<_> = layers.iter().map(|l| (&l.attention.qkv_proj, 0)).collect();

--- a/openinfer-qwen3-4b/src/lib.rs
+++ b/openinfer-qwen3-4b/src/lib.rs
@@ -169,6 +169,7 @@ pub struct Qwen3LaunchOptions {
     pub lora: Option<Qwen3LoraOptions>,
     /// How prefill and decode share the GPU (`--decode-overlap`).
     pub decode_overlap: DecodeOverlap,
+    pub batch_invariant: bool,
 }
 
 /// Start the Qwen3 engine from server-facing [`Qwen3LaunchOptions`].
@@ -218,6 +219,7 @@ pub fn launch(model_path: &Path, options: Qwen3LaunchOptions) -> Result<EngineHa
                 options.max_prefill_tokens,
                 options.memory,
                 options.decode_overlap,
+                options.batch_invariant,
             )
         }
         None => start_engine_with_offload(
@@ -228,6 +230,7 @@ pub fn launch(model_path: &Path, options: Qwen3LaunchOptions) -> Result<EngineHa
             options.max_prefill_tokens,
             options.memory,
             options.decode_overlap,
+            options.batch_invariant,
         ),
     }
 }
@@ -241,6 +244,7 @@ pub fn start_engine(model_path: &Path, options: EngineLoadOptions) -> Result<Eng
         DEFAULT_MAX_PREFILL_TOKENS,
         Qwen3MemoryOptions::default(),
         DecodeOverlap::Off,
+        false,
     )
 }
 
@@ -264,6 +268,7 @@ pub fn start_engine_with_offload(
     max_prefill_tokens: usize,
     memory_options: Qwen3MemoryOptions,
     decode_overlap: DecodeOverlap,
+    batch_invariant: bool,
 ) -> Result<EngineHandle> {
     let EngineLoadOptions {
         enable_cuda_graph,
@@ -274,6 +279,8 @@ pub fn start_engine_with_offload(
     let model_path = model_path
         .to_str()
         .ok_or_else(|| anyhow::anyhow!("model path must be valid UTF-8"))?;
+    ensure_batch_invariant_supported(decode_overlap, batch_invariant)?;
+    apply_batch_invariant_policy(batch_invariant);
     scheduler::start_qwen3(
         model_path,
         enable_cuda_graph,
@@ -296,6 +303,7 @@ pub fn start_engine_with_lora_control(
     max_prefill_tokens: usize,
     memory_options: Qwen3MemoryOptions,
     decode_overlap: DecodeOverlap,
+    batch_invariant: bool,
 ) -> Result<EngineHandle> {
     let EngineLoadOptions {
         enable_cuda_graph,
@@ -306,6 +314,11 @@ pub fn start_engine_with_lora_control(
     let model_path = model_path
         .to_str()
         .ok_or_else(|| anyhow::anyhow!("model path must be valid UTF-8"))?;
+    ensure_batch_invariant_supported(decode_overlap, batch_invariant)?;
+    if batch_invariant {
+        anyhow::bail!("--batch-invariant is not yet validated with LoRA serving");
+    }
+    apply_batch_invariant_policy(batch_invariant);
     scheduler::start_qwen3_with_lora_control(
         model_path,
         enable_cuda_graph,
@@ -318,4 +331,27 @@ pub fn start_engine_with_lora_control(
         memory_options,
         decode_overlap,
     )
+}
+
+fn apply_batch_invariant_policy(batch_invariant: bool) {
+    use openinfer_kernels::ops::{NumericPolicy, set_numeric_policy};
+    let policy = if batch_invariant {
+        NumericPolicy::Pin
+    } else {
+        NumericPolicy::Tuned
+    };
+    info!("Qwen3 numeric policy: {policy:?} (--batch-invariant={batch_invariant})");
+    set_numeric_policy(policy);
+}
+
+fn ensure_batch_invariant_supported(
+    decode_overlap: DecodeOverlap,
+    batch_invariant: bool,
+) -> Result<()> {
+    if batch_invariant && !matches!(decode_overlap, DecodeOverlap::Off) {
+        anyhow::bail!(
+            "--batch-invariant is not compatible with --decode-overlap; Pin falls back to per-token under a stream override"
+        );
+    }
+    Ok(())
 }

--- a/openinfer-qwen3-4b/tests/batch_invariance_decode_gemm_graph.rs
+++ b/openinfer-qwen3-4b/tests/batch_invariance_decode_gemm_graph.rs
@@ -1,0 +1,183 @@
+//! Decode-GEMM batch-invariance under CUDA-graph, per-policy isolated.
+//!
+//! The decode graph is captured once per (bucket, attention_path) and replayed; the cache key
+//! excludes numeric_policy and replay skips the kernel closure, so each policy needs its own fresh
+//! executor with the policy set before build. A (row 0) fixed; filler count varies A's bucket → its
+//! decode-GEMM N (Tuned: a plan per bucket = drift; Pin: one algo = invariant).
+//!
+//!   OPENINFER_TEST_MODEL_PATH=<Qwen3-4B-base> cargo test --release \
+//!     -p openinfer-qwen3-4b --test batch_invariance_decode_gemm_graph -- --nocapture
+
+use openinfer_core::sampler::SamplingParams;
+use openinfer_kernels::ops::{NumericPolicy, pin_counters, reset_pin_counters, set_numeric_policy};
+use openinfer_qwen3_4b::runtime::{
+    DecodePlan, DecodeStepItem, PrefillPlan, PrefillStepItem, Qwen3Executor, RequestId,
+};
+
+const LOGPROBS: usize = 64;
+const MAX_OUTPUT_TOKENS: usize = 4;
+const SHORT_LEN: usize = 8; // < split-KV threshold (1024) -> NonPartition decode attention
+
+// (label, real_small, real_large). bucket_for: 1->1, 3->4, 7->8, 15->16.
+// A (row 0) identical in all; only the bucket A pads into changes (decode GEMM N).
+const PAIRS: [(&str, usize, usize); 6] = [
+    ("ident_b8v8  ", 7, 7), // sanity: identical batch -> must be equal under every policy
+    ("b1v8(1,7)   ", 1, 7), // bucket 1 vs 8
+    ("b4v8(3,7)   ", 3, 7), // bucket 4 vs 8
+    ("b4v16(3,15) ", 3, 15), // bucket 4 vs 16
+    // Large buckets: the pin keys on {M,K} only, so A's algo must stay identical across two LARGE
+    // decode buckets — where a capture/replay layout-lifetime bug would surface.
+    ("b40v72     ", 40, 71),   // buckets 40 vs 72
+    ("b200v256   ", 200, 255), // top buckets 200 vs 256
+];
+
+fn model_path_or_skip() -> Option<String> {
+    let Ok(p) = std::env::var("OPENINFER_TEST_MODEL_PATH") else {
+        eprintln!(
+            "skipping qwen3 batch_invariance_decode_gemm_graph: set OPENINFER_TEST_MODEL_PATH to Qwen3-4B-base"
+        );
+        return None;
+    };
+    Some(p)
+}
+
+fn pitem(id: RequestId, prompt: Vec<u32>) -> PrefillStepItem {
+    PrefillStepItem::new(
+        id,
+        prompt,
+        MAX_OUTPUT_TOKENS,
+        SamplingParams::default(),
+        LOGPROBS,
+        false,
+    )
+}
+
+fn short_prompt(seed: u32) -> Vec<u32> {
+    (0..SHORT_LEN as u32)
+        .map(|i| 1000 + (seed * 131 + i * 7) % 50000)
+        .collect()
+}
+
+/// A (request 0)'s `(prefill first_token, one-step decode top-K)` when co-batched with
+/// `n_requests - 1` fillers. first_token lets the caller confirm prefill is unchanged.
+fn a_first_and_decode(ex: &mut Qwen3Executor, n_requests: usize) -> (u32, Vec<(u32, f32)>) {
+    let batch: Vec<(RequestId, Vec<u32>)> = (0..n_requests)
+        .map(|i| (RequestId::new(1 + i as u64), short_prompt(i as u32)))
+        .collect();
+    let pitems: Vec<PrefillStepItem> = batch.iter().map(|(id, p)| pitem(*id, p.clone())).collect();
+    let pr = ex
+        .execute_prefill(PrefillPlan {
+            sample_seed: 0,
+            requests: &pitems,
+            echo: false,
+        })
+        .expect("prefill");
+    let a_first = pr.requests[0].first_token;
+    let ditems: Vec<DecodeStepItem> = batch
+        .iter()
+        .zip(&pr.requests)
+        .map(|((id, _), req)| {
+            DecodeStepItem::new(*id, req.first_token, SamplingParams::default(), LOGPROBS)
+        })
+        .collect();
+    let dr = ex
+        .execute_decode(DecodePlan {
+            sample_seed: 0,
+            requests: &ditems,
+        })
+        .expect("decode");
+    let topk = dr.requests[0]
+        .logprob
+        .as_ref()
+        .expect("logprobs requested but none returned")
+        .top_logprobs
+        .clone();
+    for (id, _) in &batch {
+        ex.drop_request(*id).expect("drop request");
+    }
+    (a_first, topk)
+}
+
+/// One fresh executor with `policy` active before first decode (graph captured under it).
+fn run_policy(policy: NumericPolicy, model_path: &str) -> Vec<(bool, bool, u64, u64)> {
+    set_numeric_policy(policy);
+    let mut ex = Qwen3Executor::from_runtime(model_path, true, &[0]).expect("build executor");
+    ex.set_prefix_cache_enabled(false);
+    let mut out = Vec::new();
+    for (_, small, large) in PAIRS {
+        reset_pin_counters();
+        let (ft_s, tk_s) = a_first_and_decode(&mut ex, small);
+        let (ft_l, tk_l) = a_first_and_decode(&mut ex, large);
+        let (served, fallback) = pin_counters();
+        let ft_eq = ft_s == ft_l;
+        let tk_eq = tk_s == tk_l;
+        // served counts the CAPTURE step only (replay skips the closure). Under baseline/per_token,
+        // launch_gemm_pin is never called → served/fallback are structurally 0 (N/A).
+        out.push((ft_eq, tk_eq, served, fallback));
+    }
+    out
+}
+
+#[test]
+fn batch_invariance_decode_gemm_graph() {
+    let Some(model_path) = model_path_or_skip() else {
+        return;
+    };
+    let baseline = run_policy(NumericPolicy::Tuned, &model_path);
+    let pin = run_policy(NumericPolicy::Pin, &model_path);
+    let pertoken = run_policy(NumericPolicy::PerToken, &model_path);
+
+    // Prefill must be identical for A in every batch/policy, else the decode comparison is
+    // prefill-contaminated.
+    for (name, rows) in [
+        ("baseline", &baseline),
+        ("pin", &pin),
+        ("per_token", &pertoken),
+    ] {
+        for (i, (ft_eq, _, _, _)) in rows.iter().enumerate() {
+            assert!(
+                *ft_eq,
+                "{name}: A's prefill first_token differs across batch on pair {} — decode \
+                 comparison is prefill-contaminated, not a decode result",
+                PAIRS[i].0.trim()
+            );
+        }
+    }
+
+    // Control: baseline must drift on at least one pair (else not reproduced here).
+    let baseline_drifted = baseline.iter().any(|(_, tk_eq, _, _)| !tk_eq);
+    assert!(
+        baseline_drifted,
+        "baseline did NOT drift on any pair — decode-GEMM coupling not reproduced; \
+         the pin proof would be vacuous"
+    );
+
+    // Pin: every pair invariant, served>0 (pin ran at capture), fallback==0 (per-token oracle
+    // did not cover for it).
+    for (i, (_, tk_eq, served, fallback)) in pin.iter().enumerate() {
+        assert!(
+            *tk_eq,
+            "PIN: A's graph decode top-K changed on pair {} — pin did NOT make graph decode \
+             batch-invariant (graph captured under Pin)",
+            PAIRS[i].0.trim()
+        );
+        assert!(
+            *served > 0,
+            "PIN: pin did not run on pair {} (served=0) — vacuous",
+            PAIRS[i].0.trim()
+        );
+        assert!(
+            *fallback == 0,
+            "PIN: pair {} fell back to per-token (fallback={fallback}) — invariance carried by the \
+             fallback oracle, not the pinned algo (if a large bucket: check LT_WORKSPACE_SIZE)",
+            PAIRS[i].0.trim()
+        );
+    }
+    for (i, (_, tk_eq, _, _)) in pertoken.iter().enumerate() {
+        assert!(
+            *tk_eq,
+            "PER_TOKEN: A's graph decode top-K changed on pair {} — harness bug",
+            PAIRS[i].0.trim()
+        );
+    }
+}

--- a/openinfer-qwen3-4b/tests/batch_invariance_endtoend.rs
+++ b/openinfer-qwen3-4b/tests/batch_invariance_endtoend.rs
@@ -1,0 +1,133 @@
+//! End-to-end prefill repro: pinning the projection GEMMs makes prompt_a's next-token top-K stop
+//! depending on its batch-mates in this tested prefill path. Scope is the GEMM-N reduction-order
+//! axis, not whole-model invariance — attention-path and decode-vs-unified residuals survive the pin.
+//!
+//! prompt_a's top-K alone vs co-batched with a filler, under three policies: baseline (Tuned,
+//! drifts = the bug), pin (top-K bit-identical = the fix), per_token (oracle). Pass requires full
+//! ordered top-K equality + a baseline-drift guard + fallback=0 for total_N≤32.
+//!
+//!   OPENINFER_TEST_MODEL_PATH=<Qwen3-4B-base> cargo test --release \
+//!     -p openinfer-qwen3-4b --test batch_invariance_endtoend -- --nocapture
+
+use openinfer_core::sampler::SamplingParams;
+use openinfer_kernels::ops::{NumericPolicy, pin_counters, reset_pin_counters, set_numeric_policy};
+use openinfer_qwen3_4b::runtime::{PrefillPlan, PrefillStepItem, Qwen3Executor, RequestId};
+
+const LOGPROBS: usize = 64;
+const MAX_OUTPUT_TOKENS: usize = 4;
+
+fn model_path_or_skip() -> Option<String> {
+    let Ok(p) = std::env::var("OPENINFER_TEST_MODEL_PATH") else {
+        eprintln!(
+            "skipping qwen3 batch_invariance_endtoend: set OPENINFER_TEST_MODEL_PATH to Qwen3-4B-base"
+        );
+        return None;
+    };
+    Some(p)
+}
+
+fn item(id: RequestId, prompt: Vec<u32>) -> PrefillStepItem {
+    PrefillStepItem::new(
+        id,
+        prompt,
+        MAX_OUTPUT_TOKENS,
+        SamplingParams::default(),
+        LOGPROBS,
+        false,
+    )
+}
+
+/// prompt_a (request 0)'s next-token `(token, logprob)` top-K table; drops every
+/// request afterward so ids can be reused for the next call.
+fn dist_for_first(ex: &mut Qwen3Executor, batch: &[(RequestId, Vec<u32>)]) -> Vec<(u32, f32)> {
+    let items: Vec<PrefillStepItem> = batch.iter().map(|(id, p)| item(*id, p.clone())).collect();
+    let pr = ex
+        .execute_prefill(PrefillPlan {
+            sample_seed: 0,
+            requests: &items,
+            echo: false,
+        })
+        .expect("prefill");
+    let out = pr.requests[0]
+        .first_token_logprob
+        .as_ref()
+        .expect("logprobs requested but none returned")
+        .top_logprobs
+        .clone();
+    for (id, _) in batch {
+        ex.drop_request(*id).expect("drop request");
+    }
+    out
+}
+
+#[test]
+fn batch_invariance_endtoend() {
+    let Some(model_path) = model_path_or_skip() else {
+        return;
+    };
+    let mut ex = Qwen3Executor::from_runtime(&model_path, false, &[0]).expect("build executor");
+    ex.set_prefix_cache_enabled(false);
+
+    let prompt_a: Vec<u32> = vec![9707];
+    let nbs: [usize; 5] = [1, 7, 15, 31, 63]; // total_N = 2,8,16,32,64 — straddles GEMM_LT_MAX_N
+    let id_a = RequestId::new(1);
+
+    let mut baseline_drifted = false;
+
+    for policy in [
+        NumericPolicy::Tuned,
+        NumericPolicy::Pin,
+        NumericPolicy::PerToken,
+    ] {
+        set_numeric_policy(policy);
+        let alone = dist_for_first(&mut ex, &[(id_a, prompt_a.clone())]);
+        for &nb in &nbs {
+            reset_pin_counters();
+            let id_b = RequestId::new(1000 + nb as u64);
+            let batched = dist_for_first(
+                &mut ex,
+                &[(id_a, prompt_a.clone()), (id_b, vec![785u32; nb])],
+            );
+            let (served, fallback) = pin_counters();
+            let total_n = prompt_a.len() + nb;
+            let topk_equal = alone == batched;
+
+            match policy {
+                NumericPolicy::Tuned => {
+                    if !topk_equal {
+                        baseline_drifted = true;
+                    }
+                }
+                NumericPolicy::Pin => {
+                    assert!(
+                        topk_equal,
+                        "PIN: prompt_a top-K changed when co-batched (+Nb={nb}, total_N={total_n}) \
+                         — projection-GEMM reduction-order NOT invariant under the pin in this prefill path"
+                    );
+                    assert!(
+                        served > 0,
+                        "PIN: no GEMM ran the pinned algo (+Nb={nb}) — vacuous"
+                    );
+                    if total_n <= 32 {
+                        assert_eq!(
+                            fallback, 0,
+                            "PIN: fell back to per-token at total_N={total_n}<=32 (+Nb={nb}) — \
+                             proving the fallback, not the pin"
+                        );
+                    }
+                }
+                NumericPolicy::PerToken => {
+                    assert!(
+                        topk_equal,
+                        "PER_TOKEN oracle: top-K changed (+Nb={nb}) — harness bug, not a result"
+                    );
+                }
+            }
+        }
+    }
+
+    assert!(
+        baseline_drifted,
+        "baseline did NOT drift on any case — was not reproduced here, so the pin pass is vacuous"
+    );
+}

--- a/openinfer-qwen3-4b/tests/batch_invariance_envelope.rs
+++ b/openinfer-qwen3-4b/tests/batch_invariance_envelope.rs
@@ -1,0 +1,147 @@
+//! Production-envelope fallback guard: under Pin the {M,K} algo is pinned and reused for every N;
+//! this asserts zero per-token fallback across the swept Qwen3-4B envelope — Unified at
+//! N=101/201/513/1024/1279 and pure-Decode at bs=256 (exactly these points, not all N).
+use openinfer_core::sampler::SamplingParams;
+use openinfer_kernels::ops::{
+    NumericPolicy, pin_counters, pin_fallback_shapes, reset_pin_counters, set_numeric_policy,
+};
+use openinfer_qwen3_4b::runtime::{
+    DecodePlan, DecodeStepItem, PrefillPlan, PrefillStepItem, Qwen3Executor, RequestId, UnifiedPlan,
+};
+
+fn model_path_or_skip() -> Option<String> {
+    if let Ok(p) = std::env::var("OPENINFER_TEST_MODEL_PATH") {
+        Some(p)
+    } else {
+        eprintln!("skip batch_invariance_envelope: set OPENINFER_TEST_MODEL_PATH to Qwen3-4B-base");
+        None
+    }
+}
+
+fn synth(ctx: usize, seed: u64) -> Vec<u32> {
+    (0..ctx as u32)
+        .map(|i| (i + seed as u32 * 13) % 2000 + 10)
+        .collect()
+}
+
+fn prefill_first(ex: &mut Qwen3Executor, id: RequestId, prompt: &[u32]) -> u32 {
+    ex.execute_prefill(PrefillPlan {
+        requests: &[PrefillStepItem::new(
+            id,
+            prompt.to_vec(),
+            64,
+            SamplingParams::default(),
+            0,
+            false,
+        )],
+        echo: false,
+        sample_seed: 0,
+    })
+    .expect("prefill")
+    .requests[0]
+        .first_token
+}
+
+fn assert_no_fallback(label: &str, n: usize) {
+    let (served, fb) = pin_counters();
+    let shapes = pin_fallback_shapes();
+    assert!(
+        served > 0,
+        "{label} N={n}: served=0 — pin never ran (vacuous)"
+    );
+    assert!(
+        shapes.is_empty(),
+        "{label} N={n}: {fb} per-token fallback(s), shapes {shapes:?} — pin cannot serve this N"
+    );
+    eprintln!("[envelope] {label} N={n}: served={served} fallback={fb} ok");
+}
+
+#[test]
+fn pin_serves_production_envelope_without_fallback() {
+    let Some(model_path) = model_path_or_skip() else {
+        return;
+    };
+    set_numeric_policy(NumericPolicy::Pin);
+    let mut ex = Qwen3Executor::from_runtime(&model_path, false, &[0]).expect("executor");
+    ex.set_prefix_cache_enabled(false);
+
+    for (i, &pf) in [100usize, 200, 512, 1023].iter().enumerate() {
+        let id_d = RequestId::new(50000 + i as u64);
+        let t = prefill_first(&mut ex, id_d, &synth(8, i as u64));
+        let id_p = RequestId::new(51000 + i as u64);
+        reset_pin_counters();
+        let _ = ex
+            .execute_unified(UnifiedPlan {
+                prefill_requests: &[PrefillStepItem::new(
+                    id_p,
+                    synth(pf, 100 + i as u64),
+                    64,
+                    SamplingParams::default(),
+                    0,
+                    false,
+                )],
+                decode_requests: &[DecodeStepItem::new(id_d, t, SamplingParams::default(), 64)],
+                sample_seed: 0,
+            })
+            .expect("unified envelope");
+        assert_no_fallback("Unified", pf + 1);
+        let _ = ex.drop_request(id_p);
+        let _ = ex.drop_request(id_d);
+    }
+
+    let dec: Vec<(RequestId, u32)> = (0..256u64)
+        .map(|i| {
+            let id = RequestId::new(20000 + i);
+            let t = prefill_first(&mut ex, id, &synth(16, i));
+            (id, t)
+        })
+        .collect();
+    let items: Vec<DecodeStepItem> = dec
+        .iter()
+        .map(|&(id, tok)| DecodeStepItem::new(id, tok, SamplingParams::default(), 0))
+        .collect();
+    reset_pin_counters();
+    let _ = ex
+        .execute_decode(DecodePlan {
+            requests: &items,
+            sample_seed: 0,
+        })
+        .expect("decode bs=256");
+    assert_no_fallback("pure-Decode", 256);
+    for (id, _) in &dec {
+        let _ = ex.drop_request(*id);
+    }
+
+    let decoders: Vec<(RequestId, u32)> = (0..255u64)
+        .map(|i| {
+            let id = RequestId::new(30000 + i);
+            let t = prefill_first(&mut ex, id, &synth(16, 1000 + i));
+            (id, t)
+        })
+        .collect();
+    let id_big = RequestId::new(40000);
+    let decode_items: Vec<DecodeStepItem> = decoders
+        .iter()
+        .map(|&(id, tok)| DecodeStepItem::new(id, tok, SamplingParams::default(), 0))
+        .collect();
+    reset_pin_counters();
+    let _ = ex
+        .execute_unified(UnifiedPlan {
+            prefill_requests: &[PrefillStepItem::new(
+                id_big,
+                synth(1024, 7),
+                64,
+                SamplingParams::default(),
+                0,
+                false,
+            )],
+            decode_requests: &decode_items,
+            sample_seed: 0,
+        })
+        .expect("unified N=1279");
+    assert_no_fallback("Unified", 1279);
+    let _ = ex.drop_request(id_big);
+    for (id, _) in &decoders {
+        let _ = ex.drop_request(*id);
+    }
+}

--- a/openinfer-qwen3-4b/tests/batch_invariance_reject.rs
+++ b/openinfer-qwen3-4b/tests/batch_invariance_reject.rs
@@ -1,0 +1,67 @@
+//! `--batch-invariant` is rejected at the Qwen3 builder boundary for unsupported combos:
+//! stream overlap would silently fall back to per-token, and LoRA shapes are not gated.
+
+use std::path::Path;
+use std::sync::Mutex;
+
+use openinfer_core::engine::EngineLoadOptions;
+use openinfer_kernels::ops::{NumericPolicy, numeric_policy, set_numeric_policy};
+use openinfer_qwen3_4b::{
+    DEFAULT_MAX_PREFILL_TOKENS, DecodeOverlap, Qwen3LoraOptions, Qwen3MemoryOptions,
+    Qwen3OffloadOptions, start_engine_with_lora_control, start_engine_with_offload,
+};
+
+// Serialize the two #[test]s — they share the process-global numeric policy.
+static POLICY_LOCK: Mutex<()> = Mutex::new(());
+
+#[test]
+fn batch_invariant_rejects_decode_overlap() {
+    let _g = POLICY_LOCK.lock().unwrap();
+    set_numeric_policy(NumericPolicy::Tuned);
+    let err = start_engine_with_offload(
+        Path::new("/nonexistent-model"),
+        EngineLoadOptions::default(),
+        Qwen3OffloadOptions::disabled(),
+        false,
+        DEFAULT_MAX_PREFILL_TOKENS,
+        Qwen3MemoryOptions::default(),
+        DecodeOverlap::SharedSm,
+        true,
+    )
+    .err()
+    .expect("--batch-invariant + --decode-overlap must be rejected");
+    assert!(
+        format!("{err}").contains("decode-overlap"),
+        "unexpected error: {err}"
+    );
+    assert_eq!(
+        numeric_policy(),
+        NumericPolicy::Tuned,
+        "guard must reject before apply_batch_invariant_policy — global policy was polluted to Pin"
+    );
+}
+
+#[test]
+fn batch_invariant_rejects_lora() {
+    let _g = POLICY_LOCK.lock().unwrap();
+    set_numeric_policy(NumericPolicy::Tuned);
+    let err = start_engine_with_lora_control(
+        Path::new("/nonexistent-model"),
+        EngineLoadOptions::default(),
+        Qwen3LoraOptions::default(),
+        Qwen3OffloadOptions::disabled(),
+        false,
+        DEFAULT_MAX_PREFILL_TOKENS,
+        Qwen3MemoryOptions::default(),
+        DecodeOverlap::Off,
+        true,
+    )
+    .err()
+    .expect("--batch-invariant + LoRA must be rejected");
+    assert!(format!("{err}").contains("LoRA"), "unexpected error: {err}");
+    assert_eq!(
+        numeric_policy(),
+        NumericPolicy::Tuned,
+        "guard must reject before apply_batch_invariant_policy — global policy was polluted to Pin"
+    );
+}

--- a/openinfer-qwen3-4b/tests/batch_invariance_unified.rs
+++ b/openinfer-qwen3-4b/tests/batch_invariance_unified.rs
@@ -1,0 +1,185 @@
+//! Unified within-path GEMM-N invariance: a decode row co-batched with prefill chunks of different
+//! lengths (so the projection GEMM runs at different N) must give a bit-identical top-K under Pin.
+//! The pure-Decode-vs-Unified cross-path case drifts even under Pin and is the `#[ignore]` below.
+use openinfer_core::sampler::SamplingParams;
+use openinfer_kernels::ops::{
+    NumericPolicy, pin_counters, pin_fallback_shapes, reset_pin_counters, set_numeric_policy,
+};
+use openinfer_qwen3_4b::runtime::{
+    DecodePlan, DecodeStepItem, PrefillPlan, PrefillStepItem, Qwen3Executor, RequestId, UnifiedPlan,
+};
+use std::sync::Mutex;
+
+// Serialize the two #[test]s — they share the process-global numeric policy.
+static POLICY_LOCK: Mutex<()> = Mutex::new(());
+
+fn model_path_or_skip() -> Option<String> {
+    if let Ok(p) = std::env::var("OPENINFER_TEST_MODEL_PATH") {
+        Some(p)
+    } else {
+        eprintln!("skip batch_invariance_unified: set OPENINFER_TEST_MODEL_PATH to Qwen3-4B-base");
+        None
+    }
+}
+
+fn prefill_first(ex: &mut Qwen3Executor, id: RequestId, prompt: &[u32]) -> u32 {
+    ex.execute_prefill(PrefillPlan {
+        requests: &[PrefillStepItem::new(
+            id,
+            prompt.to_vec(),
+            64,
+            SamplingParams::default(),
+            0,
+            false,
+        )],
+        echo: false,
+        sample_seed: 0,
+    })
+    .expect("prefill")
+    .requests[0]
+        .first_token
+}
+
+fn unified_decode_row(
+    ex: &mut Qwen3Executor,
+    p: &[u32],
+    cobatch: usize,
+    id_dec: u64,
+    id_pf: u64,
+) -> (Vec<(u32, f32)>, (u64, u64)) {
+    let id_a = RequestId::new(id_dec);
+    let t0 = prefill_first(ex, id_a, p);
+    let id_b = RequestId::new(id_pf);
+    let chunk: Vec<u32> = (0..cobatch as u32).map(|i| (i % 1000) + 10).collect();
+    reset_pin_counters();
+    let ur = ex
+        .execute_unified(UnifiedPlan {
+            prefill_requests: &[PrefillStepItem::new(
+                id_b,
+                chunk,
+                64,
+                SamplingParams::default(),
+                0,
+                false,
+            )],
+            decode_requests: &[DecodeStepItem::new(id_a, t0, SamplingParams::default(), 64)],
+            sample_seed: 0,
+        })
+        .expect("unified");
+    let topk = ur.decode_requests[0]
+        .logprob
+        .clone()
+        .map(|l| l.top_logprobs)
+        .unwrap_or_default();
+    let counters = pin_counters();
+    let _ = ex.drop_request(id_b);
+    let _ = ex.drop_request(id_a);
+    (topk, counters)
+}
+
+fn pure_decode_row(ex: &mut Qwen3Executor, p: &[u32], id_dec: u64) -> Vec<(u32, f32)> {
+    let id = RequestId::new(id_dec);
+    let t0 = prefill_first(ex, id, p);
+    reset_pin_counters();
+    let dr = ex
+        .execute_decode(DecodePlan {
+            requests: &[DecodeStepItem::new(id, t0, SamplingParams::default(), 64)],
+            sample_seed: 0,
+        })
+        .expect("decode");
+    let topk = dr.requests[0]
+        .logprob
+        .clone()
+        .map(|l| l.top_logprobs)
+        .unwrap_or_default();
+    let _ = ex.drop_request(id);
+    topk
+}
+
+fn maxd(a: &[(u32, f32)], b: &[(u32, f32)]) -> f32 {
+    let n = a.len().min(b.len());
+    (0..n).fold(0.0f32, |m, i| m.max((a[i].1 - b[i].1).abs()))
+}
+
+const PROMPT: [u32; 8] = [9707, 785, 11, 1879, 13, 358, 1079, 264];
+const COBATCH: [usize; 4] = [100, 200, 512, 1023];
+
+#[test]
+fn unified_within_path_gemm_n_invariant_under_pin() {
+    let Some(model_path) = model_path_or_skip() else {
+        return;
+    };
+    let _g = POLICY_LOCK.lock().unwrap();
+    let p = PROMPT.to_vec();
+
+    set_numeric_policy(NumericPolicy::Pin);
+    let mut ex = Qwen3Executor::from_runtime(&model_path, false, &[0]).expect("executor");
+    ex.set_prefix_cache_enabled(false);
+    let mut base: Option<Vec<(u32, f32)>> = None;
+    for (i, &c) in COBATCH.iter().enumerate() {
+        let n = c + 1;
+        let (topk, (served, fb)) =
+            unified_decode_row(&mut ex, &p, c, 100 + i as u64 * 2, 101 + i as u64 * 2);
+        assert!(served > 0, "Pin N={n}: served=0 — pin never ran (vacuous)");
+        assert!(
+            pin_fallback_shapes().is_empty(),
+            "Pin N={n}: {fb} per-token fallback(s), shapes {:?}",
+            pin_fallback_shapes()
+        );
+        match &base {
+            None => base = Some(topk),
+            Some(b) => assert_eq!(
+                *b, topk,
+                "Pin: Unified decode row drifted at N={n} vs N=101 — GEMM-N not invariant within Unified"
+            ),
+        }
+        eprintln!("[unified-gate] Pin N={n}: served={served} fb={fb} bit-eq-vs-N101=ok");
+    }
+    drop(ex);
+
+    set_numeric_policy(NumericPolicy::Tuned);
+    let mut ex = Qwen3Executor::from_runtime(&model_path, false, &[0]).expect("executor");
+    ex.set_prefix_cache_enabled(false);
+    let mut tbase: Option<Vec<(u32, f32)>> = None;
+    let mut drifted = false;
+    for (i, &c) in COBATCH.iter().enumerate() {
+        let (topk, _) = unified_decode_row(&mut ex, &p, c, 200 + i as u64 * 2, 201 + i as u64 * 2);
+        match &tbase {
+            None => tbase = Some(topk),
+            Some(b) => drifted |= *b != topk,
+        }
+    }
+    eprintln!(
+        "[unified-gate] Tuned within-Unified baseline drift: {}",
+        if drifted {
+            "drifts (reproduced)"
+        } else {
+            "STABLE"
+        }
+    );
+    assert!(
+        drifted,
+        "Tuned within-Unified did not drift across N — batch-dependence not reproduced here, Pin pass vacuous"
+    );
+}
+
+#[test]
+#[ignore = "decode/unified cross-path drift survives the pin; tracked follow-up"]
+fn cross_path_decode_vs_unified_drifts_under_pin() {
+    let Some(model_path) = model_path_or_skip() else {
+        return;
+    };
+    let _g = POLICY_LOCK.lock().unwrap();
+    let p = PROMPT.to_vec();
+    set_numeric_policy(NumericPolicy::Pin);
+    let mut ex = Qwen3Executor::from_runtime(&model_path, false, &[0]).expect("executor");
+    ex.set_prefix_cache_enabled(false);
+    let dec = pure_decode_row(&mut ex, &p, 900);
+    let (uni, _) = unified_decode_row(&mut ex, &p, 100, 901, 902);
+    let d = maxd(&dec, &uni);
+    eprintln!("[cross-path] pure-Decode vs Unified under Pin: maxΔ={d:e}");
+    assert!(
+        d > 0.0,
+        "cross-path drift vanished — the cross-path residual may now be closed; revisit the follow-up"
+    );
+}

--- a/openinfer-qwen3-4b/tests/lora_smoke.rs
+++ b/openinfer-qwen3-4b/tests/lora_smoke.rs
@@ -232,6 +232,7 @@ fn qwen3_lora_loads_rank_and_generates(rank: usize, adapter_name: &str) {
         openinfer_qwen3_4b::DEFAULT_MAX_PREFILL_TOKENS,
         openinfer_qwen3_4b::Qwen3MemoryOptions::default(),
         openinfer_qwen3_4b::DecodeOverlap::Off,
+        false,
     )
     .expect("start LoRA-capable Qwen3 engine");
 

--- a/openinfer-qwen3-4b/tests/scheduler_robustness.rs
+++ b/openinfer-qwen3-4b/tests/scheduler_robustness.rs
@@ -4,9 +4,12 @@
 //! this test owns the one thing that gate does not — that the scheduler keeps
 //! running when a client hangs up mid-flight. We submit a request, drop its
 //! receiver immediately, and assert the engine retires that request cleanly and
-//! still serves the next one. It drives the real engine (`start_engine` +
-//! `submit`) rather than a mocked scheduler, so it exercises the actual
-//! send-failure retirement path.
+//! still serves the next one. It drives the real engine + `submit` rather than a
+//! mocked scheduler, so it exercises the actual send-failure retirement path.
+//!
+//! Started via the `--batch-invariant` builder, it also checks that the flag sets
+//! the pin policy before serving. CUDA-graph pin behavior is covered by
+//! `batch_invariance_decode_gemm_graph`.
 //!
 //! Requires a CUDA GPU and Qwen3-4B weights; skips cleanly when the model is
 //! absent (point `OPENINFER_TEST_MODEL_PATH` at the weights to run it).
@@ -18,6 +21,7 @@ use openinfer_core::engine::{
     EngineHandle, EngineLoadOptions, GenerateRequest, TokenEvent, TokenSink,
 };
 use openinfer_core::sampler::SamplingParams;
+use openinfer_kernels::ops::{NumericPolicy, numeric_policy, pin_counters, reset_pin_counters};
 use vllm_text::tokenizer::DynTokenizer;
 
 mod common;
@@ -85,7 +89,7 @@ fn scheduler_survives_consumer_drop() {
         return;
     };
 
-    let handle = openinfer_qwen3_4b::start_engine(
+    let handle = openinfer_qwen3_4b::start_engine_with_offload(
         Path::new(&model_path),
         EngineLoadOptions {
             enable_cuda_graph: true,
@@ -94,8 +98,19 @@ fn scheduler_survives_consumer_drop() {
             seed: 42,
             ..EngineLoadOptions::default()
         },
+        openinfer_qwen3_4b::Qwen3OffloadOptions::disabled(),
+        true,
+        openinfer_qwen3_4b::DEFAULT_MAX_PREFILL_TOKENS,
+        openinfer_qwen3_4b::Qwen3MemoryOptions::default(),
+        openinfer_qwen3_4b::DecodeOverlap::Off,
+        true,
     )
     .expect("failed to start engine");
+    assert_eq!(
+        numeric_policy(),
+        NumericPolicy::Pin,
+        "--batch-invariant did not reach the pin policy before serving"
+    );
     let tokenizer = common::load_tokenizer(&model_path);
 
     // Submit, then drop the receiver immediately — the scheduler should notice
@@ -118,7 +133,27 @@ fn scheduler_survives_consumer_drop() {
         .expect("submit failed");
     std::thread::sleep(Duration::from_millis(500));
 
-    // The engine must still serve a fresh request after the orphan is retired.
+    // Barrier: drain the dropped orphan before the counted runs (else its prefill leaks into prefill_served).
+    let _ = generate_text(&handle, &tokenizer, "Hello", 1);
+
+    reset_pin_counters();
+    let _ = generate_text(&handle, &tokenizer, "Hello", 1);
+    let (prefill_served, _) = pin_counters();
+
+    reset_pin_counters();
     let text = generate_text(&handle, &tokenizer, "Hello", 5);
+    let (full_served, fallback) = pin_counters();
+    eprintln!(
+        "[scheduler-robustness] pin served: prefill={prefill_served} full={full_served} fallback={fallback}"
+    );
+
     assert!(!text.is_empty(), "scheduler dead after consumer drop");
+    assert!(
+        full_served > prefill_served,
+        "pin served no decode GEMM beyond prefill (prefill={prefill_served} full={full_served}) — flag→builder→graph-capture may be broken"
+    );
+    assert_eq!(
+        fallback, 0,
+        "Pin fell back during serving (fallback={fallback})"
+    );
 }

--- a/openinfer-server/src/config.rs
+++ b/openinfer-server/src/config.rs
@@ -118,6 +118,11 @@ pub(crate) struct Args {
     /// go to prefill). Ignored in other modes.
     #[arg(long, default_value_t = 20)]
     pub decode_sm_pct: u32,
+
+    /// Enable Qwen3 projection-GEMM batch-invariant pinning. Off by default;
+    /// does not cover path-selection residuals. Qwen3-only.
+    #[arg(long, default_value_t = false)]
+    pub batch_invariant: bool,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -168,11 +173,24 @@ impl Args {
             bail!("--lora-modules requires --enable-lora");
         }
         #[cfg(feature = "qwen3-4b")]
-        let lora_capable = matches!(model_type, ModelType::Qwen3);
+        let is_qwen3 = matches!(model_type, ModelType::Qwen3);
         #[cfg(not(feature = "qwen3-4b"))]
-        let lora_capable = false;
-        if self.enable_lora && !lora_capable {
+        let is_qwen3 = false;
+        if self.enable_lora && !is_qwen3 {
             bail!("--enable-lora is currently supported only for Qwen3");
+        }
+        if self.batch_invariant && !is_qwen3 {
+            bail!("--batch-invariant is currently supported only for Qwen3");
+        }
+        if self.batch_invariant && self.enable_lora {
+            bail!(
+                "--batch-invariant is not yet validated with --enable-lora; enable one at a time"
+            );
+        }
+        if self.batch_invariant && !matches!(self.decode_overlap, CliDecodeOverlap::Off) {
+            bail!(
+                "--batch-invariant is not compatible with --decode-overlap; Pin falls back to per-token under a stream override"
+            );
         }
         Ok(())
     }

--- a/openinfer-server/src/main.rs
+++ b/openinfer-server/src/main.rs
@@ -170,6 +170,7 @@ fn load_engine(args: &Args, model_type: ModelType) -> anyhow::Result<EngineHandl
                     .validate()?,
                     lora,
                     decode_overlap: args.decode_overlap.resolve(args.decode_sm_pct),
+                    batch_invariant: args.batch_invariant,
                 },
             )
             .context("failed to start Qwen3 engine")?


### PR DESCRIPTION
## Description

Refs #414 

A request's next-token logits depend on which other requests share its batch. This adds an opt-in NumericPolicy (default Tuned, unchanged from today) that ~~removes the two measured reduction-order batch dependencies~~ removes the measured projection-GEMM N-dependence in the deterministic Qwen3 paths tested here. It pins ~~two batch-coupled reductions~~ one batch-coupled reduction:

Projection GEMMs: pin one cuBLASLt algo (fixed tile/stages/split-K factor) per weight shape (M,K), reused for every N, so the fp32-accumulate reduction order no longer changes with batch width. If the pinned algo cannot serve a live N, or would exceed the pinned workspace budget, the policy falls back to a per-token GEMM, which is itself batch-invariant.

~~Decode split-KV attention: derive the split chunk size from max_context_tokens (a process constant) instead of the live batch max, so a request's chunk count, and therefore its softmax-rescale order, depends only on its own sequence length.~~

## Behavior

bf16-in / fp32-accumulate GEMMs reduce in an order cuBLAS picks as a function of N (the cuBLASLt plan is keyed on {M,N,K})~~; the split-KV chunk size was keyed on the batch's max_seq_len.~~ Either shifts a shared row by about 1 ULP, which flips a near-tie argmax. Norm (per-row), embedding, and prefill attention (fixed cta_tile_q, no partition-KV) are already batch-invariant. Within the isolated deterministic path tested here (prefix cache and LoRA off, fixed sampling), ~~these two are the measured reduction-order sources~~. Measured: down_proj split-K = 4 → 16 → 3 across N = 1 → 16 → 32~~; a 5000-token request decoded alone uses 64 chunks but 40 co-batched with an 8000-token request~~.

## Test Env

Tests: ~~4~~ 5 batch-invariance gates, each with a baseline-drift guard against a vacuous pass. GEMM seam: maxΔ=0 across the N-sweep. ~~End-to-end and the two CUDA-graph guards: prompt_a's ordered top-K (token, logprob) table is bit-identical alone vs co-batched.~~  End-to-end prefill and decode CUDA-graph gates check ordered top-K bit-identity on the tested GEMM-N axis; the unified-step gate covers mixed prefill+decode within-path GEMM-N; the envelope gate asserts served>0 and fallback=0 through the swept Qwen3 production envelope. Verified on both archs, eager and production CUDA-graph: Single GPU (x86_64, sm_89) and GH200 (aarch64, sm_90).

## follow-ups

- Opt-in, default-off (by design). ~~The fix is verified to make decode batch-invariant when enabled~~(OPENINFER_NUMERIC_POLICY=pin|pertoken); it is gated off by default, so the production Tuned path stays byte-identical to today. Promoting it to the default is a separate decision: it carries a prefill perf cost and wants the blast-radius data (in the supplementary notes) first, and is not part of delivering the fix.
- Set the policy before CUDA-graph capture. The decode graph cache key excludes the numeric policy, and numeric_policy() lazily reads OPENINFER_NUMERIC_POLICY, so the first capture of each bucket bakes whatever policy is active. Deployment is expected to set the env before startup, before any capture; the tests set it before executor construction. Switching after a capture replays the captured policy's behavior, held by convention rather than by API.
- Global switch. NumericPolicy lives in the shared GEMM layer, so the GEMM pin applies to any model routing through launch_gemm; ~~the split-KV chunk fix and~~ the gates are qwen3-specific.
- TP=1. The pin gives invariance at a fixed TP degree (fixed NCCL order), not TP-size (TP=1 vs TP=2) invariance, which is a separate problem.
- Perf. The pin is  ~~about free~~ low-overhead at decode and ~~2.6 to 4.5× on prefill-heavy shapes~~ about 2.6–4.5× at the per-GEMM level; whole-prefill e2e is ~1.8–1.85× on sm_89 and ~1.9–2.1× on sm_90. the hybrid (pin + per-token fallback) fits decode-dominated serving. The trade-off and the cuBLASLt-pin-vs-custom-kernel comparison are in the supplementary notes.

---

## Supplementary notes for #414 (for reference)

Background for the scope and perf decisions in the PR. Everything here is measured. Hardware labels: Single GPU (x86_64, sm_89) and GH200 (aarch64, sm_90).

### Blast radius: how often a near-tie actually flips

On a realistic workload (12 prompts of 24 tokens plus 16 decode steps), GH200:
- positions whose logits moved when co-batched: 204 / 204
- near-ties (top1 vs top2 logit gap below 0.20 nat): 7 / 204
- argmax flips: 1 / 204, that is 1 of the 7 near-ties

So co-batching perturbs essentially every position by about 1 ULP, and roughly 0.5% sit close enough to a tie to flip the argmax. The flip rate is set by how many positions land in a near-tie. Treat this as an illustrative single run, an order-of-magnitude figure rather than a reproducible constant.

### Alternatives measured

Two complementary measurements.

Eager per-GEMM is the un-diluted kernel ratio, each divided by its own cuBLAS, over down_proj / o_proj / qkv:
- cuBLASLt pin at decode (N ≤ 64): about 1.0× on both archs (sm_89 0.96 to 1.14, sm_90 1.00 to 1.02 at N ≤ 32; the worst small-batch point measured is 1.35× at o_proj N=64).
- The two open-source batch-invariant reference kernels, TML's batch_invariant_ops and the llm_reproducibility (TBIK) repo, both verified batch-invariant, hit a decode cliff: 2 to 4× on sm_89 (N=1 spikes to about 9×) and 3 to 32× on GH200 at N ≤ 64. A persistent kernel wastes its grid at small N and recovers only at prefill.
- The per-token oracle runs 5 to 50×, useful only as the hybrid's fallback leg.

<img width="1802" height="1145" alt="methods_chart" src="https://github.com/user-attachments/assets/df9c45a1-fae1-4fc2-b460-5690026517f6" />

Production CUDA-graph end-to-end step latency, pin vs baseline, same harness, batch in {1,4,8,16,32,64}: about 1.0 to 1.05× for batch ≤ 32, up to 1.23× at batch 64, with fallback=0 at every tested batch. This e2e ratio is diluted toward 1.0 by common-mode host work (per-step sync, full-vocab argmax) that is identical in both arms, so it is the floor and the eager per-GEMM number is the un-diluted ceiling.

~~Prefill costs about 2.6 to 4.5× under the pin, which is why it is opt-in and decode-targeted.~~
The 2.6–4.5× number is the per-GEMM ceiling; whole-prefill e2e is ~1.8–1.85× on sm_89 and ~1.9–2.1× on sm_90.

~~The attention side has a narrow-batch cost in the split-KV prong. We did not bench it separately. It is characterized from the same tradeoff between chunk count and SM occupancy that our production attention tuning already measured. It costs latency in one narrow regime: long context (over 4096 tokens) at small batch (about 1 to 8). Pinning the chunk size to a process constant gives a below-max-length request fewer chunks, so fewer attention CTAs and lower SM occupancy at small batch. It washes out by batch 8, and it only applies at batch ≤ 32, since above that the step uses the non-partitioned attention path, with no chunking and no cost.~~

### Caveats

- The graph correctness guard covers decode buckets up to 256 (bit-identical, zero fallback). The production end-to-end throughput sweep only runs to batch 64, so throughput at the large buckets is unmeasured; a fallback there would cost throughput, not correctness.
- Determinism is stable across restarts within a fixed cuBLAS and driver version. Cross-version is untested.
- All tests force the prefix cache off, to isolate reduction order. With the cache on, a cache-hit versus cold-prefill request still drifts by bf16 ULPs, which is separate and filed separately.
- CUDA-graph replay is validated bit-identical on both archs. The pin rebuilds its transient B/C cuBLASLt layouts per call, so under capture a layout is freed before replay; this held on both archs (cuBLASLt appears to snapshot the layout at capture). Persisting the layouts per bucket is a hardening follow-up.

### Out of scope (separate batch-dependences, not addressed here)

Prefix-cache KV provenance, sampling at temperature above 0 (Philox is keyed on the batch row index), LoRA delta-kernel N-dependence.

There is also the decode attention-path selection. NonPartition versus SplitKv keys on the batch's live max_seq_len, not on policy, so a request whose context is below 1024, co-batched with one at 1024 or more, runs a different attention kernel. That is a residual batch-variance of the same ULP class, and it survives the Pin. It is self-limiting, since it goes away once the request's own context passes 1024, and it is confined to batch ≤ 32. A clean follow-up if batch-invariant decode is ever promised by default.
