### PR TITLE
perf(glm52): tensor-core mma path for batch-4/8 weight-only GEMV — solo span-8 step 36.9 → 32.2 ms

### DIFF
--- a/docs/models/glm52/whole-step-decode-graph.md
+++ b/docs/models/glm52/whole-step-decode-graph.md
@@ -138,6 +138,48 @@ untouched.** Matches the microbench-weighted −9.1 ms prediction. Artifacts:
 traces + kern-sum CSVs `~/develop/xingming/b8span* b1ctrl*`, microbench
 `~/develop/xingming/gemv_bench` on jz-38.
 
+## Tensor-core GEMV for batches 4/8 (jz-38, 2026-07-05, #559)
+
+Post-#558 re-attribution (same two-window method, fixed binary): the b8−b1
+delta fell +22.9 → +15.2 ms and the GEMV was still the largest term:
+
+| component (per rank-step, totals) | b1 | b8 post-#558 | Δ |
+|---|---|---|---|
+| weight-only GEMV | 6.4 | 13.2 | **+6.8** |
+| expert grouped GEMM | 3.4 | 7.2 | +3.8 |
+| MoE combine | 4.3 | 6.2 | +1.9 |
+| glue | 5.8 | 7.0 | +1.2 |
+| MLA splitkv | 2.1 | 3.3 | +1.2 |
+| dispatch (incl wait) | 5.3 | 5.7 | +0.4 |
+
+ncu on the ROWS=4 tile showed the wall had MOVED: L1TEX 46% (fixed), DRAM 24%,
+Compute 65% — the BATCH×16-term f32 FMA chain itself. Computed CUDA-core
+floor for o_proj at batch 8 ≈ 32 µs vs the 28.5 µs weight-read floor;
+occupancy and cache-policy variants (KernelWiki NVFP4-GEMV levers) measured
+flat or worse. Conclusion: the CUDA-core design space was exhausted — the fix
+is `mma.m16n8k16.bf16` (fp8 e4m3 decodes losslessly to bf16).
+
+Key trick: no weight repack. The mma k-slot→column map is a free permutation
+when A and B agree, so σ(step s, tid, d) = tid·16+4s+d over a k64 super-chunk
+reads the *original* row-major layout with one 16-byte LDG per owned row —
+no second weight copy, m=1/batch-2 paths byte-untouched. KSPLIT k-slices
+write f32 partials to a 12.6 MB per-device scratch (allocated by the
+pre-capture bucket warm-up) and a fixed-order epilogue reduces them:
+deterministic and replay-stable per bucket, but **not** bit-identical to m=1
+(validated by tolerance: max_rel < 2e-2, ≥90 % of bf16 outputs exact, plus
+e2e greedy coherence and dspark accept-rate parity).
+
+A packed fragment layout is ~30 % faster still on the big shapes (o_proj 32 vs
+46 µs) but needs either a second weight copy (+15 GB/rank — doesn't fit) or an
+m=1 kernel rewrite that changes bucket-1 numerics; recorded as a non-goal.
+The vendored TRT-LLM dense fp8 `gemm()` entry (w8a8 library route) is a no-op
+in our AOT setup — its SM90 dense path expects the DeepGEMM JIT runtime.
+
+**e2e measured (jz-38): solo span-8 ingest step 36.9 → 32.2 ms (−12.6 %),
+c64 diverse decode 1046 → 1121 tok/s (−8 % step); b1/b2 flat.** Iteration ran
+on the in-process `glm52_step_bench` (one weight load, ~3 min/cycle).
+
 ## Next action
 
-Follow-ups: #542 (collective latency floor / GEMV BW / `num_sm_parts`), #541 indexer reference re-pin.
+Follow-ups: #542 (collective latency floor / expert GEMM swapAB), #559 residual
+(expert GEMM +3.8, combine +1.9, MLA +1.2 at b8), #541 indexer reference re-pin.

--- a/openinfer-glm52/src/fp8.rs
+++ b/openinfer-glm52/src/fp8.rs
@@ -14,7 +14,8 @@ use cudarc::driver::CudaSlice;
 use half::bf16;
 
 use openinfer_kernels::ops::{
-    glm52_fp8_weight_only_gemv_launch, glm52_silu_and_mul_weighted_bf16_launch,
+    GLM52_GEMV_MMA_SCRATCH_FLOATS_PER_ROW, glm52_fp8_weight_only_gemv_launch,
+    glm52_silu_and_mul_weighted_bf16_launch,
 };
 use openinfer_kernels::tensor::DeviceContext;
 
@@ -157,13 +158,17 @@ pub(crate) fn pack_proj_pair(
 
 /// One fp8 projection into a pre-allocated output: weight-only GEMV of `rows`
 /// bf16 activation rows against the fp8 `[n,k]` weight, block scale dequanted
-/// on the fly. rows > 1 runs the weight-stationary batched kernel — the weight
-/// is still read once, and every row is bit-identical to the rows=1 kernel.
+/// on the fly. rows > 1 runs a weight-stationary batched kernel — the weight
+/// is still read once. rows 1/2 keep bit-stable CUDA-core paths; rows 4/8
+/// dispatch to a tensor-core mma path on winning shapes (deterministic per
+/// bucket, not bit-identical to rows=1 — cross-bucket FP divergence is the
+/// accepted whole-step contract; numerics notes in glm52_moe_gemv.cu).
 pub(crate) fn fp8_linear_into(
     ctx: &DeviceContext,
     w: &ProjWeight,
     rows: usize,
     input: &CudaSlice<bf16>,
+    scratch: Option<&mut CudaSlice<f32>>,
     out: &mut CudaSlice<bf16>,
 ) -> Result<()> {
     ensure!(
@@ -172,7 +177,9 @@ pub(crate) fn fp8_linear_into(
         input.len(),
         w.k
     );
-    glm52_fp8_weight_only_gemv_launch(ctx, rows, w.n, w.k, input, &w.weight, &w.scale, out)
+    glm52_fp8_weight_only_gemv_launch(
+        ctx, rows, w.n, w.k, input, &w.weight, &w.scale, scratch, out,
+    )
 }
 
 /// Allocating convenience over [`fp8_linear_into`] for the oracle-gate/test
@@ -184,7 +191,7 @@ pub(crate) fn fp8_linear(
     input: &CudaSlice<bf16>,
 ) -> Result<CudaSlice<bf16>> {
     let mut out = ctx.stream.alloc_zeros::<bf16>(w.n)?;
-    fp8_linear_into(ctx, w, 1, input, &mut out)?;
+    fp8_linear_into(ctx, w, 1, input, None, &mut out)?;
     Ok(out)
 }
 
@@ -196,6 +203,9 @@ pub(crate) struct Glm52MlpScratch {
     rows: usize,
     gate_up: CudaSlice<bf16>,
     silu_out: CudaSlice<bf16>,
+    // Owned mma partial buffer: one per scratch so the ctx/aux stream overlap
+    // can never see a shared pointer (see glm52_fp8_weight_only_gemv_launch).
+    gemv_partial: CudaSlice<f32>,
 }
 
 impl Glm52MlpScratch {
@@ -210,6 +220,9 @@ impl Glm52MlpScratch {
             rows,
             gate_up: ctx.stream.alloc_zeros::<bf16>(rows * 2 * intermediate)?,
             silu_out: ctx.stream.alloc_zeros::<bf16>(rows * intermediate)?,
+            gemv_partial: ctx
+                .stream
+                .alloc_zeros::<f32>(rows * GLM52_GEMV_MMA_SCRATCH_FLOATS_PER_ROW)?,
         })
     }
 }
@@ -246,7 +259,14 @@ pub(crate) fn fp8_mlp_into(
         "GLM5.2 fp8_mlp scratch sized for intermediate {} but weights have {intermediate}",
         s.intermediate
     );
-    fp8_linear_into(ctx, gate_up, s.rows, input, &mut s.gate_up)?;
+    fp8_linear_into(
+        ctx,
+        gate_up,
+        s.rows,
+        input,
+        Some(&mut s.gemv_partial),
+        &mut s.gate_up,
+    )?;
     // bf16 SwiGLU (no route weight, no activation quant) -> bf16 down input.
     glm52_silu_and_mul_weighted_bf16_launch(
         ctx,
@@ -256,7 +276,14 @@ pub(crate) fn fp8_mlp_into(
         None,
         &mut s.silu_out,
     )?;
-    fp8_linear_into(ctx, down, s.rows, &s.silu_out, out)
+    fp8_linear_into(
+        ctx,
+        down,
+        s.rows,
+        &s.silu_out,
+        Some(&mut s.gemv_partial),
+        out,
+    )
 }
 
 /// Allocating convenience over [`fp8_mlp_into`] for the oracle-gate/test

--- a/openinfer-glm52/src/indexer.rs
+++ b/openinfer-glm52/src/indexer.rs
@@ -34,10 +34,10 @@ use cudarc::driver::CudaSlice;
 use half::bf16;
 
 use openinfer_kernels::ops::{
-    GLM52_INDEXER_HEAD_DIM, GLM52_INDEXER_TOPK, Glm52DeepGemmMqaLogitsShape,
-    Glm52IndexerCacheInsert, Glm52IndexerCacheLayout, Glm52IndexerLocalTopKToSlots,
-    Glm52IndexerScaleFormat, Glm52IndexerTopK, Glm52MoeQuantShape, bf16_bytes_to_f32_into,
-    gemm_strided_batched_bf16, glm52_deepgemm_paged_mqa_logits_launch,
+    GLM52_GEMV_MMA_SCRATCH_FLOATS_PER_ROW, GLM52_INDEXER_HEAD_DIM, GLM52_INDEXER_TOPK,
+    Glm52DeepGemmMqaLogitsShape, Glm52IndexerCacheInsert, Glm52IndexerCacheLayout,
+    Glm52IndexerLocalTopKToSlots, Glm52IndexerScaleFormat, Glm52IndexerTopK, Glm52MoeQuantShape,
+    bf16_bytes_to_f32_into, gemm_strided_batched_bf16, glm52_deepgemm_paged_mqa_logits_launch,
     glm52_deepgemm_paged_mqa_metadata_launch, glm52_flashinfer_topk_2048_launch,
     glm52_fp8_per_token_group_quant_bf16_launch, glm52_indexer_k_quant_and_cache_launch,
     glm52_indexer_local_topk_to_slots_launch, glm52_indexer_rope_launch,
@@ -268,6 +268,10 @@ pub(crate) struct Glm52IndexerScratch {
     topk_values: CudaSlice<f32>,
     pub(crate) global_slots: CudaSlice<i32>,
     topk_lens: CudaSlice<i32>,
+    // Owned mma partial buffer (wq_b/wk). The indexer chain runs on the AUX
+    // stream concurrently with the ctx-side MLA front — this buffer being
+    // owned here (not shared per device) is what makes that overlap safe.
+    gemv_partial: CudaSlice<f32>,
 }
 
 impl Glm52IndexerScratch {
@@ -296,6 +300,9 @@ impl Glm52IndexerScratch {
             topk_values: ctx.stream.alloc_zeros::<f32>(t * GLM52_INDEXER_TOPK)?,
             global_slots: ctx.stream.alloc_zeros::<i32>(t * GLM52_INDEXER_TOPK)?,
             topk_lens: ctx.stream.alloc_zeros::<i32>(t)?,
+            gemv_partial: ctx
+                .stream
+                .alloc_zeros::<f32>(t * GLM52_GEMV_MMA_SCRATCH_FLOATS_PER_ROW)?,
             shape,
         })
     }
@@ -387,8 +394,22 @@ pub(crate) fn glm52_indexer_forward_into(
     );
 
     // ---- projections ----
-    fp8_linear_into(ctx, &w.wq_b, t, q_resid, &mut s.q)?; // [T, 32*128]
-    fp8_linear_into(ctx, &w.wk, t, hidden, &mut s.k_raw)?; // [T, 128]
+    fp8_linear_into(
+        ctx,
+        &w.wq_b,
+        t,
+        q_resid,
+        Some(&mut s.gemv_partial),
+        &mut s.q,
+    )?; // [T, 32*128]
+    fp8_linear_into(
+        ctx,
+        &w.wk,
+        t,
+        hidden,
+        Some(&mut s.gemv_partial),
+        &mut s.k_raw,
+    )?; // [T, 128]
     // weights_proj: bf16 GEMM (transformers keeps weights_proj in fp32 via
     // _keep_in_fp32_modules; checkpoint stores bf16, so bf16 GEMM is the
     // closest match without a dedicated f32 GEMM path).

--- a/openinfer-glm52/src/mla_decode.rs
+++ b/openinfer-glm52/src/mla_decode.rs
@@ -20,10 +20,11 @@ use half::bf16;
 #[cfg(test)]
 use openinfer_kernels::ops::GLM52_FLASHMLA_SPARSE_PAGE_SIZE;
 use openinfer_kernels::ops::{
-    Glm52FlashMlaSparseDecode, Glm52MoeQuantShape, gemm_strided_batched_bf16,
-    glm52_flashmla_sparse_decode_launch, glm52_flashmla_sparse_decode_metadata_launch,
-    glm52_fp8_per_token_group_quant_bf16_launch, glm52_mla_cache_pack_launch,
-    glm52_mla_ckv_split_launch, glm52_mla_query_assemble_launch, rms_norm_rows_into,
+    GLM52_GEMV_MMA_SCRATCH_FLOATS_PER_ROW, Glm52FlashMlaSparseDecode, Glm52MoeQuantShape,
+    gemm_strided_batched_bf16, glm52_flashmla_sparse_decode_launch,
+    glm52_flashmla_sparse_decode_metadata_launch, glm52_fp8_per_token_group_quant_bf16_launch,
+    glm52_mla_cache_pack_launch, glm52_mla_ckv_split_launch, glm52_mla_query_assemble_launch,
+    rms_norm_rows_into,
 };
 use openinfer_kernels::tensor::{DeviceContext, DeviceVec};
 
@@ -224,6 +225,9 @@ pub(crate) struct Glm52MlaFront {
     kv_c_raw: CudaSlice<bf16>,           // [T, 512] pre kv_a_layernorm
     kv_c: CudaSlice<bf16>,               // [T, 512] post kv_a_layernorm
     k_pe: CudaSlice<bf16>,               // [T, 64] pre-rope
+    // Owned mma partial buffer for the front projections (q_a/q_b/kv_a). One
+    // per scratch struct: the ctx/aux stream overlap must never share one.
+    gemv_partial: CudaSlice<f32>,
 }
 
 impl Glm52MlaFront {
@@ -238,6 +242,9 @@ impl Glm52MlaFront {
             kv_c_raw: ctx.stream.alloc_zeros::<bf16>(tokens * KV_LORA)?,
             kv_c: ctx.stream.alloc_zeros::<bf16>(tokens * KV_LORA)?,
             k_pe: ctx.stream.alloc_zeros::<bf16>(tokens * ROPE_DIM)?,
+            gemv_partial: ctx
+                .stream
+                .alloc_zeros::<f32>(tokens * GLM52_GEMV_MMA_SCRATCH_FLOATS_PER_ROW)?,
         })
     }
 }
