### PR TITLE
fix(qwen3): serve uncompiled GQA groups through the prefill path

### DIFF
--- a/openinfer-qwen3/src/config.rs
+++ b/openinfer-qwen3/src/config.rs
@@ -165,16 +165,29 @@ impl Config {
         let mut config: Config = serde_json::from_str(&content)?;
         anyhow::ensure!(
             config.num_key_value_heads > 0
-                && config.num_attention_heads % config.num_key_value_heads == 0
-                && openinfer_core::ops::SUPPORTED_GQA_GROUP_SIZES
-                    .contains(&(config.num_attention_heads / config.num_key_value_heads)),
-            "unsupported GQA group size {}/{}; the attention kernels instantiate {:?}",
+                && config
+                    .num_attention_heads
+                    .is_multiple_of(config.num_key_value_heads),
+            "num_attention_heads ({}) must be a positive multiple of num_key_value_heads ({})",
             config.num_attention_heads,
             config.num_key_value_heads,
-            openinfer_core::ops::SUPPORTED_GQA_GROUP_SIZES,
         );
+        if !config.decode_group_is_compiled() {
+            log::warn!(
+                "Qwen3 GQA group {}/{} has no compiled decode kernel; decode runs eager \
+                 through the prefill path (CUDA-graph decode disabled, --decode-overlap unavailable)",
+                config.num_attention_heads,
+                config.num_key_value_heads,
+            );
+        }
         config.stop_token_ids = Self::load_stop_token_ids(model_path, config.eos_token_id)?;
         Ok(config)
+    }
+
+    /// GQA ratio is TP-invariant, so the global head counts match the per-rank ones.
+    pub(crate) fn decode_group_is_compiled(&self) -> bool {
+        openinfer_core::ops::SUPPORTED_GQA_GROUP_SIZES
+            .contains(&(self.num_attention_heads / self.num_key_value_heads))
     }
 
     pub(crate) fn lm_head_tensor_name(&self) -> &'static str {

--- a/openinfer-qwen3/src/executor.rs
+++ b/openinfer-qwen3/src/executor.rs
@@ -1386,6 +1386,15 @@ impl Qwen3Executor {
                 && !matches!(overlap, crate::DecodeOverlap::Off)),
             "--batch-invariant (NumericPolicy::Pin) is not compatible with decode-overlap: the stream override would force the pinned GEMM to bail at runtime"
         );
+        // Overlap's split-concurrent decode stream uses the group-limited decode
+        // kernel this GQA group can't instantiate; reject at load, not mid-serving.
+        anyhow::ensure!(
+            self.metadata.config.decode_group_is_compiled()
+                || matches!(overlap, crate::DecodeOverlap::Off),
+            "decode-overlap is unsupported for GQA group size {}/{}: no compiled decode kernel",
+            self.metadata.config.num_attention_heads,
+            self.metadata.config.num_key_value_heads,
+        );
         let device_ordinal = 0; // single-GPU path
         self.overlap = crate::green_ctx::OverlapStreams::create(device_ordinal, overlap)?;
         Ok(())
@@ -2198,6 +2207,17 @@ impl ModelExecutor for Qwen3Executor {
     }
 
     fn execute_decode(&mut self, plan: DecodePlan<'_>) -> Result<DecodeResult> {
+        if !self.metadata.config.decode_group_is_compiled() {
+            let unified = self.execute_unified(UnifiedPlan {
+                prefill_requests: &[],
+                decode_requests: plan.requests,
+                sample_seed: plan.sample_seed,
+            })?;
+            return Ok(DecodeResult {
+                requests: unified.decode_requests,
+            });
+        }
+
         // 1. Schedule decode for all active requests
         for req in plan.requests {
             let rkv = self

--- a/openinfer-qwen3/src/unified_forward.rs
+++ b/openinfer-qwen3/src/unified_forward.rs
@@ -58,16 +58,19 @@ impl Qwen3Model {
 
         // Force the decode CUDA-Graph/buffer path before the unified peak
         // sample. The synthetic views are short, but the pre-allocated decode
-        // arena and graph state are the same serving objects used later.
-        self.batch_decode(
-            &decode_tokens,
-            &decode_views,
-            &decode_adapters,
-            kv_buffer.buffer(),
-            &layout,
-            decode_bufs,
-        )?;
-        mark_peak()?;
+        // arena and graph state are the same serving objects used later. Skip it
+        // for uncompiled-group models: the unified sample below bounds their KV.
+        if self.config.decode_group_is_compiled() {
+            self.batch_decode(
+                &decode_tokens,
+                &decode_views,
+                &decode_adapters,
+                kv_buffer.buffer(),
+                &layout,
+                decode_bufs,
+            )?;
+            mark_peak()?;
+        }
 
         // Reachable worst-case unified profile: admission caps
         // active decode rows + admitted/prefilling rows at the decode batch
@@ -160,7 +163,9 @@ impl Qwen3Model {
         assert_eq!(num_prefill_reqs, prefill_lora_adapters.len());
         assert_eq!(num_decode_reqs, decode_views.len());
         assert_eq!(num_decode_reqs, decode_lora_adapters.len());
-        assert!(num_prefill_reqs > 0 && num_decode_reqs > 0);
+        // Decode-only (empty prefill) is the fallback for GQA groups with no
+        // compiled decode kernel.
+        assert!(num_prefill_reqs > 0 || num_decode_reqs > 0);
 
         let prefill_seq_lens: Vec<usize> = prefill_prompts.iter().map(|p| p.len()).collect();
         let total_prefill: usize = prefill_seq_lens.iter().sum();


### PR DESCRIPTION
## Description

Fixes #519.

Qwen3-14B (40 Q / 8 KV heads = GQA group 5) aborted at load: FlashInfer's decode dispatch bakes the group size as a compile-time constant and only instantiates {1,2,3,4,8}, throwing on 5. FlashInfer's own Python API falls back decode→prefill for uncompiled groups (its prefill kernel takes the group size at runtime); openinfer, calling the C++ decode dispatch directly, bypassed that fallback. group 5 is not rare — Qwen2.5-14B/32B share it.

This does the same fallback inside openinfer, with no flashinfer fork: when the model's GQA group has no compiled decode kernel, a pure-decode step is served through the existing group-agnostic prefill path (a decode-only unified step) instead of the group-limited decode kernel. `Config::decode_group_is_compiled()` is the single predicate, used by the scheduler reroute, the KV-budget profiler (which skips the group-limited decode sample), and a load-time rejection of `--decode-overlap` for these models (its split-concurrent decode stream is the group-limited kernel). The #520 load gate keeps its divisibility guard and drops only the group-set check.

## Test Env

Single GPU (sm_89, x86_64):

- Qwen3-14B (group 5) loads and serves coherent greedy output (was: abort at startup in the KV-budget profiler).
- Qwen3-14B `--decode-overlap` is rejected at load with a clear message instead of crashing mid-serving.
- Qwen3-4B (group 4) unchanged — still on the CUDA-graph decode path, coherent output.
- clippy clean on the touched files.

<details>
<summary>Qwen3-14B greedy output (group 5, served via the prefill fallback)</summary>

```
The capital of France is | Paris. What is the capital of the United States? ... Washington, D.C.
The chemical symbol for gold is | Au. What is the origin of this symbol? ... originates from its Latin name
The speed of light is approximately | $3 \times 10^8$ meters per second.
```

</details>

<details>
<summary>Qwen3-14B --decode-overlap load rejection</summary>

```
decode-overlap is unsupported for GQA group size 40/8: no compiled decode kernel
```

</details>




## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


