### PR TITLE
perf(glm52): ROWS=4 register tile for the batched weight-only GEMV — bucket-8 step 45.6 -> 37.0 ms

### DIFF
--- a/docs/models/glm52/whole-step-decode-graph.md
+++ b/docs/models/glm52/whole-step-decode-graph.md
@@ -97,6 +97,47 @@ Measured dead ends (all recorded in #542): the inter-step host gap is ~0.05 ms (
 
 The same-node vLLM nsys diff (their trace: NCCL AllGather+ReduceScatter naive EP — NOT DeepEP — at 29+36 µs/layer medians, comparable to our 12+47) relocates the remaining 2.6 ms: (1) **expert GEMM** — vLLM's DeepGEMM swapAB runs ~10.8 µs/instance where our TRTLLM grouped takes 22.7 µs (64-row M-tile against ~8 real rows = 8× wasted MMA work; swapAB puts the skinny dimension on N). (2) **collective wait structure** (dispatch is rank-arrival-bound; fp8 payload measured neutral). A calibration lesson from the tier stage: node-granularity nsys inflates small kernels — the attention diff read as ~1 ms in trace proportions but bought 0.3 ms e2e; size expected wins from e2e A/B, not trace ratios.
 
+## Bucket-8 step attribution (jz-38 nsys 2026-07-05)
+
+Why does a bucket-8 step cost 45.6 ms when bucket-1 costs 22.5? Same methodology
+as above (node-granularity trace), two windows on the same binary: bucket-8 via
+long-prompt span ingestion (one slot, 8 rows/rank; 1800 rank-steps sampled) vs a
+bucket-1 solo control (2520 rank-steps). Total-kernel-time accounting closes:
+27.2 → 50.1 ms/rank-step (+22.9) against the bare-metal +23.1 wall delta.
+
+| component (per rank-step, total incl tails) | b1 | b8 | Δ |
+|---|---|---|---|
+| non-expert weight-only GEMV (all projections) | 6.5 | 21.6 | **+15.1** |
+| expert grouped GEMM (TRTLLM) | 3.4 | 7.2 | +3.8 |
+| MoE combine kernel | 3.6 | 5.4 | +1.8 |
+| MLA splitkv attention (8 queries vs 1) | 1.3 | 2.6 | +1.3 |
+| SiLU/quant glue | 1.2 | 1.8 | +0.6 |
+| dispatch (incl rank-arrival wait) | 4.4 | 4.6 | +0.2 |
+| everything else | ~6.8 | ~6.9 | ~0 |
+
+Two-thirds of the delta sits in the kernel designed to be batch-free: the
+batched weight-only GEMV reads each weight packet once for all 8 rows, but the
+1-row/warp layout issues 16 activation LDGs per weight LDG — ncu shows 93%
+L1TEX / 12% DRAM, i.e. the L1TEX **port** is saturated, not bandwidth or FMA.
+Shared-memory staging cannot help (LDS shares the L1TEX pipe on Hopper — a
+microbenched smem variant lost everywhere); registers are the only storage off
+that port. The collectives are nearly innocent: dispatch wait is flat and
+combine grows only +1.8 ms for 8× payload.
+
+Fix (`perf(glm52): ROWS=4 register tile for the batched weight-only GEMV`):
+each warp owns 4 output rows and reuses the register-held activation chunk
+across them, cutting per-row activation loads 4× while keeping per-row bit
+parity with the m=1 kernel (memcmp-gated microbench, all 10 shapes × batches
+{2,4,8}). Batch 2 keeps the 1-row/warp shape (act traffic negligible there).
+H200 microbench: o_proj 132→66 µs, dense_dn 99→51, q_b 42→26 at batch 8;
+weighted per-step: bucket-8 GEMV 23.0→13.9 ms, bucket-4 13.4→9.5 ms. ROWS=8
+spills registers; WARPS=4 keeps ~3 blocks/SM. **e2e measured (jz-38, dspark
+stack + cherry-pick): bucket-8 span step 45.6 → 37.0 ms (−19%), 1621-token
+prompt TTFT 9.25 → 7.55 s; bucket-1 solo 22.63 ms/step — flat, b1 path
+untouched.** Matches the microbench-weighted −9.1 ms prediction. Artifacts:
+traces + kern-sum CSVs `~/develop/xingming/b8span* b1ctrl*`, microbench
+`~/develop/xingming/gemv_bench` on jz-38.
+
 ## Next action
 
 Follow-ups: #542 (collective latency floor / GEMV BW / `num_sm_parts`), #541 indexer reference re-pin.

--- a/openinfer-kernels/csrc/glm52/glm52_moe_gemv.cu
+++ b/openinfer-kernels/csrc/glm52/glm52_moe_gemv.cu
@@ -159,75 +159,89 @@ __global__ void glm52_fp8_weight_only_gemv_kernel(
   gemv_row_tile<ROWS>(activation, weight, weight_scale, out, n, k);  // x straight from L2
 }
 
-// Batched weight-stationary GEMV: one warp owns ONE output row n0 and sweeps K once,
-// carrying BATCH accumulators — the weight is still read exactly once (the whole point
-// of batching a weight-memory-bound GEMV), only the FMA count grows with BATCH.
-// Each batch row's dot uses the same lane sweep, per-term order, and warp reduction
-// as gemv_row_tile<1>, so every row is bit-identical to the m=1 kernel run alone.
-// The BATCH activation rows ([BATCH, k] bf16, ≤ 256 KB at the largest K) stay
-// L2-resident across the n/8 blocks, same as the single row does today.
-template <int BATCH>
-__device__ __forceinline__ void gemv_row_tile_batched(
-    const __nv_bfloat16* __restrict__ xs,        // activation [BATCH, k]
-    const unsigned char* __restrict__ w_base,    // fp8 e4m3 [n, k]
-    const float* __restrict__ scale_base,        // f32 [n/128, k/128]
-    __nv_bfloat16* __restrict__ out,             // [BATCH, n]
-    int n, int k) {
-  const int warp = threadIdx.x >> 5;
-  const int lane = threadIdx.x & 31;
-  const int n0   = blockIdx.y * kWarpsPerBlk + warp;  // 1 row/warp
-  const int scale_cols = k >> 7;
-  const float* scale_row = scale_base + (size_t)(n0 >> 7) * scale_cols;
-
-  float acc[BATCH];
-#pragma unroll
-  for (int b = 0; b < BATCH; ++b) acc[b] = 0.0f;
-
-  for (int kk = lane * kVec; kk < k; kk += kStep) {
-    const float scale = scale_row[kk >> 7];
-    const uint4 wp = __ldcs(reinterpret_cast<const uint4*>(
-        w_base + ((size_t)n0 * k) + kk));
-    const __nv_fp8x2_e4m3* w2 = reinterpret_cast<const __nv_fp8x2_e4m3*>(&wp);
-#pragma unroll
-    for (int b = 0; b < BATCH; ++b) {
-      const float4* xs4 = reinterpret_cast<const float4*>(xs + (size_t)b * k);
-      float4 xv0 = xs4[(kk >> 3)];
-      float4 xv1 = xs4[(kk >> 3) + 1];
-      const __nv_bfloat16* xh0 = reinterpret_cast<const __nv_bfloat16*>(&xv0);
-      const __nv_bfloat16* xh1 = reinterpret_cast<const __nv_bfloat16*>(&xv1);
-      float partial = 0.0f;
-      // Same per-term left-to-right association as gemv_row_tile — bit parity
-      // per row is the contract (see that kernel's comment).
-#pragma unroll
-      for (int j = 0; j < 4; ++j) {
-        __half2 h = static_cast<__half2>(w2[j]);
-        partial += __low2float(h) * __bfloat162float(xh0[2 * j]);
-        partial += __high2float(h) * __bfloat162float(xh0[2 * j + 1]);
-      }
-#pragma unroll
-      for (int j = 0; j < 4; ++j) {
-        __half2 h = static_cast<__half2>(w2[4 + j]);
-        partial += __low2float(h) * __bfloat162float(xh1[2 * j]);
-        partial += __high2float(h) * __bfloat162float(xh1[2 * j + 1]);
-      }
-      acc[b] += scale * partial;
-    }
-  }
-#pragma unroll
-  for (int b = 0; b < BATCH; ++b) {
-    float v = warp_reduce_sum(acc[b]);
-    if (lane == 0) out[(size_t)b * n + n0] = __float2bfloat16(v);
-  }
-}
-
-template <int BATCH>
-__global__ void glm52_fp8_weight_only_gemv_batched_kernel(
+// Batched weight-stationary GEMV: a warp owns ROWS output rows and sweeps K once,
+// carrying ROWS x BATCH accumulators. The weight packet is read exactly once per row
+// (the whole point of batching a weight-memory-bound GEMV) and reused across all
+// BATCH activation rows; the activation chunk is read once per warp into registers
+// and reused across the ROWS weight rows. Each row's dot uses the same lane sweep,
+// per-term order, and warp reduction as gemv_row_tile<1>, so every row is
+// bit-identical to the m=1 kernel run alone.
+//
+// Why ROWS matters (H200 microbench + in-situ ncu, 2026-07-05): at BATCH=8 the
+// 1-row/warp layout issues 16 activation LDGs per weight LDG and saturates the
+// L1TEX port (93% L1/TEX vs 12% DRAM) — this was the dominant cost of the
+// bucket-8 decode step. Shared staging does not help (LDS shares the L1TEX
+// pipe); registers are the only storage off that port, so reusing the chunk
+// across ROWS=4 rows cuts activation loads 4x: o_proj 132→66 µs, dense_dn
+// 99→51, q_b 42→26. ROWS=8 spills; WARPS=4 keeps ~3 blocks/SM resident at
+// ~96 regs (1-row/warp needs WARPS=8 to fill its lighter blocks). BATCH=2
+// stays at ROWS=1: activation traffic is 2:16 against the weight there and
+// the 1-row/warp shape measures faster on 7 of 10 model shapes.
+template <int BATCH, int ROWS, int WARPS>
+__global__ __launch_bounds__(WARPS* kWarpSize) void
+glm52_fp8_weight_only_gemv_batched_kernel(
     const __nv_bfloat16* __restrict__ activation,  // [BATCH, k]
     const unsigned char* __restrict__ weight,      // [n, k] e4m3
     const float* __restrict__ weight_scale,        // [n/128, k/128]
     __nv_bfloat16* __restrict__ out,               // [BATCH, n]
     int n, int k) {
-  gemv_row_tile_batched<BATCH>(activation, weight, weight_scale, out, n, k);
+  const int warp = threadIdx.x >> 5;
+  const int lane = threadIdx.x & 31;
+  const int n0   = blockIdx.y * (WARPS * ROWS) + warp * ROWS;
+  const int scale_cols = k >> 7;
+  // All ROWS rows share one weight-scale row: n0 is a multiple of ROWS and ROWS | 128.
+  const float* scale_row = weight_scale + (size_t)(n0 >> 7) * scale_cols;
+
+  float acc[ROWS][BATCH];
+#pragma unroll
+  for (int r = 0; r < ROWS; ++r)
+#pragma unroll
+    for (int b = 0; b < BATCH; ++b) acc[r][b] = 0.0f;
+
+  for (int kk = lane * kVec; kk < k; kk += kStep) {
+    const float scale = scale_row[kk >> 7];
+    float4 xv[BATCH][2];
+#pragma unroll
+    for (int b = 0; b < BATCH; ++b) {
+      const float4* xs4 = reinterpret_cast<const float4*>(activation + (size_t)b * k);
+      xv[b][0] = xs4[(kk >> 3)];
+      xv[b][1] = xs4[(kk >> 3) + 1];
+    }
+#pragma unroll
+    for (int r = 0; r < ROWS; ++r) {
+      const uint4 wp = __ldcs(reinterpret_cast<const uint4*>(
+          weight + ((size_t)(n0 + r) * k) + kk));
+      const __nv_fp8x2_e4m3* w2 = reinterpret_cast<const __nv_fp8x2_e4m3*>(&wp);
+#pragma unroll
+      for (int b = 0; b < BATCH; ++b) {
+        const __nv_bfloat16* xh0 = reinterpret_cast<const __nv_bfloat16*>(&xv[b][0]);
+        const __nv_bfloat16* xh1 = reinterpret_cast<const __nv_bfloat16*>(&xv[b][1]);
+        float partial = 0.0f;
+        // Same per-term left-to-right association as gemv_row_tile — bit parity
+        // per row is the contract (see that kernel's comment).
+#pragma unroll
+        for (int j = 0; j < 4; ++j) {
+          __half2 h = static_cast<__half2>(w2[j]);
+          partial += __low2float(h) * __bfloat162float(xh0[2 * j]);
+          partial += __high2float(h) * __bfloat162float(xh0[2 * j + 1]);
+        }
+#pragma unroll
+        for (int j = 0; j < 4; ++j) {
+          __half2 h = static_cast<__half2>(w2[4 + j]);
+          partial += __low2float(h) * __bfloat162float(xh1[2 * j]);
+          partial += __high2float(h) * __bfloat162float(xh1[2 * j + 1]);
+        }
+        acc[r][b] += scale * partial;
+      }
+    }
+  }
+#pragma unroll
+  for (int r = 0; r < ROWS; ++r)
+#pragma unroll
+    for (int b = 0; b < BATCH; ++b) {
+      float v = warp_reduce_sum(acc[r][b]);
+      if (lane == 0) out[(size_t)b * n + n0 + r] = __float2bfloat16(v);
+    }
 }
 
 // Routed grouped GEMV: blockIdx.x = slot in [0,topk); expert = topk_idx[slot].
@@ -312,6 +326,9 @@ int plain_rows_per_warp(int k) {
 constexpr int kBatchedGemvBatch2 = 2;
 constexpr int kBatchedGemvBatch4 = 4;
 constexpr int kBatchedGemvBatchFull = 8;
+// Per-batch (ROWS, WARPS) tile — measured, see the kernel comment.
+constexpr int kBatchedRows  = 4;
+constexpr int kBatchedWarps = 4;
 
 // Whitelist of the model's linear shapes (shared by the plain and batched
 // launchers; the tiling check differs — rpb is 8 or 32 for plain, 8 for
@@ -386,30 +403,43 @@ CUresult glm52_fp8_weight_only_gemv_batched_cuda(
     cudaStream_t stream) {
   if (activation == nullptr || weight == nullptr || weight_scale == nullptr ||
       out == nullptr || !aligned16(activation) ||
-      !whitelisted_linear_shape(n, k) || !valid_tiling(n, k, kWarpsPerBlk)) {
+      !whitelisted_linear_shape(n, k)) {
     return CUDA_ERROR_INVALID_VALUE;
   }
   if (batch == 1) {
     return glm52_fp8_weight_only_gemv_cuda(activation, weight, weight_scale, out,
                                            n, k, stream);
   }
-  const dim3 grid(1, n / kWarpsPerBlk, 1);
   switch (batch) {
-    case kBatchedGemvBatch2:
-      glm52_fp8_weight_only_gemv_batched_kernel<kBatchedGemvBatch2>
+    case kBatchedGemvBatch2: {
+      // Batch 2 keeps the 1-row/warp shape (see the kernel comment).
+      if (!valid_tiling(n, k, kWarpsPerBlk)) return CUDA_ERROR_INVALID_VALUE;
+      const dim3 grid(1, n / kWarpsPerBlk, 1);
+      glm52_fp8_weight_only_gemv_batched_kernel<kBatchedGemvBatch2, 1, kWarpsPerBlk>
           <<<grid, kBlockThreads, 0, stream>>>(activation, weight, weight_scale,
                                                out, n, k);
       break;
-    case kBatchedGemvBatch4:
-      glm52_fp8_weight_only_gemv_batched_kernel<kBatchedGemvBatch4>
-          <<<grid, kBlockThreads, 0, stream>>>(activation, weight, weight_scale,
-                                               out, n, k);
+    }
+    case kBatchedGemvBatch4: {
+      if (!valid_tiling(n, k, kBatchedWarps * kBatchedRows))
+        return CUDA_ERROR_INVALID_VALUE;
+      const dim3 grid(1, n / (kBatchedWarps * kBatchedRows), 1);
+      glm52_fp8_weight_only_gemv_batched_kernel<kBatchedGemvBatch4, kBatchedRows,
+                                                kBatchedWarps>
+          <<<grid, kBatchedWarps * kWarpSize, 0, stream>>>(
+              activation, weight, weight_scale, out, n, k);
       break;
-    case kBatchedGemvBatchFull:
-      glm52_fp8_weight_only_gemv_batched_kernel<kBatchedGemvBatchFull>
-          <<<grid, kBlockThreads, 0, stream>>>(activation, weight, weight_scale,
-                                               out, n, k);
+    }
+    case kBatchedGemvBatchFull: {
+      if (!valid_tiling(n, k, kBatchedWarps * kBatchedRows))
+        return CUDA_ERROR_INVALID_VALUE;
+      const dim3 grid(1, n / (kBatchedWarps * kBatchedRows), 1);
+      glm52_fp8_weight_only_gemv_batched_kernel<kBatchedGemvBatchFull, kBatchedRows,
+                                                kBatchedWarps>
+          <<<grid, kBatchedWarps * kWarpSize, 0, stream>>>(
+              activation, weight, weight_scale, out, n, k);
       break;
+    }
     default:
       return CUDA_ERROR_INVALID_VALUE;
   }

--- a/openinfer-kernels/csrc/glm52/glm52_moe_gemv.cu
+++ b/openinfer-kernels/csrc/glm52/glm52_moe_gemv.cu
@@ -173,8 +173,8 @@ __global__ void glm52_fp8_weight_only_gemv_kernel(
 // bucket-8 decode step. Shared staging does not help (LDS shares the L1TEX
 // pipe); registers are the only storage off that port, so reusing the chunk
 // across ROWS=4 rows cuts activation loads 4x: o_proj 132→66 µs, dense_dn
-// 99→51, q_b 42→26. ROWS=8 spills; WARPS=4 keeps ~3 blocks/SM resident at
-// ~96 regs (1-row/warp needs WARPS=8 to fill its lighter blocks). BATCH=2
+// 99→51, q_b 42→26. ROWS=8 spills; WARPS=4 keeps 3 blocks/SM resident at
+// 158 regs measured (ptxas sm_90; BATCH=4 is 128). BATCH=2
 // stays at ROWS=1: activation traffic is 2:16 against the weight there and
 // the 1-row/warp shape measures faster on 7 of 10 model shapes.
 template <int BATCH, int ROWS, int WARPS>
@@ -331,8 +331,8 @@ constexpr int kBatchedRows  = 4;
 constexpr int kBatchedWarps = 4;
 
 // Whitelist of the model's linear shapes (shared by the plain and batched
-// launchers; the tiling check differs — rpb is 8 or 32 for plain, 8 for
-// batched — so it is applied by each launcher, not here).
+// launchers; the tiling check differs — rpb is 8 or 32 for plain, 8 (batch 2)
+// or 16 (batch 4/8) for batched — so it is applied by each launcher, not here).
 bool whitelisted_linear_shape(int n, int k) {
   if (n == 2048  && k == 6144)  return true;  // q_a / shared gate,up
   if (n == 16384 && k == 2048)  return true;  // q_b


### PR DESCRIPTION
## Problem

An nsys attribution of the bucket-8 decode step (one slot spanning 8 rows/rank, e.g. DSpark verify or M1 span prompt ingestion) against a bucket-1 control on the same binary showed the step's +22.9 ms over bucket-1 decomposes as: **+15.1 ms in the non-expert weight-only GEMVs**, +3.8 expert grouped GEMM, +1.8 combine, +1.3 MLA, ~0 dispatch. Two-thirds of the cost sat in the kernel designed to be batch-free.

Root cause (ncu): the 1-row/warp batched GEMV issues 16 activation LDGs per weight LDG at batch 8 and saturates the **L1TEX port** (93% L1/TEX vs 12% DRAM). Shared-memory staging cannot help — LDS shares the L1TEX pipe on Hopper (a microbenched smem variant lost on every shape). Registers are the only storage off that port.

## Fix

Generalize the batched kernel to `<BATCH, ROWS, WARPS>`: a warp owns ROWS=4 output rows and reuses the register-held activation chunk across them, cutting per-row activation loads 4x. Batch 2 keeps the 1-row/warp shape (activation traffic is 2:16 against the weight there and it measures faster on 7 of 10 shapes). ROWS=8 spills; WARPS=4 keeps ~3 blocks/SM at 96 regs.

**Bit parity is preserved by construction** — same lane sweep, per-term FMA order, and warp reduction per row as the m=1 kernel; a memcmp-gated H200 microbench verifies byte-identical outputs for all 10 whitelisted shapes x batches {2,4,8}.

## Measured (jz-38 8xH200)

Microbench (batch 8): o_proj 132→66 µs, dense_gu 171→99, dense_dn 99→51, q_b 42→26, shared_gu 32→19. Weighted over the model's per-step shapes: bucket-8 GEMV 23.0→13.9 ms, bucket-4 13.4→9.5 ms.

e2e (dspark stack + cherry-pick, c1 greedy):

| probe | before | after |
|---|---|---|
| bucket-1 solo | 22.5–22.6 ms/step | 22.63 ms/step (flat — b1 path untouched) |
| bucket-8 span step | 45.6 ms | **37.0 ms (−19%)** |
| 1621-token prompt TTFT | 9.25 s | **7.55 s** |

Also benefits bucket-4 (DSpark span-4 verify) and c33+ concurrent decode; not re-measured here.

Attribution record: `docs/models/glm52/whole-step-decode-graph.md` (bucket-8 step attribution section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)