### PR TITLE
fix(qwen3): disable cuda graph under tensor parallelism

### DIFF
--- a/openinfer-qwen3/src/executor.rs
+++ b/openinfer-qwen3/src/executor.rs
@@ -1074,6 +1074,13 @@ impl Qwen3Executor {
             "KV block events are only supported on the single-GPU path; got {} devices",
             device_ordinals.len()
         );
+        anyhow::ensure!(
+            !enable_cuda_graph || device_ordinals.len() == 1,
+            "CUDA Graph is not supported under tensor parallelism (the captured decode \
+             graph would record NCCL collectives with no cross-rank capture alignment); \
+             got {} devices",
+            device_ordinals.len()
+        );
         // The store cursor announces a block as cacheable the moment it is
         // registered, assuming GPU-resident reuse. With KV offload on, a block
         // can be evicted to the host tier and restored under a different lineage

--- a/openinfer-qwen3/src/lib.rs
+++ b/openinfer-qwen3/src/lib.rs
@@ -156,16 +156,17 @@ pub fn probe_model(model_path: &Path) -> Result<Option<ModelInfo>> {
 /// Server-facing launch knobs for the Qwen3 engine.
 ///
 /// The binary maps raw CLI flags into this struct; [`launch`] then owns the
-/// Qwen3 startup policy — the TP→device mapping and the LoRA↔CUDA-Graph
-/// exclusion — and dispatches to the right low-level entry. That policy lives
-/// with the model instead of leaking into the server.
+/// Qwen3 startup policy — the TP→device mapping and the LoRA↔CUDA-Graph and
+/// TP↔CUDA-Graph exclusions — and dispatches to the right low-level entry.
+/// That policy lives with the model instead of leaking into the server.
 #[derive(Clone, Debug)]
 pub struct Qwen3LaunchOptions {
     /// CUDA device for single-GPU loads (ignored when `tp_size > 1`).
     pub device_ordinal: usize,
     /// Tensor-parallel world size; `> 1` uses devices `0..tp_size`.
     pub tp_size: usize,
-    /// Whether the user requested CUDA Graph. LoRA serving forces it off.
+    /// Whether the user requested CUDA Graph. LoRA serving and tensor
+    /// parallelism force it off.
     pub cuda_graph: bool,
     pub offload: Qwen3OffloadOptions,
     pub no_prefix_cache: bool,
@@ -193,10 +194,16 @@ pub fn launch(model_path: &Path, options: Qwen3LaunchOptions) -> Result<EngineHa
         (0..options.tp_size).collect()
     };
     // LoRA serving repoints adapter weights between steps, which a captured
-    // decode graph bakes in — the two cannot coexist, so LoRA wins.
+    // decode graph bakes in; under TP the graph would capture each layer's
+    // NCCL all-reduces with nothing aligning capture across ranks.
     let enable_cuda_graph = if options.lora.is_some() {
         if options.cuda_graph {
             warn!("Qwen3: CUDA Graph is disabled while LoRA serving is enabled");
+        }
+        false
+    } else if options.tp_size > 1 {
+        if options.cuda_graph {
+            warn!("Qwen3: CUDA Graph is disabled under tensor parallelism");
         }
         false
     } else {

--- a/openinfer-qwen3/tests/tp_concurrent_decode.rs
+++ b/openinfer-qwen3/tests/tp_concurrent_decode.rs
@@ -1,0 +1,125 @@
+//! TP=2 launch with CUDA Graph requested — guards the graph clamp in `launch`.
+//! The drain loop polls with a deadline so a deadlock fails instead of wedging the run.
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use openinfer_core::engine::{GenerateRequest, TokenEvent, TokenSink};
+use openinfer_core::sampler::SamplingParams;
+use openinfer_qwen3::{
+    DEFAULT_KV_CACHE_MEMORY_MARGIN_BYTES, DEFAULT_MAX_PREFILL_TOKENS, DecodeOverlap,
+    Qwen3LaunchOptions, Qwen3MemoryOptions, Qwen3OffloadOptions,
+};
+use tokio::sync::mpsc::error::TryRecvError;
+
+mod common;
+
+const MODEL_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../models/Qwen3-4B");
+const REQUESTS: usize = 16;
+const DEADLINE_SECS: u64 = 300;
+
+fn model_path_or_skip() -> Option<String> {
+    match std::env::var("OPENINFER_TEST_MODEL_PATH") {
+        Ok(path) => Some(path),
+        Err(_) if Path::new(MODEL_PATH).join("config.json").exists() => {
+            Some(MODEL_PATH.to_string())
+        }
+        Err(_) => {
+            eprintln!(
+                "skipping tp2 concurrent decode: {MODEL_PATH}/config.json missing; set OPENINFER_TEST_MODEL_PATH"
+            );
+            None
+        }
+    }
+}
+
+fn cuda_device_count() -> usize {
+    cudarc::driver::CudaContext::device_count().map_or(0, |n| n.max(0) as usize)
+}
+
+#[test]
+fn tp2_concurrent_decode_completes() {
+    let Some(model_path) = model_path_or_skip() else {
+        return;
+    };
+    let gpus = cuda_device_count();
+    if gpus < 2 {
+        eprintln!("skipping tp2 concurrent decode: needs >=2 GPUs, have {gpus}");
+        return;
+    }
+
+    let options = Qwen3LaunchOptions {
+        device_ordinal: 0,
+        tp_size: 2,
+        cuda_graph: true,
+        offload: Qwen3OffloadOptions::disabled(),
+        no_prefix_cache: false,
+        max_prefill_tokens: DEFAULT_MAX_PREFILL_TOKENS,
+        memory: Qwen3MemoryOptions::new(0.85, DEFAULT_KV_CACHE_MEMORY_MARGIN_BYTES)
+            .validate()
+            .expect("valid memory options"),
+        lora: None,
+        decode_overlap: DecodeOverlap::Off,
+        batch_invariant: false,
+        dflash_draft_model_path: None,
+        enable_kv_events: false,
+    };
+    let handle =
+        openinfer_qwen3::launch(Path::new(&model_path), options).expect("launch tp2 engine");
+
+    let tokenizer = common::load_tokenizer(&model_path);
+    // Submit all up front so they coexist in the engine and form real decode batches.
+    let receivers: Vec<_> = (0..REQUESTS)
+        .map(|i| {
+            let prompt = format!("Write a few sentences about topic {i}:");
+            let prompt_tokens = tokenizer.encode(&prompt, false).expect("encode failed");
+            let (token_tx, rx) = TokenSink::standalone();
+            handle
+                .submit(GenerateRequest {
+                    request_id: None,
+                    queued_at_unix_s: None,
+                    prompt_tokens,
+                    params: SamplingParams::default(),
+                    max_tokens: 24 + (i % 4) * 24,
+                    lora_adapter: None,
+                    token_tx,
+                    logprobs: 0,
+                    echo: false,
+                })
+                .expect("submit failed");
+            rx
+        })
+        .collect();
+
+    let deadline = Instant::now() + Duration::from_secs(DEADLINE_SECS);
+    for (i, mut rx) in receivers.into_iter().enumerate() {
+        let mut tokens = 0usize;
+        loop {
+            match rx.try_recv() {
+                Ok((_, TokenEvent::Token { .. })) => tokens += 1,
+                Ok((_, TokenEvent::Scheduled { .. } | TokenEvent::PromptTokens { .. })) => {}
+                Ok((_, TokenEvent::Finished { .. })) => break,
+                Ok((_, TokenEvent::Error { message, .. })) => {
+                    panic!("request {i} failed: {message}")
+                }
+                Ok((_, TokenEvent::Rejected { message, .. })) => {
+                    panic!("request {i} rejected: {message}")
+                }
+                Err(TryRecvError::Empty) => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "request {i}: no progress within {DEADLINE_SECS}s, engine deadlocked"
+                    );
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+                Err(TryRecvError::Disconnected) => {
+                    panic!("request {i}: channel closed without Finished")
+                }
+            }
+        }
+        assert!(tokens > 0, "request {i} finished with zero decoded tokens");
+    }
+    // Give the engine's asynchronous teardown time to finish before process exit.
+    drop(handle);
+    std::thread::sleep(Duration::from_secs(5));
+}


### PR DESCRIPTION
## Description

Fixes #481 

`--tp-size 2` at defaults deadlocks silently on concurrent decode: `--cuda-graph` defaults to on, and the decode-graph capture closure records each layer's two NCCL all-reduces into the graph with nothing aligning capture across ranks. A single request completes; the first concurrent burst wedges the engine with nothing logged. `--tp-size 2 --cuda-graph=false` serves the same load cleanly.

Two layers, so the default keeps working and lower entries fail closed:

- `launch()` clamps the graph off when `tp_size > 1`, with a warn — the same pattern as the existing LoRA clamp there. The plain `--tp-size 2` invocation downgrades to eager and serves.
- The executor constructor rejects `enable_cuda_graph` with multiple devices — the same `ensure` the KV-offload / KV-events / DFlash guards already use, closing the direct `start_engine*` / `from_runtime*` entries that bypass `launch()`.

## Test

`tests/tp_concurrent_decode.rs`: TP=2 at production defaults (graph requested) under 16 concurrent requests. The drain loop polls with a deadline, so a reintroduced deadlock fails the test instead of wedging the run. Skips without >=2 GPUs or weights. The test waits briefly after dropping the engine so its asynchronous teardown finishes before process exit.

2x GH200 (sm_90, aarch64), A/B against the same origin/main base, one variable.

fire 32 staggered concurrent completions (temp 0, max_tokens 96):

| side | result |
|------|--------|
| base | hang: 0/32 completions, engine wedged until killed, no warn |
| base + fix | 32/32 completed; `Qwen3: CUDA Graph is disabled under tensor parallelism` logged once |

Test red/green — same command on both sides:

```
OPENINFER_TEST_MODEL_PATH=<Qwen3-4B> cargo test --release -p openinfer-qwen3-4b \
    --test tp_concurrent_decode -- --nocapture --test-threads=1
```

Base + test only (red — the 300s drain deadline fires on the deadlock):

```
failures:
    tp2_concurrent_decode_completes

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 311.81s
```

Base + fix (green):

```
test tp2_concurrent_decode_completes ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 11.15s
```