### PR TITLE
fix(qwen3): assert NumericPolicy is immutable post-construction

### DIFF
--- a/openinfer-qwen3-4b/src/batch_decode.rs
+++ b/openinfer-qwen3-4b/src/batch_decode.rs
@@ -62,6 +62,13 @@ impl Qwen3Model {
         assert_eq!(bs, kv_views.len());
         assert_eq!(bs, lora_adapters.len());
         assert!(bs > 0);
+        // Before the first live-policy read (sync_paged_meta) and on every decode path; see
+        // `policy_at_construction` for the workspace-overflow / stale-graph trap this guards.
+        assert_eq!(
+            openinfer_kernels::ops::numeric_policy(),
+            bufs.policy_at_construction,
+            "NumericPolicy changed after executor construction (policy-key-trap); build a fresh executor per policy"
+        );
         let lora_slots = self.decode_lora_slots(lora_adapters)?;
         let use_lora = lora_slots.is_some();
         let use_cuda_graph = self.enable_cuda_graph && lora_slots.is_none();

--- a/openinfer-qwen3-4b/src/batch_decode_buffers.rs
+++ b/openinfer-qwen3-4b/src/batch_decode_buffers.rs
@@ -135,6 +135,11 @@ pub(crate) struct BatchDecodeBuffers {
     /// `split_chunk_size`).
     max_context_tokens: usize,
 
+    /// `NumericPolicy` at construction; asserted unchanged at `batch_decode` entry. The split-KV
+    /// workspace is sized for it and decode graphs are keyed `(bucket, attention_path)` without it, so a
+    /// later switch would overflow the workspace or replay a stale graph — the policy-key-trap.
+    pub(crate) policy_at_construction: NumericPolicy,
+
     /// Padding page index for bucket CUDA Graph. Padding slots point here.
     padding_page_id: i32,
 
@@ -164,9 +169,8 @@ impl BatchDecodeBuffers {
         max_context_tokens: usize,
     ) -> Result<Self> {
         let bs = max_batch_size;
-        // Policy-sized: default Tuned reserves only ×64, the ×256 Pin width only under
-        // --batch-invariant. Policy is fixed before construction; a later change should source it
-        // from a recorded field rather than re-read the global here.
+        // Policy-sized: Tuned (default) ×64, Pin/PerToken ×256. Re-reading the global here is safe —
+        // the `batch_decode` entry assert pins policy immutable post-construction.
         let max_split_slots = bs.min(SPLIT_KV_MAX_BATCH_SIZE) * max_split_chunks();
 
         Ok(Self {
@@ -204,6 +208,7 @@ impl BatchDecodeBuffers {
             split_padded_slots: 0,
             max_seq_len: 0,
             max_context_tokens,
+            policy_at_construction: numeric_policy(),
             padding_page_id,
             graphs: BATCH_BUCKETS
                 .iter()

--- a/openinfer-qwen3-4b/src/verify_graph.rs
+++ b/openinfer-qwen3-4b/src/verify_graph.rs
@@ -29,6 +29,7 @@ use openinfer_core::kv_pool::KvLayout;
 use openinfer_core::ops;
 use openinfer_core::ops::PrefillPagedPlan;
 use openinfer_core::tensor::HiddenStates;
+use openinfer_kernels::ops::{NumericPolicy, numeric_policy};
 use openinfer_kv_cache::KvView;
 
 use crate::batch_decode_buffers::BATCH_BUCKETS;
@@ -60,6 +61,10 @@ pub(crate) struct VerifyGraphBuffers {
     /// between them); a segment is captured once at its exact-bucket batch and
     /// replayed thereafter. Empty (`CudaGraphState::new()`) until first captured.
     graphs: Vec<Vec<CudaGraphState>>,
+    /// `NumericPolicy` when these graphs were built; asserted unchanged at capture/replay. They bake
+    /// the policy-selected GEMM algo and are keyed `(bucket, segment)` without policy — the same
+    /// policy-key-trap the decode graphs guard.
+    policy_at_construction: NumericPolicy,
     max_batch: usize,
     span: usize,
 }
@@ -127,6 +132,7 @@ impl VerifyGraphBuffers {
                         .collect()
                 })
                 .collect(),
+            policy_at_construction: numeric_policy(),
             max_batch,
             span,
         })
@@ -273,6 +279,11 @@ impl Qwen3Model {
         let full_shape = total_tokens == batch_size * bufs.span;
         match BATCH_BUCKETS.iter().position(|&b| b == batch_size) {
             Some(bidx) if full_shape => {
+                assert_eq!(
+                    numeric_policy(),
+                    bufs.policy_at_construction,
+                    "NumericPolicy changed after the verify graphs were captured; they are keyed (bucket, segment) without policy, so build a fresh executor per policy (policy-key-trap)"
+                );
                 // Take the bucket's segment graphs out so the capture closures can
                 // borrow `bufs` mutably; restore them after (even on error).
                 let mut segs = std::mem::take(&mut bufs.graphs[bidx]);


### PR DESCRIPTION
## Description

Refs #414, #435. Follows #438

Decode reads the process-global `numeric_policy()` to (a) size the split-KV decode workspace and (b) select the GEMM algo baked into cached decode/verify CUDA graphs. Both are fixed at construction: the workspace is allocated for the construction-time policy; graphs are cached keyed `(bucket, attention_path)` / `(bucket, segment)` WITHOUT policy. A mid-run switch would overflow the workspace (`sync` writes `padded_bs × live-cap` slots into a construction-sized buffer) or replay a stale-policy graph — silently. Production sets the policy once at boot and never mutates it; this guard makes that invariant fail-loud.

Snapshots `policy_at_construction` on `BatchDecodeBuffers` and `VerifyGraphBuffers` and asserts `numeric_policy() == policy_at_construction`:
- at `batch_decode()` entry, unconditional, BEFORE the split-KV sync and the graph branch (covers eager + graph + LoRA decode);
- at the `VerifyGraphBuffers` capture/replay arm (covers the DFlash verify graph).

A trace of the relevant post-construction readers shows the guarded decode path reaches the split-KV readers (`max_split_chunks` / `split_chunk_size`) only after the entry assert, and cached decode/verify graph replay reaches policy-selected GEMMs only after their respective policy guards. Other reads are construction-time setup/snapshot reads, guard reads, or eager prefill/unified/drafter GEMMs that do not touch split-KV workspace or cached policy-keyed graphs.

## Test Env

`cargo test --release -p openinfer-qwen3-4b --test batch_invariance_decode_gemm_graph --test batch_invariance_decode_splitkv_graph`

sm_89 — both pass (per-policy executors build + decode; the entry assert holds, no false-fire):

    test result: ok. 1 passed   # decode_gemm_graph
    test result: ok. 1 passed   # decode_splitkv_graph

`batch_invariance_endtoend` (switches policy on a live executor but only `execute_prefill`s) still passes — the guard is scoped to the unsafe decode/verify paths, not a blanket reject.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)