### PR TITLE
test: tempfile scratch dirs across crates, shared qwen3 LoRA fixtures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3605,6 +3605,9 @@ dependencies = [
 [[package]]
 name = "openinfer-build"
 version = "0.0.0"
+dependencies = [
+ "tempfile",
+]
 
 [[package]]
 name = "openinfer-comm"
@@ -3839,6 +3842,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "tempfile",
  "tokio",
  "vllm-text",
 ]
@@ -3981,6 +3985,7 @@ dependencies = [
  "openinfer-kernels",
  "openinfer-kv-cache",
  "openinfer-kv-offload",
+ "openinfer-qwen3",
  "openinfer-sample",
  "openinfer-vllm-support",
  "rand 0.10.1",
@@ -3988,6 +3993,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "tempfile",
  "tokio",
  "toml",
  "vllm-text",
@@ -4012,6 +4018,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "tempfile",
  "tokio",
  "vllm-text",
 ]
@@ -4069,6 +4076,7 @@ dependencies = [
  "openinfer-vllm-frontend",
  "reqwest",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-util",
 ]

--- a/openinfer-build/Cargo.toml
+++ b/openinfer-build/Cargo.toml
@@ -3,3 +3,6 @@ edition = "2024"
 name = "openinfer-build"
 license = "Apache-2.0"
 publish = false
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/openinfer-build/src/lib.rs
+++ b/openinfer-build/src/lib.rs
@@ -210,33 +210,27 @@ pub fn emit_rerun_if_changed_files(src_dir: &str, extensions: &[&str]) {
 mod tests {
     use super::*;
 
-    struct TempTree(PathBuf);
+    struct TempTree(tempfile::TempDir);
 
     impl TempTree {
-        fn new(name: &str) -> Self {
-            let root =
-                std::env::temp_dir().join(format!("openinfer-build-{name}-{}", std::process::id()));
-            let _ = std::fs::remove_dir_all(&root);
-            std::fs::create_dir_all(&root).unwrap();
-            Self(root)
+        fn new() -> Self {
+            Self(tempfile::tempdir().unwrap())
+        }
+
+        fn root(&self) -> &Path {
+            self.0.path()
         }
 
         fn mkdirs(&self, rel: &str) -> PathBuf {
-            let dir = self.0.join(rel);
+            let dir = self.root().join(rel);
             std::fs::create_dir_all(&dir).unwrap();
             dir
         }
 
         fn touch(&self, rel: &str) {
-            let file = self.0.join(rel);
+            let file = self.root().join(rel);
             std::fs::create_dir_all(file.parent().unwrap()).unwrap();
             std::fs::write(&file, b"").unwrap();
-        }
-    }
-
-    impl Drop for TempTree {
-        fn drop(&mut self) {
-            let _ = std::fs::remove_dir_all(&self.0);
         }
     }
 
@@ -246,40 +240,40 @@ mod tests {
 
     #[test]
     fn classic_layout() {
-        let tree = TempTree::new("classic");
+        let tree = TempTree::new();
         tree.touch("include/cuda.h");
         tree.touch("bin/nvcc");
         let lib64 = tree.mkdirs("lib64");
         tree.mkdirs("lib64/stubs");
 
-        let tk = CudaToolkit::from_root(tree.0.clone());
-        assert_eq!(tk.nvcc, tree.0.join("bin/nvcc"));
-        assert_eq!(tk.header_dir("cuda.h"), Some(tree.0.join("include")));
+        let tk = CudaToolkit::from_root(tree.root().to_path_buf());
+        assert_eq!(tk.nvcc, tree.root().join("bin/nvcc"));
+        assert_eq!(tk.header_dir("cuda.h"), Some(tree.root().join("include")));
         assert_eq!(tk.lib_dirs, vec![lib64.clone()]);
         assert!(lib64.join("stubs").is_dir());
     }
 
     #[test]
     fn conda_layout() {
-        let tree = TempTree::new("conda");
+        let tree = TempTree::new();
         let target = target_dir();
         tree.mkdirs("include");
         tree.touch(&format!("targets/{target}/include/cuda.h"));
         let lib = tree.mkdirs("lib");
         let targets_lib = tree.mkdirs(&format!("targets/{target}/lib"));
 
-        let tk = CudaToolkit::from_root(tree.0.clone());
+        let tk = CudaToolkit::from_root(tree.root().to_path_buf());
         assert_eq!(tk.nvcc, PathBuf::from("nvcc"));
         assert_eq!(
             tk.header_dir("cuda.h"),
-            Some(tree.0.join(format!("targets/{target}/include")))
+            Some(tree.root().join(format!("targets/{target}/include")))
         );
         assert_eq!(tk.lib_dirs, vec![lib, targets_lib]);
     }
 
     #[test]
     fn hpc_sdk_layout_adds_math_libs_sibling() {
-        let tree = TempTree::new("hpcsdk");
+        let tree = TempTree::new();
         let root = tree.mkdirs("release/cuda/12.6");
         let lib64 = tree.mkdirs("release/cuda/12.6/lib64");
         let math = tree.mkdirs("release/math_libs/12.6/lib64");
@@ -290,33 +284,33 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn symlinked_dirs_dedupe() {
-        let tree = TempTree::new("symlink");
+        let tree = TempTree::new();
         let target = target_dir();
         tree.touch(&format!("targets/{target}/include/cuda.h"));
         tree.mkdirs(&format!("targets/{target}/lib"));
         std::os::unix::fs::symlink(
-            tree.0.join(format!("targets/{target}/include")),
-            tree.0.join("include"),
+            tree.root().join(format!("targets/{target}/include")),
+            tree.root().join("include"),
         )
         .unwrap();
         std::os::unix::fs::symlink(
-            tree.0.join(format!("targets/{target}/lib")),
-            tree.0.join("lib"),
+            tree.root().join(format!("targets/{target}/lib")),
+            tree.root().join("lib"),
         )
         .unwrap();
 
-        let tk = CudaToolkit::from_root(tree.0.clone());
+        let tk = CudaToolkit::from_root(tree.root().to_path_buf());
         assert_eq!(tk.include_dirs.len(), 1);
         assert_eq!(tk.lib_dirs.len(), 1);
-        assert_eq!(tk.header_dir("cuda.h"), Some(tree.0.join("include")));
+        assert_eq!(tk.header_dir("cuda.h"), Some(tree.root().join("include")));
     }
 
     #[test]
     fn unknown_layout_yields_nothing() {
-        let tree = TempTree::new("unknown");
+        let tree = TempTree::new();
         tree.mkdirs("weird/place");
 
-        let tk = CudaToolkit::from_root(tree.0.clone());
+        let tk = CudaToolkit::from_root(tree.root().to_path_buf());
         assert!(tk.lib_dirs.is_empty());
         assert!(tk.include_dirs.is_empty());
         assert_eq!(tk.header_dir("cuda.h"), None);
@@ -324,9 +318,9 @@ mod tests {
 
     #[test]
     fn find_package_returns_matching_root_and_check_file() {
-        let tree = TempTree::new("findpkg");
+        let tree = TempTree::new();
         tree.touch("include/gdrapi.h");
-        let root_str = tree.0.to_str().unwrap().to_string();
+        let root_str = tree.root().to_str().unwrap().to_string();
 
         let (root, header) = find_package(
             "test",
@@ -334,15 +328,15 @@ mod tests {
             &[&root_str],
             &["targets/missing/include/gdrapi.h", "include/gdrapi.h"],
         );
-        assert_eq!(root, tree.0);
-        assert_eq!(header, tree.0.join("include/gdrapi.h"));
+        assert_eq!(root, tree.root());
+        assert_eq!(header, tree.root().join("include/gdrapi.h"));
     }
 
     #[test]
     #[should_panic(expected = "none of")]
     fn missing_header_panics_with_all_candidates() {
-        let tree = TempTree::new("empty");
-        let root_str = tree.0.to_str().unwrap().to_string();
+        let tree = TempTree::new();
+        let root_str = tree.root().to_str().unwrap().to_string();
         find_package(
             "test",
             "OPENINFER_TEST_UNSET_ENV",

--- a/openinfer-deepseek-v2-lite/Cargo.toml
+++ b/openinfer-deepseek-v2-lite/Cargo.toml
@@ -30,6 +30,9 @@ sha2 = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 vllm-text = { workspace = true }
 
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [lints]
 workspace = true
 

--- a/openinfer-deepseek-v2-lite/src/nccl_backend/tests.rs
+++ b/openinfer-deepseek-v2-lite/src/nccl_backend/tests.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::HashSet,
-    env, fs,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::{collections::HashSet, fs};
 
 use super::{
     AllReduceChunk, NCCL_BF16_ALL_REDUCE_MAX_ELEMS_PER_CALL,
@@ -68,16 +64,11 @@ fn bf16_all_reduce_chunks_preserve_24_word_count_and_split_long_counts() {
 
 #[test]
 fn finds_nccl_python_wheel_lib_dir_from_python_executable() {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system time before epoch")
-        .as_nanos();
-    let root = env::temp_dir().join(format!(
-        "openinfer-nccl-wheel-test-{}-{unique}",
-        std::process::id()
-    ));
-    let python_dir = root.join("bin");
-    let wheel_dir = root.join("lib/python3.11/site-packages/nvidia/nccl/lib");
+    let root = tempfile::tempdir().expect("create temp root");
+    let python_dir = root.path().join("bin");
+    let wheel_dir = root
+        .path()
+        .join("lib/python3.11/site-packages/nvidia/nccl/lib");
     fs::create_dir_all(&python_dir).expect("create python bin dir");
     fs::create_dir_all(&wheel_dir).expect("create NCCL wheel dir");
     fs::write(wheel_dir.join("libnccl.so.2"), []).expect("create fake NCCL lib marker");
@@ -86,27 +77,24 @@ fn finds_nccl_python_wheel_lib_dir_from_python_executable() {
     let mut seen = HashSet::new();
     add_python_env_root(&mut roots, &mut seen, &python_dir.join("python"));
 
-    assert_eq!(roots, vec![root.clone()]);
-    assert_eq!(nccl_python_wheel_lib_dirs_from_root(&root), vec![wheel_dir]);
-
-    fs::remove_dir_all(root).expect("remove temp root");
+    assert_eq!(roots, vec![root.path().to_path_buf()]);
+    assert_eq!(
+        nccl_python_wheel_lib_dirs_from_root(root.path()),
+        vec![wheel_dir]
+    );
 }
 
 #[test]
 fn finds_nccl_python_wheel_lib_dir_with_unversioned_soname() {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system time before epoch")
-        .as_nanos();
-    let root = env::temp_dir().join(format!(
-        "openinfer-nccl-wheel-unversioned-test-{}-{unique}",
-        std::process::id()
-    ));
-    let wheel_dir = root.join("lib/python3.11/site-packages/nvidia/nccl/lib");
+    let root = tempfile::tempdir().expect("create temp root");
+    let wheel_dir = root
+        .path()
+        .join("lib/python3.11/site-packages/nvidia/nccl/lib");
     fs::create_dir_all(&wheel_dir).expect("create NCCL wheel dir");
     fs::write(wheel_dir.join("libnccl.so"), []).expect("create fake NCCL lib marker");
 
-    assert_eq!(nccl_python_wheel_lib_dirs_from_root(&root), vec![wheel_dir]);
-
-    fs::remove_dir_all(root).expect("remove temp root");
+    assert_eq!(
+        nccl_python_wheel_lib_dirs_from_root(root.path()),
+        vec![wheel_dir]
+    );
 }

--- a/openinfer-qwen3/Cargo.toml
+++ b/openinfer-qwen3/Cargo.toml
@@ -33,6 +33,7 @@ toml = { workspace = true, optional = true }
 
 [features]
 kernel-call-trace = ["openinfer-core/kernel-call-trace"]
+test-fixtures = []
 kernel-report = [
     "dep:clap",
     "dep:comfy-table",
@@ -45,7 +46,9 @@ kernel-report = [
 ]
 
 [dev-dependencies]
+openinfer-qwen3 = { workspace = true, features = ["test-fixtures"] }
 openinfer-vllm-support = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
 vllm-text = { workspace = true }
 

--- a/openinfer-qwen3/src/lib.rs
+++ b/openinfer-qwen3/src/lib.rs
@@ -11,6 +11,8 @@ mod executor;
 pub(crate) mod green_ctx;
 pub mod kernel_bench;
 mod lora;
+#[cfg(any(test, feature = "test-fixtures"))]
+pub use lora::fixtures as lora_fixtures;
 mod prefill;
 mod scheduler;
 mod speculative;

--- a/openinfer-qwen3/src/lora.rs
+++ b/openinfer-qwen3/src/lora.rs
@@ -25,6 +25,9 @@ const SUPPORTED_TARGET_MODULES: &[&str] = &[
     "down_proj",
 ];
 
+#[cfg(any(test, feature = "test-fixtures"))]
+pub mod fixtures;
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) struct LoraAdapterManifest {
     pub(crate) path: PathBuf,
@@ -758,16 +761,10 @@ fn shard_projection_for_tensor_parallel(
 
 #[cfg(test)]
 mod tests {
-    use std::borrow::Cow;
     use std::collections::BTreeMap;
-    use std::fs;
-    use std::sync::atomic::{AtomicUsize, Ordering};
 
-    use safetensors::View;
-
+    use super::fixtures::{self, FixtureTensor};
     use super::*;
-
-    static NEXT_TEST_DIR: AtomicUsize = AtomicUsize::new(0);
 
     fn tiny_config() -> Config {
         Config {
@@ -787,102 +784,22 @@ mod tests {
         }
     }
 
-    fn temp_adapter_dir(test_name: &str) -> PathBuf {
-        let id = NEXT_TEST_DIR.fetch_add(1, Ordering::Relaxed);
-        let path = std::env::temp_dir().join(format!(
-            "openinfer-qwen3-lora-{test_name}-{}-{id}",
-            std::process::id()
-        ));
-        let _ = fs::remove_dir_all(&path);
-        fs::create_dir_all(&path).expect("create temp adapter dir");
-        path
-    }
-
-    fn write_adapter_config(path: &Path, targets: &[&str], rank: usize) {
-        let targets = targets
-            .iter()
-            .map(|target| format!("\"{target}\""))
-            .collect::<Vec<_>>()
-            .join(", ");
-        fs::write(
-            path.join(ADAPTER_CONFIG_FILE),
-            format!(
-                r#"{{
-  "peft_type": "LORA",
-  "r": {rank},
-  "lora_alpha": 16,
-  "target_modules": [{targets}]
-}}"#
-            ),
-        )
-        .expect("write adapter config");
-    }
-
     fn write_adapter_weights(path: &Path, config: &Config, targets: &[&str], rank: usize) {
         let mut tensors = BTreeMap::new();
         for layer_idx in 0..config.num_hidden_layers {
             for target in targets {
                 let spec = projection_spec(config, target).expect("projection spec");
-                push_tensor(
+                fixtures::push_projection(
                     &mut tensors,
-                    tensor_name(layer_idx, spec.path_segment, "lora_A"),
-                    vec![rank, spec.in_dim],
-                );
-                push_tensor(
-                    &mut tensors,
-                    tensor_name(layer_idx, spec.path_segment, "lora_B"),
-                    vec![spec.out_dim, rank],
+                    layer_idx,
+                    spec.path_segment,
+                    rank,
+                    spec.in_dim,
+                    spec.out_dim,
                 );
             }
         }
-        safetensors::serialize_to_file(tensors, None, &path.join(ADAPTER_WEIGHTS_FILE))
-            .expect("write safetensors");
-    }
-
-    #[derive(Clone)]
-    struct TestTensor {
-        dtype: Dtype,
-        shape: Vec<usize>,
-        data: Vec<u8>,
-    }
-
-    impl View for TestTensor {
-        fn dtype(&self) -> Dtype {
-            self.dtype
-        }
-
-        fn shape(&self) -> &[usize] {
-            &self.shape
-        }
-
-        fn data(&self) -> Cow<'_, [u8]> {
-            Cow::Borrowed(&self.data)
-        }
-
-        fn data_len(&self) -> usize {
-            self.data.len()
-        }
-    }
-
-    fn push_tensor(tensors: &mut BTreeMap<String, TestTensor>, name: String, shape: Vec<usize>) {
-        push_tensor_with_dtype(tensors, name, shape, Dtype::BF16, 0.0);
-    }
-
-    fn push_tensor_with_dtype(
-        tensors: &mut BTreeMap<String, TestTensor>,
-        name: String,
-        shape: Vec<usize>,
-        dtype: Dtype,
-        value: f32,
-    ) {
-        let elems = shape.iter().product::<usize>();
-        let data = match dtype {
-            Dtype::BF16 => bf16::from_f32(value).to_bits().to_le_bytes().repeat(elems),
-            Dtype::F16 => f16::from_f32(value).to_bits().to_le_bytes().repeat(elems),
-            Dtype::F32 => value.to_le_bytes().repeat(elems),
-            _ => panic!("unsupported test dtype {dtype:?}"),
-        };
-        tensors.insert(name, TestTensor { dtype, shape, data });
+        fixtures::write_adapter_tensors(path, tensors);
     }
 
     fn matrix(rows: usize, cols: usize) -> LoraMatrix {
@@ -899,13 +816,14 @@ mod tests {
     #[test]
     fn validates_supported_qwen3_lora_adapter() {
         let config = tiny_config();
-        let path = temp_adapter_dir("valid");
+        let dir = tempfile::tempdir().expect("create temp adapter dir");
+        let path = dir.path();
         let targets = SUPPORTED_TARGET_MODULES;
-        write_adapter_config(&path, targets, 2);
-        write_adapter_weights(&path, &config, targets, 2);
+        fixtures::write_adapter_config(path, 2, 16, targets);
+        write_adapter_weights(path, &config, targets, 2);
 
         let manifest = load_lora_adapter(
-            &path,
+            path,
             &config,
             crate::Qwen3LoraOptions::DEFAULT_MAX_LORA_RANK,
         )
@@ -924,12 +842,13 @@ mod tests {
     #[test]
     fn loads_lora_tensors_grouped_by_layer_and_target() {
         let config = tiny_config();
-        let path = temp_adapter_dir("load");
-        write_adapter_config(&path, &["q_proj", "down_proj"], 2);
-        write_adapter_weights(&path, &config, &["q_proj", "down_proj"], 2);
+        let dir = tempfile::tempdir().expect("create temp adapter dir");
+        let path = dir.path();
+        fixtures::write_adapter_config(path, 2, 16, &["q_proj", "down_proj"]);
+        write_adapter_weights(path, &config, &["q_proj", "down_proj"], 2);
 
         let adapter = load_lora_adapter(
-            &path,
+            path,
             &config,
             crate::Qwen3LoraOptions::DEFAULT_MAX_LORA_RANK,
         )
@@ -958,31 +877,25 @@ mod tests {
     #[test]
     fn loads_supported_lora_tensor_dtypes_as_bf16() {
         let config = tiny_config();
-        let path = temp_adapter_dir("dtype-load");
-        write_adapter_config(&path, &["q_proj"], 2);
+        let dir = tempfile::tempdir().expect("create temp adapter dir");
+        let path = dir.path();
+        fixtures::write_adapter_config(path, 2, 16, &["q_proj"]);
 
         let mut tensors = BTreeMap::new();
         for layer_idx in 0..config.num_hidden_layers {
-            push_tensor_with_dtype(
-                &mut tensors,
+            tensors.insert(
                 tensor_name(layer_idx, "self_attn.q_proj", "lora_A"),
-                vec![2, config.hidden_size],
-                Dtype::F16,
-                1.5,
+                FixtureTensor::filled(Dtype::F16, vec![2, config.hidden_size], 1.5),
             );
-            push_tensor_with_dtype(
-                &mut tensors,
+            tensors.insert(
                 tensor_name(layer_idx, "self_attn.q_proj", "lora_B"),
-                vec![config.hidden_size, 2],
-                Dtype::F32,
-                2.25,
+                FixtureTensor::filled(Dtype::F32, vec![config.hidden_size, 2], 2.25),
             );
         }
-        safetensors::serialize_to_file(tensors, None, &path.join(ADAPTER_WEIGHTS_FILE))
-            .expect("write safetensors");
+        fixtures::write_adapter_tensors(path, tensors);
 
         let adapter = load_lora_adapter(
-            &path,
+            path,
             &config,
             crate::Qwen3LoraOptions::DEFAULT_MAX_LORA_RANK,
         )
@@ -996,12 +909,13 @@ mod tests {
     #[test]
     fn rejects_unsupported_target_module() {
         let config = tiny_config();
-        let path = temp_adapter_dir("unsupported-target");
-        write_adapter_config(&path, &["q_proj", "embed_tokens"], 2);
-        write_adapter_weights(&path, &config, &["q_proj"], 2);
+        let dir = tempfile::tempdir().expect("create temp adapter dir");
+        let path = dir.path();
+        fixtures::write_adapter_config(path, 2, 16, &["q_proj", "embed_tokens"]);
+        write_adapter_weights(path, &config, &["q_proj"], 2);
 
         let error = load_lora_adapter(
-            &path,
+            path,
             &config,
             crate::Qwen3LoraOptions::DEFAULT_MAX_LORA_RANK,
         )
@@ -1013,11 +927,12 @@ mod tests {
     #[test]
     fn rejects_lora_rank_above_configured_limit() {
         let config = tiny_config();
-        let path = temp_adapter_dir("rank-limit");
-        write_adapter_config(&path, &["q_proj"], 2);
-        write_adapter_weights(&path, &config, &["q_proj"], 2);
+        let dir = tempfile::tempdir().expect("create temp adapter dir");
+        let path = dir.path();
+        fixtures::write_adapter_config(path, 2, 16, &["q_proj"]);
+        write_adapter_weights(path, &config, &["q_proj"], 2);
 
-        let error = load_lora_adapter(&path, &config, 1)
+        let error = load_lora_adapter(path, &config, 1)
             .expect_err("rank above max_lora_rank should fail")
             .to_string();
 
@@ -1083,31 +998,30 @@ mod tests {
     #[test]
     fn rejects_wrong_lora_tensor_shape() {
         let config = tiny_config();
-        let path = temp_adapter_dir("bad-shape");
-        write_adapter_config(&path, &["q_proj"], 2);
+        let dir = tempfile::tempdir().expect("create temp adapter dir");
+        let path = dir.path();
+        fixtures::write_adapter_config(path, 2, 16, &["q_proj"]);
 
         let mut tensors = BTreeMap::new();
         for layer_idx in 0..config.num_hidden_layers {
-            push_tensor(
-                &mut tensors,
+            tensors.insert(
                 tensor_name(layer_idx, "self_attn.q_proj", "lora_A"),
-                vec![2, config.hidden_size],
+                FixtureTensor::filled(Dtype::BF16, vec![2, config.hidden_size], 0.0),
             );
-            push_tensor(
-                &mut tensors,
+            let b_rows = if layer_idx == 0 {
+                config.hidden_size + 1
+            } else {
+                config.hidden_size
+            };
+            tensors.insert(
                 tensor_name(layer_idx, "self_attn.q_proj", "lora_B"),
-                if layer_idx == 0 {
-                    vec![config.hidden_size + 1, 2]
-                } else {
-                    vec![config.hidden_size, 2]
-                },
+                FixtureTensor::filled(Dtype::BF16, vec![b_rows, 2], 0.0),
             );
         }
-        safetensors::serialize_to_file(tensors, None, &path.join(ADAPTER_WEIGHTS_FILE))
-            .expect("write safetensors");
+        fixtures::write_adapter_tensors(path, tensors);
 
         let error = load_lora_adapter(
-            &path,
+            path,
             &config,
             crate::Qwen3LoraOptions::DEFAULT_MAX_LORA_RANK,
         )
@@ -1161,11 +1075,12 @@ mod tests {
     #[test]
     fn shards_full_adapter_for_tensor_parallel() {
         let config = tiny_config();
-        let path = temp_adapter_dir("tp-shard");
-        write_adapter_config(&path, &["q_proj", "down_proj"], 2);
-        write_adapter_weights(&path, &config, &["q_proj", "down_proj"], 2);
+        let dir = tempfile::tempdir().expect("create temp adapter dir");
+        let path = dir.path();
+        fixtures::write_adapter_config(path, 2, 16, &["q_proj", "down_proj"]);
+        write_adapter_weights(path, &config, &["q_proj", "down_proj"], 2);
         let adapter = load_lora_adapter(
-            &path,
+            path,
             &config,
             crate::Qwen3LoraOptions::DEFAULT_MAX_LORA_RANK,
         )

--- a/openinfer-qwen3/src/lora/fixtures.rs
+++ b/openinfer-qwen3/src/lora/fixtures.rs
@@ -1,0 +1,98 @@
+//! Synthetic PEFT adapter fixtures shared by the LoRA unit and integration
+//! tests; integration tests reach it through the `test-fixtures` feature,
+//! which the self dev-dependency enables for all test builds.
+
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use half::{bf16, f16};
+use safetensors::{Dtype, View};
+
+use super::{ADAPTER_CONFIG_FILE, ADAPTER_WEIGHTS_FILE, tensor_name};
+
+#[derive(Clone)]
+pub struct FixtureTensor {
+    pub dtype: Dtype,
+    pub shape: Vec<usize>,
+    pub data: Vec<u8>,
+}
+
+impl FixtureTensor {
+    pub fn filled(dtype: Dtype, shape: Vec<usize>, value: f32) -> Self {
+        let elems = shape.iter().product::<usize>();
+        let data = match dtype {
+            Dtype::BF16 => bf16::from_f32(value).to_bits().to_le_bytes().repeat(elems),
+            Dtype::F16 => f16::from_f32(value).to_bits().to_le_bytes().repeat(elems),
+            Dtype::F32 => value.to_le_bytes().repeat(elems),
+            _ => panic!("unsupported fixture dtype {dtype:?}"),
+        };
+        Self { dtype, shape, data }
+    }
+}
+
+impl View for FixtureTensor {
+    fn dtype(&self) -> Dtype {
+        self.dtype
+    }
+
+    fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    fn data(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(&self.data)
+    }
+
+    fn data_len(&self) -> usize {
+        self.data.len()
+    }
+}
+
+/// Zero-filled bf16 `lora_A`/`lora_B` pair for one projection.
+pub fn push_projection(
+    tensors: &mut BTreeMap<String, FixtureTensor>,
+    layer_idx: usize,
+    path_segment: &str,
+    rank: usize,
+    in_dim: usize,
+    out_dim: usize,
+) {
+    tensors.insert(
+        tensor_name(layer_idx, path_segment, "lora_A"),
+        FixtureTensor::filled(Dtype::BF16, vec![rank, in_dim], 0.0),
+    );
+    tensors.insert(
+        tensor_name(layer_idx, path_segment, "lora_B"),
+        FixtureTensor::filled(Dtype::BF16, vec![out_dim, rank], 0.0),
+    );
+}
+
+pub fn write_adapter_config(dir: &Path, rank: usize, alpha: usize, targets: &[&str]) {
+    let targets = targets
+        .iter()
+        .map(|target| format!("\"{target}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    write_adapter_config_json(
+        dir,
+        &format!(
+            r#"{{
+  "peft_type": "LORA",
+  "r": {rank},
+  "lora_alpha": {alpha},
+  "target_modules": [{targets}]
+}}"#
+        ),
+    );
+}
+
+pub fn write_adapter_config_json(dir: &Path, json: &str) {
+    fs::write(dir.join(ADAPTER_CONFIG_FILE), json).expect("write adapter_config.json");
+}
+
+pub fn write_adapter_tensors(dir: &Path, tensors: BTreeMap<String, FixtureTensor>) {
+    safetensors::serialize_to_file(tensors, None, &dir.join(ADAPTER_WEIGHTS_FILE))
+        .expect("write adapter_model.safetensors");
+}

--- a/openinfer-qwen3/src/weights.rs
+++ b/openinfer-qwen3/src/weights.rs
@@ -1113,13 +1113,6 @@ mod tests {
     use super::*;
     use crate::lora::{DeviceLoraLayer, LoraAdapterManifest};
 
-    fn temp_path(name: &str) -> std::path::PathBuf {
-        std::env::temp_dir().join(format!(
-            "openinfer-qwen3-lora-{name}-{}",
-            std::process::id()
-        ))
-    }
-
     fn test_device_adapter(name: &str, path: &Path) -> DeviceLoraAdapter {
         DeviceLoraAdapter {
             name: name.to_string(),
@@ -1138,20 +1131,20 @@ mod tests {
     #[test]
     fn install_lora_adapter_requires_load_inplace_to_replace_existing_name() {
         let mut adapters = HashMap::new();
-        let first_path = temp_path("replace-first");
-        let second_path = temp_path("replace-second");
+        let first_path = Path::new("adapters/replace-first");
+        let second_path = Path::new("adapters/replace-second");
 
-        let first = test_device_adapter("adapter-a", &first_path);
+        let first = test_device_adapter("adapter-a", first_path);
         install_lora_adapter_in_registry(&mut adapters, first, false)
             .expect("install first adapter");
         assert_eq!(
             adapters
                 .get("adapter-a")
                 .map(|adapter| adapter.manifest.path.as_path()),
-            Some(first_path.as_path()),
+            Some(first_path),
         );
 
-        let duplicate = test_device_adapter("adapter-a", &second_path);
+        let duplicate = test_device_adapter("adapter-a", second_path);
         let error = install_lora_adapter_in_registry(&mut adapters, duplicate, false)
             .expect_err("duplicate adapter without load_inplace should fail")
             .to_string();
@@ -1160,17 +1153,17 @@ mod tests {
             adapters
                 .get("adapter-a")
                 .map(|adapter| adapter.manifest.path.as_path()),
-            Some(first_path.as_path()),
+            Some(first_path),
         );
 
-        let replacement = test_device_adapter("adapter-a", &second_path);
+        let replacement = test_device_adapter("adapter-a", second_path);
         install_lora_adapter_in_registry(&mut adapters, replacement, true)
             .expect("replace adapter");
         assert_eq!(
             adapters
                 .get("adapter-a")
                 .map(|adapter| adapter.manifest.path.as_path()),
-            Some(second_path.as_path()),
+            Some(second_path),
         );
     }
 

--- a/openinfer-qwen3/tests/lora_golden_gate.rs
+++ b/openinfer-qwen3/tests/lora_golden_gate.rs
@@ -15,16 +15,15 @@
 //! Needs a CUDA GPU and Qwen3-4B weights (`OPENINFER_TEST_MODEL_PATH`); skips cleanly
 //! otherwise.
 
-use std::borrow::Cow;
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use openinfer_core::engine::{LoadLoraAdapterRequest, TokenLogprob};
 use openinfer_core::sampler::SamplingParams;
+use openinfer_qwen3::lora_fixtures::{self as fixtures, FixtureTensor};
 use openinfer_qwen3::runtime::{
     DecodePlan, DecodeStepItem, PrefillPlan, PrefillStepItem, Qwen3Executor, RequestId,
 };
-use safetensors::tensor::View;
 use safetensors::{Dtype, SafeTensors};
 
 const MODEL_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../models/Qwen3-4B");
@@ -190,34 +189,12 @@ struct Golden {
     base_topk_lp: Vec<f32>,
     lora_topk_ids: Vec<i32>,
     lora_topk_lp: Vec<f32>,
-    adapter_tensors: BTreeMap<String, AdapterTensor>,
+    adapter_tensors: BTreeMap<String, FixtureTensor>,
     adapter_config_json: String,
     num_seqs: usize,
     decode_len: usize,
     positions: usize,
     k: usize,
-}
-
-#[derive(Clone)]
-struct AdapterTensor {
-    dtype: Dtype,
-    shape: Vec<usize>,
-    data: Vec<u8>,
-}
-
-impl View for AdapterTensor {
-    fn dtype(&self) -> Dtype {
-        self.dtype
-    }
-    fn shape(&self) -> &[usize] {
-        &self.shape
-    }
-    fn data(&self) -> Cow<'_, [u8]> {
-        Cow::Borrowed(&self.data)
-    }
-    fn data_len(&self) -> usize {
-        self.data.len()
-    }
 }
 
 impl Golden {
@@ -257,7 +234,7 @@ impl Golden {
                 let t = st.tensor(name).expect("adapter tensor");
                 adapter_tensors.insert(
                     tensor_name.to_string(),
-                    AdapterTensor {
+                    FixtureTensor {
                         dtype: t.dtype(),
                         shape: t.shape().to_vec(),
                         data: t.data().to_vec(),
@@ -318,25 +295,10 @@ impl Golden {
     }
 
     /// Reconstruct the PEFT adapter directory the fixture embeds.
-    fn write_adapter_dir(&self) -> PathBuf {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("system time before unix epoch")
-            .as_nanos();
-        let dir = std::env::temp_dir().join(format!(
-            "openinfer-qwen3-lora-golden-{}-{now}",
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("create temp adapter dir");
-        std::fs::write(dir.join("adapter_config.json"), &self.adapter_config_json)
-            .expect("write adapter_config.json");
-        safetensors::serialize_to_file(
-            self.adapter_tensors.clone(),
-            None,
-            &dir.join("adapter_model.safetensors"),
-        )
-        .expect("write adapter_model.safetensors");
+    fn write_adapter_dir(&self) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("create temp adapter dir");
+        fixtures::write_adapter_config_json(dir.path(), &self.adapter_config_json);
+        fixtures::write_adapter_tensors(dir.path(), self.adapter_tensors.clone());
         dir
     }
 }
@@ -509,15 +471,13 @@ fn lora_logprobs_match_peft_golden_within_bf16_tolerance() {
     let golden = Golden::load();
     let adapter_dir = golden.write_adapter_dir();
 
-    run_suite(&golden, &model_path, &adapter_dir, &[0], "");
+    run_suite(&golden, &model_path, adapter_dir.path(), &[0], "");
 
     if cuda_device_count() >= 2 {
-        run_suite(&golden, &model_path, &adapter_dir, &[0, 1], "tp2 ");
+        run_suite(&golden, &model_path, adapter_dir.path(), &[0, 1], "tp2 ");
     } else {
         eprintln!("skipping lora_golden_gate TP=2 pass: <2 CUDA devices visible");
     }
-
-    let _ = std::fs::remove_dir_all(&adapter_dir);
 }
 
 fn cuda_device_count() -> usize {

--- a/openinfer-qwen3/tests/lora_smoke.rs
+++ b/openinfer-qwen3/tests/lora_smoke.rs
@@ -1,17 +1,13 @@
-use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 
-use half::bf16;
 use openinfer_core::engine::{
     EngineHandle, EngineLoadOptions, FinishReason, GenerateRequest, LoadLoraAdapterRequest,
     TokenEvent, TokenSink,
 };
 use openinfer_core::sampler::SamplingParams;
-use safetensors::Dtype;
-use safetensors::tensor::View;
+use openinfer_qwen3::lora_fixtures as fixtures;
 use serde::Deserialize;
 use vllm_text::tokenizer::DynTokenizer;
 
@@ -27,31 +23,6 @@ struct ModelConfig {
     num_attention_heads: usize,
     num_key_value_heads: usize,
     head_dim: usize,
-}
-
-#[derive(Clone)]
-struct TestTensor {
-    dtype: Dtype,
-    shape: Vec<usize>,
-    data: Vec<u8>,
-}
-
-impl View for TestTensor {
-    fn dtype(&self) -> Dtype {
-        self.dtype
-    }
-
-    fn shape(&self) -> &[usize] {
-        &self.shape
-    }
-
-    fn data(&self) -> Cow<'_, [u8]> {
-        Cow::Borrowed(&self.data)
-    }
-
-    fn data_len(&self) -> usize {
-        self.data.len()
-    }
 }
 
 fn get_model_path() -> String {
@@ -73,76 +44,29 @@ fn load_model_config(model_path: &str) -> ModelConfig {
         .unwrap_or_else(|err| panic!("failed to parse {}: {err}", config_path.display()))
 }
 
-fn temp_adapter_dir() -> PathBuf {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system time before unix epoch")
-        .as_nanos();
-    let path = std::env::temp_dir().join(format!(
-        "openinfer-qwen3-lora-smoke-{}-{now}",
-        std::process::id()
-    ));
-    let _ = fs::remove_dir_all(&path);
-    fs::create_dir_all(&path).expect("create temp adapter dir");
-    path
-}
-
 fn write_zero_lora_adapter(path: &Path, config: &ModelConfig, rank: usize) {
-    fs::write(
-        path.join("adapter_config.json"),
-        format!(
-            r#"{{
-  "peft_type": "LORA",
-  "r": {rank},
-  "lora_alpha": {rank},
-  "target_modules": ["q_proj", "v_proj"]
-}}"#
-        ),
-    )
-    .expect("write adapter_config.json");
+    fixtures::write_adapter_config(path, rank, rank, &["q_proj", "v_proj"]);
 
     let mut tensors = BTreeMap::new();
     for layer_idx in 0..config.num_hidden_layers {
-        push_zero_tensor(
+        fixtures::push_projection(
             &mut tensors,
-            tensor_name(layer_idx, "self_attn.q_proj", "lora_A"),
-            vec![rank, config.hidden_size],
+            layer_idx,
+            "self_attn.q_proj",
+            rank,
+            config.hidden_size,
+            config.num_attention_heads * config.head_dim,
         );
-        push_zero_tensor(
+        fixtures::push_projection(
             &mut tensors,
-            tensor_name(layer_idx, "self_attn.q_proj", "lora_B"),
-            vec![config.num_attention_heads * config.head_dim, rank],
-        );
-        push_zero_tensor(
-            &mut tensors,
-            tensor_name(layer_idx, "self_attn.v_proj", "lora_A"),
-            vec![rank, config.hidden_size],
-        );
-        push_zero_tensor(
-            &mut tensors,
-            tensor_name(layer_idx, "self_attn.v_proj", "lora_B"),
-            vec![config.num_key_value_heads * config.head_dim, rank],
+            layer_idx,
+            "self_attn.v_proj",
+            rank,
+            config.hidden_size,
+            config.num_key_value_heads * config.head_dim,
         );
     }
-
-    safetensors::serialize_to_file(tensors, None, &path.join("adapter_model.safetensors"))
-        .expect("write adapter_model.safetensors");
-}
-
-fn push_zero_tensor(tensors: &mut BTreeMap<String, TestTensor>, name: String, shape: Vec<usize>) {
-    let elems = shape.iter().product::<usize>();
-    tensors.insert(
-        name,
-        TestTensor {
-            dtype: Dtype::BF16,
-            shape,
-            data: bf16::from_f32(0.0).to_bits().to_le_bytes().repeat(elems),
-        },
-    );
-}
-
-fn tensor_name(layer_idx: usize, path_segment: &str, lora_side: &str) -> String {
-    format!("base_model.model.model.layers.{layer_idx}.{path_segment}.{lora_side}.weight")
+    fixtures::write_adapter_tensors(path, tensors);
 }
 
 fn load_adapter(handle: &EngineHandle, adapter_name: &str, adapter_path: PathBuf) {
@@ -214,8 +138,8 @@ fn qwen3_lora_loads_rank_and_generates(rank: usize, adapter_name: &str) {
         "unexpected Qwen3 config dimensions"
     );
 
-    let adapter_path = temp_adapter_dir();
-    write_zero_lora_adapter(&adapter_path, &config, rank);
+    let adapter_dir = tempfile::tempdir().expect("create temp adapter dir");
+    write_zero_lora_adapter(adapter_dir.path(), &config, rank);
 
     let handle = openinfer_qwen3::start_engine_with_lora_control(
         Path::new(&model_path),
@@ -237,7 +161,7 @@ fn qwen3_lora_loads_rank_and_generates(rank: usize, adapter_name: &str) {
     .expect("start LoRA-capable Qwen3 engine");
 
     assert!(handle.supports_lora_control());
-    load_adapter(&handle, adapter_name, adapter_path);
+    load_adapter(&handle, adapter_name, adapter_dir.path().to_path_buf());
 
     let tokenizer = common::load_tokenizer(&model_path);
     let (tokens, finish_reason) = generate_tokens(

--- a/openinfer-qwen35-4b/Cargo.toml
+++ b/openinfer-qwen35-4b/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { workspace = true, features = ["sync"] }
 criterion = { workspace = true }
 openinfer-vllm-support = { workspace = true }
 sha2 = { workspace = true }
+tempfile = { workspace = true }
 vllm-text = { workspace = true }
 
 [features]

--- a/openinfer-qwen35-4b/src/config.rs
+++ b/openinfer-qwen35-4b/src/config.rs
@@ -238,8 +238,7 @@ mod tests {
 
     #[test]
     fn guard_accepts_48_value_heads() {
-        let dir = std::env::temp_dir().join(format!("qwen35-config-guard-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
+        let dir = tempfile::tempdir().unwrap();
         let json = r#"{
   "max_position_embeddings": 4096,
   "tie_word_embeddings": true,
@@ -262,7 +261,7 @@ mod tests {
     "eos_token_id": 0
   }
 }"#;
-        std::fs::write(dir.join("config.json"), json).unwrap();
-        Config35::from_file(dir.to_str().unwrap()).expect("48 value heads must load");
+        std::fs::write(dir.path().join("config.json"), json).unwrap();
+        Config35::from_file(dir.path().to_str().unwrap()).expect("48 value heads must load");
     }
 }

--- a/openinfer-sim/Cargo.toml
+++ b/openinfer-sim/Cargo.toml
@@ -18,6 +18,7 @@ tokio = { workspace = true, features = ["full"] }
 [dev-dependencies]
 reqwest = { workspace = true, features = ["json"] }
 serde_json = { workspace = true }
+tempfile = { workspace = true }
 tokio-util = { workspace = true }
 
 [lints]

--- a/openinfer-sim/tests/frontend_e2e.rs
+++ b/openinfer-sim/tests/frontend_e2e.rs
@@ -1,44 +1,41 @@
 use std::fs;
 use std::net::TcpListener;
-use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow, bail};
 use openinfer_sim::{SimulatedEngineConfig, start_engine};
 use reqwest::Client;
 use serde_json::{Value, json};
+use tempfile::TempDir;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 const MODEL_NAME: &str = "openinfer-sim-e2e";
 const SERVER_START_ATTEMPTS: usize = 5;
-static TEMP_MODEL_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 struct SimServer {
     base_url: String,
     shutdown: CancellationToken,
     task: JoinHandle<Result<()>>,
-    _model_dir: TempModelDir,
+    _model_dir: TempDir,
 }
 
 impl SimServer {
     async fn spawn() -> Result<Self> {
-        Self::spawn_with_model_dir(TempModelDir::with_minimal_metadata()?).await
+        Self::spawn_with_model_dir(model_dir_with_minimal_metadata()?).await
     }
 
     async fn spawn_with_lora_routes() -> Result<Self> {
-        Self::spawn_with_model_dir_and_lora_routes(TempModelDir::with_minimal_metadata()?, true)
-            .await
+        Self::spawn_with_model_dir_and_lora_routes(model_dir_with_minimal_metadata()?, true).await
     }
 
-    async fn spawn_with_model_dir(model_dir: TempModelDir) -> Result<Self> {
+    async fn spawn_with_model_dir(model_dir: TempDir) -> Result<Self> {
         Self::spawn_with_model_dir_and_lora_routes(model_dir, false).await
     }
 
     async fn spawn_with_model_dir_and_lora_routes(
-        model_dir: TempModelDir,
+        model_dir: TempDir,
         enable_lora_routes: bool,
     ) -> Result<Self> {
         let mut last_error = None;
@@ -67,17 +64,14 @@ impl SimServer {
             })
     }
 
-    async fn spawn_once(
-        model_dir: &TempModelDir,
-        enable_lora_routes: bool,
-    ) -> Result<StartedSimServer> {
+    async fn spawn_once(model_dir: &TempDir, enable_lora_routes: bool) -> Result<StartedSimServer> {
         let port = reserve_loopback_port()?;
         let base_url = format!("http://127.0.0.1:{port}");
         let shutdown = CancellationToken::new();
         let engine = start_engine(SimulatedEngineConfig::new(0.0, 1000.0, 0.0, 1)?);
         let server_shutdown = shutdown.clone();
-        let model_path = model_dir.path.to_string_lossy().into_owned();
-        let model_path_buf = model_dir.path.clone();
+        let model_path = model_dir.path().to_string_lossy().into_owned();
+        let model_path_buf = model_dir.path().to_path_buf();
         let mut task = tokio::spawn(async move {
             if enable_lora_routes {
                 openinfer_vllm_frontend::serve_model_with_lora_routes(
@@ -143,51 +137,27 @@ struct StartedSimServer {
     task: JoinHandle<Result<()>>,
 }
 
-struct TempModelDir {
-    path: PathBuf,
+fn empty_model_dir() -> Result<TempDir> {
+    tempfile::tempdir().context("failed to create temp model dir")
 }
 
-impl TempModelDir {
-    fn empty() -> Result<Self> {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .context("system clock is before Unix epoch")?
-            .as_nanos();
-        let sequence = TEMP_MODEL_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
-        let path = std::env::temp_dir().join(format!(
-            "openinfer-sim-e2e-{}-{now}-{sequence}",
-            std::process::id()
-        ));
-        fs::create_dir(&path)
-            .with_context(|| format!("failed to create temp model dir {}", path.display()))?;
+fn model_dir_with_minimal_metadata() -> Result<TempDir> {
+    let dir = empty_model_dir()?;
 
-        Ok(Self { path })
-    }
+    // The simulated frontend still builds the normal vLLM text/chat stack.
+    // Token-id prompts avoid tokenizer encode work, but generated ids still
+    // need a tokenizer for detokenization and a tiny config for metadata.
+    fs::write(dir.path().join("tokenizer.json"), TINY_TOKENIZER_JSON)
+        .context("failed to write tiny tokenizer.json")?;
+    fs::write(
+        dir.path().join("tokenizer_config.json"),
+        TINY_TOKENIZER_CONFIG_JSON,
+    )
+    .context("failed to write tiny tokenizer_config.json")?;
+    fs::write(dir.path().join("config.json"), TINY_CONFIG_JSON)
+        .context("failed to write tiny config.json")?;
 
-    fn with_minimal_metadata() -> Result<Self> {
-        let dir = Self::empty()?;
-
-        // The simulated frontend still builds the normal vLLM text/chat stack.
-        // Token-id prompts avoid tokenizer encode work, but generated ids still
-        // need a tokenizer for detokenization and a tiny config for metadata.
-        fs::write(dir.path.join("tokenizer.json"), TINY_TOKENIZER_JSON)
-            .context("failed to write tiny tokenizer.json")?;
-        fs::write(
-            dir.path.join("tokenizer_config.json"),
-            TINY_TOKENIZER_CONFIG_JSON,
-        )
-        .context("failed to write tiny tokenizer_config.json")?;
-        fs::write(dir.path.join("config.json"), TINY_CONFIG_JSON)
-            .context("failed to write tiny config.json")?;
-
-        Ok(dir)
-    }
-}
-
-impl Drop for TempModelDir {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir_all(&self.path);
-    }
+    Ok(dir)
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -253,9 +223,9 @@ async fn streaming_completion_emits_terminal_done() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn simulated_frontend_metadata_contract_is_executable() -> Result<()> {
-    let model_dir = TempModelDir::with_minimal_metadata()?;
+    let model_dir = model_dir_with_minimal_metadata()?;
     for file in ["tokenizer.json", "tokenizer_config.json", "config.json"] {
-        if !model_dir.path.join(file).is_file() {
+        if !model_dir.path().join(file).is_file() {
             bail!("minimal simulated frontend metadata fixture is missing {file}");
         }
     }
@@ -263,7 +233,7 @@ async fn simulated_frontend_metadata_contract_is_executable() -> Result<()> {
     let server = SimServer::spawn_with_model_dir(model_dir).await?;
     server.shutdown().await?;
 
-    let error = match SimServer::spawn_with_model_dir(TempModelDir::empty()?).await {
+    let error = match SimServer::spawn_with_model_dir(empty_model_dir()?).await {
         Ok(server) => {
             server.shutdown().await?;
             bail!("empty local model metadata directory should fail frontend startup");


### PR DESCRIPTION
## Description

Fixes #549 

Replace the hand-rolled `env::temp_dir()` scratch dirs (pid/nanos/counter suffixes, ad-hoc cleanup, two hand-written Drop guards; some sites leaked on panic, one never cleaned up) with `tempfile::TempDir` across qwen3, qwen35-4b, deepseek-v2-lite, sim, and build. The workspace already declared `tempfile`; no crate used it. qwen3 `weights.rs` `temp_path` never touched the filesystem, so it is plain literal paths now.

Consolidate the qwen3 LoRA fixture helpers, previously copy-pasted across the lora.rs unit tests, `lora_smoke`, and `lora_golden_gate`, into `src/lora/fixtures.rs`, gated by `#[cfg(any(test, feature = "test-fixtures"))]` plus a self dev-dependency (tokio's test-util pattern). The feature enables no dependencies, `tempfile` stays dev-only, and the written fixture bytes are unchanged, so the golden gate replays the same adapter.

Verification: `cargo fmt --check` and `--locked` metadata pass; clippy adds no warning in any touched file. Local: openinfer-build 7/7, openinfer-sim `frontend_e2e` 5/5. Single GPU (sm_89, x86_64): qwen3 lib 64/64 and integration tests compile, qwen35-4b lib 32/32, deepseek-v2-lite lib 50/50. One qwen3 lib-test run used to leave seven directories in the system temp dir; now zero.


## Type of Change

- [x] non-breaking change which fixes an issue
