### PR TITLE
DeepSeek-V2-Lite: HTTP concurrency evidence, subgroup decode batching, and long-prompt fix

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 
 | Path | TL;DR |
 | --- | --- |
-| `models/deepseek-v2-lite/status.md` | DeepSeek-V2-Lite EP2 model status and benchmark ledger: HF/host-staged/NCCL use a committed correctness case set; #281 adds the first greedy mixed-request serving gate with per-request decode KV; direct batch, HTTP pressure, and vLLM rows remain diagnostic, not production serving parity. |
+| `models/deepseek-v2-lite/status.md` | DeepSeek-V2-Lite EP2 status and benchmark ledger: HF/host-staged/NCCL exactness, #281 mixed-request serving, and #280 HTTP trace evidence with position-subgroup decode batches plus chunked NCCL long-prompt completion; vLLM rows, direct batch, CUDA Graph, and long-prompt latency remain diagnostic, not production serving parity. |
 | `models/deepseek-v2-lite/hf-accuracy-gate.md` | DeepSeek-V2-Lite EP2 HF accuracy gate after PR #149/#150/#274: HF `generate(use_cache=true)`, host-staged EP2, and NCCL EP2 are compared across the committed small case set. |
 | `models/deepseek-v2-lite/decode-attribution-gate.md` | DeepSeek-V2-Lite EP2 decode attribution gate for `Hello`/16-token batch sizes 1/4/8: structured JSON with accuracy hashes, timing/counters, separated NCCL all-reduce smoke, and fail-closed full-decode graph probe evidence for the retained batch-1 shape. |
 | `models/deepseek-v2-lite/source-layout.md` | DeepSeek-V2-Lite runtime layout refactor: `runtime.rs` split by responsibility, HF/host-staged/NCCL EP2 E2E exact on 2x RTX 5090; NCCL CUDA Graph smoke remains a diagnostic blocker on that host, independent of the passed correctness gate. |

--- a/docs/models/deepseek-v2-lite/status.md
+++ b/docs/models/deepseek-v2-lite/status.md
@@ -1,6 +1,6 @@
 # DeepSeek-V2-Lite Status And Benchmark Ledger
 
-> **TL;DR:** DeepSeek-V2-Lite is a feature-gated EP2 correctness and serving-semantics target. HF / host-staged / NCCL exactness is guarded by a committed case set, and #281 adds the first greedy mixed-request serving gate with per-request decode KV ownership. CUDA Graph, direct batch, HTTP pressure, and vLLM rows remain diagnostic or unclaimed as production serving parity.
+> **TL;DR:** DeepSeek-V2-Lite is a feature-gated EP2 correctness and serving-semantics target. HF / host-staged / NCCL exactness is guarded by a committed case set; #281 adds the first greedy mixed-request serving gate; #280 adds HTTP trace evidence, position-subgroup decode batching, and chunked NCCL collectives so 128-word and mixed 16/128-word HTTP runs complete. The subgroup fast-path lifts short-shape throughput, but CUDA Graph, direct batch, vLLM rows, and long-prompt latency remain diagnostic or unclaimed as production serving parity.
 
 Last touched: 2026-06
 
@@ -20,6 +20,8 @@ Last touched: 2026-06
 | NCCL route-plan replay | Available | Issue #277 builds a token-major host route plan once after top-k routing, replays that plan for NCCL expert launches and device contribution accumulation, keeps route counters visible, and preserves HF / host-staged / NCCL exactness on 2x RTX 5090. This remains the eager NCCL oracle path. |
 | NCCL CUDA Graph readiness | Covered-shape diagnostic | Schema-2 `cuda_graph_readiness` now includes a fail-closed `full_decode_graph_probe`. The 2026-06-20 run reports capture, instantiate, replay, and verification success with `8/8` verified replays for the retained batch-1 NCCL decode step. |
 | First mixed-request serving gate | Available | Issue #281 adds greedy-only request admission, FCFS deferral, explicit request-local rejection/error/finish events, and one owned `DecodeCache` per active request. The 2026-06-23 2x RTX 5090 run passed HF / host-staged / NCCL exactness and the mixed-serving E2E for host-staged and NCCL. |
+| Long-shape NCCL collectives | Available | Issue #280 chunks large bf16 dense-exchange and f32 combine all-reduces. The 2026-06-24 2x RTX 5090 NCCL checks preserve HF / host-staged / NCCL exactness and complete 24/64/128-word direct long-shape probes. |
+| HTTP trace and position-subgroup decode batching | HTTP evidence | Issue #280 logs DeepSeek-V2-Lite `openinfer_http_trace` records and batches same-position decode subgroups while letting singleton or lagging positions decode independently. The 2026-06-24 2x RTX 5090 NCCL HTTP sweeps below complete short same-shape, 128-word smoke, and mixed 16/128-word cells with full trace coverage. |
 | vLLM production parity | Not claimed | The vLLM TP2 / TP2+EP2 snapshot below is a runnable comparison from a documented validation environment, not serving parity or a stock-install claim. |
 
 ## Correctness Contract
@@ -32,7 +34,7 @@ The retained correctness gate is deliberately narrow:
 - generation mode: greedy;
 - backends: host-staged and `OPENINFER_DSV2_LITE_EP_BACKEND=nccl`.
 
-The comparison gate must be run on the same model snapshot for HF, host-staged, and NCCL outputs. Same-host comparison remains strict: HF, host-staged, and NCCL must be token-exact and text-exact for every committed case and every diagnostic batch row. Host-staged remains the baseline oracle for NCCL transport changes. The latest retained evidence is the 2026-06-23 2x RTX 5090 case-set run with `case_count=5`, top-level `classification=all_token_text_exact`, and no comparison warnings.
+The comparison gate must be run on the same model snapshot for HF, host-staged, and NCCL outputs. Same-host comparison remains strict: HF, host-staged, and NCCL must be token-exact and text-exact for every committed case and every diagnostic batch row. Host-staged remains the baseline oracle for NCCL transport changes. The latest retained evidence is the 2026-06-24 2x RTX 5090 case-set run with `case_count=5`, top-level `classification=all_token_text_exact`, no comparison warnings, token hash `4fb4c8825fe4d2c4a1d966da25c259abdf675f4de4548daa5d41aea7dfe30225`, and text hash `0eedf11429e9ac13bb799c31665c6e9f70a1ac4493a08a3f3da9ecf39c1ec347`.
 
 The mixed-request serving E2E computes sequential greedy token-id oracles with `DeepSeekV2LiteEp2Generator::generate_greedy`, then submits concurrent requests through `start_engine`. The retained 2026-06-23 run covers same-length mixed prompts for same-position batch decode, different-length mixed prompts for single-row decode fallback, and a valid request submitted beside an invalid `logprobs` request to prove explicit rejection does not poison the valid stream. Host-staged and NCCL both passed the mixed-serving E2E.
 
@@ -77,6 +79,46 @@ OpenInfer streaming currently makes the client-side TPOT fields near-zero in thi
 | NCCL | 4 | 24/24 | 6.326 | 158.083 | 9491.680 | 10097.244 |
 | NCCL | 8 | 24/24 | 6.341 | 157.710 | 17242.941 | 20110.121 |
 
+### Issue #280 HTTP Trace, Subgroup Decode, And Long Prompts
+
+Retained 2026-06-24 evidence on 2x RTX 5090, NCCL EP2 with chunked large collectives, release `openinfer-server --features deepseek-v2-lite`, `/v1/completions`, `temperature=0`, `ignore_eos=true`, `max_tokens=16`, `num_requests=8`, `repeats=3`, with server logs consumed by `scripts/bench_http_serving.py`.
+
+This is HTTP serving evidence for request-level trace attribution, completed/failed/timeout accounting, output hash stability, and same-position decode subgroups. It does not prove vLLM parity, production EP readiness, or acceptable long-prompt latency.
+
+Long-shape NCCL direct smoke after chunking:
+
+| prompt words | prompt tokens | generated | token hash |
+| ---: | ---: | ---: | --- |
+| 24 | 32 | 16 | `78dfd3123da2ed54829027384682c6eb562a6d29b2a92ee96a7b26d7acc4e226` |
+| 64 | 86 | 16 | `920f24edd016e8e16973f304e5cb909303812a930a9c6608694d0b47f2c48918` |
+| 128 | 172 | 16 | `5fd2f30c1f1c4e4477791f233c30ce6c0148dba91737c358cb357a2065482861` |
+
+HTTP 128-word smoke: `prompt_words=128`, `concurrency=1`, `num_requests=2`, `warmup=0`, actual prompt tokens `170,171`.
+
+| completed | failed/timeouts | QPS | output tok/s | TTFT avg ms | TPOT/ITL avg ms | active max | decode batch max | traces | output hash |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |
+| 2/2 | 0/0 | 0.331 | 5.295 | 2535.3 | 32.3 | 1 | 1 | 2/2 | `2299c1c50f50e819` |
+
+Same-shape sweep: `prompt_words=16`, actual prompt tokens `20..23`.
+
+| conc | completed | failed/timeouts | QPS avg | output tok/s avg | TTFT avg ms | TPOT/ITL avg ms | active max | decode batch max | traces | output hash |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |
+| 1 | 8/8 x3 | 0/0 | 2.068 | 33.083 | 240.5 | 16.2 | 1 | 1 | 8/8 x3 | `0989a10c5d842d8b` |
+| 2 | 8/8 x3 | 0/0 | 2.248 | 35.967 | 332.8 | 36.8 | 2 | 2 | 8/8 x3 | `0989a10c5d842d8b` |
+| 4 | 8/8 x3 | 0/0 | 2.243 | 35.890 | 481.1 | 85.1 | 4 | 2 | 8/8 x3 | `0989a10c5d842d8b` |
+| 8 | 8/8 x3 | 0/0 | 2.290 | 36.635 | 985.9 | 163.1 | 8 | 4 | 8/8 x3 | `0989a10c5d842d8b` |
+
+Interpretation: short-shape throughput improved at every concurrency point, while TTFT stayed queue-sensitive and moved a little in both directions. The trace fields still prove the scheduler did batch live decode rows (`decode_batch_size_max=4` at concurrency 8), so `--max-concurrency` is no longer being inferred as batch size from the client alone.
+
+Mixed-shape proof: `prompt_words=16,128`, `num_requests=8` per repeat, four short and four long requests, `warmup=2`.
+
+| conc | completed | failed/timeouts | QPS avg | output tok/s avg | TTFT avg ms | TPOT/ITL avg ms | active max | decode batch max | traces | output hash |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |
+| 4 | 8/8 x3 | 0/0 | 0.597 | 9.545 | 2756.2 | 260.2 | 4 | 2 | 8/8 x3 | `d53e286068a7cd5e` |
+| 8 | 8/8 x3 | 0/0 | 0.602 | 9.634 | 5251.0 | 527.1 | 8 | 2 | 8/8 x3 | `d53e286068a7cd5e` |
+
+Interpretation: the old long-prompt prefill failure is fixed for this HTTP contract, and the post-fastpath rerun lifts mixed 16/128 throughput a bit, but the row is still dominated by long-prompt prefill and admission queueing. The c4/c8 rows prove subgroup batching can happen with mixed prompt lengths (`decode_batch_size_max=2` here), yet the latency profile is not a production serving claim.
+
 ### vLLM Repaired-Environment Comparison
 
 In response to issue #170's request for a vLLM TP2+EP2 or pure TP2 comparison, the 2026-06-15 2x RTX 5090 run now has a successful vLLM baseline for the same DeepSeek-V2-Lite model/tokenizer snapshot and short HTTP benchmark shape as the OpenInfer table above.
