### PR TITLE
fix(kernels): point DeepGEMM submodule to openinfer-project fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/deepseek-ai/FlashMLA
 [submodule "openinfer-kernels/third_party/DeepGEMM"]
 	path = openinfer-kernels/third_party/DeepGEMM
-	url = https://github.com/deepseek-ai/DeepGEMM
+	url = https://github.com/openinfer-project/DeepGEMM


### PR DESCRIPTION
## Problem

The DeepGEMM submodule pointer (`ecbbe74`) records two local patches on top of upstream `main`:

- `91c4635` — feat: DG_NO_TORCH conditional compilation for torch-free paged MQA logits
- `ecbbe74` — fix: add #include <optional> for DG_NO_TORCH path

These commits were never pushed to `deepseek-ai/DeepGEMM`. Anyone running `git submodule update --init` on a fresh clone hits:

```
fatal: remote error: Server does not allow request for unadvertised object ecbbe74...
```

## Fix

1. Forked `deepseek-ai/DeepGEMM` → `openinfer-project/DeepGEMM`
2. Pushed the patches to the `openinfer` branch on the fork
3. Updated `.gitmodules` to point the submodule at the fork

The submodule commit (`ecbbe74`) is unchanged — only the URL is repointed, so existing checkouts are unaffected.

## Verification

```
git submodule sync openinfer-kernels/third_party/DeepGEMM
git config --get submodule.openinfer-kernels/third_party/DeepGEMM.url
# → https://github.com/openinfer-project/DeepGEMM
```

The `openinfer` branch on the fork contains:
```
ecbbe74 fix: add #include <optional> for DG_NO_TORCH path
91c4635 feat: DG_NO_TORCH conditional compilation for torch-free paged MQA logits
54e2261 Multiple updates and refactorings (#364)  ← upstream main
```