### PR TITLE
test(qwen3): extract the prefetch-tick decision and unit-test its failure paths

### DIFF
--- a/openinfer-qwen3/src/executor.rs
+++ b/openinfer-qwen3/src/executor.rs
@@ -20,11 +20,13 @@ use openinfer_kv_cache::{
     KvBlockGuard, KvBuffer, KvCacheEvent, KvCacheManager, KvView, LoadReservation, PrefixProbe,
     RegisteredBlock,
 };
-use openinfer_kv_offload::{LoadHandle, OffloadConfig, OffloadEngine, QueryOutcome};
+use openinfer_kv_offload::{LoadHandle, OffloadConfig, OffloadEngine};
 use tokio::sync::broadcast;
 
 mod dflash_lane;
 mod dflash_prefill;
+mod remote_fetch;
+use remote_fetch::{QueryView, RemoteFetchAction, remote_fetch_action};
 mod spec;
 
 use crate::dflash::DFlashDraftModel;
@@ -1639,36 +1641,43 @@ impl Qwen3Executor {
         else {
             return false;
         };
-        if std::time::Instant::now() > *deadline {
+        let timed_out = std::time::Instant::now() > *deadline;
+        if timed_out {
             log::warn!("remote KV fetch timed out for {id:?}; prefill from scratch");
-            self.prefetch.remove(&id);
-            return true;
         }
         let query_hashes = query_hashes.clone();
-        let offload = self.offload.as_ref().expect("offload present in prefetch");
-        match offload.query(&id.0.to_string(), &query_hashes) {
-            Ok(QueryOutcome::Loading) => false,
-            Ok(QueryOutcome::Ready(hit)) => {
-                let (Some(lease), num_blocks) = (hit.lease, hit.num_blocks) else {
-                    self.prefetch.remove(&id);
-                    return true;
-                };
-                // Same budget guard as begin_kv_prefetch: blocks promised to
-                // admitted requests are off-limits — reserving into them makes
-                // a later prefill chunk or decode growth fail allocation and
-                // errors out every touched request.
-                if self
-                    .kv_mgr
-                    .pool()
-                    .available_blocks()
-                    .saturating_sub(reserve_floor)
-                    < num_blocks
-                {
-                    let offload = self.offload.as_ref().expect("offload present in prefetch");
-                    offload.release_query_lease(lease);
-                    self.prefetch.remove(&id);
-                    return true;
-                }
+        let available_blocks = self.kv_mgr.pool().available_blocks();
+        let action = {
+            let offload = self.offload.as_ref().expect("offload present in prefetch");
+            remote_fetch_action(
+                timed_out,
+                || {
+                    offload
+                        .query(&id.0.to_string(), &query_hashes)
+                        .map(QueryView::from)
+                        .map_err(|e| {
+                            log::warn!(
+                                "remote KV re-query failed for {id:?} (prefill from scratch): {e}"
+                            );
+                        })
+                },
+                available_blocks,
+                reserve_floor,
+            )
+        };
+        match action {
+            RemoteFetchAction::Wait => false,
+            RemoteFetchAction::Scratch => {
+                self.prefetch.remove(&id);
+                true
+            }
+            RemoteFetchAction::Release(lease) => {
+                let offload = self.offload.as_ref().expect("offload present in prefetch");
+                offload.release_query_lease(lease);
+                self.prefetch.remove(&id);
+                true
+            }
+            RemoteFetchAction::Load(lease, num_blocks) => {
                 let probe = self
                     .prefetch
                     .remove(&id)
@@ -1678,11 +1687,6 @@ impl Qwen3Executor {
                     Ok(()) => false,
                     Err(()) => true,
                 }
-            }
-            Err(e) => {
-                log::warn!("remote KV re-query failed for {id:?} (prefill from scratch): {e}");
-                self.prefetch.remove(&id);
-                true
             }
         }
     }
@@ -2012,15 +2016,22 @@ impl ModelExecutor for Qwen3Executor {
         if query_hashes.is_empty() {
             return false;
         }
-        let outcome = match offload.query(&request_id.0.to_string(), &query_hashes) {
-            Ok(outcome) => outcome,
-            Err(e) => {
-                log::warn!("KV offload query failed for {request_id:?} (skipping): {e}");
-                return false;
-            }
-        };
-        let hit = match outcome {
-            QueryOutcome::Loading => {
+        let available_blocks = self.kv_mgr.pool().available_blocks();
+        let action = remote_fetch_action(
+            false,
+            || {
+                offload
+                    .query(&request_id.0.to_string(), &query_hashes)
+                    .map(QueryView::from)
+                    .map_err(|e| {
+                        log::warn!("KV offload query failed for {request_id:?} (skipping): {e}");
+                    })
+            },
+            available_blocks,
+            reserve_floor,
+        );
+        match action {
+            RemoteFetchAction::Wait => {
                 // pegaflow is pulling the missing prefix from a P2P peer (or
                 // SSD) into the local host tier. Park the request and re-query
                 // each tick; the probe keeps the GPU-hit prefix resident.
@@ -2034,28 +2045,19 @@ impl ModelExecutor for Qwen3Executor {
                         },
                     },
                 );
-                return true;
+                true
             }
-            QueryOutcome::Ready(hit) => hit,
-        };
-        let (Some(lease), num_blocks) = (hit.lease, hit.num_blocks) else {
-            return false; // miss
-        };
-        // Blocks promised to admitted requests are off-limits: reserving into
-        // them makes a later prefill chunk or decode growth fail allocation.
-        if self
-            .kv_mgr
-            .pool()
-            .available_blocks()
-            .saturating_sub(reserve_floor)
-            < num_blocks
-        {
-            offload.release_query_lease(lease);
-            return false;
-        }
-        match self.start_prefetch_load(request_id, probe, lease, num_blocks) {
-            Ok(()) => true,
-            Err(()) => false,
+            RemoteFetchAction::Scratch => false, // miss or query error
+            RemoteFetchAction::Release(lease) => {
+                offload.release_query_lease(lease);
+                false
+            }
+            RemoteFetchAction::Load(lease, num_blocks) => {
+                match self.start_prefetch_load(request_id, probe, lease, num_blocks) {
+                    Ok(()) => true,
+                    Err(()) => false,
+                }
+            }
         }
     }
 

--- a/openinfer-qwen3/src/executor/remote_fetch.rs
+++ b/openinfer-qwen3/src/executor/remote_fetch.rs
@@ -1,0 +1,162 @@
+//! The per-tick decision for a CPU-tier KV prefetch query.
+//!
+//! `begin_kv_prefetch` (first query) and `poll_remote_fetch` (re-query while
+//! parked in [`RemoteFetch`](super::PrefetchPhase::RemoteFetch)) share one
+//! cascade: still loading → wait; timeout / zero-hit / query error → prefill
+//! from scratch; leased hit past the reservation budget → release the lease
+//! and prefill from scratch; leased hit within budget → start the H2D load.
+//! This module owns that cascade so the two call sites cannot drift, and so
+//! the timeout / zero-hit / budget branches are testable without a GPU, an
+//! RDMA fabric, or a MetaServer (only *injecting* a real `Loading` needs
+//! those; deciding on one does not).
+//!
+//! The lease type is generic: every branch that receives a lease must route
+//! it into the returned action, so a silently dropped (never-released) lease
+//! is unrepresentable. Production monomorphizes `L` to pegaflow's opaque
+//! `QueryLeaseId`; tests use plain integers.
+
+/// A lease-carrying view of [`QueryOutcome`](openinfer_kv_offload::QueryOutcome),
+/// decoupled from pegaflow types so the decision stays constructible in tests.
+///
+/// `lease: None` only occurs together with `num_blocks == 0` (the engine
+/// builds a lease for every non-empty hit); the pair is kept as-is rather
+/// than re-encoded because the decision treats every `None` as a miss.
+pub(super) enum QueryView<L> {
+    Loading,
+    Ready { lease: Option<L>, num_blocks: usize },
+}
+
+impl From<openinfer_kv_offload::QueryOutcome> for QueryView<openinfer_kv_offload::QueryLeaseId> {
+    fn from(outcome: openinfer_kv_offload::QueryOutcome) -> Self {
+        match outcome {
+            openinfer_kv_offload::QueryOutcome::Loading => QueryView::Loading,
+            openinfer_kv_offload::QueryOutcome::Ready(hit) => QueryView::Ready {
+                lease: hit.lease,
+                num_blocks: hit.num_blocks,
+            },
+        }
+    }
+}
+
+/// What to do with the request after one prefetch query tick.
+#[derive(Debug, Eq, PartialEq)]
+pub(super) enum RemoteFetchAction<L> {
+    /// Remote fetch still in flight: park (first tick) or stay parked.
+    Wait,
+    /// Give up the prefetch — deadline passed, zero-hit, or the query
+    /// errored — and prefill from scratch. No lease was taken.
+    Scratch,
+    /// The hit is leased but reserving `num_blocks` would eat into blocks
+    /// promised to admitted requests: release the lease, then prefill from
+    /// scratch.
+    Release(L),
+    /// Leased hit within budget: reserve blocks and submit the H2D load.
+    Load(L, usize),
+}
+
+/// Decide one prefetch query tick.
+///
+/// `query` runs only when the deadline has not passed — a parked request
+/// whose deadline expired must not issue another query RPC — which is why
+/// this takes a closure rather than a pre-computed outcome. A query `Err` is
+/// already logged at the call site's level of context, so it folds into
+/// [`RemoteFetchAction::Scratch`] here.
+pub(super) fn remote_fetch_action<L, E>(
+    timed_out: bool,
+    query: impl FnOnce() -> Result<QueryView<L>, E>,
+    available_blocks: usize,
+    reserve_floor: usize,
+) -> RemoteFetchAction<L> {
+    if timed_out {
+        return RemoteFetchAction::Scratch;
+    }
+    let (lease, num_blocks) = match query() {
+        Ok(QueryView::Loading) => return RemoteFetchAction::Wait,
+        Ok(QueryView::Ready { lease, num_blocks }) => (lease, num_blocks),
+        Err(_) => return RemoteFetchAction::Scratch,
+    };
+    let Some(lease) = lease else {
+        return RemoteFetchAction::Scratch; // miss
+    };
+    // Blocks promised to admitted requests are off-limits: reserving into
+    // them makes a later prefill chunk or decode growth fail allocation.
+    if available_blocks.saturating_sub(reserve_floor) < num_blocks {
+        return RemoteFetchAction::Release(lease);
+    }
+    RemoteFetchAction::Load(lease, num_blocks)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type Action = RemoteFetchAction<u32>;
+
+    fn ready(lease: Option<u32>, num_blocks: usize) -> Result<QueryView<u32>, ()> {
+        Ok(QueryView::Ready { lease, num_blocks })
+    }
+
+    /// Past the deadline the request prefills from scratch and, critically,
+    /// no further query RPC is issued.
+    #[test]
+    fn timeout_gives_up_without_querying() {
+        let action = remote_fetch_action::<u32, ()>(
+            true,
+            || unreachable!("post-deadline tick must not query"),
+            usize::MAX,
+            0,
+        );
+        assert_eq!(action, Action::Scratch);
+    }
+
+    /// A remote fetch still in flight keeps the request parked.
+    #[test]
+    fn loading_waits() {
+        let action = remote_fetch_action::<u32, ()>(false, || Ok(QueryView::Loading), 0, 0);
+        assert_eq!(action, Action::Wait);
+    }
+
+    /// Zero-hit (peer evicted the blocks, or no owner): no lease exists, so
+    /// the request just prefills from scratch.
+    #[test]
+    fn zero_hit_prefills_from_scratch() {
+        let action = remote_fetch_action(false, || ready(None, 0), usize::MAX, 0);
+        assert_eq!(action, Action::Scratch);
+    }
+
+    /// A query error folds into prefill-from-scratch.
+    #[test]
+    fn query_error_prefills_from_scratch() {
+        let action = remote_fetch_action::<u32, &str>(false, || Err("rpc failed"), usize::MAX, 0);
+        assert_eq!(action, Action::Scratch);
+    }
+
+    /// A leased hit that would eat into promised blocks routes the lease out
+    /// for release — the type makes dropping it silently unrepresentable.
+    #[test]
+    fn budget_guard_releases_the_lease() {
+        let action = remote_fetch_action(false, || ready(Some(7), 10), 12, 3);
+        assert_eq!(action, Action::Release(7));
+    }
+
+    /// `reserve_floor > available_blocks` must saturate, not underflow.
+    #[test]
+    fn budget_guard_saturates_when_floor_exceeds_available() {
+        let action = remote_fetch_action(false, || ready(Some(7), 1), 2, 5);
+        assert_eq!(action, Action::Release(7));
+    }
+
+    /// Exactly-at-budget reserves and loads: the guard is strict-less-than.
+    #[test]
+    fn exact_budget_boundary_loads() {
+        let action = remote_fetch_action(false, || ready(Some(7), 9), 12, 3);
+        assert_eq!(action, Action::Load(7, 9));
+    }
+
+    /// The normal path: leased hit within budget starts the H2D load.
+    #[test]
+    fn leased_hit_within_budget_loads() {
+        let action = remote_fetch_action(false, || ready(Some(42), 4), 64, 8);
+        assert_eq!(action, Action::Load(42, 4));
+    }
+}


### PR DESCRIPTION
Closes the unit-testable half of #525.

## What this is

`begin_kv_prefetch` and `poll_remote_fetch` carried the same per-tick decision cascade as two hand-maintained copies (the budget-guard comment was literally duplicated between them). `src/executor/remote_fetch.rs` now owns the cascade — mirroring the `dflash_prefill.rs` extract-the-decision pattern — and both call sites just apply its action, so they cannot drift.

That extraction is also what makes #525's cases testable without the RDMA rig: only *injecting* a real `Loading` needs GPU + MetaServer; *deciding* on one does not (the M2 doc's "需 GPU 环境" was about injection, not the logic).

## Type-level guarantees

- **The lease is generic in the action type** (`RemoteFetchAction<L>`): every branch that receives a lease must route it into the returned action, so a silently dropped — never-released — lease is unrepresentable. Prod monomorphizes to pegaflow's opaque `QueryLeaseId`; tests use integers.
- **The query is a closure**, preserving the check-deadline-*before*-query ordering — the timeout test passes `|| unreachable!()`, asserting a post-deadline tick issues no query RPC at all.

## Tests (8, no GPU)

timeout / still-loading / zero-hit / query-error / budget-guard release (incl. `floor > available` saturation and the exact-boundary load) / normal leased-hit load.

## Verification

- `cargo test --release -p openinfer-qwen3 --lib remote_fetch`: **8/8** on H100 (CUDA 12.9), full crate build.
- Call-site behavior is unchanged by inspection: each action arm is the same 2–4 lines the branch previously did in place (`prefetch.remove`, `release_query_lease`, `start_prefetch_load`, park-as-`RemoteFetch`); the timeout/query-error warns stay at the call site where the request context lives.

## Not in this PR

The remaining #525 case — **drop during `Loading`**, the wait-for-H2D-before-releasing-the-reservation corruption guard — genuinely needs GPU + weights (a third scenario in the `kv_offload_cpu_hit.rs` harness: baseline `available_blocks` → prefetch in flight → `drop_request` → pool returns to baseline, resubmission still prefills). Follows as a stacked PR once weights land on my box. The `RemoteFetch`-phase drop is structural (that variant holds no local reservation by construction; pegaflow's `gc_stale_inflight` owns the orphaned server side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