@@ -108,7 +150,7 @@ Interpretation:
 
 - direct same-prompt diagnostics show NCCL is still much slower than host-staged, although aggregate decode throughput improves with larger diagnostic batch size;
 - NCCL remains a correctness-first backend and is still significantly slower than host-staged;
-- OpenInfer HTTP throughput did not scale with concurrency in this snapshot, so serving batching remains open;
+- the #280 HTTP trace proves active request sets and subgroup decode batches, but throughput still scales only weakly on NCCL EP2 and long prompts have high TTFT;
 - vLLM TP2 and TP2+EP2 both show higher aggregate output tok/s under this short HTTP pressure shape than the current OpenInfer HTTP pressure rows;
 - TP2+EP2 is slightly ahead of TP2 in this short snapshot, but this is one workload and one documented validation environment;
 - standalone Torch bf16 GEMM passed on both GPUs in the failed and repaired vLLM environments, so the earlier failures were specific to the vLLM DeepSeek-V2 server/model startup and Python package/toolchain path rather than a blanket CUDA outage.
@@ -122,6 +164,7 @@ Use these labels consistently:
 | `direct single-row` | In-process batch `1` decode. | HTTP serving throughput. |
 | `direct same-prompt diagnostic batch` | Fixed same-prompt direct batch sizes `1/4/8`. | Production continuous batching or mixed-request scheduling. |
 | `first mixed-request serving gate` | Greedy-only EP2 scheduler path with explicit admission/rejection/deferral, per-request host-side decode `DecodeCache`, active cap `8`, and exact sequential-oracle E2E. | vLLM parity, sparse dispatch, production EP readiness, HTTP throughput scaling, non-greedy sampling, or logprobs support. |
+| `HTTP trace/subgroup evidence` | `/v1/completions` requests have per-request `openinfer_http_trace` rows, and HTTP sweeps show non-1 `active_set_size` and `decode_batch_size_max`. | Fair vLLM parity, long-prompt latency readiness, or a before/after percentage unless a paired baseline run is recorded. |
 | `covered NCCL decode graph probe` | Probe-only batch-1 `Hello` decode step captured, instantiated, replayed, and token-verified under CUDA Graph. | Default serving graph coverage, multi-step graph replay, batch `4/8` graph coverage, or performance improvement. |
 | `HTTP concurrency pressure` | `vllm bench serve --max-concurrency N` against an HTTP endpoint. | True OpenInfer batch size unless the engine path proves it. |
 | `vLLM comparison from documented environment` | vLLM TP2 / TP2+EP2 after target-environment package/toolchain fixes. | Stock vLLM install support, OpenInfer serving parity, or production readiness. |
@@ -166,7 +209,8 @@ The next implementation should be chosen from measured evidence:
    - keep the fixed EP2 path and exact sequential oracle until a wider oracle replaces it;
    - keep greedy-only admission explicit until sampling/logprobs have their own gate;
    - keep direct same-prompt batch labeled diagnostic;
-   - add HTTP-serving evidence before claiming `/v1/completions` parity or production continuous batching.
+   - reduce long-prompt prefill and admission-queue TTFT before claiming long-prompt serving readiness;
+   - add paired baseline runs before claiming a percentage speedup from subgroup batching.
 
 5. Keep MoE internals readable.
    - routing, dispatch, expert execution, and combine should remain distinguishable in code and attribution;

--- a/openinfer-deepseek-v2-lite/src/host_ops.rs
+++ b/openinfer-deepseek-v2-lite/src/host_ops.rs
@@ -16,6 +16,13 @@ pub(crate) struct LayerCache {
 }
 
 impl LayerCache {
+    fn clone_for_graph_probe(&self) -> Self {
+        Self {
+            keys: self.keys.clone(),
+            values: self.values.clone(),
+        }
+    }
+
     pub(crate) fn len(&self, config: &Config) -> usize {
         let per_token = config.num_attention_heads * config.query_head_dim();
         if per_token == 0 {
@@ -61,6 +68,17 @@ impl DecodeCache {
             );
         }
         Ok(position)
+    }
+
+    pub(crate) fn clone_for_graph_probe(&self) -> Self {
+        // Keep this explicit so serving hot paths do not get blanket cache cloning.
+        Self {
+            layers: self
+                .layers
+                .iter()
+                .map(LayerCache::clone_for_graph_probe)
+                .collect(),
+        }
     }
 }
 
@@ -492,6 +510,23 @@ mod tests {
         let expected0 = bf16::from_f32(bf16::from_f32(3.0 * inv_rms).to_f32() * 3.0);
         let expected1 = bf16::from_f32(bf16::from_f32(4.0 * inv_rms).to_f32() * 0.5);
         assert_eq!(out, [expected0, expected1]);
+    }
+
+    #[test]
+    fn clone_for_graph_probe_copies_decode_cache_contents() {
+        let mut cache = DecodeCache {
+            layers: vec![LayerCache {
+                keys: vec![1.0, 2.0],
+                values: vec![3.0, 4.0],
+            }],
+        };
+
+        let cloned = cache.clone_for_graph_probe();
+        cache.layers[0].keys[0] = 9.0;
+        cache.layers[0].values[0] = 8.0;
+
+        assert_eq!(cloned.layers[0].keys, vec![1.0, 2.0]);
+        assert_eq!(cloned.layers[0].values, vec![3.0, 4.0]);
     }
 
     #[test]

--- a/openinfer-deepseek-v2-lite/src/nccl_backend.rs
+++ b/openinfer-deepseek-v2-lite/src/nccl_backend.rs
@@ -51,6 +51,20 @@ type NcclAllReduce = unsafe extern "C" fn(
 ) -> ncclResult_t;
 type NcclGetErrorString = unsafe extern "C" fn(ncclResult_t) -> *const c_char;
 
