### PR TITLE
docs(readme): add Slack community invite badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 </p>
 
 <p align="center">
+  <a href="https://join.slack.com/t/openinferhq/shared_invite/zt-41scnc53a-d0McNJDjK2lVqFGoSLUgXA">
+    <img src="https://img.shields.io/badge/Slack-join%20the%20community-4A154B?logo=slack&logoColor=white" alt="Join the openinfer Slack">
+  </a>
+</p>
+
+<p align="center">
   <a href="#quickstart">Quickstart</a> &middot;
   <a href="#supported-models">Models</a> &middot;
   <a href="#api">API</a> &middot;


### PR DESCRIPTION
Adds a Slack join badge to the README header (under the tagline, above the nav) so newcomers have an obvious place to ask questions and coordinate work.

Invite: https://join.slack.com/t/openinferhq/shared_invite/zt-41scnc53a-d0McNJDjK2lVqFGoSLUgXA

Docs-only; no code or build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)