### PR TITLE
Add GLM5.2 DP1/EP8 load-weight slice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3813,6 +3813,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "openinfer-glm52"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytesize",
+ "crossbeam-channel",
+ "cudarc",
+ "log",
+ "memmap2",
+ "openinfer-core",
+ "safetensors",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "openinfer-kernels"
 version = "0.1.0"
 dependencies = [
@@ -3960,6 +3976,7 @@ dependencies = [
  "openinfer-core",
  "openinfer-deepseek-v2-lite",
  "openinfer-deepseek-v4",
+ "openinfer-glm52",
  "openinfer-kimi-k2",
  "openinfer-qwen3-4b",
  "openinfer-qwen35-4b",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "openinfer-build",
     "openinfer-deepseek-v4",
     "openinfer-deepseek-v2-lite",
+    "openinfer-glm52",
     "openinfer-kimi-k2",
     "openinfer-qwen3-4b",
     "openinfer-qwen35-4b",
@@ -141,6 +142,7 @@ openinfer-kv-cache = { path = "openinfer-kv-cache" }
 openinfer-kv-offload = { path = "openinfer-kv-offload" }
 openinfer-cupti = { path = "openinfer-cupti" }
 openinfer-deepseek-v4 = { path = "openinfer-deepseek-v4" }
+openinfer-glm52 = { path = "openinfer-glm52" }
 openinfer-engine = { path = "openinfer-engine" }
 openinfer-kernels = { path = "openinfer-kernels" }
 openinfer-kimi-k2 = { path = "openinfer-kimi-k2" }

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,6 +93,12 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 | `models/kimi-k2/source-layout.md` | Kimi-K2 source files over 1k lines were split by responsibility; the largest Rust file under `openinfer-kimi-k2/src` is now `layers/attention.rs` at 950 lines. |
 | `models/kimi-k2/dp-design.md` | TP×DP 可配置并行：每 DP rank 是独立 decode engine，EP all-to-all 天然 sync，轻量 load balancer 做 request 路由。首批 TP1×DP8 + TP8×DP1。 |
 
+## models / glm52
+
+| Path | TL;DR |
+| --- | --- |
+| `models/glm52/load-weights-dp1-ep8.md` | GLM5.2 load-weight-only slice from latest main: rank0 loads non-expert tensors plus experts 0..31, ranks1..7 load 32 routed experts each, optimized real-checkpoint load measured `63420ms` first run / `50803ms` repeat via rank-local slabs + coalesced H2D + CUDA-event mmap lifetime guard, and generation fails closed until forward lands. |
+
 ## subsystems / runtime
 
 | Path | TL;DR |

--- a/docs/models/glm52/load-weights-dp1-ep8.md
+++ b/docs/models/glm52/load-weights-dp1-ep8.md
@@ -1,0 +1,100 @@
+# GLM5.2 DP1 EP8 Weight Loading
+
+> **TL;DR:** This PR slice adds a load-weight-only GLM5.2 path from latest main: rank0 loads non-expert tensors plus experts 0..31, ranks1..7 load 32 routed experts each, optimized real-checkpoint load measured `63420ms` first run / `50803ms` immediate repeat with rank-local slabs, coalesced H2D ranges, and an explicit CUDA-event mmap lifetime guard; generation fails closed until forward lands.
+>
+> **Last touched:** 2026-06
+
+## Preparation
+
+- **Read**:
+  - `docs/index.md` - main has no GLM5.2 docs yet, so this needs a new model-line doc.
+  - `feat/glm52-pp8-decode:openinfer-glm52/src/weights/load.rs` - useful H2D/header-check pattern, but it also packs expert weights and builds decode state, which this slice excludes.
+  - `feat/glm52-pp8-decode:openinfer-glm52/src/lib.rs` and `src/runner.rs` - useful worker/coordinator shape, but the PP/decode/MTP runtime branches are out of scope.
+- **Relevant history**:
+  - No GLM5.2 history exists on latest main.
+  - Remote checkpoint inspection found official `GLM-5.2-FP8` has `model.layers.0..78`, where layer 78 is MTP. Official attention shapes are `q_b_proj [16384,2048]` and `kv_b_proj [28672,512]`, not the older bad Provider 4x shapes.
+- **Plan**:
+  1. Add a new `openinfer-glm52` crate with config probing, safetensors manifest coverage, rank-local tensor plans, and raw H2D tensor loading.
+  2. Add a load-only rank worker/coordinator that holds `CudaSlice` weights resident and returns `Rejected` for generation.
+  3. Wire `openinfer-server --features glm52` detection and launch without adding kernel, DeepEP, DeepGEMM, TRTLLM, PP, or decode modules.
+  4. Add an ignored real-checkpoint test using `OPENINFER_TEST_MODEL_PATH` or `models/GLM-5.2-FP8` load plus fail-closed request behavior.
+  5. Verify formatting and compile/test the GLM52 feature path.
+- **Risks / open questions**:
+  - The ignored checkpoint test needs 8 visible GPUs and the full model path.
+  - This slice proves residency and manifest coverage only; it intentionally makes no decode correctness or performance claim.
+
+## Execution Log
+
+### Load-Weight Crate
+
+- Added `openinfer-glm52` with:
+  - config validation for GLM5.2 FP8 constants and MTP config markers;
+  - exact manifest coverage over checkpoint tensors;
+  - DP1/EP8 rank plans: rank0 non-expert tensors plus experts 0..31, ranks1..7 experts 32..255 in 32-expert chunks;
+  - header dtype/shape validation and coalesced `memcpy_htod` loading into rank-local slabs.
+
+### Server Wiring
+
+- Added workspace member and optional `openinfer-server` feature `glm52`.
+- Added `model_type=glm_moe_dsa` detection.
+- Added `openinfer_glm52::launch` dispatch with `--dp-size` defaulting to DP1 for GLM52, while explicit non-1 values fail validation.
+- Added an explicit `bench_serving` rejection because this branch has no forward path.
+
+### Rebase and Real-Checkpoint Load
+
+- Fetched `origin/main` on 2026-06-30; `feat/glm52-load-weights-dp1-ep8`, `origin/main`, and local `main` all point at `1c71fee26adf9fd3a7c79855f1cc6b4238bbddc2`.
+- `git rebase origin/main` was a no-op: current branch is already up to date.
+- Validated the load-only command shape:
+
+```bash
+cargo run --release -p openinfer-glm52 --bin glm52_load_weights -- --model-path models/GLM-5.2-FP8 --tp-size 1 --dp-size 1
+```
+
+- Real-checkpoint load on an 8x H200 validation host completed with:
+  - rank worker spawn: `3.68s`
+  - rank weight H2D load: `76.82s`
+  - total command elapsed: `81622ms`
+  - resident bytes: rank0 `105.1 GiB`, ranks1..7 `85.5 GiB` each
+
+### Load-Time Optimization
+
+- The original path gave every safetensors tensor its own `CudaSlice<u8>` and issued one H2D copy per tensor. That is a poor fit for GLM5.2 because each rank loads `14.6k-16.5k` tensors.
+- Changed each rank to allocate one resident GPU slab sized from the validated tensor contracts, then store tensor metadata as `name -> {offset, bytes}`.
+- Within each safetensors shard, tensors are loaded in source byte order and adjacent source ranges are coalesced into one H2D copy. This keeps load-only scope: no decode kernels, no DeepEP/DeepGEMM/FlashMLA, no runtime layout packing.
+- Added an explicit source-mmap lifetime guard: after each shard's async coalesced H2D copies, the loader records a CUDA event and keeps that shard mapping alive until the event completes. A one-shard event group was retained because larger groups kept too many mappings live and regressed the tail. The guard also synchronizes before dropping mappings on error paths.
+- Real-checkpoint A/B on the same 8x H200 validation host:
+
+| Version | Rank load cost | Command elapsed | Notes |
+| --- | ---: | ---: | --- |
+| per-tensor `CudaSlice` + per-tensor H2D | `76.82s` | `81622ms` | baseline |
+| rank-local slab + coalesced H2D, no explicit mmap guard | `46.13s` | `51221ms` | diagnostic only; rejected because async copies could outlive the mapping |
+| keep all shard mappings live until rank sync | `87.70s` | `91100ms` | rejected; mapping lifetime safe but slower than baseline |
+| sync every 16-shard window | `74.08s` | `78770ms` | rejected; lifetime safe but barely below baseline |
+| synchronous `cuMemcpyHtoD_v2` copies | `70.96s` | `75585ms` | rejected; safe but leaves too much copy overhead |
+| 16-shard event groups, 4 live groups | `79.31s` | `82585ms` | rejected; large mapping groups caused tail regression |
+| rank-local slab + coalesced H2D + one-shard CUDA event guard, first RAII run | `58.75s` | `63420ms` | retained implementation; explicit error-path mmap cleanup |
+| rank-local slab + coalesced H2D + one-shard CUDA event guard, immediate repeat | `46.04s` | `50803ms` | retained implementation; page cache warm repeat |
+
+- Retained-run profile:
+  - first RAII run: rank0 `58.75s`, ranks1..7 `36.08-53.07s`, command `63420ms`
+  - immediate repeat: rank0 `44.33s`, ranks1..7 `35.64-46.04s`, command `50803ms`
+  - rank0 loads `105.1 GiB`, `16485` tensors, `3581` H2D copies
+  - ranks1..7 each load `85.5 GiB`, `14592` tensors, `638-644` H2D copies
+
+## Debrief
+
+- **Outcome**: The branch is rebased on latest `main` and contains a load-weight-only GLM5.2 slice: config/manifest validation, DP1/EP8 rank load plans, coalesced H2D loading into rank-local slabs, server feature detection, and fail-closed generation behavior.
+- **Pitfalls encountered**:
+  - The first draft used the wrong DP wording in file names and tests. It is now consistently `DP1/EP8`; `--dp-size` must be `1`, while EP8 is modeled as GLM52 rank-local expert slicing.
+  - The first ignored checkpoint test exposed a local machine path and duplicated logging setup. It now uses `OPENINFER_TEST_MODEL_PATH` or `models/GLM-5.2-FP8`, and uses `openinfer_core::logging::init_default()`.
+  - The first slab/coalescing optimization relied on implicit async H2D/pageable staging behavior. The retained path makes the source-mmap lifetime explicit with CUDA events before releasing mappings, including early-return cleanup.
+- **Verification**:
+  - `cargo fmt --all --check`
+  - `git diff --check`
+  - `cargo check -p openinfer-glm52`
+  - `cargo check -p openinfer-server --features glm52`
+  - `cargo check -p openinfer-server --no-default-features --features glm52`
+  - `cargo test -p openinfer-glm52 --lib`
+  - `cargo test -p openinfer-server --no-default-features --features glm52 glm52_`
+  - real-checkpoint load-only binary completed with `GLM5.2 load weights complete: elapsed_ms=63420`
+  - immediate repeat completed with `GLM5.2 load weights complete: elapsed_ms=50803`

--- a/openinfer-glm52/Cargo.toml
+++ b/openinfer-glm52/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "openinfer-glm52"
+license = "Apache-2.0"
+version = "0.1.0"
+edition = "2024"
+autobenches = false
+autobins = false
+
+[[bin]]
+name = "glm52_load_weights"
+path = "src/bin/glm52_load_weights.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+bytesize = { workspace = true }
+crossbeam-channel = { workspace = true }
+cudarc = { workspace = true }
+log = { workspace = true }
+memmap2 = { workspace = true }
+openinfer-core = { workspace = true }
+safetensors = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/openinfer-glm52/src/bin/glm52_load_weights.rs
+++ b/openinfer-glm52/src/bin/glm52_load_weights.rs
@@ -1,0 +1,102 @@
+use std::{path::PathBuf, time::Instant};
+
+use anyhow::{Context, Result, bail};
+use openinfer_glm52::{Glm52LaunchOptions, launch};
+
+const DEFAULT_MODEL_PATH: &str = "models/GLM-5.2-FP8";
+
+#[derive(Debug)]
+struct Args {
+    model_path: PathBuf,
+    tp_size: usize,
+    dp_size: usize,
+}
+
+impl Default for Args {
+    fn default() -> Self {
+        Self {
+            model_path: PathBuf::from(DEFAULT_MODEL_PATH),
+            tp_size: 1,
+            dp_size: 1,
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    openinfer_core::logging::init_default();
+    let args = parse_args(std::env::args().skip(1))?;
+    let started = Instant::now();
+    let handle = launch(
+        &args.model_path,
+        Glm52LaunchOptions {
+            tp_size: args.tp_size,
+            dp_size: args.dp_size,
+        },
+    )
+    .with_context(|| {
+        format!(
+            "failed to load GLM5.2 weights from {}",
+            args.model_path.display()
+        )
+    })?;
+    drop(handle);
+    let elapsed_ms = started.elapsed().as_millis();
+    log::info!(
+        "GLM5.2 load-weight command complete: model_path={}, elapsed_ms={elapsed_ms}",
+        args.model_path.display()
+    );
+    println!("GLM5.2 load weights complete: elapsed_ms={elapsed_ms}");
+    Ok(())
+}
+
+fn parse_args(mut args: impl Iterator<Item = String>) -> Result<Args> {
+    let mut parsed = Args::default();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--model-path" => {
+                parsed.model_path = PathBuf::from(next_value(&mut args, "--model-path")?);
+            }
+            "--tp-size" => {
+                parsed.tp_size = parse_usize(&next_value(&mut args, "--tp-size")?, "--tp-size")?;
+            }
+            "--dp-size" => {
+                parsed.dp_size = parse_usize(&next_value(&mut args, "--dp-size")?, "--dp-size")?;
+            }
+            "--help" | "-h" => {
+                println!(
+                    "Usage: cargo run --release -p openinfer-glm52 --bin glm52_load_weights -- [--model-path PATH] [--tp-size 1] [--dp-size 1]"
+                );
+                std::process::exit(0);
+            }
+            _ if arg.starts_with("--model-path=") => {
+                parsed.model_path = PathBuf::from(value_after_equals(&arg, "--model-path")?);
+            }
+            _ if arg.starts_with("--tp-size=") => {
+                parsed.tp_size = parse_usize(value_after_equals(&arg, "--tp-size")?, "--tp-size")?;
+            }
+            _ if arg.starts_with("--dp-size=") => {
+                parsed.dp_size = parse_usize(value_after_equals(&arg, "--dp-size")?, "--dp-size")?;
+            }
+            _ => bail!("unknown argument {arg}"),
+        }
+    }
+    Ok(parsed)
+}
+
+fn next_value(args: &mut impl Iterator<Item = String>, flag: &str) -> Result<String> {
+    args.next()
+        .with_context(|| format!("{flag} requires a value"))
+}
+
+fn value_after_equals<'a>(arg: &'a str, flag: &str) -> Result<&'a str> {
+    arg.strip_prefix(flag)
+        .and_then(|rest| rest.strip_prefix('='))
+        .filter(|value| !value.is_empty())
+        .with_context(|| format!("{flag} requires a non-empty value"))
+}
+
+fn parse_usize(value: &str, flag: &str) -> Result<usize> {
+    value
+        .parse::<usize>()
+        .with_context(|| format!("invalid {flag}: {value}"))
+}

