### PR TITLE
fix(qwen3): size decode page indices for prefix-shared views

### DIFF
--- a/docs/models/qwen3/prefix-cache.md
+++ b/docs/models/qwen3/prefix-cache.md
@@ -2,7 +2,7 @@
 
 **TL;DR**: Prefix caching is on by default for Qwen3-4B. Full-block token-hash matching via the vendored kvbm radix tree, wired at the executor level. Repeated ~1900-token prompt: TTFT 141.8ms → 16.3ms p50 (8.7×); warm TTFT ≈ 1 decode TPOT (11.4ms) + ~5ms request-setup/eager-launch overhead. Accuracy gated by `hf_golden_gate` cached-replay surfaces (warm deltas at the cold bf16 floor).
 
-Last touched: 2026-06
+Last touched: 2026-07
 
 ## How it works
 
@@ -12,6 +12,7 @@ Last touched: 2026-06
 - **Echo requests skip matching** — prompt logprobs need every position forwarded.
 - **LoRA-scoped**: the active adapter name is folded into the block-hash chain as a salt (`compute_salt_hash`, upstream router-parity recipe), so KV computed under one adapter (or the base model) never matches a request running under another. Same tokens + same adapter still share.
 - Eviction safety: matched blocks are held as `ImmutableBlock` (strong Arc) in the sequence's assignments for the request lifetime; the inactive-pool LRU cannot reclaim them mid-request.
