### PR TITLE
chore(kv-cache): drop local lora_salt_hash, use upstream compute_salt_hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,7 +1468,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "dynamo-kv-hashing"
 version = "1.3.0"
-source = "git+https://github.com/ai-dynamo/dynamo?rev=2623ed7dac2dbd8314277bc2df49d1ebec89a884#2623ed7dac2dbd8314277bc2df49d1ebec89a884"
+source = "git+https://github.com/ai-dynamo/dynamo?rev=364cc8aa543d97f0563e17de3069d98ea051f33f#364cc8aa543d97f0563e17de3069d98ea051f33f"
 dependencies = [
  "derive_builder",
  "dynamo-tokens",
@@ -1480,7 +1480,7 @@ dependencies = [
 [[package]]
 name = "dynamo-tokens"
 version = "1.3.0"
-source = "git+https://github.com/ai-dynamo/dynamo?rev=2623ed7dac2dbd8314277bc2df49d1ebec89a884#2623ed7dac2dbd8314277bc2df49d1ebec89a884"
+source = "git+https://github.com/ai-dynamo/dynamo?rev=364cc8aa543d97f0563e17de3069d98ea051f33f#364cc8aa543d97f0563e17de3069d98ea051f33f"
 dependencies = [
  "bs58",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,8 +66,8 @@ keywords = ["llm", "genai", "inference", "nvidia", "distributed"]
 # Keep every ai-dynamo/dynamo dep on the SAME rev: crates from the same git
 # checkout unify their shared internal deps (dynamo-tokens), mixing revs would
 # split type identity.
-dynamo-tokens = { git = "https://github.com/ai-dynamo/dynamo", rev = "2623ed7dac2dbd8314277bc2df49d1ebec89a884" }
-dynamo-kv-hashing = { git = "https://github.com/ai-dynamo/dynamo", rev = "2623ed7dac2dbd8314277bc2df49d1ebec89a884" }
+dynamo-tokens = { git = "https://github.com/ai-dynamo/dynamo", rev = "364cc8aa543d97f0563e17de3069d98ea051f33f" }
+dynamo-kv-hashing = { git = "https://github.com/ai-dynamo/dynamo", rev = "364cc8aa543d97f0563e17de3069d98ea051f33f" }
 kvbm-logical = { path = "kvbm/kvbm-logical" }
 # ---- third-party ----
 anyhow = "1.0"

--- a/openinfer-dynamo-backend/Cargo.toml
+++ b/openinfer-dynamo-backend/Cargo.toml
@@ -23,11 +23,11 @@ openinfer-qwen3-4b = { path = "../openinfer-qwen3-4b" }
 # driver, and `run()`. Pinned to the SAME rev as the dynamo deps in the main
 # pegainfer workspace so the shared git checkout (and its internal type
 # identity) stay consistent.
-dynamo-backend-common = { git = "https://github.com/ai-dynamo/dynamo", rev = "2623ed7dac2dbd8314277bc2df49d1ebec89a884" }
+dynamo-backend-common = { git = "https://github.com/ai-dynamo/dynamo", rev = "364cc8aa543d97f0563e17de3069d98ea051f33f" }
 # KV-router event protocol types (KvCacheEvent / KvCacheStoreData / ...). Not
 # re-exported by backend-common, so depended on directly — same rev so the
 # `KvCacheEvent` we build is the exact type `KvEventPublisher::publish` accepts.
-dynamo-kv-router = { git = "https://github.com/ai-dynamo/dynamo", rev = "2623ed7dac2dbd8314277bc2df49d1ebec89a884" }
+dynamo-kv-router = { git = "https://github.com/ai-dynamo/dynamo", rev = "364cc8aa543d97f0563e17de3069d98ea051f33f" }
 
 anyhow = "1"
 async-trait = "0.1"
@@ -42,7 +42,7 @@ tracing = "0.1"
 # Same rev as the runtime dep above; the `testing` feature unlocks
 # `dynamo_backend_common::testing::run_conformance`, the official LLMEngine
 # conformance kit the GPU integration test in `engine.rs` drives.
-dynamo-backend-common = { git = "https://github.com/ai-dynamo/dynamo", rev = "2623ed7dac2dbd8314277bc2df49d1ebec89a884", features = ["testing"] }
+dynamo-backend-common = { git = "https://github.com/ai-dynamo/dynamo", rev = "364cc8aa543d97f0563e17de3069d98ea051f33f", features = ["testing"] }
 
 # Separate workspace on purpose. This keeps dynamo-runtime / dynamo-llm and
 # their heavy transitive deps (tonic, kube, etcd, NATS) OUT of the main

--- a/openinfer-dynamo-frontend/Cargo.toml
+++ b/openinfer-dynamo-frontend/Cargo.toml
@@ -16,9 +16,9 @@ path = "src/main.rs"
 # never touches a GPU, so it stays a light CPU-only binary. Same dep shape the
 # Python binding uses for its no-GPU build, pinned to the SAME rev as the
 # openinfer-dynamo-backend deps so the shared git checkout / type identity hold.
-dynamo-llm = { git = "https://github.com/ai-dynamo/dynamo", rev = "2623ed7dac2dbd8314277bc2df49d1ebec89a884", default-features = false }
+dynamo-llm = { git = "https://github.com/ai-dynamo/dynamo", rev = "364cc8aa543d97f0563e17de3069d98ea051f33f", default-features = false }
 # Worker / Runtime / DistributedRuntime + RouterMode.
-dynamo-runtime = { git = "https://github.com/ai-dynamo/dynamo", rev = "2623ed7dac2dbd8314277bc2df49d1ebec89a884" }
+dynamo-runtime = { git = "https://github.com/ai-dynamo/dynamo", rev = "364cc8aa543d97f0563e17de3069d98ea051f33f" }
 
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }

--- a/openinfer-kv-cache/Cargo.toml
+++ b/openinfer-kv-cache/Cargo.toml
@@ -8,13 +8,11 @@ edition = "2024"
 openinfer-kernels = { workspace = true }
 kvbm-logical = { workspace = true }
 dynamo-tokens = { workspace = true }
+dynamo-kv-hashing = { workspace = true }
 anyhow = { workspace = true }
 cudarc = { workspace = true }
 half = { workspace = true }
 tokio = { workspace = true }
-
-[dev-dependencies]
-dynamo-kv-hashing = { workspace = true }
 
 [lints]
 workspace = true

--- a/openinfer-kv-cache/src/pool.rs
+++ b/openinfer-kv-cache/src/pool.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use dynamo_tokens::{CHAIN_XXH3_SEED, SaltHash, compute_hash_v2};
+use dynamo_kv_hashing::compute_salt_hash;
 use kvbm_logical::blocks::{ImmutableBlock, MutableBlock};
 use kvbm_logical::events::{EventsManager, KvCacheEvent};
 use kvbm_logical::integrations::{DecodeOutcome, SchedulableSequence, ScheduleError};
@@ -17,21 +17,6 @@ use crate::view::KvView;
 /// dropped event silently desyncs the router's prefix tree. Only allocated on
 /// the [`BlockPool::with_events`] path.
 const KV_EVENT_CHANNEL_CAPACITY: usize = 65_536;
-
-/// Prefix-cache salt for a LoRA adapter.
-///
-/// Replicates upstream dynamo's canonical derivation on the no-extra-salt path
-/// (`lib/kv-hashing/src/salt.rs`, `pub(crate)` there), which is also the seed
-/// `dynamo-kv-router` uses in `compute_block_hash_for_seq` — so our block-hash
-/// chain stays byte-comparable with a dynamo KV indexer. `Some("")` shares the
-/// cache with `None`, matching the router's `filter(|n| !n.is_empty())`.
-/// Parity with upstream is pinned by `lora_salt_matches_upstream_request_hashing`.
-fn lora_salt_hash(lora_name: Option<&str>) -> SaltHash {
-    match lora_name.filter(|n| !n.is_empty()) {
-        Some(name) => CHAIN_XXH3_SEED.wrapping_add(compute_hash_v2(name.as_bytes(), 0)),
-        None => CHAIN_XXH3_SEED,
-    }
-}
 
 /// Logical KV block pool: a `BlockManager` plus the reserved padding block.
 ///
@@ -155,7 +140,8 @@ impl BlockPool {
         max_output_tokens: usize,
         lora_name: Option<&str>,
     ) -> RequestKv {
-        let salt_hash = lora_salt_hash(lora_name);
+        let salt_hash = compute_salt_hash(None, lora_name)
+            .expect("compute_salt_hash is infallible for (None, lora_name)");
         let seq = SchedulableSequence::new(
             prompt_tokens,
             max_output_tokens,
@@ -620,28 +606,6 @@ fn sequence_hash_bytes(hash: &SequenceHash) -> [u8; 16] {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// `lora_salt_hash` re-derives what upstream keeps `pub(crate)`. If upstream
-    /// ever changes the salt scheme, this is the test that catches the drift —
-    /// our hashes must equal `dynamo_kv_hashing::Request`'s for the same
-    /// (tokens, lora) so they stay comparable with a dynamo KV indexer.
-    #[test]
-    fn lora_salt_matches_upstream_request_hashing() {
-        let pool = BlockPool::new(16, 64).unwrap();
-        let tokens: Vec<u32> = (1..=64).collect(); // 4 full blocks
-        for lora in [None, Some("adapter-a")] {
-            let upstream = dynamo_kv_hashing::Request::builder()
-                .tokens(tokens.clone())
-                .lora_name(lora.map(String::from))
-                .build()
-                .unwrap()
-                .positional_lineage_hashes(16)
-                .unwrap();
-            let rkv = pool.new_request(tokens.clone(), 0, lora);
-            let ours = rkv.seq.inner().sequence().all_sequence_hashes();
-            assert_eq!(ours, upstream, "lora={lora:?}");
-        }
-    }
 
     /// The offload CPU-tier query keys are `prompt_block_hashes`. The whole
     /// load path is built on these being identical for any two requests that


### PR DESCRIPTION
## TL;DR

Upstream [dynamo#10652](https://github.com/ai-dynamo/dynamo/pull/10652) landed and exposed `compute_salt_hash` as a public free function. This drops our local re-implementation (`lora_salt_hash` in `pool.rs`) and the drift-parity test that guarded it.

Closes #373.

## Changes

- **Bump `ai-dynamo/dynamo` rev pin** across the workspace (`2623ed7` → `364cc8a`), a main HEAD containing #10652. Three Cargo.toml files move together (shared-rev rule):
  - main workspace (`dynamo-tokens`, `dynamo-kv-hashing`)
  - `openinfer-dynamo-backend` (`dynamo-backend-common`, `dynamo-kv-router`)
  - `openinfer-dynamo-frontend` (`dynamo-llm`, `dynamo-runtime`)
- **Delete `lora_salt_hash()`** in `openinfer-kv-cache/src/pool.rs`; call `dynamo_kv_hashing::compute_salt_hash(None, lora_name)` at the admission site.
- **Move `dynamo-kv-hashing`** from dev-dependency to dependency in `openinfer-kv-cache/Cargo.toml`.
- **Delete `lora_salt_matches_upstream_request_hashing`** — the local parity test. The upstream contract test `compute_salt_hash_matches_request_driven_hashing` (added in #10652) covers the same invariant; keeping a local copy would just be a second guard over a contract the upstream crate owns.

## Note

`compute_salt_hash` returns `Result<SaltHash, KvHashingError>` but its body is infallible (always `Ok`). We `.expect()` at the call site rather than propagating — a salt-derivation failure is a non-recoverable state corruption, and silently degrading the prefix-cache isolation key would be worse than crashing. Will surface the unnecessary `Result` upstream separately.

## Verification

```
cargo build --release -p openinfer-kv-cache
cargo test  --release -p openinfer-kv-cache --lib
cargo clippy --release -p openinfer-kv-cache --all-targets
```

All green.