### PR TITLE
fix(qwen35): load the untied lm_head instead of reusing embed_tokens

### DIFF
--- a/docs/models/qwen35/optimization.md
+++ b/docs/models/qwen35/optimization.md
@@ -92,7 +92,7 @@ Reference — Qwen3-4B on same GPU: TTFT(2048,1)=213ms, TPOT(1,128)≈10.6ms.
 - hidden_dim: 2560
 - MLP intermediate_size: 9216
 - RMSNorm: (1 + weight) offset variant, eps=1e-6
-- Tied word embeddings (embed_tokens = lm_head)
+- Word embeddings: 4B ties them (embed_tokens doubles as the LM head); 9B/27B are untied with a top-level `lm_head.weight`
 - Vocab size: 248,320
 
 **Full attention (8 layers):**

--- a/openinfer-qwen35-4b/src/batch_decode.rs
+++ b/openinfer-qwen35-4b/src/batch_decode.rs
@@ -319,7 +319,7 @@ impl Qwen35Model {
         )?;
         ops::gemm_into(
             &self.ctx,
-            &self.embed_tokens,
+            self.output_projection(),
             &bufs.normed,
             &mut bufs.logits,
         );

--- a/openinfer-qwen35-4b/src/config.rs
+++ b/openinfer-qwen35-4b/src/config.rs
@@ -32,6 +32,7 @@ struct TextConfig {
     linear_value_head_dim: usize,
     rope_parameters: RopeParameters,
     max_position_embeddings: Option<usize>,
+    tie_word_embeddings: Option<bool>,
     eos_token_id: u32,
 }
 
@@ -39,6 +40,7 @@ struct TextConfig {
 struct RawConfig {
     text_config: TextConfig,
     max_position_embeddings: Option<usize>,
+    tie_word_embeddings: Option<bool>,
 }
 
 /// Qwen3.5 model configuration (text-only).
@@ -71,6 +73,9 @@ pub(crate) struct Config35 {
 
     // Layer layout
     pub(crate) layer_types: Vec<LayerType>,
+
+    /// `false` requires a top-level `lm_head.weight`; `true` reuses `embed_tokens`.
+    pub(crate) tie_word_embeddings: bool,
 }
 
 /// GDN dims the Triton-AOT kernels are built for; a mismatched model is rejected at load.
@@ -84,7 +89,13 @@ impl Config35 {
         let content = fs::read_to_string(&config_path)?;
         let raw: RawConfig = serde_json::from_str(&content)?;
         let root_max_position_embeddings = raw.max_position_embeddings;
+        let root_tie_word_embeddings = raw.tie_word_embeddings;
         let t = raw.text_config;
+
+        let tie_word_embeddings = t
+            .tie_word_embeddings
+            .or(root_tie_word_embeddings)
+            .ok_or_else(|| anyhow::anyhow!("Qwen3.5 config missing tie_word_embeddings"))?;
 
         let layer_types: Vec<LayerType> = t
             .layer_types
@@ -147,6 +158,7 @@ impl Config35 {
             rotary_dim,
             max_position_embeddings,
             layer_types,
+            tie_word_embeddings,
         })
     }
 

--- a/openinfer-qwen35-4b/src/kernel_plan.rs
+++ b/openinfer-qwen35-4b/src/kernel_plan.rs
@@ -157,9 +157,9 @@ pub static KERNEL_PLAN: KernelPlan = KernelPlan {
                 },
                 KernelOp {
                     id: "lm_head_prefill",
-                    rust: "prefill::batch_last_hidden_logits -> ops::gemm (tied embed_tokens)",
+                    rust: "prefill::batch_last_hidden_logits -> ops::gemm (output_projection)",
                     backend: "cuBLAS",
-                    notes: "LM head using tied embeddings (one cuBLAS GEMM over request rows)",
+                    notes: "LM head: untied lm_head.weight when the config unties embeddings, else embed_tokens (one cuBLAS GEMM over request rows)",
                 },
             ],
         },
@@ -268,9 +268,9 @@ pub static KERNEL_PLAN: KernelPlan = KernelPlan {
                 },
                 KernelOp {
                     id: "lm_head_decode",
-                    rust: "batch_decode::batch_decode_kernels_graph -> ops::gemm_into (tied embed_tokens)",
+                    rust: "batch_decode::batch_decode_kernels_graph -> ops::gemm_into (output_projection)",
                     backend: "cuBLAS",
-                    notes: "LM head using tied embeddings (one cuBLAS GEMM over the bucket-padded batch)",
+                    notes: "LM head: untied lm_head.weight when the config unties embeddings, else embed_tokens (one cuBLAS GEMM over the bucket-padded batch)",
                 },
                 // batched sampling
                 KernelOp {

--- a/openinfer-qwen35-4b/src/prefill.rs
+++ b/openinfer-qwen35-4b/src/prefill.rs
@@ -110,7 +110,7 @@ impl Qwen35Model {
             self.config.rms_norm_eps,
             &mut normed,
         )?;
-        let logits = ops::gemm(&self.ctx, &self.embed_tokens, &normed)?;
+        let logits = ops::gemm(&self.ctx, self.output_projection(), &normed)?;
         debug_assert_eq!(logits.seq_len, n);
         Ok(logits)
     }