+- **Pages are counted by reference, not by physical block.** N views holding the same cached prefix each list those page ids again, so anything sized off the pool's *physical* block count under-allocates under sharing — admission won't catch it, it also charges physical blocks. `BatchDecodeBuffers::page_indices_d` hit exactly this (#403 fault 1: cudarc copy assert → dead worker → wedged engine; deterministic with N concurrent same-prompt requests once the prefix is sealed). It is now sized for `max_batch × full-context views` and `sync_paged_meta` fails loud instead of tripping the assert. Any future consumer of concatenated per-request page lists must use the by-reference bound.
 - Toggle: `Qwen3Executor::set_prefix_cache_enabled(false)` — used by tests that need cold determinism; there is no server flag.
 
 ## Numbers (RTX 5090, 2026-06, drained-stream measurement)

--- a/openinfer-qwen3-4b/src/batch_decode_buffers.rs
+++ b/openinfer-qwen3-4b/src/batch_decode_buffers.rs
@@ -273,7 +273,7 @@ impl BatchDecodeBuffers {
         intermediate_size: usize,
         vocab_size: usize,
         max_batch_size: usize,
-        max_total_pages: usize,
+        page_size: usize,
         padding_page_id: i32,
         num_qo_heads: usize,
         max_context_tokens: usize,
@@ -284,6 +284,15 @@ impl BatchDecodeBuffers {
         let policy = numeric_policy();
         let max_split_slots =
             bs.min(SPLIT_KV_MAX_BATCH_SIZE) * split_kv_config(policy).max_chunks_per_request;
+        // The concatenated page-index list is counted by reference, not by
+        // physical block: prefix-cached blocks are shared, so N views holding
+        // the same cached prefix each list those page ids again. Sizing this
+        // off the pool's physical block count therefore under-allocates under
+        // prefix sharing (#403); the honest bound is every row presenting a
+        // full-context view. Padding rows list 1 page each, so `bs *
+        // max_view_pages` covers them too (max_view_pages >= 1).
+        anyhow::ensure!(page_size > 0, "page_size must be > 0");
+        let max_view_pages = max_context_tokens.div_ceil(page_size).max(1);
 
         Ok(Self {
             max_batch_size: bs,
@@ -303,8 +312,7 @@ impl BatchDecodeBuffers {
             token_ids_d: ctx.stream.alloc_zeros(bs)?,
             positions_d: ctx.stream.alloc_zeros(bs)?,
             lora_token_slots_d: ctx.stream.alloc_zeros(bs)?,
-            // Paged attention: worst case all requests use max_total_pages + padding slots
-            page_indices_d: ctx.stream.alloc_zeros(max_total_pages + bs)?,
+            page_indices_d: ctx.stream.alloc_zeros(bs * max_view_pages)?,
             page_indptr_d: ctx.stream.alloc_zeros(bs + 1)?,
             last_page_len_d: ctx.stream.alloc_zeros(bs)?,
             request_indices_d: ctx.stream.alloc_zeros(bs)?,
@@ -392,6 +400,17 @@ impl BatchDecodeBuffers {
         let request_indices: Vec<i32> = (0..padded_bs as i32).collect();
         let kv_tile_indices = vec![0i32; padded_bs];
 
+        // Fail loud instead of tripping cudarc's copy assert (a panic here
+        // kills the worker thread and wedges the engine — #403). Reachable
+        // only if a view exceeds the context limit the buffer was sized for.
+        anyhow::ensure!(
+            all_page_indices.len() <= self.page_indices_d.len(),
+            "decode page-index overflow: {} view pages (bs={real_bs}, padded={padded_bs}) \
+             exceed buffer capacity {}; a view is larger than the context limit \
+             the buffers were sized for",
+            all_page_indices.len(),
+            self.page_indices_d.len()
+        );
         ctx.stream
             .memcpy_htod(&all_page_indices, &mut self.page_indices_d)?;
         ctx.stream.memcpy_htod(&indptr, &mut self.page_indptr_d)?;
@@ -480,7 +499,52 @@ impl BatchDecodeBuffers {
 
 #[cfg(test)]
 mod tests {
-    use super::build_split_kv_csr;
+    use super::{BatchDecodeBuffers, build_split_kv_csr};
+    use openinfer_core::tensor::DeviceContext;
+    use openinfer_kv_cache::KvView;
+
+    #[test]
+    fn shared_prefix_views_are_counted_by_reference() {
+        let ctx = DeviceContext::new().expect("CUDA context");
+        let page_size = 16;
+        let max_context_tokens = 64; // 4 pages per full-context view
+        let bs = 4;
+        let mut bufs = BatchDecodeBuffers::new(
+            &ctx,
+            8,
+            8,
+            8,
+            8,
+            16,
+            bs,
+            page_size,
+            0,
+            1,
+            max_context_tokens,
+        )
+        .expect("buffer alloc");
+
+        // Every view lists the SAME 4 physical pages (a shared cached prefix):
+        // 16 listed entries backed by only 4 physical blocks. A buffer sized
+        // off the physical pool count under-allocates exactly here (#403).
+        let views: Vec<KvView> = (0..bs)
+            .map(|_| KvView::new(vec![0, 1, 2, 3], 64, page_size))
+            .collect();
+        let refs: Vec<&KvView> = views.iter().collect();
+        bufs.sync_paged_meta(&ctx, &refs, bs)
+            .expect("shared views fit");
+
+        // A view past the context limit the buffers were sized for must error
+        // (fail loud), not trip cudarc's copy assert and kill the worker.
+        let oversized: Vec<KvView> = (0..bs)
+            .map(|_| KvView::new(vec![0, 1, 2, 3, 4], 80, page_size))
+            .collect();
+        let refs: Vec<&KvView> = oversized.iter().collect();
+        let err = bufs
+            .sync_paged_meta(&ctx, &refs, bs)
+            .expect_err("oversized views must fail loud");
+        assert!(err.to_string().contains("page-index overflow"), "{err}");
+    }
 
     #[test]
     fn uniform_batch_csr() {

--- a/openinfer-qwen3-4b/src/batch_decode_trace.rs
+++ b/openinfer-qwen3-4b/src/batch_decode_trace.rs
@@ -87,7 +87,7 @@ pub fn trace_decode_kernel_calls(
         model.local_intermediate_size(),
         model.config().vocab_size,
         batch_size,
-        kv_mgr.pool().total_blocks(),
+        layout.page_size,
         kv_mgr.pool().padding_block_id(),
         model.local_num_attention_heads(),
         model.config().max_position_embeddings,

--- a/openinfer-qwen3-4b/src/executor.rs
+++ b/openinfer-qwen3-4b/src/executor.rs
@@ -2517,7 +2517,7 @@ impl LocalQwen3Lane {
             model.local_intermediate_size(),
             model.config().vocab_size,
             max_bucket,
-            total_blocks,
+            buf_layout.page_size,
             padding_block_id,
             model.local_num_attention_heads(),
             model.config().max_position_embeddings,

--- a/openinfer-qwen3-4b/src/weights.rs
+++ b/openinfer-qwen3-4b/src/weights.rs
@@ -956,7 +956,7 @@ impl Qwen3Model {
             self.local_intermediate_size(),
             self.config.vocab_size,
             max_decode_batch_size,
-            profile_blocks,
+            geometry.block_size,
             0,
             self.local_num_attention_heads(),
             self.config.max_position_embeddings,


### PR DESCRIPTION
## Problem

`BatchDecodeBuffers::page_indices_d` is sized `total_blocks + max_bs`, assuming the concatenated per-request page lists of a decode step are bounded by the physical pool. Prefix caching breaks that assumption: matched blocks are shared `ImmutableBlock`s, so N views holding the same cached prefix each list those page ids again — the concatenated list is counted **by reference**, not by physical block. Admission cannot catch it either: `request_lifetime_blocks` charges physical blocks, and sharing makes physical usage far smaller than the by-reference count.

Once the sum crosses the buffer size, `sync_paged_meta`'s `memcpy_htod` trips cudarc's `dst.len() >= src.len()` assert, killing `qwen3-tp-rank-0`; every later step fails with `tensor-parallel worker step channel closed` while `/health` stays 200 — the permanent wedge of #403 (fault 1; fault 2, the blast radius, is #420's territory). Backtrace from a live repro on `main` @ `1275262`:

```
3: cudarc::driver::safe::core::CudaStream::memcpy_htod::<i32, ...>
4: openinfer_qwen3_4b::batch_decode_buffers::BatchDecodeBuffers::sync_paged_meta
5: openinfer_qwen3_4b::weights::Qwen3Model::batch_decode
6: openinfer_qwen3_4b::executor::execute_step_on_lane
```

This also explains the two puzzles in the issue report. A one-shot 160-request burst cannot reproduce: blocks only become matchable once sealed, and simultaneous prefills do not match each other — sharing needs sustained arrivals over an already-sealed prefix. And the 5070 Ti repro is intermittent because `scripts/bench_http_serving.py`'s 24-word vocabulary yields only 24 distinct prompts, so the shared double-count hovers right at the `+ max_bs` slack the old sizing left.

With a shared prefix the failure is deterministic, not intermittent: warm one long prompt, then fire N concurrent requests with the same prompt (repro script in #403). Common prefixes are the serving norm — a system prompt is exactly this shape.

## Change

- Size `page_indices_d` for the reachable worst case — every decode row presenting a full-context view: `max_batch × ceil(max_context_tokens / page_size)`. The constructor takes `page_size` instead of `max_total_pages`; the physical pool size no longer appears in the bound. For Qwen3-4B (bucket 256 × 2560 pages) this is 2.6 MiB of i32 vs ~98 KiB before — noise next to the pool it indexes, and the memory profiler builds the same buffers, so profiled KV sizing absorbs it automatically.
- Fail loud in `sync_paged_meta` if the concatenated list ever exceeds the buffer (reachable only if a view exceeds the context limit the buffers were sized for): a step `Err` instead of a dead worker thread.
- Regression test `shared_prefix_views_are_counted_by_reference`: N views listing the same physical pages sync fine; oversized views return the error instead of tripping the assert. GPU-only, no weights needed.
- `docs/models/qwen3/prefix-cache.md`: recorded the by-reference page accounting rule so the next concatenated-page-list consumer doesn't re-derive it.

## Verification (H100 80GB, sm_90, CUDA 12.4, Qwen3-8B serving / Qwen3-4B gates)

Repro A/B — warm a 3000-word prompt, then 256 concurrent identical requests (max_tokens 64):

| | main @ 1275262 | this branch |
|---|---|---|
| requests OK | 193/256 (63 × HTTP 500) | **256/256** |
| worker panic | cudarc assert (backtrace above) | none |
| engine after | wedged: trivial completion 500, `/health` 200 | healthy: completion 200 |

Gates:

```
cargo test --release -p openinfer-qwen3-4b -p openinfer-core -p openinfer-kv-cache -p openinfer-sample --lib   # 76 passed
OPENINFER_TEST_MODEL_PATH=<Qwen3-4B> cargo test --release -p openinfer-qwen3-4b --test hf_golden_gate           # pass, 31.5s
OPENINFER_TEST_MODEL_PATH=<Qwen3-4B> cargo test --release -p openinfer-qwen3-4b --test prefix_cache             # pass, 8.3s
```

(`--workspace --lib` is not runnable on this box — `openinfer-cupti` needs CUPTI headers the CUDA 12.4 install lacks; the per-crate runs above cover every touched crate.)

Serving A/B, same box/base, `vllm bench serve` random 256-out conc=64, N=200 (allocation-only change — expected noise, observed noise):

| workload | metric | main | this branch |
|---|---|---:|---:|
| 128-in | output tok/s | 5421.6 | 5514.2 |
| 128-in | TPOT mean | 9.24 ms | 9.03 ms |
| 2048-in | output tok/s | 2030.7 | 2030.5 |
| 2048-in | TPOT mean | 25.96 ms | 26.11 ms |

## Notes for review

- qwen35's `decode_buffers.rs:116` has the same physical-pool sizing. It is unreachable today (no prefix cache on that line yet), so it is flagged for the qwen35 prefix-cache design (#257) rather than changed here.
- The new `ensure!` is defense in depth: with the honest bound it should never fire; if it does, it composes with #420's containment (step error, not dead worker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
