### PR TITLE
perf(kernels): vectorize batched embedding gather to 16-byte row copies (#484)

### DIFF
--- a/openinfer-kernels/csrc/shared/elementwise.cu
+++ b/openinfer-kernels/csrc/shared/elementwise.cu
@@ -1,4 +1,5 @@
 #include "common.cuh"
+#include <cstdint>
 #include <cuda.h>
 
 // ============================================================================
@@ -255,6 +256,33 @@ __global__ void embedding_batched_kernel(
   }
 }
 
+// Vectorized batched embedding lookup: grid.x indexes the token, grid.y
+// splits the row into block-wide segments of 16-byte vectors, token id
+// loaded once per block. The scalar kernel above moves 2 bytes per thread
+// per access with a div+mod and a token_ids reload per element, which caps
+// it near a quarter of DRAM bandwidth; the vectorized row copy streams at
+// full width, and the 2D grid keeps enough blocks in flight at small token
+// counts (decode) that the launch floor does not regress. Requires
+// hidden_size % 8 == 0 and 16-byte-aligned base pointers — the launcher
+// falls back to the scalar kernel otherwise.
+__global__ void embedding_batched_vec4_kernel(
+    const uint4 *__restrict__ embed,
+    const uint32_t *__restrict__ token_ids,
+    uint4 *__restrict__ out,
+    int hidden_vec, int seq_len) {
+  const int token = blockIdx.x;
+  if (token >= seq_len) {
+    return;
+  }
+  const uint32_t token_id = __ldg(&token_ids[token]);
+  const uint4 *__restrict__ src = embed + (size_t)token_id * hidden_vec;
+  uint4 *__restrict__ dst = out + (size_t)token * hidden_vec;
+  for (int v = blockIdx.y * blockDim.x + threadIdx.x; v < hidden_vec;
+       v += gridDim.y * blockDim.x) {
+    dst[v] = src[v];
+  }
+}
+
 // ============================================================================
 // Tensor-parallel vocab-sharded embedding lookup.
 //
@@ -282,6 +310,36 @@ __global__ void embedding_batched_vocab_shard_kernel(
       out[idx] = embed[(size_t)local_token_id * hidden_size + dim_offset];
     } else {
       out[idx] = __float2bfloat16(0.0f);
+    }
+  }
+}
+
+// Vectorized variant of the vocab-sharded lookup; same layout contract as
+// embedding_batched_vec4_kernel, with non-local tokens writing zero vectors.
+__global__ void embedding_batched_vocab_shard_vec4_kernel(
+    const uint4 *__restrict__ embed,
+    const uint32_t *__restrict__ token_ids,
+    uint4 *__restrict__ out,
+    int hidden_vec, int seq_len, uint32_t vocab_start,
+    uint32_t part_vocab_size) {
+  const int token = blockIdx.x;
+  if (token >= seq_len) {
+    return;
+  }
+  const uint32_t token_id = __ldg(&token_ids[token]);
+  uint4 *__restrict__ dst = out + (size_t)token * hidden_vec;
+  if (token_id >= vocab_start && token_id < vocab_start + part_vocab_size) {
+    const uint4 *__restrict__ src =
+        embed + (size_t)(token_id - vocab_start) * hidden_vec;
+    for (int v = blockIdx.y * blockDim.x + threadIdx.x; v < hidden_vec;
+         v += gridDim.y * blockDim.x) {
+      dst[v] = src[v];
+    }
+  } else {
+    const uint4 zero = make_uint4(0u, 0u, 0u, 0u);
+    for (int v = blockIdx.y * blockDim.x + threadIdx.x; v < hidden_vec;
+         v += gridDim.y * blockDim.x) {
+      dst[v] = zero;
     }
   }
 }
@@ -489,11 +547,36 @@ CUresult embedding_decode_cuda(
   return (CUresult)cudaGetLastError();
 }
 