--- a/openinfer-glm52/src/config.rs
+++ b/openinfer-glm52/src/config.rs
@@ -1,0 +1,279 @@
+//! GLM5.2 constants and config probing.
+
+use anyhow::{Context, Result, bail, ensure};
+use serde_json::Value;
+
+pub const GLM52_HIDDEN: usize = 6144;
+pub const GLM52_VOCAB: usize = 154_880;
+pub const GLM52_LAYERS: usize = 78;
+pub const GLM52_DENSE_LAYERS: usize = 3;
+pub const GLM52_MOE_LAYERS: usize = GLM52_LAYERS - GLM52_DENSE_LAYERS;
+const GLM52_MAX_CONTEXT: usize = 1_048_576;
+
+pub(crate) const GLM52_HEADS: usize = 64;
+const GLM52_KV_HEADS: usize = 64;
+const GLM52_HEAD_DIM: usize = 192;
+pub(crate) const GLM52_Q_LORA_RANK: usize = 2048;
+pub(crate) const GLM52_KV_LORA_RANK: usize = 512;
+pub(crate) const GLM52_QK_NOPE_HEAD_DIM: usize = 192;
+pub(crate) const GLM52_QK_ROPE_HEAD_DIM: usize = 64;
+pub(crate) const GLM52_QK_HEAD_DIM: usize = GLM52_QK_NOPE_HEAD_DIM + GLM52_QK_ROPE_HEAD_DIM;
+pub(crate) const GLM52_V_HEAD_DIM: usize = 256;
+pub(crate) const GLM52_Q_B_OUT: usize = GLM52_HEADS * GLM52_QK_HEAD_DIM;
+pub(crate) const GLM52_KV_A_OUT: usize = GLM52_KV_LORA_RANK + GLM52_QK_ROPE_HEAD_DIM;
+pub(crate) const GLM52_KV_B_OUT: usize = GLM52_HEADS * (GLM52_QK_NOPE_HEAD_DIM + GLM52_V_HEAD_DIM);
+pub(crate) const GLM52_O_PROJ_IN: usize = GLM52_HEADS * GLM52_V_HEAD_DIM;
+
+pub(crate) const GLM52_DENSE_INTERMEDIATE: usize = 12_288;
+pub(crate) const GLM52_EXPERT_INTERMEDIATE: usize = 2048;
+pub const GLM52_ROUTED_EXPERTS: usize = 256;
+pub const GLM52_TOPK: usize = 8;
+const GLM52_SHARED_EXPERTS: usize = 1;
+const GLM52_ROUTED_SCALING_FACTOR: f64 = 2.5;
+const GLM52_RMS_NORM_EPS: f64 = 1.0e-5;
+
+pub const GLM52_INDEX_TOPK: usize = 2048;
+const GLM52_INDEX_TOPK_FREQ: usize = 4;
+pub(crate) const GLM52_INDEX_HEAD_DIM: usize = 128;
+pub(crate) const GLM52_INDEX_HEADS: usize = 32;
+const GLM52_INDEX_SKIP_TOPK_OFFSET: usize = 3;
+const GLM52_NEXTN_LAYERS: usize = 1;
+
+const GLM52_ROPE_THETA: f64 = 8_000_000.0;
+
+pub fn probe_config_json(json: &Value) -> Result<()> {
+    let model_type = string_field(json, "model_type")?;
+    if model_type != "glm_moe_dsa" {
+        bail!("not a GLM5.2 config: model_type={model_type}");
+    }
+    ensure!(
+        string_array_field(json, "architectures")?
+            .iter()
+            .any(|value| value == "GlmMoeDsaForCausalLM"),
+        "GLM5.2 architectures must contain GlmMoeDsaForCausalLM"
+    );
+    ensure!(
+        string_field(json, "dtype")? == "bfloat16",
+        "GLM5.2 dtype must be bfloat16"
+    );
+    ensure!(
+        !bool_field(json, "attention_bias")?,
+        "GLM5.2 attention_bias must be false"
+    );
+    ensure!(
+        string_field(json, "hidden_act")? == "silu",
+        "GLM5.2 hidden_act must be silu"
+    );
+
+    ensure_eq_usize(json, "hidden_size", GLM52_HIDDEN)?;
+    ensure_eq_usize(json, "vocab_size", GLM52_VOCAB)?;
+    ensure_eq_usize(json, "num_hidden_layers", GLM52_LAYERS)?;
+    ensure_eq_usize(json, "first_k_dense_replace", GLM52_DENSE_LAYERS)?;
+    ensure_eq_usize(json, "max_position_embeddings", GLM52_MAX_CONTEXT)?;
+    ensure_eq_usize(json, "intermediate_size", GLM52_DENSE_INTERMEDIATE)?;
+    ensure_eq_usize(json, "moe_intermediate_size", GLM52_EXPERT_INTERMEDIATE)?;
+
+    ensure_eq_usize(json, "num_attention_heads", GLM52_HEADS)?;
+    ensure_eq_usize(json, "num_key_value_heads", GLM52_KV_HEADS)?;
+    ensure_eq_usize(json, "head_dim", GLM52_HEAD_DIM)?;
+    ensure_eq_usize(json, "q_lora_rank", GLM52_Q_LORA_RANK)?;
+    ensure_eq_usize(json, "kv_lora_rank", GLM52_KV_LORA_RANK)?;
+    ensure_eq_usize(json, "qk_nope_head_dim", GLM52_QK_NOPE_HEAD_DIM)?;
+    ensure_eq_usize(json, "qk_rope_head_dim", GLM52_QK_ROPE_HEAD_DIM)?;
+    ensure_eq_usize(json, "qk_head_dim", GLM52_QK_HEAD_DIM)?;
+    ensure_eq_usize(json, "v_head_dim", GLM52_V_HEAD_DIM)?;
+    ensure!(
+        bool_field(json, "rope_interleave")?,
+        "GLM5.2 rope_interleave must be true"
+    );
+    let rope = json
+        .get("rope_parameters")
+        .ok_or_else(|| anyhow::anyhow!("GLM5.2 config missing rope_parameters"))?;
+    ensure!(
+        string_field(rope, "rope_type")? == "default",
+        "GLM5.2 rope_parameters.rope_type must be default"
+    );
+    ensure_float_close(
+        number_field(rope, "rope_theta")?,
+        GLM52_ROPE_THETA,
+        1.0e-6,
+        "rope_parameters.rope_theta",
+    )?;
+
+    ensure_eq_usize(json, "n_routed_experts", GLM52_ROUTED_EXPERTS)?;
+    ensure_eq_usize(json, "num_experts_per_tok", GLM52_TOPK)?;
+    ensure_eq_usize(json, "n_shared_experts", GLM52_SHARED_EXPERTS)?;
+    ensure_eq_usize(json, "n_group", 1)?;
+    ensure_eq_usize(json, "topk_group", 1)?;
+    ensure!(
+        string_field(json, "topk_method")? == "noaux_tc",
+        "GLM5.2 topk_method must be noaux_tc"
+    );
+    ensure!(
+        string_field(json, "scoring_func")? == "sigmoid",
+        "GLM5.2 scoring_func must be sigmoid"
+    );
+    ensure!(
+        bool_field(json, "norm_topk_prob")?,
+        "GLM5.2 norm_topk_prob must be true"
+    );
+    ensure_float_close(
+        number_field(json, "routed_scaling_factor")?,
+        GLM52_ROUTED_SCALING_FACTOR,
+        1.0e-12,
+        "routed_scaling_factor",
+    )?;
+    ensure_float_close(
+        number_field(json, "rms_norm_eps")?,
+        GLM52_RMS_NORM_EPS,
+        1.0e-12,
+        "rms_norm_eps",
+    )?;
+
+    ensure_eq_usize(json, "index_topk", GLM52_INDEX_TOPK)?;
+    ensure_eq_usize(json, "index_topk_freq", GLM52_INDEX_TOPK_FREQ)?;
+    ensure_eq_usize(json, "index_head_dim", GLM52_INDEX_HEAD_DIM)?;
+    ensure_eq_usize(json, "index_n_heads", GLM52_INDEX_HEADS)?;
+    ensure_eq_usize(json, "index_skip_topk_offset", GLM52_INDEX_SKIP_TOPK_OFFSET)?;
+    ensure!(
+        bool_field(json, "indexer_rope_interleave")?,
+        "GLM5.2 indexer_rope_interleave must be true"
+    );
+
+    ensure_eq_usize(json, "num_nextn_predict_layers", GLM52_NEXTN_LAYERS)?;
+    ensure!(
+        bool_field(json, "index_share_for_mtp_iteration")?,
+        "GLM5.2 index_share_for_mtp_iteration must be true"
+    );
+    ensure!(
+        !bool_field(json, "tie_word_embeddings")?,
+        "GLM5.2 tie_word_embeddings must be false"
+    );
+    ensure_mlp_layer_types(json)?;
+    ensure_indexer_types(json)?;
+    ensure_fp8_quantization(json)?;
+
+    Ok(())
+}
+
+fn ensure_mlp_layer_types(json: &Value) -> Result<()> {
+    let types = string_array_field(json, "mlp_layer_types")?;
+    ensure!(
+        types.len() == GLM52_LAYERS,
+        "GLM5.2 mlp_layer_types length mismatch: got {}, expected {GLM52_LAYERS}",
+        types.len()
+    );
+    for (idx, kind) in types.iter().enumerate() {
+        let expected = if idx < GLM52_DENSE_LAYERS {
+            "dense"
+        } else {
+            "sparse"
+        };
+        ensure!(
+            kind == expected,
+            "GLM5.2 mlp_layer_types[{idx}] mismatch: got {kind}, expected {expected}"
+        );
+    }
+    Ok(())
+}
+
+fn ensure_indexer_types(json: &Value) -> Result<()> {
+    let types = string_array_field(json, "indexer_types")?;
+    ensure!(
+        types.len() == GLM52_LAYERS,
+        "GLM5.2 indexer_types length mismatch: got {}, expected {GLM52_LAYERS}",
+        types.len()
+    );
+    ensure!(
+        types.iter().all(|kind| kind == "full" || kind == "shared"),
+        "GLM5.2 indexer_types must contain only full/shared entries"
+    );
+    Ok(())
+}
+
+fn ensure_fp8_quantization(json: &Value) -> Result<()> {
+    let quant = json
+        .get("quantization_config")
+        .ok_or_else(|| anyhow::anyhow!("GLM5.2 config missing quantization_config"))?;
+    ensure!(
+        string_field(quant, "quant_method")? == "fp8",
+        "GLM5.2 quantization_config.quant_method must be fp8"
+    );
+    ensure!(
+        string_field(quant, "fmt")? == "e4m3",
+        "GLM5.2 quantization_config.fmt must be e4m3"
+    );
+    ensure!(
+        string_field(quant, "activation_scheme")? == "dynamic",
+        "GLM5.2 quantization_config.activation_scheme must be dynamic"
+    );
+    let block = quant
+        .get("weight_block_size")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("GLM5.2 quantization_config.weight_block_size missing"))?;
+    ensure!(
+        block.len() == 2 && block[0].as_u64() == Some(128) && block[1].as_u64() == Some(128),
+        "GLM5.2 weight_block_size must be [128, 128]"
+    );
+    Ok(())
+}
+
+fn string_field(json: &Value, key: &str) -> Result<String> {
+    json.get(key)
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow::anyhow!("missing string field {key}"))
+}
+
+fn string_array_field(json: &Value, key: &str) -> Result<Vec<String>> {
+    let values = json
+        .get(key)
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("missing string array field {key}"))?;
+    values
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .map(ToOwned::to_owned)
+                .ok_or_else(|| anyhow::anyhow!("field {key} contains a non-string entry"))
+        })
+        .collect()
+}
+
+fn usize_field(json: &Value, key: &str) -> Result<usize> {
+    let value = json
+        .get(key)
+        .and_then(Value::as_u64)
+        .ok_or_else(|| anyhow::anyhow!("missing unsigned integer field {key}"))?;
+    usize::try_from(value).with_context(|| format!("field {key} does not fit usize"))
+}
+
+fn bool_field(json: &Value, key: &str) -> Result<bool> {
+    json.get(key)
+        .and_then(Value::as_bool)
+        .ok_or_else(|| anyhow::anyhow!("missing bool field {key}"))
+}
+
+fn number_field(json: &Value, key: &str) -> Result<f64> {
+    json.get(key)
+        .and_then(Value::as_f64)
+        .ok_or_else(|| anyhow::anyhow!("missing numeric field {key}"))
+}
+
+fn ensure_eq_usize(json: &Value, key: &str, expected: usize) -> Result<()> {
+    let actual = usize_field(json, key)?;
+    ensure!(
+        actual == expected,
+        "{key} mismatch: got {actual}, expected {expected}"
+    );
+    Ok(())
+}
+
+fn ensure_float_close(actual: f64, expected: f64, tolerance: f64, label: &str) -> Result<()> {
+    ensure!(
+        (actual - expected).abs() <= tolerance,
+        "{label} mismatch: got {actual}, expected {expected}"
+    );
+    Ok(())
+}