+// Keep the correctness-first NCCL bridge below the long-prompt failure band
+// observed on the 2x RTX 5090 validation host. These are not hardware limits;
+// they are conservative per-call caps that preserve the short-shape path as one
+// collective while splitting the long bf16 dense exchange and f32 combine rows
+// that previously failed in prefill.
+const NCCL_BF16_ALL_REDUCE_MAX_ELEMS_PER_CALL: usize = 64 * 1024;
+const NCCL_F32_ALL_REDUCE_MAX_ELEMS_PER_CALL: usize = 48 * 1024;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct AllReduceChunk {
+    offset: usize,
+    len: usize,
+}
+
 pub(crate) struct NaiveNcclEp2Backend {
     lib: Arc<RawNcclLib>,
     comms: Vec<ncclComm_t>,
@@ -366,27 +380,16 @@ impl NaiveNcclEp2Backend {
         // Correctness-first dense exchange: rank0 contributes the hidden state
         // and rank1 contributes zeros. This makes rank0 hidden visible on rank1
         // without pretending to be sparse routed dispatch.
-        self.grouped("DeepSeek-V2-Lite NCCL dense hidden all-reduce", || {
-            activate(rank0)?;
-            self.all_reduce_bf16(
-                0,
-                &input.data,
-                rank0_recv,
-                elems,
-                rank0.stream.cu_stream(),
-                "DeepSeek-V2-Lite NCCL dense hidden rank0 all-reduce",
-            )?;
-            activate(rank1)?;
-            self.all_reduce_bf16(
-                1,
-                rank1_send_zero,
-                rank1_recv,
-                elems,
-                rank1.stream.cu_stream(),
-                "DeepSeek-V2-Lite NCCL dense hidden rank1 all-reduce",
-            )?;
-            Ok(())
-        })?;
+        self.all_reduce_bf16_pair_chunked(
+            rank0,
+            rank1,
+            &input.data,
+            rank0_recv,
+            rank1_send_zero,
+            rank1_recv,
+            elems,
+            "DeepSeek-V2-Lite NCCL dense hidden all-reduce",
+        )?;
         Ok(DenseExchangeOutput { scratch })
     }
 
@@ -501,27 +504,16 @@ impl NaiveNcclEp2Backend {
             .as_mut()
             .context("DeepSeek-V2-Lite NCCL rank1 combine recv scratch is missing")?;
 
-        self.grouped("DeepSeek-V2-Lite NCCL combine all-reduce", || {
-            activate(rank0)?;
-            self.all_reduce_f32(
-                0,
-                rank0_send,
-                rank0_recv,
-                elems,
-                rank0.stream.cu_stream(),
-                "DeepSeek-V2-Lite NCCL combine rank0 all-reduce",
-            )?;
-            activate(rank1)?;
-            self.all_reduce_f32(
-                1,
-                rank1_send,
-                rank1_recv,
-                elems,
-                rank1.stream.cu_stream(),
-                "DeepSeek-V2-Lite NCCL combine rank1 all-reduce",
-            )?;
-            Ok(())
-        })?;
+        self.all_reduce_f32_pair_chunked(
+            rank0,
+            rank1,
+            rank0_send,
+            rank0_recv,
+            rank1_send,
+            rank1_recv,
+            elems,
+            "DeepSeek-V2-Lite NCCL combine all-reduce",
+        )?;
 
         activate(rank0)?;
         let mut routed = HiddenStates::zeros(rank0, hidden_dim, seq_len)?;
@@ -582,27 +574,16 @@ impl NaiveNcclEp2Backend {
             .as_mut()
             .context("DeepSeek-V2-Lite NCCL rank1 combine recv scratch is missing")?;
 
-        self.grouped("DeepSeek-V2-Lite NCCL combine all-reduce", || {
-            activate(rank0)?;
-            self.all_reduce_f32(
-                0,
-                rank0_send,
-                rank0_recv,
-                elems,
-                rank0.stream.cu_stream(),
-                "DeepSeek-V2-Lite NCCL combine rank0 all-reduce",
-            )?;
-            activate(rank1)?;
-            self.all_reduce_f32(
-                1,
-                rank1_send,
-                rank1_recv,
-                elems,
-                rank1.stream.cu_stream(),
-                "DeepSeek-V2-Lite NCCL combine rank1 all-reduce",
-            )?;
-            Ok(())
-        })?;
+        self.all_reduce_f32_pair_chunked(
+            rank0,
+            rank1,
+            rank0_send,
+            rank0_recv,
+            rank1_send,
+            rank1_recv,
+            elems,
+            "DeepSeek-V2-Lite NCCL combine all-reduce",
+        )?;
 
         activate(rank0)?;
         ops::f32_to_bf16_hidden_into(rank0, rank0_recv, out)
@@ -828,34 +809,80 @@ impl NaiveNcclEp2Backend {
         Ok(())
     }
 
-    fn all_reduce_bf16(
+    #[allow(clippy::too_many_arguments)]
+    fn all_reduce_bf16_pair_chunked(
+        &self,
+        rank0: &DeviceContext,
+        rank1: &DeviceContext,
+        rank0_send: &CudaSlice<bf16>,
+        rank0_recv: &mut CudaSlice<bf16>,
+        rank1_send: &CudaSlice<bf16>,
+        rank1_recv: &mut CudaSlice<bf16>,
+        count: usize,
+        context: &str,
+    ) -> Result<()> {
+        for chunk in bf16_all_reduce_chunks(count) {
+            let chunk_context =
+                format!("{context} chunk offset={} len={}", chunk.offset, chunk.len);
+            self.grouped(&chunk_context, || {
+                activate(rank0)?;
+                self.all_reduce_bf16_range(
+                    0,
+                    rank0_send,
+                    rank0_recv,
+                    chunk.offset,
+                    chunk.len,
+                    rank0.stream.cu_stream(),
+                    "DeepSeek-V2-Lite NCCL dense hidden rank0 all-reduce",
+                )?;
+                activate(rank1)?;
+                self.all_reduce_bf16_range(
+                    1,
+                    rank1_send,
+                    rank1_recv,
+                    chunk.offset,
+                    chunk.len,
+                    rank1.stream.cu_stream(),
+                    "DeepSeek-V2-Lite NCCL dense hidden rank1 all-reduce",
+                )?;
+                Ok(())
+            })?;
+        }
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn all_reduce_bf16_range(
         &self,
         rank: usize,
         send: &CudaSlice<bf16>,
         recv: &mut CudaSlice<bf16>,
+        offset: usize,
         count: usize,
         stream: CUstream,
         context: &str,
     ) -> Result<()> {
         ensure!(
-            recv.len() >= count,
-            "{context}: recv buffer too small: recv={}, required={count}",
+            offset
+                .checked_add(count)
+                .is_some_and(|end| end <= send.len() && end <= recv.len()),
+            "{context}: dense exchange buffer range out of bounds: offset={offset}, count={count}, send={}, recv={}",
+            send.len(),
             recv.len()
-        );
-        ensure!(
-            send.len() >= count,
-            "{context}: send buffer too small: send={}, required={count}",
-            send.len()
         );
         let stream_ref = recv.stream().clone();
         let (send_ptr, _send_guard) = send.device_ptr(&stream_ref);
         let (recv_ptr, _recv_guard) = recv.device_ptr_mut(&stream_ref);
+        let byte_offset = offset
+            .checked_mul(std::mem::size_of::<bf16>())
+            .context("DeepSeek-V2-Lite NCCL bf16 all-reduce byte offset overflow")?;
         let status = unsafe {
             // SAFETY: Device pointers come from cudarc allocations on the
-            // active CUDA devices, and `count` was checked against both buffers.
+            // active CUDA devices, and `count` plus `offset` were checked
+            // against both buffers. `CUdeviceptr` arithmetic uses byte offsets.
             (self.lib.all_reduce)(
-                send_ptr as *const c_void,
-                recv_ptr as *mut c_void,
+                (send_ptr + byte_offset as u64) as *const c_void,
+                (recv_ptr + byte_offset as u64) as *mut c_void,
                 count,
                 ncclDataType_t::ncclBfloat16,
                 ncclRedOp_t::ncclSum,
@@ -881,13 +908,87 @@ impl NaiveNcclEp2Backend {
             send.len(),
             recv.len()
         );
+        self.all_reduce_f32_range(rank, send, recv, 0, count, stream, context)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn all_reduce_f32_pair_chunked(
+        &self,
+        rank0: &DeviceContext,
+        rank1: &DeviceContext,
+        rank0_send: &CudaSlice<f32>,
+        rank0_recv: &mut CudaSlice<f32>,
+        rank1_send: &CudaSlice<f32>,
+        rank1_recv: &mut CudaSlice<f32>,
+        count: usize,
+        context: &str,
+    ) -> Result<()> {
+        for chunk in f32_all_reduce_chunks(count) {
+            let chunk_context =
+                format!("{context} chunk offset={} len={}", chunk.offset, chunk.len);
+            self.grouped(&chunk_context, || {
+                activate(rank0)?;
+                self.all_reduce_f32_range(
+                    0,
+                    rank0_send,
+                    rank0_recv,
+                    chunk.offset,
+                    chunk.len,
+                    rank0.stream.cu_stream(),
+                    "DeepSeek-V2-Lite NCCL combine rank0 all-reduce",
+                )?;
+                activate(rank1)?;
+                self.all_reduce_f32_range(
+                    1,
+                    rank1_send,
+                    rank1_recv,
+                    chunk.offset,
+                    chunk.len,
+                    rank1.stream.cu_stream(),
+                    "DeepSeek-V2-Lite NCCL combine rank1 all-reduce",
+                )?;
+                Ok(())
+            })?;
+        }
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn all_reduce_f32_range(
+        &self,
+        rank: usize,
+        send: &CudaSlice<f32>,
+        recv: &mut CudaSlice<f32>,
+        offset: usize,
+        count: usize,
+        stream: CUstream,
+        context: &str,
+    ) -> Result<()> {
+        ensure!(
+            offset
+                .checked_add(count)
+                .is_some_and(|end| end <= send.len() && end <= recv.len()),
+            "{context}: contribution buffer range out of bounds: offset={offset}, count={count}, send={}, recv={}",
+            send.len(),
+            recv.len()
+        );
         let stream_ref = recv.stream().clone();
         let (send_ptr, _send_guard) = send.device_ptr(&stream_ref);
         let (recv_ptr, _recv_guard) = recv.device_ptr_mut(&stream_ref);
+        let byte_offset = offset
+            .checked_mul(std::mem::size_of::<f32>())
+            .context("DeepSeek-V2-Lite NCCL f32 all-reduce byte offset overflow")?;
         let status = unsafe {
             // SAFETY: Device pointers come from cudarc allocations and `count`
-            // was checked against both buffers before enqueueing the collective.
-            self.enqueue_all_reduce_f32(rank, send_ptr, recv_ptr, count, stream)?
+            // plus `offset` were checked against both buffers before enqueueing
+            // the collective. `CUdeviceptr` arithmetic uses byte offsets.
+            self.enqueue_all_reduce_f32(
+                rank,
+                send_ptr + byte_offset as u64,
+                recv_ptr + byte_offset as u64,
+                count,
+                stream,
+            )?
         };
         self.lib.check(status, context)
     }
@@ -982,6 +1083,29 @@ fn combine_elems(hidden_dim: usize, seq_len: usize) -> Result<usize> {
             "DeepSeek-V2-Lite NCCL device combine shape overflow: hidden_dim={hidden_dim}, seq_len={seq_len}"
         )
     })
+}
+
+fn f32_all_reduce_chunks(count: usize) -> Vec<AllReduceChunk> {
+    all_reduce_chunks(count, NCCL_F32_ALL_REDUCE_MAX_ELEMS_PER_CALL)
+}
+
+fn bf16_all_reduce_chunks(count: usize) -> Vec<AllReduceChunk> {
+    all_reduce_chunks(count, NCCL_BF16_ALL_REDUCE_MAX_ELEMS_PER_CALL)
+}
+
+fn all_reduce_chunks(count: usize, max_elems_per_call: usize) -> Vec<AllReduceChunk> {
+    debug_assert!(max_elems_per_call > 0);
+    if count == 0 {
+        return Vec::new();
+    }
+    let mut chunks = Vec::with_capacity(count.div_ceil(max_elems_per_call));
+    let mut offset = 0usize;
+    while offset < count {
+        let len = (count - offset).min(max_elems_per_call);
+        chunks.push(AllReduceChunk { offset, len });
+        offset += len;
+    }
+    chunks
 }
 
 fn dense_exchange_elems(hidden_dim: usize, seq_len: usize) -> Result<usize> {

--- a/openinfer-deepseek-v2-lite/src/nccl_backend/tests.rs
+++ b/openinfer-deepseek-v2-lite/src/nccl_backend/tests.rs
@@ -4,7 +4,67 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+use super::{
+    AllReduceChunk, NCCL_BF16_ALL_REDUCE_MAX_ELEMS_PER_CALL,
+    NCCL_F32_ALL_REDUCE_MAX_ELEMS_PER_CALL, bf16_all_reduce_chunks, f32_all_reduce_chunks,
+};
 use super::{add_python_env_root, nccl_python_wheel_lib_dirs_from_root};
+
+#[test]
+fn f32_all_reduce_chunks_preserve_short_counts_and_split_long_counts() {
+    assert!(f32_all_reduce_chunks(0).is_empty());
+    assert_eq!(
+        f32_all_reduce_chunks(47_104),
+        vec![AllReduceChunk {
+            offset: 0,
+            len: 47_104,
+        }]
+    );
+    assert_eq!(
+        f32_all_reduce_chunks(NCCL_F32_ALL_REDUCE_MAX_ELEMS_PER_CALL),
+        vec![AllReduceChunk {
+            offset: 0,
+            len: NCCL_F32_ALL_REDUCE_MAX_ELEMS_PER_CALL,
+        }]
+    );
+    assert_eq!(
+        f32_all_reduce_chunks(NCCL_F32_ALL_REDUCE_MAX_ELEMS_PER_CALL + 16_384),
+        vec![
+            AllReduceChunk {
+                offset: 0,
+                len: NCCL_F32_ALL_REDUCE_MAX_ELEMS_PER_CALL,
+            },
+            AllReduceChunk {
+                offset: NCCL_F32_ALL_REDUCE_MAX_ELEMS_PER_CALL,
+                len: 16_384,
+            },
+        ]
+    );
+}
+
+#[test]
+fn bf16_all_reduce_chunks_preserve_24_word_count_and_split_long_counts() {
+    assert_eq!(
+        bf16_all_reduce_chunks(NCCL_BF16_ALL_REDUCE_MAX_ELEMS_PER_CALL),
+        vec![AllReduceChunk {
+            offset: 0,
+            len: NCCL_BF16_ALL_REDUCE_MAX_ELEMS_PER_CALL,
+        }]
+    );
+    assert_eq!(
+        bf16_all_reduce_chunks(NCCL_BF16_ALL_REDUCE_MAX_ELEMS_PER_CALL + 45_056),
+        vec![
+            AllReduceChunk {
+                offset: 0,
+                len: NCCL_BF16_ALL_REDUCE_MAX_ELEMS_PER_CALL,
+            },
+            AllReduceChunk {
+                offset: NCCL_BF16_ALL_REDUCE_MAX_ELEMS_PER_CALL,
+                len: 45_056,
+            },
+        ]
+    );
+}
 
 #[test]
 fn finds_nccl_python_wheel_lib_dir_from_python_executable() {

--- a/openinfer-deepseek-v2-lite/src/runtime/graph_probe.rs
+++ b/openinfer-deepseek-v2-lite/src/runtime/graph_probe.rs
@@ -166,7 +166,7 @@ impl DeepSeekV2LiteEp2Generator {
         )?;
         let position = prompt_tokens.len();
 
-        let mut retained_cache = prefill_cache.clone();
+        let mut retained_cache = prefill_cache.clone_for_graph_probe();
         trace_graph_probe("run retained eager decode oracle");
         let retained_next = self.decode_next_token(
             first_token,

--- a/openinfer-deepseek-v2-lite/src/scheduler.rs
+++ b/openinfer-deepseek-v2-lite/src/scheduler.rs
@@ -5,9 +5,13 @@
 //! honor exactly, and retires each request independently when validation,
 //! disconnect, EOS, length, or request-local decode errors occur.
 
-use std::{collections::VecDeque, mem};
+use std::{collections::VecDeque, mem, time::Instant};
+
+mod grouping;
+mod trace;
 
 use anyhow::{Result, ensure};
+use log::info;
 use openinfer_engine::{
     engine::{FinishReason, GenerateRequest, TokenEvent, TokenSink, unix_now_s},
     sampler::SamplingParams,
@@ -20,6 +24,8 @@ use crate::{
     host_ops::DecodeCache,
     runtime::{DeepSeekV2LiteEp2Generator, GenerationStats},
 };
+use grouping::{common_decode_position, restore_surviving_rows, take_decode_position_groups};
+use trace::{RequestTrace, ScheduledTrace, http_trace_payload};
 
 pub(crate) const DEFAULT_MAX_ACTIVE_REQUESTS: usize = 8;
 
@@ -53,6 +59,7 @@ struct ActiveRequestState {
     finish_policy: FinishPolicy,
     cache: DecodeCache,
     stats: GenerationStats,
+    trace: RequestTrace,
 }
 
 #[derive(Clone, Copy)]
@@ -72,13 +79,6 @@ enum AdmissionDecision {
     Admit,
     Reject(String),
     Finish(FinishReason),
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-enum DecodeGrouping {
-    Empty,
-    BatchSamePosition { position: usize, rows: usize },
-    SingleRows,
 }
 
 impl MixedRequestScheduler {
@@ -135,24 +135,38 @@ impl MixedRequestScheduler {
         );
 
         for (pending, message) in batch.rejected {
-            if send_scheduled(&pending) {
-                let _ = send_prompt_echo(&pending);
-                let _ = pending.token_tx.send(TokenEvent::Rejected {
-                    message,
-                    prompt_tokens: pending.prompt_tokens.len(),
-                    completion_tokens: 0,
-                });
+            match send_scheduled(&pending) {
+                Ok(scheduled) => {
+                    let _ = send_prompt_echo(&pending);
+                    log_pending_terminal_trace(
+                        &pending,
+                        &scheduled,
+                        FinishReason::Error,
+                        0,
+                        Some(&message),
+                    );
+                    let _ = pending.token_tx.send(TokenEvent::Rejected {
+                        message,
+                        prompt_tokens: pending.prompt_tokens.len(),
+                        completion_tokens: 0,
+                    });
+                }
+                Err(scheduled) => log_schedule_disconnect_trace(&pending, &scheduled),
             }
         }
 
         for pending in batch.finished {
-            if send_scheduled(&pending) {
-                let _ = send_prompt_echo(&pending);
-                let _ = pending.token_tx.send(TokenEvent::Finished {
-                    finish_reason: FinishReason::Length,
-                    prompt_tokens: pending.prompt_tokens.len(),
-                    completion_tokens: 0,
-                });
+            match send_scheduled(&pending) {
+                Ok(scheduled) => {
+                    let _ = send_prompt_echo(&pending);
+                    log_pending_terminal_trace(&pending, &scheduled, FinishReason::Length, 0, None);
+                    let _ = pending.token_tx.send(TokenEvent::Finished {
+                        finish_reason: FinishReason::Length,
+                        prompt_tokens: pending.prompt_tokens.len(),
+                        completion_tokens: 0,
+                    });
+                }
+                Err(scheduled) => log_schedule_disconnect_trace(&pending, &scheduled),
             }
         }
 
@@ -169,14 +183,26 @@ impl MixedRequestScheduler {
 
     fn prefill_request(&mut self, pending: PendingRequest) -> Option<ActiveRequestState> {
         let prompt_len = pending.prompt_tokens.len();
-        if !send_scheduled(&pending) {
-            return None;
-        }
+        let scheduled = match send_scheduled(&pending) {
+            Ok(scheduled) => scheduled,
+            Err(scheduled) => {
+                log_schedule_disconnect_trace(&pending, &scheduled);
+                return None;
+            }
+        };
 
         if !send_prompt_echo(&pending) {
+            log_pending_terminal_trace(
+                &pending,
+                &scheduled,
+                FinishReason::Error,
+                0,
+                Some("client disconnected before prompt echo"),
+            );
             return None;
         }
 
+        let prefill_start = Instant::now();
         let mut cache = DecodeCache::new(self.generator.config());
         let mut stats = self.generator.new_generation_stats(prompt_len);
         let mut attribution = DecodeAttributionProfile::disabled();
@@ -188,14 +214,24 @@ impl MixedRequestScheduler {
         ) {
             Ok(token) => token,
             Err(err) => {
+                let message = err.to_string();
+                log_prefill_error_trace(
+                    &pending,
+                    &scheduled,
+                    prompt_len,
+                    prefill_start.elapsed().as_secs_f64() * 1000.0,
+                    &message,
+                );
                 let _ = pending.token_tx.send(TokenEvent::Error {
-                    message: err.to_string(),
+                    message,
                     prompt_tokens: prompt_len,
                     completion_tokens: 0,
                 });
                 return None;
             }
         };
+        let prefill_done_unix_s = unix_now_s();
+        let prefill_ms = prefill_start.elapsed().as_secs_f64() * 1000.0;
 
         let mut active = ActiveRequestState {
             request_id: pending.request_id,
@@ -210,7 +246,14 @@ impl MixedRequestScheduler {
             },
             cache,
             stats,
+            trace: RequestTrace::new(
+                scheduled.queued_at_unix_s,
+                scheduled.scheduled_at_unix_s,
+                prefill_done_unix_s,
+                prefill_ms,
+            ),
         };
+        active.trace.note_active_set(self.active.len() + 1);
 
         if active.emit_token_or_finish(next) {
             return None;
@@ -220,20 +263,42 @@ impl MixedRequestScheduler {
 
     fn decode_round(&mut self) {
         self.retire_bad_cache_positions();
-        let positions: Vec<_> = self
-            .active
-            .iter()
-            .map(ActiveRequestState::next_decode_position)
-            .collect();
-        match decode_grouping_for_positions(&positions) {
-            DecodeGrouping::Empty => {}
-            DecodeGrouping::BatchSamePosition { position, rows } if rows > 1 => {
-                self.decode_batch_round(position);
+        let active_set_size = self.active.len();
+        if active_set_size == 0 {
+            return;
+        }
+        for state in &mut self.active {
+            state.trace.note_active_set(active_set_size);
+        }
+        if active_set_size == 1 {
+            let row = self.active.pop().expect("single active row present");
+            if let Some(survivor) = self.decode_single_row((0, row)) {
+                self.active.push(survivor.1);
             }
-            DecodeGrouping::BatchSamePosition { .. } | DecodeGrouping::SingleRows => {
-                self.decode_single_rows();
+            return;
+        }
+
+        if let Some(position) = common_decode_position(&self.active) {
+            let rows: Vec<_> = self.active.drain(..).enumerate().collect();
+            self.active = restore_surviving_rows(self.decode_batch_group(position, rows));
+            return;
+        }
+
+        let groups = take_decode_position_groups(&mut self.active);
+        let mut survivors = Vec::new();
+        for group in groups {
+            if group.rows.len() > 1 {
+                survivors.extend(self.decode_batch_group(group.position, group.rows));
+            } else {
+                let mut rows = group.rows;
+                if let Some(row) = rows.pop() {
+                    if let Some(survivor) = self.decode_single_row(row) {
+                        survivors.push(survivor);
+                    }
+                }
             }
         }
+        self.active = restore_surviving_rows(survivors);
     }
 
     fn retire_bad_cache_positions(&mut self) {
@@ -248,22 +313,27 @@ impl MixedRequestScheduler {
         self.active = survivors;
     }
 
-    fn decode_batch_round(&mut self, position: usize) {
-        let tokens: Vec<_> = self.active.iter().map(|state| state.last_token).collect();
-        let token_index = self
-            .active
+    fn decode_batch_group(
+        &mut self,
+        position: usize,
+        rows: Vec<(usize, ActiveRequestState)>,
+    ) -> Vec<(usize, ActiveRequestState)> {
+        let group_size = rows.len();
+        let (indices, mut states): (Vec<_>, Vec<_>) = rows.into_iter().unzip();
+        let tokens: Vec<_> = states.iter().map(|state| state.last_token).collect();
+        let token_index = states
             .iter()
             .map(|state| state.generated)
             .min()
             .unwrap_or(0);
-        let prompt_tokens = self.active.iter().map(|state| state.prompt_len).sum();
+        let prompt_tokens = states.iter().map(|state| state.prompt_len).sum();
         let mut stats = self.generator.new_generation_stats(prompt_tokens);
         let mut attribution = DecodeAttributionProfile::disabled();
-        let mut caches: Vec<_> = self
-            .active
+        let mut caches: Vec<_> = states
             .iter_mut()
             .map(|state| mem::take(&mut state.cache))
             .collect();
+        let decode_start = Instant::now();
         let result = self.generator.decode_next_tokens_batch(
             &tokens,
             position,
@@ -272,72 +342,89 @@ impl MixedRequestScheduler {
             &mut attribution,
             token_index,
         );
+        let decode_ms = decode_start.elapsed().as_secs_f64() * 1000.0;
 
         match result {
-            Ok(next_tokens) if next_tokens.len() == self.active.len() => {
-                for (state, cache) in self.active.iter_mut().zip(caches) {
+            Ok(next_tokens) if next_tokens.len() == group_size => {
+                for (state, cache) in states.iter_mut().zip(caches) {
                     state.cache = cache;
+                    state.trace.note_decode_step(group_size, decode_ms);
                 }
-                self.apply_decoded_tokens(next_tokens);
+                apply_decoded_tokens_to_rows(indices, states, next_tokens)
             }
             // The batched path mutates per-row caches as it advances through the
             // model. This gate avoids full-cache rollback clones; a batch decode
             // failure is therefore a shared runtime error for the active rows.
-            Ok(next_tokens) => self.retire_active_batch_error(format!(
-                "DeepSeek-V2-Lite batched decode returned {} rows for {} active requests",
-                next_tokens.len(),
-                self.active.len()
-            )),
-            Err(err) => self.retire_active_batch_error(format!(
-                "DeepSeek-V2-Lite batched decode failed for {} active requests: {err}",
-                self.active.len()
-            )),
-        }
-    }
-
-    fn decode_single_rows(&mut self) {
-        let mut survivors = Vec::with_capacity(self.active.len());
-        for mut state in self.active.drain(..) {
-            let token = state.last_token;
-            let position = state.next_decode_position();
-            let token_index = state.generated;
-            let result = self.generator.decode_next_token(
-                token,
-                position,
-                &mut state.cache,
-                &mut state.stats,
-                &mut DecodeAttributionProfile::disabled(),
-                token_index,
-            );
-            match result {
-                Ok(next) => {
-                    if !state.emit_token_or_finish(next) {
-                        survivors.push(state);
-                    }
-                }
-                Err(err) => state.emit_error(err.to_string()),
+            Ok(next_tokens) => {
+                retire_rows_with_error(
+                    states,
+                    format!(
+                        "DeepSeek-V2-Lite batched decode returned {} rows for {} active requests",
+                        next_tokens.len(),
+                        group_size
+                    ),
+                );
+                Vec::new()
+            }
+            Err(err) => {
+                retire_rows_with_error(
+                    states,
+                    format!(
+                        "DeepSeek-V2-Lite batched decode failed for {} active requests: {err}",
+                        group_size
+                    ),
+                );
+                Vec::new()
             }
         }
-        self.active = survivors;
     }
 
-    fn apply_decoded_tokens(&mut self, next_tokens: Vec<u32>) {
-        let mut survivors = Vec::with_capacity(self.active.len());
-        for (mut state, token) in self.active.drain(..).zip(next_tokens) {
-            if !state.emit_token_or_finish(token) {
-                survivors.push(state);
+    fn decode_single_row(
+        &mut self,
+        (idx, mut state): (usize, ActiveRequestState),
+    ) -> Option<(usize, ActiveRequestState)> {
+        let token = state.last_token;
+        let position = state.next_decode_position();
+        let token_index = state.generated;
+        let decode_start = Instant::now();
+        let result = self.generator.decode_next_token(
+            token,
+            position,
+            &mut state.cache,
+            &mut state.stats,
+            &mut DecodeAttributionProfile::disabled(),
+            token_index,
+        );
+        let decode_ms = decode_start.elapsed().as_secs_f64() * 1000.0;
+        match result {
+            Ok(next) => {
+                state.trace.note_decode_step(1, decode_ms);
+                (!state.emit_token_or_finish(next)).then_some((idx, state))
+            }
+            Err(err) => {
+                state.emit_error(err.to_string());
+                None
             }
         }
-        self.active = survivors;
-    }
-
-    fn retire_active_batch_error(&mut self, message: String) {
-        retire_active_requests_with_error(&mut self.active, message);
     }
 }
 
-fn retire_active_requests_with_error(active: &mut Vec<ActiveRequestState>, message: String) {
-    for state in active.drain(..) {
+fn apply_decoded_tokens_to_rows(
+    indices: Vec<usize>,
+    states: Vec<ActiveRequestState>,
+    next_tokens: Vec<u32>,
+) -> Vec<(usize, ActiveRequestState)> {
+    indices
+        .into_iter()
+        .zip(states.into_iter().zip(next_tokens))
+        .filter_map(|(idx, (mut state, token))| {
+            (!state.emit_token_or_finish(token)).then_some((idx, state))
+        })
+        .collect()
+}
+
+fn retire_rows_with_error(states: Vec<ActiveRequestState>, message: String) {
+    for state in states {
         state.emit_error(message.clone());
     }
 }
@@ -378,6 +465,7 @@ impl ActiveRequestState {
     fn emit_token_or_finish(&mut self, token: u32) -> bool {
         self.last_token = token;
         if !self.finish_policy.ignore_eos && token == self.finish_policy.eos_token_id {
+            self.log_http_trace(FinishReason::Stop, None);
             let _ = self.token_tx.send(TokenEvent::Finished {
                 finish_reason: FinishReason::Stop,
                 prompt_tokens: self.prompt_len,
@@ -386,6 +474,11 @@ impl ActiveRequestState {
             return true;
         }
 
+        let first_emit_at = self
+            .trace
+            .first_token_emit_unix_s
+            .is_none()
+            .then(unix_now_s);
         if self
             .token_tx
             .send(TokenEvent::Token {
@@ -394,11 +487,19 @@ impl ActiveRequestState {
             })
             .is_err()
         {
+            self.log_http_trace(
+                FinishReason::Error,
+                Some("client disconnected before token emit"),
+            );
             return true;
+        }
+        if let Some(first_emit_at) = first_emit_at {
+            self.trace.first_token_emit_unix_s = Some(first_emit_at);
         }
         self.generated += 1;
 
         if self.generated == self.max_tokens {
+            self.log_http_trace(FinishReason::Length, None);
             let _ = self.token_tx.send(TokenEvent::Finished {
                 finish_reason: FinishReason::Length,
                 prompt_tokens: self.prompt_len,
@@ -410,25 +511,47 @@ impl ActiveRequestState {
     }
 
     fn emit_error(self, message: String) {
+        self.log_http_trace(FinishReason::Error, Some(&message));
         let _ = self.token_tx.send(TokenEvent::Error {
             message,
             prompt_tokens: self.prompt_len,
             completion_tokens: self.generated,
         });
     }
+
+    fn log_http_trace(&self, finish_reason: FinishReason, error: Option<&str>) {
+        log_http_trace(
+            trace_request_id(self.request_id.as_deref(), &self.token_tx),
+            &self.trace,
+            self.prompt_len,
+            self.generated,
+            finish_reason,
+            error,
+        );
+    }
 }
 
-fn send_scheduled(pending: &PendingRequest) -> bool {
+fn send_scheduled(pending: &PendingRequest) -> std::result::Result<ScheduledTrace, ScheduledTrace> {
     let now = unix_now_s();
-    pending
+    let queued_at_unix_s = pending.queued_at_unix_s.unwrap_or(now);
+    let scheduled = ScheduledTrace {
+        queued_at_unix_s,
+        scheduled_at_unix_s: now,
+    };
+    if pending
         .token_tx
         .send(TokenEvent::Scheduled {
-            queued_at_unix_s: pending.queued_at_unix_s.unwrap_or(now),
+            queued_at_unix_s,
             scheduled_at_unix_s: now,
             prompt_tokens: pending.prompt_tokens.len(),
             cached_tokens: 0,
         })
         .is_ok()
+    {
+        Ok(scheduled)
+    } else {
+        Err(scheduled)
+    }
 }
 
 fn send_prompt_echo(pending: &PendingRequest) -> bool {
@@ -442,6 +565,78 @@ fn send_prompt_echo(pending: &PendingRequest) -> bool {
             logprobs: vec![None; pending.prompt_tokens.len()],
         })
         .is_ok()
+}
+
+fn trace_request_id<'a>(request_id: Option<&'a str>, token_tx: &'a TokenSink) -> &'a str {
+    request_id.unwrap_or_else(|| token_tx.tag().as_ref())
+}
+
+fn log_pending_terminal_trace(
+    pending: &PendingRequest,
+    scheduled: &ScheduledTrace,
+    finish_reason: FinishReason,
+    completion_tokens: usize,
+    error: Option<&str>,
+) {
+    let trace = RequestTrace::terminal(scheduled.queued_at_unix_s, scheduled.scheduled_at_unix_s);
+    log_http_trace(
+        trace_request_id(pending.request_id.as_deref(), &pending.token_tx),
+        &trace,
+        pending.prompt_tokens.len(),
+        completion_tokens,
+        finish_reason,
+        error,
+    );
+}
+
+fn log_schedule_disconnect_trace(pending: &PendingRequest, scheduled: &ScheduledTrace) {
+    log_pending_terminal_trace(
+        pending,
+        scheduled,
+        FinishReason::Error,
+        0,
+        Some("client disconnected before scheduled event"),
+    );
+}
+
+fn log_prefill_error_trace(
+    pending: &PendingRequest,
+    scheduled: &ScheduledTrace,
+    prompt_tokens: usize,
+    prefill_ms: f64,
+    message: &str,
+) {
+    let mut trace =
+        RequestTrace::terminal(scheduled.queued_at_unix_s, scheduled.scheduled_at_unix_s);
+    trace.prefill_done_unix_s = Some(unix_now_s());
+    trace.prefill_ms = Some(prefill_ms);
+    log_http_trace(
+        trace_request_id(pending.request_id.as_deref(), &pending.token_tx),
+        &trace,
+        prompt_tokens,
+        0,
+        FinishReason::Error,
+        Some(message),
+    );
+}
+
+fn log_http_trace(
+    request_id: &str,
+    trace: &RequestTrace,
+    prompt_tokens: usize,
+    completion_tokens: usize,
+    finish_reason: FinishReason,
+    error: Option<&str>,
+) {
+    let payload = http_trace_payload(
+        request_id,
+        trace,
+        prompt_tokens,
+        completion_tokens,
+        finish_reason,
+        error,
+    );
+    info!("openinfer_http_trace {payload}");
 }
 
 fn take_admission_batch(
@@ -521,407 +716,5 @@ fn admission_decision(req: &PendingRequest, supported_context: usize) -> Admissi
     AdmissionDecision::Admit
 }
 
-fn decode_grouping_for_positions(positions: &[usize]) -> DecodeGrouping {
-    let Some((&first, rest)) = positions.split_first() else {
-        return DecodeGrouping::Empty;
-    };
-    if positions.len() > 1 && rest.iter().all(|position| *position == first) {
-        return DecodeGrouping::BatchSamePosition {
-            position: first,
-            rows: positions.len(),
-        };
-    }
-    DecodeGrouping::SingleRows
-}
-
 #[cfg(test)]
-mod tests {
-    use std::sync::{Arc, atomic::AtomicBool};
-
-    use openinfer_engine::engine::RequestTag;
-    use openinfer_engine::sampler::SamplingParams;
-    use tokio::sync::mpsc;
-
-    use super::*;
-    use crate::config::test_lite_config;
-
-    fn request(
-        id: &str,
-        prompt_len: usize,
-        max_tokens: usize,
-    ) -> (
-        PendingRequest,
-        openinfer_engine::engine::TokenStreamReceiver,
-    ) {
-        let (token_tx, token_rx) = TokenSink::standalone();
-        (
-            PendingRequest {
-                request_id: Some(id.to_string()),
-                queued_at_unix_s: None,
-                prompt_tokens: vec![1; prompt_len],
-                params: SamplingParams::default(),
-                max_tokens,
-                lora_adapter: None,
-                token_tx,
-                logprobs: 0,
-                echo: false,
-            },
-            token_rx,
-        )
-    }
-
-    fn recv_event(rx: &mut openinfer_engine::engine::TokenStreamReceiver) -> TokenEvent {
-        rx.try_recv().expect("expected event").1
-    }
-
-    #[test]
-    fn admission_rejects_unsupported_shapes() {
-        let context = 16;
-
-        let (mut sampling, _rx) = request("sampling", 1, 1);
-        sampling.params.temperature = 0.8;
-        assert!(matches!(
-            admission_decision(&sampling, context),
-            AdmissionDecision::Reject(message) if message.contains("greedy")
-        ));
-
-        let (mut logprobs, _rx) = request("logprobs", 1, 1);
-        logprobs.logprobs = 1;
-        assert!(matches!(
-            admission_decision(&logprobs, context),
-            AdmissionDecision::Reject(message) if message.contains("logprobs")
-        ));
-
-        let (mut lora, _rx) = request("lora", 1, 1);
-        lora.lora_adapter = Some("adapter-a".to_string());
-        assert!(matches!(
-            admission_decision(&lora, context),
-            AdmissionDecision::Reject(message) if message.contains("LoRA")
-        ));
-
-        let (empty, _rx) = request("empty", 0, 1);
-        assert!(matches!(
-            admission_decision(&empty, context),
-            AdmissionDecision::Reject(message) if message.contains("non-empty prompt")
-        ));
-
-        let (zero, _rx) = request("zero", 1, 0);
-        assert_eq!(
-            admission_decision(&zero, context),
-            AdmissionDecision::Finish(FinishReason::Length)
-        );
-    }
-
-    #[test]
-    fn context_overflow_is_rejected() {
-        let (req, _rx) = request("too-long", 12, 5);
-
-        assert!(matches!(
-            admission_decision(&req, 16),
-            AdmissionDecision::Reject(message)
-                if message.contains("context") && message.contains("total=17")
-        ));
-    }
-
-    #[test]
-    fn active_cap_defers_in_fcfs_order() {
-        let mut pending = VecDeque::new();
-        pending.push_back(request("first", 2, 1).0);
-        pending.push_back(request("second", 2, 1).0);
-        pending.push_back(request("third", 2, 1).0);
-
-        let batch = take_admission_batch(&mut pending, 1, 3, 16);
-
-        assert_eq!(
-            batch
-                .admitted
-                .iter()
-                .map(|req| req.request_id.as_deref())
-                .collect::<Vec<_>>(),
-            vec![Some("first"), Some("second")]
-        );
-        assert!(batch.rejected.is_empty());
-        assert!(batch.finished.is_empty());
-        assert_eq!(pending.len(), 1);
-        assert_eq!(pending[0].request_id.as_deref(), Some("third"));
-    }
-
-    #[test]
-    fn terminal_requests_do_not_wait_for_active_capacity() {
-        let mut pending = VecDeque::new();
-        pending.push_back(request("zero", 2, 0).0);
-        let (mut invalid, _rx) = request("invalid", 2, 1);
-        invalid.logprobs = 1;
-        pending.push_back(invalid);
-        pending.push_back(request("valid", 2, 1).0);
-
-        let batch = take_admission_batch(&mut pending, 8, 8, 16);
-
-        assert!(batch.admitted.is_empty());
-        assert_eq!(batch.finished.len(), 1);
-        assert_eq!(batch.finished[0].request_id.as_deref(), Some("zero"));
-        assert_eq!(batch.rejected.len(), 1);
-        assert_eq!(batch.rejected[0].0.request_id.as_deref(), Some("invalid"));
-        assert_eq!(pending.len(), 1);
-        assert_eq!(pending[0].request_id.as_deref(), Some("valid"));
-    }
-
-    #[test]
-    fn invalid_request_does_not_block_later_admission_when_cap_has_room() {
-        let mut pending = VecDeque::new();
-        let (mut invalid, _rx) = request("invalid", 2, 1);
-        invalid.logprobs = 1;
-        pending.push_back(invalid);
-        pending.push_back(request("valid", 2, 1).0);
-
-        let batch = take_admission_batch(&mut pending, 0, 2, 16);
-
-        assert_eq!(batch.rejected.len(), 1);
-        assert_eq!(batch.rejected[0].0.request_id.as_deref(), Some("invalid"));
-        assert_eq!(batch.admitted.len(), 1);
-        assert_eq!(batch.admitted[0].request_id.as_deref(), Some("valid"));
-        assert!(pending.is_empty());
-    }
-
-    #[test]
-    fn terminal_admission_events_keep_scheduler_contract() {
-        let (mut zero, mut zero_rx) = request("zero", 2, 0);
-        zero.echo = true;
-        assert!(send_scheduled(&zero));
-        assert!(send_prompt_echo(&zero));
-        let _ = zero.token_tx.send(TokenEvent::Finished {
-            finish_reason: FinishReason::Length,
-            prompt_tokens: zero.prompt_tokens.len(),
-            completion_tokens: 0,
-        });
-
-        assert!(matches!(
-            recv_event(&mut zero_rx),
-            TokenEvent::Scheduled { .. }
-        ));
-        assert!(matches!(
-            recv_event(&mut zero_rx),
-            TokenEvent::PromptTokens { ids, .. } if ids == vec![1, 1]
-        ));
-        assert!(matches!(
-            recv_event(&mut zero_rx),
-            TokenEvent::Finished {
-                finish_reason: FinishReason::Length,
-                completion_tokens: 0,
-                ..
-            }
-        ));
-
-        let (rejected, mut rejected_rx) = request("rejected", 2, 1);
-        assert!(send_scheduled(&rejected));
-        let _ = rejected.token_tx.send(TokenEvent::Rejected {
-            message: "nope".to_string(),
-            prompt_tokens: rejected.prompt_tokens.len(),
-            completion_tokens: 0,
-        });
-
-        assert!(matches!(
-            recv_event(&mut rejected_rx),
-            TokenEvent::Scheduled { .. }
-        ));
-        assert!(matches!(
-            recv_event(&mut rejected_rx),
-            TokenEvent::Rejected {
-                completion_tokens: 0,
-                ..
-            }
-        ));
-    }
-
-    #[test]
-    fn eos_retirement_is_independent_per_request() {
-        let config = test_lite_config();
-        let (tx_stop, mut rx_stop) = TokenSink::standalone();
-        let (tx_live, mut rx_live) = TokenSink::standalone();
-        let mut stop_state = ActiveRequestState {
-            request_id: Some("stop".to_string()),
-            token_tx: tx_stop,
-            prompt_len: 3,
-            max_tokens: 4,
-            generated: 1,
-            last_token: 10,
-            finish_policy: FinishPolicy {
-                eos_token_id: config.eos_token_id,
-                ignore_eos: false,
-            },
-            cache: DecodeCache::new(&config),
-            stats: GenerationStats::default(),
-        };
-        let mut live_state = ActiveRequestState {
-            request_id: Some("live".to_string()),
-            token_tx: tx_live,
-            prompt_len: 2,
-            max_tokens: 4,
-            generated: 1,
-            last_token: 11,
-            finish_policy: FinishPolicy {
-                eos_token_id: config.eos_token_id,
-                ignore_eos: false,
-            },
-            cache: DecodeCache::new(&config),
-            stats: GenerationStats::default(),
-        };
-
-        assert!(stop_state.emit_token_or_finish(config.eos_token_id));
-        assert!(!live_state.emit_token_or_finish(12));
-
-        match recv_event(&mut rx_stop) {
-            TokenEvent::Finished {
-                finish_reason,
-                completion_tokens,
-                ..
-            } => {
-                assert_eq!(finish_reason, FinishReason::Stop);
-                assert_eq!(completion_tokens, 1);
-            }
-            _ => panic!("EOS request should finish without emitting EOS"),
-        }
-        match recv_event(&mut rx_live) {
-            TokenEvent::Token { id, .. } => assert_eq!(id, 12),
-            _ => panic!("live request should receive its own token"),
-        }
-        assert!(rx_live.try_recv().is_err());
-    }
-
-    #[test]
-    fn cancelled_token_sink_retires_request() {
-        let config = test_lite_config();
-        let (stream_tx, mut stream_rx) = mpsc::unbounded_channel();
-        let cancelled = Arc::new(AtomicBool::new(true));
-        let sink = TokenSink::new(
-            RequestTag::from("cancelled"),
-            stream_tx,
-            Arc::clone(&cancelled),
-        );
-        let mut state = ActiveRequestState {
-            request_id: Some("cancelled".to_string()),
-            token_tx: sink,
-            prompt_len: 2,
-            max_tokens: 4,
-            generated: 1,
-            last_token: 11,
-            finish_policy: FinishPolicy {
-                eos_token_id: config.eos_token_id,
-                ignore_eos: false,
-            },
-            cache: DecodeCache::new(&config),
-            stats: GenerationStats::default(),
-        };
-
-        assert!(state.emit_token_or_finish(12));
-        assert!(stream_rx.try_recv().is_err());
-    }
-
-    #[test]
-    fn closed_token_sink_retires_request() {
-        let config = test_lite_config();
-        let (sink, rx) = TokenSink::standalone();
-        drop(rx);
-        let mut state = ActiveRequestState {
-            request_id: Some("closed".to_string()),
-            token_tx: sink,
-            prompt_len: 2,
-            max_tokens: 4,
-            generated: 1,
-            last_token: 11,
-            finish_policy: FinishPolicy {
-                eos_token_id: config.eos_token_id,
-                ignore_eos: false,
-            },
-            cache: DecodeCache::new(&config),
-            stats: GenerationStats::default(),
-        };
-
-        assert!(state.emit_token_or_finish(12));
-    }
-
-    #[test]
-    fn batch_decode_error_retires_all_active_requests() {
-        let config = test_lite_config();
-        let (first_tx, mut first_rx) = TokenSink::standalone();
-        let (second_tx, mut second_rx) = TokenSink::standalone();
-        let mut active = vec![
-            ActiveRequestState {
-                request_id: Some("first".to_string()),
-                token_tx: first_tx,
-                prompt_len: 3,
-                max_tokens: 8,
-                generated: 2,
-                last_token: 11,
-                finish_policy: FinishPolicy {
-                    eos_token_id: config.eos_token_id,
-                    ignore_eos: false,
-                },
-                cache: DecodeCache::new(&config),
-                stats: GenerationStats::default(),
-            },
-            ActiveRequestState {
-                request_id: Some("second".to_string()),
-                token_tx: second_tx,
-                prompt_len: 4,
-                max_tokens: 8,
-                generated: 1,
-                last_token: 12,
-                finish_policy: FinishPolicy {
-                    eos_token_id: config.eos_token_id,
-                    ignore_eos: false,
-                },
-                cache: DecodeCache::new(&config),
-                stats: GenerationStats::default(),
-            },
-        ];
-
-        retire_active_requests_with_error(&mut active, "batch failed".to_string());
-
-        assert!(active.is_empty());
-        match recv_event(&mut first_rx) {
-            TokenEvent::Error {
-                message,
-                prompt_tokens,
-                completion_tokens,
-            } => {
-                assert_eq!(message, "batch failed");
-                assert_eq!(prompt_tokens, 3);
-                assert_eq!(completion_tokens, 2);
-            }
-            _ => panic!("first active request should receive batch error"),
-        }
-        match recv_event(&mut second_rx) {
-            TokenEvent::Error {
-                message,
-                prompt_tokens,
-                completion_tokens,
-            } => {
-                assert_eq!(message, "batch failed");
-                assert_eq!(prompt_tokens, 4);
-                assert_eq!(completion_tokens, 1);
-            }
-            _ => panic!("second active request should receive batch error"),
-        }
-    }
-
-    #[test]
-    fn decode_grouping_batches_only_uniform_positions() {
-        assert_eq!(decode_grouping_for_positions(&[]), DecodeGrouping::Empty);
-        assert_eq!(
-            decode_grouping_for_positions(&[5]),
-            DecodeGrouping::SingleRows
-        );
-        assert_eq!(
-            decode_grouping_for_positions(&[7, 7, 7]),
-            DecodeGrouping::BatchSamePosition {
-                position: 7,
-                rows: 3
-            }
-        );
-        assert_eq!(
-            decode_grouping_for_positions(&[7, 8, 7]),
-            DecodeGrouping::SingleRows
-        );
-    }
-}
+mod tests;

--- a/openinfer-deepseek-v2-lite/src/scheduler/grouping.rs
+++ b/openinfer-deepseek-v2-lite/src/scheduler/grouping.rs
@@ -1,0 +1,76 @@
+use super::ActiveRequestState;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct DecodePositionGroupPlan {
+    pub(super) position: usize,
+    pub(super) indices: Vec<usize>,
+}
+
+pub(super) struct DecodePositionGroup {
+    pub(super) position: usize,
+    pub(super) rows: Vec<(usize, ActiveRequestState)>,
+}
+
+pub(super) fn decode_position_groups_for_positions(
+    positions: &[usize],
+) -> Vec<DecodePositionGroupPlan> {
+    let mut groups: Vec<DecodePositionGroupPlan> = Vec::new();
+    for (idx, position) in positions.iter().copied().enumerate() {
+        if let Some(group) = groups.iter_mut().find(|group| group.position == position) {
+            group.indices.push(idx);
+        } else {
+            groups.push(DecodePositionGroupPlan {
+                position,
+                indices: vec![idx],
+            });
+        }
+    }
+    groups
+}
+
+pub(super) fn common_decode_position(active: &[ActiveRequestState]) -> Option<usize> {
+    let first = active.first()?.next_decode_position();
+    active
+        .iter()
+        .all(|state| state.next_decode_position() == first)
+        .then_some(first)
+}
+
+pub(super) fn take_decode_position_groups(
+    active: &mut Vec<ActiveRequestState>,
+) -> Vec<DecodePositionGroup> {
+    let positions: Vec<_> = active
+        .iter()
+        .map(ActiveRequestState::next_decode_position)
+        .collect();
+    let plans = decode_position_groups_for_positions(&positions);
+    let mut rows: Vec<_> = active.drain(..).map(Some).collect();
+    plans
+        .into_iter()
+        .map(|plan| DecodePositionGroup {
+            position: plan.position,
+            rows: plan
+                .indices
+                .into_iter()
+                .map(|idx| {
+                    (
+                        idx,
+                        rows[idx]
+                            .take()
+                            .expect("decode position group indices come from active rows"),
+                    )
+                })
+                .collect(),
+        })
+        .collect()
+}
+
+pub(super) fn restore_surviving_rows(
+    mut survivors: Vec<(usize, ActiveRequestState)>,
+) -> Vec<ActiveRequestState> {
+    survivors.sort_by_key(|(idx, _)| *idx);
+    survivors
+        .into_iter()
+        .map(|(_, state)| state)
+        .collect::<Vec<_>>()
+}

--- a/openinfer-deepseek-v2-lite/src/scheduler/tests.rs
+++ b/openinfer-deepseek-v2-lite/src/scheduler/tests.rs
@@ -1,0 +1,537 @@
+use std::sync::{Arc, atomic::AtomicBool};
+
+use openinfer_engine::engine::RequestTag;
+use openinfer_engine::sampler::SamplingParams;
+use tokio::sync::mpsc;
+
+use super::grouping::{
+    DecodePositionGroupPlan, common_decode_position, decode_position_groups_for_positions,
+};
+use super::*;
+use crate::config::test_lite_config;
+
+fn request(
+    id: &str,
+    prompt_len: usize,
+    max_tokens: usize,
+) -> (
+    PendingRequest,
+    openinfer_engine::engine::TokenStreamReceiver,
+) {
+    let (token_tx, token_rx) = TokenSink::standalone();
+    (
+        PendingRequest {
+            request_id: Some(id.to_string()),
+            queued_at_unix_s: None,
+            prompt_tokens: vec![1; prompt_len],
+            params: SamplingParams::default(),
+            max_tokens,
+            lora_adapter: None,
+            token_tx,
+            logprobs: 0,
+            echo: false,
+        },
+        token_rx,
+    )
+}
+
+fn recv_event(rx: &mut openinfer_engine::engine::TokenStreamReceiver) -> TokenEvent {
+    rx.try_recv().expect("expected event").1
+}
+
+fn trace() -> RequestTrace {
+    RequestTrace::new(1.0, 2.0, 3.0, 4.0)
+}
+
+fn active_state(
+    id: &str,
+    token_tx: TokenSink,
+    prompt_len: usize,
+    generated: usize,
+    last_token: u32,
+    config: &Config,
+) -> ActiveRequestState {
+    ActiveRequestState {
+        request_id: Some(id.to_string()),
+        token_tx,
+        prompt_len,
+        max_tokens: 8,
+        generated,
+        last_token,
+        finish_policy: FinishPolicy {
+            eos_token_id: config.eos_token_id,
+            ignore_eos: false,
+        },
+        cache: DecodeCache::new(config),
+        stats: GenerationStats::default(),
+        trace: trace(),
+    }
+}
+
+#[test]
+fn admission_rejects_unsupported_shapes() {
+    let context = 16;
+
+    let (mut sampling, _rx) = request("sampling", 1, 1);
+    sampling.params.temperature = 0.8;
+    assert!(matches!(
+        admission_decision(&sampling, context),
+        AdmissionDecision::Reject(message) if message.contains("greedy")
+    ));
+
+    let (mut logprobs, _rx) = request("logprobs", 1, 1);
+    logprobs.logprobs = 1;
+    assert!(matches!(
+        admission_decision(&logprobs, context),
+        AdmissionDecision::Reject(message) if message.contains("logprobs")
+    ));
+
+    let (mut lora, _rx) = request("lora", 1, 1);
+    lora.lora_adapter = Some("adapter-a".to_string());
+    assert!(matches!(
+        admission_decision(&lora, context),
+        AdmissionDecision::Reject(message) if message.contains("LoRA")
+    ));
+
+    let (empty, _rx) = request("empty", 0, 1);
+    assert!(matches!(
+        admission_decision(&empty, context),
+        AdmissionDecision::Reject(message) if message.contains("non-empty prompt")
+    ));
+
+    let (zero, _rx) = request("zero", 1, 0);
+    assert_eq!(
+        admission_decision(&zero, context),
+        AdmissionDecision::Finish(FinishReason::Length)
+    );
+}
+
+#[test]
+fn context_overflow_is_rejected() {
+    let (req, _rx) = request("too-long", 12, 5);
+
+    assert!(matches!(
+        admission_decision(&req, 16),
+        AdmissionDecision::Reject(message)
+            if message.contains("context") && message.contains("total=17")
+    ));
+}
+
+#[test]
+fn active_cap_defers_in_fcfs_order() {
+    let mut pending = VecDeque::new();
+    pending.push_back(request("first", 2, 1).0);
+    pending.push_back(request("second", 2, 1).0);
+    pending.push_back(request("third", 2, 1).0);
+
+    let batch = take_admission_batch(&mut pending, 1, 3, 16);
+
+    assert_eq!(
+        batch
+            .admitted
+            .iter()
+            .map(|req| req.request_id.as_deref())
+            .collect::<Vec<_>>(),
+        vec![Some("first"), Some("second")]
+    );
+    assert!(batch.rejected.is_empty());
+    assert!(batch.finished.is_empty());
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].request_id.as_deref(), Some("third"));
+}
+
+#[test]
+fn terminal_requests_do_not_wait_for_active_capacity() {
+    let mut pending = VecDeque::new();
+    pending.push_back(request("zero", 2, 0).0);
+    let (mut invalid, _rx) = request("invalid", 2, 1);
+    invalid.logprobs = 1;
+    pending.push_back(invalid);
+    pending.push_back(request("valid", 2, 1).0);
+
+    let batch = take_admission_batch(&mut pending, 8, 8, 16);
+
+    assert!(batch.admitted.is_empty());
+    assert_eq!(batch.finished.len(), 1);
+    assert_eq!(batch.finished[0].request_id.as_deref(), Some("zero"));
+    assert_eq!(batch.rejected.len(), 1);
+    assert_eq!(batch.rejected[0].0.request_id.as_deref(), Some("invalid"));
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].request_id.as_deref(), Some("valid"));
+}
+
+#[test]
+fn invalid_request_does_not_block_later_admission_when_cap_has_room() {
+    let mut pending = VecDeque::new();
+    let (mut invalid, _rx) = request("invalid", 2, 1);
+    invalid.logprobs = 1;
+    pending.push_back(invalid);
+    pending.push_back(request("valid", 2, 1).0);
+
+    let batch = take_admission_batch(&mut pending, 0, 2, 16);
+
+    assert_eq!(batch.rejected.len(), 1);
+    assert_eq!(batch.rejected[0].0.request_id.as_deref(), Some("invalid"));
+    assert_eq!(batch.admitted.len(), 1);
+    assert_eq!(batch.admitted[0].request_id.as_deref(), Some("valid"));
+    assert!(pending.is_empty());
+}
+
+#[test]
+fn terminal_admission_events_keep_scheduler_contract() {
+    let (mut zero, mut zero_rx) = request("zero", 2, 0);
+    zero.echo = true;
+    assert!(send_scheduled(&zero).is_ok());
+    assert!(send_prompt_echo(&zero));
+    let _ = zero.token_tx.send(TokenEvent::Finished {
+        finish_reason: FinishReason::Length,
+        prompt_tokens: zero.prompt_tokens.len(),
+        completion_tokens: 0,
+    });
+
+    assert!(matches!(
+        recv_event(&mut zero_rx),
+        TokenEvent::Scheduled { .. }
+    ));
+    assert!(matches!(
+        recv_event(&mut zero_rx),
+        TokenEvent::PromptTokens { ids, .. } if ids == vec![1, 1]
+    ));
+    assert!(matches!(
+        recv_event(&mut zero_rx),
+        TokenEvent::Finished {
+            finish_reason: FinishReason::Length,
+            completion_tokens: 0,
+            ..
+        }
+    ));
+
+    let (rejected, mut rejected_rx) = request("rejected", 2, 1);
+    assert!(send_scheduled(&rejected).is_ok());
+    let _ = rejected.token_tx.send(TokenEvent::Rejected {
+        message: "nope".to_string(),
+        prompt_tokens: rejected.prompt_tokens.len(),
+        completion_tokens: 0,
+    });
+
+    assert!(matches!(
+        recv_event(&mut rejected_rx),
+        TokenEvent::Scheduled { .. }
+    ));
+    assert!(matches!(
+        recv_event(&mut rejected_rx),
+        TokenEvent::Rejected {
+            completion_tokens: 0,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn send_scheduled_returns_trace_when_client_is_closed() {
+    let (pending, rx) = request("closed-before-schedule", 2, 1);
+    drop(rx);
+
+    let scheduled = send_scheduled(&pending).expect_err("send should fail");
+
+    assert_eq!(
+        scheduled.queued_at_unix_s,
+        pending
+            .queued_at_unix_s
+            .unwrap_or(scheduled.scheduled_at_unix_s)
+    );
+    assert!(scheduled.scheduled_at_unix_s > 0.0);
+}
+
+#[test]
+fn trace_request_id_falls_back_to_sink_tag() {
+    let (sink, _rx) = TokenSink::standalone();
+
+    assert_eq!(trace_request_id(None, &sink), sink.tag().as_ref());
+    assert_eq!(trace_request_id(Some("explicit"), &sink), "explicit");
+}
+
+#[test]
+fn eos_retirement_is_independent_per_request() {
+    let config = test_lite_config();
+    let (tx_stop, mut rx_stop) = TokenSink::standalone();
+    let (tx_live, mut rx_live) = TokenSink::standalone();
+    let mut stop_state = active_state("stop", tx_stop, 3, 1, 10, &config);
+    let mut live_state = active_state("live", tx_live, 2, 1, 11, &config);
+
+    assert!(stop_state.emit_token_or_finish(config.eos_token_id));
+    assert!(!live_state.emit_token_or_finish(12));
+
+    match recv_event(&mut rx_stop) {
+        TokenEvent::Finished {
+            finish_reason,
+            completion_tokens,
+            ..
+        } => {
+            assert_eq!(finish_reason, FinishReason::Stop);
+            assert_eq!(completion_tokens, 1);
+        }
+        _ => panic!("EOS request should finish without emitting EOS"),
+    }
+    match recv_event(&mut rx_live) {
+        TokenEvent::Token { id, .. } => assert_eq!(id, 12),
+        _ => panic!("live request should receive its own token"),
+    }
+    assert!(rx_live.try_recv().is_err());
+}
+
+#[test]
+fn batch_decoded_tokens_retire_eos_independently() {
+    let config = test_lite_config();
+    let (tx_stop, mut rx_stop) = TokenSink::standalone();
+    let (tx_live, mut rx_live) = TokenSink::standalone();
+    let stop_state = active_state("stop", tx_stop, 3, 1, 10, &config);
+    let live_state = active_state("live", tx_live, 3, 1, 11, &config);
+
+    let survivors = apply_decoded_tokens_to_rows(
+        vec![0, 1],
+        vec![stop_state, live_state],
+        vec![config.eos_token_id, 12],
+    );
+
+    assert_eq!(survivors.len(), 1);
+    assert_eq!(survivors[0].0, 1);
+    assert_eq!(survivors[0].1.request_id.as_deref(), Some("live"));
+    assert_eq!(survivors[0].1.generated, 2);
+    match recv_event(&mut rx_stop) {
+        TokenEvent::Finished {
+            finish_reason,
+            completion_tokens,
+            ..
+        } => {
+            assert_eq!(finish_reason, FinishReason::Stop);
+            assert_eq!(completion_tokens, 1);
+        }
+        _ => panic!("EOS row should finish without emitting EOS"),
+    }
+    match recv_event(&mut rx_live) {
+        TokenEvent::Token { id, .. } => assert_eq!(id, 12),
+        _ => panic!("live row should receive its decoded token"),
+    }
+}
+
+#[test]
+fn cancelled_token_sink_retires_request() {
+    let config = test_lite_config();
+    let (stream_tx, mut stream_rx) = mpsc::unbounded_channel();
+    let cancelled = Arc::new(AtomicBool::new(true));
+    let sink = TokenSink::new(
+        RequestTag::from("cancelled"),
+        stream_tx,
+        Arc::clone(&cancelled),
+    );
+    let mut state = active_state("cancelled", sink, 2, 1, 11, &config);
+
+    assert!(state.emit_token_or_finish(12));
+    assert!(stream_rx.try_recv().is_err());
+}
+
+#[test]
+fn closed_token_sink_retires_request() {
+    let config = test_lite_config();
+    let (sink, rx) = TokenSink::standalone();
+    drop(rx);
+    let mut state = active_state("closed", sink, 2, 1, 11, &config);
+
+    assert!(state.emit_token_or_finish(12));
+}
+
+#[test]
+fn batch_decode_error_retires_all_active_requests() {
+    let config = test_lite_config();
+    let (first_tx, mut first_rx) = TokenSink::standalone();
+    let (second_tx, mut second_rx) = TokenSink::standalone();
+    let active = vec![
+        active_state("first", first_tx, 3, 2, 11, &config),
+        active_state("second", second_tx, 4, 1, 12, &config),
+    ];
+
+    retire_rows_with_error(active, "batch failed".to_string());
+
+    match recv_event(&mut first_rx) {
+        TokenEvent::Error {
+            message,
+            prompt_tokens,
+            completion_tokens,
+        } => {
+            assert_eq!(message, "batch failed");
+            assert_eq!(prompt_tokens, 3);
+            assert_eq!(completion_tokens, 2);
+        }
+        _ => panic!("first active request should receive batch error"),
+    }
+    match recv_event(&mut second_rx) {
+        TokenEvent::Error {
+            message,
+            prompt_tokens,
+            completion_tokens,
+        } => {
+            assert_eq!(message, "batch failed");
+            assert_eq!(prompt_tokens, 4);
+            assert_eq!(completion_tokens, 1);
+        }
+        _ => panic!("second active request should receive batch error"),
+    }
+}
+
+#[test]
+fn subgroup_decode_error_retires_only_group_rows() {
+    let config = test_lite_config();
+    let (first_tx, mut first_rx) = TokenSink::standalone();
+    let (second_tx, mut second_rx) = TokenSink::standalone();
+    let (third_tx, mut third_rx) = TokenSink::standalone();
+    let first = active_state("first", first_tx, 3, 2, 11, &config);
+    let _untouched = active_state("second", second_tx, 4, 1, 12, &config);
+    let third = active_state("third", third_tx, 3, 2, 13, &config);
+
+    retire_rows_with_error(vec![first, third], "group failed".to_string());
+
+    match recv_event(&mut first_rx) {
+        TokenEvent::Error { message, .. } => assert_eq!(message, "group failed"),
+        _ => panic!("first subgroup row should receive decode error"),
+    }
+    assert!(second_rx.try_recv().is_err());
+    match recv_event(&mut third_rx) {
+        TokenEvent::Error { message, .. } => assert_eq!(message, "group failed"),
+        _ => panic!("third subgroup row should receive decode error"),
+    }
+}
+
+#[test]
+fn http_trace_payload_includes_error_and_batch_fields() {
+    let mut trace = trace();
+    trace.note_active_set(4);
+    trace.note_decode_step(2, 7.5);
+
+    let payload = http_trace_payload("req-a", &trace, 3, 2, FinishReason::Error, Some("boom"));
+
+    assert_eq!(payload["request_id"], "req-a");
+    assert_eq!(payload["finish_reason"], "error");
+    assert_eq!(payload["prompt_tokens"], 3);
+    assert_eq!(payload["completion_tokens"], 2);
+    assert_eq!(payload["active_set_size"], 4);
+    assert_eq!(payload["decode_batch_size_max"], 2);
+    assert_eq!(payload["batch_decode_steps"], 1);
+    assert_eq!(payload["first_decode_ms"], 7.5);
+    assert_eq!(payload["error"], "boom");
+}
+
+#[test]
+fn decode_grouping_batches_same_position_subgroups() {
+    assert!(decode_position_groups_for_positions(&[]).is_empty());
+    assert_eq!(
+        decode_position_groups_for_positions(&[5]),
+        vec![DecodePositionGroupPlan {
+            position: 5,
+            indices: vec![0],
+        }]
+    );
+    assert_eq!(
+        decode_position_groups_for_positions(&[7, 7, 7]),
+        vec![DecodePositionGroupPlan {
+            position: 7,
+            indices: vec![0, 1, 2],
+        }]
+    );
+    assert_eq!(
+        decode_position_groups_for_positions(&[7, 8, 7, 8, 9]),
+        vec![
+            DecodePositionGroupPlan {
+                position: 7,
+                indices: vec![0, 2],
+            },
+            DecodePositionGroupPlan {
+                position: 8,
+                indices: vec![1, 3],
+            },
+            DecodePositionGroupPlan {
+                position: 9,
+                indices: vec![4],
+            },
+        ]
+    );
+}
+
+#[test]
+fn common_decode_position_detects_only_uniform_positions() {
+    let config = test_lite_config();
+    let (a_tx, _a_rx) = TokenSink::standalone();
+    let (b_tx, _b_rx) = TokenSink::standalone();
+    let (c_tx, _c_rx) = TokenSink::standalone();
+
+    let uniform = vec![
+        active_state("a", a_tx, 4, 1, 10, &config),
+        active_state("b", b_tx, 3, 2, 11, &config),
+    ];
+    assert_eq!(common_decode_position(&uniform), Some(4));
+
+    let mixed = vec![
+        active_state("a", c_tx, 4, 1, 10, &config),
+        active_state("b", TokenSink::standalone().0, 5, 1, 11, &config),
+    ];
+    assert_eq!(common_decode_position(&mixed), None);
+}
+
+#[test]
+fn take_decode_position_groups_preserves_original_indices() {
+    let config = test_lite_config();
+    let (a_tx, _a_rx) = TokenSink::standalone();
+    let (b_tx, _b_rx) = TokenSink::standalone();
+    let (c_tx, _c_rx) = TokenSink::standalone();
+    let mut active = vec![
+        active_state("a", a_tx, 4, 1, 10, &config), // position 4
+        active_state("b", b_tx, 4, 2, 11, &config), // position 5
+        active_state("c", c_tx, 2, 3, 12, &config), // position 4
+    ];
+
+    let groups = take_decode_position_groups(&mut active);
+
+    assert!(active.is_empty());
+    assert_eq!(groups.len(), 2);
+    assert_eq!(groups[0].position, 4);
+    assert_eq!(
+        groups[0]
+            .rows
+            .iter()
+            .map(|(idx, _)| *idx)
+            .collect::<Vec<_>>(),
+        vec![0, 2]
+    );
+    assert_eq!(groups[1].position, 5);
+    assert_eq!(
+        groups[1]
+            .rows
+            .iter()
+            .map(|(idx, _)| *idx)
+            .collect::<Vec<_>>(),
+        vec![1]
+    );
+}
+
+#[test]
+fn restore_surviving_rows_keeps_original_active_order() {
+    let config = test_lite_config();
+    let (a_tx, _a_rx) = TokenSink::standalone();
+    let (b_tx, _b_rx) = TokenSink::standalone();
+    let (d_tx, _d_rx) = TokenSink::standalone();
+    let survivors = vec![
+        (3, active_state("d", d_tx, 5, 1, 13, &config)),
+        (1, active_state("b", b_tx, 4, 1, 11, &config)),
+        (0, active_state("a", a_tx, 3, 1, 10, &config)),
+    ];
+
+    let restored = restore_surviving_rows(survivors);
+
+    assert_eq!(
+        restored
+            .iter()
+            .map(|state| state.request_id.as_deref())
+            .collect::<Vec<_>>(),
+        vec![Some("a"), Some("b"), Some("d")]
+    );
+}

--- a/openinfer-deepseek-v2-lite/src/scheduler/trace.rs
+++ b/openinfer-deepseek-v2-lite/src/scheduler/trace.rs
@@ -1,0 +1,109 @@
+use openinfer_engine::engine::FinishReason;
+
+#[derive(Clone, Debug)]
+pub(super) struct RequestTrace {
+    pub(super) queued_at_unix_s: f64,
+    pub(super) scheduled_at_unix_s: f64,
+    pub(super) prefill_done_unix_s: Option<f64>,
+    pub(super) first_token_emit_unix_s: Option<f64>,
+    pub(super) prefill_ms: Option<f64>,
+    pub(super) first_decode_ms: Option<f64>,
+    pub(super) active_set_size_max: usize,
+    pub(super) decode_batch_size_max: usize,
+    pub(super) batch_decode_steps: usize,
+}
+
+#[derive(Debug)]
+pub(super) struct ScheduledTrace {
+    pub(super) queued_at_unix_s: f64,
+    pub(super) scheduled_at_unix_s: f64,
+}
+
+impl RequestTrace {
+    pub(super) fn new(
+        queued_at_unix_s: f64,
+        scheduled_at_unix_s: f64,
+        prefill_done_unix_s: f64,
+        prefill_ms: f64,
+    ) -> Self {
+        Self {
+            queued_at_unix_s,
+            scheduled_at_unix_s,
+            prefill_done_unix_s: Some(prefill_done_unix_s),
+            first_token_emit_unix_s: None,
+            prefill_ms: Some(prefill_ms),
+            first_decode_ms: None,
+            active_set_size_max: 1,
+            decode_batch_size_max: 0,
+            batch_decode_steps: 0,
+        }
+    }
+
+    pub(super) fn terminal(queued_at_unix_s: f64, scheduled_at_unix_s: f64) -> Self {
+        Self {
+            queued_at_unix_s,
+            scheduled_at_unix_s,
+            prefill_done_unix_s: None,
+            first_token_emit_unix_s: None,
+            prefill_ms: None,
+            first_decode_ms: None,
+            active_set_size_max: 0,
+            decode_batch_size_max: 0,
+            batch_decode_steps: 0,
+        }
+    }
+
+    pub(super) fn note_active_set(&mut self, active_set_size: usize) {
+        self.active_set_size_max = self.active_set_size_max.max(active_set_size);
+    }
+
+    pub(super) fn note_decode_step(&mut self, batch_size: usize, decode_ms: f64) {
+        self.first_decode_ms.get_or_insert(decode_ms);
+        self.decode_batch_size_max = self.decode_batch_size_max.max(batch_size);
+        if batch_size > 1 {
+            self.batch_decode_steps += 1;
+        }
+    }
+}
+
+pub(super) fn http_trace_payload(
+    request_id: &str,
+    trace: &RequestTrace,
+    prompt_tokens: usize,
+    completion_tokens: usize,
+    finish_reason: FinishReason,
+    error: Option<&str>,
+) -> serde_json::Value {
+    let mut payload = serde_json::json!({
+        "request_id": request_id,
+        "queued_at_unix_s": trace.queued_at_unix_s,
+        "scheduled_at_unix_s": trace.scheduled_at_unix_s,
+        "prefill_done_unix_s": trace.prefill_done_unix_s,
+        "first_token_emit_unix_s": trace.first_token_emit_unix_s,
+        "prefill_ms": trace.prefill_ms,
+        "first_decode_ms": trace.first_decode_ms,
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "finish_reason": finish_reason_label(finish_reason),
+        "active_set_size": trace.active_set_size_max,
+        "decode_batch_size_max": trace.decode_batch_size_max,
+        "batch_decode_steps": trace.batch_decode_steps,
+    });
+    if let Some(error) = error
+        && let Some(object) = payload.as_object_mut()
+    {
+        object.insert(
+            "error".to_string(),
+            serde_json::Value::String(error.to_string()),
+        );
+    }
+    payload
+}
+
+fn finish_reason_label(finish_reason: FinishReason) -> &'static str {
+    match finish_reason {
+        FinishReason::Length => "length",
+        FinishReason::Stop => "stop",
+        FinishReason::Error => "error",
+    }
+}


### PR DESCRIPTION
### Summary
- Add DeepSeek-V2-Lite `openinfer_http_trace` records for HTTP request attribution.
- Refactor scheduler grouping and trace helpers out of the main scheduler file.
- Replace all-or-nothing decode batching with same-position subgroup batching plus singleton and uniform-position fast paths.
- Keep request retirement independent on EOS, disconnect, and batch decode errors.
- Chunk large NCCL all-reduce calls so long-prompt HTTP and direct probes complete.
- Refresh the DeepSeek-V2-Lite status ledger with HTTP benchmark evidence and claim boundaries.

### Validation
- `git diff --check`
- `cargo fmt --all --check`
- `python3 -m unittest tests/test_bench_http_serving.py`
- Remote release build and lib tests for `openinfer-deepseek-v2-lite`
- Remote HTTP sweeps for short same-shape, 128-word smoke, and mixed 16/128 workloads

### Evidence
- Short same-shape throughput improved at concurrency 1/2/4/8.
- Mixed 16/128 HTTP runs completed with no failures and full trace coverage.
- 128-word HTTP requests now complete, but long-prompt TTFT remains high.

### Boundary
- This is HTTP serving evidence for issue #280.
- It does not claim vLLM parity or production EP readiness.

Fixes #280