@@ -254,7 +261,14 @@ pub(crate) fn glm52_mla_front_q_into(
 ) -> Result<()> {
     let t = front.tokens;
     ensure!(hidden.len() >= t * HIDDEN, "GLM5.2 MLA hidden too small");
-    fp8_linear_into(ctx, &w.q_a, t, hidden, &mut front.q_a)?; // [T, 2048]
+    fp8_linear_into(
+        ctx,
+        &w.q_a,
+        t,
+        hidden,
+        Some(&mut front.gemv_partial),
+        &mut front.q_a,
+    )?; // [T, 2048]
     rms_norm_rows_into(
         ctx,
         &front.q_a,
@@ -275,8 +289,22 @@ pub(crate) fn glm52_mla_front_rest_into(
     front: &mut Glm52MlaFront,
 ) -> Result<()> {
     let t = front.tokens;
-    fp8_linear_into(ctx, &w.q_b, t, &front.q_resid, &mut front.q_full)?; // [T, 64, 256]
-    fp8_linear_into(ctx, &w.kv_a, t, hidden, &mut front.ckv)?; // [T, 576]
+    fp8_linear_into(
+        ctx,
+        &w.q_b,
+        t,
+        &front.q_resid,
+        Some(&mut front.gemv_partial),
+        &mut front.q_full,
+    )?; // [T, 64, 256]
+    fp8_linear_into(
+        ctx,
+        &w.kv_a,
+        t,
+        hidden,
+        Some(&mut front.gemv_partial),
+        &mut front.ckv,
+    )?; // [T, 576]
     glm52_mla_ckv_split_launch(ctx, t, &front.ckv, &mut front.kv_c_raw, &mut front.k_pe)?;
     rms_norm_rows_into(
         ctx,
@@ -316,6 +344,8 @@ pub(crate) struct Glm52MlaAttendScratch {
     lse_accum: CudaSlice<f32>,
     o_accum: CudaSlice<f32>,
     v: CudaSlice<bf16>,
+    // Owned mma partial buffer for the o_proj projection (see Glm52MlaFront).
+    gemv_partial: CudaSlice<f32>,
 }
 
 impl Glm52MlaAttendScratch {
@@ -331,6 +361,9 @@ impl Glm52MlaAttendScratch {
             lse_accum: ctx.stream.alloc_zeros::<f32>(contract.lse_accum_len())?,
             o_accum: ctx.stream.alloc_zeros::<f32>(contract.o_accum_len())?,
             v: ctx.stream.alloc_zeros::<bf16>(t * HEADS * V_HEAD)?,
+            gemv_partial: ctx
+                .stream
+                .alloc_zeros::<f32>(t * GLM52_GEMV_MMA_SCRATCH_FLOATS_PER_ROW)?,
         })
     }
 }
@@ -563,5 +596,5 @@ pub(crate) fn glm52_mla_attend_into(
         V_HEAD,
         HEADS,
     )?;
-    fp8_linear_into(ctx, &w.o_proj, t, &s.v, out) // [T, 6144]
+    fp8_linear_into(ctx, &w.o_proj, t, &s.v, Some(&mut s.gemv_partial), out) // [T, 6144]
 }

--- a/openinfer-glm52/src/model.rs
+++ b/openinfer-glm52/src/model.rs
@@ -19,10 +19,11 @@ use cudarc::driver::CudaSlice;
 use half::bf16;
 use openinfer_core::cuda_graph::CudaGraphState;
 use openinfer_kernels::ops::{
-    GLM52_FLASHMLA_SPARSE_PAGE_SIZE, GLM52_FLASHMLA_SPARSE_TOPK, Glm52FlashMlaSparseDecode,
-    Glm52IndexerCacheLayout, add_into, argmax_bf16_split_into, copy_hidden_rows_raw_into,
-    embedding_rows_into, glm52_flashmla_sparse_decode_num_sm_parts,
-    glm52_fp8_weight_only_gemv_launch, rms_norm_rows_into,
+    GLM52_FLASHMLA_SPARSE_PAGE_SIZE, GLM52_FLASHMLA_SPARSE_TOPK,
+    GLM52_GEMV_MMA_SCRATCH_FLOATS_PER_ROW, Glm52FlashMlaSparseDecode, Glm52IndexerCacheLayout,
+    add_into, argmax_bf16_split_into, copy_hidden_rows_raw_into, embedding_rows_into,
+    glm52_flashmla_sparse_decode_num_sm_parts, glm52_fp8_weight_only_gemv_launch,
+    rms_norm_rows_into,
 };
 use openinfer_kernels::tensor::{DeviceContext, DeviceMatrix, DeviceVec};
 
@@ -481,6 +482,9 @@ impl Glm52RankModel {
             let mut out = ctx
                 .stream
                 .alloc_zeros::<bf16>(GLM52_MAX_BATCH_PER_RANK * n)?;
+            let mut gemv_partial = ctx.stream.alloc_zeros::<f32>(
+                GLM52_MAX_BATCH_PER_RANK * GLM52_GEMV_MMA_SCRATCH_FLOATS_PER_ROW,
+            )?;
             for rows in GLM52_DECODE_BUCKETS {
                 glm52_fp8_weight_only_gemv_launch(
                     ctx,
@@ -490,6 +494,7 @@ impl Glm52RankModel {
                     &activation,
                     &weight,
                     &scale,
+                    Some(&mut gemv_partial),
                     &mut out,
                 )
                 .with_context(|| {

--- a/openinfer-kernels/csrc/glm52/glm52_moe_gemv.cu
+++ b/openinfer-kernels/csrc/glm52/glm52_moe_gemv.cu
@@ -244,6 +244,226 @@ glm52_fp8_weight_only_gemv_batched_kernel(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Tensor-core batched path (batches 4/8, whitelisted shapes where it wins).
+//
+// At batch 8 the register-tile kernel above is compute-walled: the per-term
+// f32 FMA chain runs BATCH x 16 terms per 16-byte weight packet and caps
+// o_proj at ~66 us against a 28.5 us weight-read floor (H200, ncu: 65% SM,
+// occupancy/cache tweaks measured flat). mma.m16n8k16.bf16 retires that chain
+// on the tensor cores: fp8 e4m3 is exactly representable in bf16, so the
+// fp8 -> half2 -> f32 -> bf16x2 decode is lossless and the only numerics
+// change is the f32 accumulation order inside the mma (fixed by hardware, so
+// per-bucket deterministic and replay-stable — but NOT bit-identical to the
+// m=1 kernel; buckets 1/2 keep their exact paths, and cross-bucket FP
+// divergence is already the accepted whole-step contract since the expert
+// GEMM reassociates across buckets anyway).
+//
+// The kernel reads the ORIGINAL row-major [n, k] fp8 layout — no repack, no
+// second weight copy. The mma k-slot -> column map is a free permutation as
+// long as A and B slots agree (dot products are permutation-invariant):
+// sigma(step s, tid, d) = tid*16 + 4*s + d over a k64 super-chunk makes each
+// lane's A bytes one contiguous 16-byte LDG per owned row, with mma step s
+// consuming word s of that uint4, and the matching B slots one 8-byte load.
+//
+// Structure per warp: NTILES independent 16-row mma chains (shared B
+// fragments, 2-deep weight prefetch per chain) x KSPLIT k-slices in separate
+// blocks writing f32 partials to scratch; a tiny epilogue reduces the slices
+// in fixed order (deterministic) and converts to bf16. KSPLIT is the
+// occupancy lever the bit-parity kernels could never use.
+//
+// Measured (jz-38 H200 microbench, batch 8, us): o_proj 66.5 -> 45.8,
+// dense_gu 99.4 -> 58.6, dense_dn 50.9 -> 33.0, q_b 26.2 -> 16.9,
+// q_a 16.4 -> 10.7, kv_a 13.2 -> 7.7, shared_gu 19.3 -> 13.6,
+// shared_dn 11.5 -> 9.3, idx_wq_b 8.8 -> 7.8, idx_wk 12.5 -> 7.5
+// (~ -66 us per MoE layer). Batch 4 wins only on the k=6144 column (see
+// mma_config); the rest stay on the register tile.
+constexpr int kMmaWarps = 4;
+// The f32 partial scratch [KSPLIT, BATCH, n] is CALLER-OWNED and passed per
+// launch. Ownership matters: the layer forward deliberately overlaps the ctx
+// and aux streams (indexer fork, shared-expert fork), and both sides run
+// batched GEMVs — a shared per-device buffer would race on the device even
+// though the host is single-threaded per rank. Each Rust-side scratch struct
+// owns its own buffer, so two streams can never see the same pointer.
+
+// fp8 e4m3 pair -> packed bf16x2, exact (e4m3 c bf16 via the f16/f32 path).
+__device__ __forceinline__ unsigned mma_cvt_pair(unsigned char b0, unsigned char b1) {
+  __nv_fp8x2_e4m3 p;
+  p.__x = (unsigned short)(b0 | (b1 << 8));
+  __half2 h = static_cast<__half2>(p);
+  float2 f = __half22float2(h);
+  __nv_bfloat162 bb = __float22bfloat162_rn(f);
+  return *reinterpret_cast<unsigned*>(&bb);
+}
+
+template <int BATCH, int KSPLIT, int NTILES>
+__global__ __launch_bounds__(kMmaWarps * kWarpSize) void
+glm52_gemv_batched_mma_kernel(
+    const __nv_bfloat16* __restrict__ activation,  // [BATCH, k]
+    const unsigned char* __restrict__ weight,      // [n, k] e4m3, original layout
+    const float* __restrict__ weight_scale,        // [n/128, k/128]
+    float* __restrict__ partial,                   // [KSPLIT, BATCH, n] f32
+    int n, int k) {
+  const int warp = threadIdx.x >> 5;
+  const int lane = threadIdx.x & 31;
+  const int tile0 = (blockIdx.y * kMmaWarps + warp) * NTILES;  // 16-row tiles
+  if (tile0 * 16 >= n) return;
+  const int gid = lane >> 2, tid = lane & 3;
+  const int kslice = k / KSPLIT;  // multiple of 128
+  const int k_begin = blockIdx.x * kslice;
+  const int scale_cols = k >> 7;
+
+  float macc[NTILES][4], cacc[NTILES][4];
+#pragma unroll
+  for (int t = 0; t < NTILES; ++t)
+#pragma unroll
+    for (int i = 0; i < 4; ++i) { macc[t][i] = 0.f; cacc[t][i] = 0.f; }
+
+  // Per chain: rows (gid, gid+8) of its tile; one 16B packet per row per k64.
+  const unsigned char* w0[NTILES];
+  const unsigned char* w1[NTILES];
+#pragma unroll
+  for (int t = 0; t < NTILES; ++t) {
+    const int n0 = (tile0 + t) * 16;
+    w0[t] = weight + (size_t)(n0 + gid) * k + k_begin + tid * 16;
+    w1[t] = weight + (size_t)(n0 + gid + 8) * k + k_begin + tid * 16;
+  }
+
+  // 2-deep weight-packet pipeline per chain: 2*NTILES LDGs in flight while the
+  // previous chunk's (serializing) asm mma chain retires.
+  uint4 wp0[NTILES], wp1[NTILES];
+#pragma unroll
+  for (int t = 0; t < NTILES; ++t) {
+    wp0[t] = __ldcs(reinterpret_cast<const uint4*>(w0[t]));
+    wp1[t] = __ldcs(reinterpret_cast<const uint4*>(w1[t]));
+  }
+  for (int kk = k_begin; kk < k_begin + kslice; kk += 64) {
+    uint4 c0[NTILES], c1[NTILES];
+#pragma unroll
+    for (int t = 0; t < NTILES; ++t) {
+      c0[t] = wp0[t]; c1[t] = wp1[t];
+      w0[t] += 64; w1[t] += 64;
+    }
+    if (kk + 64 < k_begin + kslice) {
+#pragma unroll
+      for (int t = 0; t < NTILES; ++t) {
+        wp0[t] = __ldcs(reinterpret_cast<const uint4*>(w0[t]));
+        wp1[t] = __ldcs(reinterpret_cast<const uint4*>(w1[t]));
+      }
+    }
+#pragma unroll
+    for (int s = 0; s < 4; ++s) {  // four k16 mma steps per k64 super-chunk
+      unsigned b01 = 0, b23 = 0;
+      if (gid < BATCH) {
+        // sigma: B slots (tid*2, +1, +8, +9) = cols tid*16 + 4s + {0,1,2,3}.
+        const __nv_bfloat16* xrow =
+            activation + (size_t)gid * k + kk + tid * 16 + 4 * s;
+        const uint2 bv = *reinterpret_cast<const uint2*>(xrow);
+        b01 = bv.x; b23 = bv.y;
+      }
+#pragma unroll
+      for (int t = 0; t < NTILES; ++t) {
+        const unsigned char* p0 = reinterpret_cast<const unsigned char*>(&c0[t]) + 4 * s;
+        const unsigned char* p1 = reinterpret_cast<const unsigned char*>(&c1[t]) + 4 * s;
+        unsigned a0 = mma_cvt_pair(p0[0], p0[1]);  // row gid,   slots tid*2/+1
+        unsigned a1 = mma_cvt_pair(p1[0], p1[1]);  // row gid+8, slots tid*2/+1
+        unsigned a2 = mma_cvt_pair(p0[2], p0[3]);  // row gid,   slots tid*2+8/+9
+        unsigned a3 = mma_cvt_pair(p1[2], p1[3]);  // row gid+8, slots tid*2+8/+9
+        asm volatile(
+            "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 "
+            "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};"
+            : "+f"(cacc[t][0]), "+f"(cacc[t][1]), "+f"(cacc[t][2]), "+f"(cacc[t][3])
+            : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b01), "r"(b23));
+      }
+    }
+    if (((kk + 64) & 127) == 0) {  // end of a 128-col scale group
+#pragma unroll
+      for (int t = 0; t < NTILES; ++t) {
+        // A 16-row tile never straddles a /128 scale-row boundary (16 | 128).
+        const float scale =
+            weight_scale[(size_t)(((tile0 + t) * 16) >> 7) * scale_cols + (kk >> 7)];
+#pragma unroll
+        for (int i = 0; i < 4; ++i) { macc[t][i] += scale * cacc[t][i]; cacc[t][i] = 0.f; }
+      }
+    }
+  }
+  // C fragment: c0=(row gid, col tid*2) c1=(gid, +1) c2=(gid+8, tid*2) c3=(gid+8, +1);
+  // cols are batch indices.
+  float* out_slice = partial + (size_t)blockIdx.x * BATCH * n;
+  const int col0 = tid * 2;
+#pragma unroll
+  for (int t = 0; t < NTILES; ++t) {
+    const int n0 = (tile0 + t) * 16;
+    if (col0 < BATCH)     out_slice[(size_t)col0 * n + n0 + gid] = macc[t][0];
+    if (col0 + 1 < BATCH) out_slice[(size_t)(col0 + 1) * n + n0 + gid] = macc[t][1];
+    if (col0 < BATCH)     out_slice[(size_t)col0 * n + n0 + gid + 8] = macc[t][2];
+    if (col0 + 1 < BATCH) out_slice[(size_t)(col0 + 1) * n + n0 + gid + 8] = macc[t][3];
+  }
+}
+
+// Fixed-order k-slice reduction + bf16 store (deterministic epilogue).
+template <int BATCH, int KSPLIT>
+__global__ void glm52_gemv_batched_mma_reduce_kernel(
+    const float* __restrict__ partial, __nv_bfloat16* __restrict__ out, int n) {
+  const int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i >= BATCH * n) return;
+  float v = partial[i];
+#pragma unroll
+  for (int s = 1; s < KSPLIT; ++s) v += partial[(size_t)s * BATCH * n + i];
+  out[i] = __float2bfloat16(v);
+}
+
+// (ksplit, ntiles) per (batch, whitelisted shape); ksplit == 0 keeps the
+// register tile. Measured winners ONLY, jz-38 H200 2026-07-05 (see block
+// comment) — an explicit per-shape table so a future whitelist addition lands
+// on the register tile until someone measures it into here.
+struct MmaConfig { int ksplit; int ntiles; };
+MmaConfig mma_config(int batch, int n, int k) {
+  if (batch == 8) {
+    if (n == 2048  && k == 6144)  return {16, 2};  // q_a / shared gate,up
+    if (n == 16384 && k == 2048)  return {8, 4};   // q_b
+    if (n == 576   && k == 6144)  return {16, 2};  // kv_a
+    if (n == 6144  && k == 16384) return {16, 2};  // o_proj
+    if (n == 24576 && k == 6144)  return {16, 2};  // dense gate|up
+    if (n == 6144  && k == 12288) return {16, 2};  // dense down
+    if (n == 4096  && k == 6144)  return {16, 2};  // shared gate|up
+    if (n == 6144  && k == 2048)  return {8, 1};   // shared down
+    if (n == 4096  && k == 2048)  return {8, 1};   // indexer wq_b
+    if (n == 128   && k == 6144)  return {16, 2};  // indexer wk
+  }
+  if (batch == 4) {
+    // Only the shapes where mma measured ahead of the register tile at batch 4.
+    if (n == 2048  && k == 6144) return {16, 2};  // q_a / shared gate,up
+    if (n == 576   && k == 6144) return {16, 2};  // kv_a
+    if (n == 24576 && k == 6144) return {16, 2};  // dense gate|up
+    if (n == 4096  && k == 6144) return {16, 2};  // shared gate|up
+    if (n == 128   && k == 6144) return {16, 2};  // indexer wk
+  }
+  return {0, 0};
+}
+
+template <int BATCH, int KSPLIT, int NTILES>
+CUresult launch_gemv_batched_mma(const __nv_bfloat16* activation,
+                                 const unsigned char* weight,
+                                 const float* weight_scale, __nv_bfloat16* out,
+                                 float* scratch, size_t scratch_floats, int n,
+                                 int k, cudaStream_t stream) {
+  if (n % 16 != 0 || k % (128 * KSPLIT) != 0 || (n / 16) % NTILES != 0 ||
+      scratch == nullptr || (size_t)KSPLIT * BATCH * n > scratch_floats) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  const int tiles = n / 16;
+  const dim3 grid(KSPLIT, (tiles / NTILES + kMmaWarps - 1) / kMmaWarps, 1);
+  glm52_gemv_batched_mma_kernel<BATCH, KSPLIT, NTILES>
+      <<<grid, kMmaWarps * kWarpSize, 0, stream>>>(activation, weight,
+                                                   weight_scale, scratch, n, k);
+  const int rthreads = 256;
+  glm52_gemv_batched_mma_reduce_kernel<BATCH, KSPLIT>
+      <<<(BATCH * n + rthreads - 1) / rthreads, rthreads, 0, stream>>>(scratch,
+                                                                       out, n);
+  return consume_last_cuda_error();
+}
+
 // Routed grouped GEMV: blockIdx.x = slot in [0,topk); expert = topk_idx[slot].
 __global__ void glm52_moe_fp8_weight_only_gemv_kernel(
     const __nv_bfloat16* __restrict__ activation,  // W13: [k]; W2: [topk, k]
@@ -394,13 +614,19 @@ CUresult glm52_fp8_weight_only_gemv_cuda(
 }
 
 // Batched plain GEMV: `out[b] = deq(weight) @ activation[b]` for b in [0, batch).
-// batch == 1 routes to the m=1 kernel (identical result — the batched tile is
-// per-row bit-identical to it by construction); the other supported batches
-// are the decode buckets {2, 4, 8}, one template instantiation each.
+// batch == 1 routes to the m=1 kernel; batch 2 keeps the bit-parity register
+// tile; batches 4/8 dispatch per shape between the tensor-core mma path and
+// the register tile (mma_config — deterministic per bucket, not bit-identical
+// to m=1; see the mma block comment for the numerics contract).
+// `scratch`/`scratch_floats` = caller-owned f32 partial buffer for the
+// tensor-core path (see the mma block comment for the ownership contract:
+// one buffer per stream, never shared across the ctx/aux overlap). Batches
+// that stay on the register tile ignore it; an mma-routed launch with a
+// null/short buffer fails INVALID_VALUE instead of racing.
 CUresult glm52_fp8_weight_only_gemv_batched_cuda(
     const __nv_bfloat16* activation, const unsigned char* weight,
-    const float* weight_scale, __nv_bfloat16* out, int batch, int n, int k,
-    cudaStream_t stream) {
+    const float* weight_scale, __nv_bfloat16* out, float* scratch,
+    size_t scratch_floats, int batch, int n, int k, cudaStream_t stream) {
   if (activation == nullptr || weight == nullptr || weight_scale == nullptr ||
       out == nullptr || !aligned16(activation) ||
       !whitelisted_linear_shape(n, k)) {
@@ -421,6 +647,12 @@ CUresult glm52_fp8_weight_only_gemv_batched_cuda(
       break;
     }
     case kBatchedGemvBatch4: {
+      const MmaConfig cfg = mma_config(batch, n, k);
+      if (cfg.ksplit == 16 && cfg.ntiles == 2) {
+        return launch_gemv_batched_mma<kBatchedGemvBatch4, 16, 2>(
+            activation, weight, weight_scale, out, scratch, scratch_floats, n,
+            k, stream);
+      }
       if (!valid_tiling(n, k, kBatchedWarps * kBatchedRows))
         return CUDA_ERROR_INVALID_VALUE;
       const dim3 grid(1, n / (kBatchedWarps * kBatchedRows), 1);
@@ -431,6 +663,23 @@ CUresult glm52_fp8_weight_only_gemv_batched_cuda(
       break;
     }
     case kBatchedGemvBatchFull: {
+      // Every whitelisted shape runs the tensor-core path at batch 8.
+      const MmaConfig cfg = mma_config(batch, n, k);
+      if (cfg.ksplit == 16 && cfg.ntiles == 2) {
+        return launch_gemv_batched_mma<kBatchedGemvBatchFull, 16, 2>(
+            activation, weight, weight_scale, out, scratch, scratch_floats, n,
+            k, stream);
+      }
+      if (cfg.ksplit == 8 && cfg.ntiles == 4) {
+        return launch_gemv_batched_mma<kBatchedGemvBatchFull, 8, 4>(
+            activation, weight, weight_scale, out, scratch, scratch_floats, n,
+            k, stream);
+      }
+      if (cfg.ksplit == 8 && cfg.ntiles == 1) {
+        return launch_gemv_batched_mma<kBatchedGemvBatchFull, 8, 1>(
+            activation, weight, weight_scale, out, scratch, scratch_floats, n,
+            k, stream);
+      }
       if (!valid_tiling(n, k, kBatchedWarps * kBatchedRows))
         return CUDA_ERROR_INVALID_VALUE;
       const dim3 grid(1, n / (kBatchedWarps * kBatchedRows), 1);

--- a/openinfer-kernels/src/ffi/glm52.rs
+++ b/openinfer-kernels/src/ffi/glm52.rs
@@ -325,6 +325,8 @@ unsafe extern "C" {
         weight: *const u8,
         weight_scale: *const f32,
         out: *mut Half,
+        scratch: *mut f32,
+        scratch_floats: usize,
         batch: i32,
         n: i32,
         k: i32,

--- a/openinfer-kernels/src/ops/glm52/moe_gemv.rs
+++ b/openinfer-kernels/src/ops/glm52/moe_gemv.rs
@@ -171,12 +171,25 @@ pub fn glm52_moe_combine_slots_launch(
     .map_err(|err| anyhow!("GLM5.2 combine-slots launch failed: {err}"))
 }
 
+/// f32 partial-scratch floats PER ROW the tensor-core batched GEMV path can
+/// need: max ksplit (16) × max whitelisted n (dense gate|up 24576). Callers
+/// size their buffer as `rows * GLM52_GEMV_MMA_SCRATCH_FLOATS_PER_ROW` — one
+/// constant instead of mirroring the CUDA-side per-shape config table; the
+/// launcher still guards the exact requirement and rejects a short buffer.
+pub const GLM52_GEMV_MMA_SCRATCH_FLOATS_PER_ROW: usize = 16 * 24576;
+
 /// Plain weight-only fp8 GEMV (bs=1): `out[n] = deq(weight[n,k]) @ activation[k]`
 /// with the bf16 activation read directly (no activation quant, no scale
 /// relayout) and the e4m3 block-scale weight dequanted on the fly. Replaces
 /// the TRTLLM CUTLASS block-scale GEMM at m=1, where the M-tile pads 1->64 and
 /// runs compute-bound. `scale_bytes` is the checkpoint `weight_scale_inv`
 /// (f32 `[ceil(n/128), k/128]`) kept as raw bytes.
+///
+/// `scratch` is the caller-owned f32 partial buffer for the rows-4/8
+/// tensor-core path. Ownership contract: the layer forward overlaps the ctx
+/// and aux streams, so a scratch buffer must belong to exactly one launch
+/// stream — every scratch struct owns its own. Pass `None` only on rows ≤ 2
+/// paths; an mma-routed launch without a buffer fails loudly.
 pub fn glm52_fp8_weight_only_gemv_launch(
     ctx: &DeviceContext,
     rows: usize,
@@ -185,6 +198,7 @@ pub fn glm52_fp8_weight_only_gemv_launch(
     activation: &CudaSlice<bf16>,
     weight: &CudaSlice<u8>,
     scale_bytes: &CudaSlice<u8>,
+    scratch: Option<&mut CudaSlice<f32>>,
     out: &mut CudaSlice<bf16>,
 ) -> Result<()> {
     ensure!(
@@ -210,15 +224,26 @@ pub fn glm52_fp8_weight_only_gemv_launch(
     let (w_ptr, _w) = weight.device_ptr(&ctx.stream);
     let (s_ptr, _s) = scale_bytes.device_ptr(&ctx.stream);
     let (out_ptr, _o) = out.device_ptr_mut(&ctx.stream);
-    // rows == 1 runs the m=1 kernel; rows > 1 the weight-stationary batched
-    // kernel (per-row bit-identical to m=1; the CUDA side whitelists the
-    // supported batches — a drifted GLM52_DECODE_BUCKETS crashes here).
+    let (scr_ptr, scr_floats, _scr) = match scratch {
+        Some(buf) => {
+            let len = buf.len();
+            let (ptr, guard) = buf.device_ptr_mut(&ctx.stream);
+            (ptr as *mut f32, len, Some(guard))
+        }
+        None => (std::ptr::null_mut(), 0, None),
+    };
+    // rows == 1 runs the m=1 kernel; rows 2 the bit-parity register tile;
+    // rows 4/8 the tensor-core mma path on winning shapes (deterministic per
+    // bucket, not bit-identical to m=1). The CUDA side whitelists the
+    // supported batches — a drifted GLM52_DECODE_BUCKETS crashes here.
     unsafe {
         ffi::glm52_fp8_weight_only_gemv_batched_cuda(
             act_ptr as *const ffi::Half,
             w_ptr as *const u8,
             s_ptr as *const f32,
             out_ptr as *mut ffi::Half,
+            scr_ptr,
+            scr_floats,
             rows as i32,
             n as i32,
             k as i32,


### PR DESCRIPTION
Re-lands #561 onto main. #561 was reviewed and merged, but its base branch was \`feat/glm52-step-bench\` (stacked PR), not \`main\` — the merge landed on the stack branch after #560 had already been squashed, so main never received the mma work. This is a clean cherry-pick of the #561 squash commit (b7fe8d9); no content changes.

See #561 for the full description, measurements (jz-38 8×H200), and review thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)