### PR TITLE
fix(kernels): correct rerun-if-changed tracking of third-party dirs

### DIFF
--- a/openinfer-kernels/build.rs
+++ b/openinfer-kernels/build.rs
@@ -1796,16 +1796,20 @@ fn main() {
     println!("cargo:rerun-if-env-changed=OPENINFER_BUILD_TIMING");
     println!("cargo:rerun-if-env-changed=OPENINFER_NVCC_JOBS");
     println!("cargo:rerun-if-env-changed=OPENINFER_NCCL_ROOT");
-    println!(
-        "cargo:rerun-if-changed={}",
-        root.join("third_party/DeepEP/deep_ep/include").display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        root.join("third_party/DeepGEMM").display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        root.join("third_party/FlashMLA").display()
-    );
+    let mut tracked_dirs = vec![
+        flashinfer.include.clone(),
+        flashinfer.csrc.clone(),
+        flashinfer.cutlass.clone(),
+        flashinfer.cutlass_util.clone(),
+        flashinfer.spdlog.clone(),
+    ];
+    tracked_dirs.extend(flashinfer.cccl.iter().cloned());
+    tracked_dirs.push(root.join("third_party/DeepEP/deep_ep/include"));
+    tracked_dirs.push(root.join("third_party/DeepGEMM"));
+    tracked_dirs.push(root.join("third_party/FlashMLA"));
+    for dir in tracked_dirs {
+        if dir.exists() {
+            println!("cargo:rerun-if-changed={}", dir.display());
+        }
+    }
 }


### PR DESCRIPTION
## Description

Two defects in `openinfer-kernels/build.rs` dependency tracking, found while A/B-testing a FlashInfer header change:

1. **FlashInfer include dir is not tracked.** `rerun-if-changed` covers `csrc/`, `build.rs`, the Triton generators, and the DeepEP/DeepGEMM/FlashMLA dirs — but not the FlashInfer include dir the kernels actually compile against. Editing a header there ships a stale binary silently.
2. **Missing submodule dirs force a full rebuild every time.** The DeepEP/DeepGEMM/FlashMLA `rerun-if-changed` paths are emitted unconditionally, but those submodules are only checked out for their feature builds. cargo treats a missing `rerun-if-changed` path as always-dirty, so on a tree without them (any default-feature checkout) every `cargo build` recompiles the whole kernels crate from scratch (~40 s per build here).

| check | base | fixed |
|---|---|---|
| steady rebuild with DeepEP missing | recompiles every build | quiet |
| touch a FlashInfer header | ignored (stale binary) | recompiles |
| touch a file in an existing tracked dir (DeepGEMM) | — | recompiles |
| steady build, no changes | — | quiet |


## Test Env

Single GPU (sm_89, x86_64).

- `cargo test --release --workspace --lib`: 5 targets, 500 tests passed, 0 failed.
- All 20 qwen3 integration tests ok (`--test-threads=1`), incl. `hf_golden_gate`, the batch-invariance set, `lora_golden_gate`, `lora_smoke -- --ignored` (2 passed); `tp_concurrent_decode` skips on 1 GPU.
- qwen35 (`--features qwen35-4b`): `chunked_prefill`, `e2e_scheduler`, `sampling_behavior`, `hf_golden_gate` ok.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)