--- a/openinfer-glm52/src/lib.rs
+++ b/openinfer-glm52/src/lib.rs
@@ -1,0 +1,233 @@
+//! GLM5.2 load-weight bring-up surface.
+//!
+//! This crate intentionally stops at startup weight residency. It validates the
+//! official GLM5.2 FP8 checkpoint layout, loads DP1/EP8 rank slices to GPU
+//! memory, and returns a fail-closed engine handle until forward is introduced.
+
+mod config;
+mod runner;
+mod weights;
+
+use std::{collections::BTreeSet, path::Path, time::Instant};
+
+use anyhow::{Result, ensure};
+use bytesize::ByteSize;
+use openinfer_core::engine::EngineHandle;
+use runner::{Glm52RankPlacement, Glm52RankWorker, run_rejecting_load_only_coordinator};
+use tokio::sync::mpsc;
+use weights::{GLM52_EP_RANKS, Glm52RankLoadBundle, Glm52WeightManifest};
+
+pub use config::{
+    GLM52_DENSE_LAYERS, GLM52_HIDDEN, GLM52_INDEX_TOPK, GLM52_LAYERS, GLM52_MOE_LAYERS,
+    GLM52_ROUTED_EXPERTS, GLM52_TOPK, GLM52_VOCAB, probe_config_json,
+};
+
+/// First GLM5.2 cut: TP1/DP1 plus eight EP ranks. Rank 0 is the only rank with
+/// non-expert weights; every rank owns 32 routed experts.
+#[derive(Clone, Debug)]
+pub struct Glm52LaunchOptions {
+    pub tp_size: usize,
+    pub dp_size: usize,
+}
+
+pub fn launch(model_path: &Path, options: Glm52LaunchOptions) -> Result<EngineHandle> {
+    ensure!(
+        options.tp_size == 1,
+        "GLM5.2 load-weight branch requires --tp-size=1, got {}",
+        options.tp_size
+    );
+    ensure!(
+        options.dp_size == 1,
+        "GLM5.2 load-weight branch requires --dp-size=1; EP8 is a separate expert-rank split, got {}",
+        options.dp_size
+    );
+    start_engine(
+        model_path,
+        Glm52LoadOptions {
+            device_ordinals: (0..GLM52_EP_RANKS).collect(),
+            tp_size: options.tp_size,
+            dp_size: options.dp_size,
+            ep_size: GLM52_EP_RANKS,
+        },
+    )
+}
+
+#[derive(Clone, Debug)]
+struct Glm52LoadOptions {
+    device_ordinals: Vec<usize>,
+    tp_size: usize,
+    dp_size: usize,
+    ep_size: usize,
+}
+
+#[derive(Debug)]
+struct StartupValidation {
+    device_ordinals: Vec<usize>,
+    rank_bundles: Vec<Glm52RankLoadBundle>,
+    rank_tensor_counts: Vec<usize>,
+    rank_expert_ranges: Vec<std::ops::Range<usize>>,
+}
+
+#[derive(Debug)]
+struct GpuWeightLoadReport {
+    rank_tensor_counts: Vec<usize>,
+    rank_bytes: Vec<usize>,
+}
+
+struct LoadedGlm52Runtime {
+    workers: Vec<Glm52RankWorker>,
+    report: GpuWeightLoadReport,
+}
+
+fn start_engine(model_path: &Path, options: Glm52LoadOptions) -> Result<EngineHandle> {
+    let startup = validate_startup(model_path, &options)?;
+    let loaded = load_rank_weights_to_gpu(model_path, &startup)?;
+    log::info!(
+        "GLM5.2 load-weight startup complete: ranks={}, rank_plan_tensors={:?}, rank_gpu_tensors={:?}, rank_gpu_bytes={:?}",
+        startup.device_ordinals.len(),
+        startup.rank_tensor_counts,
+        loaded.report.rank_tensor_counts,
+        format_bytes(&loaded.report.rank_bytes),
+    );
+
+    let (submit_tx, submit_rx) = mpsc::unbounded_channel();
+    let coord_handle = std::thread::Builder::new()
+        .name("glm52-load-coord".into())
+        .spawn(move || run_rejecting_load_only_coordinator(submit_rx, loaded.workers))
+        .map_err(|err| anyhow::anyhow!("failed to spawn GLM5.2 load-only coordinator: {err}"))?;
+    Ok(EngineHandle::new_with_join_handle(submit_tx, coord_handle))
+}
+
+fn validate_startup(model_path: &Path, options: &Glm52LoadOptions) -> Result<StartupValidation> {
+    let config_path = model_path.join("config.json");
+    let content = std::fs::read_to_string(&config_path)
+        .map_err(|err| anyhow::anyhow!("read {}: {err}", config_path.display()))?;
+    let json: serde_json::Value = serde_json::from_str(&content)
+        .map_err(|err| anyhow::anyhow!("parse {}: {err}", config_path.display()))?;
+    probe_config_json(&json)?;
+
+    ensure!(
+        options.device_ordinals.len() == GLM52_EP_RANKS,
+        "GLM5.2 EP8 load requires {GLM52_EP_RANKS} devices, got {:?}",
+        options.device_ordinals
+    );
+    ensure!(
+        options.tp_size == 1 && options.dp_size == 1 && options.ep_size == GLM52_EP_RANKS,
+        "GLM5.2 load-weight branch requires TP1/DP1/EP8, got TP{} DP{} EP{}",
+        options.tp_size,
+        options.dp_size,
+        options.ep_size
+    );
+    let unique_devices = options
+        .device_ordinals
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    ensure!(
+        unique_devices.len() == options.device_ordinals.len(),
+        "GLM5.2 device ordinals must be unique, got {:?}",
+        options.device_ordinals
+    );
+
+    let manifest = Glm52WeightManifest::from_model_dir(model_path)?;
+    let rank_bundles = manifest.all_rank_load_bundles()?;
+    let mut rank_tensor_counts = Vec::with_capacity(rank_bundles.len());
+    let mut rank_expert_ranges = Vec::with_capacity(rank_bundles.len());
+    for bundle in &rank_bundles {
+        rank_tensor_counts.push(bundle.plan.tensor_count);
+        rank_expert_ranges.push(bundle.plan.expert_range.clone());
+    }
+
+    log::info!(
+        "GLM5.2 load-weight startup validated: model_path={}, ranks={}, device_ordinals={:?}, logical_parallel=TP{} DP{} EP{}, rank_expert_ranges={:?}, rank_plan_tensors={:?}",
+        model_path.display(),
+        rank_bundles.len(),
+        options.device_ordinals,
+        options.tp_size,
+        options.dp_size,
+        options.ep_size,
+        rank_expert_ranges,
+        rank_tensor_counts,
+    );
+
+    Ok(StartupValidation {
+        device_ordinals: options.device_ordinals.clone(),
+        rank_bundles,
+        rank_tensor_counts,
+        rank_expert_ranges,
+    })
+}
+
+fn load_rank_weights_to_gpu(
+    model_path: &Path,
+    startup: &StartupValidation,
+) -> Result<LoadedGlm52Runtime> {
+    let spawn_started = Instant::now();
+    log::info!(
+        "start spawn GLM5.2 rank workers: ranks={}",
+        startup.rank_bundles.len()
+    );
+    let mut workers = Vec::with_capacity(startup.rank_bundles.len());
+    for (rank, bundle) in startup.rank_bundles.iter().enumerate() {
+        let placement = Glm52RankPlacement::new(rank, startup.device_ordinals[rank])?;
+        workers.push(Glm52RankWorker::spawn(placement, bundle.clone())?);
+    }
+    log::info!(
+        "spawn GLM5.2 rank workers cost {:.2}s: ranks={}",
+        spawn_started.elapsed().as_secs_f64(),
+        workers.len()
+    );
+
+    let load_started = Instant::now();
+    log::info!(
+        "start load GLM5.2 rank weights: ranks={}, rank_expert_ranges={:?}",
+        workers.len(),
+        startup.rank_expert_ranges,
+    );
+    let load_results = workers
+        .iter()
+        .map(|worker| worker.load_weights_async(model_path))
+        .collect::<Result<Vec<_>>>()?;
+    let mut reports = Vec::with_capacity(load_results.len());
+    for (rank, rx) in load_results.into_iter().enumerate() {
+        let report = rx
+            .recv()
+            .map_err(|_| anyhow::anyhow!("GLM5.2 rank {rank} worker dropped load response"))??;
+        ensure!(
+            report.rank == rank && report.loaded_to_gpu,
+            "GLM5.2 rank {rank} invalid weight-load report: {:?}",
+            report
+        );
+        reports.push(report);
+    }
+    let rank_tensor_counts = reports
+        .iter()
+        .map(|report| report.loaded_tensor_count)
+        .collect::<Vec<_>>();
+    let rank_bytes = reports
+        .iter()
+        .map(|report| report.loaded_total_bytes)
+        .collect::<Vec<_>>();
+    log::info!(
+        "GLM5.2 rank weight load cost {:.2}s: ranks={}, tensors={:?}, resident_bytes={:?}",
+        load_started.elapsed().as_secs_f64(),
+        reports.len(),
+        rank_tensor_counts,
+        format_bytes(&rank_bytes),
+    );
+
+    Ok(LoadedGlm52Runtime {
+        workers,
+        report: GpuWeightLoadReport {
+            rank_tensor_counts,
+            rank_bytes,
+        },
+    })
+}
+
+fn format_bytes(values: &[usize]) -> Vec<String> {
+    values
+        .iter()
+        .map(|&value| ByteSize(value as u64).to_string())
+        .collect()
+}

