### PR TITLE
test(qwen35): cover chunked prefill resumed paged kv

### DIFF
--- a/openinfer-qwen35-4b/Cargo.toml
+++ b/openinfer-qwen35-4b/Cargo.toml
@@ -45,6 +45,10 @@ required-features = ["qwen35-4b"]
 name = "sampling_behavior"
 required-features = ["qwen35-4b"]
 
+[[test]]
+name = "chunked_prefill"
+required-features = ["qwen35-4b"]
+
 [[bench]]
 name = "qwen35_ops"
 harness = false

--- a/openinfer-qwen35-4b/tests/chunked_prefill.rs
+++ b/openinfer-qwen35-4b/tests/chunked_prefill.rs
@@ -1,0 +1,133 @@
+//! Qwen3.5 scheduler-level chunked prefill regression tests.
+//!
+//! These tests exercise resumed prefill (`base_pos > 0`) through the real
+//! scheduler path. A small `max_prefill_tokens` budget forces one request's
+//! prompt to be prefilling across multiple scheduler steps; the same prompt is
+//! also run with an effectively unchunked budget and the generated greedy token
+//! ids must match.
+
+use std::path::Path;
+
+use openinfer_core::engine::{
+    EngineHandle, EngineLoadOptions, FinishReason, GenerateRequest, TokenEvent, TokenSink,
+};
+use openinfer_core::sampler::SamplingParams;
+
+mod common;
+
+const MODEL_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../models/Qwen3.5-4B");
+const CHUNK_BUDGET: usize = 16;
+const BASELINE_PREFILL_BUDGET: usize = 1 << 20;
+const MAX_BATCH: usize = 2;
+const GENERATED_TOKENS: usize = 8;
+
+fn model_path_or_skip() -> Option<String> {
+    match std::env::var("OPENINFER_TEST_MODEL_PATH") {
+        Ok(path) => Some(path),
+        Err(_) if Path::new(MODEL_PATH).join("config.json").exists() => {
+            Some(MODEL_PATH.to_string())
+        }
+        Err(_) => {
+            eprintln!(
+                "skipping qwen35 chunked_prefill: {MODEL_PATH}/config.json is missing; set OPENINFER_TEST_MODEL_PATH to run it"
+            );
+            None
+        }
+    }
+}
+
+fn start_engine(model_path: &str, max_prefill_tokens: usize) -> EngineHandle {
+    openinfer_qwen35_4b::start_engine_with_capacity(
+        Path::new(model_path),
+        EngineLoadOptions {
+            enable_cuda_graph: true,
+            enable_prefill_profile: false,
+            device_ordinals: vec![0],
+            seed: 42,
+            ..EngineLoadOptions::default()
+        },
+        MAX_BATCH,
+        max_prefill_tokens,
+    )
+    .expect("failed to start Qwen3.5 engine")
+}
+
+fn generate(handle: &EngineHandle, prompt_tokens: Vec<u32>) -> (Vec<u32>, FinishReason) {
+    let (token_tx, mut rx) = TokenSink::standalone();
+    handle
+        .submit(GenerateRequest {
+            request_id: None,
+            queued_at_unix_s: None,
+            prompt_tokens,
+            params: SamplingParams {
+                ignore_eos: true,
+                ..SamplingParams::default()
+            },
+            max_tokens: GENERATED_TOKENS,
+            lora_adapter: None,
+            token_tx,
+            logprobs: 0,
+            echo: false,
+        })
+        .expect("submit failed");
+
+    let mut tokens = Vec::new();
+    loop {
+        match rx.blocking_recv().map(|(_, event)| event) {
+            Some(TokenEvent::Token { id, .. }) => tokens.push(id),
+            Some(TokenEvent::Scheduled { .. } | TokenEvent::PromptTokens { .. }) => {}
+            Some(TokenEvent::Finished { finish_reason, .. }) => return (tokens, finish_reason),
+            Some(TokenEvent::Error { message, .. }) => panic!("generation failed: {message}"),
+            Some(TokenEvent::Rejected { message, .. }) => panic!("generation rejected: {message}"),
+            None => panic!("scheduler channel closed without Finished"),
+        }
+    }
+}
+
+#[test]
+fn chunked_prefill_matches_unchunked_prefill_for_resumed_paged_kv() {
+    let Some(model_path) = model_path_or_skip() else {
+        return;
+    };
+    let tokenizer = common::load_tokenizer(&model_path);
+    let prompt = concat!(
+        "Write a concise technical explanation of paged KV cache updates, ",
+        "chunked prefill scheduling, and deterministic greedy decoding. ",
+        "Mention request state ownership, recurrent state, and why resumed ",
+        "prefill must append K/V instead of overwriting earlier pages. ",
+        "Then summarize the behavior in three short sentences. ",
+        "Repeat the explanation with different wording so the prompt is long ",
+        "enough to cross several small prefill chunks."
+    );
+    let prompt_tokens = tokenizer.encode(prompt, false).expect("encode failed");
+    assert!(
+        prompt_tokens.len() > CHUNK_BUDGET * 2,
+        "test prompt must force resumed prefill: prompt_len={} chunk_budget={CHUNK_BUDGET}",
+        prompt_tokens.len()
+    );
+
+    let (baseline_tokens, baseline_finish) = {
+        let handle = start_engine(&model_path, BASELINE_PREFILL_BUDGET);
+        generate(&handle, prompt_tokens.clone())
+    };
+    assert_eq!(
+        baseline_finish,
+        FinishReason::Length,
+        "ignore_eos should force baseline generation to the requested length"
+    );
+
+    let (chunked_tokens, chunked_finish) = {
+        let handle = start_engine(&model_path, CHUNK_BUDGET);
+        generate(&handle, prompt_tokens)
+    };
+    assert_eq!(
+        chunked_finish,
+        FinishReason::Length,
+        "ignore_eos should force chunked generation to the requested length"
+    );
+
+    assert_eq!(
+        chunked_tokens, baseline_tokens,
+        "chunked prefill must match effectively unchunked prefill; a mismatch suggests resumed direct-paged K/V writes used the wrong base_pos and corrupted earlier cache positions"
+    );
+}


### PR DESCRIPTION
## Description

Fixes #313

This PR follows up on the completed Qwen3.5 chunked prefill work by adding a focused regression test for resumed direct-paged prefill.

The new test covers the case where a request prompt is split across multiple scheduler prefill steps. It compares:

- an effectively unchunked prefill run with a very large `max_prefill_tokens`
- a forced chunked prefill run with `max_prefill_tokens = 16`

Both runs use the same prompt and greedy generation settings, then assert that the generated token IDs match exactly.

The important behavior under test is `base_pos > 0` resumed prefill. When a long prompt resumes after the first chunk, newly computed K/V must be appended at the correct paged-KV offset rather than overwriting earlier prompt positions. If the resumed direct-paged K/V write uses the wrong base position, the cache is corrupted and the chunked run diverges from the unchunked baseline.

Tested locally on a single NVIDIA RTX 3090 with CUDA 12.4.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project (see `docs/conventions/coding-style.md`).
- [x] I have performed a self-review of my own code.
- [x] I have formatted my commits according to Commitizen conventions.
- [x] I have run the local test suite and all tests pass (see `CLAUDE.md`).

