### PR TITLE
fix(qwen3-dflash): set enable_kv_events in DFlash test launch options

### DIFF
--- a/openinfer-qwen3-4b/tests/dflash_speculative_gate.rs
+++ b/openinfer-qwen3-4b/tests/dflash_speculative_gate.rs
@@ -116,6 +116,7 @@ fn launch_options(draft: Option<PathBuf>) -> Qwen3LaunchOptions {
         decode_overlap: DecodeOverlap::Off,
         batch_invariant: false,
         dflash_draft_model_path: draft,
+        enable_kv_events: false,
     }
 }
 

--- a/openinfer-qwen3-4b/tests/dflash_speculative_perf.rs
+++ b/openinfer-qwen3-4b/tests/dflash_speculative_perf.rs
@@ -66,6 +66,7 @@ fn launch_options(draft: Option<PathBuf>) -> Qwen3LaunchOptions {
         decode_overlap: DecodeOverlap::Off,
         batch_invariant: false,
         dflash_draft_model_path: draft,
+        enable_kv_events: false,
     }
 }
 


### PR DESCRIPTION
## Description

Just fix missing field.

## Test Env

`cargo build --release -p openinfer-qwen3-4b --tests`

```sh
error[E0063]: missing field `enable_kv_events` in initializer of `Qwen3LaunchOptions`
        --> openinfer-qwen3-4b/tests/dflash_speculative_perf.rs:55
        --> openinfer-qwen3-4b/tests/dflash_speculative_gate.rs:103
      error: could not compile `openinfer-qwen3-4b` (exit 101)
```

After — same command: `Finished`, exit 0.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
