### PR TITLE
chore(deps): bump vllm rust frontend to dedicated-runtime perf rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,7 +453,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -4568,7 +4579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -4589,7 +4600,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7042,7 +7053,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 [[package]]
 name = "vllm-chat"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=a7fdfeef72323eb3db6f0620e4ea200290d0ca5a#a7fdfeef72323eb3db6f0620e4ea200290d0ca5a"
+source = "git+https://github.com/vllm-project/vllm.git?rev=489abadfb808e1255577f4fb51b6092ec8ca771f#489abadfb808e1255577f4fb51b6092ec8ca771f"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
@@ -7073,12 +7084,13 @@ dependencies = [
  "vllm-text",
  "vllm-tokenizer",
  "vllm-tool-parser",
+ "xgrammar-structural-tag",
 ]
 
 [[package]]
 name = "vllm-engine-core-client"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=a7fdfeef72323eb3db6f0620e4ea200290d0ca5a#a7fdfeef72323eb3db6f0620e4ea200290d0ca5a"
+source = "git+https://github.com/vllm-project/vllm.git?rev=489abadfb808e1255577f4fb51b6092ec8ca771f#489abadfb808e1255577f4fb51b6092ec8ca771f"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -7112,7 +7124,7 @@ dependencies = [
 [[package]]
 name = "vllm-llm"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=a7fdfeef72323eb3db6f0620e4ea200290d0ca5a#a7fdfeef72323eb3db6f0620e4ea200290d0ca5a"
+source = "git+https://github.com/vllm-project/vllm.git?rev=489abadfb808e1255577f4fb51b6092ec8ca771f#489abadfb808e1255577f4fb51b6092ec8ca771f"
 dependencies = [
  "easy-ext",
  "enum-as-inner",
@@ -7132,7 +7144,7 @@ dependencies = [
 [[package]]
 name = "vllm-metrics"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=a7fdfeef72323eb3db6f0620e4ea200290d0ca5a#a7fdfeef72323eb3db6f0620e4ea200290d0ca5a"
+source = "git+https://github.com/vllm-project/vllm.git?rev=489abadfb808e1255577f4fb51b6092ec8ca771f#489abadfb808e1255577f4fb51b6092ec8ca771f"
 dependencies = [
  "itertools 0.14.0",
  "prometheus-client",
@@ -7141,7 +7153,7 @@ dependencies = [
 [[package]]
 name = "vllm-reasoning-parser"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=a7fdfeef72323eb3db6f0620e4ea200290d0ca5a#a7fdfeef72323eb3db6f0620e4ea200290d0ca5a"
+source = "git+https://github.com/vllm-project/vllm.git?rev=489abadfb808e1255577f4fb51b6092ec8ca771f#489abadfb808e1255577f4fb51b6092ec8ca771f"
 dependencies = [
  "thiserror 2.0.18",
  "vllm-tokenizer",
@@ -7150,7 +7162,7 @@ dependencies = [
 [[package]]
 name = "vllm-server"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=a7fdfeef72323eb3db6f0620e4ea200290d0ca5a#a7fdfeef72323eb3db6f0620e4ea200290d0ca5a"
+source = "git+https://github.com/vllm-project/vllm.git?rev=489abadfb808e1255577f4fb51b6092ec8ca771f#489abadfb808e1255577f4fb51b6092ec8ca771f"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
@@ -7158,6 +7170,7 @@ dependencies = [
  "educe",
  "futures",
  "http-body",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "libc",
  "llm-multimodal",
@@ -7177,6 +7190,7 @@ dependencies = [
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-futures",
@@ -7193,7 +7207,7 @@ dependencies = [
 [[package]]
 name = "vllm-text"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=a7fdfeef72323eb3db6f0620e4ea200290d0ca5a#a7fdfeef72323eb3db6f0620e4ea200290d0ca5a"
+source = "git+https://github.com/vllm-project/vllm.git?rev=489abadfb808e1255577f4fb51b6092ec8ca771f#489abadfb808e1255577f4fb51b6092ec8ca771f"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
@@ -7217,7 +7231,7 @@ dependencies = [
 [[package]]
 name = "vllm-tokenizer"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=a7fdfeef72323eb3db6f0620e4ea200290d0ca5a#a7fdfeef72323eb3db6f0620e4ea200290d0ca5a"
+source = "git+https://github.com/vllm-project/vllm.git?rev=489abadfb808e1255577f4fb51b6092ec8ca771f#489abadfb808e1255577f4fb51b6092ec8ca771f"
 dependencies = [
  "base64 0.22.1",
  "fastokens",
@@ -7236,7 +7250,7 @@ dependencies = [
 [[package]]
 name = "vllm-tool-parser"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=a7fdfeef72323eb3db6f0620e4ea200290d0ca5a#a7fdfeef72323eb3db6f0620e4ea200290d0ca5a"
+source = "git+https://github.com/vllm-project/vllm.git?rev=489abadfb808e1255577f4fb51b6092ec8ca771f#489abadfb808e1255577f4fb51b6092ec8ca771f"
 dependencies = [
  "easy-ext",
  "serde",
@@ -7244,6 +7258,7 @@ dependencies = [
  "thiserror 2.0.18",
  "thiserror-ext",
  "winnow",
+ "xgrammar-structural-tag",
 ]
 
 [[package]]
@@ -7896,6 +7911,19 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xgrammar-structural-tag"
+version = "0.1.0+xgrammar.0.2.2.4d145cc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2436dea2393d55a3b188588aa300c5a8afe8f45a77da52c611fb4498a6c876e6"
+dependencies = [
+ "auto_impl",
+ "serde",
+ "serde_json",
+ "strum",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,10 +185,10 @@ url = { version = "2.5", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 validator = { version = "0.20.0", features = ["derive"] }
 velo = "0.1.0"
-vllm-engine-core-client = { git = "https://github.com/vllm-project/vllm.git", rev = "a7fdfeef72323eb3db6f0620e4ea200290d0ca5a" }
-vllm-server = { git = "https://github.com/vllm-project/vllm.git", rev = "a7fdfeef72323eb3db6f0620e4ea200290d0ca5a" }
-vllm-text = { git = "https://github.com/vllm-project/vllm.git", rev = "a7fdfeef72323eb3db6f0620e4ea200290d0ca5a" }
-vllm-tokenizer = { git = "https://github.com/vllm-project/vllm.git", rev = "a7fdfeef72323eb3db6f0620e4ea200290d0ca5a" }
+vllm-engine-core-client = { git = "https://github.com/vllm-project/vllm.git", rev = "489abadfb808e1255577f4fb51b6092ec8ca771f" }
+vllm-server = { git = "https://github.com/vllm-project/vllm.git", rev = "489abadfb808e1255577f4fb51b6092ec8ca771f" }
+vllm-text = { git = "https://github.com/vllm-project/vllm.git", rev = "489abadfb808e1255577f4fb51b6092ec8ca771f" }
+vllm-tokenizer = { git = "https://github.com/vllm-project/vllm.git", rev = "489abadfb808e1255577f4fb51b6092ec8ca771f" }
 xxhash-rust = { version = "0.8", features = ["xxh3", "const_xxh3"] }
 zeromq = { version = "0.6.0", default-features = false, features = [
     "tokio-runtime",

--- a/openinfer-vllm-frontend/src/bridge.rs
+++ b/openinfer-vllm-frontend/src/bridge.rs
@@ -67,6 +67,9 @@ impl LocalEngineBridge {
             dp_stats_address: None,
             dtype: ModelDtype::BFloat16,
             vllm_version: "openinfer-local-bridge".to_string(),
+            // The in-process bridge fronts a single engine instance.
+            world_size: 1,
+            data_parallel_size: 1,
             kv_cache_size_tokens: None,
             kv_cache_max_concurrency: None,
         };

--- a/openinfer-vllm-frontend/src/lib.rs
+++ b/openinfer-vllm-frontend/src/lib.rs
@@ -13,8 +13,8 @@ use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 use vllm_engine_core_client::TransportMode;
 use vllm_server::{
-    ApiServerOptions, ChatTemplateContentFormatOption, Config, CoordinatorMode, HttpListenerMode,
-    ParserSelection, RendererSelection,
+    ApiServerOptions, ChatTemplateContentFormatOption, Config, CoordinatorMode, CorsConfig,
+    HttpListenerMode, ParserSelection, RendererSelection,
 };
 
 use openinfer_engine::engine::EngineHandle;
@@ -192,6 +192,7 @@ where
         transport_mode: TransportMode::Bootstrapped {
             input_address,
             output_address,
+            engine_start_index: 0,
             engine_count: 1,
             // The in-process bridge registers once the engine future resolves,
             // so this bounds the whole engine load (multi-GPU MoE models take
@@ -211,6 +212,7 @@ where
         chat_template_content_format: ChatTemplateContentFormatOption::default(),
         max_logprobs: None,
         language_model_only: true,
+        cors: CorsConfig::default(),
         api_keys: Vec::new(),
         api_server_options: ApiServerOptions {
             enable_log_requests: true,


### PR DESCRIPTION
## What

Bump the four `vllm-project/vllm` git pins from `a7fdfee` (2026-06-16) to `489abad` (2026-06-24) to pick up the Rust frontend perf change [#46051](https://github.com/vllm-project/vllm/pull/46051) — *[Rust Frontend][Perf] Use dedicated runtime for HTTP/request-processing/ZMQ*.

## Why

Upstream splits the frontend's work across three dedicated tokio runtimes so heavyweight request preprocessing (tokenization, chat-template render, request lowering) and ZMQ engine transport no longer monopolize HTTP worker threads:

- **HTTP runtime** — accept connections, lightweight routes, write responses
- **Request runtime** — `/v1/completions`, `/v1/chat/completions`, `/tokenize`, `/inference/v1/generate` (`VLLM_RS_REQUEST_WORKER_THREADS`)
- **ZMQ runtime** — engine-core transport send/recv, output dispatch, abort, coordinator (`VLLM_RS_ZMQ_WORKER_THREADS`)

Upstream mock-engine numbers (Qwen3-0.6B, high concurrency long prompt): **+30% throughput, TTFT p99 -23%, `/health` p99.9 -93%, `/health` max -91%**. Our in-process bridge goes through `TransportMode::Bootstrapped`, so it exercises the same ZMQ-runtime path. Real serving A/B on openinfer is not measured here — this only secures the dependency.

This commit is newer than any tagged vllm release (latest tag `v0.23.1rc0` is 2026-06-15, before the perf commit), so following main is the only way to get it today.

## API adaptation

The bump pulled in three upstream struct changes, adapted with single-engine / single-GPU in-process semantics:

- `Config` gains `cors` → `CorsConfig::default()`
- `TransportMode::Bootstrapped` gains `engine_start_index` → `0`
- `EngineCoreReadyResponse` gains `world_size` / `data_parallel_size` → `1`

The lockfile also picks up `xgrammar-structural-tag` and `auto_impl`, transitively introduced by unrelated tool-calling / structured-output commits in the same range.

## Test

- `cargo check --release -p openinfer-vllm-support -p openinfer-vllm-frontend` — passes
- `cargo test --release -p openinfer-vllm-support -p openinfer-vllm-frontend` — 28 passed
- pre-commit (fmt + clippy) — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)