### PR TITLE
Lower Qwen3 speculative accept trace to debug

### DIFF
--- a/docs/models/qwen3/dspark-integration.md
+++ b/docs/models/qwen3/dspark-integration.md
@@ -210,7 +210,7 @@ Per-case mean accepted draft tokens:
 - **Method:** `run_sweep.sh` (session scratch, on the 5090 at `/data/dspark-bench/`) launches each server and runs `/root/.cargo/bin/vllm-bench` across chat / poem / rand / code × c1/c4/c8, parsing tok/s + `cumulative_accept_rate` from the server log. Raw artifacts were copied to `/tmp/openinfer-bench/dspark-sweep-20260629/` locally; `accept_distribution.csv` there has the per-case histograms.
 - **MTP metric note:** the Python `vllm bench serve --help=all` on this 5090 exposes a `spec_bench` dataset, but not direct MTP/spec accept metrics. The Rust `vllm-bench` result JSON also only contains standard serving metrics. For accepted length, use OpenInfer's `accepted_draft` / `committed_tokens` log lines until we add a structured metric.
 - **Invalid rows:** `low_entropy`/`high_entropy` are absent from the selected SPEED-Bench split in this harness, so their JSON files are missing and those rows are dropped.
-- **The accept log** (`cumulative_accept_rate`) is currently emitted at `info` once per request per decode step for measurement — **gate or aggregate it before shipping** (too noisy for production info).
+- **The accept trace** (`cumulative_accept_rate`) is `debug`-level only. It is useful for one-off DSpark/DFlash acceptance analysis, but production's default `info` logging must not emit one line per request per verify round; use a debug run or a structured metric for future acceptance studies.
 
 ## Integration delta — what's new on top of DFlash (Phase 1)
 

--- a/openinfer-qwen3-4b/src/executor/dflash_lane.rs
+++ b/openinfer-qwen3-4b/src/executor/dflash_lane.rs
@@ -140,7 +140,7 @@ impl LocalQwen3Lane {
 
     /// Seed the next draft round from a verify step: append the target hidden
     /// states for the *accepted* span positions to each request's pending
-    /// context, and log the cumulative acceptance rate.
+    /// context, and keep the cumulative acceptance trace at debug level.
     pub(super) fn record_verify_dflash_context(
         &mut self,
         requests: &[VerifyStepItem],
@@ -195,7 +195,7 @@ impl LocalQwen3Lane {
             } else {
                 dflash.accepted_draft_tokens as f64 / dflash.verified_draft_tokens as f64
             };
-            log::info!(
+            log::debug!(
                 "Qwen3 DFlash request={} accepted_draft={} committed_tokens={} cumulative_accept_rate={:.3}",
                 req.request_id.get(),
                 result.matched_draft_tokens,


### PR DESCRIPTION
## Summary
- Move the per-request DFlash/DSpark speculative acceptance trace from info to debug so default production logging does not emit one line per request per verify round.
- Update the DSpark integration notes to document debug-level acceptance tracing and future structured metrics usage.

## Validation
- cargo fmt --check
- git diff --check
- cargo test --release -p openinfer-qwen3-4b --lib
- Pre-commit toxic-reviewer pass: Ready; no remaining DFlash/DSpark production info hot-path trace found.