+// Whether the vectorized row-copy embedding kernels can serve this call:
+// whole 16-byte vectors per row and 16-byte-aligned base pointers. Row
+// offsets stay aligned because every row is a whole number of vectors.
+static bool embedding_vec4_ok(
+    const void *embed, const void *out, int hidden_size) {
+  return hidden_size % 8 == 0 &&
+         ((reinterpret_cast<uintptr_t>(embed) |
+           reinterpret_cast<uintptr_t>(out)) & 15) == 0;
+}
+
+// Measured on H100 with the 2D grid (seq 128/2048/10000, bs 1/32): 128
+// threads edges out 256 by ~2% at 10k tokens and is level elsewhere — more
+// row segments per token hide the gather latency slightly better.
+static const int EMBEDDING_VEC4_BLOCK = 128;
+
 CUresult embedding_batched_cuda(
     const __nv_bfloat16 *embed, const uint32_t *token_ids,
     __nv_bfloat16 *out, int hidden_size, int seq_len, cudaStream_t stream) {
-  int total = hidden_size * seq_len;
+  if (embedding_vec4_ok(embed, out, hidden_size)) {
+    int hidden_vec = hidden_size / 8;
+    int row_segs =
+        (hidden_vec + EMBEDDING_VEC4_BLOCK - 1) / EMBEDDING_VEC4_BLOCK;
+    dim3 grid(seq_len, row_segs);
+    embedding_batched_vec4_kernel<<<grid, EMBEDDING_VEC4_BLOCK, 0, stream>>>(
+        reinterpret_cast<const uint4 *>(embed), token_ids,
+        reinterpret_cast<uint4 *>(out), hidden_vec, seq_len);
+    return (CUresult)cudaGetLastError();
+  }
   int block = 256;
+  int total = hidden_size * seq_len;
   int grid = (total + block - 1) / block;
   embedding_batched_kernel<<<grid, block, 0, stream>>>(embed, token_ids, out, hidden_size, seq_len);
   return (CUresult)cudaGetLastError();
@@ -503,8 +586,20 @@ CUresult embedding_batched_vocab_shard_cuda(
     const __nv_bfloat16 *embed, const uint32_t *token_ids,
     __nv_bfloat16 *out, int hidden_size, int seq_len,
     uint32_t vocab_start, uint32_t part_vocab_size, cudaStream_t stream) {
-  int total = hidden_size * seq_len;
+  if (embedding_vec4_ok(embed, out, hidden_size)) {
+    int hidden_vec = hidden_size / 8;
+    int row_segs =
+        (hidden_vec + EMBEDDING_VEC4_BLOCK - 1) / EMBEDDING_VEC4_BLOCK;
+    dim3 grid(seq_len, row_segs);
+    embedding_batched_vocab_shard_vec4_kernel<<<
+        grid, EMBEDDING_VEC4_BLOCK, 0, stream>>>(
+        reinterpret_cast<const uint4 *>(embed), token_ids,
+        reinterpret_cast<uint4 *>(out), hidden_vec, seq_len,
+        vocab_start, part_vocab_size);
+    return (CUresult)cudaGetLastError();
+  }
   int block = 256;
+  int total = hidden_size * seq_len;
   int grid = (total + block - 1) / block;
   embedding_batched_vocab_shard_kernel<<<grid, block, 0, stream>>>(
       embed, token_ids, out, hidden_size, seq_len, vocab_start, part_vocab_size);

--- a/openinfer-kernels/src/ops/embedding.rs
+++ b/openinfer-kernels/src/ops/embedding.rs
@@ -96,6 +96,77 @@ mod tests {
 
     use super::*;
 
+    /// The vectorized row-copy path (hidden % 8 == 0) must be bit-exact
+    /// against a host-side gather — it is a pure copy.
+    #[test]
+    fn embedding_batch_vectorized_path_is_bit_exact() {
+        let ctx = DeviceContext::new().expect("create CUDA context");
+        let hidden_size = 2560; // production Qwen3 width -> vec4 path
+        let vocab = 64;
+        let seq_len = 33; // not a multiple of the block count on purpose
+        let embed_host: Vec<bf16> = (0..vocab * hidden_size)
+            .map(|i| bf16::from_f32((((i % 509) as f32) - 254.0) * 0.01))
+            .collect();
+        let embed =
+            DeviceMatrix::from_host(&ctx, &embed_host, vocab, hidden_size).expect("embed");
+        let ids: Vec<u32> = (0..seq_len).map(|i| ((i * 31) % vocab) as u32).collect();
+        let token_ids = ctx.stream.clone_htod(&ids).expect("token ids");
+        let mut out = HiddenStates::zeros(&ctx, hidden_size, seq_len).expect("out");
+
+        embedding_batch(&ctx, &embed, &token_ids, &mut out).expect("embedding");
+        let got = ctx.stream.clone_dtoh(&out.data).expect("dtoh");
+        ctx.sync().expect("sync");
+
+        for (token, &id) in ids.iter().enumerate() {
+            let row = &embed_host[id as usize * hidden_size..(id as usize + 1) * hidden_size];
+            let col = &got[token * hidden_size..(token + 1) * hidden_size];
+            assert!(
+                row.iter().zip(col).all(|(a, b)| a.to_bits() == b.to_bits()),
+                "token {token} (id {id}) differs from host gather"
+            );
+        }
+    }
+
+    /// Same contract for the vectorized vocab-shard path, including the
+    /// zero-fill of non-local tokens.
+    #[test]
+    fn embedding_batch_vocab_shard_vectorized_masks_nonlocal_tokens() {
+        let ctx = DeviceContext::new().expect("create CUDA context");
+        let hidden_size = 16; // multiple of 8 -> vec4 path
+        let embed_host: Vec<bf16> = (0..2 * hidden_size)
+            .map(|i| bf16::from_f32(i as f32))
+            .collect();
+        let embed = DeviceMatrix::from_host(&ctx, &embed_host, 2, hidden_size).expect("embed");
+        let token_ids = ctx.stream.clone_htod(&[4_u32, 5, 6, 3]).expect("token ids");
+        let mut out = HiddenStates::zeros(&ctx, hidden_size, 4).expect("out");
+
+        embedding_batch_vocab_shard(&ctx, &embed, &token_ids, &mut out, 4, 2)
+            .expect("embedding shard");
+        let got = ctx.stream.clone_dtoh(&out.data).expect("dtoh");
+        ctx.sync().expect("sync");
+
+        assert!(
+            got[..hidden_size]
+                .iter()
+                .zip(&embed_host[..hidden_size])
+                .all(|(a, b)| a.to_bits() == b.to_bits()),
+            "local token 4 must copy row 0"
+        );
+        assert!(
+            got[hidden_size..2 * hidden_size]
+                .iter()
+                .zip(&embed_host[hidden_size..])
+                .all(|(a, b)| a.to_bits() == b.to_bits()),
+            "local token 5 must copy row 1"
+        );
+        assert!(
+            got[2 * hidden_size..]
+                .iter()
+                .all(|v| v.to_bits() == bf16::ZERO.to_bits()),
+            "non-local tokens 6 and 3 must be zero-filled"
+        );
+    }
+
     #[test]
     fn embedding_batch_vocab_shard_masks_nonlocal_tokens() {
         let ctx = DeviceContext::new().expect("create CUDA context");


### PR DESCRIPTION
Closes #484. The batched embedding gather now streams 16-byte vectors instead of scalar bf16 elements: **2.92× at 10k prefill tokens (113.25 → 38.73µs, 27% → 79% of DRAM speed-of-light), no regression at any decode batch size.**

## Problem

`embedding_batched_kernel` walks `hidden_size × seq_len` elements one bf16 at a time: 2 bytes per thread per access, a div+mod per element, and a `token_ids[token]` reload per element. That caps it near a quarter of DRAM bandwidth — flat ~27% of the traffic bound across 2k–10k tokens (#484), while `fused_add_rms_norm` runs 86% at the same token counts on the same box.

## Change

- New `embedding_batched_vec4_kernel`: 2D grid — `grid.x` indexes the token, `grid.y` splits the row into block-wide `uint4` segments; token id loaded once per block; pure 16-byte row copy.
- Launcher gates on `hidden_size % 8 == 0` and 16-byte-aligned base pointers (row offsets stay aligned because every row is a whole number of vectors); the scalar kernel remains the fallback, so odd hidden sizes and the existing `hidden=3` shard test keep their exact old path.
- The vocab-shard TP variant gets the same treatment (local rows copy, non-local rows zero-fill in vectors).
- `embedding_decode_kernel` (single-token, CUDA-Graph-captured) is untouched — it sits on the launch floor and has nothing to gain.

## Why the 2D grid (measured, not guessed)

The obvious one-block-per-token shape hit 2.97× on long prefill but **regressed decode ~11%** (6.0 → 6.8µs at bs 1–128: too few blocks in flight at small token counts). The 2D grid keeps `row_segs × tokens` blocks in flight and removes the trade-off:

| shape | scalar | 1D vec4 | **2D vec4 (this PR)** |
|---|---:|---:|---:|
| decode bs=1 | 6.01µs | 6.78µs (0.89×) | **5.88µs (1.02×)** |
| decode bs=128 | 7.80µs | 7.94µs (0.98×) | **6.97µs (1.12×)** |
| decode bs=256 | 9.13µs | 8.18µs (1.12×) | **7.32µs (1.25×)** |
| prefill 10k | 113.25µs | 38.19µs (2.97×) | **38.73µs (2.92×)** |

Block size: 128 vs 256 vs 512 measured on both grid shapes; 128 wins by ~2% at 10k and is level elsewhere.

## Verification (H100 80GB SXM, sm_90, CUDA 12.4, cold L2, 128 iters, `qwen3_kernel_report`)

Full sweeps, before → after:

| tokens | latency | speedup | % of DRAM SoL |
|---:|---|---:|---|
| 128 | 7.44 → 6.56µs | 1.13× | — (launch floor) |
| 512 | 11.70 → 8.00µs | 1.46× | 18% → 27% |
| 1024 | 17.39 → 9.75µs | 1.78× | 18% → 32% |
| 2048 | 27.99 → 12.47µs | 2.24× | 22% → 50% |
| 4096 | 49.54 → 18.19µs | 2.72× | 25% → 69% |
| 8192 | 93.83 → 32.36µs | 2.90× | 27% → 78% |
| 10000 | 113.25 → 38.73µs | 2.92× | 27% → **79%** |

decode_embedding (bs 1→256): 1.01× / 1.01× / 1.02× / 1.02× / 1.01× / 1.02× / 1.07× / 1.12× / 1.25× — no regression anywhere.

Correctness:

- New `embedding_batch_vectorized_path_is_bit_exact`: hidden=2560 (production width → vec path), 33 tokens, bit-compared against a host-side gather — the vec path is a pure copy, so exact equality is the contract.
- New `embedding_batch_vocab_shard_vectorized_masks_nonlocal_tokens`: vec-path shard copy + zero-fill.
- Existing `hidden=3` shard test still exercises the scalar fallback unchanged.
- `OPENINFER_TEST_MODEL_PATH=<Qwen3-4B> cargo test --release -p openinfer-qwen3-4b --test hf_golden_gate` — pass (31.6s).

## Notes for review

- Numbers are from the #456 report tooling (`run --op {prefill,decode}_embedding` + `rank`); snapshots regenerate with those commands on any GPU. On the 5090 the absolute ceiling differs but the shape of the win (scalar → vectorized traffic) is architecture-independent.
- Remaining ~21% at 10k is gather irregularity (row-granular random access vs pure streaming); the flat-copy ops on this box top out ~86%, so most of the recoverable headroom is taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
