### PR TITLE
fix(kernels): format embedding batch test to satisfy cargo fmt CI

### DIFF
--- a/openinfer-kernels/src/ops/embedding.rs
+++ b/openinfer-kernels/src/ops/embedding.rs
@@ -107,8 +107,7 @@ mod tests {
         let embed_host: Vec<bf16> = (0..vocab * hidden_size)
             .map(|i| bf16::from_f32((((i % 509) as f32) - 254.0) * 0.01))
             .collect();
-        let embed =
-            DeviceMatrix::from_host(&ctx, &embed_host, vocab, hidden_size).expect("embed");
+        let embed = DeviceMatrix::from_host(&ctx, &embed_host, vocab, hidden_size).expect("embed");
         let ids: Vec<u32> = (0..seq_len).map(|i| ((i * 31) % vocab) as u32).collect();
         let token_ids = ctx.stream.clone_htod(&ids).expect("token ids");
         let mut out = HiddenStates::zeros(&ctx, hidden_size, seq_len).expect("out");


### PR DESCRIPTION
## TL;DR

CI `cargo fmt --check` is red on main since #488 (`perf(kernels): vectorize batched embedding gather`) merged. One line in the `embedding_batch_vectorized_path_is_bit_exact` test wraps at 82 cols where rustfmt wants it collapsed onto a single line. `cargo fmt --all` fixes it; no behavior change.

## Root cause

#488 introduced `openinfer-kernels/src/ops/embedding.rs:110-111` with a line break rustfmt does not agree with. The PR must have skipped local `cargo fmt --all --check`, so the formatting check in the `CPU checks` job has been failing on every main push since.

## What changed

- Run `cargo fmt --all` -> `embedding.rs` 3 lines -> 2 lines (collapse `let embed = ...`).
- No code logic change.

## Verification

```
cargo fmt --all --check   # FMT OK
```

Only this single hunk was produced by `cargo fmt --all`; nothing else in the workspace drifts. The flashinfer submodule pointer drift in the working tree is unrelated and left untouched here.

## CI

This is itself the CI fix; once merged the red `Check formatting` step on main goes green again.