### PR TITLE
feat(sampling): min_p end to end, per-request seed groundwork, fail-loud on unsupported params (#490)

### DIFF
--- a/openinfer-dynamo-backend/src/convert.rs
+++ b/openinfer-dynamo-backend/src/convert.rs
@@ -29,16 +29,19 @@ pub const DEFAULT_MAX_TOKENS: usize = 16_384;
 /// Map Dynamo `SamplingOptions` onto openinfer's `SamplingParams`.
 ///
 /// openinfer's sampler is deliberately small — temperature / top-k / top-p /
-/// ignore-eos. Penalties, min-p, seed, beam search and guided decoding have no
-/// engine-side knob yet, so they are dropped here rather than silently faked.
-/// `ignore_eos` lives on `StopConditions` in Dynamo but on `SamplingParams` in
-/// openinfer.
+/// min-p / ignore-eos. Penalties, beam search and guided decoding have no
+/// engine-side knob yet, so they are dropped here rather than silently faked;
+/// per-request seeds wait on the scheduler step wiring (sampling-parity
+/// tracking issue) and are dropped for the same reason. `ignore_eos` lives on
+/// `StopConditions` in Dynamo but on `SamplingParams` in openinfer.
 pub fn to_sampling_params(request: &PreprocessedRequest) -> SamplingParams {
     let s = &request.sampling_options;
     SamplingParams {
         temperature: s.temperature.unwrap_or(0.0),
         top_k: s.top_k.unwrap_or(-1),
         top_p: s.top_p.unwrap_or(1.0),
+        min_p: s.min_p.unwrap_or(0.0),
+        seed: None,
         ignore_eos: request.stop_conditions.ignore_eos.unwrap_or(false),
     }
 }

--- a/openinfer-engine/src/sampler.rs
+++ b/openinfer-engine/src/sampler.rs
@@ -3,6 +3,14 @@ pub struct SamplingParams {
     pub temperature: f32,
     pub top_k: i32,
     pub top_p: f32,
+    /// Minimum probability threshold relative to the most likely token:
+    /// tokens with `p < min_p * p_max` are masked. `0.0` disables (the
+    /// default); valid range is [0, 1).
+    pub min_p: f32,
+    /// Per-request sampling seed. `Some` makes the request's sampled tokens a
+    /// pure function of (seed, request step, distribution) — independent of
+    /// batch composition — so a fixed-seed request replays identically.
+    pub seed: Option<u64>,
     pub ignore_eos: bool,
 }
 
@@ -12,6 +20,8 @@ impl Default for SamplingParams {
             temperature: 0.0,
             top_k: -1,
             top_p: 1.0,
+            min_p: 0.0,
+            seed: None,
             ignore_eos: false,
         }
     }

--- a/openinfer-kernels/csrc/shared/flashinfer_radix_scratch.cuh
+++ b/openinfer-kernels/csrc/shared/flashinfer_radix_scratch.cuh
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+
+#include <cuda_runtime.h>
+
+#include <flashinfer/sampling.cuh>
+
+// Scratch sizing for FlashInfer's deterministic multi-CTA radix passes
+// (top-1 argmax and the top-k renorm on the min_p pipeline): one
+// RadixRowState + collect-scratch slot per SM, with a 1MiB floor kept from
+// the original top1 wrapper. Single source for both `extern "C"` entry
+// points so the layout contract can't drift.
+inline size_t flashinfer_radix_row_states_bytes() {
+  int device = 0;
+  int sm_count = 0;
+  cudaError_t err = cudaGetDevice(&device);
+  if (err == cudaSuccess) {
+    err = cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, device);
+  }
+  size_t groups = err == cudaSuccess && sm_count > 0
+                      ? static_cast<size_t>(sm_count)
+                      : static_cast<size_t>(
+                            flashinfer::sampling::RADIX_TOPK_MAX_DETERMINISTIC_CTAS_PER_GROUP);
+  size_t radix_bytes =
+      groups * (sizeof(flashinfer::sampling::RadixRowState) +
+                sizeof(flashinfer::sampling::RadixDeterministicCollectScratch));
+  return std::max<size_t>(1024 * 1024, radix_bytes);
+}

--- a/openinfer-kernels/csrc/shared/flashinfer_sampling.cu
+++ b/openinfer-kernels/csrc/shared/flashinfer_sampling.cu
@@ -1,7 +1,6 @@
 #include "common.cuh"
 #include "flashinfer_radix_scratch.cuh"
 
-#include <algorithm>
 #include <cuda_bf16.h>
 #include <stdint.h>
 

--- a/openinfer-kernels/csrc/shared/flashinfer_sampling.cu
+++ b/openinfer-kernels/csrc/shared/flashinfer_sampling.cu
@@ -1,9 +1,11 @@
 #include "common.cuh"
 
+#include <algorithm>
 #include <cuda_bf16.h>
 #include <stdint.h>
 
 #include <flashinfer/sampling.cuh>
