### PR TITLE
feat(kernels): gate MoE third-party substrates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,9 @@
 [submodule "openinfer-kernels/third_party/DeepEP"]
 	path = openinfer-kernels/third_party/DeepEP
 	url = https://github.com/deepseek-ai/DeepEP
+[submodule "openinfer-kernels/third_party/FlashMLA"]
+	path = openinfer-kernels/third_party/FlashMLA
+	url = https://github.com/deepseek-ai/FlashMLA
+[submodule "openinfer-kernels/third_party/DeepGEMM"]
+	path = openinfer-kernels/third_party/DeepGEMM
+	url = https://github.com/deepseek-ai/DeepGEMM

--- a/docs/index.md
+++ b/docs/index.md
@@ -134,7 +134,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 
 | Path | TL;DR |
 | --- | --- |
-| `subsystems/kernels/openinfer-kernels-boundary.md` | Architecture decision: openinfer should use reusable frontend/runtime/data-plane layers plus per-model engines; kernels become first-class assets through a ledger, simulator, and request tracing. |
+| `subsystems/kernels/openinfer-kernels-boundary.md` | Architecture decision: reusable frontend/runtime/data-plane layers plus per-model engines; `openinfer-kernels` keeps shared MoE/MLA substrate (`moe`: DeepEP/DeepGEMM/FlashMLA) separate from model-local surfaces such as the narrow GLM5.2 DeepGEMM/FlashMLA wrappers. |
 | `subsystems/kernels/kernel-op-reports.md` | Qwen3 kernel/report tooling is feature-gated: `qwen3_kernel_report` covers per-op kernel reports, and `qwen3_model_report` emits runtime-traced eager-DAG decode operator rollups with TensorSpec `KernelCall`s, latency stats, tables, and Graphviz DOT; measured FA2 `CTA_TILE_Q=64` prefill default in place. |
 | `subsystems/kernels/typed-forward-pipeline.md` | Reusable typed tensor pipeline macro in `openinfer-kernels` so model crates can express common `typed_ops` chains without model-specific wrapper macros. |
 | `subsystems/kernels/tvm-ffi-mvp.md` | Optional `tvm-ffi-triton-cubin` bridge in `openinfer-kernels` plus a packed TVM wrapper for the Qwen3.5 GDR solve Triton AOT CUBIN launcher. |

--- a/docs/subsystems/kernels/openinfer-kernels-boundary.md
+++ b/docs/subsystems/kernels/openinfer-kernels-boundary.md
@@ -2,7 +2,8 @@
 
 **Created**: 2026-05-03
 **Status**: complete
-**TL;DR**: openinfer should evolve as reusable frontend/data-plane infrastructure plus per-model engines, not as one universal model abstraction. The first concrete step is extracting a kernels crate; kernels then become first-class assets through an index, ledger, simulator, and request tracing. PegaFlow remains the KV data plane instead of being folded into model internals.
+**Last touched**: 2026-06
+**TL;DR**: openinfer should evolve as reusable frontend/data-plane infrastructure plus per-model engines, not as one universal model abstraction. `openinfer-kernels` now separates shared MoE/MLA third-party substrate (`moe`: DeepEP/DeepGEMM/FlashMLA) from model-local surfaces (`glm52`: narrow DeepGEMM + FlashMLA sparse decode wrappers). PegaFlow remains the KV data plane instead of being folded into model internals.
 
 ## Preparation
 
@@ -66,6 +67,17 @@ LLM coding is cheap enough that maintaining clean model-local context can be mor
 ## Kernel Boundary
 
 Kernel performance and correctness dominate model quality. The first reusable code artifact should be a kernels crate, not a larger model trait. The first reusable knowledge artifact on top of that crate should be a compact kernel index and then a kernel ledger.
+
+The `openinfer-kernels` feature boundary separates model entry points from shared third-party substrates. Model features such as `kimi-k2` describe which model-local CUDA/Rust surface is built; the `moe` feature owns the MoE/MLA dependency substrate (`DeepEP`, `DeepGEMM`, `FlashMLA`) so future MoE model lines can reuse those repositories without making one model feature the build switch for another model's communication or attention backend.
+
+`glm52` builds on that substrate as a narrow model-local surface: it currently exposes DeepGEMM scale-layout/grouped-FP8 contracts plus FlashMLA sparse decode wrappers. The FlashMLA sparse wrapper is SM90-only, fixes V32 `topk=2048`, and does not expose dynamic `topk_length`; the grouped DeepGEMM compute entry is fail-closed with `CUDA_ERROR_NOT_SUPPORTED` until a real runner is wired. Router, indexer/top-k, PP P2P, TRTLLM fallbacks, and local route/scatter/combine kernels remain out of the shared surface until the GLM5.2 model crate proves it needs them as stable kernel contracts.
+
+## GLM5.2 MoE Substrate Work
+
+- **Read**: `docs/index.md`, this boundary doc, `openinfer-kernels/KERNELS.md`, GLM5.2 wrapper files under `openinfer-kernels/src/ops/glm52`, `openinfer-kernels/src/ffi/glm52`, and `openinfer-kernels/csrc/glm52`.
+- **Execution log**: added the `moe` substrate feature, made `glm52` depend on it, gated DeepEP on `moe`, added DeepGEMM/FlashMLA submodule checks, and exposed only the GLM5.2 DeepGEMM scale-layout/grouped-contract plus FlashMLA sparse-decode interfaces.
+- **Review follow-up**: removed `topk_length` from the FlashMLA sparse ABI because the V32 kernel requires it to be null, bounded `num_sm_parts` to FlashMLA's 160 split cap, converted C++ assertion exceptions at the FlashMLA FFI boundary to `CUresult`, and documented that upstream `CHECK_CUDA`/`FLASH_ASSERT` can still terminate the process on internal CUDA/launch failures.
+- **Debrief**: the shared surface is now intentionally narrow. Future GLM5.2 work should wire the real DeepGEMM grouped runner and add model-owned router/indexer/PP contracts only after the model crate has concrete callers.
 
 A kernel ledger should track:
 

--- a/openinfer-kernels/Cargo.toml
+++ b/openinfer-kernels/Cargo.toml
@@ -25,7 +25,10 @@ qwen35-4b = []
 deepseek-v4 = []
 deepseek-v4-cutedsl-diagnostic = ["deepseek-v4"]
 deepseek-v2-lite = []
-kimi-k2 = []
+# Shared MoE/MLA third-party substrate: DeepEP, DeepGEMM, and FlashMLA.
+moe = []
+glm52 = ["moe"]
+kimi-k2 = ["moe"]
 
 [[example]]
 name = "triton_cubin_tvm_ffi"

--- a/openinfer-kernels/KERNELS.md
+++ b/openinfer-kernels/KERNELS.md
@@ -100,6 +100,20 @@ AG/RS.
 | `kimi_k2.moe.marlin_align_block_size` | `openinfer-kimi-k2` | `ops::kimi_moe_marlin_align_block_size` | `kimi_moe_marlin_align_block_size_cuda` | `csrc/kimi_k2/kimi_experts.cu` | CUDA routing metadata | Device-resident vLLM Marlin/WNA16 alignment: `sorted_token_ids`, `expert_ids`, and `num_tokens_post_padded` for local EP experts. It ignores non-local experts like vLLM `ignore_invalid_experts=True`, pads each local expert to block size `8/16/32/48/64`, uses sentinel `active_tokens * topk`, and performs no D2H or allocation in the decode step. |
 | `kimi_k2.moe.int4_marlin_package` | `openinfer-kimi-k2` | `ops::kimi_marlin_int4_reorder_weight`, `ops::kimi_marlin_int4_reorder_scale`, `ops::kimi_marlin_int4_fuse_w13` | `kimi_marlin_int4_reorder_weight_cuda`, `kimi_marlin_int4_reorder_scale_cuda`, `kimi_marlin_int4_fuse_w13_cuda` | `csrc/kimi_k2/kimi_marlin_int4.cu` | CUDA load-time package helpers | Weight package preserves vLLM `uint4b8` bias=8 nibbles. Single projections repack checkpoint `[expert,out,K/8] int32` into Marlin no-actorder `[expert,K/16,N*2] int32`; scale package converts checkpoint `[expert,out,K/32]` into vLLM Marlin group-major+perm64 `[expert,K/32,out]`. Final runtime package fuses gate/up into W13 `[expert,K/16,4096*2]` and W13 scale `[expert,K/32,4096]`; W2 remains `[expert,2048/16,7168*2]` and `[expert,2048/32,7168]`. These are load/package helpers, not decode hot-path kernels. |
 
+## GLM5.2 MoE Bring-Up Surface
+
+GLM5.2 uses the `openinfer-kernels/glm52` feature, which depends on the shared
+`moe` substrate for DeepEP, DeepGEMM, and FlashMLA. The current surface is only
+the GLM5.2 decode substrate that has a stable caller shape; router/indexer,
+pipeline-parallel P2P, TRTLLM fallbacks, and local route/scatter/combine stay out
+until the model crate proves their contracts.
+
+| op_id | Runtime owner | Rust wrapper | FFI symbols | Source | Backend | Shape / layout notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| `glm52.deepgemm.scale_layout` | future GLM5.2 model crate | `ops::glm52_deepgemm_mn_major_tma_aligned_f32_launch` | `glm52_deepgemm_mn_major_tma_aligned_f32_cuda` | `csrc/glm52/glm52_deepgemm_layout.cu` | CUDA layout helper for DeepGEMM | Converts row-major f32 scales `[rows, scale_cols]` into MN-major/TMA-aligned storage with `aligned_rows` padded to 16-byte f32 row alignment. |
+| `glm52.deepgemm.grouped_fp8_contract` | future GLM5.2 model crate | `ops::glm52_deepgemm_grouped_fp8_contract_validate`, `ops::glm52_deepgemm_grouped_fp8_metadata_launch`, `ops::glm52_deepgemm_grouped_fp8_launch` | `glm52_deepgemm_grouped_fp8_contract_cuda`, `glm52_deepgemm_grouped_fp8_metadata_cuda`, `glm52_deepgemm_grouped_fp8_launch_cuda` | `csrc/glm52/glm52_deepgemm_grouped.cu` | CUDA metadata shim over DeepGEMM ABI | W13 contract is `N=4096,K=6144`, W2 contract is `N=6144,K=2048`; expert alignment is 64 rows. Metadata generation is real; grouped FP8 compute returns `CUDA_ERROR_NOT_SUPPORTED` until a real DeepGEMM runner is wired. |
+| `glm52.flashmla.sparse_decode` | future GLM5.2 model crate | `ops::glm52_flashmla_sparse_decode_num_sm_parts`, `ops::glm52_flashmla_sparse_decode_metadata_launch`, `ops::glm52_flashmla_sparse_decode_launch` | `glm52_flashmla_sparse_decode_num_sm_parts_cuda`, `glm52_flashmla_sparse_decode_metadata_cuda`, `glm52_flashmla_sparse_decode_launch_cuda` | `csrc/glm52/glm52_flashmla_sparse.cu` | FlashMLA SM90 sparse decode | SM90-only sparse decode for V32 layout: `batch<=128`, `heads=64`, `qk_dim=576`, `v_dim=512`, `page_size=64`, packed KV token stride `656`, fixed `topk=2048`, and `num_sm_parts<=160`. Dynamic `topk_length` is intentionally not exposed because this kernel asserts it must be null. |
+
 ## Non-Qwen3 Compatibility
 
 The crate still builds CUDA/Triton symbols needed by the current root binary:
@@ -112,8 +126,8 @@ These are preserved for build compatibility. They are not part of the Qwen3-4B P
 
 ## Editing Rule
 
-When adding or replacing a kernel used by Qwen3-4B or DeepSeek V4, update this
-routing table.
+When adding or replacing a kernel used by Qwen3-4B, DeepSeek V4, Kimi-K2, or
+GLM5.2, update this routing table.
 
 Do not add model-specific machine-readable manifests here. The kernels crate
 owns reusable operator implementations; model crates should own model DAG

--- a/openinfer-kernels/build.rs
+++ b/openinfer-kernels/build.rs
@@ -264,6 +264,88 @@ fn nvcc_arch_args(normalized_sms: &[String]) -> Vec<String> {
     args
 }
 
+fn nvcc_accepts_gencode(nvcc: &str, compute: &str, sm: &str) -> bool {
+    let stem = format!(
+        "openinfer_nvcc_probe_{}_compute_{compute}_sm_{sm}",
+        std::process::id()
+    );
+    let cu_path = std::env::temp_dir().join(format!("{stem}.cu"));
+    let obj_path = std::env::temp_dir().join(format!("{stem}.o"));
+    if let Err(err) = fs::write(
+        &cu_path,
+        "extern \"C\" __global__ void openinfer_nvcc_probe() {}\n",
+    ) {
+        println!(
+            "cargo:warning=Failed to write nvcc probe {}: {err}",
+            cu_path.display()
+        );
+        return false;
+    }
+
+    let output = Command::new(nvcc)
+        .args(["-c"])
+        .arg(&cu_path)
+        .arg("-o")
+        .arg(&obj_path)
+        .arg("-gencode")
+        .arg(format!("arch=compute_{compute},code=sm_{sm}"))
+        .output();
+    let _ = fs::remove_file(&cu_path);
+    let _ = fs::remove_file(&obj_path);
+
+    match output {
+        Ok(output) if output.status.success() => true,
+        Ok(output) => {
+            println!(
+                "cargo:warning=nvcc rejected compute_{compute}/sm_{sm} probe: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+            false
+        }
+        Err(err) => {
+            println!("cargo:warning=Failed to run nvcc arch probe: {err}");
+            false
+        }
+    }
+}
+
+fn glm52_flashmla_arch_args(normalized_sms: &[String], nvcc: &str) -> Vec<String> {
+    let sm90a_supported = normalized_sms.iter().any(|sm| sm == "90" || sm == "90a")
+        && nvcc_accepts_gencode(nvcc, "90a", "90a");
+    let mut promoted_sms = Vec::new();
+    for sm in normalized_sms {
+        let promoted = if sm == "90" || sm == "90a" {
+            if sm90a_supported {
+                "90a"
+            } else {
+                println!(
+                    "cargo:warning=nvcc cannot compile compute_90a/sm_90a; GLM5.2 FlashMLA sparse decode will use sm_{sm}"
+                );
+                sm
+            }
+        } else {
+            sm
+        };
+
+        if !promoted_sms.iter().any(|existing| existing == promoted) {
+            promoted_sms.push(promoted.to_string());
+        }
+    }
+
+    if promoted_sms != normalized_sms {
+        println!(
+            "cargo:warning=Compiling GLM5.2 FlashMLA sparse decode for nvcc targets: {}",
+            promoted_sms
+                .iter()
+                .map(|sm| format!("sm_{sm}"))
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+    }
+
+    nvcc_arch_args(&promoted_sms)
+}
+
 fn collect_files_recursively(dir: &Path, out: &mut Vec<PathBuf>) {
     let mut entries: Vec<_> = std::fs::read_dir(dir)
         .unwrap_or_else(|err| panic!("Failed to read {}: {err}", dir.display()))
@@ -310,8 +392,8 @@ fn is_kimi_k2_source(csrc_dir: &Path, path: &Path) -> bool {
     }
 }
 
-/// DeepEP elastic shim (csrc/deepep/): Kimi-K2's EP all-to-all backend.
-/// Compiled only with the `kimi-k2` feature; needs NCCL >= 2.30.4 headers/lib.
+/// DeepEP elastic shim (csrc/deepep/): shared MoE EP all-to-all substrate.
+/// Compiled only with the `moe` feature; needs NCCL >= 2.30.4 headers/lib.
 fn is_deepep_source(csrc_dir: &Path, path: &Path) -> bool {
     match path.strip_prefix(csrc_dir) {
         Ok(relative) => relative
@@ -319,6 +401,46 @@ fn is_deepep_source(csrc_dir: &Path, path: &Path) -> bool {
             .any(|part| part.as_os_str() == "deepep"),
         Err(_) => false,
     }
+}
+
+/// GLM5.2 model-local CUDA shims over DeepGEMM/FlashMLA contracts.
+fn is_glm52_source(csrc_dir: &Path, path: &Path) -> bool {
+    match path.strip_prefix(csrc_dir) {
+        Ok(relative) => relative
+            .components()
+            .any(|part| part.as_os_str() == "glm52"),
+        Err(_) => false,
+    }
+}
+
+fn require_submodule_file(root: &Path, feature: &str, label: &str, relative: &str) {
+    let path = root.join(relative);
+    assert!(
+        path.exists(),
+        "The {feature} feature requires the {label} submodule. Missing {}. Run `git submodule update --init --recursive {}`.",
+        path.display(),
+        relative
+    );
+}
+
+fn require_moe_submodules(root: &Path) {
+    require_submodule_file(root, "moe", "DeepEP", "third_party/DeepEP/README.md");
+    require_submodule_file(root, "moe", "DeepGEMM", "third_party/DeepGEMM/README.md");
+    require_submodule_file(
+        root,
+        "moe",
+        "FlashMLA",
+        "third_party/FlashMLA/csrc/params.h",
+    );
+}
+
+fn require_glm52_submodules(root: &Path) {
+    require_submodule_file(
+        root,
+        "glm52",
+        "FlashMLA nested CUTLASS",
+        "third_party/FlashMLA/csrc/cutlass/include/cutlass/bfloat16.h",
+    );
 }
 
 /// NCCL >= 2.30.4 root (include/nccl.h + lib/libnccl.so.2) for the DeepEP
@@ -332,7 +454,7 @@ fn is_deepep_source(csrc_dir: &Path, path: &Path) -> bool {
 fn deepep_nccl_root() -> PathBuf {
     let Ok(root) = std::env::var("OPENINFER_NCCL_ROOT").map(PathBuf::from) else {
         panic!(
-            "The kimi-k2 feature builds the DeepEP shim, which needs NCCL >= 2.30.4. \
+            "The moe feature builds the DeepEP shim, which needs NCCL >= 2.30.4. \
              Set OPENINFER_NCCL_ROOT to an install with include/nccl.h and lib/libnccl.so.2 \
              (e.g. the unpacked nvidia-nccl-cu13 wheel)."
         )
@@ -1129,6 +1251,8 @@ fn main() {
     let arch_args = nvcc_arch_args(&nvcc_sm_targets);
     let deepseek_enabled = cfg!(feature = "deepseek-v4");
     let deepseek_v2_lite_enabled = cfg!(feature = "deepseek-v2-lite");
+    let moe_enabled = cfg!(feature = "moe");
+    let glm52_enabled = cfg!(feature = "glm52");
     let kimi_k2_enabled = cfg!(feature = "kimi-k2");
     let qwen35_enabled = cfg!(feature = "qwen35-4b");
     let cutedsl_enabled = cfg!(feature = "deepseek-v4");
@@ -1163,6 +1287,12 @@ fn main() {
         BTreeSet::from(["activation.cu", "embedding.cu", "fused_attention.cu"]);
 
     let root = crate_root();
+    if moe_enabled {
+        require_moe_submodules(&root);
+    }
+    if glm52_enabled {
+        require_glm52_submodules(&root);
+    }
     let csrc_dir = root.join("csrc");
     let mut csrc_files = Vec::new();
     collect_files_recursively(&csrc_dir, &mut csrc_files);
@@ -1176,9 +1306,13 @@ fn main() {
             if !deepseek_v2_lite_enabled && is_deepseek_v2_lite_source(&csrc_dir, path) {
                 return None;
             }
-            if !kimi_k2_enabled
-                && (is_kimi_k2_source(&csrc_dir, path) || is_deepep_source(&csrc_dir, path))
-            {
+            if !moe_enabled && is_deepep_source(&csrc_dir, path) {
+                return None;
+            }
+            if !glm52_enabled && is_glm52_source(&csrc_dir, path) {
+                return None;
+            }
+            if !kimi_k2_enabled && is_kimi_k2_source(&csrc_dir, path) {
                 return None;
             }
             if path.extension().and_then(|e| e.to_str()) == Some("cu")
@@ -1217,7 +1351,7 @@ fn main() {
         flashinfer.include.display()
     );
 
-    let deepep_nccl = kimi_k2_enabled.then(deepep_nccl_root);
+    let deepep_nccl = moe_enabled.then(deepep_nccl_root);
 
     let mut nvcc_tasks = Vec::new();
     for cu_file in &cu_files {
@@ -1235,7 +1369,11 @@ fn main() {
             "-I".to_string(),
             csrc_dir.to_string_lossy().to_string(),
         ];
-        nvcc_args.extend(arch_args.clone());
+        if stem == "glm52_flashmla_sparse" {
+            nvcc_args.extend(glm52_flashmla_arch_args(&nvcc_sm_targets, &nvcc));
+        } else {
+            nvcc_args.extend(arch_args.clone());
+        }
         nvcc_args.extend(["--compiler-options".to_string(), "-fPIC".to_string()]);
 
         // Files that include FlashInfer headers (C++17, header-only)
@@ -1283,7 +1421,7 @@ fn main() {
         if is_deepep_source(&csrc_dir, cu_file) {
             let nccl_root = deepep_nccl
                 .as_ref()
-                .expect("deepep sources are collected only with the kimi-k2 feature");
+                .expect("deepep sources are collected only with the moe feature");
             nvcc_args.extend(
                 [
                     "--std=c++20",
@@ -1331,6 +1469,38 @@ fn main() {
             ]);
         }
 
+        if stem == "glm52_flashmla_sparse" {
+            let flashmla = root.join("third_party/FlashMLA/csrc");
+            nvcc_args.extend([
+                "--std=c++20".to_string(),
+                "--expt-relaxed-constexpr".to_string(),
+                "--expt-extended-lambda".to_string(),
+                "-I".to_string(),
+                flashmla.to_string_lossy().to_string(),
+                "-I".to_string(),
+                flashmla
+                    .join("cutlass/include")
+                    .to_string_lossy()
+                    .to_string(),
+                "-I".to_string(),
+                flashmla
+                    .join("cutlass/tools/util/include")
+                    .to_string_lossy()
+                    .to_string(),
+                "-I".to_string(),
+                flashmla
+                    .join("kerutils/include")
+                    .to_string_lossy()
+                    .to_string(),
+                "-I".to_string(),
+                flashinfer.cutlass.to_string_lossy().to_string(),
+                "-I".to_string(),
+                flashinfer.cutlass_util.to_string_lossy().to_string(),
+            ]);
+        } else if stem.starts_with("glm52_") {
+            nvcc_args.extend(["--std=c++17".to_string()]);
+        }
+
         nvcc_tasks.push(NvccTask {
             cu_file: cu_file.clone(),
             obj_file,
@@ -1341,6 +1511,16 @@ fn main() {
     if !deepseek_enabled {
         println!(
             "cargo:warning=DeepSeek V4 CUDA/TileLang kernels disabled; enable the openinfer-kernels `deepseek-v4` feature to build them"
+        );
+    }
+    if !moe_enabled {
+        println!(
+            "cargo:warning=MoE third-party substrate disabled; enable the openinfer-kernels `moe` feature to build DeepEP-backed kernels"
+        );
+    }
+    if !glm52_enabled {
+        println!(
+            "cargo:warning=GLM5.2 DeepGEMM/FlashMLA interfaces disabled; enable the openinfer-kernels `glm52` feature to build them"
         );
     }
     if !kimi_k2_enabled {
@@ -1533,5 +1713,13 @@ fn main() {
     println!(
         "cargo:rerun-if-changed={}",
         root.join("third_party/DeepEP/deep_ep/include").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        root.join("third_party/DeepGEMM").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        root.join("third_party/FlashMLA").display()
     );
 }

--- a/openinfer-kernels/csrc/glm52/glm52_deepgemm_grouped.cu
+++ b/openinfer-kernels/csrc/glm52/glm52_deepgemm_grouped.cu
@@ -1,0 +1,161 @@
+#include "../common.cuh"
+
+#include <cuda.h>
+#include <cstdint>
+
+namespace {
+
+constexpr int kKindW13 = 1;
+constexpr int kKindW2 = 2;
+// PP8 EP1: groups (256 local experts) and m_capacity (bs=1 = top_k*alignment) are
+// RUNTIME args to the group-generic metadata kernel; only the 64-row expert
+// alignment is a fixed design constant.
+constexpr int kExpertAlignment = 64;
+constexpr int kW13N = 4096;
+constexpr int kW13K = 6144;
+constexpr int kW13ScaleRows = 32;
+constexpr int kW13ScaleCols = 48;
+constexpr int kW2N = 6144;
+constexpr int kW2K = 2048;
+constexpr int kW2ScaleRows = 48;
+constexpr int kW2ScaleCols = 16;
+constexpr int kMetadataThreads = 32;
+
+__device__ __forceinline__ int align_up_int(int value, int alignment) {
+  return ((value + alignment - 1) / alignment) * alignment;
+}
+
+__device__ __forceinline__ int clamp_nonnegative(int value) {
+  return value < 0 ? 0 : value;
+}
+
+__device__ __forceinline__ int min_int(int lhs, int rhs) {
+  return lhs < rhs ? lhs : rhs;
+}
+
+__global__ void deepgemm_grouped_fp8_metadata_kernel(
+    const int* __restrict__ psum_expert,
+    int64_t* __restrict__ expert_offsets,
+    int* __restrict__ w13_problem_sizes,
+    int* __restrict__ w2_problem_sizes, int groups, int m_capacity,
+    int expert_alignment) {
+  int expert = blockIdx.x * blockDim.x + threadIdx.x;
+  if (expert >= groups) {
+    return;
+  }
+
+  int previous_end =
+      expert == 0 ? 0 : clamp_nonnegative(psum_expert[expert - 1]);
+  int end = clamp_nonnegative(psum_expert[expert]);
+  int start = expert == 0 ? 0 : align_up_int(previous_end, expert_alignment);
+  int m = end >= start ? end - start : 0;
+  if (start > m_capacity || end > m_capacity) {
+    m = 0;
+  }
+
+  expert_offsets[expert] = static_cast<int64_t>(start);
+
+  int* w13 = w13_problem_sizes + expert * 3;
+  w13[0] = m;
+  w13[1] = kW13N;
+  w13[2] = kW13K;
+
+  int* w2 = w2_problem_sizes + expert * 3;
+  w2[0] = m;
+  w2[1] = kW2N;
+  w2[2] = kW2K;
+
+  if (expert == groups - 1) {
+    int expanded_rows = align_up_int(end, expert_alignment);
+    expert_offsets[groups] =
+        static_cast<int64_t>(min_int(expanded_rows, m_capacity));
+  }
+}
+
+CUresult map_cuda_error(cudaError_t err) {
+  if (err == cudaSuccess) return CUDA_SUCCESS;
+  if (err == cudaErrorInvalidValue || err == cudaErrorInvalidDevicePointer) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  if (err == cudaErrorMemoryAllocation) return CUDA_ERROR_OUT_OF_MEMORY;
+  if (err == cudaErrorNotSupported) return CUDA_ERROR_NOT_SUPPORTED;
+  return CUDA_ERROR_LAUNCH_FAILED;
+}
+
+CUresult consume_last_cuda_error() { return map_cuda_error(cudaGetLastError()); }
+
+bool valid_common(int groups, int m_capacity, int psum_entries,
+                  int expert_alignment, int activation_scale_tma_rows) {
+  return groups > 0 && m_capacity > 0 && psum_entries == groups &&
+         expert_alignment == kExpertAlignment &&
+         activation_scale_tma_rows == m_capacity;
+}
+
+bool valid_w13(int n, int k, int weight_scale_rows, int weight_scale_cols,
+               int activation_scale_cols) {
+  return n == kW13N && k == kW13K && weight_scale_rows == kW13ScaleRows &&
+         weight_scale_cols == kW13ScaleCols &&
+         activation_scale_cols == kW13ScaleCols;
+}
+
+bool valid_w2(int n, int k, int weight_scale_rows, int weight_scale_cols,
+              int activation_scale_cols) {
+  return n == kW2N && k == kW2K && weight_scale_rows == kW2ScaleRows &&
+         weight_scale_cols == kW2ScaleCols &&
+         activation_scale_cols == kW2ScaleCols;
+}
+
+}  // namespace
+
+extern "C" {
+
+CUresult glm52_deepgemm_grouped_fp8_contract_cuda(
+    int operand_kind, int groups, int m_capacity, int n, int k,
+    int weight_scale_rows, int weight_scale_cols, int activation_scale_cols,
+    int activation_scale_tma_rows, int psum_entries, int expert_alignment) {
+  if (!valid_common(groups, m_capacity, psum_entries, expert_alignment,
+                    activation_scale_tma_rows)) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  if (operand_kind == kKindW13 &&
+      valid_w13(n, k, weight_scale_rows, weight_scale_cols,
+                activation_scale_cols)) {
+    return CUDA_SUCCESS;
+  }
+  if (operand_kind == kKindW2 &&
+      valid_w2(n, k, weight_scale_rows, weight_scale_cols,
+               activation_scale_cols)) {
+    return CUDA_SUCCESS;
+  }
+  return CUDA_ERROR_INVALID_VALUE;
+}
+
+CUresult glm52_deepgemm_grouped_fp8_metadata_cuda(
+    const int* psum_expert, int64_t* expert_offsets, int* w13_problem_sizes,
+    int* w2_problem_sizes, int groups, int m_capacity, int expert_alignment,
+    cudaStream_t stream) {
+  if (psum_expert == nullptr || expert_offsets == nullptr ||
+      w13_problem_sizes == nullptr || w2_problem_sizes == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  if (groups <= 0 || m_capacity <= 0 || expert_alignment != kExpertAlignment) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  int blocks = (groups + kMetadataThreads - 1) / kMetadataThreads;
+  deepgemm_grouped_fp8_metadata_kernel<<<blocks, kMetadataThreads, 0, stream>>>(
+      psum_expert, expert_offsets, w13_problem_sizes, w2_problem_sizes, groups,
+      m_capacity, expert_alignment);
+  return consume_last_cuda_error();
+}
+
+CUresult glm52_deepgemm_grouped_fp8_launch_cuda(
+    int /*operand_kind*/, const unsigned char* /*a*/,
+    const float* /*a_scale*/, const unsigned char* /*b*/,
+    const float* /*b_scale*/, const int* /*psum_expert*/,
+    unsigned short* /*out*/, int /*groups*/, int /*m_capacity*/, int /*n*/,
+    int /*k*/, cudaStream_t /*stream*/) {
+  return CUDA_ERROR_NOT_SUPPORTED;
+}
+
+}  // extern "C"

--- a/openinfer-kernels/csrc/glm52/glm52_deepgemm_layout.cu
+++ b/openinfer-kernels/csrc/glm52/glm52_deepgemm_layout.cu
@@ -1,0 +1,63 @@
+#include "../common.cuh"
+
+#include <cuda.h>
+
+namespace {
+
+constexpr int kTmaAlignmentBytes = 16;
+constexpr int kF32Bytes = 4;
+constexpr int kF32TmaRowAlignment = kTmaAlignmentBytes / kF32Bytes;
+constexpr int kLayoutThreads = 256;
+
+__global__ void deepgemm_mn_major_tma_aligned_f32_kernel(
+    const float* __restrict__ input, float* __restrict__ output, int rows,
+    int scale_cols, int aligned_rows) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int total = aligned_rows * scale_cols;
+  if (idx >= total) return;
+
+  int row = idx % aligned_rows;
+  int col = idx / aligned_rows;
+  output[idx] = row < rows ? input[row * scale_cols + col] : 0.0f;
+}
+
+CUresult map_cuda_error(cudaError_t err) {
+  if (err == cudaSuccess) return CUDA_SUCCESS;
+  if (err == cudaErrorInvalidValue || err == cudaErrorInvalidDevicePointer) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  if (err == cudaErrorMemoryAllocation) return CUDA_ERROR_OUT_OF_MEMORY;
+  if (err == cudaErrorNotSupported) return CUDA_ERROR_NOT_SUPPORTED;
+  return CUDA_ERROR_LAUNCH_FAILED;
+}
+
+CUresult consume_last_cuda_error() { return map_cuda_error(cudaGetLastError()); }
+
+bool valid_layout_shape(int rows, int scale_cols, int aligned_rows) {
+  return rows > 0 && scale_cols > 0 && aligned_rows >= rows &&
+         aligned_rows % kF32TmaRowAlignment == 0;
+}
+
+}  // namespace
+
+extern "C" {
+
+CUresult glm52_deepgemm_mn_major_tma_aligned_f32_cuda(
+    const float* input, float* output, int rows, int scale_cols,
+    int aligned_rows, cudaStream_t stream) {
+  if (input == nullptr || output == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  if (!valid_layout_shape(rows, scale_cols, aligned_rows)) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  int total = aligned_rows * scale_cols;
+  int blocks = (total + kLayoutThreads - 1) / kLayoutThreads;
+  deepgemm_mn_major_tma_aligned_f32_kernel<<<blocks, kLayoutThreads, 0,
+                                             stream>>>(
+      input, output, rows, scale_cols, aligned_rows);
+  return consume_last_cuda_error();
+}
+
+}  // extern "C"

--- a/openinfer-kernels/csrc/glm52/glm52_flashmla_sparse.cu
+++ b/openinfer-kernels/csrc/glm52/glm52_flashmla_sparse.cu
@@ -1,0 +1,222 @@
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <exception>
+
+#include "params.h"
+#include "sm90/decode/sparse_fp8/splitkv_mla.cuh"
+#include "smxx/decode/combine/combine.cu"
+#include "smxx/decode/get_decoding_sched_meta/get_decoding_sched_meta.cu"
+
+namespace {
+
+constexpr int kBatchCapacity = 128;
+constexpr int kSq = 1;
+constexpr int kHeads = 64;
+constexpr int kKvHeads = 1;
+constexpr int kQkDim = 576;
+constexpr int kVDim = 512;
+constexpr int kPageSize = 64;
+constexpr int kBytesPerToken = 656;
+constexpr int kTopk = 2048;
+constexpr int kSchedMetaInts = sizeof(DecodingSchedMeta) / sizeof(int);
+constexpr int kMaxSmParts = 160;
+constexpr int kBlockSizeTopk = 64;
+constexpr int kFixedOverheadBlocks = 5;
+constexpr float kLog2E = 1.4426950408889634f;
+
+CUresult map_cuda_error(cudaError_t err) {
+  if (err == cudaSuccess) return CUDA_SUCCESS;
+  if (err == cudaErrorInvalidValue || err == cudaErrorInvalidDevicePointer) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  if (err == cudaErrorMemoryAllocation) return CUDA_ERROR_OUT_OF_MEMORY;
+  if (err == cudaErrorNotSupported) return CUDA_ERROR_NOT_SUPPORTED;
+  return CUDA_ERROR_LAUNCH_FAILED;
+}
+
+CUresult consume_last_cuda_error() { return map_cuda_error(cudaGetLastError()); }
+
+template <typename Fn>
+CUresult run_flashmla_host(Fn&& fn) {
+  try {
+    fn();
+  } catch (const std::exception&) {
+    return CUDA_ERROR_INVALID_VALUE;
+  } catch (...) {
+    return CUDA_ERROR_LAUNCH_FAILED;
+  }
+  return consume_last_cuda_error();
+}
+
+CUresult current_sm90_num_sm_parts(int* num_sm_parts) {
+  if (num_sm_parts == nullptr) return CUDA_ERROR_INVALID_VALUE;
+
+  int device = 0;
+  cudaError_t err = cudaGetDevice(&device);
+  if (err != cudaSuccess) return map_cuda_error(err);
+
+  cudaDeviceProp prop{};
+  err = cudaGetDeviceProperties(&prop, device);
+  if (err != cudaSuccess) return map_cuda_error(err);
+  if (prop.major != 9 || prop.minor != 0) return CUDA_ERROR_NOT_SUPPORTED;
+
+  int parts = std::max(prop.multiProcessorCount / kSq / (kHeads / 64), 1);
+  if (parts > kMaxSmParts) return CUDA_ERROR_NOT_SUPPORTED;
+  *num_sm_parts = parts;
+  return CUDA_SUCCESS;
+}
+
+bool valid_common_shape(int batch_size, int num_blocks, int topk,
+                        int num_sm_parts) {
+  return batch_size > 0 && batch_size <= kBatchCapacity && num_blocks > 0 &&
+         topk == kTopk && num_sm_parts > 0 && num_sm_parts <= kMaxSmParts;
+}
+
+}  // namespace
+
+extern "C" CUresult glm52_flashmla_sparse_decode_num_sm_parts_cuda(
+    int* num_sm_parts) {
+  return current_sm90_num_sm_parts(num_sm_parts);
+}
+
+extern "C" CUresult glm52_flashmla_sparse_decode_metadata_cuda(
+    int* tile_scheduler_metadata, int* num_splits, int batch_size, int topk,
+    int num_sm_parts, cudaStream_t stream) {
+  if (tile_scheduler_metadata == nullptr || num_splits == nullptr ||
+      !valid_common_shape(batch_size, 1, topk, num_sm_parts)) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  GetDecodeSchedMetaParams params{
+      batch_size,
+      kSq,
+      kBlockSizeTopk,
+      kFixedOverheadBlocks,
+      topk,
+      0,
+      nullptr,
+      nullptr,
+      nullptr,
+      reinterpret_cast<DecodingSchedMeta*>(tile_scheduler_metadata),
+      num_splits,
+      num_sm_parts,
+      stream,
+  };
+  return run_flashmla_host(
+      [&] { smxx::decode::run_get_decoding_sched_meta_kernel(params); });
+}
+
+extern "C" CUresult glm52_flashmla_sparse_decode_launch_cuda(
+    const void* q, const void* packed_kv_cache, const int* topk_indices,
+    const int* tile_scheduler_metadata, const int* num_splits, void* out_latent,
+    float* lse, float* lse_accum, float* o_accum, int batch_size,
+    int num_blocks, int topk, int num_sm_parts, float sm_scale,
+    cudaStream_t stream) {
+  if (q == nullptr || packed_kv_cache == nullptr || topk_indices == nullptr ||
+      tile_scheduler_metadata == nullptr || num_splits == nullptr ||
+      out_latent == nullptr || lse == nullptr || lse_accum == nullptr ||
+      o_accum == nullptr ||
+      !valid_common_shape(batch_size, num_blocks, topk, num_sm_parts)) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  SparseAttnDecodeParams params{};
+  params.b = batch_size;
+  params.s_q = kSq;
+  params.h_q = kHeads;
+  params.h_kv = kKvHeads;
+  params.d_qk = kQkDim;
+  params.d_v = kVDim;
+  params.sm_scale = sm_scale;
+  params.sm_scale_div_log2 = sm_scale * kLog2E;
+  params.num_blocks = num_blocks;
+  params.page_block_size = kPageSize;
+  params.topk = topk;
+  params.model_type = ModelType::V32;
+
+  params.q = reinterpret_cast<cutlass::bfloat16_t*>(const_cast<void*>(q));
+  params.kv =
+      reinterpret_cast<cutlass::bfloat16_t*>(const_cast<void*>(packed_kv_cache));
+  params.indices = const_cast<int*>(topk_indices);
+  params.topk_length = nullptr;
+  params.attn_sink = nullptr;
+  params.lse = lse;
+  params.out = reinterpret_cast<cutlass::bfloat16_t*>(out_latent);
+
+  params.extra_num_blocks = 0;
+  params.extra_page_block_size = 0;
+  params.extra_topk = 0;
+  params.extra_kv = nullptr;
+  params.extra_indices = nullptr;
+  params.extra_topk_length = nullptr;
+
+  params.stride_q_b = kSq * kHeads * kQkDim;
+  params.stride_q_s_q = kHeads * kQkDim;
+  params.stride_q_h_q = kQkDim;
+  params.stride_kv_block = kPageSize * kBytesPerToken;
+  params.stride_kv_row = kBytesPerToken;
+  params.stride_indices_b = kSq * topk;
+  params.stride_indices_s_q = topk;
+  params.stride_lse_b = kSq * kHeads;
+  params.stride_lse_s_q = kHeads;
+  params.stride_o_b = kSq * kHeads * kVDim;
+  params.stride_o_s_q = kHeads * kVDim;
+  params.stride_o_h_q = kVDim;
+  params.stride_extra_kv_block = 0;
+  params.stride_extra_kv_row = 0;
+  params.stride_extra_indices_b = 0;
+  params.stride_extra_indices_s_q = 0;
+  params.stream = stream;
+
+  params.lse_accum = lse_accum;
+  params.o_accum = o_accum;
+  params.stride_lse_accum_split = kSq * kHeads;
+  params.stride_lse_accum_s_q = kHeads;
+  params.stride_o_accum_split = kSq * kHeads * kVDim;
+  params.stride_o_accum_s_q = kHeads * kVDim;
+  params.stride_o_accum_h_q = kVDim;
+  params.tile_scheduler_metadata_ptr =
+      reinterpret_cast<DecodingSchedMeta*>(const_cast<int*>(tile_scheduler_metadata));
+  params.num_splits_ptr = const_cast<int*>(num_splits);
+  params.num_sm_parts = num_sm_parts;
+
+  CUresult result = run_flashmla_host([&] {
+    sm90::decode::sparse_fp8::run_flash_splitkv_mla_fp8_sparse_kernel<
+        ModelType::V32, kHeads>(params);
+  });
+  if (result != CUDA_SUCCESS) return result;
+
+  CombineParams combine_params{};
+  combine_params.b = batch_size;
+  combine_params.s_q = kSq;
+  combine_params.h_q = kHeads;
+  combine_params.d_v = kVDim;
+  combine_params.lse = lse;
+  combine_params.out = out_latent;
+  combine_params.stride_lse_b = params.stride_lse_b;
+  combine_params.stride_lse_s_q = params.stride_lse_s_q;
+  combine_params.stride_o_b = params.stride_o_b;
+  combine_params.stride_o_s_q = params.stride_o_s_q;
+  combine_params.stride_o_h_q = params.stride_o_h_q;
+  combine_params.lse_accum = lse_accum;
+  combine_params.o_accum = o_accum;
+  combine_params.stride_lse_accum_split = params.stride_lse_accum_split;
+  combine_params.stride_lse_accum_s_q = params.stride_lse_accum_s_q;
+  combine_params.stride_o_accum_split = params.stride_o_accum_split;
+  combine_params.stride_o_accum_s_q = params.stride_o_accum_s_q;
+  combine_params.stride_o_accum_h_q = params.stride_o_accum_h_q;
+  combine_params.tile_scheduler_metadata_ptr =
+      params.tile_scheduler_metadata_ptr;
+  combine_params.num_splits_ptr = params.num_splits_ptr;
+  combine_params.num_sm_parts = num_sm_parts;
+  combine_params.attn_sink = nullptr;
+  combine_params.stream = stream;
+
+  return run_flashmla_host([&] {
+    smxx::decode::run_flash_mla_combine_kernel<cutlass::bfloat16_t>(
+        combine_params);
+  });
+}

--- a/openinfer-kernels/src/ffi.rs
+++ b/openinfer-kernels/src/ffi.rs
@@ -4,21 +4,25 @@
 // Half type (16-bit float) - same layout as CUDA half. Shared ABI type used by all submodules.
 pub type Half = u16;
 
-#[cfg(feature = "kimi-k2")]
+#[cfg(feature = "moe")]
 mod deepep;
 mod deepseek;
 #[cfg(feature = "deepseek-v2-lite")]
 mod deepseek_v2_lite;
+#[cfg(feature = "glm52")]
+mod glm52;
 #[cfg(feature = "kimi-k2")]
 mod kimi;
 mod lora;
 mod qwen35;
 mod shared;
-#[cfg(feature = "kimi-k2")]
+#[cfg(feature = "moe")]
 pub use deepep::*;
 pub use deepseek::*;
 #[cfg(feature = "deepseek-v2-lite")]
 pub use deepseek_v2_lite::*;
+#[cfg(feature = "glm52")]
+pub use glm52::*;
 #[cfg(feature = "kimi-k2")]
 pub use kimi::*;
 pub use lora::*;

--- a/openinfer-kernels/src/ffi/glm52.rs
+++ b/openinfer-kernels/src/ffi/glm52.rs
@@ -1,0 +1,56 @@
+use super::Half;
+use cudarc::driver::sys::{CUresult, CUstream};
+
+mod flashmla_sparse;
+pub use flashmla_sparse::*;
+
+unsafe extern "C" {
+    pub fn glm52_deepgemm_mn_major_tma_aligned_f32_cuda(
+        input: *const f32,
+        output: *mut f32,
+        rows: i32,
+        scale_cols: i32,
+        aligned_rows: i32,
+        stream: CUstream,
+    ) -> CUresult;
+
+    pub fn glm52_deepgemm_grouped_fp8_contract_cuda(
+        operand_kind: i32,
+        groups: i32,
+        m_capacity: i32,
+        n: i32,
+        k: i32,
+        weight_scale_rows: i32,
+        weight_scale_cols: i32,
+        activation_scale_cols: i32,
+        activation_scale_tma_rows: i32,
+        psum_entries: i32,
+        expert_alignment: i32,
+    ) -> CUresult;
+
+    pub fn glm52_deepgemm_grouped_fp8_metadata_cuda(
+        psum_expert: *const i32,
+        expert_offsets: *mut i64,
+        w13_problem_sizes: *mut i32,
+        w2_problem_sizes: *mut i32,
+        groups: i32,
+        m_capacity: i32,
+        expert_alignment: i32,
+        stream: CUstream,
+    ) -> CUresult;
+
+    pub fn glm52_deepgemm_grouped_fp8_launch_cuda(
+        operand_kind: i32,
+        a: *const u8,
+        a_scale: *const f32,
+        b: *const u8,
+        b_scale: *const f32,
+        psum_expert: *const i32,
+        out: *mut Half,
+        groups: i32,
+        m_capacity: i32,
+        n: i32,
+        k: i32,
+        stream: CUstream,
+    ) -> CUresult;
+}

--- a/openinfer-kernels/src/ffi/glm52/flashmla_sparse.rs
+++ b/openinfer-kernels/src/ffi/glm52/flashmla_sparse.rs
@@ -1,0 +1,34 @@
+use cudarc::driver::sys::{CUresult, CUstream};
+
+use crate::ffi::Half;
+
+unsafe extern "C" {
+    pub fn glm52_flashmla_sparse_decode_num_sm_parts_cuda(num_sm_parts: *mut i32) -> CUresult;
+
+    pub fn glm52_flashmla_sparse_decode_metadata_cuda(
+        tile_scheduler_metadata: *mut i32,
+        num_splits: *mut i32,
+        batch_size: i32,
+        topk: i32,
+        num_sm_parts: i32,
+        stream: CUstream,
+    ) -> CUresult;
+
+    pub fn glm52_flashmla_sparse_decode_launch_cuda(
+        q: *const Half,
+        packed_kv_cache: *const u8,
+        topk_indices: *const i32,
+        tile_scheduler_metadata: *const i32,
+        num_splits: *const i32,
+        out_latent: *mut Half,
+        lse: *mut f32,
+        lse_accum: *mut f32,
+        o_accum: *mut f32,
+        batch_size: i32,
+        num_blocks: i32,
+        topk: i32,
+        num_sm_parts: i32,
+        sm_scale: f32,
+        stream: CUstream,
+    ) -> CUresult;
+}

--- a/openinfer-kernels/src/ops.rs
+++ b/openinfer-kernels/src/ops.rs
@@ -1,12 +1,14 @@
 //! GPU operations on device tensors.
 
 mod attention;
-#[cfg(feature = "kimi-k2")]
+#[cfg(feature = "moe")]
 mod deepep;
 #[cfg(feature = "deepseek-v2-lite")]
 mod deepseek_v2_lite;
 mod elementwise;
 mod embedding;
+#[cfg(feature = "glm52")]
+mod glm52;
 #[cfg(feature = "kimi-k2")]
 mod kimi_k2;
 mod linear;
@@ -20,7 +22,7 @@ pub use attention::{
     prefill_attention_paged_into, qk_norm_partial_rope_batched_decode_hd256_into,
     qk_norm_rope_batch_decode_into, single_prefill_nhd_noncausal_into,
 };
-#[cfg(feature = "kimi-k2")]
+#[cfg(feature = "moe")]
 pub use deepep::{
     DeepEp, DeepEpDispatchScratch, DeepEpPrefillCounts, deepep_info, deepep_unique_id,
 };
@@ -35,6 +37,8 @@ pub use elementwise::{
     silu_mul_batch, silu_mul_batch_into, silu_mul_fused_batch_into, write_vec_into,
 };
 pub use embedding::{embedding_batch, embedding_batch_vocab_shard, embedding_decode_into};
+#[cfg(feature = "glm52")]
+pub use glm52::*;
 #[cfg(feature = "kimi-k2")]
 pub use kimi_k2::*;
 pub use linear::{

--- a/openinfer-kernels/src/ops/glm52.rs
+++ b/openinfer-kernels/src/ops/glm52.rs
@@ -1,0 +1,7 @@
+mod deepgemm_grouped;
+mod deepgemm_layout;
+mod flashmla_sparse;
+
+pub use deepgemm_grouped::*;
+pub use deepgemm_layout::*;
+pub use flashmla_sparse::*;

--- a/openinfer-kernels/src/ops/glm52/deepgemm_grouped.rs
+++ b/openinfer-kernels/src/ops/glm52/deepgemm_grouped.rs
@@ -1,0 +1,263 @@
+use anyhow::{Result, anyhow, ensure};
+use cudarc::driver::{CudaSlice, DevicePtr, DevicePtrMut};
+use half::bf16;
+
+use crate::ffi;
+use crate::tensor::DeviceContext;
+
+pub const GLM52_DEEPGEMM_GROUPED_W13_KIND: i32 = 1;
+pub const GLM52_DEEPGEMM_GROUPED_W2_KIND: i32 = 2;
+/// Per-expert row alignment of the grouped layout (a fixed design constant; the
+/// group count and m_capacity are runtime — PP8 EP1 owns all 256 experts and
+/// bs=1 decode sizes m_capacity to top_k*alignment).
+pub const GLM52_DEEPGEMM_GROUPED_EXPERT_ALIGNMENT: usize = 64;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Glm52DeepGemmGroupedFp8Kind {
+    W13,
+    W2,
+}
+
+impl Glm52DeepGemmGroupedFp8Kind {
+    fn abi(self) -> i32 {
+        match self {
+            Self::W13 => GLM52_DEEPGEMM_GROUPED_W13_KIND,
+            Self::W2 => GLM52_DEEPGEMM_GROUPED_W2_KIND,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Glm52DeepGemmGroupedFp8Contract {
+    pub groups: usize,
+    pub m_capacity: usize,
+    pub n: usize,
+    pub k: usize,
+    pub weight_scale_rows: usize,
+    pub weight_scale_cols: usize,
+    pub activation_scale_cols: usize,
+    pub activation_scale_tma_rows: usize,
+    pub psum_entries: usize,
+    pub expert_alignment: usize,
+}
+
+impl Glm52DeepGemmGroupedFp8Contract {
+    pub fn validate(self, kind: Glm52DeepGemmGroupedFp8Kind) -> Result<()> {
+        ensure!(
+            self.groups > 0 && self.psum_entries == self.groups,
+            "GLM5.2 DeepGEMM grouped FP8 needs groups>0 with one psum entry per group, got groups={}, psum_entries={}",
+            self.groups,
+            self.psum_entries
+        );
+        ensure!(
+            self.m_capacity > 0 && self.activation_scale_tma_rows == self.m_capacity,
+            "GLM5.2 DeepGEMM grouped FP8 needs m_capacity>0 == activation scale rows, got m_capacity={}, activation_scale_tma_rows={}",
+            self.m_capacity,
+            self.activation_scale_tma_rows
+        );
+        ensure!(
+            self.expert_alignment == GLM52_DEEPGEMM_GROUPED_EXPERT_ALIGNMENT,
+            "GLM5.2 DeepGEMM grouped FP8 expert alignment must be {}, got {}",
+            GLM52_DEEPGEMM_GROUPED_EXPERT_ALIGNMENT,
+            self.expert_alignment
+        );
+        match kind {
+            Glm52DeepGemmGroupedFp8Kind::W13 => self.validate_w13(),
+            Glm52DeepGemmGroupedFp8Kind::W2 => self.validate_w2(),
+        }
+    }
+
+    fn validate_w13(self) -> Result<()> {
+        ensure!(
+            self.n == 4096
+                && self.k == 6144
+                && self.weight_scale_rows == 32
+                && self.weight_scale_cols == 48
+                && self.activation_scale_cols == 48,
+            "GLM5.2 DeepGEMM W13 contract drifted: {self:?}"
+        );
+        Ok(())
+    }
+
+    fn validate_w2(self) -> Result<()> {
+        ensure!(
+            self.n == 6144
+                && self.k == 2048
+                && self.weight_scale_rows == 48
+                && self.weight_scale_cols == 16
+                && self.activation_scale_cols == 16,
+            "GLM5.2 DeepGEMM W2 contract drifted: {self:?}"
+        );
+        Ok(())
+    }
+}
+
+pub fn glm52_deepgemm_grouped_fp8_contract_validate(
+    kind: Glm52DeepGemmGroupedFp8Kind,
+    contract: Glm52DeepGemmGroupedFp8Contract,
+) -> Result<()> {
+    contract.validate(kind)?;
+    let result = unsafe {
+        ffi::glm52_deepgemm_grouped_fp8_contract_cuda(
+            kind.abi(),
+            contract.groups as i32,
+            contract.m_capacity as i32,
+            contract.n as i32,
+            contract.k as i32,
+            contract.weight_scale_rows as i32,
+            contract.weight_scale_cols as i32,
+            contract.activation_scale_cols as i32,
+            contract.activation_scale_tma_rows as i32,
+            contract.psum_entries as i32,
+            contract.expert_alignment as i32,
+        )
+    };
+    result
+        .result()
+        .map_err(|err| anyhow!("GLM5.2 DeepGEMM grouped FP8 ABI contract check failed: {err}"))
+}
+
+pub fn glm52_deepgemm_grouped_fp8_metadata_launch(
+    ctx: &DeviceContext,
+    groups: usize,
+    m_capacity: usize,
+    psum_expert: &CudaSlice<i32>,
+    expert_offsets: &mut CudaSlice<i64>,
+    w13_problem_sizes: &mut CudaSlice<i32>,
+    w2_problem_sizes: &mut CudaSlice<i32>,
+) -> Result<()> {
+    ensure!(
+        groups > 0 && m_capacity > 0,
+        "GLM5.2 DeepGEMM grouped FP8 metadata needs groups>0 and m_capacity>0, got groups={groups}, m_capacity={m_capacity}"
+    );
+    ensure!(
+        psum_expert.len() >= groups
+            && expert_offsets.len() > groups
+            && w13_problem_sizes.len() >= groups * 3
+            && w2_problem_sizes.len() >= groups * 3,
+        "GLM5.2 DeepGEMM grouped FP8 metadata buffers too small for {groups} groups: psum={}, offsets={}, w13={}, w2={}",
+        psum_expert.len(),
+        expert_offsets.len(),
+        w13_problem_sizes.len(),
+        w2_problem_sizes.len()
+    );
+    let (psum_ptr, _psum_guard) = psum_expert.device_ptr(&ctx.stream);
+    let (offsets_ptr, _offsets_guard) = expert_offsets.device_ptr_mut(&ctx.stream);
+    let (w13_ptr, _w13_guard) = w13_problem_sizes.device_ptr_mut(&ctx.stream);
+    let (w2_ptr, _w2_guard) = w2_problem_sizes.device_ptr_mut(&ctx.stream);
+    let result = unsafe {
+        ffi::glm52_deepgemm_grouped_fp8_metadata_cuda(
+            psum_ptr as *const i32,
+            offsets_ptr as *mut i64,
+            w13_ptr as *mut i32,
+            w2_ptr as *mut i32,
+            groups as i32,
+            m_capacity as i32,
+            GLM52_DEEPGEMM_GROUPED_EXPERT_ALIGNMENT as i32,
+            ctx.stream.cu_stream(),
+        )
+    };
+    result
+        .result()
+        .map_err(|err| anyhow!("GLM5.2 DeepGEMM grouped FP8 metadata launch failed: {err}"))
+}
+
+pub fn glm52_deepgemm_grouped_fp8_launch(
+    ctx: &DeviceContext,
+    kind: Glm52DeepGemmGroupedFp8Kind,
+    contract: Glm52DeepGemmGroupedFp8Contract,
+    activation: &CudaSlice<u8>,
+    activation_scale_tma: &CudaSlice<f32>,
+    weight: &CudaSlice<u8>,
+    weight_scale: &CudaSlice<f32>,
+    psum_expert: &CudaSlice<i32>,
+    output: &mut CudaSlice<bf16>,
+) -> Result<()> {
+    validate_launch_buffers(
+        kind,
+        contract,
+        activation,
+        activation_scale_tma,
+        weight,
+        weight_scale,
+        psum_expert,
+        output,
+    )?;
+    let (activation_ptr, _activation_guard) = activation.device_ptr(&ctx.stream);
+    let (activation_scale_ptr, _activation_scale_guard) =
+        activation_scale_tma.device_ptr(&ctx.stream);
+    let (weight_ptr, _weight_guard) = weight.device_ptr(&ctx.stream);
+    let (weight_scale_ptr, _weight_scale_guard) = weight_scale.device_ptr(&ctx.stream);
+    let (psum_ptr, _psum_guard) = psum_expert.device_ptr(&ctx.stream);
+    let (output_ptr, _output_guard) = output.device_ptr_mut(&ctx.stream);
+    let result = unsafe {
+        ffi::glm52_deepgemm_grouped_fp8_launch_cuda(
+            kind.abi(),
+            activation_ptr as *const u8,
+            activation_scale_ptr as *const f32,
+            weight_ptr as *const u8,
+            weight_scale_ptr as *const f32,
+            psum_ptr as *const i32,
+            output_ptr as *mut ffi::Half,
+            contract.groups as i32,
+            contract.m_capacity as i32,
+            contract.n as i32,
+            contract.k as i32,
+            ctx.stream.cu_stream(),
+        )
+    };
+    result
+        .result()
+        .map_err(|err| anyhow!("GLM5.2 DeepGEMM grouped FP8 launch failed: {err}"))
+}
+
+fn validate_launch_buffers(
+    kind: Glm52DeepGemmGroupedFp8Kind,
+    contract: Glm52DeepGemmGroupedFp8Contract,
+    activation: &CudaSlice<u8>,
+    activation_scale_tma: &CudaSlice<f32>,
+    weight: &CudaSlice<u8>,
+    weight_scale: &CudaSlice<f32>,
+    psum_expert: &CudaSlice<i32>,
+    output: &CudaSlice<bf16>,
+) -> Result<()> {
+    contract.validate(kind)?;
+    let activation_len = contract.m_capacity * contract.k;
+    ensure!(
+        activation.len() >= activation_len,
+        "GLM5.2 DeepGEMM grouped FP8 activation buffer too small: have {}, need {activation_len}",
+        activation.len()
+    );
+    let activation_scale_len = contract.activation_scale_tma_rows * contract.activation_scale_cols;
+    ensure!(
+        activation_scale_tma.len() >= activation_scale_len,
+        "GLM5.2 DeepGEMM grouped FP8 activation scale buffer too small: have {}, need {activation_scale_len}",
+        activation_scale_tma.len()
+    );
+    let weight_len = contract.groups * contract.n * contract.k;
+    ensure!(
+        weight.len() >= weight_len,
+        "GLM5.2 DeepGEMM grouped FP8 weight buffer too small: have {}, need {weight_len}",
+        weight.len()
+    );
+    let weight_scale_len =
+        contract.groups * contract.weight_scale_rows * contract.weight_scale_cols;
+    ensure!(
+        weight_scale.len() >= weight_scale_len,
+        "GLM5.2 DeepGEMM grouped FP8 weight scale buffer too small: have {}, need {weight_scale_len}",
+        weight_scale.len()
+    );
+    ensure!(
+        psum_expert.len() >= contract.psum_entries,
+        "GLM5.2 DeepGEMM grouped FP8 psum_expert buffer too small: have {}, need {}",
+        psum_expert.len(),
+        contract.psum_entries
+    );
+    let output_len = contract.m_capacity * contract.n;
+    ensure!(
+        output.len() >= output_len,
+        "GLM5.2 DeepGEMM grouped FP8 output buffer too small: have {}, need {output_len}",
+        output.len()
+    );
+    Ok(())
+}

--- a/openinfer-kernels/src/ops/glm52/deepgemm_layout.rs
+++ b/openinfer-kernels/src/ops/glm52/deepgemm_layout.rs
@@ -1,0 +1,103 @@
+use anyhow::{Result, anyhow, ensure};
+use cudarc::driver::{CudaSlice, DevicePtr, DevicePtrMut};
+
+use crate::ffi;
+use crate::tensor::DeviceContext;
+
+pub const GLM52_DEEPGEMM_TMA_ALIGNMENT_BYTES: usize = 16;
+pub const GLM52_DEEPGEMM_F32_TMA_ROW_ALIGNMENT: usize =
+    GLM52_DEEPGEMM_TMA_ALIGNMENT_BYTES / std::mem::size_of::<f32>();
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Glm52DeepGemmScaleLayout {
+    pub rows: usize,
+    pub scale_cols: usize,
+    pub aligned_rows: usize,
+}
+
+impl Glm52DeepGemmScaleLayout {
+    pub fn f32(rows: usize, scale_cols: usize) -> Self {
+        Self {
+            rows,
+            scale_cols,
+            aligned_rows: glm52_deepgemm_tma_aligned_rows(rows),
+        }
+    }
+
+    pub fn output_len(self) -> Result<usize> {
+        self.validate()?;
+        Ok(self.aligned_rows * self.scale_cols)
+    }
+
+    pub fn input_len(self) -> Result<usize> {
+        self.validate()?;
+        Ok(self.rows * self.scale_cols)
+    }
+
+    pub fn validate(self) -> Result<()> {
+        ensure!(
+            self.rows > 0,
+            "GLM5.2 DeepGEMM scale layout rows must be positive"
+        );
+        ensure!(
+            self.scale_cols > 0,
+            "GLM5.2 DeepGEMM scale layout scale_cols must be positive"
+        );
+        let expected = glm52_deepgemm_tma_aligned_rows(self.rows);
+        ensure!(
+            self.aligned_rows == expected,
+            "GLM5.2 DeepGEMM scale layout aligned_rows must be {expected}, got {}",
+            self.aligned_rows
+        );
+        Ok(())
+    }
+}
+
+pub fn glm52_deepgemm_tma_aligned_rows(rows: usize) -> usize {
+    rows.div_ceil(GLM52_DEEPGEMM_F32_TMA_ROW_ALIGNMENT) * GLM52_DEEPGEMM_F32_TMA_ROW_ALIGNMENT
+}
+
+pub fn glm52_deepgemm_mn_major_tma_aligned_f32_launch(
+    ctx: &DeviceContext,
+    layout: Glm52DeepGemmScaleLayout,
+    input: &CudaSlice<f32>,
+    output: &mut CudaSlice<f32>,
+) -> Result<()> {
+    validate_scale_layout_buffers(layout, input, output)?;
+    let (input_ptr, _input_guard) = input.device_ptr(&ctx.stream);
+    let (output_ptr, _output_guard) = output.device_ptr_mut(&ctx.stream);
+    let result = unsafe {
+        ffi::glm52_deepgemm_mn_major_tma_aligned_f32_cuda(
+            input_ptr as *const f32,
+            output_ptr as *mut f32,
+            layout.rows as i32,
+            layout.scale_cols as i32,
+            layout.aligned_rows as i32,
+            ctx.stream.cu_stream(),
+        )
+    };
+    result
+        .result()
+        .map_err(|err| anyhow!("GLM5.2 DeepGEMM scale layout launch failed: {err}"))
+}
+
+fn validate_scale_layout_buffers(
+    layout: Glm52DeepGemmScaleLayout,
+    input: &CudaSlice<f32>,
+    output: &CudaSlice<f32>,
+) -> Result<()> {
+    layout.validate()?;
+    let input_len = layout.input_len()?;
+    ensure!(
+        input.len() >= input_len,
+        "GLM5.2 DeepGEMM scale layout input too small: have {}, need {input_len}",
+        input.len()
+    );
+    let output_len = layout.output_len()?;
+    ensure!(
+        output.len() >= output_len,
+        "GLM5.2 DeepGEMM scale layout output too small: have {}, need {output_len}",
+        output.len()
+    );
+    Ok(())
+}

--- a/openinfer-kernels/src/ops/glm52/flashmla_sparse.rs
+++ b/openinfer-kernels/src/ops/glm52/flashmla_sparse.rs
@@ -1,0 +1,285 @@
+use anyhow::{Result, anyhow, ensure};
+use cudarc::driver::{CudaSlice, DevicePtr, DevicePtrMut};
+use half::bf16;
+
+use crate::ffi;
+use crate::tensor::DeviceContext;
+
+pub const GLM52_FLASHMLA_SPARSE_BATCH_CAPACITY: usize = 128;
+pub const GLM52_FLASHMLA_SPARSE_HEADS: usize = 64;
+pub const GLM52_FLASHMLA_SPARSE_QK_HEAD_DIM: usize = 576;
+pub const GLM52_FLASHMLA_SPARSE_V_HEAD_DIM: usize = 512;
+pub const GLM52_FLASHMLA_SPARSE_PAGE_SIZE: usize = 64;
+pub const GLM52_FLASHMLA_SPARSE_BYTES_PER_TOKEN: usize = 656;
+pub const GLM52_FLASHMLA_SPARSE_TOPK: usize = 2048;
+pub const GLM52_FLASHMLA_SPARSE_SCHED_META_INTS: usize = 8;
+pub const GLM52_FLASHMLA_SPARSE_MAX_SM_PARTS: usize = 160;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Glm52FlashMlaSparseDecode {
+    pub batch_size: usize,
+    pub num_blocks: usize,
+    pub topk: usize,
+    pub num_sm_parts: usize,
+    pub sm_scale: f32,
+}
+
+impl Glm52FlashMlaSparseDecode {
+    pub fn validate(self) -> Result<()> {
+        ensure!(
+            (1..=GLM52_FLASHMLA_SPARSE_BATCH_CAPACITY).contains(&self.batch_size),
+            "GLM5.2 FlashMLA sparse decode batch_size {} out of 1..={}",
+            self.batch_size,
+            GLM52_FLASHMLA_SPARSE_BATCH_CAPACITY
+        );
+        ensure!(
+            self.num_blocks > 0,
+            "GLM5.2 FlashMLA sparse decode num_blocks must be positive"
+        );
+        ensure!(
+            self.topk == GLM52_FLASHMLA_SPARSE_TOPK,
+            "GLM5.2 FlashMLA sparse decode topk must be {}, got {}",
+            GLM52_FLASHMLA_SPARSE_TOPK,
+            self.topk
+        );
+        ensure!(
+            (1..=GLM52_FLASHMLA_SPARSE_MAX_SM_PARTS).contains(&self.num_sm_parts),
+            "GLM5.2 FlashMLA sparse decode num_sm_parts {} out of 1..={}",
+            self.num_sm_parts,
+            GLM52_FLASHMLA_SPARSE_MAX_SM_PARTS
+        );
+        ensure!(
+            self.sm_scale.is_finite() && self.sm_scale > 0.0,
+            "GLM5.2 FlashMLA sparse decode sm_scale must be finite and positive"
+        );
+        Ok(())
+    }
+
+    pub fn q_len(self) -> usize {
+        self.batch_size * GLM52_FLASHMLA_SPARSE_HEADS * GLM52_FLASHMLA_SPARSE_QK_HEAD_DIM
+    }
+
+    pub fn packed_kv_cache_len(self) -> usize {
+        self.num_blocks * GLM52_FLASHMLA_SPARSE_PAGE_SIZE * GLM52_FLASHMLA_SPARSE_BYTES_PER_TOKEN
+    }
+
+    pub fn topk_indices_len(self) -> usize {
+        self.batch_size * self.topk
+    }
+
+    pub fn tile_scheduler_metadata_len(self) -> usize {
+        self.num_sm_parts * GLM52_FLASHMLA_SPARSE_SCHED_META_INTS
+    }
+
+    pub fn num_splits_len(self) -> usize {
+        self.batch_size + 1
+    }
+
+    pub fn lse_len(self) -> usize {
+        self.batch_size * GLM52_FLASHMLA_SPARSE_HEADS
+    }
+
+    pub fn latent_len(self) -> usize {
+        self.batch_size * GLM52_FLASHMLA_SPARSE_HEADS * GLM52_FLASHMLA_SPARSE_V_HEAD_DIM
+    }
+
+    pub fn split_count(self) -> usize {
+        self.batch_size + self.num_sm_parts
+    }
+
+    pub fn lse_accum_len(self) -> usize {
+        self.split_count() * GLM52_FLASHMLA_SPARSE_HEADS
+    }
+
+    pub fn o_accum_len(self) -> usize {
+        self.split_count() * GLM52_FLASHMLA_SPARSE_HEADS * GLM52_FLASHMLA_SPARSE_V_HEAD_DIM
+    }
+}
+
+pub fn glm52_flashmla_sparse_decode_num_sm_parts() -> Result<usize> {
+    let mut num_sm_parts = 0i32;
+    let result = unsafe { ffi::glm52_flashmla_sparse_decode_num_sm_parts_cuda(&mut num_sm_parts) };
+    result
+        .result()
+        .map_err(|err| anyhow!("GLM5.2 FlashMLA sparse num_sm_parts query failed: {err}"))?;
+    ensure!(
+        (1..=GLM52_FLASHMLA_SPARSE_MAX_SM_PARTS).contains(&(num_sm_parts as usize)),
+        "GLM5.2 FlashMLA sparse num_sm_parts query returned {num_sm_parts}; supported range is 1..={}",
+        GLM52_FLASHMLA_SPARSE_MAX_SM_PARTS
+    );
+    Ok(num_sm_parts as usize)
+}
+
+pub fn glm52_flashmla_sparse_decode_metadata_launch(
+    ctx: &DeviceContext,
+    batch_size: usize,
+    num_sm_parts: usize,
+    tile_scheduler_metadata: &mut CudaSlice<i32>,
+    num_splits: &mut CudaSlice<i32>,
+) -> Result<()> {
+    let contract = Glm52FlashMlaSparseDecode {
+        batch_size,
+        num_blocks: 1,
+        topk: GLM52_FLASHMLA_SPARSE_TOPK,
+        num_sm_parts,
+        sm_scale: 1.0,
+    };
+    contract.validate()?;
+    validate_metadata_buffers(contract, tile_scheduler_metadata, num_splits)?;
+
+    let (sched_ptr, _sched_guard) = tile_scheduler_metadata.device_ptr_mut(&ctx.stream);
+    let (splits_ptr, _splits_guard) = num_splits.device_ptr_mut(&ctx.stream);
+    let result = unsafe {
+        ffi::glm52_flashmla_sparse_decode_metadata_cuda(
+            sched_ptr as *mut i32,
+            splits_ptr as *mut i32,
+            batch_size as i32,
+            GLM52_FLASHMLA_SPARSE_TOPK as i32,
+            num_sm_parts as i32,
+            ctx.stream.cu_stream(),
+        )
+    };
+    result
+        .result()
+        .map_err(|err| anyhow!("GLM5.2 FlashMLA sparse metadata launch failed: {err}"))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn glm52_flashmla_sparse_decode_launch(
+    ctx: &DeviceContext,
+    contract: Glm52FlashMlaSparseDecode,
+    q: &CudaSlice<bf16>,
+    packed_kv_cache: &CudaSlice<u8>,
+    topk_indices: &CudaSlice<i32>,
+    tile_scheduler_metadata: &CudaSlice<i32>,
+    num_splits: &CudaSlice<i32>,
+    out_latent: &mut CudaSlice<bf16>,
+    lse: &mut CudaSlice<f32>,
+    lse_accum: &mut CudaSlice<f32>,
+    o_accum: &mut CudaSlice<f32>,
+) -> Result<()> {
+    validate_decode_buffers(
+        contract,
+        q,
+        packed_kv_cache,
+        topk_indices,
+        tile_scheduler_metadata,
+        num_splits,
+        out_latent,
+        lse,
+        lse_accum,
+        o_accum,
+    )?;
+
+    let (q_ptr, _q_guard) = q.device_ptr(&ctx.stream);
+    let (kv_ptr, _kv_guard) = packed_kv_cache.device_ptr(&ctx.stream);
+    let (indices_ptr, _indices_guard) = topk_indices.device_ptr(&ctx.stream);
+    let (sched_ptr, _sched_guard) = tile_scheduler_metadata.device_ptr(&ctx.stream);
+    let (splits_ptr, _splits_guard) = num_splits.device_ptr(&ctx.stream);
+    let (out_ptr, _out_guard) = out_latent.device_ptr_mut(&ctx.stream);
+    let (lse_ptr, _lse_guard) = lse.device_ptr_mut(&ctx.stream);
+    let (lse_accum_ptr, _lse_accum_guard) = lse_accum.device_ptr_mut(&ctx.stream);
+    let (o_accum_ptr, _o_accum_guard) = o_accum.device_ptr_mut(&ctx.stream);
+    let result = unsafe {
+        ffi::glm52_flashmla_sparse_decode_launch_cuda(
+            q_ptr as *const ffi::Half,
+            kv_ptr as *const u8,
+            indices_ptr as *const i32,
+            sched_ptr as *const i32,
+            splits_ptr as *const i32,
+            out_ptr as *mut ffi::Half,
+            lse_ptr as *mut f32,
+            lse_accum_ptr as *mut f32,
+            o_accum_ptr as *mut f32,
+            contract.batch_size as i32,
+            contract.num_blocks as i32,
+            contract.topk as i32,
+            contract.num_sm_parts as i32,
+            contract.sm_scale,
+            ctx.stream.cu_stream(),
+        )
+    };
+    result
+        .result()
+        .map_err(|err| anyhow!("GLM5.2 FlashMLA sparse decode launch failed: {err}"))
+}
+
+fn validate_metadata_buffers(
+    contract: Glm52FlashMlaSparseDecode,
+    tile_scheduler_metadata: &CudaSlice<i32>,
+    num_splits: &CudaSlice<i32>,
+) -> Result<()> {
+    ensure!(
+        tile_scheduler_metadata.len() >= contract.tile_scheduler_metadata_len(),
+        "GLM5.2 FlashMLA sparse scheduler metadata too small: have {}, need {}",
+        tile_scheduler_metadata.len(),
+        contract.tile_scheduler_metadata_len()
+    );
+    ensure!(
+        num_splits.len() >= contract.num_splits_len(),
+        "GLM5.2 FlashMLA sparse num_splits too small: have {}, need {}",
+        num_splits.len(),
+        contract.num_splits_len()
+    );
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_decode_buffers(
+    contract: Glm52FlashMlaSparseDecode,
+    q: &CudaSlice<bf16>,
+    packed_kv_cache: &CudaSlice<u8>,
+    topk_indices: &CudaSlice<i32>,
+    tile_scheduler_metadata: &CudaSlice<i32>,
+    num_splits: &CudaSlice<i32>,
+    out_latent: &CudaSlice<bf16>,
+    lse: &CudaSlice<f32>,
+    lse_accum: &CudaSlice<f32>,
+    o_accum: &CudaSlice<f32>,
+) -> Result<()> {
+    contract.validate()?;
+    ensure!(
+        q.len() >= contract.q_len(),
+        "GLM5.2 FlashMLA sparse q too small: have {}, need {}",
+        q.len(),
+        contract.q_len()
+    );
+    ensure!(
+        packed_kv_cache.len() >= contract.packed_kv_cache_len(),
+        "GLM5.2 FlashMLA sparse packed kv cache too small: have {}, need {}",
+        packed_kv_cache.len(),
+        contract.packed_kv_cache_len()
+    );
+    ensure!(
+        topk_indices.len() >= contract.topk_indices_len(),
+        "GLM5.2 FlashMLA sparse topk_indices too small: have {}, need {}",
+        topk_indices.len(),
+        contract.topk_indices_len()
+    );
+    validate_metadata_buffers(contract, tile_scheduler_metadata, num_splits)?;
+    ensure!(
+        out_latent.len() >= contract.latent_len(),
+        "GLM5.2 FlashMLA sparse latent output too small: have {}, need {}",
+        out_latent.len(),
+        contract.latent_len()
+    );
+    ensure!(
+        lse.len() >= contract.lse_len(),
+        "GLM5.2 FlashMLA sparse lse too small: have {}, need {}",
+        lse.len(),
+        contract.lse_len()
+    );
+    ensure!(
+        lse_accum.len() >= contract.lse_accum_len(),
+        "GLM5.2 FlashMLA sparse lse_accum too small: have {}, need {}",
+        lse_accum.len(),
+        contract.lse_accum_len()
+    );
+    ensure!(
+        o_accum.len() >= contract.o_accum_len(),
+        "GLM5.2 FlashMLA sparse o_accum too small: have {}, need {}",
+        o_accum.len(),
+        contract.o_accum_len()
+    );
+    Ok(())
+}

--- a/openinfer-server/src/bin/bench_serving/main.rs
+++ b/openinfer-server/src/bin/bench_serving/main.rs
@@ -193,6 +193,11 @@ fn main() -> Result<()> {
                 openinfer_qwen3_4b::Qwen3OffloadOptions::disabled(),
                 false,
                 max_prefill_tokens,
+                openinfer_qwen3_4b::Qwen3MemoryOptions::default(),
+                openinfer_qwen3_4b::DecodeOverlap::Off,
+                false,
+                None,
+                false,
             )?;
             finish(handle, cli.cuda_graph)
         }


### PR DESCRIPTION
## Summary
- add DeepGEMM and FlashMLA as kernel submodules and introduce the shared `moe` feature for DeepEP/DeepGEMM/FlashMLA substrates
- add the narrow `glm52` kernel surface for DeepGEMM scale layout/grouped FP8 contracts and FlashMLA SM90 sparse decode wrappers
- update kernel docs and keep non-GLM52/router/indexer/PP/TRTLLM surfaces out until the model crate has stable callers
- align `bench_serving` with the current Qwen3 engine signature so the existing pre-commit clippy gate passes

## Verification
- `cargo fmt`
- `OPENINFER_CUDA_SM=90 cargo check -p openinfer-kernels --no-default-features`
- `OPENINFER_CUDA_SM=90 OPENINFER_NCCL_ROOT=/data/code/workspace-rustllm/ep-moe-demo/.venv/lib/python3.12/site-packages/nvidia/nccl cargo check -p openinfer-kernels --no-default-features --features moe`
- `OPENINFER_CUDA_SM=90 OPENINFER_NCCL_ROOT=/data/code/workspace-rustllm/ep-moe-demo/.venv/lib/python3.12/site-packages/nvidia/nccl cargo check -p openinfer-kernels --no-default-features --features glm52`
- `OPENINFER_CUDA_SM=90 OPENINFER_NCCL_ROOT=/data/code/workspace-rustllm/ep-moe-demo/.venv/lib/python3.12/site-packages/nvidia/nccl cargo check -p openinfer-kernels --no-default-features --features kimi-k2`
- `OPENINFER_CUDA_SM=90 cargo check --release -p openinfer-server --bin bench_serving`
- pre-commit hooks via `OPENINFER_CUDA_SM=90 OPENINFER_NCCL_ROOT=/data/code/workspace-rustllm/ep-moe-demo/.venv/lib/python3.12/site-packages/nvidia/nccl git commit ...`

## Notes
- GLM5.2 FlashMLA sparse decode is SM90-only, fixes V32 `topk=2048`, and intentionally does not expose dynamic `topk_length`.
- The grouped DeepGEMM compute entry is fail-closed with `CUDA_ERROR_NOT_SUPPORTED` until a real DeepGEMM runner is wired.
- Upstream FlashMLA `CHECK_CUDA` / `FLASH_ASSERT` paths can still terminate the process on internal CUDA/launch failures; this PR only converts C++ assertion exceptions at the FFI boundary into `CUresult`.
- No performance win is claimed; this is feature-gated substrate/API bring-up, so no A/B benchmark is attached.