--- a/openinfer-qwen35-4b/src/weights.rs
+++ b/openinfer-qwen35-4b/src/weights.rs
@@ -73,6 +73,7 @@ pub struct Qwen35Model {
     pub(super) ctx: DeviceContext,
     pub(super) config: Config35,
     pub(super) embed_tokens: DeviceMatrix,
+    pub(super) lm_head: Option<DeviceMatrix>,
     pub(super) layers: Vec<TransformerBlock35>,
     pub(super) norm: DeviceVec,
     // Partial RoPE cache: [max_seq_len * rotary_dim]
@@ -129,6 +130,23 @@ impl Qwen35Model {
             "embed_tokens: [{}, {}]",
             embed_tokens.rows, embed_tokens.cols
         );
+
+        let lm_head = if config.tie_word_embeddings {
+            info!("output projection: tied embed_tokens");
+            None
+        } else {
+            let m = load_tensor_2d(&ctx, &shards, &weight_map, "lm_head.weight")?;
+            anyhow::ensure!(
+                m.rows == config.vocab_size && m.cols == config.hidden_size,
+                "lm_head.weight is [{}, {}], expected [vocab {}, hidden {}]",
+                m.rows,
+                m.cols,
+                config.vocab_size,
+                config.hidden_size,
+            );
+            info!("output projection: untied lm_head [{}, {}]", m.rows, m.cols);
+            Some(m)
+        };
 
         debug!(
             "Loading layers to GPU: num_layers={}",
@@ -356,6 +374,7 @@ impl Qwen35Model {
             ctx,
             config,
             embed_tokens,
+            lm_head,
             layers,
             norm,
             cos_cache,
@@ -366,6 +385,10 @@ impl Qwen35Model {
 
     pub(crate) fn config(&self) -> &Config35 {
         &self.config
+    }
+
+    pub(super) fn output_projection(&self) -> &DeviceMatrix {
+        self.lm_head.as_ref().unwrap_or(&self.embed_tokens)
     }
 
     pub(crate) fn ensure_rope_cache_covers(&self, positions: usize) -> Result<()> {
@@ -476,7 +499,7 @@ impl Qwen35Model {
             .iter()
             .map(|layer| (&layer.mlp.down_proj, 0))
             .collect();
-        let lm_head_samples = [(&self.embed_tokens, 0)];
+        let lm_head_samples = [(self.output_projection(), 0)];
 
         for &n in super::batch_decode_graph::BATCH_BUCKETS
             .iter()


### PR DESCRIPTION
## Description

Fixes #516.

Qwen3.5-9B and 27B set `tie_word_embeddings: false` and ship a top-level `lm_head.weight`. The qwen35 crate unconditionally reused `embed_tokens` as the LM head, so on 9B every completion projects final hidden states through the wrong matrix and collapses into repeated tokens.

Root-cause check: forcing HF 9B to reuse its input embeddings as the LM head reproduces openinfer's broken output token-for-token, while stock HF 9B is coherent. The divergence is exactly the tied/untied choice.

`config.rs` parses `tie_word_embeddings` from the root or `text_config` level and rejects a config with neither. `weights.rs` loads `lm_head.weight` through the loader's fallback-aware path when untied (matching the qwen3 crate — a missing tensor fails loud), validates its shape, and `output_projection()` picks the matrix at the prefill / batch-decode / GEMM-tune sites.

## Test Env

Single GPU (sm_89, x86_64): 4B golden gate green (tied path unchanged). 9B with the fix — the degenerate-output sentinel (10 greedy completions) is green; greedy completions are coherent. Dual-GH200 (aarch64, sm_90): 9B with the fix produces the same coherent greedy output, and a long-context prompt that was garbage on the unfixed build is coherent. The same sentinel is 6/10 degenerate on the unfixed 9B (measurement below).

<details>
<summary>9B greedy completions with the fix (sm_89)</summary>

```
The capital of France is | Paris.
Water boils at | 100°C at sea level. At what temperature does water boil at the top of Mount Everest, where the
The chemical symbol for gold is | Au. What is the origin of this symbol?
In 1969, Apollo 11 | landed on the Moon, and the astronauts planted a flag.
The speed of light is approximately | $3 \times 10^8$ meters per second.
```

</details>

<details>
<summary>Same sentinel on the unfixed 9B — 6/10 degenerate (Dual-GH200, aarch64, sm_90)</summary>

```
DEGENERATE  len=50 distinct_ratio=0.160 max_run=43   prompt: The capital of France is
DEGENERATE  len=50 distinct_ratio=0.340 max_run=18   prompt: Water boils at
DEGENERATE  len=50 distinct_ratio=0.200 max_run=27   prompt: The chemical symbol for gold is
DEGENERATE  len=50 distinct_ratio=0.200 max_run=20   prompt: In 1969, Apollo 11
DEGENERATE  len=50 distinct_ratio=0.200 max_run=28   prompt: The speed of light is approximately
DEGENERATE  len=50 distinct_ratio=0.040 max_run=49   prompt: def fibonacci(n):
```

</details>

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)