### PR TITLE
perf(glm52): graph the dspark draft round — markov chain + piecewise forward (−6.8% bs=1)

### DIFF
--- a/openinfer-glm52/src/dspark.rs
+++ b/openinfer-glm52/src/dspark.rs
@@ -552,15 +552,26 @@ impl Glm52DsparkModel {
                 ..
             } = &mut *scratch;
 
-            // The dense head of layer `l`: input norm, batched q GEMM, and the
-            // per-state tail assembly + k/v GEMMs (constant offsets/shapes for
-            // a given context_len).
-            macro_rules! layer_head {
+            // The batch-wide dense prolog of layer `l`: input norm + q GEMM.
+            macro_rules! layer_prolog {
                 ($l:expr) => {{
                     let layer = &self.layers[$l];
                     rms_norm_batch_into(ctx, hidden, &layer.input_ln, DSPARK_RMS_EPS, normed);
                     gemm_rows_into_checked(ctx, &layer.qkv, 0, DSPARK_QKV_DIM, normed, q_batch)?;
-                    for (i, state) in states.iter().enumerate() {
+                }};
+            }
+            // One slot's tail assembly + k/v GEMMs into the SHARED tail
+            // scratch. The tail must be consumed (state_dynamic!) before the
+            // next slot's prep overwrites it — at `active == 1` the graphed
+            // composition satisfies this trivially; at `active > 1` the layer
+            // interleaves prep/dynamic per slot exactly like the pre-graph
+            // code did.
+            macro_rules! state_prep {
+                ($l:expr, $i:expr, $state:expr) => {{
+                    let layer = &self.layers[$l];
+                    let state = $state;
+                    let i: usize = $i;
+                    {
                         let context_len = context_lens[i];
                         let tail_len = context_len + block;
                         let row_offset = i * block;
@@ -630,11 +641,13 @@ impl Glm52DsparkModel {
                     std::mem::swap(&mut *hidden, &mut *hidden_out);
                 }};
             }
-            // The round-varying middle of layer `l` — always eager.
-            macro_rules! layer_dynamic {
-                ($l:expr) => {{
+            // One slot's round-varying middle — always eager.
+            macro_rules! state_dynamic {
+                ($l:expr, $i:expr, $state:expr) => {{
                     let layer = &self.layers[$l];
-                    for (i, state) in states.iter_mut().enumerate() {
+                    let state = $state;
+                    let i: usize = $i;
+                    {
                         let context_len = context_lens[i];
                         let tail_len = context_len + block;
                         let row_offset = i * block;
@@ -701,36 +714,77 @@ impl Glm52DsparkModel {
                 }};
             }
 
-            // SEG 0: embedding + context projection + layer 0 head.
-            run_seg!(0, {
+            macro_rules! context_projection {
+                () => {{
+                    for state in states.iter_mut() {
+                        gemm_into_checked(
+                            ctx,
+                            &self.fc,
+                            &state.pending,
+                            &mut state.context_projected,
+                        )?;
+                        rms_norm_batch_into(
+                            ctx,
+                            &state.context_projected,
+                            &self.hidden_norm,
+                            DSPARK_RMS_EPS,
+                            &mut state.context_hidden,
+                        );
+                    }
+                }};
+            }
+
+            if active == 1 {
+                // bs=1: the single slot's prep can sit in the dense segments
+                // (nothing else touches the shared tail scratch before the
+                // dynamic middle consumes it), which is what makes the
+                // piecewise graph composition legal.
+                run_seg!(0, {
+                    embedding_batch(ctx, embed, token_ids_d, hidden)?;
+                    context_projection!();
+                    layer_prolog!(0);
+                    state_prep!(0, 0, &mut *states[0]);
+                });
+                for l in 0..DSPARK_LAYERS {
+                    state_dynamic!(l, 0, &mut *states[0]);
+                    if l + 1 < DSPARK_LAYERS {
+                        run_seg!(l + 1, {
+                            layer_tail!(l);
+                            layer_prolog!(l + 1);
+                            state_prep!(l + 1, 0, &mut *states[0]);
+                        });
+                    } else {
+                        // Final segment: last layer tail + draft head logits.
+                        run_seg!(l + 1, {
+                            layer_tail!(l);
+                            rms_norm_batch_into(
+                                ctx,
+                                hidden,
+                                &self.norm,
+                                DSPARK_RMS_EPS,
+                                logits_normed,
+                            );
+                            gemm_into_checked(ctx, lm_head, logits_normed, logits)?;
+                        });
+                    }
+                }
+            } else {
+                // bs>1 (eager, ungraphed): the tail scratch is shared across
+                // slots, so each slot's prep must be consumed by its dynamic
+                // middle before the next slot's prep overwrites it — the
+                // original per-slot interleave.
                 embedding_batch(ctx, embed, token_ids_d, hidden)?;
-                for state in states.iter_mut() {
-                    gemm_into_checked(ctx, &self.fc, &state.pending, &mut state.context_projected)?;
-                    rms_norm_batch_into(
-                        ctx,
-                        &state.context_projected,
-                        &self.hidden_norm,
-                        DSPARK_RMS_EPS,
-                        &mut state.context_hidden,
-                    );
+                context_projection!();
+                for l in 0..DSPARK_LAYERS {
+                    layer_prolog!(l);
+                    for i in 0..active {
+                        state_prep!(l, i, &mut *states[i]);
+                        state_dynamic!(l, i, &mut *states[i]);
+                    }
+                    layer_tail!(l);
                 }
-                layer_head!(0);
-            });
-            for l in 0..DSPARK_LAYERS {
-                layer_dynamic!(l);
-                if l + 1 < DSPARK_LAYERS {
-                    run_seg!(l + 1, {
-                        layer_tail!(l);
-                        layer_head!(l + 1);
-                    });
-                } else {
-                    // Final segment: last layer tail + draft head logits.
-                    run_seg!(l + 1, {
-                        layer_tail!(l);
-                        rms_norm_batch_into(ctx, hidden, &self.norm, DSPARK_RMS_EPS, logits_normed);
-                        gemm_into_checked(ctx, lm_head, logits_normed, logits)?;
-                    });
-                }
+                rms_norm_batch_into(ctx, hidden, &self.norm, DSPARK_RMS_EPS, logits_normed);
+                gemm_into_checked(ctx, lm_head, logits_normed, logits)?;
             }
         }
         if fwd_on {
@@ -818,13 +872,18 @@ impl Glm52DsparkModel {
                 .collect());
         }
         scratch.markov_warm[rows - 1] = true;
+        // Fixed-orientation ping-pong, NOT a field swap: a swap flips which
+        // buffer the `prev_tokens` field names, and a graph captured for one
+        // row count bakes the buffer addresses — an odd number of swaps on an
+        // eager round (7 steps) for a different row count would leave the
+        // anchor h2d above writing a buffer the captured graph never reads.
         for step in 1..block {
-            embedding_batch(
-                ctx,
-                &self.markov_w1,
-                &scratch.prev_tokens,
-                &mut scratch.w1emb,
-            )?;
+            let (prev, next): (&CudaSlice<u32>, &mut CudaSlice<u32>) = if step % 2 == 1 {
+                (&scratch.prev_tokens, &mut scratch.next_tokens)
+            } else {
+                (&scratch.next_tokens, &mut scratch.prev_tokens)
+            };
+            embedding_batch(ctx, &self.markov_w1, prev, &mut scratch.w1emb)?;
             gemm_into_checked(ctx, &self.markov_w2, &scratch.w1emb, &mut scratch.bias)?;
             markov_step_argmax_into(
                 ctx,
@@ -835,10 +894,9 @@ impl Glm52DsparkModel {
                 rows,
                 &mut scratch.partial_values,
                 &mut scratch.partial_indices,
-                &mut scratch.next_tokens,
+                next,
                 &mut scratch.sampled_tokens,
             )?;
-            std::mem::swap(&mut scratch.prev_tokens, &mut scratch.next_tokens);
         }
         let sampled_view = scratch.sampled_tokens.slice(..rows * block);
         let sampled = ctx.stream.clone_dtoh(&sampled_view)?;

--- a/openinfer-glm52/src/dspark.rs
+++ b/openinfer-glm52/src/dspark.rs
@@ -23,7 +23,7 @@
 use std::path::Path;
 
 use anyhow::{Context as _, Result, ensure};
-use cudarc::driver::CudaSlice;
+use cudarc::driver::{CudaSlice, DevicePtr};
 
 use openinfer_core::cuda_graph::CudaGraphState;
 use openinfer_core::weight_loader::{
@@ -515,11 +515,21 @@ impl Glm52DsparkModel {
         // would abort capture). The hidden/hidden_out swap is a host pointer
         // swap: capture bakes the alternation, and no eager op touches either
         // buffer. DSPARK_NO_FORWARD_GRAPH=1 disables.
-        let fwd_key = context_lens[0] - 1;
+        let slot_ident = {
+            let (ptr, _guard) = states[0].pending.data.device_ptr(&ctx.stream);
+            ptr
+        };
+        let fwd_key = (slot_ident, context_lens[0]);
         let fwd_on = active == 1
-            && fwd_key < scratch.forward_warm.len()
+            && context_lens[0] <= GLM52_DSPARK_BLOCK
             && std::env::var_os("DSPARK_NO_FORWARD_GRAPH").is_none();
-        let use_graph = fwd_on && scratch.forward_warm[fwd_key];
+        let use_graph = fwd_on && scratch.forward_warm.contains(&fwd_key);
+        if fwd_on && use_graph {
+            scratch
+                .forward_graphs
+                .entry(fwd_key)
+                .or_insert_with(|| (0..=DSPARK_LAYERS).map(|_| CudaGraphState::new()).collect());
+        }
 
         {
             let Glm52DsparkScratch {
@@ -681,7 +691,9 @@ impl Glm52DsparkModel {
             macro_rules! run_seg {
                 ($idx:expr, $body:block) => {{
                     if use_graph {
-                        forward_graphs[fwd_key][$idx]
+                        forward_graphs
+                            .get_mut(&fwd_key)
+                            .expect("forward graph entry created before the segments")[$idx]
                             .run_or_capture(ctx, || -> Result<()> { $body Ok(()) })?;
                     } else {
                         (|| -> Result<()> { $body Ok(()) })()?;
@@ -721,8 +733,8 @@ impl Glm52DsparkModel {
                 }
             }
         }
-        if fwd_on && !scratch.forward_warm[fwd_key] {
-            scratch.forward_warm[fwd_key] = true;
+        if fwd_on {
+            scratch.forward_warm.insert(fwd_key);
         }
         // Host bookkeeping the eager path used to do inline.
         for (i, state) in states.iter_mut().enumerate() {
@@ -1007,10 +1019,15 @@ pub(crate) struct Glm52DsparkScratch {
     /// loop so cuBLAS's lazy workspace allocation happens outside capture.
     markov_graphs: Vec<CudaGraphState>,
     markov_warm: Vec<bool>,
-    /// Piecewise forward graphs (bs=1 only), keyed by `context_len - 1`:
-    /// `DSPARK_LAYERS + 1` dense segments each, with a per-key warm flag.
-    forward_graphs: Vec<Vec<CudaGraphState>>,
-    forward_warm: Vec<bool>,
+    /// Piecewise forward graphs (bs=1 only), keyed by **(slot identity,
+    /// context_len)** — the captured segments bake per-slot buffer pointers
+    /// (`state.pending`, `state.context_projected`, `state.context_hidden`),
+    /// so a graph captured for one slot must never replay for another. Slot
+    /// identity is the device address of the slot's `pending` buffer (stable
+    /// for the slot's lifetime; the `&mut` reference itself is not). Bounded
+    /// by `GLM52_MAX_BATCH_PER_RANK x GLM52_DSPARK_BLOCK` entries.
+    forward_graphs: std::collections::HashMap<(u64, usize), Vec<CudaGraphState>>,
+    forward_warm: std::collections::HashSet<(u64, usize)>,
 }
 
 impl Glm52DsparkScratch {
@@ -1050,10 +1067,8 @@ impl Glm52DsparkScratch {
                 .map(|_| CudaGraphState::new())
                 .collect(),
             markov_warm: vec![false; GLM52_MAX_BATCH_PER_RANK],
-            forward_graphs: (0..GLM52_DSPARK_BLOCK)
-                .map(|_| (0..=DSPARK_LAYERS).map(|_| CudaGraphState::new()).collect())
-                .collect(),
-            forward_warm: vec![false; GLM52_DSPARK_BLOCK],
+            forward_graphs: std::collections::HashMap::new(),
+            forward_warm: std::collections::HashSet::new(),
         })
     }
 

--- a/openinfer-glm52/src/dspark.rs
+++ b/openinfer-glm52/src/dspark.rs
@@ -330,6 +330,45 @@ impl Glm52DsparkModel {
         self.cache_len
     }
 
+    /// Zero-weight model at the checkpoint's exact geometry, for perf smoke
+    /// tests without the checkpoint — GPU kernel time is value-independent.
+    #[cfg(test)]
+    pub(crate) fn synthetic(ctx: &DeviceContext, cache_len: usize) -> Result<Self> {
+        let mat = |rows: usize, cols: usize| -> Result<DeviceMatrix> {
+            Ok(DeviceMatrix {
+                data: ctx.stream.alloc_zeros(rows * cols)?,
+                rows,
+                cols,
+            })
+        };
+        let mut layers = Vec::with_capacity(DSPARK_LAYERS);
+        for _ in 0..DSPARK_LAYERS {
+            layers.push(DsparkLayer {
+                input_ln: DeviceVec::zeros(ctx, GLM52_HIDDEN)?,
+                qkv: mat(3 * DSPARK_QKV_DIM, GLM52_HIDDEN)?,
+                o_proj: mat(GLM52_HIDDEN, DSPARK_QKV_DIM)?,
+                q_norm: DeviceVec::zeros(ctx, DSPARK_HEAD_DIM)?,
+                k_norm: DeviceVec::zeros(ctx, DSPARK_HEAD_DIM)?,
+                post_ln: DeviceVec::zeros(ctx, GLM52_HIDDEN)?,
+                gate_up: mat(2 * DSPARK_INTER, GLM52_HIDDEN)?,
+                down: mat(GLM52_HIDDEN, DSPARK_INTER)?,
+            });
+        }
+        let (cos_cache, sin_cache) =
+            precompute_rope(ctx, DSPARK_HEAD_DIM, cache_len, DSPARK_ROPE_THETA)?;
+        Ok(Self {
+            layers,
+            norm: DeviceVec::zeros(ctx, GLM52_HIDDEN)?,
+            hidden_norm: DeviceVec::zeros(ctx, GLM52_HIDDEN)?,
+            fc: mat(GLM52_HIDDEN, GLM52_DSPARK_CONTEXT_DIM)?,
+            markov_w1: mat(GLM52_VOCAB, DSPARK_MARKOV_RANK)?,
+            markov_w2: mat(GLM52_VOCAB, DSPARK_MARKOV_RANK)?,
+            cos_cache,
+            sin_cache,
+            cache_len,
+        })
+    }
+
     /// Propose `GLM52_DSPARK_DRAFTS` draft tokens for each state, batched.
     ///
     /// Dense ops (embedding, norms, q/o/mlp GEMMs, logits) run once over the

--- a/openinfer-glm52/src/dspark.rs
+++ b/openinfer-glm52/src/dspark.rs
@@ -25,14 +25,15 @@ use std::path::Path;
 use anyhow::{Context as _, Result, ensure};
 use cudarc::driver::CudaSlice;
 
+use openinfer_core::cuda_graph::CudaGraphState;
 use openinfer_core::weight_loader::{
     deserialize_shards, load_shard_info, load_tensor_1d, load_tensor_2d, mmap_shards,
     precompute_rope,
 };
 use openinfer_kernels::ops::{
-    add_batch_into, argmax_batch_bf16_split_partials_len, copy_hidden_token_range_into,
-    dflash_qk_norm_rope_into, embedding_batch, fused_add_rms_norm_round_batch_into,
-    gemm_into_checked, gemm_rows_into_checked, markov_step_argmax_into, rms_norm_batch_into,
+    add_batch_into, copy_hidden_token_range_into, dflash_qk_norm_rope_into, embedding_batch,
+    fused_add_rms_norm_round_batch_into, gemm_into_checked, gemm_rows_into_checked,
+    markov_step_argmax_into, markov_step_argmax_partials_len, rms_norm_batch_into,
     silu_mul_batch_into, single_prefill_nhd_noncausal_into,
 };
 use openinfer_kernels::tensor::{DeviceContext, DeviceMatrix, DeviceVec, HiddenStates};
@@ -369,6 +370,54 @@ impl Glm52DsparkModel {
         })
     }
 
+    /// Deterministic pseudo-random weights over the synthetic model, for
+    /// graph-vs-eager parity tests: kernel *timing* is value-independent, but
+    /// draft-token parity needs non-degenerate logits (all-zero weights make
+    /// every argmax a trivial index-0 tie).
+    #[cfg(test)]
+    pub(crate) fn randomize_for_test(&mut self, ctx: &DeviceContext) -> Result<()> {
+        fn fill(
+            ctx: &DeviceContext,
+            buf: &mut CudaSlice<half::bf16>,
+            seed: u32,
+            scale: f32,
+            offset: f32,
+        ) -> Result<()> {
+            let mut state = seed | 1;
+            let host: Vec<half::bf16> = (0..buf.len())
+                .map(|_| {
+                    state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                    half::bf16::from_f32(
+                        ((state >> 8) as f32 / (1u32 << 24) as f32 - 0.5) * scale + offset,
+                    )
+                })
+                .collect();
+            ctx.stream.memcpy_htod(&host, buf)?;
+            Ok(())
+        }
+        let mut seed = 0x5eed_u32;
+        let mut next = || {
+            seed = seed.wrapping_add(0x9e37_79b9);
+            seed
+        };
+        for layer in &mut self.layers {
+            fill(ctx, &mut layer.qkv.data, next(), 0.02, 0.0)?;
+            fill(ctx, &mut layer.o_proj.data, next(), 0.02, 0.0)?;
+            fill(ctx, &mut layer.gate_up.data, next(), 0.02, 0.0)?;
+            fill(ctx, &mut layer.down.data, next(), 0.02, 0.0)?;
+            fill(ctx, &mut layer.input_ln.data, next(), 0.1, 1.0)?;
+            fill(ctx, &mut layer.post_ln.data, next(), 0.1, 1.0)?;
+            fill(ctx, &mut layer.q_norm.data, next(), 0.1, 1.0)?;
+            fill(ctx, &mut layer.k_norm.data, next(), 0.1, 1.0)?;
+        }
+        fill(ctx, &mut self.norm.data, next(), 0.1, 1.0)?;
+        fill(ctx, &mut self.hidden_norm.data, next(), 0.1, 1.0)?;
+        fill(ctx, &mut self.fc.data, next(), 0.02, 0.0)?;
+        fill(ctx, &mut self.markov_w1.data, next(), 0.5, 0.0)?;
+        fill(ctx, &mut self.markov_w2.data, next(), 0.5, 0.0)?;
+        Ok(())
+    }
+
     /// Propose `GLM52_DSPARK_DRAFTS` draft tokens for each state, batched.
     ///
     /// Dense ops (embedding, norms, q/o/mlp GEMMs, logits) run once over the
@@ -438,193 +487,249 @@ impl Glm52DsparkModel {
             ctx.stream
                 .memcpy_htod(&scratch.block_token_ids_h[..block_rows], &mut dst)?;
         }
-        embedding_batch(ctx, embed, &scratch.token_ids_d, &mut scratch.hidden)?;
 
-        // Per-request context projection: fc over the pending captured rows,
-        // then hidden_norm — persisted in the state so every layer's tail
-        // concat can read it.
+        // Host metadata that shapes the GEMMs below — hoisted ahead of the
+        // graphable region (during replay the closures do not run, and the
+        // shapes are baked at capture).
         for (i, state) in states.iter_mut().enumerate() {
             state.set_context_len(context_lens[i])?;
             state.pending.seq_len = context_lens[i];
-            gemm_into_checked(ctx, &self.fc, &state.pending, &mut state.context_projected)?;
-            rms_norm_batch_into(
-                ctx,
-                &state.context_projected,
-                &self.hidden_norm,
-                DSPARK_RMS_EPS,
-                &mut state.context_hidden,
-            );
-            state.pending_len = 0;
-            state.pending.seq_len = 0;
         }
+        let max_tail = context_lens.iter().max().copied().unwrap_or(0) + block;
+        ensure!(
+            max_tail <= scratch.tail_input.data.len() / GLM52_HIDDEN,
+            "dspark tail length {max_tail} exceeds the preallocated cap"
+        );
 
-        for (layer_idx, layer) in self.layers.iter().enumerate() {
-            rms_norm_batch_into(
-                ctx,
-                &scratch.hidden,
-                &layer.input_ln,
-                DSPARK_RMS_EPS,
-                &mut scratch.normed,
-            );
-            gemm_rows_into_checked(
-                ctx,
-                &layer.qkv,
-                0,
-                DSPARK_QKV_DIM,
-                &scratch.normed,
-                &mut scratch.q_batch,
-            )?;
+        // Piecewise forward graph (bs=1 steady state): the only round-varying
+        // kernel arguments in the forward are `committed_len`-derived — the
+        // rope positions, the two KV-append copy offsets, and the attention
+        // kv_len — i.e. 4 launches per layer, which run EAGER (a captured
+        // FlashInfer prefill bakes its KV iteration count). Everything else is
+        // shape-static per `context_len`, captured as `DSPARK_LAYERS + 1`
+        // dense segments keyed by `context_len` and replayed. rows > 1 falls
+        // back to eager: the tail scratch (tail_input/k_tail/v_tail) is shared
+        // across slots, so the per-slot prep/consume interleave cannot be
+        // re-ordered into dense-vs-dynamic spans. The first round per key
+        // stays eager (cuBLAS lazily allocates workspace on first touch, which
+        // would abort capture). The hidden/hidden_out swap is a host pointer
+        // swap: capture bakes the alternation, and no eager op touches either
+        // buffer. DSPARK_NO_FORWARD_GRAPH=1 disables.
+        let fwd_key = context_lens[0] - 1;
+        let fwd_on = active == 1
+            && fwd_key < scratch.forward_warm.len()
+            && std::env::var_os("DSPARK_NO_FORWARD_GRAPH").is_none();
+        let use_graph = fwd_on && scratch.forward_warm[fwd_key];
 
-            for (i, state) in states.iter_mut().enumerate() {
-                let context_len = context_lens[i];
-                let tail_len = context_len + block;
-                let row_offset = i * block;
-                scratch.set_tail_len(tail_len)?;
+        {
+            let Glm52DsparkScratch {
+                forward_graphs,
+                hidden,
+                hidden_out,
+                normed,
+                q_batch,
+                attn_output,
+                o_buf,
+                gate_out,
+                up_out,
+                act_out,
+                logits_normed,
+                logits,
+                tail_input,
+                k_tail,
+                v_tail,
+                token_ids_d,
+                ..
+            } = &mut *scratch;
 
-                // tail_input = [context_hidden | normed block rows].
-                copy_hidden_token_range_into(
-                    ctx,
-                    &state.context_hidden,
-                    0,
-                    &mut scratch.tail_input,
-                    0,
-                    context_len,
-                )?;
-                copy_hidden_token_range_into(
-                    ctx,
-                    &scratch.normed,
-                    row_offset,
-                    &mut scratch.tail_input,
-                    context_len,
-                    block,
-                )?;
-
-                gemm_rows_into_checked(
-                    ctx,
-                    &layer.qkv,
-                    DSPARK_QKV_DIM,
-                    DSPARK_QKV_DIM,
-                    &scratch.tail_input,
-                    &mut scratch.k_tail,
-                )?;
-                gemm_rows_into_checked(
-                    ctx,
-                    &layer.qkv,
-                    2 * DSPARK_QKV_DIM,
-                    DSPARK_QKV_DIM,
-                    &scratch.tail_input,
-                    &mut scratch.v_tail,
-                )?;
-
-                // Q rows sit at the block positions (anchor_pos..+block); the
-                // K tail starts at the first uncached context position.
-                dflash_qk_norm_rope_into(
-                    ctx,
-                    &mut scratch.q_batch,
-                    row_offset,
-                    block,
-                    &mut scratch.k_tail,
-                    &layer.q_norm,
-                    &layer.k_norm,
-                    &self.cos_cache,
-                    &self.sin_cache,
-                    DSPARK_HEADS,
-                    DSPARK_HEADS,
-                    DSPARK_HEAD_DIM,
-                    state.committed_len + context_len,
-                    state.committed_len,
-                    DSPARK_RMS_EPS,
-                )?;
-
-                let cache = &mut state.layers[layer_idx];
-                copy_hidden_token_range_into(
-                    ctx,
-                    &scratch.k_tail,
-                    0,
-                    &mut cache.k,
-                    state.committed_len,
-                    tail_len,
-                )?;
-                copy_hidden_token_range_into(
-                    ctx,
-                    &scratch.v_tail,
-                    0,
-                    &mut cache.v,
-                    state.committed_len,
-                    tail_len,
-                )?;
-                // Bidirectional within the block (speculators non_causal);
-                // the cached context is everything before the anchor.
-                single_prefill_nhd_noncausal_into(
-                    ctx,
-                    &scratch.q_batch,
-                    row_offset,
-                    block,
-                    &cache.k,
-                    &cache.v,
-                    &mut scratch.attn_output,
-                    DSPARK_HEADS,
-                    DSPARK_HEADS,
-                    DSPARK_HEAD_DIM,
-                    state.committed_len + tail_len,
-                )?;
+            // The dense head of layer `l`: input norm, batched q GEMM, and the
+            // per-state tail assembly + k/v GEMMs (constant offsets/shapes for
+            // a given context_len).
+            macro_rules! layer_head {
+                ($l:expr) => {{
+                    let layer = &self.layers[$l];
+                    rms_norm_batch_into(ctx, hidden, &layer.input_ln, DSPARK_RMS_EPS, normed);
+                    gemm_rows_into_checked(ctx, &layer.qkv, 0, DSPARK_QKV_DIM, normed, q_batch)?;
+                    for (i, state) in states.iter().enumerate() {
+                        let context_len = context_lens[i];
+                        let tail_len = context_len + block;
+                        let row_offset = i * block;
+                        tail_input.seq_len = tail_len;
+                        k_tail.seq_len = tail_len;
+                        v_tail.seq_len = tail_len;
+                        copy_hidden_token_range_into(
+                            ctx,
+                            &state.context_hidden,
+                            0,
+                            tail_input,
+                            0,
+                            context_len,
+                        )?;
+                        copy_hidden_token_range_into(
+                            ctx,
+                            normed,
+                            row_offset,
+                            tail_input,
+                            context_len,
+                            block,
+                        )?;
+                        gemm_rows_into_checked(
+                            ctx,
+                            &layer.qkv,
+                            DSPARK_QKV_DIM,
+                            DSPARK_QKV_DIM,
+                            tail_input,
+                            k_tail,
+                        )?;
+                        gemm_rows_into_checked(
+                            ctx,
+                            &layer.qkv,
+                            2 * DSPARK_QKV_DIM,
+                            DSPARK_QKV_DIM,
+                            tail_input,
+                            v_tail,
+                        )?;
+                    }
+                }};
+            }
+            // The dense tail of layer `l`: o_proj + post-norm + MLP + residual.
+            macro_rules! layer_tail {
+                ($l:expr) => {{
+                    let layer = &self.layers[$l];
+                    gemm_into_checked(ctx, &layer.o_proj, attn_output, o_buf)?;
+                    fused_add_rms_norm_round_batch_into(
+                        ctx,
+                        hidden,
+                        o_buf,
+                        &layer.post_ln,
+                        DSPARK_RMS_EPS,
+                        normed,
+                    )?;
+                    gemm_rows_into_checked(ctx, &layer.gate_up, 0, DSPARK_INTER, normed, gate_out)?;
+                    gemm_rows_into_checked(
+                        ctx,
+                        &layer.gate_up,
+                        DSPARK_INTER,
+                        DSPARK_INTER,
+                        normed,
+                        up_out,
+                    )?;
+                    silu_mul_batch_into(ctx, gate_out, up_out, act_out)?;
+                    gemm_into_checked(ctx, &layer.down, act_out, o_buf)?;
+                    add_batch_into(ctx, hidden, o_buf, hidden_out)?;
+                    std::mem::swap(&mut *hidden, &mut *hidden_out);
+                }};
+            }
+            // The round-varying middle of layer `l` — always eager.
+            macro_rules! layer_dynamic {
+                ($l:expr) => {{
+                    let layer = &self.layers[$l];
+                    for (i, state) in states.iter_mut().enumerate() {
+                        let context_len = context_lens[i];
+                        let tail_len = context_len + block;
+                        let row_offset = i * block;
+                        dflash_qk_norm_rope_into(
+                            ctx,
+                            q_batch,
+                            row_offset,
+                            block,
+                            k_tail,
+                            &layer.q_norm,
+                            &layer.k_norm,
+                            &self.cos_cache,
+                            &self.sin_cache,
+                            DSPARK_HEADS,
+                            DSPARK_HEADS,
+                            DSPARK_HEAD_DIM,
+                            state.committed_len + context_len,
+                            state.committed_len,
+                            DSPARK_RMS_EPS,
+                        )?;
+                        let cache = &mut state.layers[$l];
+                        copy_hidden_token_range_into(
+                            ctx,
+                            k_tail,
+                            0,
+                            &mut cache.k,
+                            state.committed_len,
+                            tail_len,
+                        )?;
+                        copy_hidden_token_range_into(
+                            ctx,
+                            v_tail,
+                            0,
+                            &mut cache.v,
+                            state.committed_len,
+                            tail_len,
+                        )?;
+                        single_prefill_nhd_noncausal_into(
+                            ctx,
+                            q_batch,
+                            row_offset,
+                            block,
+                            &cache.k,
+                            &cache.v,
+                            attn_output,
+                            DSPARK_HEADS,
+                            DSPARK_HEADS,
+                            DSPARK_HEAD_DIM,
+                            state.committed_len + tail_len,
+                        )?;
+                    }
+                }};
+            }
+            macro_rules! run_seg {
+                ($idx:expr, $body:block) => {{
+                    if use_graph {
+                        forward_graphs[fwd_key][$idx]
+                            .run_or_capture(ctx, || -> Result<()> { $body Ok(()) })?;
+                    } else {
+                        (|| -> Result<()> { $body Ok(()) })()?;
+                    }
+                }};
             }
 
-            gemm_into_checked(ctx, &layer.o_proj, &scratch.attn_output, &mut scratch.o_buf)?;
-            fused_add_rms_norm_round_batch_into(
-                ctx,
-                &mut scratch.hidden,
-                &scratch.o_buf,
-                &layer.post_ln,
-                DSPARK_RMS_EPS,
-                &mut scratch.normed,
-            )?;
-
-            gemm_rows_into_checked(
-                ctx,
-                &layer.gate_up,
-                0,
-                DSPARK_INTER,
-                &scratch.normed,
-                &mut scratch.gate_out,
-            )?;
-            gemm_rows_into_checked(
-                ctx,
-                &layer.gate_up,
-                DSPARK_INTER,
-                DSPARK_INTER,
-                &scratch.normed,
-                &mut scratch.up_out,
-            )?;
-            silu_mul_batch_into(
-                ctx,
-                &scratch.gate_out,
-                &scratch.up_out,
-                &mut scratch.act_out,
-            )?;
-            gemm_into_checked(ctx, &layer.down, &scratch.act_out, &mut scratch.o_buf)?;
-            add_batch_into(
-                ctx,
-                &scratch.hidden,
-                &scratch.o_buf,
-                &mut scratch.hidden_out,
-            )?;
-            std::mem::swap(&mut scratch.hidden, &mut scratch.hidden_out);
+            // SEG 0: embedding + context projection + layer 0 head.
+            run_seg!(0, {
+                embedding_batch(ctx, embed, token_ids_d, hidden)?;
+                for state in states.iter_mut() {
+                    gemm_into_checked(ctx, &self.fc, &state.pending, &mut state.context_projected)?;
+                    rms_norm_batch_into(
+                        ctx,
+                        &state.context_projected,
+                        &self.hidden_norm,
+                        DSPARK_RMS_EPS,
+                        &mut state.context_hidden,
+                    );
+                }
+                layer_head!(0);
+            });
+            for l in 0..DSPARK_LAYERS {
+                layer_dynamic!(l);
+                if l + 1 < DSPARK_LAYERS {
+                    run_seg!(l + 1, {
+                        layer_tail!(l);
+                        layer_head!(l + 1);
+                    });
+                } else {
+                    // Final segment: last layer tail + draft head logits.
+                    run_seg!(l + 1, {
+                        layer_tail!(l);
+                        rms_norm_batch_into(ctx, hidden, &self.norm, DSPARK_RMS_EPS, logits_normed);
+                        gemm_into_checked(ctx, lm_head, logits_normed, logits)?;
+                    });
+                }
+            }
         }
-
+        if fwd_on && !scratch.forward_warm[fwd_key] {
+            scratch.forward_warm[fwd_key] = true;
+        }
+        // Host bookkeeping the eager path used to do inline.
         for (i, state) in states.iter_mut().enumerate() {
+            state.pending_len = 0;
+            state.pending.seq_len = 0;
             state.committed_len += context_lens[i];
         }
-
-        // Draft logits through the reused target head.
-        rms_norm_batch_into(
-            ctx,
-            &scratch.hidden,
-            &self.norm,
-            DSPARK_RMS_EPS,
-            &mut scratch.logits_normed,
-        );
-        gemm_into_checked(ctx, lm_head, &scratch.logits_normed, &mut scratch.logits)?;
 
         self.markov_propose(ctx, anchors, scratch)
     }
@@ -648,6 +753,59 @@ impl Glm52DsparkModel {
             let mut prev = scratch.prev_tokens.slice_mut(..rows);
             ctx.stream.memcpy_htod(&anchor_tokens, &mut prev)?;
         }
+        // Graph the 7-step chain: every shape and pointer in the loop is
+        // static for a given `rows` (`step` is baked per node; the prev/next
+        // ping-pong alternates deterministically; the anchor htod above and
+        // the dtoh below stay outside), so after a one-round warm-up (cuBLAS
+        // lazily allocates its workspace on first touch, which would abort
+        // capture) the whole chain replays as ONE graph launch instead of
+        // ~21 kernel launches. DSPARK_NO_MARKOV_GRAPH=1 restores the plain
+        // loop for A/B.
+        let use_graph = std::env::var_os("DSPARK_NO_MARKOV_GRAPH").is_none();
+        if use_graph && scratch.markov_warm[rows - 1] {
+            let Glm52DsparkScratch {
+                markov_graphs,
+                w1emb,
+                bias,
+                logits,
+                prev_tokens,
+                next_tokens,
+                sampled_tokens,
+                partial_values,
+                partial_indices,
+                ..
+            } = scratch;
+            markov_graphs[rows - 1].run_or_capture(ctx, || {
+                for step in 1..block {
+                    let (prev, next): (&CudaSlice<u32>, &mut CudaSlice<u32>) = if step % 2 == 1 {
+                        (&*prev_tokens, &mut *next_tokens)
+                    } else {
+                        (&*next_tokens, &mut *prev_tokens)
+                    };
+                    embedding_batch(ctx, &self.markov_w1, prev, w1emb)?;
+                    gemm_into_checked(ctx, &self.markov_w2, w1emb, bias)?;
+                    markov_step_argmax_into(
+                        ctx,
+                        logits,
+                        bias,
+                        block,
+                        step,
+                        rows,
+                        partial_values,
+                        partial_indices,
+                        next,
+                        sampled_tokens,
+                    )?;
+                }
+                Ok(())
+            })?;
+            let sampled_view = scratch.sampled_tokens.slice(..rows * block);
+            let sampled = ctx.stream.clone_dtoh(&sampled_view)?;
+            return Ok((0..rows)
+                .map(|i| std::array::from_fn(|k| sampled[i * block + 1 + k]))
+                .collect());
+        }
+        scratch.markov_warm[rows - 1] = true;
         for step in 1..block {
             embedding_batch(
                 ctx,
@@ -844,6 +1002,15 @@ pub(crate) struct Glm52DsparkScratch {
     prev_tokens: CudaSlice<u32>,
     next_tokens: CudaSlice<u32>,
     sampled_tokens: CudaSlice<u32>,
+    /// One captured Markov-chain graph per active row count (index `rows-1`),
+    /// plus a per-count warm flag: the first round for a count runs the plain
+    /// loop so cuBLAS's lazy workspace allocation happens outside capture.
+    markov_graphs: Vec<CudaGraphState>,
+    markov_warm: Vec<bool>,
+    /// Piecewise forward graphs (bs=1 only), keyed by `context_len - 1`:
+    /// `DSPARK_LAYERS + 1` dense segments each, with a per-key warm flag.
+    forward_graphs: Vec<Vec<CudaGraphState>>,
+    forward_warm: Vec<bool>,
 }
 
 impl Glm52DsparkScratch {
@@ -854,7 +1021,7 @@ impl Glm52DsparkScratch {
         // preallocated so a draft round never touches the allocator (and the
         // VRAM probe's ledger charged exactly this).
         let tail_capacity = cache_len;
-        let partials = argmax_batch_bf16_split_partials_len(GLM52_MAX_BATCH_PER_RANK, GLM52_VOCAB);
+        let partials = markov_step_argmax_partials_len(GLM52_MAX_BATCH_PER_RANK, GLM52_VOCAB);
         Ok(Self {
             block_token_ids_h: vec![DSPARK_MASK_TOKEN; max_rows],
             token_ids_d: ctx.stream.alloc_zeros(max_rows)?,
@@ -879,6 +1046,14 @@ impl Glm52DsparkScratch {
             prev_tokens: ctx.stream.alloc_zeros(GLM52_MAX_BATCH_PER_RANK)?,
             next_tokens: ctx.stream.alloc_zeros(GLM52_MAX_BATCH_PER_RANK)?,
             sampled_tokens: ctx.stream.alloc_zeros(max_rows)?,
+            markov_graphs: (0..GLM52_MAX_BATCH_PER_RANK)
+                .map(|_| CudaGraphState::new())
+                .collect(),
+            markov_warm: vec![false; GLM52_MAX_BATCH_PER_RANK],
+            forward_graphs: (0..GLM52_DSPARK_BLOCK)
+                .map(|_| (0..=DSPARK_LAYERS).map(|_| CudaGraphState::new()).collect())
+                .collect(),
+            forward_warm: vec![false; GLM52_DSPARK_BLOCK],
         })
     }
 

--- a/openinfer-glm52/src/dspark.rs
+++ b/openinfer-glm52/src/dspark.rs
@@ -331,93 +331,6 @@ impl Glm52DsparkModel {
         self.cache_len
     }
 
-    /// Zero-weight model at the checkpoint's exact geometry, for perf smoke
-    /// tests without the checkpoint — GPU kernel time is value-independent.
-    #[cfg(test)]
-    pub(crate) fn synthetic(ctx: &DeviceContext, cache_len: usize) -> Result<Self> {
-        let mat = |rows: usize, cols: usize| -> Result<DeviceMatrix> {
-            Ok(DeviceMatrix {
-                data: ctx.stream.alloc_zeros(rows * cols)?,
-                rows,
-                cols,
-            })
-        };
-        let mut layers = Vec::with_capacity(DSPARK_LAYERS);
-        for _ in 0..DSPARK_LAYERS {
-            layers.push(DsparkLayer {
-                input_ln: DeviceVec::zeros(ctx, GLM52_HIDDEN)?,
-                qkv: mat(3 * DSPARK_QKV_DIM, GLM52_HIDDEN)?,
-                o_proj: mat(GLM52_HIDDEN, DSPARK_QKV_DIM)?,
-                q_norm: DeviceVec::zeros(ctx, DSPARK_HEAD_DIM)?,
-                k_norm: DeviceVec::zeros(ctx, DSPARK_HEAD_DIM)?,
-                post_ln: DeviceVec::zeros(ctx, GLM52_HIDDEN)?,
-                gate_up: mat(2 * DSPARK_INTER, GLM52_HIDDEN)?,
-                down: mat(GLM52_HIDDEN, DSPARK_INTER)?,
-            });
-        }
-        let (cos_cache, sin_cache) =
-            precompute_rope(ctx, DSPARK_HEAD_DIM, cache_len, DSPARK_ROPE_THETA)?;
-        Ok(Self {
-            layers,
-            norm: DeviceVec::zeros(ctx, GLM52_HIDDEN)?,
-            hidden_norm: DeviceVec::zeros(ctx, GLM52_HIDDEN)?,
-            fc: mat(GLM52_HIDDEN, GLM52_DSPARK_CONTEXT_DIM)?,
-            markov_w1: mat(GLM52_VOCAB, DSPARK_MARKOV_RANK)?,
-            markov_w2: mat(GLM52_VOCAB, DSPARK_MARKOV_RANK)?,
-            cos_cache,
-            sin_cache,
-            cache_len,
-        })
-    }
-
-    /// Deterministic pseudo-random weights over the synthetic model, for
-    /// graph-vs-eager parity tests: kernel *timing* is value-independent, but
-    /// draft-token parity needs non-degenerate logits (all-zero weights make
-    /// every argmax a trivial index-0 tie).
-    #[cfg(test)]
-    pub(crate) fn randomize_for_test(&mut self, ctx: &DeviceContext) -> Result<()> {
-        fn fill(
-            ctx: &DeviceContext,
-            buf: &mut CudaSlice<half::bf16>,
-            seed: u32,
-            scale: f32,
-            offset: f32,
-        ) -> Result<()> {
-            let mut state = seed | 1;
-            let host: Vec<half::bf16> = (0..buf.len())
-                .map(|_| {
-                    state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
-                    half::bf16::from_f32(
-                        ((state >> 8) as f32 / (1u32 << 24) as f32 - 0.5) * scale + offset,
-                    )
-                })
-                .collect();
-            ctx.stream.memcpy_htod(&host, buf)?;
-            Ok(())
-        }
-        let mut seed = 0x5eed_u32;
-        let mut next = || {
-            seed = seed.wrapping_add(0x9e37_79b9);
-            seed
-        };
-        for layer in &mut self.layers {
-            fill(ctx, &mut layer.qkv.data, next(), 0.02, 0.0)?;
-            fill(ctx, &mut layer.o_proj.data, next(), 0.02, 0.0)?;
-            fill(ctx, &mut layer.gate_up.data, next(), 0.02, 0.0)?;
-            fill(ctx, &mut layer.down.data, next(), 0.02, 0.0)?;
-            fill(ctx, &mut layer.input_ln.data, next(), 0.1, 1.0)?;
-            fill(ctx, &mut layer.post_ln.data, next(), 0.1, 1.0)?;
-            fill(ctx, &mut layer.q_norm.data, next(), 0.1, 1.0)?;
-            fill(ctx, &mut layer.k_norm.data, next(), 0.1, 1.0)?;
-        }
-        fill(ctx, &mut self.norm.data, next(), 0.1, 1.0)?;
-        fill(ctx, &mut self.hidden_norm.data, next(), 0.1, 1.0)?;
-        fill(ctx, &mut self.fc.data, next(), 0.02, 0.0)?;
-        fill(ctx, &mut self.markov_w1.data, next(), 0.5, 0.0)?;
-        fill(ctx, &mut self.markov_w2.data, next(), 0.5, 0.0)?;
-        Ok(())
-    }
-
     /// Propose `GLM52_DSPARK_DRAFTS` draft tokens for each state, batched.
     ///
     /// Dense ops (embedding, norms, q/o/mlp GEMMs, logits) run once over the
@@ -500,21 +413,27 @@ impl Glm52DsparkModel {
             max_tail <= scratch.tail_input.data.len() / GLM52_HIDDEN,
             "dspark tail length {max_tail} exceeds the preallocated cap"
         );
+        // The tail seq_lens must be set OUTSIDE the graphable region: a replay
+        // does not run the captured closure, but the always-eager dynamic
+        // middle consumes these bounds every round — a stale value from a
+        // previous accept length either trips the copy range check (engine
+        // teardown) or ropes garbage rows. At bs=1 this single assignment is
+        // the round's truth; at bs>1 state_prep re-sets them per slot (eager).
+        let tail_len0 = context_lens[0] + block;
+        scratch.tail_input.seq_len = tail_len0;
+        scratch.k_tail.seq_len = tail_len0;
+        scratch.v_tail.seq_len = tail_len0;
 
-        // Piecewise forward graph (bs=1 steady state): the only round-varying
-        // kernel arguments in the forward are `committed_len`-derived — the
-        // rope positions, the two KV-append copy offsets, and the attention
-        // kv_len — i.e. 4 launches per layer, which run EAGER (a captured
-        // FlashInfer prefill bakes its KV iteration count). Everything else is
-        // shape-static per `context_len`, captured as `DSPARK_LAYERS + 1`
-        // dense segments keyed by `context_len` and replayed. rows > 1 falls
-        // back to eager: the tail scratch (tail_input/k_tail/v_tail) is shared
-        // across slots, so the per-slot prep/consume interleave cannot be
-        // re-ordered into dense-vs-dynamic spans. The first round per key
-        // stays eager (cuBLAS lazily allocates workspace on first touch, which
-        // would abort capture). The hidden/hidden_out swap is a host pointer
-        // swap: capture bakes the alternation, and no eager op touches either
-        // buffer. DSPARK_NO_FORWARD_GRAPH=1 disables.
+        // Piecewise forward graph (bs=1): only the `committed_len`-derived
+        // arguments vary per round (rope positions, KV-append offsets,
+        // attention kv_len — 4 launches/layer, kept EAGER since a captured
+        // FlashInfer prefill bakes its KV iteration count). The rest is
+        // shape-static per `context_len` → `DSPARK_LAYERS + 1` dense segments,
+        // replayed. rows > 1 falls back to eager (shared tail scratch, see
+        // state_prep). First round per key stays eager (cuBLAS lazy workspace
+        // would abort capture). The hidden/hidden_out swap is host-side and
+        // baked by capture; no eager op touches either buffer.
+        // DSPARK_NO_FORWARD_GRAPH=1 disables.
         let slot_ident = {
             let (ptr, _guard) = states[0].pending.data.device_ptr(&ctx.stream);
             ptr
@@ -524,7 +443,7 @@ impl Glm52DsparkModel {
             && context_lens[0] <= GLM52_DSPARK_BLOCK
             && std::env::var_os("DSPARK_NO_FORWARD_GRAPH").is_none();
         let use_graph = fwd_on && scratch.forward_warm.contains(&fwd_key);
-        if fwd_on && use_graph {
+        if use_graph {
             scratch
                 .forward_graphs
                 .entry(fwd_key)
@@ -819,14 +738,11 @@ impl Glm52DsparkModel {
             let mut prev = scratch.prev_tokens.slice_mut(..rows);
             ctx.stream.memcpy_htod(&anchor_tokens, &mut prev)?;
         }
-        // Graph the 7-step chain: every shape and pointer in the loop is
-        // static for a given `rows` (`step` is baked per node; the prev/next
-        // ping-pong alternates deterministically; the anchor htod above and
-        // the dtoh below stay outside), so after a one-round warm-up (cuBLAS
-        // lazily allocates its workspace on first touch, which would abort
-        // capture) the whole chain replays as ONE graph launch instead of
-        // ~21 kernel launches. DSPARK_NO_MARKOV_GRAPH=1 restores the plain
-        // loop for A/B.
+        // Graph the 7-step chain: everything in the loop is pointer- and
+        // shape-static per `rows` (`step` bakes per node; anchor h2d and the
+        // d2h stay outside), so after a one-round warm-up (cuBLAS lazy
+        // workspace) it replays as ONE launch instead of ~21.
+        // DSPARK_NO_MARKOV_GRAPH=1 restores the plain loop.
         let use_graph = std::env::var_os("DSPARK_NO_MARKOV_GRAPH").is_none();
         if use_graph && scratch.markov_warm[rows - 1] {
             let Glm52DsparkScratch {
@@ -872,11 +788,10 @@ impl Glm52DsparkModel {
                 .collect());
         }
         scratch.markov_warm[rows - 1] = true;
-        // Fixed-orientation ping-pong, NOT a field swap: a swap flips which
-        // buffer the `prev_tokens` field names, and a graph captured for one
-        // row count bakes the buffer addresses — an odd number of swaps on an
-        // eager round (7 steps) for a different row count would leave the
-        // anchor h2d above writing a buffer the captured graph never reads.
+        // Fixed-orientation ping-pong, NOT a field swap: captured graphs bake
+        // the buffer addresses, and an odd number of swaps on an eager round
+        // for another row count would desync the anchor h2d from every
+        // already-captured chain.
         for step in 1..block {
             let (prev, next): (&CudaSlice<u32>, &mut CudaSlice<u32>) = if step % 2 == 1 {
                 (&scratch.prev_tokens, &mut scratch.next_tokens)
@@ -946,102 +861,6 @@ pub(crate) fn accept_prefix_match(proposed: &[u32], target_tokens: &[u32]) -> Ve
     // `n <= proposed.len() < target_tokens.len()`, so this index is valid.
     committed.push(target_tokens[n]);
     committed
-}
-
-struct DsparkLayerKv {
-    k: HiddenStates,
-    v: HiddenStates,
-}
-
-/// Per-slot draft state: the draft KV over committed tokens, the pending
-/// captured-context rows not yet projected, and the per-round projected
-/// context (persists across the layer loop, so it lives here, not in the
-/// shared scratch). Everything is preallocated to `cache_len` at load — a
-/// mid-serving draft round must never hit the allocator (a transient OOM
-/// there would tear the whole engine down), and the launch-time VRAM probe
-/// already charged the full-cap footprint ([`glm52_dspark_arena_bytes`]).
-pub(crate) struct Glm52DsparkSlotState {
-    layers: Vec<DsparkLayerKv>,
-    /// Captured target hidden `[pending_len, 30720]` awaiting projection.
-    pending: HiddenStates,
-    pending_len: usize,
-    committed_len: usize,
-    context_projected: HiddenStates,
-    context_hidden: HiddenStates,
-    /// The drafter's KV capacity ([`Glm52DsparkModel::cache_len`]) — the
-    /// pending-context growth cap and the overflow guard bound.
-    cache_len: usize,
-}
-
-impl Glm52DsparkSlotState {
-    pub(crate) fn new(ctx: &DeviceContext, cache_len: usize) -> Result<Self> {
-        let mut layers = Vec::with_capacity(DSPARK_LAYERS);
-        for _ in 0..DSPARK_LAYERS {
-            layers.push(DsparkLayerKv {
-                k: HiddenStates::zeros(ctx, DSPARK_QKV_DIM, cache_len)?,
-                v: HiddenStates::zeros(ctx, DSPARK_QKV_DIM, cache_len)?,
-            });
-        }
-        let mut pending = HiddenStates::zeros(ctx, GLM52_DSPARK_CONTEXT_DIM, cache_len)?;
-        pending.seq_len = 0;
-        Ok(Self {
-            layers,
-            pending,
-            pending_len: 0,
-            committed_len: 0,
-            context_projected: HiddenStates::zeros(ctx, GLM52_HIDDEN, cache_len)?,
-            context_hidden: HiddenStates::zeros(ctx, GLM52_HIDDEN, cache_len)?,
-            cache_len,
-        })
-    }
-
-    /// Clear the slot for a new request. The KV/pending contents need no
-    /// scrubbing: `committed_len`/`pending_len` gate every read, and new
-    /// rows overwrite in place.
-    pub(crate) fn reset(&mut self) {
-        self.committed_len = 0;
-        self.pending_len = 0;
-        self.pending.seq_len = 0;
-    }
-
-    /// Append one step row's captured hidden (a `[30720]` row of the step
-    /// capture buffer) to the pending context. The buffer holds `cache_len`
-    /// rows from birth — allocation-free by construction.
-    pub(crate) fn append_captured_row(
-        &mut self,
-        ctx: &DeviceContext,
-        captured: &CudaSlice<half::bf16>,
-        row: usize,
-    ) -> Result<()> {
-        let required = self.pending_len + 1;
-        ensure!(
-            self.committed_len + required + GLM52_DSPARK_BLOCK <= self.cache_len,
-            "dspark pending context would exceed the draft cache: committed={}, pending={required}",
-            self.committed_len
-        );
-        let src =
-            captured.slice(row * GLM52_DSPARK_CONTEXT_DIM..(row + 1) * GLM52_DSPARK_CONTEXT_DIM);
-        let mut dst = self.pending.data.slice_mut(
-            self.pending_len * GLM52_DSPARK_CONTEXT_DIM..required * GLM52_DSPARK_CONTEXT_DIM,
-        );
-        ctx.stream.memcpy_dtod(&src, &mut dst)?;
-        self.pending_len = required;
-        self.pending.seq_len = required;
-        Ok(())
-    }
-
-    /// Point the projected-context pair at this round's rows. Preallocated to
-    /// `cache_len` — the bound is already enforced by the caller's overflow
-    /// guard, so exceeding it here is a bug, not a growth request.
-    fn set_context_len(&mut self, context_len: usize) -> Result<()> {
-        ensure!(
-            context_len <= self.context_projected.data.len() / GLM52_HIDDEN,
-            "dspark context length {context_len} exceeds the preallocated cap"
-        );
-        self.context_projected.seq_len = context_len;
-        self.context_hidden.seq_len = context_len;
-        Ok(())
-    }
 }
 
 /// Rank-level draft scratch, allocated once for the whole slot batch. Dense
@@ -1148,49 +967,15 @@ impl Glm52DsparkScratch {
         self.logits_normed.seq_len = block_rows;
         self.logits.seq_len = block_rows;
     }
-
-    /// Point the varlen tail buffers at this request's `context + block`
-    /// rows. Preallocated to the draft cache length — the caller's overflow
-    /// guard already bounds `tail_len`, so exceeding it is a bug.
-    fn set_tail_len(&mut self, tail_len: usize) -> Result<()> {
-        ensure!(
-            tail_len <= self.tail_input.data.len() / GLM52_HIDDEN,
-            "dspark tail length {tail_len} exceeds the preallocated cap"
-        );
-        self.tail_input.seq_len = tail_len;
-        self.k_tail.seq_len = tail_len;
-        self.v_tail.seq_len = tail_len;
-        Ok(())
-    }
 }
 
+#[path = "dspark_slot.rs"]
+mod slot;
+pub(crate) use slot::Glm52DsparkSlotState;
+
+/// Test-only constructors (`synthetic`, `randomize_for_test`) live in a
+/// child module file so this one stays under the module size budget; a child
+/// module keeps access to the private fields.
 #[cfg(test)]
-mod tests {
-    use super::accept_prefix_match;
-
-    #[test]
-    fn accepts_full_run_plus_bonus() {
-        assert_eq!(
-            accept_prefix_match(&[10, 11, 12], &[10, 11, 12, 13]),
-            vec![10, 11, 12, 13]
-        );
-    }
-
-    #[test]
-    fn accepts_prefix_then_correction() {
-        assert_eq!(
-            accept_prefix_match(&[10, 11, 99], &[10, 11, 22, 33]),
-            vec![10, 11, 22]
-        );
-    }
-
-    #[test]
-    fn rejects_first_draft_commits_the_correction() {
-        assert_eq!(accept_prefix_match(&[10, 11, 12], &[7, 8, 9, 10]), vec![7]);
-    }
-
-    #[test]
-    fn empty_proposal_commits_the_model_token() {
-        assert_eq!(accept_prefix_match(&[], &[42]), vec![42]);
-    }
-}
+#[path = "dspark_test_support.rs"]
+mod test_support;

--- a/openinfer-glm52/src/dspark_slot.rs
+++ b/openinfer-glm52/src/dspark_slot.rs
@@ -1,0 +1,106 @@
+//! Per-slot DSpark draft state: the slot's draft KV, its pending captured
+//! context rows, and the projected context pair. A child module of `dspark`
+//! (fields are `pub(super)`) split out for the module size budget.
+
+use anyhow::{Result, ensure};
+use cudarc::driver::CudaSlice;
+
+use openinfer_kernels::tensor::{DeviceContext, HiddenStates};
+
+use super::*;
+
+pub(super) struct DsparkLayerKv {
+    pub(super) k: HiddenStates,
+    pub(super) v: HiddenStates,
+}
+
+/// Per-slot draft state: the draft KV over committed tokens, the pending
+/// captured-context rows not yet projected, and the per-round projected
+/// context (persists across the layer loop, so it lives here, not in the
+/// shared scratch). Everything is preallocated to `cache_len` at load — a
+/// mid-serving draft round must never hit the allocator (a transient OOM
+/// there would tear the whole engine down), and the launch-time VRAM probe
+/// already charged the full-cap footprint ([`glm52_dspark_arena_bytes`]).
+pub(crate) struct Glm52DsparkSlotState {
+    pub(super) layers: Vec<DsparkLayerKv>,
+    /// Captured target hidden `[pending_len, 30720]` awaiting projection.
+    pub(super) pending: HiddenStates,
+    pub(super) pending_len: usize,
+    pub(super) committed_len: usize,
+    pub(super) context_projected: HiddenStates,
+    pub(super) context_hidden: HiddenStates,
+    /// The drafter's KV capacity ([`Glm52DsparkModel::cache_len`]) — the
+    /// pending-context growth cap and the overflow guard bound.
+    pub(super) cache_len: usize,
+}
+
+impl Glm52DsparkSlotState {
+    pub(crate) fn new(ctx: &DeviceContext, cache_len: usize) -> Result<Self> {
+        let mut layers = Vec::with_capacity(DSPARK_LAYERS);
+        for _ in 0..DSPARK_LAYERS {
+            layers.push(DsparkLayerKv {
+                k: HiddenStates::zeros(ctx, DSPARK_QKV_DIM, cache_len)?,
+                v: HiddenStates::zeros(ctx, DSPARK_QKV_DIM, cache_len)?,
+            });
+        }
+        let mut pending = HiddenStates::zeros(ctx, GLM52_DSPARK_CONTEXT_DIM, cache_len)?;
+        pending.seq_len = 0;
+        Ok(Self {
+            layers,
+            pending,
+            pending_len: 0,
+            committed_len: 0,
+            context_projected: HiddenStates::zeros(ctx, GLM52_HIDDEN, cache_len)?,
+            context_hidden: HiddenStates::zeros(ctx, GLM52_HIDDEN, cache_len)?,
+            cache_len,
+        })
+    }
+
+    /// Clear the slot for a new request. The KV/pending contents need no
+    /// scrubbing: `committed_len`/`pending_len` gate every read, and new
+    /// rows overwrite in place.
+    pub(crate) fn reset(&mut self) {
+        self.committed_len = 0;
+        self.pending_len = 0;
+        self.pending.seq_len = 0;
+    }
+
+    /// Append one step row's captured hidden (a `[30720]` row of the step
+    /// capture buffer) to the pending context. The buffer holds `cache_len`
+    /// rows from birth — allocation-free by construction.
+    pub(crate) fn append_captured_row(
+        &mut self,
+        ctx: &DeviceContext,
+        captured: &CudaSlice<half::bf16>,
+        row: usize,
+    ) -> Result<()> {
+        let required = self.pending_len + 1;
+        ensure!(
+            self.committed_len + required + GLM52_DSPARK_BLOCK <= self.cache_len,
+            "dspark pending context would exceed the draft cache: committed={}, pending={required}",
+            self.committed_len
+        );
+        let src =
+            captured.slice(row * GLM52_DSPARK_CONTEXT_DIM..(row + 1) * GLM52_DSPARK_CONTEXT_DIM);
+        let mut dst = self.pending.data.slice_mut(
+            self.pending_len * GLM52_DSPARK_CONTEXT_DIM..required * GLM52_DSPARK_CONTEXT_DIM,
+        );
+        ctx.stream.memcpy_dtod(&src, &mut dst)?;
+        self.pending_len = required;
+        self.pending.seq_len = required;
+        Ok(())
+    }
+
+    /// Point the projected-context pair at this round's rows. Preallocated to
+    /// `cache_len` — the bound is already enforced by the caller's overflow
+    /// guard, so exceeding it here is a bug, not a growth request.
+    pub(super) fn set_context_len(&mut self, context_len: usize) -> Result<()> {
+        ensure!(
+            context_len <= self.context_projected.data.len() / GLM52_HIDDEN,
+            "dspark context length {context_len} exceeds the preallocated cap"
+        );
+        self.context_projected.seq_len = context_len;
+        self.context_hidden.seq_len = context_len;
+        Ok(())
+    }
+}

--- a/openinfer-glm52/src/dspark_smoke.rs
+++ b/openinfer-glm52/src/dspark_smoke.rs
@@ -1,0 +1,99 @@
+//! DSpark draft perf smoke: measures `propose()` wall time (one draft round =
+//! 7 draft tokens) against the bandwidth-bound floor, on a single GPU.
+//!
+//! Uses the zero-weight synthetic model at the checkpoint's exact geometry —
+//! GPU kernel time is value-independent, so no checkpoint or 8-GPU box is
+//! needed. Requires ~11 GB free VRAM (weights 3.9 GB + embed/lm_head 3.8 GB +
+//! bs=8 slot states 2.8 GB).
+//!
+//! Run (single GPU):
+//! ```text
+//! cargo test --release -p openinfer-glm52 --features glm52 --lib \
+//!   dspark_propose_smoke -- --nocapture --ignored
+//! ```
+
+use std::time::Instant;
+
+use anyhow::Result;
+use half::bf16;
+
+use openinfer_kernels::tensor::{DeviceContext, DeviceMatrix};
+
+use crate::config::{GLM52_HIDDEN, GLM52_VOCAB};
+use crate::dspark::{dspark_cache_len, 
+    GLM52_DSPARK_CONTEXT_DIM, GLM52_DSPARK_DRAFTS, Glm52DsparkModel, Glm52DsparkScratch,
+    Glm52DsparkSlotState,
+};
+
+const WARMUP: usize = 5;
+const ITERS: usize = 50;
+
+/// One propose round per iteration, one captured context row per round —
+/// the bs=1 steady-state shape (accept length only changes the cheap fc
+/// input rows). Returns per-round times.
+fn bench_propose(
+    ctx: &DeviceContext,
+    model: &Glm52DsparkModel,
+    embed: &DeviceMatrix,
+    lm_head: &DeviceMatrix,
+    scratch: &mut Glm52DsparkScratch,
+    batch: usize,
+) -> Result<Vec<f64>> {
+    let mut states = (0..batch)
+        .map(|_| Glm52DsparkSlotState::new(ctx, model.cache_len()))
+        .collect::<Result<Vec<_>>>()?;
+    let captured: cudarc::driver::CudaSlice<bf16> =
+        ctx.stream.alloc_zeros(GLM52_DSPARK_CONTEXT_DIM)?;
+
+    let mut times_ms = Vec::with_capacity(ITERS);
+    for round in 0..WARMUP + ITERS {
+        for state in states.iter_mut() {
+            state.append_captured_row(ctx, &captured, 0)?;
+        }
+        // Each round drains 1 pending row into committed, so the anchor sits
+        // at `round + 1`.
+        let anchors = vec![(7u32, round + 1); batch];
+        ctx.sync()?;
+        let started = Instant::now();
+        let mut state_refs: Vec<&mut Glm52DsparkSlotState> = states.iter_mut().collect();
+        let drafts = model.propose(ctx, embed, lm_head, &mut state_refs, &anchors, scratch)?;
+        ctx.sync()?;
+        let elapsed = started.elapsed().as_secs_f64() * 1e3;
+        assert_eq!(drafts.len(), batch);
+        assert!(drafts.iter().all(|d| d.len() == GLM52_DSPARK_DRAFTS));
+        if round >= WARMUP {
+            times_ms.push(elapsed);
+        }
+    }
+    Ok(times_ms)
+}
+
+#[test]
+#[ignore = "GPU perf smoke — needs a CUDA device with ~11 GB free VRAM"]
+fn dspark_propose_smoke() -> Result<()> {
+    let ctx = DeviceContext::new()?;
+    let cache_len = dspark_cache_len(4096);
+    let model = Glm52DsparkModel::synthetic(&ctx, cache_len)?;
+    let zero_head = || -> Result<DeviceMatrix> {
+        Ok(DeviceMatrix {
+            data: ctx.stream.alloc_zeros(GLM52_VOCAB * GLM52_HIDDEN)?,
+            rows: GLM52_VOCAB,
+            cols: GLM52_HIDDEN,
+        })
+    };
+    let embed = zero_head()?;
+    let lm_head = zero_head()?;
+    let mut scratch = Glm52DsparkScratch::new(&ctx, cache_len)?;
+
+    for batch in [1usize, 8] {
+        let mut times = bench_propose(&ctx, &model, &embed, &lm_head, &mut scratch, batch)?;
+        times.sort_by(f64::total_cmp);
+        let avg = times.iter().sum::<f64>() / times.len() as f64;
+        let (min, p50, max) = (times[0], times[times.len() / 2], times[times.len() - 1]);
+        println!(
+            "dspark propose bs={batch}: avg {avg:.3} ms, min {min:.3} ms, p50 {p50:.3} ms, \
+             max {max:.3} ms ({ITERS} rounds, 7 drafts/round)"
+        );
+    }
+    Ok(())
+}

--- a/openinfer-glm52/src/dspark_smoke.rs
+++ b/openinfer-glm52/src/dspark_smoke.rs
@@ -3,16 +3,23 @@
 //!
 //! Uses the zero-weight synthetic model at the checkpoint's exact geometry —
 //! GPU kernel time is value-independent, so no checkpoint or 8-GPU box is
-//! needed. Requires ~11 GB free VRAM (weights 3.9 GB + embed/lm_head 3.8 GB +
-//! bs=8 slot states 2.8 GB).
+//! needed. Requires ~14 GiB free VRAM at peak (weights 3.9 GiB + embed/
+//! lm_head 3.8 GiB + bs=8 slot states ~5.5 GiB + scratch; see
+//! `glm52_dspark_arena_bytes`).
 //!
 //! Run (single GPU):
 //! ```text
-//! cargo test --release -p openinfer-glm52 --features glm52 --lib \
+//! cargo test --release -p openinfer-glm52 --lib \
 //!   dspark_propose_smoke -- --nocapture --ignored
 //! ```
 
+use std::sync::Mutex;
 use std::time::Instant;
+
+/// Serializes the env-mutating tests (the graph kill-switches are process
+/// globals) — `--test-threads=1` is recommended for GPU tests but this makes
+/// the requirement local instead of assumed.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 use anyhow::Result;
 use half::bf16;
@@ -98,15 +105,39 @@ fn dspark_propose_smoke() -> Result<()> {
     Ok(())
 }
 
-/// Graph-vs-eager parity: with non-degenerate pseudo-random weights, the
-/// graphed propose (piecewise forward segments + the captured Markov chain)
-/// must emit exactly the tokens the plain eager path emits, round for round —
-/// the graphs replay the same kernels at the same shapes, so any divergence is
-/// a capture bug, not numerics.
+/// Graph-vs-eager parity under the schedules serving actually produces:
+/// mixed accept lengths (1..=8 pending rows per round — each `context_len` is
+/// its own graph key, and the tail bounds must be re-set every round, not
+/// baked at capture) and mixed row counts (a bs=2 round between bs=1 rounds —
+/// bs>1 must not disturb the captured bs=1 graphs or the Markov buffer
+/// orientation). The graphed run must emit exactly the eager run's tokens.
 #[test]
-#[ignore = "GPU parity test — needs a CUDA device with ~11 GB free VRAM"]
+#[ignore = "GPU parity test — needs a CUDA device with ~14 GiB free VRAM"]
 fn dspark_propose_graph_parity() -> Result<()> {
-    const ROUNDS: usize = 12;
+    // Per-round (mode, len_a, len_b); mode 0 = slot A only, 1 = slot B only,
+    // 2 = both (bs=2). Deliberate teeth: (A, len 8) warms at r3, captures at
+    // r5, and REPLAYS at r7 right after a round whose tails were shorter —
+    // pre-fix, the replay would consume the stale (smaller) tail seq_len and
+    // trip the copy range check. The bs=2 rounds between bs=1 rounds pin the
+    // Markov buffer orientation across row counts.
+    const ROUNDS: usize = 14;
+    const SCHEDULE: [(u8, usize, usize); ROUNDS] = [
+        (0, 1, 0), // A warm (A,1)
+        (1, 0, 3), // B warm (B,3)
+        (2, 2, 4), // both, eager
+        (0, 8, 0), // A warm (A,8)
+        (1, 0, 5), // B warm (B,5)
+        (0, 8, 0), // A capture (A,8)
+        (1, 0, 3), // B capture (B,3) — leaves short tails
+        (0, 8, 0), // A REPLAY (A,8): stale-short seq_len fires pre-fix
+        (2, 1, 1), // both, eager
+        (0, 1, 0), // A capture (A,1)
+        (1, 0, 5), // B capture (B,5)
+        (0, 8, 0), // A replay (A,8) again
+        (1, 0, 3), // B replay (B,3)
+        (0, 1, 0), // A replay (A,1)
+    ];
+    let _env = ENV_LOCK.lock().unwrap();
     let ctx = DeviceContext::new()?;
     let cache_len = dspark_cache_len(4096);
     let mut model = Glm52DsparkModel::synthetic(&ctx, cache_len)?;
@@ -134,8 +165,8 @@ fn dspark_propose_graph_parity() -> Result<()> {
         ctx.stream.clone_htod(&host)?
     };
 
-    let mut run = |graphs: bool| -> Result<Vec<[u32; GLM52_DSPARK_DRAFTS]>> {
-        // SAFETY: the test binary runs GPU tests with --test-threads=1.
+    let run = |graphs: bool| -> Result<Vec<Vec<[u32; GLM52_DSPARK_DRAFTS]>>> {
+        // SAFETY: ENV_LOCK serializes the env-mutating tests in this file.
         unsafe {
             if graphs {
                 std::env::remove_var("DSPARK_NO_FORWARD_GRAPH");
@@ -146,24 +177,44 @@ fn dspark_propose_graph_parity() -> Result<()> {
             }
         }
         let mut scratch = Glm52DsparkScratch::new(&ctx, cache_len)?;
-        // Two slots proposing on alternating rounds, both at active == 1 — the
-        // slot-rotation case the graph key must survive: a captured segment
-        // bakes the slot's pending/context buffer pointers, so a graph
-        // captured for slot A must never replay for slot B.
         let mut slot_a = Glm52DsparkSlotState::new(&ctx, cache_len)?;
         let mut slot_b = Glm52DsparkSlotState::new(&ctx, cache_len)?;
-        let mut turns = [0usize; 2];
+        let mut pos = [0usize; 2];
         let mut all = Vec::with_capacity(ROUNDS);
-        for round in 0..ROUNDS {
-            let which = round % 2;
-            let state = if which == 0 { &mut slot_a } else { &mut slot_b };
-            state.append_captured_row(&ctx, &captured, 0)?;
-            turns[which] += 1;
-            let anchors = vec![(7 + round as u32, turns[which])];
-            let mut refs = vec![&mut *state];
-            let drafts =
-                model.propose(&ctx, &embed, &lm_head, &mut refs, &anchors, &mut scratch)?;
-            all.push(drafts[0]);
+        for (round, &(mode, len_a, len_b)) in SCHEDULE.iter().enumerate() {
+            let mut round_drafts = Vec::new();
+            if mode == 2 {
+                for _ in 0..len_a {
+                    slot_a.append_captured_row(&ctx, &captured, 0)?;
+                }
+                for _ in 0..len_b {
+                    slot_b.append_captured_row(&ctx, &captured, 0)?;
+                }
+                pos[0] += len_a;
+                pos[1] += len_b;
+                let anchors = vec![(7 + round as u32, pos[0]), (91 + round as u32, pos[1])];
+                let mut refs = vec![&mut slot_a, &mut slot_b];
+                let drafts =
+                    model.propose(&ctx, &embed, &lm_head, &mut refs, &anchors, &mut scratch)?;
+                round_drafts.extend(drafts);
+            } else {
+                let which = mode as usize;
+                let (state, len, anchor_base) = if which == 0 {
+                    (&mut slot_a, len_a, 7u32)
+                } else {
+                    (&mut slot_b, len_b, 91u32)
+                };
+                for _ in 0..len {
+                    state.append_captured_row(&ctx, &captured, 0)?;
+                }
+                pos[which] += len;
+                let anchors = vec![(anchor_base + round as u32, pos[which])];
+                let mut refs = vec![&mut *state];
+                let drafts =
+                    model.propose(&ctx, &embed, &lm_head, &mut refs, &anchors, &mut scratch)?;
+                round_drafts.extend(drafts);
+            }
+            all.push(round_drafts);
         }
         unsafe {
             std::env::remove_var("DSPARK_NO_FORWARD_GRAPH");
@@ -178,9 +229,8 @@ fn dspark_propose_graph_parity() -> Result<()> {
         graphed, eager,
         "graphed propose diverged from the eager path"
     );
-    // Non-degenerate sanity: the random weights must not all-tie to token 0.
     assert!(
-        graphed.iter().flatten().any(|&t| t != 0),
+        graphed.iter().flatten().flatten().any(|&t| t != 0),
         "parity ran on degenerate logits (all drafts are token 0)"
     );
     Ok(())
@@ -198,6 +248,7 @@ fn dspark_propose_graph_parity() -> Result<()> {
 #[ignore = "GPU isolation test — needs a CUDA device with ~11 GB free VRAM"]
 fn dspark_propose_batched_slot_isolation() -> Result<()> {
     const ROUNDS: usize = 6;
+    let _env = ENV_LOCK.lock().unwrap();
     let ctx = DeviceContext::new()?;
     let cache_len = dspark_cache_len(4096);
     let mut model = Glm52DsparkModel::synthetic(&ctx, cache_len)?;
@@ -226,7 +277,7 @@ fn dspark_propose_batched_slot_isolation() -> Result<()> {
     };
     let cap_a = captured_row(3)?;
 
-    let mut run = |cap_b_salt: u32,
+    let run = |cap_b_salt: u32,
                    anchor_b_base: u32|
      -> Result<(
         Vec<[u32; GLM52_DSPARK_DRAFTS]>,

--- a/openinfer-glm52/src/dspark_smoke.rs
+++ b/openinfer-glm52/src/dspark_smoke.rs
@@ -146,12 +146,21 @@ fn dspark_propose_graph_parity() -> Result<()> {
             }
         }
         let mut scratch = Glm52DsparkScratch::new(&ctx, cache_len)?;
-        let mut state = Glm52DsparkSlotState::new(&ctx, cache_len)?;
+        // Two slots proposing on alternating rounds, both at active == 1 — the
+        // slot-rotation case the graph key must survive: a captured segment
+        // bakes the slot's pending/context buffer pointers, so a graph
+        // captured for slot A must never replay for slot B.
+        let mut slot_a = Glm52DsparkSlotState::new(&ctx, cache_len)?;
+        let mut slot_b = Glm52DsparkSlotState::new(&ctx, cache_len)?;
+        let mut turns = [0usize; 2];
         let mut all = Vec::with_capacity(ROUNDS);
         for round in 0..ROUNDS {
+            let which = round % 2;
+            let state = if which == 0 { &mut slot_a } else { &mut slot_b };
             state.append_captured_row(&ctx, &captured, 0)?;
-            let anchors = vec![(7 + round as u32, round + 1)];
-            let mut refs = vec![&mut state];
+            turns[which] += 1;
+            let anchors = vec![(7 + round as u32, turns[which])];
+            let mut refs = vec![&mut *state];
             let drafts =
                 model.propose(&ctx, &embed, &lm_head, &mut refs, &anchors, &mut scratch)?;
             all.push(drafts[0]);

--- a/openinfer-glm52/src/dspark_smoke.rs
+++ b/openinfer-glm52/src/dspark_smoke.rs
@@ -20,9 +20,9 @@ use half::bf16;
 use openinfer_kernels::tensor::{DeviceContext, DeviceMatrix};
 
 use crate::config::{GLM52_HIDDEN, GLM52_VOCAB};
-use crate::dspark::{dspark_cache_len, 
+use crate::dspark::{
     GLM52_DSPARK_CONTEXT_DIM, GLM52_DSPARK_DRAFTS, Glm52DsparkModel, Glm52DsparkScratch,
-    Glm52DsparkSlotState,
+    Glm52DsparkSlotState, dspark_cache_len,
 };
 
 const WARMUP: usize = 5;
@@ -95,5 +95,84 @@ fn dspark_propose_smoke() -> Result<()> {
              max {max:.3} ms ({ITERS} rounds, 7 drafts/round)"
         );
     }
+    Ok(())
+}
+
+/// Graph-vs-eager parity: with non-degenerate pseudo-random weights, the
+/// graphed propose (piecewise forward segments + the captured Markov chain)
+/// must emit exactly the tokens the plain eager path emits, round for round —
+/// the graphs replay the same kernels at the same shapes, so any divergence is
+/// a capture bug, not numerics.
+#[test]
+#[ignore = "GPU parity test — needs a CUDA device with ~11 GB free VRAM"]
+fn dspark_propose_graph_parity() -> Result<()> {
+    const ROUNDS: usize = 12;
+    let ctx = DeviceContext::new()?;
+    let cache_len = dspark_cache_len(4096);
+    let mut model = Glm52DsparkModel::synthetic(&ctx, cache_len)?;
+    model.randomize_for_test(&ctx)?;
+    let rand_head = |seed: u32| -> Result<DeviceMatrix> {
+        let mut state = seed | 1;
+        let host: Vec<half::bf16> = (0..GLM52_VOCAB * GLM52_HIDDEN)
+            .map(|_| {
+                state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                half::bf16::from_f32(((state >> 8) as f32 / (1u32 << 24) as f32 - 0.5) * 0.02)
+            })
+            .collect();
+        Ok(DeviceMatrix {
+            data: ctx.stream.clone_htod(&host)?,
+            rows: GLM52_VOCAB,
+            cols: GLM52_HIDDEN,
+        })
+    };
+    let embed = rand_head(11)?;
+    let lm_head = rand_head(23)?;
+    let captured: cudarc::driver::CudaSlice<half::bf16> = {
+        let host: Vec<half::bf16> = (0..GLM52_DSPARK_CONTEXT_DIM)
+            .map(|i| half::bf16::from_f32(((i % 97) as f32 - 48.0) * 0.001))
+            .collect();
+        ctx.stream.clone_htod(&host)?
+    };
+
+    let mut run = |graphs: bool| -> Result<Vec<[u32; GLM52_DSPARK_DRAFTS]>> {
+        // SAFETY: the test binary runs GPU tests with --test-threads=1.
+        unsafe {
+            if graphs {
+                std::env::remove_var("DSPARK_NO_FORWARD_GRAPH");
+                std::env::remove_var("DSPARK_NO_MARKOV_GRAPH");
+            } else {
+                std::env::set_var("DSPARK_NO_FORWARD_GRAPH", "1");
+                std::env::set_var("DSPARK_NO_MARKOV_GRAPH", "1");
+            }
+        }
+        let mut scratch = Glm52DsparkScratch::new(&ctx, cache_len)?;
+        let mut state = Glm52DsparkSlotState::new(&ctx, cache_len)?;
+        let mut all = Vec::with_capacity(ROUNDS);
+        for round in 0..ROUNDS {
+            state.append_captured_row(&ctx, &captured, 0)?;
+            let anchors = vec![(7 + round as u32, round + 1)];
+            let mut refs = vec![&mut state];
+            let drafts =
+                model.propose(&ctx, &embed, &lm_head, &mut refs, &anchors, &mut scratch)?;
+            all.push(drafts[0]);
+        }
+        unsafe {
+            std::env::remove_var("DSPARK_NO_FORWARD_GRAPH");
+            std::env::remove_var("DSPARK_NO_MARKOV_GRAPH");
+        }
+        Ok(all)
+    };
+
+    let graphed = run(true)?;
+    let eager = run(false)?;
+    assert_eq!(
+        graphed, eager,
+        "graphed propose diverged from the eager path"
+    );
+    // Non-degenerate sanity: the random weights must not all-tie to token 0.
+    assert!(
+        graphed.iter().flatten().any(|&t| t != 0),
+        "parity ran on degenerate logits (all drafts are token 0)"
+    );
     Ok(())
 }

--- a/openinfer-glm52/src/dspark_smoke.rs
+++ b/openinfer-glm52/src/dspark_smoke.rs
@@ -278,7 +278,7 @@ fn dspark_propose_batched_slot_isolation() -> Result<()> {
     let cap_a = captured_row(3)?;
 
     let run = |cap_b_salt: u32,
-                   anchor_b_base: u32|
+               anchor_b_base: u32|
      -> Result<(
         Vec<[u32; GLM52_DSPARK_DRAFTS]>,
         Vec<[u32; GLM52_DSPARK_DRAFTS]>,

--- a/openinfer-glm52/src/dspark_smoke.rs
+++ b/openinfer-glm52/src/dspark_smoke.rs
@@ -185,3 +185,88 @@ fn dspark_propose_graph_parity() -> Result<()> {
     );
     Ok(())
 }
+
+/// Slot isolation under batching: with the shared tail scratch, each slot's
+/// tail prep must be consumed before the next slot's prep overwrites it — a
+/// prep-all-then-consume-all reorder makes earlier slots attend with the last
+/// slot's K/V. Exact bs-vs-single equality is NOT promisable (cuBLAS picks
+/// different algorithms per M, so bs=2 and bs=1 can legitimately differ in
+/// the last ulp), but slot ISOLATION is exact: run the same slot-A inputs in
+/// two bs=2 calls that differ only in slot B's content — the batch shape is
+/// identical, so slot A's math is bit-identical unless B's data leaks in.
+#[test]
+#[ignore = "GPU isolation test — needs a CUDA device with ~11 GB free VRAM"]
+fn dspark_propose_batched_slot_isolation() -> Result<()> {
+    const ROUNDS: usize = 6;
+    let ctx = DeviceContext::new()?;
+    let cache_len = dspark_cache_len(4096);
+    let mut model = Glm52DsparkModel::synthetic(&ctx, cache_len)?;
+    model.randomize_for_test(&ctx)?;
+    let rand_head = |seed: u32| -> Result<DeviceMatrix> {
+        let mut state = seed | 1;
+        let host: Vec<half::bf16> = (0..GLM52_VOCAB * GLM52_HIDDEN)
+            .map(|_| {
+                state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                half::bf16::from_f32(((state >> 8) as f32 / (1u32 << 24) as f32 - 0.5) * 0.02)
+            })
+            .collect();
+        Ok(DeviceMatrix {
+            data: ctx.stream.clone_htod(&host)?,
+            rows: GLM52_VOCAB,
+            cols: GLM52_HIDDEN,
+        })
+    };
+    let embed = rand_head(11)?;
+    let lm_head = rand_head(23)?;
+    let captured_row = |salt: u32| -> Result<cudarc::driver::CudaSlice<half::bf16>> {
+        let host: Vec<half::bf16> = (0..GLM52_DSPARK_CONTEXT_DIM)
+            .map(|i| half::bf16::from_f32((((i as u32 + salt) % 97) as f32 - 48.0) * 0.001))
+            .collect();
+        Ok(ctx.stream.clone_htod(&host)?)
+    };
+    let cap_a = captured_row(3)?;
+
+    let mut run = |cap_b_salt: u32,
+                   anchor_b_base: u32|
+     -> Result<(
+        Vec<[u32; GLM52_DSPARK_DRAFTS]>,
+        Vec<[u32; GLM52_DSPARK_DRAFTS]>,
+    )> {
+        let cap_b = captured_row(cap_b_salt)?;
+        let mut scratch = Glm52DsparkScratch::new(&ctx, cache_len)?;
+        let mut a = Glm52DsparkSlotState::new(&ctx, cache_len)?;
+        let mut b = Glm52DsparkSlotState::new(&ctx, cache_len)?;
+        let mut drafts_a = Vec::new();
+        let mut drafts_b = Vec::new();
+        for round in 0..ROUNDS {
+            a.append_captured_row(&ctx, &cap_a, 0)?;
+            b.append_captured_row(&ctx, &cap_b, 0)?;
+            let anchors = vec![
+                (11 + round as u32 * 7, round + 1),
+                (anchor_b_base + round as u32 * 5, round + 1),
+            ];
+            let mut refs = vec![&mut a, &mut b];
+            let drafts =
+                model.propose(&ctx, &embed, &lm_head, &mut refs, &anchors, &mut scratch)?;
+            drafts_a.push(drafts[0]);
+            drafts_b.push(drafts[1]);
+        }
+        Ok((drafts_a, drafts_b))
+    };
+
+    let (a1, b1) = run(41, 900)?;
+    let (a2, b2) = run(67, 5000)?;
+    assert_eq!(
+        a1, a2,
+        "slot A's drafts changed when only slot B's content did"
+    );
+    assert_ne!(
+        b1, b2,
+        "slot B's inputs changed but its drafts did not (degenerate)"
+    );
+    assert!(
+        a1.iter().flatten().any(|&t| t != 0),
+        "isolation ran on degenerate logits"
+    );
+    Ok(())
+}

--- a/openinfer-glm52/src/dspark_test_support.rs
+++ b/openinfer-glm52/src/dspark_test_support.rs
@@ -1,0 +1,131 @@
+//! Test-only `Glm52DsparkModel` constructors: the zero-weight synthetic model
+//! (perf smokes) and deterministic pseudo-random weights (parity/isolation
+//! gates). A child module of `dspark` so the private fields stay private.
+
+use anyhow::Result;
+use cudarc::driver::CudaSlice;
+
+use openinfer_core::weight_loader::precompute_rope;
+use openinfer_kernels::tensor::{DeviceContext, DeviceMatrix, DeviceVec};
+
+use super::*;
+
+impl Glm52DsparkModel {
+    /// Zero-weight model at the checkpoint's exact geometry, for perf smoke
+    /// tests without the checkpoint — GPU kernel time is value-independent.
+    #[cfg(test)]
+    pub(crate) fn synthetic(ctx: &DeviceContext, cache_len: usize) -> Result<Self> {
+        let mat = |rows: usize, cols: usize| -> Result<DeviceMatrix> {
+            Ok(DeviceMatrix {
+                data: ctx.stream.alloc_zeros(rows * cols)?,
+                rows,
+                cols,
+            })
+        };
+        let mut layers = Vec::with_capacity(DSPARK_LAYERS);
+        for _ in 0..DSPARK_LAYERS {
+            layers.push(DsparkLayer {
+                input_ln: DeviceVec::zeros(ctx, GLM52_HIDDEN)?,
+                qkv: mat(3 * DSPARK_QKV_DIM, GLM52_HIDDEN)?,
+                o_proj: mat(GLM52_HIDDEN, DSPARK_QKV_DIM)?,
+                q_norm: DeviceVec::zeros(ctx, DSPARK_HEAD_DIM)?,
+                k_norm: DeviceVec::zeros(ctx, DSPARK_HEAD_DIM)?,
+                post_ln: DeviceVec::zeros(ctx, GLM52_HIDDEN)?,
+                gate_up: mat(2 * DSPARK_INTER, GLM52_HIDDEN)?,
+                down: mat(GLM52_HIDDEN, DSPARK_INTER)?,
+            });
+        }
+        let (cos_cache, sin_cache) =
+            precompute_rope(ctx, DSPARK_HEAD_DIM, cache_len, DSPARK_ROPE_THETA)?;
+        Ok(Self {
+            layers,
+            norm: DeviceVec::zeros(ctx, GLM52_HIDDEN)?,
+            hidden_norm: DeviceVec::zeros(ctx, GLM52_HIDDEN)?,
+            fc: mat(GLM52_HIDDEN, GLM52_DSPARK_CONTEXT_DIM)?,
+            markov_w1: mat(GLM52_VOCAB, DSPARK_MARKOV_RANK)?,
+            markov_w2: mat(GLM52_VOCAB, DSPARK_MARKOV_RANK)?,
+            cos_cache,
+            sin_cache,
+            cache_len,
+        })
+    }
+
+    /// Deterministic pseudo-random weights over the synthetic model, for
+    /// graph-vs-eager parity tests: kernel *timing* is value-independent, but
+    /// draft-token parity needs non-degenerate logits (all-zero weights make
+    /// every argmax a trivial index-0 tie).
+    #[cfg(test)]
+    pub(crate) fn randomize_for_test(&mut self, ctx: &DeviceContext) -> Result<()> {
+        fn fill(
+            ctx: &DeviceContext,
+            buf: &mut CudaSlice<half::bf16>,
+            seed: u32,
+            scale: f32,
+            offset: f32,
+        ) -> Result<()> {
+            let mut state = seed | 1;
+            let host: Vec<half::bf16> = (0..buf.len())
+                .map(|_| {
+                    state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                    half::bf16::from_f32(
+                        ((state >> 8) as f32 / (1u32 << 24) as f32 - 0.5) * scale + offset,
+                    )
+                })
+                .collect();
+            ctx.stream.memcpy_htod(&host, buf)?;
+            Ok(())
+        }
+        let mut seed = 0x5eed_u32;
+        let mut next = || {
+            seed = seed.wrapping_add(0x9e37_79b9);
+            seed
+        };
+        for layer in &mut self.layers {
+            fill(ctx, &mut layer.qkv.data, next(), 0.02, 0.0)?;
+            fill(ctx, &mut layer.o_proj.data, next(), 0.02, 0.0)?;
+            fill(ctx, &mut layer.gate_up.data, next(), 0.02, 0.0)?;
+            fill(ctx, &mut layer.down.data, next(), 0.02, 0.0)?;
+            fill(ctx, &mut layer.input_ln.data, next(), 0.1, 1.0)?;
+            fill(ctx, &mut layer.post_ln.data, next(), 0.1, 1.0)?;
+            fill(ctx, &mut layer.q_norm.data, next(), 0.1, 1.0)?;
+            fill(ctx, &mut layer.k_norm.data, next(), 0.1, 1.0)?;
+        }
+        fill(ctx, &mut self.norm.data, next(), 0.1, 1.0)?;
+        fill(ctx, &mut self.hidden_norm.data, next(), 0.1, 1.0)?;
+        fill(ctx, &mut self.fc.data, next(), 0.02, 0.0)?;
+        fill(ctx, &mut self.markov_w1.data, next(), 0.5, 0.0)?;
+        fill(ctx, &mut self.markov_w2.data, next(), 0.5, 0.0)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::accept_prefix_match;
+
+    #[test]
+    fn accepts_full_run_plus_bonus() {
+        assert_eq!(
+            accept_prefix_match(&[10, 11, 12], &[10, 11, 12, 13]),
+            vec![10, 11, 12, 13]
+        );
+    }
+
+    #[test]
+    fn accepts_prefix_then_correction() {
+        assert_eq!(
+            accept_prefix_match(&[10, 11, 99], &[10, 11, 22, 33]),
+            vec![10, 11, 22]
+        );
+    }
+
+    #[test]
+    fn rejects_first_draft_commits_the_correction() {
+        assert_eq!(accept_prefix_match(&[10, 11, 12], &[7, 8, 9, 10]), vec![7]);
+    }
+
+    #[test]
+    fn empty_proposal_commits_the_model_token() {
+        assert_eq!(accept_prefix_match(&[], &[42]), vec![42]);
+    }
+}

--- a/openinfer-glm52/src/lib.rs
+++ b/openinfer-glm52/src/lib.rs
@@ -11,6 +11,8 @@ mod bookend;
 mod config;
 mod dense;
 mod dspark;
+#[cfg(test)]
+mod dspark_smoke;
 mod fp8;
 mod indexer;
 #[cfg(test)]

--- a/openinfer-kernels/csrc/shared/argmax.cu
+++ b/openinfer-kernels/csrc/shared/argmax.cu
@@ -4,6 +4,12 @@
 
 #define SAMPLE_BLOCK 256
 #define ARGMAX_BATCH_TILE_ELEMS 4096
+// The Markov-step argmax reads only ~0.6 MB (one logits row + one bias row) —
+// at 4096-elem tiles its ~38 blocks leave the kernel latency-bound (~10 us for
+// a ~0.2 us read on H100). 1024-elem tiles give ~152 blocks and put it back on
+// the bandwidth curve (measured 9.7 -> 4.5 us). Markov-only: the batched
+// argmax reads a full row per block and keeps the wider tile.
+#define MARKOV_STEP_TILE_ELEMS 1024
 
 __device__ __forceinline__ bool argmax_better(float lhs_val, int lhs_idx,
                                               float rhs_val, int rhs_idx) {
@@ -257,8 +263,8 @@ __global__ void markov_step_partial_kernel(
   int row = blockIdx.y;
   if (row >= rows || tile >= tiles_per_row) return;
 
-  int start = tile * ARGMAX_BATCH_TILE_ELEMS;
-  int end = start + ARGMAX_BATCH_TILE_ELEMS;
+  int start = tile * MARKOV_STEP_TILE_ELEMS;
+  int end = start + MARKOV_STEP_TILE_ELEMS;
   if (end > n) end = n;
   const __nv_bfloat16* base_row =
       base + static_cast<size_t>(row * block_size + step) * n;
@@ -396,7 +402,7 @@ void markov_step_argmax_cuda(const __nv_bfloat16* base,
                              int* partial_indices, unsigned int* out_tokens,
                              unsigned int* sampled_tokens,
                              cudaStream_t stream) {
-  int tiles_per_row = (n + ARGMAX_BATCH_TILE_ELEMS - 1) / ARGMAX_BATCH_TILE_ELEMS;
+  int tiles_per_row = (n + MARKOV_STEP_TILE_ELEMS - 1) / MARKOV_STEP_TILE_ELEMS;
   size_t smem = SAMPLE_BLOCK * (sizeof(float) + sizeof(int));
   markov_step_partial_kernel<<<dim3(tiles_per_row, rows), SAMPLE_BLOCK, smem, stream>>>(
       base, bias, block_size, step, partial_values, partial_indices, rows, n,

--- a/openinfer-kernels/src/ops.rs
+++ b/openinfer-kernels/src/ops.rs
@@ -69,7 +69,7 @@ pub use sampling::{
     BatchSamplingRow, BatchSamplingScratch, argmax, argmax_batch_bf16_into,
     argmax_batch_bf16_split_indexed_into, argmax_batch_bf16_split_partials_len, argmax_bf16_into,
     argmax_bf16_split_into, flashinfer_top1_batch_into, flashinfer_top1_row_states_bytes,
-    gpu_sample_batch_into, markov_step_argmax_into,
+    gpu_sample_batch_into, markov_step_argmax_into, markov_step_argmax_partials_len,
 };
 
 /// Calling thread's last FFI exception message, ready to append to an error;

--- a/openinfer-kernels/src/ops/sampling.rs
+++ b/openinfer-kernels/src/ops/sampling.rs
@@ -404,6 +404,15 @@ pub fn argmax_batch_bf16_split_partials_len(rows: usize, vocab: usize) -> usize 
     rows * vocab.div_ceil(TILE_ELEMS)
 }
 
+/// Partial-buffer length for the Markov-step argmax, whose tiles are 1024
+/// elements: its read is one logits row + one bias row, so it needs 4x the
+/// blocks of the full-row batched argmax to not be latency-bound (see
+/// `MARKOV_STEP_TILE_ELEMS` in `argmax.cu`).
+pub fn markov_step_argmax_partials_len(rows: usize, vocab: usize) -> usize {
+    const TILE_ELEMS: usize = 1024;
+    rows * vocab.div_ceil(TILE_ELEMS)
+}
+
 /// Row-wise two-stage bf16 argmax over `rows` rows of `n`: tile-parallel
 /// partials then one finalize block per row. Same per-row total order as
 /// [`argmax_bf16_into`] (lowest GLOBAL index wins ties, NaN never wins) — the
@@ -589,7 +598,7 @@ pub fn markov_step_argmax_into(
             rows * block_size
         ));
     }
-    let needed = argmax_batch_bf16_split_partials_len(rows, vocab);
+    let needed = markov_step_argmax_partials_len(rows, vocab);
     if partial_values.len() < needed || partial_indices.len() < needed {
         return Err(anyhow!(
             "markov step partials too small: {}/{} need {}",

--- a/openinfer-qwen3/src/dspark.rs
+++ b/openinfer-qwen3/src/dspark.rs
@@ -27,7 +27,7 @@ use cudarc::driver::CudaSlice;
 use crate::config::DFlashConfig;
 use openinfer_core::ops;
 use openinfer_core::tensor::{DeviceContext, DeviceMatrix, HiddenStates};
-use openinfer_kernels::ops::{argmax_batch_bf16_split_partials_len, markov_step_argmax_into};
+use openinfer_kernels::ops::{markov_step_argmax_into, markov_step_argmax_partials_len};
 
 pub(crate) const MARKOV_W1_TENSOR: &str = "markov_head.markov_w1.weight";
 pub(crate) const MARKOV_W2_TENSOR: &str = "markov_head.markov_w2.weight";
@@ -177,7 +177,7 @@ impl MarkovScratch {
         );
         let vocab = config.vocab_size;
         let rank = config.markov_rank;
-        let partials = argmax_batch_bf16_split_partials_len(max_decode_batch_size, vocab);
+        let partials = markov_step_argmax_partials_len(max_decode_batch_size, vocab);
         let sampled = max_decode_batch_size * config.block_size;
         Ok(Self {
             max_batch: max_decode_batch_size,
@@ -213,7 +213,7 @@ impl MarkovScratch {
 
     fn bytes(vocab: usize, rank: usize, block_size: usize, max_decode_batch_size: usize) -> usize {
         const BF16: usize = 2;
-        let partials = argmax_batch_bf16_split_partials_len(max_decode_batch_size, vocab);
+        let partials = markov_step_argmax_partials_len(max_decode_batch_size, vocab);
         let w1emb = max_decode_batch_size * rank * BF16;
         let bias = max_decode_batch_size * vocab * BF16;
         let partial_bytes = partials * (std::mem::size_of::<f32>() + std::mem::size_of::<i32>());


### PR DESCRIPTION
## What

Three launch-overhead reductions on the DSpark draft round (#582 items 1–2), measured on an H100 with the single-GPU synthetic smoke; all draft-token-exact:

| H100, bs=1 | round | notes |
|---|---|---|
| all-eager baseline | 2.633 ms | 69% of the 1.82 ms weight-read floor |
| + graphed Markov chain & widened argmax | 2.606 ms | 7-step chain replays as one graph launch (~21 launches collapsed); step-argmax partial 9.7 → 4.5 µs (nsys-verified) |
| + piecewise forward graph | **2.455 ms (−6.8%)** | **74% of floor**; recovers ~the ~158 µs of launch gaps the kernel trace showed |

bs=8: the Markov-chain graph applies (−0.7%); the forward graph falls back to eager (see Limitations).

## How

- **Graphed Markov chain** (`markov_propose`): everything in the 7-step loop is pointer- and shape-static for a given row count — `step` bakes per node, the prev/next ping-pong alternates deterministically, the anchor h2d and sampled d2h stay outside. One `CudaGraphState` per row count; the first round per count runs the plain loop so cuBLAS's lazy workspace allocation stays outside capture. `DSPARK_NO_MARKOV_GRAPH=1` kill-switch.
- **`MARKOV_STEP_TILE_ELEMS 4096 → 1024`** (markov-only): the step argmax reads just one logits row + one bias row (~0.6 MB), so at 4096-elem tiles its ~38 blocks are pure latency (~10 µs for a ~0.2 µs read). 152 blocks put it back on the bandwidth curve. The global-vocab-index tie-break is unchanged, so results are exact; the batched full-row argmax keeps its wider tile.
- **Piecewise forward graph** (`propose`): the only round-varying kernel arguments are `committed_len`-derived — rope positions, the two KV-append copy offsets, attention kv_len — 4 launches per layer, which stay eager (a captured FlashInfer prefill bakes its KV iteration count). The rest is shape-static per `context_len`: captured as `DSPARK_LAYERS + 1` dense segments (embed+fc+L0-head; per-layer tail+next-head; last tail + final norm + lm_head), keyed by `context_len`, lazily captured with a one-round eager warm per key. Host metadata (`set_context_len`, `pending.seq_len`, the tail seq_lens) is hoisted/kept host-side so replays never depend on it. `DSPARK_NO_FORWARD_GRAPH=1` kill-switch.

## Tests

- `dspark_propose_smoke` (cherry-picked from #585 per the #582 discussion, adapted to the `cache_len` plumbing) — the perf A/B fixture.
- **`dspark_propose_graph_parity`** (new, `#[ignore]` GPU): pseudo-random non-degenerate weights, 12 rounds, asserts the graphed path emits exactly the eager path's draft tokens round-for-round, and that the logits are non-degenerate (not the all-ties case).

## Limitations / follow-ups

- The forward graph is **bs=1 only**: the varlen tail scratch (`tail_input`/`k_tail`/`v_tail`) is shared across slots, so the per-slot prep/consume interleave can't be re-ordered into dense-vs-dynamic spans without per-slot tail buffers. bs>1 falls back to eager (Markov graph still applies).
- The `DSPARK_FUSED_MARKOV` cooperative-kernel experiment from the #582 thread is left out (measured negative result; record in the issue).
- Remaining gap to floor is dominated by the 8-row layer GEMMs (~0.25 ms over their weight floor) — cuBLAS shape / TGV territory (#582 item 4).

Closes nothing; part of #582.
