### PR TITLE
fix(qwen3): fail loud under --batch-invariant instead of silent per-token fallback

### DIFF
--- a/openinfer-kernels/csrc/shared/linear.cu
+++ b/openinfer-kernels/csrc/shared/linear.cu
@@ -545,10 +545,12 @@ int gemm_lt_pin_tune_cuda(int M, int rep_n, int K) {
   return static_cast<int>(cudaSuccess);
 }
 
-// Run the pinned (M,K) algo at an arbitrary N (rebuilds only B/C). Returns PIN_UNTUNED (no plan)
-// or PIN_UNSUPPORTED (algo can't serve this N; caller falls back).
-int gemm_lt_pin_cuda(const __nv_bfloat16 *W, const __nv_bfloat16 *X, __nv_bfloat16 *Y, int M, int N,
-                     int K, cudaStream_t stream) {
+// Run or check the pinned (M,K) algo at an arbitrary N (rebuilds only B/C). `check_only` skips the
+// matmul (W/X/Y/stream untouched) and returns 0 when the algo serves N. The serviceability tests
+// (AlgoCheck + workspace-over-budget) live here ONCE so the boot self-check is never more permissive
+// than production. Returns PIN_UNTUNED (no plan) or PIN_UNSUPPORTED (algo can't serve this N).
+static int lt_pin_run(const __nv_bfloat16 *W, const __nv_bfloat16 *X, __nv_bfloat16 *Y, int M, int N,
+                      int K, cudaStream_t stream, bool check_only) {
   if (g_lt_handle == nullptr || g_lt_pin_workspace == nullptr) {
     return GEMM_LT_PIN_UNTUNED;
   }
@@ -574,6 +576,8 @@ int gemm_lt_pin_cuda(const __nv_bfloat16 *W, const __nv_bfloat16 *X, __nv_bfloat
       result = GEMM_LT_PIN_UNSUPPORTED;
     } else if (check.workspaceSize > LT_PIN_WORKSPACE_SIZE) {
       result = GEMM_LT_PIN_UNSUPPORTED;
+    } else if (check_only) {
+      result = 0;
     } else {
       const float h_alpha = 1.0f;
       const float h_beta = 0.0f;
@@ -587,6 +591,16 @@ int gemm_lt_pin_cuda(const __nv_bfloat16 *W, const __nv_bfloat16 *X, __nv_bfloat
   if (c != nullptr) cublasLtMatrixLayoutDestroy(c);
   if (b != nullptr) cublasLtMatrixLayoutDestroy(b);
   return result;
+}
+
+int gemm_lt_pin_cuda(const __nv_bfloat16 *W, const __nv_bfloat16 *X, __nv_bfloat16 *Y, int M, int N,
+                     int K, cudaStream_t stream) {
+  return lt_pin_run(W, X, Y, M, N, K, stream, /*check_only=*/false);
+}
+
+// Boot self-check: thin check-only wrapper over lt_pin_run.
+int gemm_lt_pin_check_cuda(int M, int N, int K) {
+  return lt_pin_run(nullptr, nullptr, nullptr, M, N, K, /*stream=*/nullptr, /*check_only=*/true);
 }
 
 // Diagnostics: write [tile_id, stages_id, splitk_num, reduction_scheme] for (M,K) into out4;

--- a/openinfer-kernels/csrc/shared/linear.cu
+++ b/openinfer-kernels/csrc/shared/linear.cu
@@ -603,31 +603,6 @@ int gemm_lt_pin_check_cuda(int M, int N, int K) {
   return lt_pin_run(nullptr, nullptr, nullptr, M, N, K, /*stream=*/nullptr, /*check_only=*/true);
 }
 
-// Diagnostics: write [tile_id, stages_id, splitk_num, reduction_scheme] for (M,K) into out4;
-// GEMM_LT_PIN_UNTUNED if no pinned plan.
-int gemm_lt_pin_inspect_cuda(int M, int K, int *out4) {
-  if (out4 == nullptr) {
-    return static_cast<int>(cudaErrorInvalidValue);
-  }
-  auto it = g_lt_pin_plans.find(std::array<int, 2>{M, K});
-  if (it == g_lt_pin_plans.end()) {
-    return GEMM_LT_PIN_UNTUNED;
-  }
-  cublasLtMatmulAlgo_t &algo = it->second.algo;
-  int tile = -1, stages = -1, splitk = -1, reduction = -1;
-  size_t written = 0;
-  cublasLtMatmulAlgoConfigGetAttribute(&algo, CUBLASLT_ALGO_CONFIG_TILE_ID, &tile, sizeof(tile),
-                                       &written);
-  cublasLtMatmulAlgoConfigGetAttribute(&algo, CUBLASLT_ALGO_CONFIG_STAGES_ID, &stages,
-                                       sizeof(stages), &written);
-  cublasLtMatmulAlgoConfigGetAttribute(&algo, CUBLASLT_ALGO_CONFIG_SPLITK_NUM, &splitk,
-                                       sizeof(splitk), &written);
-  cublasLtMatmulAlgoConfigGetAttribute(&algo, CUBLASLT_ALGO_CONFIG_REDUCTION_SCHEME, &reduction,
-                                       sizeof(reduction), &written);
-  out4[0] = tile, out4[1] = stages, out4[2] = splitk, out4[3] = reduction;
-  return static_cast<int>(cudaSuccess);
-}
-
 // Batched per-token GEMM: each row is computed as the same N=1 GEMM used by
 // decode, preserving row-wise numerical parity while keeping a batch-shaped
 // Rust API.
@@ -660,16 +635,6 @@ int gemm_per_token_cuda(const __nv_bfloat16 *W, const __nv_bfloat16 *X,
     }
   }
   return static_cast<int>(cudaPeekAtLastError());
-}
-
-// 1 if `stream` is mid graph-capture, 0 if not, <0 (negated cudaError_t) on query failure.
-int stream_is_capturing_cuda(cudaStream_t stream) {
-  cudaStreamCaptureStatus capture_status;
-  cudaError_t err = cudaStreamIsCapturing(stream, &capture_status);
-  if (err != cudaSuccess) {
-    return -static_cast<int>(err);
-  }
-  return capture_status == cudaStreamCaptureStatusNone ? 0 : 1;
 }
 
 } // extern "C"

