### PR TITLE
fix(vllm-frontend): report real KV capacity for engines that publish it

### DIFF
--- a/openinfer-qwen35-4b/src/scheduler.rs
+++ b/openinfer-qwen35-4b/src/scheduler.rs
@@ -20,8 +20,8 @@ use crate::logprobs::snapshot_requested_logprobs;
 use crate::recurrent_state::RecurrentState;
 use crate::weights::Qwen35Model;
 use openinfer_core::engine::{
-    EngineHandle as SchedulerHandle, FinishReason, GenerateRequest as SchedulerRequest, TokenEvent,
-    TokenLogprob, TokenSink,
+    EngineHandle as SchedulerHandle, FinishReason, GenerateRequest as SchedulerRequest, KvCapacity,
+    TokenEvent, TokenLogprob, TokenSink,
 };
 use openinfer_core::kv_pool::KvState;
 use openinfer_core::sampler::SamplingParams;
@@ -85,10 +85,12 @@ pub fn start_with_capacity(
     );
     // Static instance cap for the vLLM bridge's max_model_len. Live admission
     // still uses the current page budget inside the scheduler loop.
+    let total_blocks = model.kv_pool().capacity_pages().saturating_sub(1);
+    let block_size = model.kv_pool().layout().page_size;
     let servable = servable_len(
         model.config().max_position_embeddings,
-        model.kv_pool().capacity_pages().saturating_sub(1),
-        model.kv_pool().layout().page_size,
+        total_blocks,
+        block_size,
     );
     let graph_state = model.create_batch_decode_graph_state_with_capacity(max_batch)?;
 
@@ -115,7 +117,14 @@ pub fn start_with_capacity(
         let _ = join_handle.join();
         return Err(err);
     }
-    Ok(SchedulerHandle::new_with_join_handle(submit_tx, join_handle).with_servable_len(servable))
+    Ok(
+        SchedulerHandle::new_with_join_handle(submit_tx, join_handle)
+            .with_servable_len(servable)
+            .with_kv_capacity(KvCapacity {
+                total_blocks,
+                block_size,
+            }),
+    )
 }
 
 fn servable_len(max_context: usize, max_pages: usize, page_size: usize) -> u32 {

--- a/openinfer-vllm-frontend/src/bridge.rs
+++ b/openinfer-vllm-frontend/src/bridge.rs
@@ -59,29 +59,37 @@ impl LocalEngineBridge {
         })?;
 
         let kv_capacity = self.handle.kv_capacity();
+        let (num_gpu_blocks, block_size, kv_cache_size_tokens, kv_cache_max_concurrency) =
+            match kv_capacity {
+                Some(c) => {
+                    // vLLM single-group concurrency: blocks / ceil(max_len / block_size).
+                    let blocks_per_req =
+                        u64::from(self.max_model_len).div_ceil(c.block_size as u64);
+                    (
+                        c.total_blocks as u64,
+                        c.block_size as u64,
+                        Some(c.total_tokens() as u64),
+                        Some(c.total_blocks as f64 / blocks_per_req as f64),
+                    )
+                }
+                None => (0, 16, None, None),
+            };
         let ready = EngineCoreReadyResponse {
             max_model_len: u64::from(self.max_model_len),
-            num_gpu_blocks: kv_capacity.map_or(0, |c| c.total_blocks as u64),
-            block_size: kv_capacity.map_or(16, |c| c.block_size as u64),
+            num_gpu_blocks,
+            block_size,
             dp_stats_address: None,
             dtype: ModelDtype::BFloat16,
             vllm_version: "openinfer-local-bridge".to_string(),
             world_size: 1,
             data_parallel_size: 1,
-            kv_cache_size_tokens: kv_capacity.map(|c| c.total_tokens() as u64),
-            // vLLM single-group concurrency: blocks / ceil(max_len / block_size).
-            kv_cache_max_concurrency: kv_capacity.map(|c| {
-                let blocks_per_req = u64::from(self.max_model_len).div_ceil(c.block_size as u64);
-                c.total_blocks as f64 / blocks_per_req as f64
-            }),
+            kv_cache_size_tokens,
+            kv_cache_max_concurrency,
         };
         info!(
-            "local engine KV capacity: {kv_capacity:?} -> num_gpu_blocks={} \
-             block_size={} kv_cache_size_tokens={:?} kv_cache_max_concurrency={:?}",
-            ready.num_gpu_blocks,
-            ready.block_size,
-            ready.kv_cache_size_tokens,
-            ready.kv_cache_max_concurrency
+            "local engine KV capacity: {kv_capacity:?} -> \
+             kv_cache_size_tokens={kv_cache_size_tokens:?} \
+             kv_cache_max_concurrency={kv_cache_max_concurrency:?}"
         );
         input
             .send(ZmqMessage::from(encode_msgpack(&ready)?))