+#include <flashinfer/topk.cuh>
 
 namespace {
 
@@ -44,9 +46,41 @@ __global__ void gather_cast_logits_f32_kernel(const __nv_bfloat16* __restrict__ 
 // top_k_arr entries must be pre-clamped to [1, vocab_size] when top-k is used;
 // temperature_arr entries must be > 0 — greedy rows belong on the argmax path,
 // not here.
+// Workspace for the radix top-k renorm used on the min_p pipeline; same
+// layout contract as flashinfer_top1_row_states_bytes_cuda.
+extern "C" size_t gpu_sample_topk_renorm_row_states_bytes_cuda() {
+  int device = 0;
+  int sm_count = 0;
+  cudaError_t err = cudaGetDevice(&device);
+  if (err == cudaSuccess) {
+    err = cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, device);
+  }
+  size_t groups = err == cudaSuccess && sm_count > 0
+                      ? static_cast<size_t>(sm_count)
+                      : static_cast<size_t>(
+                            flashinfer::sampling::RADIX_TOPK_MAX_DETERMINISTIC_CTAS_PER_GROUP);
+  size_t radix_bytes =
+      groups * (sizeof(flashinfer::sampling::RadixRowState) +
+                sizeof(flashinfer::sampling::RadixDeterministicCollectScratch));
+  return std::max<size_t>(1024 * 1024, radix_bytes);
+}
+
+// min_p_arr enables the min_p pipeline: (optional) top-k renorm, (optional)
+// top-p renorm, then FlashInfer's MinPSamplingFromProb with the per-row
+// thresholds. min_p_arr == nullptr keeps the original fused single-kernel
+// paths bit-for-bit (the fast path).
+//
+// Per-request seeds deliberately do NOT go through FlashInfer's `seed_arr`:
+// these kernels read `seed_arr[0]` (one seed for the whole batch) and fold
+// `blockIdx.x` into the philox subsequence, so a request's stream would
+// change with its position in the batch. Seeded rows are instead sampled as
+// their own n_rows=1 calls by the Rust layer, with the request seed and step
+// mixed into `seed` — blockIdx is then always 0 and replay is independent of
+// batch composition.
 extern "C" int gpu_sample_batch_flashinfer_cuda(
     const __nv_bfloat16* logits, const int* row_indices, float* probs_scratch,
     const float* temperature_arr, const int* top_k_arr, const float* top_p_arr,
+    const float* min_p_arr, uint8_t* topk_row_states_scratch,
     uint8_t* valid_scratch, int* output, void* softmax_workspace,
     size_t softmax_workspace_bytes, int n_rows, int vocab_size, int has_top_k_filter,
     int has_top_p_filter, uint64_t seed, uint64_t offset, cudaStream_t stream) {
@@ -72,6 +106,37 @@ extern "C" int gpu_sample_batch_flashinfer_cuda(
   }
 
   bool* valid = reinterpret_cast<bool*>(valid_scratch);
+  if (min_p_arr != nullptr) {
+    if (has_top_k_filter) {
+      auto* row_states =
+          reinterpret_cast<flashinfer::sampling::RadixRowState*>(topk_row_states_scratch);
+      if (row_states == nullptr) {
+        return static_cast<int>(cudaErrorInvalidValue);
+      }
+      // In-place: the renorm kernels reduce a threshold first, then rewrite
+      // each element from its own index.
+      err = flashinfer::sampling::RadixTopKRenormProbMultiCTA<float, int>(
+          probs_scratch, probs_scratch, const_cast<int*>(top_k_arr), n_rows,
+          /*top_k_val=*/0, vocab_size, row_states, stream);
+      if (err != cudaSuccess) {
+        return static_cast<int>(err);
+      }
+    }
+    if (has_top_p_filter) {
+      err = flashinfer::sampling::TopPRenormProb<float>(
+          probs_scratch, probs_scratch, const_cast<float*>(top_p_arr), n_rows,
+          /*top_p_val=*/0.0f, vocab_size, stream);
+      if (err != cudaSuccess) {
+        return static_cast<int>(err);
+      }
+    }
+    err = flashinfer::sampling::MinPSamplingFromProb<float, int>(
+        probs_scratch, const_cast<float*>(min_p_arr), output, valid,
+        /*indices=*/nullptr, n_rows, /*min_p_val=*/0.0f, vocab_size,
+        /*deterministic=*/true, /*seed_arr=*/nullptr, seed, /*offset_arr=*/nullptr, offset,
+        stream);
+    return static_cast<int>(err);
+  }
   if (has_top_k_filter) {
     err = flashinfer::sampling::TopKTopPSamplingFromProb<float, int>(
         probs_scratch, const_cast<int*>(top_k_arr), const_cast<float*>(top_p_arr), output, valid,

--- a/openinfer-kernels/csrc/shared/flashinfer_sampling.cu
+++ b/openinfer-kernels/csrc/shared/flashinfer_sampling.cu
@@ -1,4 +1,5 @@
 #include "common.cuh"
+#include "flashinfer_radix_scratch.cuh"
 
 #include <algorithm>
 #include <cuda_bf16.h>
@@ -49,20 +50,7 @@ __global__ void gather_cast_logits_f32_kernel(const __nv_bfloat16* __restrict__ 
 // Workspace for the radix top-k renorm used on the min_p pipeline; same
 // layout contract as flashinfer_top1_row_states_bytes_cuda.
 extern "C" size_t gpu_sample_topk_renorm_row_states_bytes_cuda() {
-  int device = 0;
-  int sm_count = 0;
-  cudaError_t err = cudaGetDevice(&device);
-  if (err == cudaSuccess) {
-    err = cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, device);
-  }
-  size_t groups = err == cudaSuccess && sm_count > 0
-                      ? static_cast<size_t>(sm_count)
-                      : static_cast<size_t>(
-                            flashinfer::sampling::RADIX_TOPK_MAX_DETERMINISTIC_CTAS_PER_GROUP);
-  size_t radix_bytes =
-      groups * (sizeof(flashinfer::sampling::RadixRowState) +
-                sizeof(flashinfer::sampling::RadixDeterministicCollectScratch));
-  return std::max<size_t>(1024 * 1024, radix_bytes);
+  return flashinfer_radix_row_states_bytes();
 }
 
 // min_p_arr enables the min_p pipeline: (optional) top-k renorm, (optional)

--- a/openinfer-kernels/csrc/shared/flashinfer_top1.cu
+++ b/openinfer-kernels/csrc/shared/flashinfer_top1.cu
@@ -1,4 +1,5 @@
 #include "common.cuh"
+#include "flashinfer_radix_scratch.cuh"
 
 #include <algorithm>
 #include <cstddef>
@@ -9,22 +10,7 @@
 #include <flashinfer/topk.cuh>
 
 extern "C" size_t flashinfer_top1_row_states_bytes_cuda() {
-  int device = 0;
-  int sm_count = 0;
-  cudaError_t err = cudaGetDevice(&device);
-  if (err == cudaSuccess) {
-    err = cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, device);
-  }
-  size_t groups = err == cudaSuccess && sm_count > 0
-                      ? static_cast<size_t>(sm_count)
-                      : static_cast<size_t>(
-                            flashinfer::sampling::RADIX_TOPK_MAX_DETERMINISTIC_CTAS_PER_GROUP);
-  size_t radix_bytes =
-      groups * (sizeof(flashinfer::sampling::RadixRowState) +
-                sizeof(flashinfer::sampling::RadixDeterministicCollectScratch));
-  // Preserve the old 1MiB floor while covering FlashInfer's multi-CTA deterministic
-  // radix collect scratch, which is laid out after the row-state array.
-  return std::max<size_t>(1024 * 1024, radix_bytes);
+  return flashinfer_radix_row_states_bytes();
 }
 
 extern "C" void flashinfer_top1_cuda(const __nv_bfloat16* logits,

--- a/openinfer-kernels/csrc/shared/flashinfer_top1.cu
+++ b/openinfer-kernels/csrc/shared/flashinfer_top1.cu
@@ -1,8 +1,6 @@
 #include "common.cuh"
 #include "flashinfer_radix_scratch.cuh"
 
-#include <algorithm>
-#include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 

--- a/openinfer-kernels/src/ffi/shared.rs
+++ b/openinfer-kernels/src/ffi/shared.rs
@@ -115,6 +115,8 @@ unsafe extern "C" {
 
     pub fn flashinfer_top1_row_states_bytes_cuda() -> usize;
 
+    pub fn gpu_sample_topk_renorm_row_states_bytes_cuda() -> usize;
+
     pub fn gpu_sample_batch_flashinfer_cuda(
         logits: *const Half,
         row_indices: *const i32,
@@ -122,6 +124,8 @@ unsafe extern "C" {
         temperature_arr: *const f32,
         top_k_arr: *const i32,
         top_p_arr: *const f32,
+        min_p_arr: *const f32,
+        topk_row_states_scratch: *mut u8,
         valid_scratch: *mut u8,
         output: *mut i32,
         softmax_workspace: *mut u8,

--- a/openinfer-kernels/src/ops/sampling.rs
+++ b/openinfer-kernels/src/ops/sampling.rs
@@ -86,7 +86,8 @@ impl BatchSamplingScratch {
 /// differ from the fused fast path — a min_p == 0 row could then sample a
 /// different token than it would alone. Partitioning here (not in callers)
 /// keeps "min_p == 0 rows take the original path" true for every caller, at
-/// one extra launch + sync only when a batch actually mixes.
+/// the cost of a second full pass (gather + softmax + sample, own sync) only
+/// when a batch actually mixes.
 pub fn gpu_sample_batch_into(
     ctx: &DeviceContext,
     logits: HiddenStatesRef<'_>,
@@ -94,7 +95,6 @@ pub fn gpu_sample_batch_into(
     seed: u64,
     scratch: &mut BatchSamplingScratch,
 ) -> Result<Vec<u32>> {
-    ensure!(!rows.is_empty(), "batch sampling requires at least one row");
     if rows.iter().all(|r| r.min_p > 0.0) || rows.iter().all(|r| r.min_p <= 0.0) {
         return sample_uniform_batch_into(ctx, logits, rows, seed, scratch);
     }

--- a/openinfer-kernels/src/ops/sampling.rs
+++ b/openinfer-kernels/src/ops/sampling.rs
@@ -9,9 +9,8 @@ use crate::tensor::{DeviceContext, DeviceVec, HiddenStates, HiddenStatesRef};
 /// `temperature` must be > 0 and `top_p` in (0, 1] — greedy rows
 /// (`temperature <= 0` or `top_k == 1`) belong on the argmax path.
 /// `top_k <= 0` means disabled. `min_p` in [0, 1); `0.0` means disabled —
-/// any enabled `min_p` row routes the whole call onto the renorm + min_p
-/// pipeline, so callers should batch min_p rows separately when they want
-/// the fused fast path for the rest.
+/// `gpu_sample_batch_into` partitions min_p rows into their own pass, so
+/// callers may mix freely.
 #[derive(Clone, Copy, Debug)]
 pub struct BatchSamplingRow {
     /// Row index into the logits arena.
@@ -81,7 +80,48 @@ impl BatchSamplingScratch {
 /// `seed` must be fresh per decode step (one philox seed per call; rows
 /// decorrelate through the philox subsequence). Returns one token per row, in
 /// `rows` order.
+///
+/// min_p rows run as their own pass: if they shared a call, every row would
+/// ride the min_p kernel, whose u-scaling (`u * q`) and survivor predicate
+/// differ from the fused fast path — a min_p == 0 row could then sample a
+/// different token than it would alone. Partitioning here (not in callers)
+/// keeps "min_p == 0 rows take the original path" true for every caller, at
+/// one extra launch + sync only when a batch actually mixes.
 pub fn gpu_sample_batch_into(
+    ctx: &DeviceContext,
+    logits: HiddenStatesRef<'_>,
+    rows: &[BatchSamplingRow],
+    seed: u64,
+    scratch: &mut BatchSamplingScratch,
+) -> Result<Vec<u32>> {
+    ensure!(!rows.is_empty(), "batch sampling requires at least one row");
+    if rows.iter().all(|r| r.min_p > 0.0) || rows.iter().all(|r| r.min_p <= 0.0) {
+        return sample_uniform_batch_into(ctx, logits, rows, seed, scratch);
+    }
+    let (minp, plain): (Vec<BatchSamplingRow>, Vec<BatchSamplingRow>) =
+        rows.iter().copied().partition(|r| r.min_p > 0.0);
+    let plain_tokens = sample_uniform_batch_into(ctx, logits, &plain, seed, scratch)?;
+    // Distinct philox key for the second pass: both passes restart their
+    // subsequences at 0, so reusing `seed` would hand minp row i the same
+    // uniform stream as plain row i and correlate their tokens.
+    let minp_seed = seed ^ 0x9E37_79B9_7F4A_7C15;
+    let minp_tokens = sample_uniform_batch_into(ctx, logits, &minp, minp_seed, scratch)?;
+    let mut plain_it = plain_tokens.into_iter();
+    let mut minp_it = minp_tokens.into_iter();
+    Ok(rows
+        .iter()
+        .map(|r| {
+            if r.min_p > 0.0 {
+                minp_it.next().expect("minp token per minp row")
+            } else {
+                plain_it.next().expect("plain token per plain row")
+            }
+        })
+        .collect())
+}
+
+/// One homogeneous FlashInfer pass (rows are all-min_p or all-plain).
+fn sample_uniform_batch_into(
     ctx: &DeviceContext,
     logits: HiddenStatesRef<'_>,
     rows: &[BatchSamplingRow],
@@ -171,7 +211,14 @@ pub fn gpu_sample_batch_into(
         let (top_k_ptr, _gk) = scratch.top_k.device_ptr(&ctx.stream);
         let (top_p_ptr, _gtp) = scratch.top_p.device_ptr(&ctx.stream);
         let (min_p_ptr, _gmp) = scratch.min_p.device_ptr(&ctx.stream);
-        let (row_states_ptr, _grs) = scratch.topk_row_states.device_ptr_mut(&ctx.stream);
+        // topk_row_states is only read on the min_p pipeline; the fast path
+        // hands the kernel a null instead of borrowing the buffer.
+        let row_states = if has_min_p_filter {
+            Some(scratch.topk_row_states.device_ptr_mut(&ctx.stream))
+        } else {
+            None
+        };
+        let row_states_ptr = row_states.as_ref().map_or(0, |(ptr, _guard)| *ptr);
         let (valid_ptr, _gv) = scratch.valid.device_ptr_mut(&ctx.stream);
         let (out_ptr, _go) = scratch.out.device_ptr_mut(&ctx.stream);
         let (ws_ptr, _gw) = scratch.softmax_workspace.device_ptr_mut(&ctx.stream);

--- a/openinfer-kernels/src/ops/sampling.rs
+++ b/openinfer-kernels/src/ops/sampling.rs
@@ -8,7 +8,10 @@ use crate::tensor::{DeviceContext, DeviceVec, HiddenStates, HiddenStatesRef};
 ///
 /// `temperature` must be > 0 and `top_p` in (0, 1] — greedy rows
 /// (`temperature <= 0` or `top_k == 1`) belong on the argmax path.
-/// `top_k <= 0` means disabled.
+/// `top_k <= 0` means disabled. `min_p` in [0, 1); `0.0` means disabled —
+/// any enabled `min_p` row routes the whole call onto the renorm + min_p
+/// pipeline, so callers should batch min_p rows separately when they want
+/// the fused fast path for the rest.
 #[derive(Clone, Copy, Debug)]
 pub struct BatchSamplingRow {
     /// Row index into the logits arena.
@@ -16,6 +19,7 @@ pub struct BatchSamplingRow {
     pub temperature: f32,
     pub top_k: i32,
     pub top_p: f32,
+    pub min_p: f32,
 }
 
 /// Device buffers for `gpu_sample_batch_into`, sized for `max_rows` x `vocab`.
@@ -25,6 +29,8 @@ pub struct BatchSamplingScratch {
     temperature: CudaSlice<f32>,
     top_k: CudaSlice<i32>,
     top_p: CudaSlice<f32>,
+    min_p: CudaSlice<f32>,
+    topk_row_states: CudaSlice<u8>,
     valid: CudaSlice<u8>,
     out: CudaSlice<i32>,
     softmax_workspace: CudaSlice<u8>,
@@ -41,6 +47,7 @@ impl BatchSamplingScratch {
         // OnlineSoftmax vocab-splitting path: batch x ceil(vocab / 8192)
         // partials of {f32 max, f32 denominator}, plus alignment slack.
         let softmax_workspace_bytes = max_rows * vocab.div_ceil(8192) * 8 + 256;
+        let topk_row_states_bytes = unsafe { ffi::gpu_sample_topk_renorm_row_states_bytes_cuda() };
         let alloc = |n: usize| -> Result<CudaSlice<f32>> {
             ctx.stream
                 .alloc_zeros(n)
@@ -52,6 +59,8 @@ impl BatchSamplingScratch {
             temperature: alloc(max_rows)?,
             top_k: ctx.stream.alloc_zeros(max_rows)?,
             top_p: alloc(max_rows)?,
+            min_p: alloc(max_rows)?,
+            topk_row_states: ctx.stream.alloc_zeros(topk_row_states_bytes)?,
             valid: ctx.stream.alloc_zeros(max_rows)?,
             out: ctx.stream.alloc_zeros(max_rows)?,
             softmax_workspace: ctx.stream.alloc_zeros(softmax_workspace_bytes)?,
@@ -97,8 +106,10 @@ pub fn gpu_sample_batch_into(
     let mut temperature = Vec::with_capacity(n);
     let mut top_k = Vec::with_capacity(n);
     let mut top_p = Vec::with_capacity(n);
+    let mut min_p = Vec::with_capacity(n);
     let mut has_top_k_filter = false;
     let mut has_top_p_filter = false;
+    let mut has_min_p_filter = false;
     for r in rows {
         ensure!(
             r.row < logits.seq_len,
@@ -116,6 +127,11 @@ pub fn gpu_sample_batch_into(
             "batch sampling top_p {} must be in (0, 1]",
             r.top_p
         );
+        ensure!(
+            (0.0..1.0).contains(&r.min_p) && r.min_p.is_finite(),
+            "batch sampling min_p {} must be in [0, 1)",
+            r.min_p
+        );
         row_indices.push(i32::try_from(r.row)?);
         temperature.push(r.temperature);
         // FlashInfer reads top_k as u32; "disabled" is any k >= vocab.
@@ -131,6 +147,10 @@ pub fn gpu_sample_batch_into(
             has_top_p_filter = true;
         }
         top_p.push(r.top_p);
+        if r.min_p > 0.0 {
+            has_min_p_filter = true;
+        }
+        min_p.push(r.min_p);
     }
     ctx.stream
         .memcpy_htod(&row_indices, &mut scratch.row_indices)?;
@@ -138,6 +158,9 @@ pub fn gpu_sample_batch_into(
         .memcpy_htod(&temperature, &mut scratch.temperature)?;
     ctx.stream.memcpy_htod(&top_k, &mut scratch.top_k)?;
     ctx.stream.memcpy_htod(&top_p, &mut scratch.top_p)?;
+    if has_min_p_filter {
+        ctx.stream.memcpy_htod(&min_p, &mut scratch.min_p)?;
+    }
 
     {
         let softmax_workspace_bytes = scratch.softmax_workspace.len();
@@ -147,6 +170,8 @@ pub fn gpu_sample_batch_into(
         let (temp_ptr, _gt) = scratch.temperature.device_ptr(&ctx.stream);
         let (top_k_ptr, _gk) = scratch.top_k.device_ptr(&ctx.stream);
         let (top_p_ptr, _gtp) = scratch.top_p.device_ptr(&ctx.stream);
+        let (min_p_ptr, _gmp) = scratch.min_p.device_ptr(&ctx.stream);
+        let (row_states_ptr, _grs) = scratch.topk_row_states.device_ptr_mut(&ctx.stream);
         let (valid_ptr, _gv) = scratch.valid.device_ptr_mut(&ctx.stream);
         let (out_ptr, _go) = scratch.out.device_ptr_mut(&ctx.stream);
         let (ws_ptr, _gw) = scratch.softmax_workspace.device_ptr_mut(&ctx.stream);
@@ -159,6 +184,12 @@ pub fn gpu_sample_batch_into(
                 temp_ptr as *const f32,
                 top_k_ptr as *const i32,
                 top_p_ptr as *const f32,
+                if has_min_p_filter {
+                    min_p_ptr as *const f32
+                } else {
+                    std::ptr::null()
+                },
+                row_states_ptr as *mut u8,
                 valid_ptr as *mut u8,
                 out_ptr as *mut i32,
                 ws_ptr as *mut u8,
@@ -566,18 +597,21 @@ mod tests {
                 temperature: 1.0,
                 top_k: 5,
                 top_p: 1.0,
+                min_p: 0.0,
             },
             BatchSamplingRow {
                 row: 4,
                 temperature: 1.0,
                 top_k: -1,
                 top_p: 0.5,
+                min_p: 0.0,
             },
             BatchSamplingRow {
                 row: 6,
                 temperature: 0.05,
                 top_k: -1,
                 top_p: 1.0,
+                min_p: 0.0,
             },
         ];
 
@@ -614,6 +648,7 @@ mod tests {
             temperature: 1.0,
             top_k: -1,
             top_p: 1e-6,
+            min_p: 0.0,
         }];
         let tokens =
             gpu_sample_batch_into(&ctx, logits.as_ref(), &rows, 17, &mut scratch).expect("sample");
@@ -633,12 +668,14 @@ mod tests {
                 temperature: 1.0,
                 top_k: -1,
                 top_p: 1.0,
+                min_p: 0.0,
             },
             BatchSamplingRow {
                 row: 5,
                 temperature: 1.0,
                 top_k: -1,
                 top_p: 1.0,
+                min_p: 0.0,
             },
         ];
 
@@ -672,12 +709,14 @@ mod tests {
                 temperature: 1.0,
                 top_k: -1,
                 top_p: 1.0,
+                min_p: 0.0,
             },
             BatchSamplingRow {
                 row: 7,
                 temperature: 4.0,
                 top_k: -1,
                 top_p: 1.0,
+                min_p: 0.0,
             },
         ];
 
@@ -710,6 +749,89 @@ mod tests {
     }
 
     #[test]
+    fn batch_sampling_min_p_masks_below_threshold() {
+        let ctx = DeviceContext::new().expect("create CUDA context");
+        // Two-token support: P(100) ≈ 0.7, P(200) ≈ 0.28, tail ≈ 0 (logits
+        // ln(0.7/0.28) apart, rest at -120). min_p thresholds against the max
+        // prob: 0.5 * 0.7 = 0.35 keeps only token 100; 0.2 * 0.7 = 0.14 keeps
+        // both.
+        let mut row = flat_row(-120.0);
+        row[100] = (0.7f32 / 0.28).ln();
+        row[200] = 0.0;
+        let logits = arena_with_rows(&ctx, &[(1, row.clone()), (3, row)]);
+        let mut scratch = BatchSamplingScratch::new(&ctx, ARENA_ROWS, VOCAB).expect("scratch");
+
+        let strict = [BatchSamplingRow {
+            row: 1,
+            temperature: 1.0,
+            top_k: -1,
+            top_p: 1.0,
+            min_p: 0.5,
+        }];
+        for seed in 0..64u64 {
+            let tokens = gpu_sample_batch_into(&ctx, logits.as_ref(), &strict, seed, &mut scratch)
+                .expect("sample");
+            assert_eq!(
+                tokens[0], 100,
+                "seed {seed}: min_p=0.5 must mask the 0.28-prob token"
+            );
+        }
+
+        let loose = [BatchSamplingRow {
+            row: 3,
+            temperature: 1.0,
+            top_k: -1,
+            top_p: 1.0,
+            min_p: 0.2,
+        }];
+        let mut saw_minor = false;
+        for seed in 0..128u64 {
+            let tokens = gpu_sample_batch_into(&ctx, logits.as_ref(), &loose, seed, &mut scratch)
+                .expect("sample");
+            assert!(
+                tokens[0] == 100 || tokens[0] == 200,
+                "seed {seed}: min_p=0.2 sampled {} outside the surviving pair",
+                tokens[0]
+            );
+            saw_minor |= tokens[0] == 200;
+        }
+        assert!(
+            saw_minor,
+            "min_p=0.2 never sampled the 0.28-prob token in 128 draws (~1e-19 if unmasked)"
+        );
+    }
+
+    #[test]
+    fn batch_sampling_min_p_composes_with_top_k_and_top_p() {
+        let ctx = DeviceContext::new().expect("create CUDA context");
+        // Five spaced tokens; top_k=3 keeps {11, 503, 1024}, then the top-p /
+        // min_p stages cut deeper. With min_p=0.6 after top-k renorm the
+        // survivor set is exactly the argmax.
+        let picks: Vec<usize> = vec![11, 503, 1024, 9000, 32000];
+        let mut row = flat_row(-120.0);
+        for (i, &t) in picks.iter().enumerate() {
+            row[t] = 8.0 - 1.0 * i as f32;
+        }
+        let logits = arena_with_rows(&ctx, &[(2, row)]);
+        let mut scratch = BatchSamplingScratch::new(&ctx, ARENA_ROWS, VOCAB).expect("scratch");
+        let rows = [BatchSamplingRow {
+            row: 2,
+            temperature: 1.0,
+            top_k: 3,
+            top_p: 0.99,
+            min_p: 0.6,
+        }];
+        for seed in 0..64u64 {
+            let tokens = gpu_sample_batch_into(&ctx, logits.as_ref(), &rows, seed, &mut scratch)
+                .expect("sample");
+            assert_eq!(
+                tokens[0], 11,
+                "seed {seed}: top_k=3 + min_p=0.6 must collapse to the argmax"
+            );
+        }
+    }
+
+    #[test]
     fn batch_sampling_rejects_greedy_rows() {
         let ctx = DeviceContext::new().expect("create CUDA context");
         let logits = arena_with_rows(&ctx, &[]);
@@ -719,6 +841,7 @@ mod tests {
             temperature: 0.0,
             top_k: -1,
             top_p: 1.0,
+            min_p: 0.0,
         }];
         assert!(
             gpu_sample_batch_into(&ctx, logits.as_ref(), &rows, 1, &mut scratch).is_err(),

--- a/openinfer-kimi-k2/src/batch_decode_trace.rs
+++ b/openinfer-kimi-k2/src/batch_decode_trace.rs
@@ -126,6 +126,8 @@ pub fn trace_runtime_decode_kernel_calls(
                     temperature: 0.0,
                     top_k: 1,
                     top_p: 1.0,
+                    min_p: 0.0,
+                    seed: None,
                     ignore_eos: true,
                 },
                 max_tokens: 2,

--- a/openinfer-kimi-k2/src/runner/scheduler.rs
+++ b/openinfer-kimi-k2/src/runner/scheduler.rs
@@ -821,6 +821,8 @@ mod tests {
             temperature: 0.8,
             top_k: -1,
             top_p: 0.9,
+            min_p: 0.0,
+            seed: None,
             ignore_eos: false,
         };
 

--- a/openinfer-kimi-k2/src/runner/worker/state.rs
+++ b/openinfer-kimi-k2/src/runner/worker/state.rs
@@ -358,6 +358,7 @@ impl KimiRankThreadState {
                 temperature: r.sampling.temperature,
                 top_k: r.sampling.top_k,
                 top_p: r.sampling.top_p,
+                min_p: 0.0,
             })
             .collect();
         let sampled = if sampling_rows.is_empty() {
@@ -631,6 +632,7 @@ impl KimiRankThreadState {
                 temperature: row.sampling.temperature,
                 top_k: row.sampling.top_k,
                 top_p: row.sampling.top_p,
+                min_p: 0.0,
             }];
             let scratch = decode_arena.scratch.sampling.batch_sampling(&device_ctx)?;
             let sampled = openinfer_sample::gpu_sample_batch_into(

--- a/openinfer-kimi-k2/src/runner/worker/state.rs
+++ b/openinfer-kimi-k2/src/runner/worker/state.rs
@@ -358,7 +358,7 @@ impl KimiRankThreadState {
                 temperature: r.sampling.temperature,
                 top_k: r.sampling.top_k,
                 top_p: r.sampling.top_p,
-                min_p: 0.0,
+                min_p: r.sampling.min_p,
             })
             .collect();
         let sampled = if sampling_rows.is_empty() {
@@ -632,7 +632,7 @@ impl KimiRankThreadState {
                 temperature: row.sampling.temperature,
                 top_k: row.sampling.top_k,
                 top_p: row.sampling.top_p,
-                min_p: 0.0,
+                min_p: row.sampling.min_p,
             }];
             let scratch = decode_arena.scratch.sampling.batch_sampling(&device_ctx)?;
             let sampled = openinfer_sample::gpu_sample_batch_into(

--- a/openinfer-kimi-k2/tests/vllm_golden_gate.rs
+++ b/openinfer-kimi-k2/tests/vllm_golden_gate.rs
@@ -331,6 +331,8 @@ fn submit(
                 temperature: 0.0,
                 top_k: -1,
                 top_p: 1.0,
+                min_p: 0.0,
+                seed: None,
                 ignore_eos: true,
             },
             max_tokens,

--- a/openinfer-qwen3/src/executor.rs
+++ b/openinfer-qwen3/src/executor.rs
@@ -237,15 +237,13 @@ fn build_batch_decode_request_results(
     sample_seed: u64,
 ) -> Result<Vec<DecodeRequestResult>> {
     let params: Vec<&SamplingParams> = requests.iter().map(|req| &req.params).collect();
-    // Request-local sampling steps: zeros until the scheduler wires
-    // generated counts through (seeded requests are rejected at the
-    // frontend until then — see the sampling-parity tracking issue).
-    let steps = vec![0u64; params.len()];
+    lane.steps_buf.clear();
+    lane.steps_buf.resize(params.len(), 0);
     let tokens = openinfer_sample::select_batch(
         lane.model.device_ctx(),
         &lane.bufs.logits,
         &params,
-        &steps,
+        &lane.steps_buf,
         sample_seed,
         &mut lane.sample_scratch,
     )?;
@@ -2477,6 +2475,10 @@ struct LocalQwen3Lane {
     layout: KvLayout,
     bufs: BatchDecodeBuffers,
     sample_scratch: openinfer_sample::SampleScratch,
+    /// Request-local decode steps handed to `select_batch`, reused across
+    /// steps to keep the sampling hot path allocation-free. All zeros until
+    /// the scheduler wires generated counts through (sampling-parity 1b).
+    steps_buf: Vec<u64>,
     /// Prefill-chunk token cap; bounds the Pin self-check's unified-N envelope in `bind`.
     max_prefill_tokens: usize,
     /// In-flight prefill from a previous SplitConcurrent step (not yet synced).
@@ -2547,6 +2549,7 @@ impl LocalQwen3Lane {
             layout,
             bufs,
             sample_scratch,
+            steps_buf: Vec::new(),
             max_prefill_tokens,
             inflight_prefill: None,
             dflash: None,
@@ -2642,13 +2645,13 @@ impl LocalQwen3Lane {
                 params.len(),
             )?;
         }
-        // Zero steps until scheduler wiring lands; see select_batch docs.
-        let steps = vec![0u64; params.len()];
+        self.steps_buf.clear();
+        self.steps_buf.resize(params.len(), 0);
         openinfer_sample::select_batch(
             self.model.device_ctx(),
             logits,
             params,
-            &steps,
+            &self.steps_buf,
             sample_seed,
             &mut self.sample_scratch,
         )

--- a/openinfer-qwen3/src/executor.rs
+++ b/openinfer-qwen3/src/executor.rs
@@ -237,10 +237,15 @@ fn build_batch_decode_request_results(
     sample_seed: u64,
 ) -> Result<Vec<DecodeRequestResult>> {
     let params: Vec<&SamplingParams> = requests.iter().map(|req| &req.params).collect();
+    // Request-local sampling steps: zeros until the scheduler wires
+    // generated counts through (seeded requests are rejected at the
+    // frontend until then — see the sampling-parity tracking issue).
+    let steps = vec![0u64; params.len()];
     let tokens = openinfer_sample::select_batch(
         lane.model.device_ctx(),
         &lane.bufs.logits,
         &params,
+        &steps,
         sample_seed,
         &mut lane.sample_scratch,
     )?;
@@ -2637,10 +2642,13 @@ impl LocalQwen3Lane {
                 params.len(),
             )?;
         }
+        // Zero steps until scheduler wiring lands; see select_batch docs.
+        let steps = vec![0u64; params.len()];
         openinfer_sample::select_batch(
             self.model.device_ctx(),
             logits,
             params,
+            &steps,
             sample_seed,
             &mut self.sample_scratch,
         )

--- a/openinfer-qwen3/src/kernel_bench.rs
+++ b/openinfer-qwen3/src/kernel_bench.rs
@@ -1349,6 +1349,8 @@ impl DenseCase {
                         temperature: 0.8,
                         top_k: 50,
                         top_p: 0.9,
+                        min_p: 0.0,
+                        seed: None,
                         ignore_eos: true,
                     }
                 };
@@ -1456,8 +1458,16 @@ impl DenseCase {
             } => {
                 let param_refs: Vec<&openinfer_core::sampler::SamplingParams> =
                     params.iter().collect();
+                let steps = vec![0u64; param_refs.len()];
                 *seed = seed.wrapping_add(1);
-                openinfer_sample::select_batch(&self.ctx, logits, &param_refs, *seed, scratch)?;
+                openinfer_sample::select_batch(
+                    &self.ctx,
+                    logits,
+                    &param_refs,
+                    &steps,
+                    *seed,
+                    scratch,
+                )?;
                 Ok(())
             }
         }

--- a/openinfer-qwen3/src/unified_forward.rs
+++ b/openinfer-qwen3/src/unified_forward.rs
@@ -99,10 +99,12 @@ impl Qwen3Model {
         let total_reqs = num_prefill_reqs + profile_decode_rows;
         let params = vec![SamplingParams::default(); total_reqs];
         let param_refs: Vec<&SamplingParams> = params.iter().collect();
+        let steps = vec![0u64; param_refs.len()];
         let _ = openinfer_sample::select_batch(
             self.device_ctx(),
             &logits,
             &param_refs,
+            &steps,
             0,
             sample_scratch,
         )?;

--- a/openinfer-qwen35-4b/src/batch_decode.rs
+++ b/openinfer-qwen35-4b/src/batch_decode.rs
@@ -33,7 +33,15 @@ impl Qwen35Model {
             params.len(),
             bufs.max_batch_size
         );
-        openinfer_sample::select_batch(&self.ctx, logits, params, sample_seed, &mut bufs.sample)
+        let steps = vec![0u64; params.len()];
+        openinfer_sample::select_batch(
+            &self.ctx,
+            logits,
+            params,
+            &steps,
+            sample_seed,
+            &mut bufs.sample,
+        )
     }
 
     pub(crate) fn select_tokens_batch_varied(
@@ -58,10 +66,12 @@ impl Qwen35Model {
             params.len(),
             bufs.max_batch_size
         );
+        let steps = vec![0u64; params.len()];
         openinfer_sample::select_batch(
             &self.ctx,
             &bufs.logits,
             params,
+            &steps,
             sample_seed,
             &mut bufs.sample,
         )

--- a/openinfer-qwen35-4b/src/batch_decode.rs
+++ b/openinfer-qwen35-4b/src/batch_decode.rs
@@ -33,12 +33,13 @@ impl Qwen35Model {
             params.len(),
             bufs.max_batch_size
         );
-        let steps = vec![0u64; params.len()];
+        bufs.steps.clear();
+        bufs.steps.resize(params.len(), 0);
         openinfer_sample::select_batch(
             &self.ctx,
             logits,
             params,
-            &steps,
+            &bufs.steps,
             sample_seed,
             &mut bufs.sample,
         )
@@ -66,12 +67,13 @@ impl Qwen35Model {
             params.len(),
             bufs.max_batch_size
         );
-        let steps = vec![0u64; params.len()];
+        bufs.steps.clear();
+        bufs.steps.resize(params.len(), 0);
         openinfer_sample::select_batch(
             &self.ctx,
             &bufs.logits,
             params,
-            &steps,
+            &bufs.steps,
             sample_seed,
             &mut bufs.sample,
         )

--- a/openinfer-qwen35-4b/src/decode_buffers.rs
+++ b/openinfer-qwen35-4b/src/decode_buffers.rs
@@ -56,6 +56,10 @@ pub(crate) struct BatchDecodeBuffers35 {
 
     // Sampling scratch
     pub(crate) sample: openinfer_sample::SampleScratch,
+    /// Request-local decode steps handed to `select_batch`, reused across
+    /// steps to keep the sampling hot path allocation-free. All zeros until
+    /// the scheduler wires generated counts through (sampling-parity 1b).
+    pub(crate) steps: Vec<u64>,
 
     /// Page index reserved for CUDA Graph padding slots. Padding entries point
     /// here with seq_len=1 so FlashInfer accesses valid (but discarded) memory.
@@ -121,6 +125,7 @@ impl BatchDecodeBuffers35 {
             kv_chunk_size_d: ctx.stream.alloc_zeros(bs)?,
 
             sample: openinfer_sample::SampleScratch::new(ctx, config.vocab_size, bs)?,
+            steps: Vec::new(),
 
             padding_page_id,
         })

--- a/openinfer-qwen35-4b/src/unified_forward.rs
+++ b/openinfer-qwen35-4b/src/unified_forward.rs
@@ -134,7 +134,9 @@ mod tests {
         let mut scratch =
             openinfer_sample::SampleScratch::new(&model.ctx, model.config.vocab_size, rows)
                 .unwrap();
-        openinfer_sample::select_batch(&model.ctx, logits, &params_refs, 0, &mut scratch).unwrap()
+        let steps = vec![0u64; params_refs.len()];
+        openinfer_sample::select_batch(&model.ctx, logits, &params_refs, &steps, 0, &mut scratch)
+            .unwrap()
     }
 
     /// Verify that unified_step decode output matches batch_decode_graph standalone.

--- a/openinfer-sample/benches/select_batch.rs
+++ b/openinfer-sample/benches/select_batch.rs
@@ -23,6 +23,8 @@ fn p(temperature: f32, top_k: i32, top_p: f32) -> SamplingParams {
         temperature,
         top_k,
         top_p,
+        min_p: 0.0,
+        seed: None,
         ignore_eos: false,
     }
 }
@@ -54,9 +56,10 @@ fn bench_select_batch(c: &mut Criterion) {
             let param_refs: Vec<&SamplingParams> = params.iter().collect();
             group.bench_with_input(BenchmarkId::new(*name, batch), &batch, |b, _| {
                 let mut seed = 0u64;
+                let steps = vec![0u64; param_refs.len()];
                 b.iter(|| {
                     seed = seed.wrapping_add(1);
-                    select_batch(&ctx, &a, &param_refs, seed, &mut scratch).unwrap()
+                    select_batch(&ctx, &a, &param_refs, &steps, seed, &mut scratch).unwrap()
                 });
             });
         }

--- a/openinfer-sample/src/lib.rs
+++ b/openinfer-sample/src/lib.rs
@@ -318,76 +318,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{SampleScratch, SamplingParams, select_batch, token_logprob_from_row};
+    use super::token_logprob_from_row;
     use half::bf16;
-    use openinfer_kernels::tensor::{DeviceContext, HiddenStates};
-
-    const VOCAB: usize = 32768;
-
-    fn flat_arena(ctx: &DeviceContext, rows: usize) -> HiddenStates {
-        let host = vec![bf16::ZERO; rows * VOCAB];
-        HiddenStates {
-            data: ctx.stream.clone_htod(&host).expect("htod"),
-            hidden_dim: VOCAB,
-            seq_len: rows,
-        }
-    }
-
-    fn seeded(seed: u64) -> SamplingParams {
-        SamplingParams {
-            temperature: 1.0,
-            seed: Some(seed),
-            ..Default::default()
-        }
-    }
-
-    /// The per-request seed contract: a seeded row's token is a pure function
-    /// of (seed, step, distribution) — independent of where the row sits in
-    /// the batch and of what else is in flight.
-    #[test]
-    fn seeded_rows_replay_independent_of_batch_position() {
-        let ctx = DeviceContext::new().expect("CUDA context");
-        let logits = flat_arena(&ctx, 3);
-        let mut scratch = SampleScratch::new(&ctx, VOCAB, 3).expect("scratch");
-
-        let greedy = SamplingParams::default();
-        let unseeded = SamplingParams {
-            temperature: 1.0,
-            ..Default::default()
-        };
-
-        // Batch A: seeded row last; batch B: seeded row first, different
-        // neighbors. Same seed + step must produce the same token.
-        let a = select_batch(
-            &ctx,
-            &logits,
-            &[&greedy, &unseeded, &seeded(7)],
-            &[0, 0, 5],
-            99,
-            &mut scratch,
-        )
-        .expect("batch a");
-        let b = select_batch(
-            &ctx,
-            &logits,
-            &[&seeded(7), &greedy],
-            &[5, 0],
-            1234,
-            &mut scratch,
-        )
-        .expect("batch b");
-        assert_eq!(
-            a[2], b[0],
-            "seeded row must replay across batch layouts and engine seeds"
-        );
-
-        // Advancing the step or changing the seed moves the stream. On a flat
-        // 32k-token distribution an accidental collision is ~3e-5.
-        let c = select_batch(&ctx, &logits, &[&seeded(7)], &[6], 0, &mut scratch).expect("step 6");
-        let d = select_batch(&ctx, &logits, &[&seeded(8)], &[5], 0, &mut scratch).expect("seed 8");
-        assert_ne!(a[2], c[0], "step must advance the seeded stream");
-        assert_ne!(a[2], d[0], "seed must select a distinct stream");
-    }
 
     #[test]
     fn token_logprob_matches_exact_log_softmax() {

--- a/openinfer-sample/src/lib.rs
+++ b/openinfer-sample/src/lib.rs
@@ -109,12 +109,20 @@ impl SampleScratch {
 /// arbitrary member of a bf16-tied top — and skips a softmax it does not need.
 ///
 /// `seed` must be fresh per decode step (one engine seed at startup, advanced
-/// per step); rows decorrelate through the philox subsequence. There is
-/// deliberately no per-row RNG.
+/// per step); unseeded rows decorrelate through the philox subsequence.
+///
+/// `steps[i]` is row `i`'s request-local decode step. It only matters for
+/// rows whose params carry a `seed`: a seeded row is sampled as its own
+/// single-row call with `mix_seed(request_seed, step)` as the philox seed, so
+/// its tokens are a pure function of (seed, step, distribution) — FlashInfer's
+/// kernels fold the batch position into the philox subsequence, so seeded rows
+/// cannot ride the batched call without their stream changing with batch
+/// composition.
 pub fn select_batch(
     ctx: &DeviceContext,
     logits: &HiddenStates,
     params: &[&SamplingParams],
+    steps: &[u64],
     seed: u64,
     scratch: &mut SampleScratch,
 ) -> Result<Vec<u32>> {
@@ -122,6 +130,11 @@ pub fn select_batch(
     if n == 0 {
         return Ok(Vec::new());
     }
+    ensure!(
+        steps.len() == n,
+        "select_batch: {} steps for {n} rows",
+        steps.len()
+    );
     ensure!(
         n <= scratch.max_rows,
         "select_batch: {n} rows exceeds scratch capacity {}",
@@ -172,16 +185,17 @@ pub fn select_batch(
         }
     }
 
-    // The rest -> one batched FlashInfer sampling pass.
+    // Unseeded sampling rows -> one batched FlashInfer sampling pass.
     let sampling_rows: Vec<BatchSamplingRow> = params
         .iter()
         .enumerate()
-        .filter(|(_, p)| !is_argmax(p))
+        .filter(|(_, p)| !is_argmax(p) && p.seed.is_none())
         .map(|(i, p)| BatchSamplingRow {
             row: i,
             temperature: p.temperature,
             top_k: p.top_k,
             top_p: p.top_p,
+            min_p: p.min_p,
         })
         .collect();
     if !sampling_rows.is_empty() {
@@ -197,7 +211,43 @@ pub fn select_batch(
         }
     }
 
+    // Seeded rows -> one single-row call each, philox seed mixed from the
+    // request seed and step so replay is independent of batch composition
+    // (blockIdx is always 0 in an n=1 call).
+    for (i, p) in params.iter().enumerate() {
+        let Some(request_seed) = p.seed else {
+            continue;
+        };
+        if is_argmax(p) {
+            continue;
+        }
+        let row = [BatchSamplingRow {
+            row: i,
+            temperature: p.temperature,
+            top_k: p.top_k,
+            top_p: p.top_p,
+            min_p: p.min_p,
+        }];
+        let sampled = gpu_sample_batch_into(
+            ctx,
+            logits.as_ref(),
+            &row,
+            mix_seed(request_seed, steps[i]),
+            &mut scratch.sampling,
+        )?;
+        tokens[i] = sampled[0];
+    }
+
     Ok(tokens)
+}
+
+/// SplitMix64 over (seed, step): a distinct, well-mixed philox seed per
+/// request step, deterministic across runs and batch layouts.
+fn mix_seed(seed: u64, step: u64) -> u64 {
+    let mut z = seed ^ step.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
 }
 
 /// Whether a row can take the argmax path without changing sampling semantics.
@@ -268,8 +318,76 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::token_logprob_from_row;
+    use super::{SampleScratch, SamplingParams, select_batch, token_logprob_from_row};
     use half::bf16;
+    use openinfer_kernels::tensor::{DeviceContext, HiddenStates};
+
+    const VOCAB: usize = 32768;
+
+    fn flat_arena(ctx: &DeviceContext, rows: usize) -> HiddenStates {
+        let host = vec![bf16::ZERO; rows * VOCAB];
+        HiddenStates {
+            data: ctx.stream.clone_htod(&host).expect("htod"),
+            hidden_dim: VOCAB,
+            seq_len: rows,
+        }
+    }
+
+    fn seeded(seed: u64) -> SamplingParams {
+        SamplingParams {
+            temperature: 1.0,
+            seed: Some(seed),
+            ..Default::default()
+        }
+    }
+
+    /// The per-request seed contract: a seeded row's token is a pure function
+    /// of (seed, step, distribution) — independent of where the row sits in
+    /// the batch and of what else is in flight.
+    #[test]
+    fn seeded_rows_replay_independent_of_batch_position() {
+        let ctx = DeviceContext::new().expect("CUDA context");
+        let logits = flat_arena(&ctx, 3);
+        let mut scratch = SampleScratch::new(&ctx, VOCAB, 3).expect("scratch");
+
+        let greedy = SamplingParams::default();
+        let unseeded = SamplingParams {
+            temperature: 1.0,
+            ..Default::default()
+        };
+
+        // Batch A: seeded row last; batch B: seeded row first, different
+        // neighbors. Same seed + step must produce the same token.
+        let a = select_batch(
+            &ctx,
+            &logits,
+            &[&greedy, &unseeded, &seeded(7)],
+            &[0, 0, 5],
+            99,
+            &mut scratch,
+        )
+        .expect("batch a");
+        let b = select_batch(
+            &ctx,
+            &logits,
+            &[&seeded(7), &greedy],
+            &[5, 0],
+            1234,
+            &mut scratch,
+        )
+        .expect("batch b");
+        assert_eq!(
+            a[2], b[0],
+            "seeded row must replay across batch layouts and engine seeds"
+        );
+
+        // Advancing the step or changing the seed moves the stream. On a flat
+        // 32k-token distribution an accidental collision is ~3e-5.
+        let c = select_batch(&ctx, &logits, &[&seeded(7)], &[6], 0, &mut scratch).expect("step 6");
+        let d = select_batch(&ctx, &logits, &[&seeded(8)], &[5], 0, &mut scratch).expect("seed 8");
+        assert_ne!(a[2], c[0], "step must advance the seeded stream");
+        assert_ne!(a[2], d[0], "seed must select a distinct stream");
+    }
 
     #[test]
     fn token_logprob_matches_exact_log_softmax() {

--- a/openinfer-sample/src/lib.rs
+++ b/openinfer-sample/src/lib.rs
@@ -4,9 +4,11 @@
 //! Two model-agnostic jobs live here:
 //!
 //! * [`select_batch`] — turn one logits arena into one next-token id per row.
-//!   Greedy rows take a batched indexed argmax; the rest take one FlashInfer
-//!   temperature/top-k/top-p pass. There is no per-row escape hatch, so a caller
-//!   cannot regress to `for i { sample(i) }`.
+//!   Greedy rows take a batched indexed argmax; the rest take batched
+//!   FlashInfer temperature/top-k/top-p/min_p passes (min_p rows partitioned
+//!   off the fused fast path, seeded rows as single-row replayable calls).
+//!   There is no per-row escape hatch, so a caller cannot regress to
+//!   `for i { sample(i) }`.
 //! * [`token_logprob_from_row`] — host-side log-softmax + top-k over one logits
 //!   row into a [`TokenLogprob`]. Generic over the row element so a caller can
 //!   feed `f32` (Qwen) or `bf16` (Kimi) without a widening copy.

--- a/openinfer-sample/src/lib.rs
+++ b/openinfer-sample/src/lib.rs
@@ -99,8 +99,10 @@ impl SampleScratch {
 ///
 /// `params[i]` governs arena row `i`. Argmax rows are resolved together with a
 /// batched indexed argmax; the remaining rows are resolved together with one
-/// FlashInfer temperature/top-k/top-p pass seeded by `seed`. Returns one token
-/// id per row, in row order.
+/// FlashInfer temperature/top-k/top-p pass seeded by `seed` (min_p rows are
+/// partitioned into their own pass inside `gpu_sample_batch_into`, so
+/// min_p-free rows always take the fused fast path). Returns one token id per
+/// row, in row order.
 ///
 /// A row takes the argmax path when [`effectively_greedy`] holds: explicit
 /// greedy params, or a `top_p` nucleus so tight (`<= 1/vocab`) that only the
@@ -185,7 +187,9 @@ pub fn select_batch(
         }
     }
 
-    // Unseeded sampling rows -> one batched FlashInfer sampling pass.
+    // Unseeded sampling rows -> batched FlashInfer sampling. min_p rows may
+    // mix freely: `gpu_sample_batch_into` partitions them into their own pass
+    // so min_p-free rows always ride the fused fast path.
     let sampling_rows: Vec<BatchSamplingRow> = params
         .iter()
         .enumerate()

--- a/openinfer-sample/tests/select_batch.rs
+++ b/openinfer-sample/tests/select_batch.rs
@@ -234,6 +234,54 @@ fn min_p_row_takes_the_sampler_path_and_filters() {
 /// (seed, step, distribution) — independent of where the row sits in the
 /// batch, of its neighbors, and of the engine's per-step seed.
 #[test]
+fn mixed_batch_keeps_plain_rows_on_the_fast_path() {
+    // A min_p neighbor must not perturb plain sampling rows: select_batch
+    // batches min_p rows separately, so a plain row's philox subsequence is
+    // its index among plain rows and its tokens match a min_p-free batch
+    // exactly. The plain rows carry top_k+top_p on a spread distribution so
+    // the fused fast path (rejection sampling, several uniform draws) and the
+    // min_p pipeline (renorm + one draw) genuinely diverge — riding the wrong
+    // path shows up as different tokens, not a 1-ulp coin flip.
+    let ctx = DeviceContext::new().unwrap();
+    let vocab = 16;
+    let spread: Vec<f32> = (0..vocab).map(|i| i as f32 * 0.3).collect();
+    let rows: Vec<Vec<f32>> = vec![spread.clone(), spread.clone(), spread.clone()];
+    let arena_mixed = make_arena(&ctx, &rows);
+    let arena_plain = make_arena(&ctx, &rows[..2]);
+    let mut scratch = SampleScratch::new(&ctx, vocab, rows.len()).unwrap();
+
+    let plain = sampling(1.0, 4, 0.9);
+    let mut minp = sampling(1.0, 0, 1.0);
+    minp.min_p = 0.5;
+
+    for seed in 0..64u64 {
+        let mixed = select_batch(
+            &ctx,
+            &arena_mixed,
+            &[&plain, &minp, &plain],
+            &[0, 0, 0],
+            seed,
+            &mut scratch,
+        )
+        .unwrap();
+        let alone = select_batch(
+            &ctx,
+            &arena_plain,
+            &[&plain, &plain],
+            &[0, 0],
+            seed,
+            &mut scratch,
+        )
+        .unwrap();
+        assert_eq!(
+            [mixed[0], mixed[2]],
+            [alone[0], alone[1]],
+            "seed {seed}: plain rows changed tokens because a min_p row joined the batch"
+        );
+    }
+}
+
+#[test]
 fn seeded_rows_replay_independent_of_batch_position() {
     let ctx = DeviceContext::new().unwrap();
     let vocab = 32_768;

--- a/openinfer-sample/tests/select_batch.rs
+++ b/openinfer-sample/tests/select_batch.rs
@@ -32,12 +32,7 @@ fn refs(params: &[SamplingParams]) -> Vec<&SamplingParams> {
 }
 
 fn greedy() -> SamplingParams {
-    SamplingParams {
-        temperature: 0.0,
-        top_k: -1,
-        top_p: 1.0,
-        ignore_eos: false,
-    }
+    SamplingParams::default()
 }
 
 fn sampling(temperature: f32, top_k: i32, top_p: f32) -> SamplingParams {
@@ -45,7 +40,7 @@ fn sampling(temperature: f32, top_k: i32, top_p: f32) -> SamplingParams {
         temperature,
         top_k,
         top_p,
-        ignore_eos: false,
+        ..SamplingParams::default()
     }
 }
 
@@ -66,7 +61,7 @@ fn greedy_batch_picks_each_rows_argmax() {
     let params = vec![greedy(); peaks.len()];
     let mut scratch = SampleScratch::new(&ctx, vocab, peaks.len()).unwrap();
 
-    let tokens = select_batch(&ctx, &arena, &refs(&params), 0, &mut scratch).unwrap();
+    let tokens = select_batch(&ctx, &arena, &refs(&params), &vec![0; params.len()], 0, &mut scratch).unwrap();
 
     assert_eq!(tokens, vec![3, 7, 0, 15]);
 }
@@ -80,7 +75,7 @@ fn top_k_one_routes_through_greedy_path() {
     let params = vec![sampling(1.0, 1, 1.0)];
     let mut scratch = SampleScratch::new(&ctx, vocab, 1).unwrap();
 
-    let tokens = select_batch(&ctx, &arena, &refs(&params), 123, &mut scratch).unwrap();
+    let tokens = select_batch(&ctx, &arena, &refs(&params), &[0], 123, &mut scratch).unwrap();
 
     assert_eq!(tokens, vec![5]);
 }
@@ -103,7 +98,7 @@ fn mixed_batch_routes_and_places_each_row() {
     let params = vec![greedy(), sampling(1.0, -1, 0.5), greedy()];
     let mut scratch = SampleScratch::new(&ctx, vocab, 3).unwrap();
 
-    let tokens = select_batch(&ctx, &arena, &refs(&params), 7, &mut scratch).unwrap();
+    let tokens = select_batch(&ctx, &arena, &refs(&params), &[0, 0, 0], 7, &mut scratch).unwrap();
 
     assert_eq!(tokens, vec![2, 9, 4]);
 }
@@ -119,13 +114,13 @@ fn sampling_is_seed_deterministic_and_actually_samples() {
     let params = vec![sampling(1.0, -1, 1.0)];
     let mut scratch = SampleScratch::new(&ctx, vocab, 1).unwrap();
 
-    let a = select_batch(&ctx, &arena, &refs(&params), 42, &mut scratch).unwrap();
-    let b = select_batch(&ctx, &arena, &refs(&params), 42, &mut scratch).unwrap();
+    let a = select_batch(&ctx, &arena, &refs(&params), &[0], 42, &mut scratch).unwrap();
+    let b = select_batch(&ctx, &arena, &refs(&params), &[0], 42, &mut scratch).unwrap();
     assert_eq!(a, b, "same seed must be deterministic");
 
     let mut seen = HashSet::new();
     for s in 0..64u64 {
-        seen.insert(select_batch(&ctx, &arena, &refs(&params), s, &mut scratch).unwrap()[0]);
+        seen.insert(select_batch(&ctx, &arena, &refs(&params), &[0], s, &mut scratch).unwrap()[0]);
     }
     assert!(
         seen.len() > 1,
@@ -154,7 +149,7 @@ fn tiny_top_p_routes_to_argmax_even_under_bf16_ties() {
     let arena = make_arena(&ctx, &[row]);
     let mut scratch = SampleScratch::new(&ctx, vocab, 1).unwrap();
 
-    let greedy_tok = select_batch(&ctx, &arena, &[&greedy()], 0, &mut scratch).unwrap();
+    let greedy_tok = select_batch(&ctx, &arena, &[&greedy()], &[0], 0, &mut scratch).unwrap();
     assert_eq!(
         greedy_tok,
         vec![lo as u32],
@@ -164,7 +159,7 @@ fn tiny_top_p_routes_to_argmax_even_under_bf16_ties() {
     let tiny = sampling(1.0, -1, 1e-6); // 1e-6 < 1/vocab (~6.6e-6)
     for s in 0..64u64 {
         assert_eq!(
-            select_batch(&ctx, &arena, &[&tiny], s, &mut scratch).unwrap(),
+            select_batch(&ctx, &arena, &[&tiny], &[0], s, &mut scratch).unwrap(),
             greedy_tok,
             "seed {s}: tiny top_p must match greedy, not sample the tied peer"
         );
@@ -179,5 +174,81 @@ fn batch_larger_than_scratch_is_rejected() {
     let params = vec![greedy(); 2];
     let mut scratch = SampleScratch::new(&ctx, vocab, 1).unwrap();
 
-    assert!(select_batch(&ctx, &arena, &refs(&params), 0, &mut scratch).is_err());
+    assert!(select_batch(&ctx, &arena, &refs(&params), &vec![0; params.len()], 0, &mut scratch).is_err());
+}
+
+#[test]
+fn min_p_row_takes_the_sampler_path_and_filters() {
+    // Two-token support: P(3) ~ 0.73, P(11) ~ 0.27. min_p = 0.5 thresholds at
+    // 0.5 * 0.73 = 0.37, masking token 11 — every draw must return token 3.
+    // With min_p = 0.0 the same row explores both (checked over many seeds),
+    // proving the row genuinely rides the sampler, not argmax.
+    let ctx = DeviceContext::new().unwrap();
+    let vocab = 16;
+    let mut row = vec![-60.0f32; vocab];
+    row[3] = 1.0;
+    row[11] = 0.0;
+    let arena = make_arena(&ctx, &[row]);
+    let mut scratch = SampleScratch::new(&ctx, vocab, 1).unwrap();
+
+    let mut filtered = sampling(1.0, -1, 1.0);
+    filtered.min_p = 0.5;
+    for s in 0..64u64 {
+        assert_eq!(
+            select_batch(&ctx, &arena, &[&filtered], &[0], s, &mut scratch).unwrap(),
+            vec![3],
+            "seed {s}: min_p=0.5 must mask the 0.27-prob token"
+        );
+    }
+
+    let open = sampling(1.0, -1, 1.0);
+    let mut seen = HashSet::new();
+    for s in 0..128u64 {
+        seen.insert(select_batch(&ctx, &arena, &[&open], &[0], s, &mut scratch).unwrap()[0]);
+    }
+    assert!(
+        seen.contains(&11),
+        "min_p=0 should reach the 0.27-prob token across 128 seeds, saw {seen:?}"
+    );
+}
+
+/// The per-request seed contract: a seeded row's token is a pure function of
+/// (seed, step, distribution) — independent of where the row sits in the
+/// batch, of its neighbors, and of the engine's per-step seed.
+#[test]
+fn seeded_rows_replay_independent_of_batch_position() {
+    let ctx = DeviceContext::new().unwrap();
+    let vocab = 32_768;
+    let flat = vec![0.0f32; vocab];
+    let arena = make_arena(&ctx, &[flat.clone(), flat.clone(), flat]);
+    let mut scratch = SampleScratch::new(&ctx, vocab, 3).unwrap();
+
+    let seeded = |seed: u64| SamplingParams {
+        temperature: 1.0,
+        seed: Some(seed),
+        ..SamplingParams::default()
+    };
+    let unseeded = sampling(1.0, -1, 1.0);
+
+    // Batch A: seeded row last; batch B: seeded row first, different
+    // neighbors and engine seed. Same request seed + step => same token.
+    let a = select_batch(
+        &ctx,
+        &arena,
+        &[&greedy(), &unseeded, &seeded(7)],
+        &[0, 0, 5],
+        99,
+        &mut scratch,
+    )
+    .unwrap();
+    let b = select_batch(&ctx, &arena, &[&seeded(7), &greedy()], &[5, 0], 1234, &mut scratch)
+        .unwrap();
+    assert_eq!(a[2], b[0], "seeded row must replay across batch layouts");
+
+    // Advancing the step or changing the seed moves the stream; on a flat
+    // 32k-token distribution an accidental collision is ~3e-5.
+    let c = select_batch(&ctx, &arena, &[&seeded(7)], &[6], 0, &mut scratch).unwrap();
+    let d = select_batch(&ctx, &arena, &[&seeded(8)], &[5], 0, &mut scratch).unwrap();
+    assert_ne!(a[2], c[0], "step must advance the seeded stream");
+    assert_ne!(a[2], d[0], "seed must select a distinct stream");
 }

--- a/openinfer-sample/tests/select_batch.rs
+++ b/openinfer-sample/tests/select_batch.rs
@@ -230,9 +230,6 @@ fn min_p_row_takes_the_sampler_path_and_filters() {
     );
 }
 
-/// The per-request seed contract: a seeded row's token is a pure function of
-/// (seed, step, distribution) — independent of where the row sits in the
-/// batch, of its neighbors, and of the engine's per-step seed.
 #[test]
 fn mixed_batch_keeps_plain_rows_on_the_fast_path() {
     // A min_p neighbor must not perturb plain sampling rows: select_batch
@@ -281,6 +278,9 @@ fn mixed_batch_keeps_plain_rows_on_the_fast_path() {
     }
 }
 
+/// The per-request seed contract: a seeded row's token is a pure function of
+/// (seed, step, distribution) — independent of where the row sits in the
+/// batch, of its neighbors, and of the engine's per-step seed.
 #[test]
 fn seeded_rows_replay_independent_of_batch_position() {
     let ctx = DeviceContext::new().unwrap();

--- a/openinfer-sample/tests/select_batch.rs
+++ b/openinfer-sample/tests/select_batch.rs
@@ -61,7 +61,15 @@ fn greedy_batch_picks_each_rows_argmax() {
     let params = vec![greedy(); peaks.len()];
     let mut scratch = SampleScratch::new(&ctx, vocab, peaks.len()).unwrap();
 
-    let tokens = select_batch(&ctx, &arena, &refs(&params), &vec![0; params.len()], 0, &mut scratch).unwrap();
+    let tokens = select_batch(
+        &ctx,
+        &arena,
+        &refs(&params),
+        &vec![0; params.len()],
+        0,
+        &mut scratch,
+    )
+    .unwrap();
 
     assert_eq!(tokens, vec![3, 7, 0, 15]);
 }
@@ -174,7 +182,17 @@ fn batch_larger_than_scratch_is_rejected() {
     let params = vec![greedy(); 2];
     let mut scratch = SampleScratch::new(&ctx, vocab, 1).unwrap();
 
-    assert!(select_batch(&ctx, &arena, &refs(&params), &vec![0; params.len()], 0, &mut scratch).is_err());
+    assert!(
+        select_batch(
+            &ctx,
+            &arena,
+            &refs(&params),
+            &vec![0; params.len()],
+            0,
+            &mut scratch
+        )
+        .is_err()
+    );
 }
 
 #[test]
@@ -241,8 +259,15 @@ fn seeded_rows_replay_independent_of_batch_position() {
         &mut scratch,
     )
     .unwrap();
-    let b = select_batch(&ctx, &arena, &[&seeded(7), &greedy()], &[5, 0], 1234, &mut scratch)
-        .unwrap();
+    let b = select_batch(
+        &ctx,
+        &arena,
+        &[&seeded(7), &greedy()],
+        &[5, 0],
+        1234,
+        &mut scratch,
+    )
+    .unwrap();
     assert_eq!(a[2], b[0], "seeded row must replay across batch layouts");
 
     // Advancing the step or changing the seed moves the stream; on a flat

--- a/openinfer-server/src/bin/bench_serving/main.rs
+++ b/openinfer-server/src/bin/bench_serving/main.rs
@@ -268,6 +268,7 @@ mod tests {
             top_k: -1,
             top_p: 0.95,
             ignore_eos: true,
+            ..SamplingParams::default()
         };
 
         assert_dsv2_lite_sampling_contract(&sampling);

--- a/openinfer-vllm-frontend/src/bridge.rs
+++ b/openinfer-vllm-frontend/src/bridge.rs
@@ -245,6 +245,22 @@ impl LocalEngineBridge {
             return Ok(());
         };
 
+        // Fail loud on sampling parameters the engine cannot honor yet —
+        // silently ignoring a requested seed or penalty changes outputs
+        // without telling the client.
+        if let Some(unsupported) = crate::wire::unsupported_sampling(&sampling_params) {
+            warn!("request {request_id} rejected: unsupported sampling params: {unsupported}");
+            send_terminal_output(
+                output_tx,
+                request_id,
+                EngineCoreFinishReason::Error,
+                None,
+                None,
+                None,
+            )?;
+            return Ok(());
+        }
+
         let tag: RequestTag = Arc::from(request_id.as_str());
         let cancelled = Arc::new(AtomicBool::new(false));
         let token_tx = TokenSink::new(tag.clone(), event_tx.clone(), Arc::clone(&cancelled));

--- a/openinfer-vllm-frontend/src/wire.rs
+++ b/openinfer-vllm-frontend/src/wire.rs
@@ -50,6 +50,8 @@ pub(crate) fn convert_sampling(params: &EngineCoreSamplingParams) -> SamplingPar
             temperature: 0.0,
             top_k: -1,
             top_p: 1.0,
+            min_p: 0.0,
+            seed: None,
             ignore_eos,
         };
     }
@@ -62,8 +64,49 @@ pub(crate) fn convert_sampling(params: &EngineCoreSamplingParams) -> SamplingPar
             i32::try_from(params.top_k).unwrap_or(i32::MAX)
         },
         top_p: params.top_p,
+        min_p: params.min_p,
+        // Per-request seeds need the scheduler to feed request-local step
+        // counts into select_batch; until that lands, seeded requests are
+        // rejected in the bridge instead of silently ignored. See the
+        // sampling-parity tracking issue.
+        seed: None,
         ignore_eos,
     }
+}
+
+/// Reject sampling parameters the engine would otherwise silently ignore.
+/// Returns the offending description; `None` means the request is servable.
+///
+/// The float comparisons are exact on purpose: they detect "the client sent
+/// anything other than the wire default", not numeric closeness — a request
+/// carrying 1.0000001 wants a penalty and must be rejected, not rounded away.
+#[allow(clippy::float_cmp)]
+pub(crate) fn unsupported_sampling(params: &EngineCoreSamplingParams) -> Option<String> {
+    if !(0.0..1.0).contains(&params.min_p) || !params.min_p.is_finite() {
+        return Some(format!("min_p {} outside [0, 1)", params.min_p));
+    }
+    if params.temperature > 0.0 && params.seed.is_some() {
+        return Some("per-request seed is not supported yet".to_string());
+    }
+    if params.frequency_penalty != 0.0 {
+        return Some(format!(
+            "frequency_penalty {} is not supported yet",
+            params.frequency_penalty
+        ));
+    }
+    if params.presence_penalty != 0.0 {
+        return Some(format!(
+            "presence_penalty {} is not supported yet",
+            params.presence_penalty
+        ));
+    }
+    if params.repetition_penalty != 1.0 {
+        return Some(format!(
+            "repetition_penalty {} is not supported yet",
+            params.repetition_penalty
+        ));
+    }
+    None
 }
 
 pub(crate) fn requested_logprobs(params: &EngineCoreSamplingParams) -> usize {
@@ -129,6 +172,54 @@ mod tests {
         params.eos_token_id = None;
         params.stop_token_ids = vec![42];
         assert!(!convert_sampling(&params).ignore_eos);
+    }
+
+    #[test]
+    fn convert_sampling_passes_min_p_and_never_seed() {
+        let mut params = EngineCoreSamplingParams::for_test();
+        params.eos_token_id = Some(1);
+        params.temperature = 0.8;
+        params.min_p = 0.15;
+        params.seed = Some(42);
+        let converted = convert_sampling(&params);
+        assert!((converted.min_p - 0.15).abs() < f32::EPSILON);
+        // Seeds are rejected upstream until scheduler step wiring lands;
+        // convert must never smuggle one through.
+        assert_eq!(converted.seed, None);
+
+        // Greedy lowering zeroes min_p along with the rest.
+        params.temperature = 0.0;
+        assert_eq!(convert_sampling(&params).min_p, 0.0);
+    }
+
+    #[test]
+    fn unsupported_sampling_rejects_what_the_engine_would_ignore() {
+        let mut params = EngineCoreSamplingParams::for_test();
+        params.repetition_penalty = 1.0;
+        assert_eq!(unsupported_sampling(&params), None);
+
+        params.min_p = 0.2;
+        assert_eq!(unsupported_sampling(&params), None);
+        params.min_p = 1.5;
+        assert!(unsupported_sampling(&params).is_some());
+        params.min_p = 0.0;
+
+        params.temperature = 0.8;
+        params.seed = Some(7);
+        assert!(unsupported_sampling(&params).is_some());
+        // A greedy request's seed is a no-op, not a lie — allowed.
+        params.temperature = 0.0;
+        assert_eq!(unsupported_sampling(&params), None);
+        params.seed = None;
+
+        params.frequency_penalty = 0.5;
+        assert!(unsupported_sampling(&params).is_some());
+        params.frequency_penalty = 0.0;
+        params.presence_penalty = -0.5;
+        assert!(unsupported_sampling(&params).is_some());
+        params.presence_penalty = 0.0;
+        params.repetition_penalty = 1.2;
+        assert!(unsupported_sampling(&params).is_some());
     }
 
     #[test]


### PR DESCRIPTION
Slice 1 of #490 (roadmap #203, workstream 4 — sampling parity). **min_p works end to end; per-request seed gets its correct foundation; everything the engine still can't honor now fails loud instead of silently ignoring the client.**

## Problem

`EngineCoreSamplingParams` already carries `min_p`, `seed`, and the three penalties, but `convert_sampling` dropped all of them on the floor. A client setting `min_p=0.1` or `seed=42` today gets default sampling with no signal — the silent-fallback shape #462 removed elsewhere, on the API surface coding agents actually use.

## What lands

**min_p, fully wired** (`SamplingParams` → wire → `select_batch` → `BatchSamplingRow` → CUDA):
- The FlashInfer launcher grows a min_p pipeline: optional `RadixTopKRenormProbMultiCTA` (workspace sized like the top1 wrapper), optional `TopPRenormProb` — both in place, threshold-reduce-then-elementwise — then `MinPSamplingFromProb` with per-row thresholds (`min_p_arr[bx]` is genuinely per-row upstream).
- `min_p == 0` passes a null `min_p_arr` and takes the *literal original* fused TopKTopP/TopP/Sampling calls — the fast path is bit-identical by construction (no measured claim needed; the branch is visible in the diff).

**Per-request seed, correct groundwork:** the obvious implementation — FlashInfer's `seed_arr` — is wrong, and this PR documents why in the launcher: these kernels read **`seed_arr[0]`** (one seed for the whole batch) and fold **`blockIdx.x` into the philox subsequence**, so a seeded request's stream would change with its batch position. Instead:
- Seeded rows sample as their own `n_rows=1` calls with `splitmix64(request_seed, step)` as the philox seed — blockIdx is always 0, so replay is a pure function of (seed, step, distribution).
- `select_batch` gains a `steps` parameter (request-local decode step). Callers currently pass zeros; **slice 1b** wires the scheduler's generated counts through, and until it lands the bridge rejects seeded sampling requests rather than serving them wrong.
- The contract is pinned by a GPU test: same seed+step replays the same token across different batch layouts and engine seeds; advancing step or changing seed diverges.

**Fail loud:** non-default `frequency_penalty` / `presence_penalty` / `repetition_penalty` (and, temporarily, seeds on sampling requests) are rejected at the bridge with the offending parameter in the log — same shape as #426's `logprobs=-1` rejection. The float comparisons are exact on purpose (detecting "non-default wire value", not closeness) and annotated as such.

## Verification (H100, CUDA 12.4)

- `openinfer-kernels` sampling tests 7/7, including two new ones: min_p threshold math on a hand-checkable two-token distribution (0.5·p_max masks the 0.28 token in 64/64 draws; 0.2·p_max lets it through), and min_p × top_k × top_p composed through the renorm pipeline.
- `openinfer-sample` 4/4 including `seeded_rows_replay_independent_of_batch_position`.
- `openinfer-vllm-frontend` 20/20 (passthrough + rejection matrix).
- `hf_golden_gate` (31.1s) and `sampling_behavior` (9.6s) integration pass on Qwen3-4B.
- Feature builds check clean: `qwen35-4b` (Triton AOT) and `kimi-k2` (against an unpacked nvidia-nccl-cu12 wheel); kimi's `BatchSamplingRow` literals gain `min_p: 0.0` with no behavior change.
- fmt clean; clippy adds zero warnings in touched files.

## Notes for review

- The `steps: &[u64]` parameter with all-zero call sites is deliberate scaffolding: zeros are correct while the bridge rejects seeds, and slice 1b replaces them with generated counts per model crate. Rejecting at the bridge until then keeps every intermediate state honest.
- An upstream FlashInfer patch making `seed_arr` truly per-row (`seed_arr[bx]`, position-free subsequence) would let seeded rows rejoin the batched call; noted in #490 as a follow-up.
- Greedy requests with a seed are accepted (a no-op, not a lie); sampling requests with a seed are rejected until 1b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
