### PR TITLE
fix(qwen35): serve uncompiled GQA groups through the prefill path

### DIFF
--- a/openinfer-qwen35-4b/src/batch_decode.rs
+++ b/openinfer-qwen35-4b/src/batch_decode.rs
@@ -179,6 +179,10 @@ impl Qwen35Model {
             super::batch_decode_graph::MAX_BATCH
         );
 
+        if !self.config.decode_group_is_compiled() {
+            return self.batch_decode_via_prefill(token_ids, kv_states, graph_state);
+        }
+
         let padded_bs = bucket_for(bs);
 
         // Advance KV states and collect positions. Slot seq_len is incremented
@@ -229,6 +233,52 @@ impl Qwen35Model {
         });
         graph_state.graphs = graphs;
         result
+    }
+
+    /// Decode an uncompiled GQA group via the prefill path, writing `buffers.logits`
+    /// so callers sample as after the graph path.
+    pub(crate) fn batch_decode_via_prefill(
+        &self,
+        token_ids: &[u32],
+        kv_states: &mut [&mut KvState],
+        graph_state: &mut BatchDecodeGraphState,
+    ) -> Result<()> {
+        let bs = token_ids.len();
+        anyhow::ensure!(
+            bs > 0,
+            "batch_decode_via_prefill requires at least one request"
+        );
+        anyhow::ensure!(bs == kv_states.len(), "token_ids / kv_states len mismatch");
+
+        let mut last_hiddens = Vec::with_capacity(bs);
+        for i in 0..bs {
+            let hidden = self.prefill_last_hidden(
+                &[token_ids[i]],
+                &mut *kv_states[i],
+                &mut graph_state.slot_states[i],
+            )?;
+            last_hiddens.push(hidden);
+        }
+
+        let bufs = &mut graph_state.buffers;
+        bufs.set_batch_size(bs);
+        for (i, hidden) in last_hiddens.iter().enumerate() {
+            ops::write_vec_into(&self.ctx, hidden, &mut bufs.hidden, i)?;
+        }
+        ops::rms_norm_batch_offset_into(
+            &self.ctx,
+            &bufs.hidden,
+            &self.norm,
+            self.config.rms_norm_eps,
+            &mut bufs.normed,
+        )?;
+        ops::gemm_into(
+            &self.ctx,
+            self.output_projection(),
+            &bufs.normed,
+            &mut bufs.logits,
+        );
+        Ok(())
     }
 
     fn batch_decode_kernels_graph(

--- a/openinfer-qwen35-4b/src/config.rs
+++ b/openinfer-qwen35-4b/src/config.rs
@@ -150,8 +150,16 @@ impl Config35 {
             t.linear_num_value_heads,
             t.linear_num_key_heads,
         );
+        anyhow::ensure!(
+            t.num_key_value_heads > 0
+                && t.num_attention_heads.is_multiple_of(t.num_key_value_heads),
+            "Qwen3.5 num_attention_heads ({}) must be a positive multiple of \
+             num_key_value_heads ({})",
+            t.num_attention_heads,
+            t.num_key_value_heads,
+        );
 
-        Ok(Self {
+        let config = Self {
             hidden_size: t.hidden_size,
             intermediate_size: t.intermediate_size,
             num_hidden_layers: t.num_hidden_layers,
@@ -171,7 +179,15 @@ impl Config35 {
             max_position_embeddings,
             layer_types,
             tie_word_embeddings,
-        })
+        };
+        if !config.decode_group_is_compiled() {
+            log::warn!(
+                "Qwen3.5 GQA group {}/{} has no compiled decode kernel; decode runs eager through the prefill path",
+                config.num_attention_heads,
+                config.num_key_value_heads,
+            );
+        }
+        Ok(config)
     }
 
     /// Number of full attention layers in the model.
@@ -195,6 +211,11 @@ impl Config35 {
     /// KV dimension for full attention.
     pub(crate) fn full_attn_kv_dim(&self) -> usize {
         self.num_key_value_heads * self.head_dim
+    }
+
+    pub(crate) fn decode_group_is_compiled(&self) -> bool {
+        openinfer_core::ops::SUPPORTED_GQA_GROUP_SIZES
+            .contains(&(self.num_attention_heads / self.num_key_value_heads))
     }
 
     /// QKV projection output dimension for linear attention.

--- a/openinfer-qwen35-4b/src/unified_forward.rs
+++ b/openinfer-qwen35-4b/src/unified_forward.rs
@@ -6,7 +6,8 @@
 //!
 //! `unified_step` combines:
 //!   1. Serial `batch_prefill` for new requests entering the batch.
-//!   2. CUDA Graph `batch_decode_graph` for existing decode requests.
+//!   2. `batch_decode_graph` for existing decode requests (CUDA Graph for
+//!      compiled GQA groups; eager prefill fallback for uncompiled ones).
 
 use anyhow::Result;
 


### PR DESCRIPTION
## Description

Fixes #563 


## Description

Qwen3.5-27B loads cleanly on openinfer-qwen35-4b (current main, GH200 / sm_90) but every decode step fails:

paged_attention_decode_cuda_hd256: Unsupported group_size: 6 (flashinfer/attention/decode.cuh:756)

27B's full attention is 24 Q / 4 KV = group 6, and FlashInfer's decode dispatch only instantiates {1, 2, 3, 4, 8}. Prefill is unaffected — it goes through batch_prefill_paged_cuda_hd256, which takes the group size at runtime — so 27B prefills fine and only fails on the first decode. This is the qwen35 analog of #519 (Qwen3-14B, group 5).

batch_decode_graph now reroutes uncompiled-group steps through the prefill path: each new token runs as a length-1 prefill (advancing KV + recurrent state in place), writing buffers.logits so all three decode call sites — scheduler decode_step, unified_step, and the executor — sample unchanged. Config::decode_group_is_compiled() is the predicate, and a load-time warning names the fallback.

## Test Env

Single GPU GH200 (aarch64, sm_90):

- Qwen3.5-27B (group 6) now serves coherent greedy outris., symbol for gold →  Au. … silver is Ag, 2 plus 2 →  5. … "2 plus 2 equals 5" is incorrect. Was: HTTP 500, Unsupported group_size: 6 on every decode.
- Load emits Qwen3.5 GQA group 24/4 has no compiled der through the prefill path.
- Qwen3.5-9B (group 4) unchanged — still on the CUDA-graph decode path, byte-identical output.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)