--- a/openinfer-glm52/src/runner.rs
+++ b/openinfer-glm52/src/runner.rs
@@ -1,0 +1,217 @@
+use std::{
+    path::{Path, PathBuf},
+    thread,
+};
+
+use anyhow::{Result, ensure};
+use crossbeam_channel::{Receiver, Sender, bounded, unbounded};
+use openinfer_core::engine::{GenerateRequest, TokenEvent, unix_now_s};
+use tokio::sync::mpsc;
+
+use crate::weights::{
+    GLM52_EP_RANKS, Glm52RankGpuContext, Glm52RankGpuWeights, Glm52RankLoadBundle,
+    load_rank_weights_to_gpu,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct Glm52RankPlacement {
+    pub(crate) rank: usize,
+    pub(crate) device_ordinal: usize,
+}
+
+impl Glm52RankPlacement {
+    pub(crate) fn new(rank: usize, device_ordinal: usize) -> Result<Self> {
+        ensure!(
+            rank < GLM52_EP_RANKS,
+            "GLM5.2 rank must be < {GLM52_EP_RANKS}, got {rank}"
+        );
+        Ok(Self {
+            rank,
+            device_ordinal,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Glm52RankWeightLoadReport {
+    pub(crate) rank: usize,
+    pub(crate) loaded_tensor_count: usize,
+    pub(crate) loaded_total_bytes: usize,
+    pub(crate) resident_raw_bytes: usize,
+    pub(crate) loaded_to_gpu: bool,
+}
+
+enum Glm52RankCommand {
+    LoadWeights {
+        model_path: PathBuf,
+        resp: Sender<Result<Glm52RankWeightLoadReport>>,
+    },
+    Shutdown,
+}
+
+pub(crate) struct Glm52RankWorker {
+    tx: Sender<Glm52RankCommand>,
+    handle: Option<thread::JoinHandle<()>>,
+}
+
+impl Glm52RankWorker {
+    pub(crate) fn spawn(
+        placement: Glm52RankPlacement,
+        bundle: Glm52RankLoadBundle,
+    ) -> Result<Self> {
+        ensure!(
+            bundle.plan.rank == placement.rank,
+            "GLM5.2 rank load plan {} does not match placement {}",
+            bundle.plan.rank,
+            placement.rank
+        );
+        let (tx, rx) = unbounded();
+        let (startup_tx, startup_rx) = bounded::<Result<()>>(1);
+        let handle = thread::Builder::new()
+            .name(format!("glm52-rank-{}", placement.rank))
+            .spawn(move || {
+                let ctx = match Glm52RankGpuContext::new(placement.device_ordinal) {
+                    Ok(ctx) => ctx,
+                    Err(err) => {
+                        let _ = startup_tx.send(Err(err));
+                        return;
+                    }
+                };
+                let _ = startup_tx.send(Ok(()));
+                rank_worker_loop(rx, Glm52RankThreadState::new(placement, ctx, bundle));
+            })
+            .map_err(|err| anyhow::anyhow!("failed to spawn GLM5.2 rank worker: {err}"))?;
+        startup_rx
+            .recv()
+            .map_err(|_| anyhow::anyhow!("GLM5.2 rank worker exited during startup"))??;
+        Ok(Self {
+            tx,
+            handle: Some(handle),
+        })
+    }
+
+    pub(crate) fn load_weights_async(
+        &self,
+        model_path: &Path,
+    ) -> Result<Receiver<Result<Glm52RankWeightLoadReport>>> {
+        let (resp_tx, resp_rx) = bounded(1);
+        self.tx
+            .send(Glm52RankCommand::LoadWeights {
+                model_path: model_path.to_path_buf(),
+                resp: resp_tx,
+            })
+            .map_err(|_| anyhow::anyhow!("GLM5.2 rank worker channel closed"))?;
+        Ok(resp_rx)
+    }
+
+    pub(crate) fn shutdown(&mut self) -> Result<()> {
+        self.request_shutdown()?;
+        self.join()
+    }
+
+    fn request_shutdown(&self) -> Result<()> {
+        self.tx
+            .send(Glm52RankCommand::Shutdown)
+            .map_err(|_| anyhow::anyhow!("GLM5.2 rank worker channel closed"))?;
+        Ok(())
+    }
+
+    fn join(&mut self) -> Result<()> {
+        let Some(handle) = self.handle.take() else {
+            return Ok(());
+        };
+        handle
+            .join()
+            .map_err(|_| anyhow::anyhow!("GLM5.2 rank worker panicked"))?;
+        Ok(())
+    }
+}
+
+impl Drop for Glm52RankWorker {
+    fn drop(&mut self) {
+        let _ = self.shutdown();
+    }
+}
+
+struct Glm52RankThreadState {
+    placement: Glm52RankPlacement,
+    ctx: Glm52RankGpuContext,
+    bundle: Glm52RankLoadBundle,
+    loaded: Option<Glm52RankLoadedState>,
+}
+
+#[allow(dead_code)]
+struct Glm52RankLoadedState {
+    weights: Glm52RankGpuWeights,
+}
+
+impl Glm52RankThreadState {
+    fn new(
+        placement: Glm52RankPlacement,
+        ctx: Glm52RankGpuContext,
+        bundle: Glm52RankLoadBundle,
+    ) -> Self {
+        Self {
+            placement,
+            ctx,
+            bundle,
+            loaded: None,
+        }
+    }
+
+    fn load_weights(&mut self, model_path: &Path) -> Result<Glm52RankWeightLoadReport> {
+        let loaded = load_rank_weights_to_gpu(&self.ctx, model_path, &self.bundle)?;
+        ensure!(
+            loaded.loaded_total_bytes == loaded.weights.total_bytes,
+            "GLM5.2 rank {} loaded bytes {} differ from resident raw bytes {}",
+            self.placement.rank,
+            loaded.loaded_total_bytes,
+            loaded.weights.total_bytes
+        );
+        let report = Glm52RankWeightLoadReport {
+            rank: self.placement.rank,
+            loaded_tensor_count: loaded.loaded_tensor_count,
+            loaded_total_bytes: loaded.loaded_total_bytes,
+            resident_raw_bytes: loaded.weights.total_bytes,
+            loaded_to_gpu: true,
+        };
+        self.loaded = Some(Glm52RankLoadedState {
+            weights: loaded.weights,
+        });
+        Ok(report)
+    }
+}
+
+fn rank_worker_loop(rx: Receiver<Glm52RankCommand>, mut state: Glm52RankThreadState) {
+    while let Ok(cmd) = rx.recv() {
+        match cmd {
+            Glm52RankCommand::LoadWeights { model_path, resp } => {
+                let _ = resp.send(state.load_weights(&model_path));
+            }
+            Glm52RankCommand::Shutdown => break,
+        }
+    }
+}
+
+pub(crate) fn run_rejecting_load_only_coordinator(
+    mut submit_rx: mpsc::UnboundedReceiver<GenerateRequest>,
+    workers: Vec<Glm52RankWorker>,
+) {
+    let _workers = workers;
+    while let Some(req) = submit_rx.blocking_recv() {
+        let prompt_tokens = req.prompt_tokens.len();
+        let queued_at_unix_s = req.queued_at_unix_s.unwrap_or_else(unix_now_s);
+        let scheduled_at_unix_s = unix_now_s();
+        let _ = req.token_tx.send(TokenEvent::Scheduled {
+            queued_at_unix_s,
+            scheduled_at_unix_s,
+            prompt_tokens,
+            cached_tokens: 0,
+        });
+        let _ = req.token_tx.send(TokenEvent::Rejected {
+            message: "GLM5.2 load-weight-only branch loaded resident GPU weights, but forward/decode is not implemented".to_owned(),
+            prompt_tokens,
+            completion_tokens: 0,
+        });
+    }
+}

--- a/openinfer-glm52/src/weights.rs
+++ b/openinfer-glm52/src/weights.rs
@@ -1,0 +1,490 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::Path,
+};
+
+use anyhow::{Context, Result, ensure};
+use memmap2::Mmap;
+use safetensors::Dtype;
+use serde_json::Value;
+
+use crate::config::{
+    GLM52_DENSE_INTERMEDIATE, GLM52_DENSE_LAYERS, GLM52_EXPERT_INTERMEDIATE, GLM52_HIDDEN,
+    GLM52_INDEX_HEAD_DIM, GLM52_INDEX_HEADS, GLM52_KV_A_OUT, GLM52_KV_B_OUT, GLM52_KV_LORA_RANK,
+    GLM52_LAYERS, GLM52_O_PROJ_IN, GLM52_Q_B_OUT, GLM52_Q_LORA_RANK, GLM52_ROUTED_EXPERTS,
+    GLM52_VOCAB,
+};
+
+mod context;
+mod load;
+
+pub(crate) use context::Glm52RankGpuContext;
+pub(crate) use load::{Glm52RankGpuWeights, load_rank_weights_to_gpu};
+
+const GLM52_WEIGHT_INDEX: &str = "model.safetensors.index.json";
+const GLM52_MTP_LAYER: usize = GLM52_LAYERS;
+pub(crate) const GLM52_EP_RANKS: usize = 8;
+pub(crate) const GLM52_LOCAL_EXPERTS: usize = GLM52_ROUTED_EXPERTS / GLM52_EP_RANKS;
+const FP8_BLOCK_SIZE: usize = 128;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Glm52TensorLoadSpec {
+    pub(crate) name: String,
+    pub(crate) shard: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Glm52ShardLoadPlan {
+    pub(crate) shard: String,
+    pub(crate) tensors: Vec<Glm52TensorLoadSpec>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Glm52RankWeightPlan {
+    pub(crate) rank: usize,
+    pub(crate) loads_non_expert: bool,
+    pub(crate) expert_range: std::ops::Range<usize>,
+    pub(crate) tensor_count: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Glm52RankLoadBundle {
+    pub(crate) plan: Glm52RankWeightPlan,
+    pub(crate) shards: Vec<Glm52ShardLoadPlan>,
+}
+
+impl Glm52RankLoadBundle {
+    pub(crate) fn planned_total_bytes(&self) -> Result<usize> {
+        self.shards
+            .iter()
+            .flat_map(|shard| shard.tensors.iter())
+            .try_fold(0usize, |total, spec| {
+                total
+                    .checked_add(expected_tensor_contract(&spec.name)?.byte_len()?)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "GLM5.2 rank {} planned byte count overflow",
+                            self.plan.rank
+                        )
+                    })
+            })
+    }
+}
+
+pub(crate) struct Glm52WeightManifest {
+    weight_map: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Glm52TensorContract {
+    pub(crate) dtype: Dtype,
+    pub(crate) shape: Vec<usize>,
+}
+
+impl Glm52TensorContract {
+    pub(crate) fn byte_len(&self) -> Result<usize> {
+        let elements = self.shape.iter().try_fold(1usize, |total, dim| {
+            total.checked_mul(*dim).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "GLM5.2 tensor shape {:?} element count overflow",
+                    self.shape
+                )
+            })
+        })?;
+        elements
+            .checked_mul(dtype_element_bytes(self.dtype)?)
+            .ok_or_else(|| anyhow::anyhow!("GLM5.2 tensor {:?} byte count overflow", self.shape))
+    }
+}
+
+impl Glm52WeightManifest {
+    pub(crate) fn from_model_dir(model_path: &Path) -> Result<Self> {
+        let index_path = model_path.join(GLM52_WEIGHT_INDEX);
+        let content = std::fs::read_to_string(&index_path)
+            .with_context(|| format!("read {}", index_path.display()))?;
+        let json: Value = serde_json::from_str(&content)
+            .with_context(|| format!("parse {}", index_path.display()))?;
+        Self::from_index_json(&json)
+    }
+
+    fn from_index_json(json: &Value) -> Result<Self> {
+        let weight_map = json
+            .get("weight_map")
+            .and_then(Value::as_object)
+            .ok_or_else(|| anyhow::anyhow!("GLM5.2 safetensors index missing weight_map"))?;
+        let mut out = BTreeMap::new();
+        for (name, shard) in weight_map {
+            let shard = shard
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("weight_map entry {name} is not a shard string"))?;
+            out.insert(name.clone(), shard.to_owned());
+        }
+        let manifest = Self { weight_map: out };
+        manifest.validate_rank_coverage()?;
+        Ok(manifest)
+    }
+
+    pub(crate) fn all_rank_load_bundles(&self) -> Result<Vec<Glm52RankLoadBundle>> {
+        (0..GLM52_EP_RANKS)
+            .map(|rank| self.rank_load_bundle(rank))
+            .collect()
+    }
+
+    fn rank_load_bundle(&self, rank: usize) -> Result<Glm52RankLoadBundle> {
+        let names = self.rank_tensor_names(rank)?;
+        let mut by_shard: BTreeMap<String, Vec<Glm52TensorLoadSpec>> = BTreeMap::new();
+        for name in names {
+            let shard = self
+                .weight_map
+                .get(&name)
+                .with_context(|| format!("GLM5.2 safetensors index missing tensor {name}"))?;
+            by_shard
+                .entry(shard.clone())
+                .or_default()
+                .push(Glm52TensorLoadSpec {
+                    name,
+                    shard: shard.clone(),
+                });
+        }
+        let tensor_count = by_shard.values().map(Vec::len).sum();
+        let expert_start = rank * GLM52_LOCAL_EXPERTS;
+        Ok(Glm52RankLoadBundle {
+            plan: Glm52RankWeightPlan {
+                rank,
+                loads_non_expert: rank == 0,
+                expert_range: expert_start..expert_start + GLM52_LOCAL_EXPERTS,
+                tensor_count,
+            },
+            shards: by_shard
+                .into_iter()
+                .map(|(shard, tensors)| Glm52ShardLoadPlan { shard, tensors })
+                .collect(),
+        })
+    }
+
+    fn rank_tensor_names(&self, rank: usize) -> Result<Vec<String>> {
+        ensure!(
+            rank < GLM52_EP_RANKS,
+            "GLM5.2 rank must be in 0..{GLM52_EP_RANKS}, got {rank}"
+        );
+        let mut names = Vec::new();
+        if rank == 0 {
+            self.push_non_expert_names(&mut names);
+        }
+        let expert_start = rank * GLM52_LOCAL_EXPERTS;
+        let expert_range = expert_start..expert_start + GLM52_LOCAL_EXPERTS;
+        for layer_idx in GLM52_DENSE_LAYERS..=GLM52_MTP_LAYER {
+            push_routed_experts(&mut names, layer_idx, expert_range.clone());
+        }
+        Ok(names)
+    }
+
+    fn push_non_expert_names(&self, names: &mut Vec<String>) {
+        names.push("model.embed_tokens.weight".to_owned());
+        names.push("model.norm.weight".to_owned());
+        names.push("lm_head.weight".to_owned());
+
+        for layer_idx in 0..GLM52_LAYERS {
+            self.push_attention_names(names, layer_idx);
+            if layer_idx < GLM52_DENSE_LAYERS {
+                push_dense_mlp(names, layer_idx);
+            } else {
+                push_moe_non_expert(names, layer_idx);
+            }
+        }
+
+        names.push(format!("model.layers.{GLM52_MTP_LAYER}.enorm.weight"));
+        names.push(format!("model.layers.{GLM52_MTP_LAYER}.hnorm.weight"));
+        names.push(format!("model.layers.{GLM52_MTP_LAYER}.eh_proj.weight"));
+        names.push(format!(
+            "model.layers.{GLM52_MTP_LAYER}.shared_head.norm.weight"
+        ));
+        self.push_attention_names(names, GLM52_MTP_LAYER);
+        push_moe_non_expert(names, GLM52_MTP_LAYER);
+    }
+
+    fn push_attention_names(&self, names: &mut Vec<String>, layer_idx: usize) {
+        let prefix = format!("model.layers.{layer_idx}");
+        names.push(format!("{prefix}.input_layernorm.weight"));
+        push_fp8(names, &format!("{prefix}.self_attn.q_a_proj"));
+        names.push(format!("{prefix}.self_attn.q_a_layernorm.weight"));
+        push_fp8(names, &format!("{prefix}.self_attn.q_b_proj"));
+        push_fp8(names, &format!("{prefix}.self_attn.kv_a_proj_with_mqa"));
+        names.push(format!("{prefix}.self_attn.kv_a_layernorm.weight"));
+        push_fp8(names, &format!("{prefix}.self_attn.kv_b_proj"));
+        push_fp8(names, &format!("{prefix}.self_attn.o_proj"));
+        names.push(format!("{prefix}.post_attention_layernorm.weight"));
+
+        let indexer = format!("{prefix}.self_attn.indexer");
+        if self
+            .weight_map
+            .contains_key(&format!("{indexer}.k_norm.weight"))
+        {
+            names.push(format!("{indexer}.k_norm.weight"));
+            names.push(format!("{indexer}.k_norm.bias"));
+            names.push(format!("{indexer}.weights_proj.weight"));
+            push_fp8(names, &format!("{indexer}.wk"));
+            push_fp8(names, &format!("{indexer}.wq_b"));
+        }
+    }
+
+    fn validate_rank_coverage(&self) -> Result<()> {
+        let mut generated = BTreeSet::new();
+        for rank in 0..GLM52_EP_RANKS {
+            for name in self.rank_tensor_names(rank)? {
+                generated.insert(name);
+            }
+        }
+        let checkpoint = self.weight_map.keys().cloned().collect::<BTreeSet<_>>();
+        let missing = checkpoint
+            .difference(&generated)
+            .take(5)
+            .cloned()
+            .collect::<Vec<_>>();
+        let extra = generated
+            .difference(&checkpoint)
+            .take(5)
+            .cloned()
+            .collect::<Vec<_>>();
+        ensure!(
+            missing.is_empty() && extra.is_empty(),
+            "GLM5.2 rank load plan does not exactly cover checkpoint tensors: missing_sample={missing:?}, extra_sample={extra:?}, checkpoint={}, generated={}",
+            checkpoint.len(),
+            generated.len()
+        );
+        Ok(())
+    }
+}
+
+fn push_dense_mlp(names: &mut Vec<String>, layer_idx: usize) {
+    let prefix = format!("model.layers.{layer_idx}.mlp");
+    push_fp8(names, &format!("{prefix}.gate_proj"));
+    push_fp8(names, &format!("{prefix}.up_proj"));
+    push_fp8(names, &format!("{prefix}.down_proj"));
+}
+
+fn push_moe_non_expert(names: &mut Vec<String>, layer_idx: usize) {
+    let prefix = format!("model.layers.{layer_idx}.mlp");
+    names.push(format!("{prefix}.gate.weight"));
+    names.push(format!("{prefix}.gate.e_score_correction_bias"));
+    push_fp8(names, &format!("{prefix}.shared_experts.gate_proj"));
+    push_fp8(names, &format!("{prefix}.shared_experts.up_proj"));
+    push_fp8(names, &format!("{prefix}.shared_experts.down_proj"));
+}
+
+fn push_routed_experts(names: &mut Vec<String>, layer_idx: usize, experts: std::ops::Range<usize>) {
+    let prefix = format!("model.layers.{layer_idx}.mlp.experts");
+    for expert_idx in experts {
+        let expert = format!("{prefix}.{expert_idx}");
+        push_fp8(names, &format!("{expert}.gate_proj"));
+        push_fp8(names, &format!("{expert}.up_proj"));
+        push_fp8(names, &format!("{expert}.down_proj"));
+    }
+}
+
+fn push_fp8(names: &mut Vec<String>, prefix: &str) {
+    names.push(format!("{prefix}.weight"));
+    names.push(format!("{prefix}.weight_scale_inv"));
+}
+
+pub(crate) fn expected_tensor_contract(name: &str) -> Result<Glm52TensorContract> {
+    if name == "model.embed_tokens.weight" || name == "lm_head.weight" {
+        return Ok(contract(Dtype::BF16, [GLM52_VOCAB, GLM52_HIDDEN]));
+    }
+    if name == "model.norm.weight" {
+        return Ok(contract(Dtype::BF16, [GLM52_HIDDEN]));
+    }
+
+    let layer_idx = parse_layer_index(name)?;
+    ensure!(
+        layer_idx <= GLM52_MTP_LAYER,
+        "GLM5.2 tensor contract excludes layer {layer_idx}: {name}"
+    );
+
+    if layer_idx == GLM52_MTP_LAYER {
+        if name.ends_with(".enorm.weight")
+            || name.ends_with(".hnorm.weight")
+            || name.ends_with(".shared_head.norm.weight")
+        {
+            return Ok(contract(Dtype::BF16, [GLM52_HIDDEN]));
+        }
+        if name.ends_with(".eh_proj.weight") {
+            return Ok(contract(Dtype::BF16, [GLM52_HIDDEN, 2 * GLM52_HIDDEN]));
+        }
+    }
+
+    if name.ends_with(".input_layernorm.weight")
+        || name.ends_with(".post_attention_layernorm.weight")
+    {
+        return Ok(contract(Dtype::BF16, [GLM52_HIDDEN]));
+    }
+    if name.ends_with(".self_attn.q_a_layernorm.weight") {
+        return Ok(contract(Dtype::BF16, [GLM52_Q_LORA_RANK]));
+    }
+    if name.ends_with(".self_attn.kv_a_layernorm.weight") {
+        return Ok(contract(Dtype::BF16, [GLM52_KV_LORA_RANK]));
+    }
+
+    if let Some(projection) = attention_projection_contract(name) {
+        return Ok(projection);
+    }
+    if let Some(indexer) = indexer_contract(name) {
+        return Ok(indexer);
+    }
+    if let Some(mlp) = mlp_contract(layer_idx, name) {
+        return Ok(mlp);
+    }
+
+    anyhow::bail!("no GLM5.2 tensor contract for {name}")
+}
+
+fn attention_projection_contract(name: &str) -> Option<Glm52TensorContract> {
+    projection_contract(name, ".self_attn.q_a_proj", GLM52_Q_LORA_RANK, GLM52_HIDDEN)
+        .or_else(|| {
+            projection_contract(
+                name,
+                ".self_attn.q_b_proj",
+                GLM52_Q_B_OUT,
+                GLM52_Q_LORA_RANK,
+            )
+        })
+        .or_else(|| {
+            projection_contract(
+                name,
+                ".self_attn.kv_a_proj_with_mqa",
+                GLM52_KV_A_OUT,
+                GLM52_HIDDEN,
+            )
+        })
+        .or_else(|| {
+            projection_contract(
+                name,
+                ".self_attn.kv_b_proj",
+                GLM52_KV_B_OUT,
+                GLM52_KV_LORA_RANK,
+            )
+        })
+        .or_else(|| projection_contract(name, ".self_attn.o_proj", GLM52_HIDDEN, GLM52_O_PROJ_IN))
+}
+
+fn indexer_contract(name: &str) -> Option<Glm52TensorContract> {
+    if name.ends_with(".self_attn.indexer.k_norm.weight")
+        || name.ends_with(".self_attn.indexer.k_norm.bias")
+    {
+        return Some(contract(Dtype::BF16, [GLM52_INDEX_HEAD_DIM]));
+    }
+    if name.ends_with(".self_attn.indexer.weights_proj.weight") {
+        return Some(contract(Dtype::BF16, [GLM52_INDEX_HEADS, GLM52_HIDDEN]));
+    }
+    projection_contract(
+        name,
+        ".self_attn.indexer.wk",
+        GLM52_INDEX_HEAD_DIM,
+        GLM52_HIDDEN,
+    )
+    .or_else(|| {
+        projection_contract(
+            name,
+            ".self_attn.indexer.wq_b",
+            GLM52_INDEX_HEADS * GLM52_INDEX_HEAD_DIM,
+            GLM52_Q_LORA_RANK,
+        )
+    })
+}
+
+fn mlp_contract(layer_idx: usize, name: &str) -> Option<Glm52TensorContract> {
+    if name.ends_with(".mlp.gate.weight") {
+        return Some(contract(Dtype::BF16, [GLM52_ROUTED_EXPERTS, GLM52_HIDDEN]));
+    }
+    if name.ends_with(".mlp.gate.e_score_correction_bias") {
+        return Some(contract(Dtype::F32, [GLM52_ROUTED_EXPERTS]));
+    }
+
+    let intermediate = if layer_idx < GLM52_DENSE_LAYERS {
+        GLM52_DENSE_INTERMEDIATE
+    } else {
+        GLM52_EXPERT_INTERMEDIATE
+    };
+    projection_contract(name, ".gate_proj", intermediate, GLM52_HIDDEN)
+        .or_else(|| projection_contract(name, ".up_proj", intermediate, GLM52_HIDDEN))
+        .or_else(|| projection_contract(name, ".down_proj", GLM52_HIDDEN, intermediate))
+}
+
+fn projection_contract(
+    name: &str,
+    stem: &str,
+    rows: usize,
+    cols: usize,
+) -> Option<Glm52TensorContract> {
+    if name.ends_with(&format!("{stem}.weight")) {
+        return Some(contract(Dtype::F8_E4M3, [rows, cols]));
+    }
+    if name.ends_with(&format!("{stem}.weight_scale_inv")) {
+        return Some(contract(
+            Dtype::F32,
+            [rows.div_ceil(FP8_BLOCK_SIZE), cols.div_ceil(FP8_BLOCK_SIZE)],
+        ));
+    }
+    None
+}
+
+fn contract<const N: usize>(dtype: Dtype, shape: [usize; N]) -> Glm52TensorContract {
+    Glm52TensorContract {
+        dtype,
+        shape: shape.to_vec(),
+    }
+}
+
+fn dtype_element_bytes(dtype: Dtype) -> Result<usize> {
+    match dtype {
+        Dtype::F8_E4M3 => Ok(1),
+        Dtype::BF16 => Ok(2),
+        Dtype::F32 => Ok(4),
+        other => anyhow::bail!("GLM5.2 loader does not support dtype {:?}", other),
+    }
+}
+
+fn parse_layer_index(name: &str) -> Result<usize> {
+    let rest = name
+        .strip_prefix("model.layers.")
+        .ok_or_else(|| anyhow::anyhow!("GLM5.2 tensor is not a layer tensor: {name}"))?;
+    let (idx, _) = rest
+        .split_once('.')
+        .ok_or_else(|| anyhow::anyhow!("GLM5.2 tensor has malformed layer prefix: {name}"))?;
+    idx.parse::<usize>()
+        .map_err(|err| anyhow::anyhow!("GLM5.2 tensor has invalid layer index in {name}: {err}"))
+}
+
+pub(crate) fn mmap_file(path: &Path) -> Result<Mmap> {
+    let file = std::fs::File::open(path)
+        .map_err(|err| anyhow::anyhow!("open {}: {err}", path.display()))?;
+    unsafe { Mmap::map(&file) }.map_err(|err| anyhow::anyhow!("mmap {}: {err}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rank_expert_ranges_cover_all_routed_experts() {
+        let ranges = (0..GLM52_EP_RANKS)
+            .map(|rank| rank * GLM52_LOCAL_EXPERTS..(rank + 1) * GLM52_LOCAL_EXPERTS)
+            .collect::<Vec<_>>();
+
+        assert_eq!(ranges[0], 0..32);
+        assert_eq!(ranges[7], 224..256);
+        assert_eq!(ranges.iter().map(std::ops::Range::len).sum::<usize>(), 256);
+    }
+
+    #[test]
+    fn official_attention_shapes_are_not_provider_4x_shapes() {
+        assert_eq!(
+            expected_tensor_contract("model.layers.0.self_attn.q_b_proj.weight").unwrap(),
+            contract(Dtype::F8_E4M3, [16_384, 2_048])
+        );
+        assert_eq!(
+            expected_tensor_contract("model.layers.0.self_attn.kv_b_proj.weight").unwrap(),
+            contract(Dtype::F8_E4M3, [28_672, 512])
+        );
+    }
+}

--- a/openinfer-glm52/src/weights/context.rs
+++ b/openinfer-glm52/src/weights/context.rs
@@ -1,0 +1,90 @@
+use std::sync::Arc;
+
+use anyhow::{Context, Result, ensure};
+use cudarc::driver::{CudaContext, CudaStream};
+
+#[derive(Clone)]
+pub(crate) struct Glm52RankGpuContext {
+    ctx: Arc<CudaContext>,
+    stream: Arc<CudaStream>,
+    device_ordinal: usize,
+}
+
+// SAFETY: a GLM5.2 rank owns one CUDA context/stream pair. The worker binds it
+// to its thread before touching device state.
+unsafe impl Send for Glm52RankGpuContext {}
+unsafe impl Sync for Glm52RankGpuContext {}
+
+impl Glm52RankGpuContext {
+    pub(crate) fn new(device_ordinal: usize) -> Result<Self> {
+        let ctx = CudaContext::new(device_ordinal)
+            .with_context(|| format!("create GLM5.2 CUDA context for device {device_ordinal}"))?;
+        ctx.bind_to_thread()
+            .with_context(|| format!("bind GLM5.2 CUDA context for device {device_ordinal}"))?;
+        retain_async_alloc_pool(device_ordinal)?;
+        unsafe {
+            ctx.disable_event_tracking();
+        }
+        let stream = ctx
+            .new_stream()
+            .with_context(|| format!("create GLM5.2 CUDA stream for device {device_ordinal}"))?;
+        Ok(Self {
+            ctx,
+            stream,
+            device_ordinal,
+        })
+    }
+
+    pub(crate) fn set_current(&self) -> Result<()> {
+        self.ctx.bind_to_thread().with_context(|| {
+            format!(
+                "bind GLM5.2 CUDA context for device {} to current thread",
+                self.device_ordinal
+            )
+        })
+    }
+
+    pub(crate) fn sync(&self) -> Result<()> {
+        self.stream
+            .synchronize()
+            .with_context(|| format!("synchronize GLM5.2 device {}", self.device_ordinal))
+    }
+
+    pub(crate) fn stream(&self) -> &Arc<CudaStream> {
+        &self.stream
+    }
+}
+
+fn retain_async_alloc_pool(device_ordinal: usize) -> Result<()> {
+    use cudarc::driver::sys;
+    unsafe {
+        let mut dev: sys::CUdevice = 0;
+        check_cu(
+            sys::cuDeviceGet(&mut dev, device_ordinal as i32),
+            "cuDeviceGet",
+        )?;
+        let mut pool: sys::CUmemoryPool = std::ptr::null_mut();
+        check_cu(
+            sys::cuDeviceGetDefaultMemPool(&mut pool, dev),
+            "cuDeviceGetDefaultMemPool",
+        )?;
+        let mut threshold: u64 = u64::MAX;
+        check_cu(
+            sys::cuMemPoolSetAttribute(
+                pool,
+                sys::CUmemPool_attribute_enum::CU_MEMPOOL_ATTR_RELEASE_THRESHOLD,
+                (&mut threshold as *mut u64).cast::<std::ffi::c_void>(),
+            ),
+            "cuMemPoolSetAttribute(RELEASE_THRESHOLD)",
+        )?;
+    }
+    Ok(())
+}
+
+fn check_cu(result: cudarc::driver::sys::CUresult, what: &str) -> Result<()> {
+    ensure!(
+        result == cudarc::driver::sys::CUresult::CUDA_SUCCESS,
+        "GLM5.2 {what} failed: {result:?}"
+    );
+    Ok(())
+}

--- a/openinfer-glm52/src/weights/load.rs
+++ b/openinfer-glm52/src/weights/load.rs
@@ -1,0 +1,431 @@
+use std::{
+    cell::Cell,
+    collections::{BTreeMap, VecDeque},
+    path::Path,
+    time::Instant,
+};
+
+use anyhow::{Context, Result, ensure};
+use bytesize::ByteSize;
+use cudarc::driver::{CudaEvent, CudaSlice};
+use log::{debug, error, info};
+use memmap2::Mmap;
+
+use super::{Glm52RankGpuContext, Glm52RankLoadBundle, expected_tensor_contract, mmap_file};
+
+// One mmap per event keeps source lifetimes explicit without the large-tail
+// regression observed when many shard mappings stay live together.
+const MMAP_EVENT_GROUP: usize = 1;
+const LIVE_MMAP_GROUPS: usize = 16;
+
+pub(crate) struct Glm52GpuRawTensor {
+    pub(crate) bytes: usize,
+    pub(crate) _offset: usize,
+}
+
+pub(crate) struct Glm52RankGpuWeights {
+    pub(crate) tensors: BTreeMap<String, Glm52GpuRawTensor>,
+    pub(crate) _slab: CudaSlice<u8>,
+    pub(crate) total_bytes: usize,
+}
+
+pub(crate) struct Glm52RankLoadOutput {
+    pub(crate) weights: Glm52RankGpuWeights,
+    pub(crate) loaded_tensor_count: usize,
+    pub(crate) loaded_total_bytes: usize,
+}
+
+pub(crate) fn load_rank_weights_to_gpu(
+    ctx: &Glm52RankGpuContext,
+    model_path: &Path,
+    bundle: &Glm52RankLoadBundle,
+) -> Result<Glm52RankLoadOutput> {
+    ctx.set_current()?;
+    let load_started = Instant::now();
+    let planned_total_bytes = bundle.planned_total_bytes()?;
+    let alloc_started = Instant::now();
+    // SAFETY: every byte in the rank-local slab is written exactly once from a
+    // validated safetensors view before the slab becomes resident model state.
+    let slab = unsafe { ctx.stream().alloc::<u8>(planned_total_bytes) }.with_context(|| {
+        format!(
+            "failed to allocate GLM5.2 rank {} weight slab of {}",
+            bundle.plan.rank,
+            ByteSize(planned_total_bytes as u64)
+        )
+    })?;
+    let alloc_secs = alloc_started.elapsed().as_secs_f64();
+
+    let mut weights = Glm52RankGpuWeights {
+        tensors: BTreeMap::new(),
+        _slab: slab,
+        total_bytes: 0,
+    };
+    let mut loaded_tensor_count = 0usize;
+    let mut loaded_total_bytes = 0usize;
+    let copy_started = Instant::now();
+    let mut slowest_shard: Option<(String, f64)> = None;
+    let mut next_offset = 0usize;
+    let mut h2d_copies = 0usize;
+    let mut mmap_guard = MmapH2dLifetimeGuard::new(ctx, bundle.plan.rank);
+    let mut sync_secs = 0.0f64;
+    debug!(
+        "GLM5.2 rank {} start weight load: tensors={}, shards={}, bytes={}, non_expert={}, experts={:?}",
+        bundle.plan.rank,
+        bundle.plan.tensor_count,
+        bundle.shards.len(),
+        ByteSize(planned_total_bytes as u64),
+        bundle.plan.loads_non_expert,
+        bundle.plan.expert_range
+    );
+
+    for shard in &bundle.shards {
+        let path = model_path.join(&shard.shard);
+        let shard_started = Instant::now();
+        let mmap = CurrentShardMmap::new(mmap_file(&path)?, ctx, bundle.plan.rank);
+        let safetensors = safetensors::SafeTensors::deserialize(mmap.as_ref())
+            .with_context(|| format!("failed to deserialize {}", path.display()))?;
+        let mmap_base = mmap.as_ref().as_ptr() as usize;
+        let mut pending = Vec::with_capacity(shard.tensors.len());
+        for spec in &shard.tensors {
+            let view = safetensors
+                .tensor(&spec.name)
+                .with_context(|| format!("missing tensor {} in {}", spec.name, path.display()))?;
+            let contract = expected_tensor_contract(&spec.name)?;
+            ensure!(
+                view.dtype() == contract.dtype,
+                "GLM5.2 tensor {} dtype mismatch: got {:?}, expected {:?}",
+                spec.name,
+                view.dtype(),
+                contract.dtype
+            );
+            ensure!(
+                view.shape() == contract.shape.as_slice(),
+                "GLM5.2 tensor {} shape mismatch: got {:?}, expected {:?}",
+                spec.name,
+                view.shape(),
+                contract.shape
+            );
+            let bytes = view.data().len();
+            ensure!(
+                bytes == contract.byte_len()?,
+                "GLM5.2 tensor {} byte mismatch: got {}, expected {}",
+                spec.name,
+                bytes,
+                contract.byte_len()?
+            );
+            let data_start = view
+                .data()
+                .as_ptr()
+                .addr()
+                .checked_sub(mmap_base)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "GLM5.2 tensor {} data pointer is outside {}",
+                        spec.name,
+                        path.display()
+                    )
+                })?;
+            let data_end = data_start.checked_add(bytes).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "GLM5.2 tensor {} source byte range overflow in {}",
+                    spec.name,
+                    path.display()
+                )
+            })?;
+            ensure!(
+                data_end <= mmap.as_ref().len(),
+                "GLM5.2 tensor {} source range [{data_start}..{data_end}) exceeds shard bytes {}",
+                spec.name,
+                mmap.as_ref().len()
+            );
+            pending.push(PendingTensor {
+                name: spec.name.as_str(),
+                data_start,
+                bytes,
+            });
+        }
+
+        pending.sort_by_key(|tensor| tensor.data_start);
+        let mut shard_tensors = Vec::with_capacity(pending.len());
+        for pending_tensor in pending {
+            let offset = next_offset;
+            next_offset = next_offset
+                .checked_add(pending_tensor.bytes)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "GLM5.2 rank {} slab offset overflow while loading {}",
+                        bundle.plan.rank,
+                        pending_tensor.name
+                    )
+                })?;
+            ensure!(
+                next_offset <= planned_total_bytes,
+                "GLM5.2 rank {} slab overflow while loading {}: next_offset={}, slab_bytes={}",
+                bundle.plan.rank,
+                pending_tensor.name,
+                next_offset,
+                planned_total_bytes
+            );
+            shard_tensors.push(PlacedTensor {
+                name: pending_tensor.name,
+                data_start: pending_tensor.data_start,
+                data_end: pending_tensor.data_start + pending_tensor.bytes,
+                dst_start: offset,
+                dst_end: next_offset,
+                bytes: pending_tensor.bytes,
+            });
+        }
+
+        let mut run_start = 0usize;
+        while run_start < shard_tensors.len() {
+            let first = &shard_tensors[run_start];
+            let mut run_end = run_start + 1;
+            let mut src_end = first.data_end;
+            let mut dst_end = first.dst_end;
+            while run_end < shard_tensors.len() {
+                let current = &shard_tensors[run_end];
+                if current.data_start != src_end || current.dst_start != dst_end {
+                    break;
+                }
+                src_end = current.data_end;
+                dst_end = current.dst_end;
+                run_end += 1;
+            }
+
+            {
+                let src = &mmap.as_ref()[first.data_start..src_end];
+                let mut dst = weights._slab.slice_mut(first.dst_start..dst_end);
+                mmap.mark_stream_work();
+                ctx.stream().memcpy_htod(src, &mut dst).with_context(|| {
+                    format!(
+                        "failed to copy GLM5.2 rank {} shard {} byte range [{}..{}) to GPU",
+                        bundle.plan.rank, shard.shard, first.data_start, src_end
+                    )
+                })?;
+            }
+            h2d_copies += 1;
+
+            for tensor in &shard_tensors[run_start..run_end] {
+                let raw = Glm52GpuRawTensor {
+                    bytes: tensor.bytes,
+                    _offset: tensor.dst_start,
+                };
+                weights.total_bytes += raw.bytes;
+                loaded_total_bytes += raw.bytes;
+                loaded_tensor_count += 1;
+                ensure!(
+                    weights
+                        .tensors
+                        .insert(tensor.name.to_owned(), raw)
+                        .is_none(),
+                    "duplicate GLM5.2 tensor {} in rank {} load plan",
+                    tensor.name,
+                    bundle.plan.rank,
+                );
+            }
+            run_start = run_end;
+        }
+        drop(safetensors);
+        sync_secs += mmap_guard.push_completed_shard(mmap.into_mmap())?;
+        let shard_secs = shard_started.elapsed().as_secs_f64();
+        match &slowest_shard {
+            Some((_, slowest_secs)) if *slowest_secs >= shard_secs => {}
+            _ => slowest_shard = Some((shard.shard.clone(), shard_secs)),
+        }
+    }
+
+    ensure!(
+        loaded_tensor_count == bundle.plan.tensor_count,
+        "GLM5.2 rank {} loaded {loaded_tensor_count} tensors but load plan has {}",
+        bundle.plan.rank,
+        bundle.plan.tensor_count
+    );
+    ensure!(
+        next_offset == planned_total_bytes,
+        "GLM5.2 rank {} loaded {} bytes but load plan has {} bytes",
+        bundle.plan.rank,
+        next_offset,
+        planned_total_bytes
+    );
+    sync_secs += mmap_guard.drain()?;
+    let copy_secs = (copy_started.elapsed().as_secs_f64() - sync_secs).max(0.0);
+    let sync_started = Instant::now();
+    ctx.sync().with_context(|| {
+        format!(
+            "failed to finish GLM5.2 rank {} H2D tensor copies",
+            bundle.plan.rank
+        )
+    })?;
+    sync_secs += sync_started.elapsed().as_secs_f64();
+
+    let (slowest_shard, slowest_secs) = slowest_shard.unwrap_or_else(|| ("none".to_owned(), 0.0));
+    info!(
+        "GLM5.2 rank {} weight load profile: total={:.2}s, alloc={:.2}s, mmap_deser_copy={:.2}s, sync={:.2}s, tensors={}, h2d_copies={}, bytes={}, slowest_shard={} {:.2}s",
+        bundle.plan.rank,
+        load_started.elapsed().as_secs_f64(),
+        alloc_secs,
+        copy_secs,
+        sync_secs,
+        loaded_tensor_count,
+        h2d_copies,
+        ByteSize(loaded_total_bytes as u64),
+        slowest_shard,
+        slowest_secs
+    );
+
+    Ok(Glm52RankLoadOutput {
+        weights,
+        loaded_tensor_count,
+        loaded_total_bytes,
+    })
+}
+
+struct PendingTensor<'a> {
+    name: &'a str,
+    data_start: usize,
+    bytes: usize,
+}
+
+struct PlacedTensor<'a> {
+    name: &'a str,
+    data_start: usize,
+    data_end: usize,
+    dst_start: usize,
+    dst_end: usize,
+    bytes: usize,
+}
+
+struct LiveMmapGroup {
+    _mmaps: Vec<Mmap>,
+    event: CudaEvent,
+}
+
+struct CurrentShardMmap<'a> {
+    mmap: Option<Mmap>,
+    ctx: &'a Glm52RankGpuContext,
+    rank: usize,
+    stream_work: Cell<bool>,
+}
+
+impl<'a> CurrentShardMmap<'a> {
+    fn new(mmap: Mmap, ctx: &'a Glm52RankGpuContext, rank: usize) -> Self {
+        Self {
+            mmap: Some(mmap),
+            ctx,
+            rank,
+            stream_work: Cell::new(false),
+        }
+    }
+
+    fn as_ref(&self) -> &Mmap {
+        self.mmap.as_ref().expect("current shard mmap is present")
+    }
+
+    fn mark_stream_work(&self) {
+        self.stream_work.set(true);
+    }
+
+    fn into_mmap(mut self) -> Mmap {
+        self.stream_work.set(false);
+        self.mmap.take().expect("current shard mmap is present")
+    }
+}
+
+impl Drop for CurrentShardMmap<'_> {
+    fn drop(&mut self) {
+        if self.stream_work.get() {
+            if let Err(error) = self.ctx.set_current().and_then(|_| self.ctx.sync()) {
+                error!(
+                    "failed to synchronize GLM5.2 rank {} before dropping current H2D mmap: {error:#}",
+                    self.rank
+                );
+            }
+        }
+    }
+}
+
+struct MmapH2dLifetimeGuard<'a> {
+    ctx: &'a Glm52RankGpuContext,
+    rank: usize,
+    pending_mmaps: Vec<Mmap>,
+    live_mmap_groups: VecDeque<LiveMmapGroup>,
+}
+
+impl<'a> MmapH2dLifetimeGuard<'a> {
+    fn new(ctx: &'a Glm52RankGpuContext, rank: usize) -> Self {
+        Self {
+            ctx,
+            rank,
+            pending_mmaps: Vec::with_capacity(MMAP_EVENT_GROUP),
+            live_mmap_groups: VecDeque::with_capacity(LIVE_MMAP_GROUPS),
+        }
+    }
+
+    fn push_completed_shard(&mut self, mmap: Mmap) -> Result<f64> {
+        self.pending_mmaps.push(mmap);
+        let mut sync_secs = 0.0;
+        if self.pending_mmaps.len() == MMAP_EVENT_GROUP {
+            self.record_pending_group()?;
+        }
+        if self.live_mmap_groups.len() >= LIVE_MMAP_GROUPS {
+            sync_secs += self.wait_oldest_group()?;
+        }
+        Ok(sync_secs)
+    }
+
+    fn drain(&mut self) -> Result<f64> {
+        let mut sync_secs = 0.0;
+        if !self.pending_mmaps.is_empty() {
+            self.record_pending_group()?;
+        }
+        while !self.live_mmap_groups.is_empty() {
+            sync_secs += self.wait_oldest_group()?;
+        }
+        Ok(sync_secs)
+    }
+
+    fn record_pending_group(&mut self) -> Result<()> {
+        let event = self.ctx.stream().record_event(None).with_context(|| {
+            format!(
+                "failed to record GLM5.2 rank {} H2D mmap group event",
+                self.rank
+            )
+        })?;
+        let mut mmaps = Vec::with_capacity(MMAP_EVENT_GROUP);
+        std::mem::swap(&mut self.pending_mmaps, &mut mmaps);
+        self.live_mmap_groups.push_back(LiveMmapGroup {
+            _mmaps: mmaps,
+            event,
+        });
+        Ok(())
+    }
+
+    fn wait_oldest_group(&mut self) -> Result<f64> {
+        let Some(live) = self.live_mmap_groups.front() else {
+            return Ok(0.0);
+        };
+        let started = Instant::now();
+        live.event.synchronize().with_context(|| {
+            format!(
+                "failed to wait for GLM5.2 rank {} H2D mmap event",
+                self.rank
+            )
+        })?;
+        self.live_mmap_groups.pop_front();
+        Ok(started.elapsed().as_secs_f64())
+    }
+}
+
+impl Drop for MmapH2dLifetimeGuard<'_> {
+    fn drop(&mut self) {
+        if self.pending_mmaps.is_empty() && self.live_mmap_groups.is_empty() {
+            return;
+        }
+        if let Err(error) = self.ctx.set_current().and_then(|_| self.ctx.sync()) {
+            error!(
+                "failed to synchronize GLM5.2 rank {} before dropping H2D mmap guard: {error:#}",
+                self.rank
+            );
+        }
+    }
+}

