### PR TITLE
fix(qwen3): make stream override an RAII guard

### DIFF
--- a/openinfer-kernels/src/tensor.rs
+++ b/openinfer-kernels/src/tensor.rs
@@ -16,20 +16,25 @@ thread_local! {
     static STREAM_OVERRIDE: Cell<Option<CUstream>> = const { Cell::new(None) };
 }
 
-/// Set a thread-local stream override. All subsequent kernel launches via
-/// [`DeviceContext::active_cu_stream`] will use this stream instead of the
-/// context's default stream. Call [`clear_stream_override`] to revert.
-///
-/// # Safety
-/// The caller must ensure the stream is valid for the lifetime of the override
-/// and belongs to the same CUDA device as the `DeviceContext`.
-pub unsafe fn set_stream_override(stream: CUstream) {
-    STREAM_OVERRIDE.with(|c| c.set(Some(stream)));
+/// Scoped stream override for [`active_cu_stream`]; drop restores the previous value.
+pub struct StreamOverrideGuard {
+    previous: Option<CUstream>,
 }
 
-/// Clear the thread-local stream override, reverting to the context's default.
-pub fn clear_stream_override() {
-    STREAM_OVERRIDE.with(|c| c.set(None));
+impl StreamOverrideGuard {
+    /// # Safety
+    /// The stream must be valid for the guard's lifetime and belong to the
+    /// same CUDA device as the `DeviceContext`.
+    pub unsafe fn activate(stream: CUstream) -> Self {
+        let previous = STREAM_OVERRIDE.with(|c| c.replace(Some(stream)));
+        Self { previous }
+    }
+}
+
+impl Drop for StreamOverrideGuard {
+    fn drop(&mut self) {
+        STREAM_OVERRIDE.with(|c| c.set(self.previous));
+    }
 }
 
 /// Returns true if a stream override is currently active on this thread.
@@ -674,6 +679,20 @@ pub struct DeviceMatrixRef<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn stream_override_guard_restores_on_drop() {
+        let outer = 0x10usize as CUstream;
+        assert!(!has_stream_override());
+        {
+            let _outer_guard = unsafe { StreamOverrideGuard::activate(outer) };
+            {
+                let _inner_guard = unsafe { StreamOverrideGuard::activate(0x20usize as CUstream) };
+            }
+            assert_eq!(STREAM_OVERRIDE.with(Cell::get), Some(outer));
+        }
+        assert!(!has_stream_override());
+    }
 
     fn copy_matrix_to_host(ctx: &DeviceContext, matrix: &DeviceMatrix) -> Vec<bf16> {
         let host = ctx

--- a/openinfer-qwen3-4b/src/executor.rs
+++ b/openinfer-qwen3-4b/src/executor.rs
@@ -403,7 +403,7 @@ fn execute_step_on_lane(
             decode_stream,
             sample_seed,
         } => {
-            use openinfer_kernels::tensor::{clear_stream_override, set_stream_override};
+            use openinfer_kernels::tensor::StreamOverrideGuard;
 
             // If there's still an inflight prefill from a previous step, sync it
             // now (shouldn't happen normally, but safety).
@@ -430,24 +430,26 @@ fn execute_step_on_lane(
             lane.model.device_ctx().sync()?;
 
             // Launch prefill on prefill partition stream.
-            unsafe { set_stream_override(prefill_stream.0) };
-            let (prefill_logits, _, _) = lane.execute_prefill(
-                &prefill_prompts,
-                prefill_kv_views,
-                &prefill_lora_adapters,
-                false,
-                None,
-            )?;
-            clear_stream_override();
+            let (prefill_logits, _, _) = {
+                let _prefill_override = unsafe { StreamOverrideGuard::activate(prefill_stream.0) };
+                lane.execute_prefill(
+                    &prefill_prompts,
+                    prefill_kv_views,
+                    &prefill_lora_adapters,
+                    false,
+                    None,
+                )?
+            };
 
             // Launch decode on the decode partition stream. CUDA graph stays
             // enabled: batch_decode captures into the split graph cache keyed on
             // the active stream override, so the replayed kernel nodes stay
             // pinned to the decode SM partition (CUDA PG §4.6.5 — capture stream
             // determines a node's execution context).
-            unsafe { set_stream_override(decode_stream.0) };
-            lane.execute_decode(&decode_tokens, decode_kv_views, &decode_lora_adapters)?;
-            clear_stream_override();
+            {
+                let _decode_override = unsafe { StreamOverrideGuard::activate(decode_stream.0) };
+                lane.execute_decode(&decode_tokens, decode_kv_views, &decode_lora_adapters)?;
+            }
 
             // Only sync decode stream — decode result is ready for sampling.
             // Prefill continues async on GPU; polled later via event.


### PR DESCRIPTION
## Description

An `Err` from the `SplitConcurrent` prefill/decode launch skips `clear_stream_override()` and leaks the thread-local override into the worker thread: later steps launch on the wrong stream, and plain decode-only steps silently select the split graph cache. Both the prefill and the decode region have this hole.

Replace the raw `set_stream_override`/`clear_stream_override` pair with an RAII `StreamOverrideGuard` that restores the previous override on drop (early returns, unwinds, nesting) — same shape as the existing `OwnedPagePermit` guard.

## Test 

EnvL Single GPU, sm_89, x86_64, Qwen3-4B

Error-path A/B with identical instrumentation in both binaries (one-shot injected `Err` inside the decode override region + a `stream_override=` trace at step entry), `--decode-overlap stream`, staggered mixed load: main keeps running steps with the leaked override after the `Err`. `cargo fmt --check`, `cargo clippy --release`, and the kernels unit tests pass.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)