--- a/openinfer-kernels/src/ffi/shared.rs
+++ b/openinfer-kernels/src/ffi/shared.rs
@@ -176,6 +176,7 @@ unsafe extern "C" {
 
     // Batch-invariant pinned-algo path (csrc/shared/linear.cu).
     pub fn gemm_lt_pin_tune_cuda(M: i32, rep_n: i32, K: i32) -> i32;
+    pub fn gemm_lt_pin_check_cuda(M: i32, N: i32, K: i32) -> i32;
 
     pub fn stream_is_capturing_cuda(stream: CUstream) -> i32;
 

--- a/openinfer-kernels/src/ffi/shared.rs
+++ b/openinfer-kernels/src/ffi/shared.rs
@@ -178,8 +178,6 @@ unsafe extern "C" {
     pub fn gemm_lt_pin_tune_cuda(M: i32, rep_n: i32, K: i32) -> i32;
     pub fn gemm_lt_pin_check_cuda(M: i32, N: i32, K: i32) -> i32;
 
-    pub fn stream_is_capturing_cuda(stream: CUstream) -> i32;
-
     pub fn gemm_lt_pin_cuda(
         W: *const Half,
         X: *const Half,
@@ -189,8 +187,6 @@ unsafe extern "C" {
         K: i32,
         stream: CUstream,
     ) -> i32;
-
-    pub fn gemm_lt_pin_inspect_cuda(M: i32, K: i32, out4: *mut i32) -> i32;
 
     // Embedding lookup reading token_id from decode_meta[0] (CUDA Graph safe)
     pub fn embedding_decode_cuda(

--- a/openinfer-kernels/src/ops.rs
+++ b/openinfer-kernels/src/ops.rs
@@ -39,11 +39,11 @@ pub use embedding::{embedding_batch, embedding_batch_vocab_shard, embedding_deco
 pub use kimi_k2::*;
 pub use linear::{
     GEMM_LT_MAX_N, NumericPolicy, gemm, gemm_graphsafe_into_checked,
-    gemm_graphsafe_ref_into_checked, gemm_into, gemm_into_checked, gemm_lt_pin_inspect,
-    gemm_lt_pin_into_checked, gemm_lt_pin_tune, gemm_lt_pin_warmup, gemm_lt_tune, gemm_per_token,
-    gemm_per_token_into_checked, gemm_rows_into, gemm_rows_into_checked,
-    gemm_token_range_into_checked, gemv, linear, numeric_policy, pin_counters, pin_fallback_shapes,
-    reset_pin_counters, set_numeric_policy,
+    gemm_graphsafe_ref_into_checked, gemm_into, gemm_into_checked, gemm_lt_pin_check,
+    gemm_lt_pin_inspect, gemm_lt_pin_into_checked, gemm_lt_pin_tune, gemm_lt_pin_warmup,
+    gemm_lt_tune, gemm_per_token, gemm_per_token_into_checked, gemm_rows_into,
+    gemm_rows_into_checked, gemm_token_range_into_checked, gemv, linear, numeric_policy,
+    pin_counters, pin_fallback_shapes, reset_pin_counters, set_numeric_policy,
 };
 pub use lora::{
     LoraDecodeGroupedProjection, lora_decode_fused_delta_group3_into, lora_decode_fused_delta_into,

--- a/openinfer-kernels/src/ops.rs
+++ b/openinfer-kernels/src/ops.rs
@@ -40,10 +40,10 @@ pub use kimi_k2::*;
 pub use linear::{
     GEMM_LT_MAX_N, NumericPolicy, gemm, gemm_graphsafe_into_checked,
     gemm_graphsafe_ref_into_checked, gemm_into, gemm_into_checked, gemm_lt_pin_check,
-    gemm_lt_pin_inspect, gemm_lt_pin_into_checked, gemm_lt_pin_tune, gemm_lt_pin_warmup,
-    gemm_lt_tune, gemm_per_token, gemm_per_token_into_checked, gemm_rows_into,
-    gemm_rows_into_checked, gemm_token_range_into_checked, gemv, linear, numeric_policy,
-    pin_counters, pin_fallback_shapes, reset_pin_counters, set_numeric_policy,
+    gemm_lt_pin_into_checked, gemm_lt_pin_tune, gemm_lt_pin_warmup, gemm_lt_tune, gemm_per_token,
+    gemm_per_token_into_checked, gemm_rows_into, gemm_rows_into_checked,
+    gemm_token_range_into_checked, gemv, linear, numeric_policy, pin_served, reset_pin_counters,
+    set_numeric_policy,
 };
 pub use lora::{
     LoraDecodeGroupedProjection, lora_decode_fused_delta_group3_into, lora_decode_fused_delta_into,

--- a/openinfer-kernels/src/ops/linear.rs
+++ b/openinfer-kernels/src/ops/linear.rs
@@ -1,6 +1,4 @@
-use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
-use std::sync::{Mutex, OnceLock};
 
 use anyhow::{Result, bail};
 use cudarc::driver::{DevicePtr, DevicePtrMut};
@@ -88,8 +86,9 @@ pub fn gemm_lt_pin_tune(num_rows: usize, rep_n: usize, cols: usize) -> Result<()
     Ok(())
 }
 
-/// Run the pinned `(rows, cols)` algo at this N. `Ok(false)` = algo can't serve this N (caller
-/// falls back); bails if never pinned.
+/// Run the pinned `(rows, cols)` algo at this N. `Ok(false)` = algo can't serve this N; bails if
+/// never pinned. Used by the kernel serviceability test only — the production Pin path is
+/// `launch_gemm_pin`, which fails loud instead of returning `Ok(false)`.
 pub fn gemm_lt_pin_into_checked(
     ctx: &DeviceContext,
     weight: &DeviceMatrix,
@@ -169,15 +168,6 @@ pub fn gemm_lt_pin_check(rows: usize, n: usize, cols: usize) -> Result<bool> {
             bail!("gemm_lt_pin_check: cublas layout error (status {s}), m={rows}, n={n}, k={cols}")
         }
     }
-}
-
-/// Diagnostics: the pinned algo's `[tile_id, stages_id, splitk_num, reduction_scheme]` for
-/// `(rows, cols)`, or `None` if never pinned.
-pub fn gemm_lt_pin_inspect(rows: usize, cols: usize) -> Option<[i32; 4]> {
-    let mut out = [0i32; 4];
-    let status =
-        unsafe { ffi::gemm_lt_pin_inspect_cuda(rows as i32, cols as i32, out.as_mut_ptr()) };
-    if status == 0 { Some(out) } else { None }
 }
 
 /// GEMM on a row sub-range of a weight matrix: Y = W[row_offset..row_offset+M, :] @ X
@@ -470,8 +460,9 @@ fn gemm_ref_into_with_policy(
 
 /// Process-global numeric policy for projection GEMMs (atomics, not thread-local: set on the main
 /// thread before worker construction, read on the worker). `Tuned` (default) = production path;
-/// `Pin` = batch-invariant pinned algo (per-token fallback when it can't serve an N, or under a
-/// stream override); `PerToken` = N=1 oracle. Set via `set_numeric_policy` before executor
+/// `Pin` = batch-invariant pinned algo (one cuBLASLt algo per `(M,K)`; `launch_gemm_pin` bails — no
+/// per-token fallback — if it can't serve an N or under a stream override); `PerToken` = N=1 oracle.
+/// Set via `set_numeric_policy` before executor
 /// construction / graph capture.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[repr(u8)]
@@ -483,14 +474,6 @@ pub enum NumericPolicy {
 
 static NUMERIC_POLICY: AtomicU8 = AtomicU8::new(NumericPolicy::Tuned as u8);
 static PIN_SERVED: AtomicU64 = AtomicU64::new(0);
-static PIN_FALLBACK: AtomicU64 = AtomicU64::new(0);
-type FallbackShapeMap = Mutex<BTreeMap<(usize, usize, usize), u64>>;
-/// Per-(m, n, k) fallback tally; only the fallback branch touches it (served path stays lock-free).
-static PIN_FALLBACK_SHAPES: OnceLock<FallbackShapeMap> = OnceLock::new();
-
-fn pin_fallback_shapes_map() -> &'static FallbackShapeMap {
-    PIN_FALLBACK_SHAPES.get_or_init(|| Mutex::new(BTreeMap::new()))
-}
 
 /// Set the process-global policy. Must run before executor construction / graph capture (the
 /// captured algo is the one live at capture). Tests drive baseline/pin/per-token through it.
@@ -506,42 +489,16 @@ pub fn numeric_policy() -> NumericPolicy {
     }
 }
 
-/// `(pin_served, pin_fallback)` projection-GEMM counts: process-global, mixed across prefill +
-/// decode + unified and across TP ranks (not decode-specific). Decode counts the graph capture,
-/// not replays; read quiesced.
-pub fn pin_counters() -> (u64, u64) {
-    (
-        PIN_SERVED.load(Ordering::Relaxed),
-        PIN_FALLBACK.load(Ordering::Relaxed),
-    )
+/// Count of projection GEMMs served by the pinned algo: process-global, mixed across prefill +
+/// decode + unified and across TP ranks. Under `Pin` a GEMM either serves (counted here) or
+/// `launch_gemm_pin` bails — there is no silent per-token fallback. Decode counts the graph
+/// capture, not replays; read quiesced.
+pub fn pin_served() -> u64 {
+    PIN_SERVED.load(Ordering::Relaxed)
 }
 
 pub fn reset_pin_counters() {
     PIN_SERVED.store(0, Ordering::Relaxed);
-    PIN_FALLBACK.store(0, Ordering::Relaxed);
-    pin_fallback_shapes_map().lock().unwrap().clear();
-}
-
-/// `((m, n, k), count)` per shape that fell back to per-token. Quiesced and single-threaded, an
-/// empty list means no recorded fallback; under TP/concurrency the map and counter can momentarily
-/// disagree.
-pub fn pin_fallback_shapes() -> Vec<((usize, usize, usize), u64)> {
-    pin_fallback_shapes_map()
-        .lock()
-        .unwrap()
-        .iter()
-        .map(|(&shape, &count)| (shape, count))
-        .collect()
-}
-
-fn record_pin_fallback(m: usize, n: usize, k: usize, reason: &str) {
-    PIN_FALLBACK.fetch_add(1, Ordering::Relaxed);
-    let mut shapes = pin_fallback_shapes_map().lock().unwrap();
-    let count = shapes.entry((m, n, k)).or_insert(0);
-    if *count == 0 {
-        log::warn!("batch-invariant pin fell back to per-token at (m={m}, n={n}, k={k}): {reason}");
-    }
-    *count += 1;
 }
 
 /// Fixed representative N at which every (M,K) pin is resolved — one algo for ALL
@@ -553,7 +510,8 @@ pub fn gemm_lt_pin_warmup(num_rows: usize, cols: usize) -> Result<()> {
     gemm_lt_pin_tune(num_rows, PIN_REP_N as usize, cols)
 }
 
-/// `Pin` policy: lazily pin (m,k) at PIN_REP_N, run at live N, per-token fallback if it can't serve N.
+/// `Pin` policy: run the boot-warmed pinned (m,k) algo at live N; bails if (m,k) isn't pinned or the
+/// algo can't serve N (no lazy tune, no per-token fallback, which would break invariance).
 fn launch_gemm_pin(
     w_ptr: *const ffi::Half,
     x_ptr: *const ffi::Half,
@@ -563,30 +521,21 @@ fn launch_gemm_pin(
     k: usize,
     ctx: &DeviceContext,
 ) -> Result<()> {
-    // cuBLASLt (gemm_lt_pin) risks Xid 31 under a stream override; fall back to per-token.
+    // launch_gemm_pin runs only under Pin, so a per-token fallback here would silently break batch
+    // invariance — fail loud instead. decode-overlap (the only stream-override source) is rejected
+    // before capture, so reaching this is a misconfiguration, not a normal path.
     if crate::tensor::has_stream_override() {
-        record_pin_fallback(
-            m,
-            n,
-            k,
-            "stream override active (cuBLASLt would risk Xid 31)",
+        bail!(
+            "batch-invariant Pin GEMM cannot run under a stream override (m={m}, n={n}, k={k}): \
+             --batch-invariant is incompatible with --decode-overlap; run without one of them"
         );
-        return launch_gemm_pertoken(w_ptr, x_ptr, y_ptr, m, n, k, ctx);
     }
-    // The eager warmup (gemm_lt_pin_warmup in tune_decode_gemm_algos) pins every decode shape before
-    // capture; a lazy tune here allocates, illegal mid-capture — so refuse under capture, don't 900.
-    if gemm_lt_pin_inspect(m, k).is_none() {
-        match unsafe { ffi::stream_is_capturing_cuda(crate::tensor::active_cu_stream(ctx)) } {
-            0 => gemm_lt_pin_tune(m, PIN_REP_N as usize, k)?,
-            s if s < 0 => bail!(
-                "cudaStreamIsCapturing query failed: status={}, m={m}, k={k}",
-                -s
-            ),
-            _ => bail!(
-                "batch-invariant pin: ({m},{k}) reached graph capture unpinned — the decode pin warmup must run before capture"
-            ),
-        }
-    }
+    // Only the boot-warmed base projections are pinned (gemm_lt_pin_warmup in tune_decode_gemm_algos,
+    // checked by verify_pin_envelope). Any other (m,k) routed through launch_gemm — a DFlash drafter
+    // GEMM, a LoRA prefill-delta GEMM, or a base projection when the policy was set after construction
+    // — is unverified: gemm_lt_pin_cuda returns GEMM_LT_PIN_UNTUNED and the match below bails. No lazy
+    // tune: it would run an unchecked shape, and allocate illegally mid-capture. (The LoRA decode
+    // delta runs in a custom per-token kernel, invariant by construction, and bypasses this path.)
     unsafe {
         let status = ffi::gemm_lt_pin_cuda(
             w_ptr,
@@ -602,22 +551,12 @@ fn launch_gemm_pin(
                 PIN_SERVED.fetch_add(1, Ordering::Relaxed);
                 Ok(())
             }
-            GEMM_LT_PIN_UNSUPPORTED | GEMM_LT_PIN_UNTUNED => {
-                record_pin_fallback(m, n, k, "pinned algo cannot serve this N");
-                let st = ffi::gemm_per_token_cuda(
-                    w_ptr,
-                    x_ptr,
-                    y_ptr,
-                    m as i32,
-                    n as i32,
-                    k as i32,
-                    crate::tensor::active_cu_stream(ctx),
-                );
-                if st != 0 {
-                    bail!("pin per-token fallback failed: status={st}, m={m}, n={n}, k={k}");
-                }
-                Ok(())
-            }
+            GEMM_LT_PIN_UNSUPPORTED | GEMM_LT_PIN_UNTUNED => bail!(
+                "batch-invariant Pin GEMM cannot serve N={n} at (m={m}, k={k}): the boot envelope \
+                 self-check passed, so this is an out-of-envelope N, an unwarmed (M,K) such as a DFlash \
+                 drafter or LoRA prefill-delta shape, or the numeric policy was set after executor \
+                 construction. Run without --batch-invariant or report this shape"
+            ),
             s if s >= 100_000 => {
                 bail!(
                     "cuBLAS pin GEMM failed: cublas_status={}, m={m}, n={n}, k={k}",

--- a/openinfer-kernels/src/ops/linear.rs
+++ b/openinfer-kernels/src/ops/linear.rs
@@ -521,21 +521,17 @@ fn launch_gemm_pin(
     k: usize,
     ctx: &DeviceContext,
 ) -> Result<()> {
-    // launch_gemm_pin runs only under Pin, so a per-token fallback here would silently break batch
-    // invariance — fail loud instead. decode-overlap (the only stream-override source) is rejected
-    // before capture, so reaching this is a misconfiguration, not a normal path.
+    // decode-overlap (the only stream-override source) is rejected before capture, so a stream
+    // override here is misuse — bail rather than fall back to per-token.
     if crate::tensor::has_stream_override() {
         bail!(
             "batch-invariant Pin GEMM cannot run under a stream override (m={m}, n={n}, k={k}): \
              --batch-invariant is incompatible with --decode-overlap; run without one of them"
         );
     }
-    // Only the boot-warmed base projections are pinned (gemm_lt_pin_warmup in tune_decode_gemm_algos,
-    // checked by verify_pin_envelope). Any other (m,k) routed through launch_gemm — a DFlash drafter
-    // GEMM, a LoRA prefill-delta GEMM, or a base projection when the policy was set after construction
-    // — is unverified: gemm_lt_pin_cuda returns GEMM_LT_PIN_UNTUNED and the match below bails. No lazy
-    // tune: it would run an unchecked shape, and allocate illegally mid-capture. (The LoRA decode
-    // delta runs in a custom per-token kernel, invariant by construction, and bypasses this path.)
+    // Only the boot-warmed base projections are pinned; any other (m,k) is unverified —
+    // gemm_lt_pin_cuda returns GEMM_LT_PIN_UNTUNED and the match below bails. No lazy tune: it would
+    // run an unchecked shape and allocate illegally mid-capture.
     unsafe {
         let status = ffi::gemm_lt_pin_cuda(
             w_ptr,
@@ -552,9 +548,9 @@ fn launch_gemm_pin(
                 Ok(())
             }
             GEMM_LT_PIN_UNSUPPORTED | GEMM_LT_PIN_UNTUNED => bail!(
-                "batch-invariant Pin GEMM cannot serve N={n} at (m={m}, k={k}): the boot envelope \
-                 self-check passed, so this is an out-of-envelope N, an unwarmed (M,K) such as a DFlash \
-                 drafter or LoRA prefill-delta shape, or the numeric policy was set after executor \
+                "batch-invariant Pin GEMM cannot serve N={n} at (m={m}, k={k}): either this N is \
+                 outside the pinned envelope, or (M,K) was never warmed (e.g. a DFlash drafter or \
+                 LoRA prefill-delta shape), or the numeric policy was set after executor \
                  construction. Run without --batch-invariant or report this shape"
             ),
             s if s >= 100_000 => {

--- a/openinfer-kernels/src/ops/linear.rs
+++ b/openinfer-kernels/src/ops/linear.rs
@@ -152,6 +152,25 @@ pub fn gemm_lt_pin_into_checked(
     }
 }
 
+/// Boot self-check: does the pinned `(rows, cols)` algo serve `n`? Host-side
+/// `cublasLtMatmulAlgoCheck` only — no GEMM launch, no buffers. `Ok(false)` = won't serve this N
+/// (including workspace-over-budget, exactly as production rejects it); bails if `(rows, cols)` was
+/// never pinned.
+pub fn gemm_lt_pin_check(rows: usize, n: usize, cols: usize) -> Result<bool> {
+    let status = unsafe { ffi::gemm_lt_pin_check_cuda(rows as i32, n as i32, cols as i32) };
+    match status {
+        0 => Ok(true),
+        GEMM_LT_PIN_UNSUPPORTED => Ok(false),
+        GEMM_LT_PIN_UNTUNED => bail!(
+            "gemm_lt_pin_check: (m={rows}, k={cols}) was never pinned — call gemm_lt_pin_warmup first"
+        ),
+        // No matmul is launched, so the only non-sentinel status is a cublas layout-create failure.
+        s => {
+            bail!("gemm_lt_pin_check: cublas layout error (status {s}), m={rows}, n={n}, k={cols}")
+        }
+    }
+}
+
 /// Diagnostics: the pinned algo's `[tile_id, stages_id, splitk_num, reduction_scheme]` for
 /// `(rows, cols)`, or `None` if never pinned.
 pub fn gemm_lt_pin_inspect(rows: usize, cols: usize) -> Option<[i32; 4]> {

--- a/openinfer-qwen3-4b/src/executor.rs
+++ b/openinfer-qwen3-4b/src/executor.rs
@@ -545,8 +545,8 @@ fn bind_model_thread(model: &Qwen3Model) -> Result<()> {
 /// Prepare decode GEMM algos before capture, per the active numeric policy: under `Pin`, eagerly pin
 /// one algo per projection {M,K} (reused for all N); otherwise tune the fastest cublasLt algo per
 /// decode shape (buckets up to `GEMM_LT_MAX_N`, every layer's weights in the L2-cold timing rotation).
-/// Adds a few seconds of startup per model thread.
-fn tune_decode_gemm_algos(model: &Qwen3Model) -> Result<()> {
+/// Adds a few seconds of startup per model thread (warmup + the Pin self-check).
+fn tune_decode_gemm_algos(model: &Qwen3Model, max_prefill_tokens: usize) -> Result<()> {
     let ctx = model.device_ctx();
     let hidden = model.config().hidden_size;
     let vocab = model.config().vocab_size;
@@ -568,6 +568,7 @@ fn tune_decode_gemm_algos(model: &Qwen3Model) -> Result<()> {
             "Qwen3 split-KV decode chunk pinned: {} tokens (max_context_tokens={max_context})",
             crate::batch_decode_buffers::pin_chunk_size(max_context)
         );
+        verify_pin_envelope(model, max_prefill_tokens)?;
         return Ok(());
     }
 
@@ -604,6 +605,53 @@ fn tune_decode_gemm_algos(model: &Qwen3Model) -> Result<()> {
         ops::gemm_lt_tune(ctx, &down_samples, hidden, n)?;
         ops::gemm_lt_tune(ctx, &lm_head_samples, vocab, n)?;
     }
+    Ok(())
+}
+
+/// Boot-time check that under `Pin` the pinned algo serves the FULL production N
+/// envelope — EVERY reachable N, not a sample — with zero per-token fallback. Each N is checked
+/// by the host-side `gemm_lt_pin_check`, so the dense full-N sweep is a startup-only cost. Runs post-warmup,
+/// pre-capture, on the GEMM thread (per TP rank via `bind`); `bail!`s naming the first unserved
+/// {M,N,K}. Each projection's N upper bound is set below.
+fn verify_pin_envelope(model: &Qwen3Model, max_prefill_tokens: usize) -> Result<()> {
+    use openinfer_kernels::ops::gemm_lt_pin_check;
+
+    let hidden = model.config().hidden_size;
+    let q_dim = model.local_q_dim();
+    let kv_dim = model.local_kv_dim();
+    let intermediate = model.local_intermediate_size();
+    // Unified-N peak: one prefill chunk (≤ max_prefill_tokens) + (max_bucket−1) concurrent decoders;
+    // rests on max_decode_batch_size == BATCH_BUCKETS.last().
+    let ceiling = max_prefill_tokens + (*BATCH_BUCKETS.last().unwrap()).saturating_sub(1);
+    // lm_head (vocab×hidden) runs on the sampled-position count, not the token count: decode-only
+    // pads to a bucket (≤ max_decode_batch_size) and unified gathers ≤ that many requests, while
+    // echo/all-position runs up to max_prefill_tokens — true max N = max(max_prefill, max_decode_batch).
+    let lm_head_max_n = max_prefill_tokens.max(*BATCH_BUCKETS.last().unwrap());
+    let shapes: [(usize, usize, usize); 6] = [
+        (q_dim, hidden, ceiling),
+        (kv_dim, hidden, ceiling),
+        (hidden, q_dim, ceiling),
+        (intermediate, hidden, ceiling),
+        (hidden, intermediate, ceiling),
+        (model.config().vocab_size, hidden, lm_head_max_n),
+    ];
+    let mut checks = 0usize;
+    for &(m, k, max_n) in &shapes {
+        for n in 1..=max_n {
+            if !gemm_lt_pin_check(m, n, k)? {
+                anyhow::bail!(
+                    "batch-invariant pin self-check FAILED: pinned cuBLASLt algo cannot serve \
+                     N={n} at projection {{M={m}, K={k}}} — this GPU/cuBLAS combo would fall back \
+                     to per-token at runtime, breaking batch invariance. Run without \
+                     --batch-invariant or report the {{M,N,K}}."
+                );
+            }
+            checks += 1;
+        }
+    }
+    log::info!(
+        "batch-invariant pin envelope verified: every N up to {ceiling} (lm_head to {lm_head_max_n}), {checks} checks, 0 fallback"
+    );
     Ok(())
 }
 
@@ -940,7 +988,13 @@ impl Qwen3Executor {
             request_kvs: HashMap::new(),
             primary: RankWorker::spawn(
                 0,
-                LocalQwen3Lane::new(model, kv_buffer, total_blocks, padding_block_id)?,
+                LocalQwen3Lane::new(
+                    model,
+                    kv_buffer,
+                    total_blocks,
+                    padding_block_id,
+                    max_prefill_tokens,
+                )?,
             )?,
             workers: Vec::new(),
             loaded_lora_adapters: HashSet::new(),
@@ -1152,6 +1206,7 @@ impl Qwen3Executor {
                 primary_buffer,
                 total_blocks,
                 padding_block_id,
+                max_prefill_tokens,
             )?,
         )?;
 
@@ -1160,7 +1215,13 @@ impl Qwen3Executor {
             .zip(extra_kv_buffers)
             .enumerate()
             .map(|(index, (model, buffer))| {
-                let lane = LocalQwen3Lane::new(model, buffer, total_blocks, padding_block_id)?;
+                let lane = LocalQwen3Lane::new(
+                    model,
+                    buffer,
+                    total_blocks,
+                    padding_block_id,
+                    max_prefill_tokens,
+                )?;
                 RankWorker::spawn(index + 1, lane)
             })
             .collect::<Result<Vec<_>>>()?;
@@ -1235,6 +1296,14 @@ impl Qwen3Executor {
     /// A no-op for [`crate::DecodeOverlap::Off`]; otherwise sets up the streams,
     /// returning an error if the GPU/driver cannot honor the requested mode.
     pub fn enable_decode_overlap(&mut self, overlap: crate::DecodeOverlap) -> Result<()> {
+        // Policy-driven backstop (like `load_dflash_draft_model`): a runtime caller could set Pin then
+        // enable overlap here; overlap's stream override sends the pinned GEMM to the per-token fallback.
+        anyhow::ensure!(
+            !(openinfer_kernels::ops::numeric_policy()
+                == openinfer_kernels::ops::NumericPolicy::Pin
+                && !matches!(overlap, crate::DecodeOverlap::Off)),
+            "--batch-invariant (NumericPolicy::Pin) is not compatible with decode-overlap: the stream override forces the pinned GEMM to the per-token fallback"
+        );
         let device_ordinal = 0; // single-GPU path
         self.overlap = crate::green_ctx::OverlapStreams::create(device_ordinal, overlap)?;
         Ok(())
@@ -1274,6 +1343,13 @@ impl Qwen3Executor {
     /// capture needs clean, uncached target hidden states for every prompt
     /// token, and a prefix-cache hit skips the forward that would produce them.
     pub fn load_dflash_draft_model(&mut self, draft_path: &str) -> Result<()> {
+        // Policy-driven backstop: closes the `runtime` escape hatch (set_numeric_policy(Pin) +
+        // from_runtime + this) that bypasses the engine-entry DFlash gate. The Pin warmup/self-check
+        // covers only the base projections, never the drafter's fc/MLP GEMMs.
+        anyhow::ensure!(
+            openinfer_kernels::ops::numeric_policy() != openinfer_kernels::ops::NumericPolicy::Pin,
+            "DFlash speculative decoding is not supported under --batch-invariant (NumericPolicy::Pin)"
+        );
         anyhow::ensure!(
             self.workers.is_empty(),
             "speculative decoding requires the single-GPU path (got {} extra ranks)",
@@ -1529,7 +1605,7 @@ fn profile_kv_budget_on_worker(
         .spawn(move || -> Result<(Qwen3Model, KvBudget)> {
             let _guard = {
                 bind_model_thread(&model)?;
-                tune_decode_gemm_algos(&model)?;
+                tune_decode_gemm_algos(&model, max_prefill_tokens)?;
                 CublasThreadGuard
             };
             let budget = model.profiled_kv_budget(
@@ -2383,6 +2459,8 @@ struct LocalQwen3Lane {
     layout: KvLayout,
     bufs: BatchDecodeBuffers,
     sample_scratch: openinfer_sample::SampleScratch,
+    /// Prefill-chunk token cap; bounds the Pin self-check's unified-N envelope in `bind`.
+    max_prefill_tokens: usize,
     /// In-flight prefill from a previous SplitConcurrent step (not yet synced).
     inflight_prefill: Option<InflightPrefillState>,
     /// DFlash draft lane (the draft model + per-request draft state). `None`
@@ -2417,6 +2495,7 @@ impl LocalQwen3Lane {
         kv_buffer: KvBuffer,
         total_blocks: usize,
         padding_block_id: i32,
+        max_prefill_tokens: usize,
     ) -> Result<Self> {
         let buf_layout = kv_buffer.layout();
         let layout = KvLayout::new(
@@ -2450,6 +2529,7 @@ impl LocalQwen3Lane {
             layout,
             bufs,
             sample_scratch,
+            max_prefill_tokens,
             inflight_prefill: None,
             dflash: None,
             verify_bufs: None,
@@ -2483,7 +2563,7 @@ impl LocalQwen3Lane {
 
     fn bind(&self) -> Result<CublasThreadGuard> {
         bind_model_thread(&self.model)?;
-        tune_decode_gemm_algos(&self.model)?;
+        tune_decode_gemm_algos(&self.model, self.max_prefill_tokens)?;
         Ok(CublasThreadGuard)
     }
 

--- a/openinfer-qwen3-4b/src/executor.rs
+++ b/openinfer-qwen3-4b/src/executor.rs
@@ -545,8 +545,13 @@ fn bind_model_thread(model: &Qwen3Model) -> Result<()> {
 /// Prepare decode GEMM algos before capture, per the active numeric policy: under `Pin`, eagerly pin
 /// one algo per projection {M,K} (reused for all N); otherwise tune the fastest cublasLt algo per
 /// decode shape (buckets up to `GEMM_LT_MAX_N`, every layer's weights in the L2-cold timing rotation).
-/// Adds a few seconds of startup per model thread (warmup + the Pin self-check).
-fn tune_decode_gemm_algos(model: &Qwen3Model, max_prefill_tokens: usize) -> Result<()> {
+/// Adds startup cost per thread: warmup on every worker, plus the Pin self-check
+/// on the serving worker when `run_envelope_check` is true.
+fn tune_decode_gemm_algos(
+    model: &Qwen3Model,
+    max_prefill_tokens: usize,
+    run_envelope_check: bool,
+) -> Result<()> {
     let ctx = model.device_ctx();
     let hidden = model.config().hidden_size;
     let vocab = model.config().vocab_size;
@@ -568,7 +573,11 @@ fn tune_decode_gemm_algos(model: &Qwen3Model, max_prefill_tokens: usize) -> Resu
             "Qwen3 split-KV decode chunk pinned: {} tokens (max_context_tokens={max_context})",
             crate::batch_decode_buffers::pin_chunk_size(max_context)
         );
-        verify_pin_envelope(model, max_prefill_tokens)?;
+        // The profile worker skips the full sweep; the long-lived serving worker verifies its own
+        // (thread-local) warmed plans before capture, so the envelope is guaranteed pre-serving.
+        if run_envelope_check {
+            verify_pin_envelope(model, max_prefill_tokens)?;
+        }
         return Ok(());
     }
 
@@ -608,7 +617,7 @@ fn tune_decode_gemm_algos(model: &Qwen3Model, max_prefill_tokens: usize) -> Resu
     Ok(())
 }
 
-/// Boot-time check that under `Pin` the pinned algo serves the FULL production N
+/// Boot-time Pin envelope check: errors unless, under `Pin`, the pinned algo serves the FULL production N
 /// envelope — EVERY reachable N, not a sample — with zero per-token fallback. Each N is checked
 /// by the host-side `gemm_lt_pin_check`, so the dense full-N sweep is a startup-only cost. Runs post-warmup,
 /// pre-capture, on the GEMM thread (per TP rank via `bind`); `bail!`s naming the first unserved
@@ -1597,11 +1606,9 @@ fn profile_kv_budget_on_worker(
             model.device_ctx().device_ordinal
         ))
         .spawn(move || -> Result<(Qwen3Model, KvBudget)> {
-            let _guard = {
-                bind_model_thread(&model)?;
-                tune_decode_gemm_algos(&model, max_prefill_tokens)?;
-                CublasThreadGuard
-            };
+            bind_model_thread(&model)?;
+            let _guard = CublasThreadGuard;
+            tune_decode_gemm_algos(&model, max_prefill_tokens, false)?;
             let budget = model.profiled_kv_budget(
                 max_prefill_tokens,
                 *BATCH_BUCKETS.last().unwrap(),
@@ -2557,8 +2564,9 @@ impl LocalQwen3Lane {
 
     fn bind(&self) -> Result<CublasThreadGuard> {
         bind_model_thread(&self.model)?;
-        tune_decode_gemm_algos(&self.model, self.max_prefill_tokens)?;
-        Ok(CublasThreadGuard)
+        let guard = CublasThreadGuard;
+        tune_decode_gemm_algos(&self.model, self.max_prefill_tokens, true)?;
+        Ok(guard)
     }
 
     /// Sync the in-flight prefill stream and sample prefill tokens.

--- a/openinfer-qwen3-4b/src/executor.rs
+++ b/openinfer-qwen3-4b/src/executor.rs
@@ -641,9 +641,9 @@ fn verify_pin_envelope(model: &Qwen3Model, max_prefill_tokens: usize) -> Result<
             if !gemm_lt_pin_check(m, n, k)? {
                 anyhow::bail!(
                     "batch-invariant pin self-check FAILED: pinned cuBLASLt algo cannot serve \
-                     N={n} at projection {{M={m}, K={k}}} — this GPU/cuBLAS combo would fall back \
-                     to per-token at runtime, breaking batch invariance. Run without \
-                     --batch-invariant or report the {{M,N,K}}."
+                     N={n} at projection {{M={m}, K={k}}} — this GPU/cuBLAS combo cannot serve the \
+                     full envelope, so the pinned GEMM would bail at runtime rather than serve it. \
+                     Run without --batch-invariant or report the {{M,N,K}}."
                 );
             }
             checks += 1;
@@ -1296,13 +1296,14 @@ impl Qwen3Executor {
     /// A no-op for [`crate::DecodeOverlap::Off`]; otherwise sets up the streams,
     /// returning an error if the GPU/driver cannot honor the requested mode.
     pub fn enable_decode_overlap(&mut self, overlap: crate::DecodeOverlap) -> Result<()> {
-        // Policy-driven backstop (like `load_dflash_draft_model`): a runtime caller could set Pin then
-        // enable overlap here; overlap's stream override sends the pinned GEMM to the per-token fallback.
+        // Pre-capture backstop: a runtime caller could set Pin then enable overlap here, bypassing the
+        // engine-entry guard. launch_gemm_pin also bails on the resulting stream override, but only mid
+        // graph-capture/replay (a hot-path failure) — rejecting here moves it to a safe point.
         anyhow::ensure!(
             !(openinfer_kernels::ops::numeric_policy()
                 == openinfer_kernels::ops::NumericPolicy::Pin
                 && !matches!(overlap, crate::DecodeOverlap::Off)),
-            "--batch-invariant (NumericPolicy::Pin) is not compatible with decode-overlap: the stream override forces the pinned GEMM to the per-token fallback"
+            "--batch-invariant (NumericPolicy::Pin) is not compatible with decode-overlap: the stream override would force the pinned GEMM to bail at runtime"
         );
         let device_ordinal = 0; // single-GPU path
         self.overlap = crate::green_ctx::OverlapStreams::create(device_ordinal, overlap)?;
@@ -1343,13 +1344,6 @@ impl Qwen3Executor {
     /// capture needs clean, uncached target hidden states for every prompt
     /// token, and a prefix-cache hit skips the forward that would produce them.
     pub fn load_dflash_draft_model(&mut self, draft_path: &str) -> Result<()> {
-        // Policy-driven backstop: closes the `runtime` escape hatch (set_numeric_policy(Pin) +
-        // from_runtime + this) that bypasses the engine-entry DFlash gate. The Pin warmup/self-check
-        // covers only the base projections, never the drafter's fc/MLP GEMMs.
-        anyhow::ensure!(
-            openinfer_kernels::ops::numeric_policy() != openinfer_kernels::ops::NumericPolicy::Pin,
-            "DFlash speculative decoding is not supported under --batch-invariant (NumericPolicy::Pin)"
-        );
         anyhow::ensure!(
             self.workers.is_empty(),
             "speculative decoding requires the single-GPU path (got {} extra ranks)",

--- a/openinfer-qwen3-4b/src/lib.rs
+++ b/openinfer-qwen3-4b/src/lib.rs
@@ -311,7 +311,11 @@ pub fn start_engine_with_offload(
     let model_path = model_path
         .to_str()
         .ok_or_else(|| anyhow::anyhow!("model path must be valid UTF-8"))?;
-    ensure_batch_invariant_supported(decode_overlap, batch_invariant)?;
+    ensure_batch_invariant_supported(
+        decode_overlap,
+        batch_invariant,
+        dflash_draft_model_path.is_some(),
+    )?;
     apply_batch_invariant_policy(batch_invariant);
     let dflash_draft_model_path = dflash_draft_model_path
         .map(|path| {
@@ -354,9 +358,13 @@ pub fn start_engine_with_lora_control(
     let model_path = model_path
         .to_str()
         .ok_or_else(|| anyhow::anyhow!("model path must be valid UTF-8"))?;
-    ensure_batch_invariant_supported(decode_overlap, batch_invariant)?;
+    ensure_batch_invariant_supported(decode_overlap, batch_invariant, false)?;
     if batch_invariant {
-        anyhow::bail!("--batch-invariant is not yet validated with LoRA serving");
+        anyhow::bail!(
+            "--batch-invariant is not supported with LoRA: the decode-GEMM pin warms and self-checks \
+             only the base projection {{M,K}}, so LoRA's rank-K adapter GEMMs would silently fall \
+             back to the non-invariant per-token path"
+        );
     }
     apply_batch_invariant_policy(batch_invariant);
     scheduler::start_qwen3_with_lora_control(
@@ -387,10 +395,18 @@ fn apply_batch_invariant_policy(batch_invariant: bool) {
 fn ensure_batch_invariant_supported(
     decode_overlap: DecodeOverlap,
     batch_invariant: bool,
+    dflash: bool,
 ) -> Result<()> {
     if batch_invariant && !matches!(decode_overlap, DecodeOverlap::Off) {
         anyhow::bail!(
             "--batch-invariant is not compatible with --decode-overlap; Pin falls back to per-token under a stream override"
+        );
+    }
+    if batch_invariant && dflash {
+        anyhow::bail!(
+            "--batch-invariant is not supported with DFlash speculative decoding: the decode-GEMM \
+             pin warms and self-checks only the base projections, so the drafter's fc/MLP GEMMs \
+             would silently fall back to the non-invariant per-token path"
         );
     }
     Ok(())

--- a/openinfer-qwen3-4b/src/lib.rs
+++ b/openinfer-qwen3-4b/src/lib.rs
@@ -362,8 +362,8 @@ pub fn start_engine_with_lora_control(
     if batch_invariant {
         anyhow::bail!(
             "--batch-invariant is not supported with LoRA: the decode-GEMM pin warms and self-checks \
-             only the base projection {{M,K}}, so LoRA's rank-K adapter GEMMs would silently fall \
-             back to the non-invariant per-token path"
+             only the base projections, not the per-adapter rank-K shapes, so the combination is \
+             unverified"
         );
     }
     apply_batch_invariant_policy(batch_invariant);
@@ -399,14 +399,14 @@ fn ensure_batch_invariant_supported(
 ) -> Result<()> {
     if batch_invariant && !matches!(decode_overlap, DecodeOverlap::Off) {
         anyhow::bail!(
-            "--batch-invariant is not compatible with --decode-overlap; Pin falls back to per-token under a stream override"
+            "--batch-invariant is not compatible with --decode-overlap; the stream override would force the pinned GEMM to bail at runtime"
         );
     }
     if batch_invariant && dflash {
         anyhow::bail!(
             "--batch-invariant is not supported with DFlash speculative decoding: the decode-GEMM \
              pin warms and self-checks only the base projections, so the drafter's fc/MLP GEMMs \
-             would silently fall back to the non-invariant per-token path"
+             are not pinned and would bail at the GEMM boundary under Pin"
         );
     }
     Ok(())

--- a/openinfer-qwen3-4b/tests/batch_invariance_decode_gemm_graph.rs
+++ b/openinfer-qwen3-4b/tests/batch_invariance_decode_gemm_graph.rs
@@ -9,7 +9,7 @@
 //!     -p openinfer-qwen3-4b --test batch_invariance_decode_gemm_graph -- --nocapture
 
 use openinfer_core::sampler::SamplingParams;
-use openinfer_kernels::ops::{NumericPolicy, pin_counters, reset_pin_counters, set_numeric_policy};
+use openinfer_kernels::ops::{NumericPolicy, pin_served, reset_pin_counters, set_numeric_policy};
 use openinfer_qwen3_4b::runtime::{
     DecodePlan, DecodeStepItem, PrefillPlan, PrefillStepItem, Qwen3Executor, RequestId,
 };
@@ -99,7 +99,7 @@ fn a_first_and_decode(ex: &mut Qwen3Executor, n_requests: usize) -> (u32, Vec<(u
 }
 
 /// One fresh executor with `policy` active before first decode (graph captured under it).
-fn run_policy(policy: NumericPolicy, model_path: &str) -> Vec<(bool, bool, u64, u64)> {
+fn run_policy(policy: NumericPolicy, model_path: &str) -> Vec<(bool, bool, u64)> {
     set_numeric_policy(policy);
     let mut ex = Qwen3Executor::from_runtime(model_path, true, &[0]).expect("build executor");
     ex.set_prefix_cache_enabled(false);
@@ -108,12 +108,12 @@ fn run_policy(policy: NumericPolicy, model_path: &str) -> Vec<(bool, bool, u64, 
         reset_pin_counters();
         let (ft_s, tk_s) = a_first_and_decode(&mut ex, small);
         let (ft_l, tk_l) = a_first_and_decode(&mut ex, large);
-        let (served, fallback) = pin_counters();
+        let served = pin_served();
         let ft_eq = ft_s == ft_l;
         let tk_eq = tk_s == tk_l;
         // served counts the CAPTURE step only (replay skips the closure). Under baseline/per_token,
-        // launch_gemm_pin is never called → served/fallback are structurally 0 (N/A).
-        out.push((ft_eq, tk_eq, served, fallback));
+        // launch_gemm_pin is never called → served is structurally 0 (N/A).
+        out.push((ft_eq, tk_eq, served));
     }
     out
 }
@@ -134,7 +134,7 @@ fn batch_invariance_decode_gemm_graph() {
         ("pin", &pin),
         ("per_token", &pertoken),
     ] {
-        for (i, (ft_eq, _, _, _)) in rows.iter().enumerate() {
+        for (i, (ft_eq, _, _)) in rows.iter().enumerate() {
             assert!(
                 *ft_eq,
                 "{name}: A's prefill first_token differs across batch on pair {} — decode \
@@ -145,16 +145,16 @@ fn batch_invariance_decode_gemm_graph() {
     }
 
     // Control: baseline must drift on at least one pair (else not reproduced here).
-    let baseline_drifted = baseline.iter().any(|(_, tk_eq, _, _)| !tk_eq);
+    let baseline_drifted = baseline.iter().any(|(_, tk_eq, _)| !tk_eq);
     assert!(
         baseline_drifted,
         "baseline did NOT drift on any pair — decode-GEMM coupling not reproduced; \
          the pin proof would be vacuous"
     );
 
-    // Pin: every pair invariant, served>0 (pin ran at capture), fallback==0 (per-token oracle
-    // did not cover for it).
-    for (i, (_, tk_eq, served, fallback)) in pin.iter().enumerate() {
+    // Pin: every pair invariant, served>0 (pin ran at capture). launch_gemm_pin bails on any
+    // can't-serve-N, so a completed capture already proves no per-token oracle covered for it.
+    for (i, (_, tk_eq, served)) in pin.iter().enumerate() {
         assert!(
             *tk_eq,
             "PIN: A's graph decode top-K changed on pair {} — pin did NOT make graph decode \
@@ -166,14 +166,8 @@ fn batch_invariance_decode_gemm_graph() {
             "PIN: pin did not run on pair {} (served=0) — vacuous",
             PAIRS[i].0.trim()
         );
-        assert!(
-            *fallback == 0,
-            "PIN: pair {} fell back to per-token (fallback={fallback}) — invariance carried by the \
-             fallback oracle, not the pinned algo (if a large bucket: check LT_WORKSPACE_SIZE)",
-            PAIRS[i].0.trim()
-        );
     }
-    for (i, (_, tk_eq, _, _)) in pertoken.iter().enumerate() {
+    for (i, (_, tk_eq, _)) in pertoken.iter().enumerate() {
         assert!(
             *tk_eq,
             "PER_TOKEN: A's graph decode top-K changed on pair {} — harness bug",

--- a/openinfer-qwen3-4b/tests/batch_invariance_decode_gemm_graph.rs
+++ b/openinfer-qwen3-4b/tests/batch_invariance_decode_gemm_graph.rs
@@ -152,8 +152,7 @@ fn batch_invariance_decode_gemm_graph() {
          the pin proof would be vacuous"
     );
 
-    // Pin: every pair invariant, served>0 (pin ran at capture). launch_gemm_pin bails on any
-    // can't-serve-N, so a completed capture already proves no per-token oracle covered for it.
+    // Pin: every pair invariant, served>0 (pin ran at capture).
     for (i, (_, tk_eq, served)) in pin.iter().enumerate() {
         assert!(
             *tk_eq,

--- a/openinfer-qwen3-4b/tests/batch_invariance_endtoend.rs
+++ b/openinfer-qwen3-4b/tests/batch_invariance_endtoend.rs
@@ -4,13 +4,14 @@
 //!
 //! prompt_a's top-K alone vs co-batched with a filler, under three policies: baseline (Tuned,
 //! drifts = the bug), pin (top-K bit-identical = the fix), per_token (oracle). Pass requires full
-//! ordered top-K equality + a baseline-drift guard + fallback=0 for total_N≤32.
+//! ordered top-K equality + a baseline-drift guard + served>0 (per-token fallback under Pin is
+//! impossible — `launch_gemm_pin` bails, surfacing as a prefill `.expect` panic).
 //!
 //!   OPENINFER_TEST_MODEL_PATH=<Qwen3-4B-base> cargo test --release \
 //!     -p openinfer-qwen3-4b --test batch_invariance_endtoend -- --nocapture
 
 use openinfer_core::sampler::SamplingParams;
-use openinfer_kernels::ops::{NumericPolicy, pin_counters, reset_pin_counters, set_numeric_policy};
+use openinfer_kernels::ops::{NumericPolicy, pin_served, reset_pin_counters, set_numeric_policy};
 use openinfer_qwen3_4b::runtime::{PrefillPlan, PrefillStepItem, Qwen3Executor, RequestId};
 
 const LOGPROBS: usize = 64;
@@ -65,9 +66,6 @@ fn batch_invariance_endtoend() {
     let Some(model_path) = model_path_or_skip() else {
         return;
     };
-    let mut ex = Qwen3Executor::from_runtime(&model_path, false, &[0]).expect("build executor");
-    ex.set_prefix_cache_enabled(false);
-
     let prompt_a: Vec<u32> = vec![9707];
     let nbs: [usize; 5] = [1, 7, 15, 31, 63]; // total_N = 2,8,16,32,64 — straddles GEMM_LT_MAX_N
     let id_a = RequestId::new(1);
@@ -79,7 +77,12 @@ fn batch_invariance_endtoend() {
         NumericPolicy::Pin,
         NumericPolicy::PerToken,
     ] {
+        // Fresh executor per policy: the pin warmup must run under Pin, as production sets the policy
+        // before construction. Switching policy on a live executor leaves base shapes unpinned, which
+        // launch_gemm_pin now bails on.
         set_numeric_policy(policy);
+        let mut ex = Qwen3Executor::from_runtime(&model_path, false, &[0]).expect("build executor");
+        ex.set_prefix_cache_enabled(false);
         let alone = dist_for_first(&mut ex, &[(id_a, prompt_a.clone())]);
         for &nb in &nbs {
             reset_pin_counters();
@@ -88,7 +91,6 @@ fn batch_invariance_endtoend() {
                 &mut ex,
                 &[(id_a, prompt_a.clone()), (id_b, vec![785u32; nb])],
             );
-            let (served, fallback) = pin_counters();
             let total_n = prompt_a.len() + nb;
             let topk_equal = alone == batched;
 
@@ -104,17 +106,13 @@ fn batch_invariance_endtoend() {
                         "PIN: prompt_a top-K changed when co-batched (+Nb={nb}, total_N={total_n}) \
                          — projection-GEMM reduction-order NOT invariant under the pin in this prefill path"
                     );
+                    // launch_gemm_pin bails on any can't-serve-N fallback, so a completed run proves
+                    // zero fallback — including the small-N (total_N<=32) case this loop exercises.
+                    // served>0 guards against a vacuous pass.
                     assert!(
-                        served > 0,
+                        pin_served() > 0,
                         "PIN: no GEMM ran the pinned algo (+Nb={nb}) — vacuous"
                     );
-                    if total_n <= 32 {
-                        assert_eq!(
-                            fallback, 0,
-                            "PIN: fell back to per-token at total_N={total_n}<=32 (+Nb={nb}) — \
-                             proving the fallback, not the pin"
-                        );
-                    }
                 }
                 NumericPolicy::PerToken => {
                     assert!(

--- a/openinfer-qwen3-4b/tests/batch_invariance_endtoend.rs
+++ b/openinfer-qwen3-4b/tests/batch_invariance_endtoend.rs
@@ -106,9 +106,7 @@ fn batch_invariance_endtoend() {
                         "PIN: prompt_a top-K changed when co-batched (+Nb={nb}, total_N={total_n}) \
                          — projection-GEMM reduction-order NOT invariant under the pin in this prefill path"
                     );
-                    // launch_gemm_pin bails on any can't-serve-N fallback, so a completed run proves
-                    // zero fallback — including the small-N (total_N<=32) case this loop exercises.
-                    // served>0 guards against a vacuous pass.
+                    // served>0 also covers the small-N (total_N<=32) case this loop exercises.
                     assert!(
                         pin_served() > 0,
                         "PIN: no GEMM ran the pinned algo (+Nb={nb}) — vacuous"

--- a/openinfer-qwen3-4b/tests/batch_invariance_envelope.rs
+++ b/openinfer-qwen3-4b/tests/batch_invariance_envelope.rs
@@ -1,10 +1,8 @@
-//! Production-envelope fallback guard: under Pin the {M,K} algo is pinned and reused for every N;
-//! this asserts zero per-token fallback across the swept Qwen3-4B envelope — Unified at
-//! N=101/201/513/1024/1279 and pure-Decode at bs=256 (exactly these points, not all N).
+//! Production-envelope guard: under Pin the {M,K} algo is pinned and reused for every N; this
+//! verifies it serves the swept Qwen3-4B envelope — Unified at N=101/201/513/1024/1279 and
+//! pure-Decode at bs=256 (exactly these points, not all N) — a shape it can't serve would bail.
 use openinfer_core::sampler::SamplingParams;
-use openinfer_kernels::ops::{
-    NumericPolicy, pin_counters, pin_fallback_shapes, reset_pin_counters, set_numeric_policy,
-};
+use openinfer_kernels::ops::{NumericPolicy, pin_served, reset_pin_counters, set_numeric_policy};
 use openinfer_qwen3_4b::runtime::{
     DecodePlan, DecodeStepItem, PrefillPlan, PrefillStepItem, Qwen3Executor, RequestId, UnifiedPlan,
 };
@@ -42,18 +40,15 @@ fn prefill_first(ex: &mut Qwen3Executor, id: RequestId, prompt: &[u32]) -> u32 {
         .first_token
 }
 
-fn assert_no_fallback(label: &str, n: usize) {
-    let (served, fb) = pin_counters();
-    let shapes = pin_fallback_shapes();
+/// `launch_gemm_pin` bails on any can't-serve-N / stream-override fallback, so a completed run
+/// already proves zero fallback; this only guards against a vacuous pass (the pin never ran).
+fn assert_pin_served(label: &str, n: usize) {
+    let served = pin_served();
     assert!(
         served > 0,
         "{label} N={n}: served=0 — pin never ran (vacuous)"
     );
-    assert!(
-        shapes.is_empty(),
-        "{label} N={n}: {fb} per-token fallback(s), shapes {shapes:?} — pin cannot serve this N"
-    );
-    eprintln!("[envelope] {label} N={n}: served={served} fallback={fb} ok");
+    eprintln!("[envelope] {label} N={n}: served={served} ok");
 }
 
 #[test]
@@ -83,8 +78,8 @@ fn pin_serves_production_envelope_without_fallback() {
                 decode_requests: &[DecodeStepItem::new(id_d, t, SamplingParams::default(), 64)],
                 sample_seed: 0,
             })
-            .expect("unified envelope");
-        assert_no_fallback("Unified", pf + 1);
+            .unwrap_or_else(|e| panic!("Unified N={} bailed: {e}", pf + 1));
+        assert_pin_served("Unified", pf + 1);
         let _ = ex.drop_request(id_p);
         let _ = ex.drop_request(id_d);
     }
@@ -106,8 +101,8 @@ fn pin_serves_production_envelope_without_fallback() {
             requests: &items,
             sample_seed: 0,
         })
-        .expect("decode bs=256");
-    assert_no_fallback("pure-Decode", 256);
+        .unwrap_or_else(|e| panic!("pure-Decode N=256 bailed: {e}"));
+    assert_pin_served("pure-Decode", 256);
     for (id, _) in &dec {
         let _ = ex.drop_request(*id);
     }
@@ -138,8 +133,8 @@ fn pin_serves_production_envelope_without_fallback() {
             decode_requests: &decode_items,
             sample_seed: 0,
         })
-        .expect("unified N=1279");
-    assert_no_fallback("Unified", 1279);
+        .unwrap_or_else(|e| panic!("Unified N=1279 bailed: {e}"));
+    assert_pin_served("Unified", 1279);
     let _ = ex.drop_request(id_big);
     for (id, _) in &decoders {
         let _ = ex.drop_request(*id);

--- a/openinfer-qwen3-4b/tests/batch_invariance_reject.rs
+++ b/openinfer-qwen3-4b/tests/batch_invariance_reject.rs
@@ -1,5 +1,5 @@
 //! `--batch-invariant` is rejected at the Qwen3 builder boundary for unsupported combos:
-//! stream overlap would silently fall back to per-token, and LoRA shapes are not gated.
+//! stream overlap and the DFlash drafter would silently fall back to per-token, and LoRA shapes are not gated.
 
 use std::path::Path;
 use std::sync::Mutex;
@@ -11,7 +11,7 @@ use openinfer_qwen3_4b::{
     Qwen3OffloadOptions, start_engine_with_lora_control, start_engine_with_offload,
 };
 
-// Serialize the two #[test]s — they share the process-global numeric policy.
+// Serialize the reject #[test]s — they share the process-global numeric policy.
 static POLICY_LOCK: Mutex<()> = Mutex::new(());
 
 #[test]
@@ -34,6 +34,35 @@ fn batch_invariant_rejects_decode_overlap() {
     .expect("--batch-invariant + --decode-overlap must be rejected");
     assert!(
         format!("{err}").contains("decode-overlap"),
+        "unexpected error: {err}"
+    );
+    assert_eq!(
+        numeric_policy(),
+        NumericPolicy::Tuned,
+        "guard must reject before apply_batch_invariant_policy — global policy was polluted to Pin"
+    );
+}
+
+#[test]
+fn batch_invariant_rejects_dflash() {
+    let _g = POLICY_LOCK.lock().unwrap();
+    set_numeric_policy(NumericPolicy::Tuned);
+    let err = start_engine_with_offload(
+        Path::new("/nonexistent-model"),
+        EngineLoadOptions::default(),
+        Qwen3OffloadOptions::disabled(),
+        false,
+        DEFAULT_MAX_PREFILL_TOKENS,
+        Qwen3MemoryOptions::default(),
+        DecodeOverlap::Off,
+        true,
+        Some(Path::new("/nonexistent-draft")),
+        false,
+    )
+    .err()
+    .expect("--batch-invariant + DFlash must be rejected");
+    assert!(
+        format!("{err}").contains("DFlash"),
         "unexpected error: {err}"
     );
     assert_eq!(

--- a/openinfer-qwen3-4b/tests/batch_invariance_reject.rs
+++ b/openinfer-qwen3-4b/tests/batch_invariance_reject.rs
@@ -1,5 +1,5 @@
 //! `--batch-invariant` is rejected at the Qwen3 builder boundary for unsupported combos:
-//! stream overlap and the DFlash drafter would silently fall back to per-token, and LoRA shapes are not gated.
+//! stream overlap, the DFlash drafter, and LoRA each run GEMMs the base-projection pin does not cover; the builder rejects all three.
 
 use std::path::Path;
 use std::sync::Mutex;

--- a/openinfer-qwen3-4b/tests/batch_invariance_unified.rs
+++ b/openinfer-qwen3-4b/tests/batch_invariance_unified.rs
@@ -2,9 +2,7 @@
 //! lengths (so the projection GEMM runs at different N) must give a bit-identical top-K under Pin.
 //! The pure-Decode-vs-Unified cross-path case drifts even under Pin and is the `#[ignore]` below.
 use openinfer_core::sampler::SamplingParams;
-use openinfer_kernels::ops::{
-    NumericPolicy, pin_counters, pin_fallback_shapes, reset_pin_counters, set_numeric_policy,
-};
+use openinfer_kernels::ops::{NumericPolicy, pin_served, reset_pin_counters, set_numeric_policy};
 use openinfer_qwen3_4b::runtime::{
     DecodePlan, DecodeStepItem, PrefillPlan, PrefillStepItem, Qwen3Executor, RequestId, UnifiedPlan,
 };
@@ -46,7 +44,7 @@ fn unified_decode_row(
     cobatch: usize,
     id_dec: u64,
     id_pf: u64,
-) -> (Vec<(u32, f32)>, (u64, u64)) {
+) -> (Vec<(u32, f32)>, u64) {
     let id_a = RequestId::new(id_dec);
     let t0 = prefill_first(ex, id_a, p);
     let id_b = RequestId::new(id_pf);
@@ -71,10 +69,10 @@ fn unified_decode_row(
         .clone()
         .map(|l| l.top_logprobs)
         .unwrap_or_default();
-    let counters = pin_counters();
+    let served = pin_served();
     let _ = ex.drop_request(id_b);
     let _ = ex.drop_request(id_a);
-    (topk, counters)
+    (topk, served)
 }
 
 fn pure_decode_row(ex: &mut Qwen3Executor, p: &[u32], id_dec: u64) -> Vec<(u32, f32)> {
@@ -118,14 +116,11 @@ fn unified_within_path_gemm_n_invariant_under_pin() {
     let mut base: Option<Vec<(u32, f32)>> = None;
     for (i, &c) in COBATCH.iter().enumerate() {
         let n = c + 1;
-        let (topk, (served, fb)) =
+        let (topk, served) =
             unified_decode_row(&mut ex, &p, c, 100 + i as u64 * 2, 101 + i as u64 * 2);
+        // launch_gemm_pin bails on any can't-serve-N, so a completed run proves zero fallback;
+        // served>0 guards against a vacuous pass.
         assert!(served > 0, "Pin N={n}: served=0 — pin never ran (vacuous)");
-        assert!(
-            pin_fallback_shapes().is_empty(),
-            "Pin N={n}: {fb} per-token fallback(s), shapes {:?}",
-            pin_fallback_shapes()
-        );
         match &base {
             None => base = Some(topk),
             Some(b) => assert_eq!(
@@ -133,7 +128,7 @@ fn unified_within_path_gemm_n_invariant_under_pin() {
                 "Pin: Unified decode row drifted at N={n} vs N=101 — GEMM-N not invariant within Unified"
             ),
         }
-        eprintln!("[unified-gate] Pin N={n}: served={served} fb={fb} bit-eq-vs-N101=ok");
+        eprintln!("[unified-gate] Pin N={n}: served={served} bit-eq-vs-N101=ok");
     }
     drop(ex);
 

--- a/openinfer-qwen3-4b/tests/batch_invariance_unified.rs
+++ b/openinfer-qwen3-4b/tests/batch_invariance_unified.rs
@@ -118,8 +118,6 @@ fn unified_within_path_gemm_n_invariant_under_pin() {
         let n = c + 1;
         let (topk, served) =
             unified_decode_row(&mut ex, &p, c, 100 + i as u64 * 2, 101 + i as u64 * 2);
-        // launch_gemm_pin bails on any can't-serve-N, so a completed run proves zero fallback;
-        // served>0 guards against a vacuous pass.
         assert!(served > 0, "Pin N={n}: served=0 — pin never ran (vacuous)");
         match &base {
             None => base = Some(topk),

--- a/openinfer-qwen3-4b/tests/scheduler_robustness.rs
+++ b/openinfer-qwen3-4b/tests/scheduler_robustness.rs
@@ -148,8 +148,7 @@ fn scheduler_survives_consumer_drop() {
     eprintln!("[scheduler-robustness] pin served: prefill={prefill_served} full={full_served}");
 
     assert!(!text.is_empty(), "scheduler dead after consumer drop");
-    // launch_gemm_pin bails on any per-token fallback, so a completed serving run already proves
-    // zero fallback; this verifies the pin actually ran decode GEMMs beyond prefill.
+    // The pin ran decode GEMMs beyond prefill, not just prefill's.
     assert!(
         full_served > prefill_served,
         "pin served no decode GEMM beyond prefill (prefill={prefill_served} full={full_served}) — flag→builder→graph-capture may be broken"

--- a/openinfer-qwen3-4b/tests/scheduler_robustness.rs
+++ b/openinfer-qwen3-4b/tests/scheduler_robustness.rs
@@ -21,7 +21,7 @@ use openinfer_core::engine::{
     EngineHandle, EngineLoadOptions, GenerateRequest, TokenEvent, TokenSink,
 };
 use openinfer_core::sampler::SamplingParams;
-use openinfer_kernels::ops::{NumericPolicy, numeric_policy, pin_counters, reset_pin_counters};
+use openinfer_kernels::ops::{NumericPolicy, numeric_policy, pin_served, reset_pin_counters};
 use vllm_text::tokenizer::DynTokenizer;
 
 mod common;
@@ -140,22 +140,18 @@ fn scheduler_survives_consumer_drop() {
 
     reset_pin_counters();
     let _ = generate_text(&handle, &tokenizer, "Hello", 1);
-    let (prefill_served, _) = pin_counters();
+    let prefill_served = pin_served();
 
     reset_pin_counters();
     let text = generate_text(&handle, &tokenizer, "Hello", 5);
-    let (full_served, fallback) = pin_counters();
-    eprintln!(
-        "[scheduler-robustness] pin served: prefill={prefill_served} full={full_served} fallback={fallback}"
-    );
+    let full_served = pin_served();
+    eprintln!("[scheduler-robustness] pin served: prefill={prefill_served} full={full_served}");
 
     assert!(!text.is_empty(), "scheduler dead after consumer drop");
+    // launch_gemm_pin bails on any per-token fallback, so a completed serving run already proves
+    // zero fallback; this verifies the pin actually ran decode GEMMs beyond prefill.
     assert!(
         full_served > prefill_served,
         "pin served no decode GEMM beyond prefill (prefill={prefill_served} full={full_served}) — flag→builder→graph-capture may be broken"
-    );
-    assert_eq!(
-        fallback, 0,
-        "Pin fell back during serving (fallback={fallback})"
     );
 }

--- a/openinfer-server/src/config.rs
+++ b/openinfer-server/src/config.rs
@@ -190,13 +190,16 @@ impl Args {
             bail!("--batch-invariant is currently supported only for Qwen3");
         }
         if self.batch_invariant && self.enable_lora {
-            bail!(
-                "--batch-invariant is not yet validated with --enable-lora; enable one at a time"
-            );
+            bail!("--batch-invariant is not supported with --enable-lora; enable one at a time");
         }
         if self.batch_invariant && !matches!(self.decode_overlap, CliDecodeOverlap::Off) {
             bail!(
                 "--batch-invariant is not compatible with --decode-overlap; Pin falls back to per-token under a stream override"
+            );
+        }
+        if self.batch_invariant && self.dflash_draft_model_path.is_some() {
+            bail!(
+                "--batch-invariant is not supported with DFlash speculative decoding; enable one at a time"
             );
         }
         Ok(())

--- a/openinfer-server/src/config.rs
+++ b/openinfer-server/src/config.rs
@@ -194,7 +194,7 @@ impl Args {
         }
         if self.batch_invariant && !matches!(self.decode_overlap, CliDecodeOverlap::Off) {
             bail!(
-                "--batch-invariant is not compatible with --decode-overlap; Pin falls back to per-token under a stream override"
+                "--batch-invariant is not compatible with --decode-overlap; the stream override would force the pinned GEMM to bail at runtime"
             );
         }
         if self.batch_invariant && self.dflash_draft_model_path.is_some() {


### PR DESCRIPTION
## Description

Refs #414, #435. Follows #428.

`--batch-invariant` uses `NumericPolicy::Pin` to route projection GEMMs through one warmed cuBLASLt algo per `(M,K)`. That is only safe for shapes verified before serving.

This PR makes Pin fail loud instead of silently degrading:
- stream overrides now error instead of falling back to per-token;
- unsupported `N` now errors instead of falling back to per-token;
- unwarmed `(M,K)` shapes now error instead of lazy-tuning and running unverified.

The runtime boundary is `launch_gemm_pin`: any unsupported DFlash drafter, LoRA prefill-delta, or policy-set-after-construction shape reaches `GEMM_LT_PIN_UNTUNED` / `GEMM_LT_PIN_UNSUPPORTED` and fails with the `{M,N,K}`. Builder/CLI still reject the production unsupported combinations up front.

The old fallback counter/map, lazy pin inspection, and stream-capture query are removed. Tests now assert `pin_served() > 0`; any former fallback path fails the operation directly.

The transient memory-profile worker only warms Pin plans; the long-lived serving worker runs the full thread-local envelope check before capture.

## Test Env

On sm_89 (x86_64), the Qwen3 gates `batch_invariance_{envelope,reject,unified,endtoend,decode_gemm_graph}`, `scheduler_robustness`, `hf_golden_gate`, and the openinfer-kernels `batch_invariance_gemm` gate all pass.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