--- a/openinfer-glm52/tests/checkpoint.rs
+++ b/openinfer-glm52/tests/checkpoint.rs
@@ -1,0 +1,74 @@
+use std::path::PathBuf;
+
+use openinfer_core::{
+    engine::{GenerateRequest, TokenEvent, TokenSink},
+    sampler::SamplingParams,
+};
+use openinfer_glm52::{Glm52LaunchOptions, launch};
+
+const DEFAULT_GLM52_MODEL_PATH: &str = "models/GLM-5.2-FP8";
+
+#[test]
+#[ignore]
+fn checkpoint_loads_dp1_ep8_weights() {
+    openinfer_core::logging::init_default();
+
+    let model_path = std::env::var_os("OPENINFER_TEST_MODEL_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_GLM52_MODEL_PATH));
+    assert!(
+        model_path.join("model.safetensors.index.json").exists(),
+        "GLM5.2 checkpoint missing at {}",
+        model_path.display()
+    );
+
+    let handle = launch(
+        &model_path,
+        Glm52LaunchOptions {
+            tp_size: 1,
+            dp_size: 1,
+        },
+    )
+    .expect("GLM5.2 checkpoint startup");
+
+    let (token_tx, mut token_rx) = TokenSink::standalone();
+    handle
+        .submit(GenerateRequest {
+            request_id: Some("glm52-load-weight-only".to_string()),
+            queued_at_unix_s: None,
+            prompt_tokens: vec![100, 2048, 9001, 12345],
+            params: SamplingParams::default(),
+            max_tokens: 1,
+            lora_adapter: None,
+            token_tx,
+            logprobs: 0,
+            echo: false,
+        })
+        .expect("submit GLM5.2 request");
+
+    let mut saw_scheduled = false;
+    loop {
+        match token_rx.blocking_recv() {
+            Some((_, TokenEvent::Scheduled { prompt_tokens, .. })) => {
+                saw_scheduled = true;
+                assert_eq!(prompt_tokens, 4);
+            }
+            Some((_, TokenEvent::Rejected { message, .. })) => {
+                assert!(
+                    saw_scheduled,
+                    "request should be scheduled before rejection"
+                );
+                assert!(
+                    message.contains("load-weight-only"),
+                    "unexpected rejection message: {message}"
+                );
+                break;
+            }
+            Some((_, TokenEvent::Error { message, .. })) => {
+                panic!("GLM5.2 load-only engine returned error: {message}");
+            }
+            Some((_, event)) => panic!("unexpected GLM5.2 load-only event: {event:?}"),
+            None => panic!("GLM5.2 token channel closed before rejection"),
+        }
+    }
+}

--- a/openinfer-server/Cargo.toml
+++ b/openinfer-server/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/bin/bench_serving/main.rs"
 openinfer-core = { workspace = true }
 openinfer-deepseek-v2-lite = { workspace = true, optional = true }
 openinfer-deepseek-v4 = { workspace = true, optional = true }
+openinfer-glm52 = { workspace = true, optional = true }
 openinfer-kimi-k2 = { workspace = true, optional = true }
 openinfer-qwen3-4b = { workspace = true, optional = true }
 openinfer-qwen35-4b = { workspace = true, optional = true }
@@ -54,6 +55,7 @@ qwen3-4b = ["dep:openinfer-qwen3-4b"]
 qwen35-4b = ["dep:openinfer-qwen35-4b", "openinfer-qwen35-4b/qwen35-4b"]
 deepseek-v4 = ["dep:openinfer-deepseek-v4", "openinfer-deepseek-v4/deepseek-v4"]
 deepseek-v2-lite = ["dep:openinfer-deepseek-v2-lite", "openinfer-deepseek-v2-lite/deepseek-v2-lite"]
+glm52 = ["dep:openinfer-glm52"]
 kimi-k2 = ["dep:openinfer-kimi-k2", "openinfer-kimi-k2/kimi-k2"]
 pplx-ep = ["deepseek-v4", "openinfer-deepseek-v4/pplx-ep"]
 deepseek-v4-cutedsl-diagnostic = [

--- a/openinfer-server/src/bin/bench_serving/main.rs
+++ b/openinfer-server/src/bin/bench_serving/main.rs
@@ -9,6 +9,17 @@
 //!   cargo run -r --bin bench_serving -- matrix --prompt-lens 32,128,512 --output-lens 32,128
 //!   cargo run -r --bin bench_serving -- curve --prompt-len 1024 --output-len 256 --window 32
 
+#![cfg_attr(
+    not(any(
+        feature = "deepseek-v2-lite",
+        feature = "deepseek-v4",
+        feature = "kimi-k2",
+        feature = "qwen3-4b",
+        feature = "qwen35-4b"
+    )),
+    allow(unused_imports, unused_variables, dead_code)
+)]
+
 use std::path::Path;
 use std::time::Instant;
 