--- a/openinfer-vllm-frontend/src/bridge.rs
+++ b/openinfer-vllm-frontend/src/bridge.rs
@@ -58,21 +58,31 @@ impl LocalEngineBridge {
             )
         })?;
 
+        let kv_capacity = self.handle.kv_capacity();
         let ready = EngineCoreReadyResponse {
-            max_model_len: self.max_model_len as u64,
-            num_gpu_blocks: 0,
-            // TODO(#401): report the real paged-KV block size and capacity from the
-            // openinfer scheduler once the vLLM frontend consumes ready_response KV fields.
-            block_size: 16,
+            max_model_len: u64::from(self.max_model_len),
+            num_gpu_blocks: kv_capacity.map_or(0, |c| c.total_blocks as u64),
+            block_size: kv_capacity.map_or(16, |c| c.block_size as u64),
             dp_stats_address: None,
             dtype: ModelDtype::BFloat16,
             vllm_version: "openinfer-local-bridge".to_string(),
-            // The in-process bridge fronts a single engine instance.
             world_size: 1,
             data_parallel_size: 1,
-            kv_cache_size_tokens: None,
-            kv_cache_max_concurrency: None,
+            kv_cache_size_tokens: kv_capacity.map(|c| c.total_tokens() as u64),
+            // vLLM single-group concurrency: blocks / ceil(max_len / block_size).
+            kv_cache_max_concurrency: kv_capacity.map(|c| {
+                let blocks_per_req = u64::from(self.max_model_len).div_ceil(c.block_size as u64);
+                c.total_blocks as f64 / blocks_per_req as f64
+            }),
         };
+        info!(
+            "local engine KV capacity: {kv_capacity:?} -> num_gpu_blocks={} \
+             block_size={} kv_cache_size_tokens={:?} kv_cache_max_concurrency={:?}",
+            ready.num_gpu_blocks,
+            ready.block_size,
+            ready.kv_cache_size_tokens,
+            ready.kv_cache_max_concurrency
+        );
         input
             .send(ZmqMessage::from(encode_msgpack(&ready)?))
             .await


### PR DESCRIPTION
## Description

Refs #401

The vLLM bridge used hardcoded KV-capacity placeholders for every engine. Report real `EngineHandle::kv_capacity()` for the engines that publish it, and wire qwen35 to publish the same metadata qwen3 already does.

## After

- qwen3 and qwen35 advertise real usable KV capacity from `EngineHandle::kv_capacity()`: `num_gpu_blocks` / `kv_cache_size_tokens` are the usable count (pool minus the CUDA-graph padding page), `kv_cache_max_concurrency` is vLLM's `num_gpu_blocks / ceil(max_model_len / block_size)`. qwen35 wires `.with_kv_capacity()`, mirroring qwen3.
- Engines that do not publish `kv_capacity()` keep the previous ready-response placeholders (`0 / 16 / None / None`), unchanged by this PR.

## Tests

Single GPU (sm_89, x86_64), `local engine KV capacity` startup log:
- qwen3 `num_gpu_blocks=15376 block_size=16 kv_cache_size_tokens=246016 kv_cache_max_concurrency=6.00625`
- qwen35 `num_gpu_blocks=61980 block_size=16 kv_cache_size_tokens=991680 kv_cache_max_concurrency=3.782958984375`

`frontend_e2e` (CI gate) covers the bridge path.

## Follow-up

kimi-k2 appears to have a real pool but does not publish capacity metadata yet, so it keeps the placeholder. Tracked as a sub-issue of #221.