@@ -154,6 +165,10 @@ fn main() -> Result<()> {
                 },
             )?;
             finish(handle, false)
+        }
+        #[cfg(feature = "glm52")]
+        ModelType::Glm52 => {
+            anyhow::bail!("bench_serving is not supported for the GLM5.2 load-weight-only branch")
         }
         #[cfg(feature = "kimi-k2")]
         ModelType::KimiK2 => {

--- a/openinfer-server/src/config.rs
+++ b/openinfer-server/src/config.rs
@@ -58,9 +58,10 @@ pub(crate) struct Args {
     #[arg(long, default_value_t = 1)]
     pub tp_size: usize,
 
-    /// Data-parallel world size for Kimi-K2
-    #[arg(long, default_value_t = 8)]
-    pub dp_size: usize,
+    /// Data-parallel world size. Defaults are model-specific: Kimi-K2 uses 8,
+    /// GLM5.2 load-weight uses 1.
+    #[arg(long)]
+    pub dp_size: Option<usize>,
 
     /// Expert-parallel backend for Kimi-K2 (TP1/DP8 requires deepep; TP8/DP1 requires nccl)
     #[arg(long, default_value = "deepep")]
@@ -95,23 +96,21 @@ pub(crate) struct Args {
     #[arg(long = "dflash-draft-model-path")]
     pub dflash_draft_model_path: Option<PathBuf>,
 
-    /// Cap on total prompt tokens forwarded in one scheduler step (chunked
-    /// prefill), for both the Qwen3 and Qwen3.5 schedulers. Prefill activation
-    /// scratch scales with the step's prompt tokens, so this bounds peak VRAM
-    /// under request bursts; prompts longer than the cap are split across steps
-    /// so running decodes keep ticking. On Qwen3, echo requests are never
-    /// split. Must be positive.
-    #[arg(long, default_value_t = openinfer_qwen3_4b::DEFAULT_MAX_PREFILL_TOKENS)]
-    pub max_prefill_tokens: usize,
+    /// Cap on total prompt tokens forwarded in one scheduler step. When omitted,
+    /// Qwen3 and Qwen3.5 use their own crate defaults.
+    #[arg(long)]
+    pub max_prefill_tokens: Option<usize>,
 
     /// Fraction of total GPU memory the Qwen3 instance may use. The KV cache is
     /// sized from this budget after startup profiling accounts for weights,
     /// runtime buffers, activation peak, CUDA Graph capture, and margin.
+    #[cfg(feature = "qwen3-4b")]
     #[arg(long, default_value_t = openinfer_qwen3_4b::DEFAULT_GPU_MEMORY_UTILIZATION)]
     pub gpu_memory_utilization: f64,
 
     /// Additional Qwen3 GPU memory to hold back after profile-based KV sizing,
     /// in MiB. Covers allocator fragmentation and small unprofiled drift.
+    #[cfg(feature = "qwen3-4b")]
     #[arg(long, default_value_t = (openinfer_qwen3_4b::DEFAULT_KV_CACHE_MEMORY_MARGIN_BYTES >> 20) as usize)]
     pub kv_cache_memory_margin_mib: usize,
     /// How prefill and decode share the GPU (single-GPU Qwen3 only).
@@ -162,6 +161,7 @@ pub(crate) enum CliDecodeOverlap {
 }
 
 impl CliDecodeOverlap {
+    #[cfg(feature = "qwen3-4b")]
     pub(crate) fn resolve(self, decode_sm_pct: u32) -> openinfer_qwen3_4b::DecodeOverlap {
         use openinfer_qwen3_4b::DecodeOverlap;
         match self {
@@ -201,6 +201,16 @@ impl Args {
             bail!(
                 "--batch-invariant is not supported with DFlash speculative decoding; enable one at a time"
             );
+        }
+        #[cfg(feature = "glm52")]
+        if matches!(model_type, ModelType::Glm52) {
+            if let Some(dp_size) = self.dp_size {
+                if dp_size != 1 {
+                    bail!(
+                        "GLM5.2 load-weight branch requires --dp-size=1 when provided; omit --dp-size to use DP1/EP8"
+                    );
+                }
+            }
         }
         Ok(())
     }
@@ -347,5 +357,25 @@ mod tests {
 
         assert!(error.contains("--max-lora-rank must be one of"));
         assert!(error.contains("16"));
+    }
+
+    #[cfg(feature = "glm52")]
+    #[test]
+    fn glm52_accepts_omitted_dp_size() {
+        let args = Args::parse_from(["openinfer"]);
+
+        args.validate(ModelType::Glm52)
+            .expect("GLM5.2 should default to DP1/EP8 when --dp-size is omitted");
+    }
+
+    #[cfg(feature = "glm52")]
+    #[test]
+    fn glm52_rejects_non_dp1() {
+        let args = Args::parse_from(["openinfer", "--dp-size", "8"]);
+        let error = args
+            .validate(ModelType::Glm52)
+            .expect_err("GLM5.2 should reject explicit non-DP1");
+
+        assert!(error.to_string().contains("DP1/EP8"));
     }
 }

--- a/openinfer-server/src/main.rs
+++ b/openinfer-server/src/main.rs
@@ -132,12 +132,21 @@ fn load_engine(args: &Args, model_type: ModelType) -> anyhow::Result<EngineHandl
             openinfer_deepseek_v2_lite::launch(&args.model_path, args.cuda_graph)
                 .context("failed to start DeepSeek V2 Lite engine")?
         }
+        #[cfg(feature = "glm52")]
+        ModelType::Glm52 => openinfer_glm52::launch(
+            &args.model_path,
+            openinfer_glm52::Glm52LaunchOptions {
+                tp_size: args.tp_size,
+                dp_size: args.dp_size.unwrap_or(1),
+            },
+        )
+        .context("failed to start GLM5.2 load-weight engine")?,
         #[cfg(feature = "kimi-k2")]
         ModelType::KimiK2 => openinfer_kimi_k2::launch(
             &args.model_path,
             openinfer_kimi_k2::KimiLaunchOptions {
                 tp_size: args.tp_size,
-                dp_size: args.dp_size,
+                dp_size: args.dp_size.unwrap_or(8),
                 ep_backend: args.ep_backend.into(),
                 cuda_graph: args.cuda_graph,
             },
@@ -190,7 +199,9 @@ fn load_engine(args: &Args, model_type: ModelType) -> anyhow::Result<EngineHandl
                     cuda_graph: args.cuda_graph,
                     offload,
                     no_prefix_cache: args.no_prefix_cache,
-                    max_prefill_tokens: args.max_prefill_tokens,
+                    max_prefill_tokens: args
+                        .max_prefill_tokens
+                        .unwrap_or(openinfer_qwen3_4b::DEFAULT_MAX_PREFILL_TOKENS),
                     memory: openinfer_qwen3_4b::Qwen3MemoryOptions::new(
                         args.gpu_memory_utilization,
                         kv_cache_memory_margin_bytes,
@@ -212,7 +223,8 @@ fn load_engine(args: &Args, model_type: ModelType) -> anyhow::Result<EngineHandl
             &args.model_path,
             args.device_ordinal,
             args.cuda_graph,
-            args.max_prefill_tokens,
+            args.max_prefill_tokens
+                .unwrap_or(openinfer_qwen35_4b::DEFAULT_MAX_PREFILL_TOKENS),
         )
         .context("failed to start Qwen3.5 engine")?,
     };

--- a/openinfer-server/src/server_engine.rs
+++ b/openinfer-server/src/server_engine.rs
@@ -12,6 +12,8 @@ pub enum ModelType {
     DeepSeekV2Lite,
     #[cfg(feature = "deepseek-v4")]
     DeepSeekV4,
+    #[cfg(feature = "glm52")]
+    Glm52,
     #[cfg(feature = "kimi-k2")]
     KimiK2,
     #[cfg(feature = "qwen3-4b")]
@@ -29,6 +31,8 @@ impl fmt::Display for ModelType {
             Self::DeepSeekV2Lite => write!(f, "DeepSeek-V2-Lite"),
             #[cfg(feature = "deepseek-v4")]
             Self::DeepSeekV4 => write!(f, "DeepSeek V4"),
+            #[cfg(feature = "glm52")]
+            Self::Glm52 => write!(f, "GLM5.2"),
             #[cfg(feature = "kimi-k2")]
             Self::KimiK2 => write!(f, "Kimi-K2.6"),
             #[cfg(feature = "qwen3-4b")]
@@ -75,6 +79,22 @@ pub fn detect_model_type(model_path: impl AsRef<Path>) -> Result<ModelType> {
         #[cfg(not(feature = "deepseek-v4"))]
         anyhow::bail!(
             "DeepSeek V4 support is feature-gated; rebuild openinfer-server with --features deepseek-v4"
+        );
+    }
+
+    if json
+        .get("model_type")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|model_type| model_type == "glm_moe_dsa")
+    {
+        #[cfg(feature = "glm52")]
+        {
+            openinfer_glm52::probe_config_json(&json)?;
+            return Ok(ModelType::Glm52);
+        }
+        #[cfg(not(feature = "glm52"))]
+        anyhow::bail!(
+            "GLM5.2 support is feature-gated; rebuild openinfer-server with --features glm52"
         );
     }
 


### PR DESCRIPTION
## Summary

- Add a GLM5.2 load-weight-only crate and binary for the DP1/EP8 shape.
- Load rank0 non-expert tensors plus experts 0..31, and ranks1..7 32 routed experts each.
- Keep generation fail-closed until forward/decode lands.
- Wire the optional `glm52` server feature and model detection without pulling in PP/decode/MTP runtime or new kernels.
- Optimize load time with rank-local GPU slabs, coalesced H2D copies, and CUDA-event mmap lifetime guards including error-path cleanup.

## Performance

Measured on jz-38, 8x H200, real `/data/models/GLM-5.2-FP8` checkpoint:

- Baseline per-tensor `CudaSlice` load: `81622ms`
- Current implementation first run: `63420ms`
- Current implementation immediate repeat: `50803ms`

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p openinfer-glm52`
- `cargo check -p openinfer-server --features glm52`
- `cargo check -p openinfer-server --no-default-features --features glm52`
- `cargo test -p openinfer-glm52 --lib`
- `cargo test -p openinfer-server --no-default-features --features glm52 glm52_`
- `cargo build --release -p openinfer-glm52 --bin glm52_load_weights` on jz-38
- `./target/release/glm52_load_weights --model-path /data/models/GLM-5.2-FP8 --tp-size 1 --dp-size 1` on jz-38, twice

## Notes

- This PR intentionally excludes forward/decode/PP/MTP runtime and kernel additions.
- The load path stores raw resident weight bytes plus tensor offsets; runtime layout packing belongs to a later forward PR.
- Error-path mmap lifetime is guarded by RAII plus stream sync; happy path uses per-shard CUDA events and a bounded live mapping ring.
