### PR TITLE
perf(qwen35): batch the uncompiled-GQA-group decode fallback

### DIFF
--- a/openinfer-core/src/ops.rs
+++ b/openinfer-core/src/ops.rs
@@ -10,7 +10,8 @@ mod traced;
 
 pub use attention::{
     paged_attention_batch_decode_hd256_into, paged_attention_batch_decode_into,
-    paged_attention_batch_decode_split_kv_into, prefill_attention_paged_into,
+    paged_attention_batch_decode_split_kv_into,
+    paged_attention_batch_decode_via_prefill_hd256_into, prefill_attention_paged_into,
 };
 pub use openinfer_kernels::ops::{
     GEMM_LT_MAX_N, LoraDecodeGroupedProjection, SUPPORTED_GQA_GROUP_SIZES,

--- a/openinfer-core/src/ops/attention.rs
+++ b/openinfer-core/src/ops/attention.rs
@@ -181,3 +181,34 @@ pub fn paged_attention_batch_decode_hd256_into(
         batch_size,
     )
 }
+
+#[allow(clippy::too_many_arguments)]
+pub fn paged_attention_batch_decode_via_prefill_hd256_into(
+    ctx: &DeviceContext,
+    q: &HiddenStates,
+    k: &HiddenStates,
+    v: &HiddenStates,
+    kv_buffer: &CudaSlice<bf16>,
+    layout: &KvLayout,
+    layer: usize,
+    plan: &PrefillPagedPlan,
+    positions_d: &CudaSlice<i32>,
+    output: &mut HiddenStates,
+    num_qo_heads: usize,
+    batch_size: usize,
+) -> Result<()> {
+    openinfer_kernels::ops::paged_attention_batch_decode_via_prefill_hd256_into(
+        ctx,
+        q,
+        k,
+        v,
+        kv_buffer,
+        &layout.kernel_layout(),
+        layer,
+        plan,
+        positions_d,
+        output,
+        num_qo_heads,
+        batch_size,
+    )
+}

--- a/openinfer-kernels/src/ops.rs
+++ b/openinfer-kernels/src/ops.rs
@@ -19,7 +19,8 @@ mod sampling;
 pub use attention::{
     PrefillPagedPlan, SUPPORTED_GQA_GROUP_SIZES, dflash_qk_norm_rope_into,
     paged_attention_batch_decode_hd256_into, paged_attention_batch_decode_into,
-    paged_attention_batch_decode_split_kv_into, prefill_attention_paged_into,
+    paged_attention_batch_decode_split_kv_into,
+    paged_attention_batch_decode_via_prefill_hd256_into, prefill_attention_paged_into,
     qk_norm_partial_rope_batched_decode_hd256_into, qk_norm_rope_batch_decode_into,
     single_prefill_nhd_noncausal_into,
 };

--- a/openinfer-kernels/src/ops/attention.rs
+++ b/openinfer-kernels/src/ops/attention.rs
@@ -1155,6 +1155,73 @@ pub fn paged_attention_batch_decode_split_kv_into(
 }
 
 #[allow(clippy::too_many_arguments)]
+fn scatter_decode_kv_into_paged(
+    ctx: &DeviceContext,
+    k: &HiddenStates,
+    v: &HiddenStates,
+    kv_buffer: &CudaSlice<bf16>,
+    layout: &PagedKvLayout,
+    layer: usize,
+    page_indices_d: &CudaSlice<i32>,
+    page_indptr_d: &CudaSlice<i32>,
+    last_page_len_d: &CudaSlice<i32>,
+    positions_d: &CudaSlice<i32>,
+    request_indices_d: &CudaSlice<i32>,
+    batch_size: usize,
+    op_name: &str,
+) -> Result<()> {
+    let num_kv_heads = layout.num_kv_heads;
+    let head_dim = layout.head_dim;
+    let page_size = layout.page_size;
+
+    let k_offset = (layer * layout.layer_stride) as i64;
+    let v_offset = (layer * layout.layer_stride + layout.kv_block_len) as i64;
+    let stride_page = layout.page_stride as i64;
+
+    let (buf_ptr, _gbuf) = kv_buffer.device_ptr(&ctx.stream);
+    let (k_ptr, _gk) = k.data.device_ptr(&ctx.stream);
+    let (v_ptr, _gv) = v.data.device_ptr(&ctx.stream);
+    let (pi_ptr, _gpi) = page_indices_d.device_ptr(&ctx.stream);
+    let (pip_ptr, _gpip) = page_indptr_d.device_ptr(&ctx.stream);
+    let (lpl_ptr, _glpl) = last_page_len_d.device_ptr(&ctx.stream);
+    let (pos_ptr, _gpos) = positions_d.device_ptr(&ctx.stream);
+    let (ri_ptr, _gri) = request_indices_d.device_ptr(&ctx.stream);
+
+    let src_stride_n = (num_kv_heads * head_dim) as i64;
+    let src_stride_h = head_dim as i64;
+    let result = unsafe {
+        ffi::paged_kv_scatter_cuda(
+            buf_ptr as *const ffi::Half,
+            k_offset,
+            v_offset,
+            pi_ptr as *const i32,
+            pip_ptr as *const i32,
+            lpl_ptr as *const i32,
+            k_ptr as *const ffi::Half,
+            v_ptr as *const ffi::Half,
+            ri_ptr as *const i32,
+            pos_ptr as *const i32,
+            batch_size as i32,
+            num_kv_heads as i32,
+            head_dim as i32,
+            page_size as i32,
+            stride_page,
+            src_stride_n,
+            src_stride_h,
+            crate::tensor::active_cu_stream(ctx),
+        )
+    };
+    if result != 0 {
+        anyhow::bail!(
+            "paged_kv_scatter_cuda ({op_name}) failed for layer {layer}, bs={batch_size}, \
+             kv_heads={num_kv_heads}, head_dim={head_dim}, page_size={page_size}: {result}{}",
+            crate::ops::ffi_exception_message(result)
+        );
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
 pub fn paged_attention_batch_decode_hd256_into(
     ctx: &DeviceContext,
     q: &HiddenStates,
@@ -1185,49 +1252,31 @@ pub fn paged_attention_batch_decode_hd256_into(
 
     let (buf_ptr, _gbuf) = kv_buffer.device_ptr(&ctx.stream);
     let (q_ptr, _gq) = q.data.device_ptr(&ctx.stream);
-    let (k_ptr, _gk) = k.data.device_ptr(&ctx.stream);
-    let (v_ptr, _gv) = v.data.device_ptr(&ctx.stream);
     let (out_ptr, _go) = output.data.device_ptr_mut(&ctx.stream);
     let (pi_ptr, _gpi) = page_indices_d.device_ptr(&ctx.stream);
     let (pip_ptr, _gpip) = page_indptr_d.device_ptr(&ctx.stream);
     let (lpl_ptr, _glpl) = last_page_len_d.device_ptr(&ctx.stream);
-    let (pos_ptr, _gpos) = positions_d.device_ptr(&ctx.stream);
     let (ri_ptr, _gri) = request_indices_d.device_ptr(&ctx.stream);
     let (kti_ptr, _gkti) = kv_tile_indices_d.device_ptr(&ctx.stream);
     let (kcs_ptr, _gkcs) = kv_chunk_size_d.device_ptr(&ctx.stream);
 
     let stream = crate::tensor::active_cu_stream(ctx);
 
-    let src_stride_n = (num_kv_heads * head_dim) as i64;
-    let src_stride_h = head_dim as i64;
-    let result = unsafe {
-        ffi::paged_kv_scatter_cuda(
-            buf_ptr as *const ffi::Half,
-            k_offset,
-            v_offset,
-            pi_ptr as *const i32,
-            pip_ptr as *const i32,
-            lpl_ptr as *const i32,
-            k_ptr as *const ffi::Half,
-            v_ptr as *const ffi::Half,
-            ri_ptr as *const i32,
-            pos_ptr as *const i32,
-            batch_size as i32,
-            num_kv_heads as i32,
-            head_dim as i32,
-            page_size as i32,
-            stride_page,
-            src_stride_n,
-            src_stride_h,
-            stream,
-        )
-    };
-    if result != 0 {
-        anyhow::bail!(
-            "paged_kv_scatter_cuda (batch hd256 decode) failed with error {result}{}",
-            crate::ops::ffi_exception_message(result)
-        );
-    }
+    scatter_decode_kv_into_paged(
+        ctx,
+        k,
+        v,
+        kv_buffer,
+        layout,
+        layer,
+        page_indices_d,
+        page_indptr_d,
+        last_page_len_d,
+        positions_d,
+        request_indices_d,
+        batch_size,
+        "batch hd256 decode",
+    )?;
 
     let sm_scale = 1.0f32 / (head_dim as f32).sqrt();
     let result = unsafe {
@@ -1256,6 +1305,105 @@ pub fn paged_attention_batch_decode_hd256_into(
     if result != 0 {
         anyhow::bail!(
             "paged_attention_decode_cuda_hd256 (batch) failed with error {result}{}",
+            crate::ops::ffi_exception_message(result)
+        );
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn paged_attention_batch_decode_via_prefill_hd256_into(
+    ctx: &DeviceContext,
+    q: &HiddenStates,
+    k: &HiddenStates,
+    v: &HiddenStates,
+    kv_buffer: &CudaSlice<bf16>,
+    layout: &PagedKvLayout,
+    layer: usize,
+    plan: &PrefillPagedPlan,
+    positions_d: &CudaSlice<i32>,
+    output: &mut HiddenStates,
+    num_qo_heads: usize,
+    batch_size: usize,
+) -> Result<()> {
+    let num_kv_heads = layout.num_kv_heads;
+    let head_dim = layout.head_dim;
+    debug_assert_eq!(head_dim, 256);
+    anyhow::ensure!(
+        batch_size == plan.total_tokens && batch_size == plan.batch_size as usize,
+        "decode-via-prefill plan shape mismatch: bs={batch_size}, total_tokens={}, plan_batch={}",
+        plan.total_tokens,
+        plan.batch_size
+    );
+
+    scatter_decode_kv_into_paged(
+        ctx,
+        k,
+        v,
+        kv_buffer,
+        layout,
+        layer,
+        &plan.page_indices_d,
+        &plan.page_indptr_d,
+        &plan.last_page_len_d,
+        positions_d,
+        &plan.batch_indices_d,
+        batch_size,
+        "batch hd256 decode via prefill",
+    )?;
+
+    let k_offset = (layer * layout.layer_stride) as i64;
+    let v_offset = (layer * layout.layer_stride + layout.kv_block_len) as i64;
+    let stride_page = layout.page_stride as i64;
+    let sm_scale = 1.0f32 / (head_dim as f32).sqrt();
+
+    let (buf_ptr, _gbuf) = kv_buffer.device_ptr(&ctx.stream);
+    let (q_ptr, _gq) = q.data.device_ptr(&ctx.stream);
+    let (out_ptr, _go) = output.data.device_ptr_mut(&ctx.stream);
+    let (pi_ptr, _gpi) = plan.page_indices_d.device_ptr(&ctx.stream);
+    let (pip_ptr, _gpip) = plan.page_indptr_d.device_ptr(&ctx.stream);
+    let (lpl_ptr, _glpl) = plan.last_page_len_d.device_ptr(&ctx.stream);
+    let (qi_ptr, _gqi) = plan.q_indptr_d.device_ptr(&ctx.stream);
+    let (ri_ptr, _gri) = plan.request_indices_d.device_ptr(&ctx.stream);
+    let (qti_ptr, _gqti) = plan.qo_tile_indices_d.device_ptr(&ctx.stream);
+    let (kti_ptr, _gkti) = plan.kv_tile_indices_d.device_ptr(&ctx.stream);
+    let (kcs_ptr, _gkcs) = plan.kv_chunk_size_d.device_ptr(&ctx.stream);
+    let (tnr_ptr, _gtnr) = plan.total_num_rows_d.device_ptr(&ctx.stream);
+
+    let result = unsafe {
+        ffi::batch_prefill_paged_cuda_hd256(
+            q_ptr as *const ffi::Half,
+            out_ptr as *mut ffi::Half,
+            buf_ptr as *const ffi::Half,
+            k_offset,
+            v_offset,
+            pi_ptr as *const i32,
+            pip_ptr as *const i32,
+            lpl_ptr as *const i32,
+            qi_ptr as *const i32,
+            ri_ptr as *const i32,
+            qti_ptr as *const i32,
+            kti_ptr as *const i32,
+            kcs_ptr as *const i32,
+            tnr_ptr as *const u32,
+            num_qo_heads as i32,
+            num_kv_heads as i32,
+            head_dim as i32,
+            layout.page_size as i32,
+            batch_size as i32,
+            plan.batch_size,
+            plan.num_tiles,
+            stride_page,
+            sm_scale,
+            crate::tensor::active_cu_stream(ctx),
+        )
+    };
+    if result != 0 {
+        anyhow::bail!(
+            "batch_prefill_paged_cuda_hd256 (decode via prefill) failed for layer {layer}, \
+             bs={batch_size}, tiles={}, qo_heads={num_qo_heads}, kv_heads={num_kv_heads}: {result}{}",
+            plan.num_tiles,
             crate::ops::ffi_exception_message(result)
         );
     }

--- a/openinfer-qwen35-4b/src/batch_decode.rs
+++ b/openinfer-qwen35-4b/src/batch_decode.rs
@@ -1,17 +1,21 @@
 //! Batched decode for Qwen3.5: N requests, 1 token each, shared full-attn kernels
 //! and per-request recurrent-state updates for linear attention.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use cudarc::driver::{DevicePtr, DevicePtrMut};
 
 use super::batch_decode_graph::{BATCH_BUCKETS, BatchDecodeGraphState, bucket_for};
 use super::decode_buffers::BatchDecodeBuffers35;
 use super::recurrent_state::RecurrentState;
-use super::weights::{FullAttentionLayer, LayerKind, LinearAttentionLayer, Qwen35Model};
+use super::weights::{
+    FullAttentionLayer, LayerKind, LinearAttentionLayer, Qwen35Model, TransformerBlock35,
+};
 use crate::ops;
 use openinfer_core::kv_pool::{KvLayout, KvState};
 use openinfer_core::sampler::SamplingParams;
 use openinfer_core::tensor::HiddenStates;
+
+static LOG_UNCOMPILED_DECODE_ROUTE: std::sync::Once = std::sync::Once::new();
 
 impl Qwen35Model {
     pub(crate) fn select_tokens_from_logits_varied(
@@ -151,6 +155,74 @@ impl Qwen35Model {
         Ok(())
     }
 
+    fn batch_decode_full_attention_via_prefill(
+        &self,
+        attn: &FullAttentionLayer,
+        kv_buffer: &cudarc::driver::CudaSlice<half::bf16>,
+        layout: &KvLayout,
+        plan: &ops::PrefillPagedPlan,
+        layer_idx: usize,
+        bs: usize,
+        bufs: &mut BatchDecodeBuffers35,
+    ) -> Result<()> {
+        let eps = self.config.rms_norm_eps;
+
+        ops::gemm_into(&self.ctx, &attn.q_proj, &bufs.normed, &mut bufs.q_full);
+        ops::gemm_into(&self.ctx, &attn.k_proj, &bufs.normed, &mut bufs.k_attn);
+        ops::gemm_into(&self.ctx, &attn.v_proj, &bufs.normed, &mut bufs.v_attn);
+
+        ops::qk_norm_partial_rope_batched_decode_hd256_into(
+            &self.ctx,
+            &bufs.q_full,
+            &mut bufs.q_attn,
+            &mut bufs.k_attn,
+            &attn.q_norm,
+            &attn.k_norm,
+            &self.cos_cache,
+            &self.sin_cache,
+            &bufs.positions_d,
+            self.config.num_attention_heads,
+            self.config.num_key_value_heads,
+            self.config.rotary_dim,
+            eps,
+        );
+
+        ops::paged_attention_batch_decode_via_prefill_hd256_into(
+            &self.ctx,
+            &bufs.q_attn,
+            &bufs.k_attn,
+            &bufs.v_attn,
+            kv_buffer,
+            layout,
+            layer_idx,
+            plan,
+            &bufs.positions_d,
+            &mut bufs.attn_out_full,
+            self.config.num_attention_heads,
+            bs,
+        )?;
+
+        unsafe {
+            let (qf_ptr, _gqf) = bufs.q_full.data.device_ptr(&self.ctx.stream);
+            let (out_ptr, _go) = bufs.attn_out_full.data.device_ptr_mut(&self.ctx.stream);
+            crate::ffi::attention_gate_batch_hd256_cuda(
+                qf_ptr as *const crate::ffi::Half,
+                out_ptr as *mut crate::ffi::Half,
+                self.config.num_attention_heads as i32,
+                bs as i32,
+                self.ctx.stream.cu_stream(),
+            );
+        }
+
+        ops::gemm_into(
+            &self.ctx,
+            &attn.o_proj,
+            &bufs.attn_out_full,
+            &mut bufs.attn_results,
+        );
+        Ok(())
+    }
+
     // =========================================================================
     // CUDA Graph batch decode
     // =========================================================================
@@ -180,7 +252,18 @@ impl Qwen35Model {
         );
 
         if !self.config.decode_group_is_compiled() {
-            return self.batch_decode_via_prefill(token_ids, kv_states, graph_state);
+            LOG_UNCOMPILED_DECODE_ROUTE.call_once(|| {
+                let group = self.config.num_attention_heads / self.config.num_key_value_heads;
+                log::info!(
+                    "Qwen3.5 decode GQA group {group} ({} q heads / {} kv heads) has no compiled BatchDecode kernel; batched hybrid eager fallback active, bs_capacity={}",
+                    self.config.num_attention_heads,
+                    self.config.num_key_value_heads,
+                    graph_state.buffers.max_batch_size,
+                );
+            });
+            // Paged-prefill attention stays eager; verify_graph records that
+            // captured prefill attention under-reads growing decode KV.
+            return self.batch_decode_batched_hybrid(token_ids, kv_states, graph_state);
         }
 
         let padded_bs = bucket_for(bs);
@@ -235,9 +318,7 @@ impl Qwen35Model {
         result
     }
 
-    /// Decode an uncompiled GQA group via the prefill path, writing `buffers.logits`
-    /// so callers sample as after the graph path.
-    pub(crate) fn batch_decode_via_prefill(
+    fn batch_decode_batched_hybrid(
         &self,
         token_ids: &[u32],
         kv_states: &mut [&mut KvState],
@@ -246,39 +327,94 @@ impl Qwen35Model {
         let bs = token_ids.len();
         anyhow::ensure!(
             bs > 0,
-            "batch_decode_via_prefill requires at least one request"
+            "batch_decode_batched_hybrid requires at least one request"
         );
-        anyhow::ensure!(bs == kv_states.len(), "token_ids / kv_states len mismatch");
+        anyhow::ensure!(
+            bs == kv_states.len(),
+            "batch_decode_batched_hybrid token_ids / kv_states len mismatch: token_ids={}, kv_states={}",
+            bs,
+            kv_states.len()
+        );
+        anyhow::ensure!(
+            bs <= graph_state.buffers.max_batch_size,
+            "batch_decode_batched_hybrid bs={bs} exceeds buffer capacity {}",
+            graph_state.buffers.max_batch_size
+        );
 
-        let mut last_hiddens = Vec::with_capacity(bs);
-        for i in 0..bs {
-            let hidden = self.prefill_last_hidden(
-                &[token_ids[i]],
-                &mut *kv_states[i],
-                &mut graph_state.slot_states[i],
-            )?;
-            last_hiddens.push(hidden);
+        let mut positions_i32 = Vec::with_capacity(bs);
+        let mut start_positions = Vec::with_capacity(bs);
+        for (i, kv) in kv_states.iter_mut().enumerate() {
+            let pos = kv.seq_len();
+            self.ensure_rope_cache_covers(pos + 1)
+                .with_context(|| format!("hybrid decode rope cache pos={} slot={i}", pos + 1))?;
+            kv.ensure_capacity(pos + 1)
+                .with_context(|| format!("hybrid decode KV capacity pos={} slot={i}", pos + 1))?;
+            kv.advance(1);
+            graph_state.slot_states[i].seq_len += 1;
+            positions_i32.push(pos as i32);
+            start_positions.push(pos);
         }
 
         let bufs = &mut graph_state.buffers;
         bufs.set_batch_size(bs);
-        for (i, hidden) in last_hiddens.iter().enumerate() {
-            ops::write_vec_into(&self.ctx, hidden, &mut bufs.hidden, i)?;
-        }
-        ops::rms_norm_batch_offset_into(
+        self.ctx
+            .stream
+            .memcpy_htod(token_ids, &mut bufs.token_ids_d)
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "hybrid decode H2D token_ids bs={bs}, cap={}: {e}",
+                    bufs.max_batch_size
+                )
+            })?;
+        self.ctx
+            .stream
+            .memcpy_htod(&positions_i32, &mut bufs.positions_d)
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "hybrid decode H2D positions bs={bs}, cap={}: {e}",
+                    bufs.max_batch_size
+                )
+            })?;
+
+        let page_indices: Vec<Vec<i32>> =
+            kv_states.iter().map(|kv| kv.page_indices_i32()).collect();
+        let last_page_lens: Vec<usize> = kv_states.iter().map(|kv| kv.last_page_len()).collect();
+        let seq_lens = vec![1usize; bs];
+        // cta_tile_q 0 = the kernel's own FA2 derivation; the hd256 FFI takes no override.
+        let plan = ops::PrefillPagedPlan::from_raw_batch_with_cta_tile_q(
             &self.ctx,
-            &bufs.hidden,
-            &self.norm,
-            self.config.rms_norm_eps,
-            &mut bufs.normed,
-        )?;
-        ops::gemm_into(
-            &self.ctx,
-            self.output_projection(),
-            &bufs.normed,
-            &mut bufs.logits,
+            &page_indices,
+            &last_page_lens,
+            &start_positions,
+            &seq_lens,
+            self.config.num_attention_heads,
+            self.config.num_key_value_heads,
+            self.config.head_dim,
+            0,
+        )
+        .with_context(|| {
+            format!(
+                "hybrid decode build PrefillPagedPlan bs={bs}, pages={}, heads={}/{}, head_dim={}",
+                page_indices.iter().map(Vec::len).sum::<usize>(),
+                self.config.num_attention_heads,
+                self.config.num_key_value_heads,
+                self.config.head_dim
+            )
+        })?;
+
+        let kv_buffer = kv_states[0].buffer();
+        let layout = *kv_states[0].layout();
+        anyhow::ensure!(
+            layout.num_kv_heads == self.config.num_key_value_heads
+                && layout.head_dim == self.config.head_dim,
+            "hybrid decode KV layout mismatch bs={bs}: layout kv_heads={}, head_dim={}; config kv_heads={}, head_dim={}",
+            layout.num_kv_heads,
+            layout.head_dim,
+            self.config.num_key_value_heads,
+            self.config.head_dim
         );
-        Ok(())
+        let slot_states = &mut graph_state.slot_states;
+        self.batch_decode_batched_hybrid_kernels(kv_buffer, &layout, &plan, bs, slot_states, bufs)
     }
 
     fn batch_decode_kernels_graph(
@@ -376,6 +512,117 @@ impl Qwen35Model {
         debug_assert_eq!(bufs.logits.seq_len, padded_bs);
 
         Ok(())
+    }
+
+    fn batch_decode_batched_hybrid_kernels(
+        &self,
+        kv_buffer: &cudarc::driver::CudaSlice<half::bf16>,
+        layout: &KvLayout,
+        plan: &ops::PrefillPagedPlan,
+        bs: usize,
+        slot_states: &mut [RecurrentState],
+        bufs: &mut BatchDecodeBuffers35,
+    ) -> Result<()> {
+        let eps = self.config.rms_norm_eps;
+
+        ops::embedding_batch(
+            &self.ctx,
+            &self.embed_tokens,
+            &bufs.token_ids_d,
+            &mut bufs.hidden,
+        )?;
+
+        let mut linear_idx = 0usize;
+        let mut full_idx = 0usize;
+        for (layer_idx, layer) in self.layers.iter().enumerate() {
+            ops::rms_norm_batch_offset_into(
+                &self.ctx,
+                &bufs.hidden,
+                &layer.input_layernorm,
+                eps,
+                &mut bufs.normed,
+            )?;
+
+            match &layer.attn {
+                LayerKind::FullAttention(attn) => {
+                    self.batch_decode_full_attention_via_prefill(
+                        attn, kv_buffer, layout, plan, full_idx, bs, bufs,
+                    )
+                    .with_context(|| {
+                        format!("hybrid decode full-attn layer_idx={layer_idx}, full_idx={full_idx}, bs={bs}")
+                    })?;
+                    full_idx += 1;
+                }
+                LayerKind::LinearAttention(attn) => {
+                    self.batch_decode_linear_attention_slots(
+                        attn, slot_states, linear_idx, bs, bufs,
+                    )
+                        .with_context(|| {
+                            format!("hybrid decode linear-attn layer_idx={layer_idx}, linear_idx={linear_idx}, bs={bs}")
+                        })?;
+                    linear_idx += 1;
+                }
+            }
+
+            self.batch_decode_mlp_tail(layer, bufs, eps)
+                .with_context(|| {
+                    format!("hybrid decode MLP tail layer_idx={layer_idx}, bs={bs}")
+                })?;
+        }
+
+        ops::rms_norm_batch_offset_into(
+            &self.ctx,
+            &bufs.hidden,
+            &self.norm,
+            eps,
+            &mut bufs.normed,
+        )?;
+        ops::gemm_into(
+            &self.ctx,
+            self.output_projection(),
+            &bufs.normed,
+            &mut bufs.logits,
+        );
+        debug_assert_eq!(bufs.logits.seq_len, bs);
+        Ok(())
+    }
+
+    fn batch_decode_mlp_tail(
+        &self,
+        layer: &TransformerBlock35,
+        bufs: &mut BatchDecodeBuffers35,
+        eps: f32,
+    ) -> Result<()> {
+        ops::add_batch_into(
+            &self.ctx,
+            &bufs.hidden,
+            &bufs.attn_results,
+            &mut bufs.hidden_mid,
+        )?;
+
+        ops::rms_norm_batch_offset_into(
+            &self.ctx,
+            &bufs.hidden_mid,
+            &layer.post_attention_layernorm,
+            eps,
+            &mut bufs.normed,
+        )?;
+
+        ops::gemm_into(
+            &self.ctx,
+            &layer.mlp.gate_up_proj,
+            &bufs.normed,
+            &mut bufs.gate_up_out,
+        );
+        ops::silu_mul_fused_batch_into(&self.ctx, &bufs.gate_up_out, &mut bufs.act_out)?;
+        ops::gemm_into(
+            &self.ctx,
+            &layer.mlp.down_proj,
+            &bufs.act_out,
+            &mut bufs.mlp_out,
+        );
+
+        ops::add_batch_into(&self.ctx, &bufs.hidden_mid, &bufs.mlp_out, &mut bufs.hidden)
     }
 
     /// Linear attention decode over slot-indexed recurrent state.

--- a/openinfer-qwen35-4b/src/config.rs
+++ b/openinfer-qwen35-4b/src/config.rs
@@ -180,13 +180,6 @@ impl Config35 {
             layer_types,
             tie_word_embeddings,
         };
-        if !config.decode_group_is_compiled() {
-            log::warn!(
-                "Qwen3.5 GQA group {}/{} has no compiled decode kernel; decode runs eager through the prefill path",
-                config.num_attention_heads,
-                config.num_key_value_heads,
-            );
-        }
         Ok(config)
     }
 
@@ -214,6 +207,7 @@ impl Config35 {
     }
 
     pub(crate) fn decode_group_is_compiled(&self) -> bool {
+        // Uncompiled GQA groups use the batched hybrid eager fallback.
         openinfer_core::ops::SUPPORTED_GQA_GROUP_SIZES
             .contains(&(self.num_attention_heads / self.num_key_value_heads))
     }

--- a/openinfer-qwen35-4b/src/kernel_plan.rs
+++ b/openinfer-qwen35-4b/src/kernel_plan.rs
@@ -165,8 +165,8 @@ pub static KERNEL_PLAN: KernelPlan = KernelPlan {
         },
         // ── Decode ──────────────────────────────────────────────────────────
         //
-        // CUDA-Graph captured. 1 token per request, bucket-padded to the
-        // nearest BATCH_BUCKET size. Recurrent state managed per slot.
+        // Compiled GQA groups use CUDA Graph bucket padding. Uncompiled groups
+        // run eager at real batch size and reuse paged prefill for full attn.
         //
         KernelPhase {
             name: "decode",
@@ -174,44 +174,50 @@ pub static KERNEL_PLAN: KernelPlan = KernelPlan {
                 // shared decode prologue
                 KernelOp {
                     id: "embedding_decode",
-                    rust: "batch_decode::batch_decode_kernels_graph -> ops::embedding_batch",
+                    rust: "batch_decode::{batch_decode_kernels_graph,batch_decode_batched_hybrid_kernels} -> ops::embedding_batch",
                     backend: "CUDA",
-                    notes: "one token per request; bucket-padded for CUDA Graph",
+                    notes: "one token per request; compiled path bucket-pads, uncompiled fallback uses real bs",
                 },
                 KernelOp {
                     id: "rms_norm_offset_decode",
-                    rust: "batch_decode::batch_decode_kernels_graph -> ops::rms_norm_batch_offset_into",
+                    rust: "batch_decode::{batch_decode_kernels_graph,batch_decode_batched_hybrid_kernels} -> ops::rms_norm_batch_offset_into",
                     backend: "FlashInfer",
                     notes: "(1+w) GemmaRMSNorm per layer (via flashinfer::norm::GemmaRMSNorm)",
                 },
                 // full-attention decode (8 layers)
                 KernelOp {
                     id: "qkv_gemm_decode_full",
-                    rust: "batch_decode::batch_decode_full_attention -> ops::gemm_into (q/k/v_proj)",
+                    rust: "batch_decode::{batch_decode_full_attention,batch_decode_full_attention_via_prefill} -> ops::gemm_into (q/k/v_proj)",
                     backend: "cuBLAS",
-                    notes: "3 cuBLAS GEMMs — Q, K, V projection over bucket-padded batch",
+                    notes: "3 cuBLAS GEMMs — Q, K, V projection over the active decode batch",
                 },
                 KernelOp {
                     id: "qk_norm_partial_rope_decode",
-                    rust: "batch_decode::batch_decode_full_attention -> ops::qk_norm_partial_rope_batched_decode_hd256_into",
+                    rust: "batch_decode::{batch_decode_full_attention,batch_decode_full_attention_via_prefill} -> ops::qk_norm_partial_rope_batched_decode_hd256_into",
                     backend: "CUDA",
                     notes: "Q/K RMSNorm + partial RoPE, head_dim=256",
                 },
                 KernelOp {
-                    id: "paged_decode_attention",
+                    id: "paged_decode_attention_compiled_group",
                     rust: "batch_decode::batch_decode_full_attention -> ops::paged_attention_batch_decode_hd256_into",
                     backend: "CUDA",
-                    notes: "wraps paged_kv_scatter + paged_attention_decode — custom CUDA, NOT FlashInfer",
+                    notes: "compiled GQA groups: shared paged_kv_scatter + ffi::paged_attention_decode_cuda_hd256",
+                },
+                KernelOp {
+                    id: "paged_decode_attention_uncompiled_group",
+                    rust: "batch_decode::batch_decode_full_attention_via_prefill -> ops::paged_attention_batch_decode_via_prefill_hd256_into",
+                    backend: "CUDA",
+                    notes: "uncompiled GQA groups: shared paged_kv_scatter + ffi::batch_prefill_paged_cuda_hd256, eager only",
                 },
                 KernelOp {
                     id: "attention_gate_decode",
-                    rust: "batch_decode::batch_decode_full_attention -> ffi::attention_gate_batch_hd256_cuda",
+                    rust: "batch_decode::{batch_decode_full_attention,batch_decode_full_attention_via_prefill} -> ffi::attention_gate_batch_hd256_cuda",
                     backend: "CUDA",
                     notes: "Q-gated attention output scaling",
                 },
                 KernelOp {
                     id: "o_proj_decode_full",
-                    rust: "batch_decode::batch_decode_full_attention -> ops::gemm_into (o_proj)",
+                    rust: "batch_decode::{batch_decode_full_attention,batch_decode_full_attention_via_prefill} -> ops::gemm_into (o_proj)",
                     backend: "cuBLAS",
                     notes: "attention output projection",
                 },
@@ -249,28 +255,28 @@ pub static KERNEL_PLAN: KernelPlan = KernelPlan {
                 // shared decode epilogue (every layer)
                 KernelOp {
                     id: "residual_add_decode",
-                    rust: "batch_decode::batch_decode_kernels_graph -> ops::add_batch_into",
+                    rust: "batch_decode::{batch_decode_kernels_graph,batch_decode_mlp_tail} -> ops::add_batch_into",
                     backend: "CUDA",
                     notes: "residual connections (post-attn, post-mlp)",
                 },
                 KernelOp {
                     id: "mlp_decode",
-                    rust: "batch_decode::batch_decode_kernels_graph -> ops::gemm_into (gate_up/down) + silu_mul_fused_batch_into",
+                    rust: "batch_decode::{batch_decode_kernels_graph,batch_decode_mlp_tail} -> ops::gemm_into (gate_up/down) + silu_mul_fused_batch_into",
                     backend: "CUDA + cuBLAS",
                     notes: "SwiGLU MLP — fused gate+up cuBLAS GEMM, CUDA SiLU*mul, down cuBLAS GEMM",
                 },
                 // final norm + sampling (once per decode step, not per layer)
                 KernelOp {
                     id: "final_norm_decode",
-                    rust: "batch_decode::batch_decode_kernels_graph -> ops::rms_norm_batch_offset_into",
+                    rust: "batch_decode::{batch_decode_kernels_graph,batch_decode_batched_hybrid_kernels} -> ops::rms_norm_batch_offset_into",
                     backend: "FlashInfer",
                     notes: "final RMSNorm on logits hidden state (via flashinfer::norm::GemmaRMSNorm)",
                 },
                 KernelOp {
                     id: "lm_head_decode",
-                    rust: "batch_decode::batch_decode_kernels_graph -> ops::gemm_into (output_projection)",
+                    rust: "batch_decode::{batch_decode_kernels_graph,batch_decode_batched_hybrid_kernels} -> ops::gemm_into (output_projection)",
                     backend: "cuBLAS",
-                    notes: "LM head: untied lm_head.weight when the config unties embeddings, else embed_tokens (one cuBLAS GEMM over the bucket-padded batch)",
+                    notes: "LM head: untied lm_head.weight when configured, else embed_tokens; logits rows are dense 0..active_bs",
                 },
                 // batched sampling
                 KernelOp {

--- a/openinfer-qwen35-4b/src/ops.rs
+++ b/openinfer-qwen35-4b/src/ops.rs
@@ -4,6 +4,7 @@ pub(crate) use openinfer_core::ops::PrefillPagedPlan;
 pub(crate) use openinfer_core::ops::{
     GEMM_LT_MAX_N, add_batch, add_batch_into, embedding_batch, extract_vec, extract_vec_into, gemm,
     gemm_into, gemm_lt_tune, paged_attention_batch_decode_hd256_into,
+    paged_attention_batch_decode_via_prefill_hd256_into,
     qk_norm_partial_rope_batched_decode_hd256_into, rms_norm_gated_batch_into,
     silu_mul_fused_batch_into, write_vec_into,
 };


### PR DESCRIPTION
## Description

Fixes #572 

Qwen3.5-27B's full attention is GQA group 6, outside FlashInfer BatchDecode's compiled set {1,2,3,4,8}, so decode fell back to `batch_decode_via_prefill`: one seq_len=1 `prefill_last_hidden` per request in a serial loop, only the final LM-head GEMM batched — ~40 tok/s, and closed-loop concurrency scaled per-token latency instead of throughput (#510).

Replace the fallback with a batched hybrid eager forward at the same dispatch point. One shared qo_len=1 `PrefillPagedPlan` routes the full-attention layers through the group-agnostic `batch_prefill_paged_cuda_hd256` (each decode row attends its full KV history); the linear-attention layers reuse the already-batched slot decode with per-slot recurrent state. The KV append is extracted into one scatter helper shared by the compiled decode op and the new via-prefill op. The path stays eager: FlashInfer's paged-prefill kernel freezes its KV trip count at graph capture, so a captured attention would under-read the growing KV.

Same-base A/B on 27B (GH200 sm_90; vllm bench serve, random in1024/out128):

| run | med TPOT (ms) | out tok/s | tok/s gain |
|---|---:|---:|---:|
| c=1 | 25.7 -> 20.2 | 37.5 -> 47.2 | 1.3x |
| c=2 | 50.1 -> 22.9 | 39.1 -> 80.8 | 2.1x |
| c=4 | 97.9 -> 28.2 | 40.0 -> 133.4 | 3.3x |
| c=8 | 194.7 -> 37.4 | 40.5 -> 200.7 | 5.0x |
| qps=1 | 365.5 -> 28.9 | 40.1 -> 111.9 | 2.8x |
| qps=4 | 502.7 -> 109.0 | 100.7 -> 298.1 | 3.0x |

The serial baseline holds ~40 tok/s at every concurrency with TPOT scaling linearly (c8/c1 = 7.6x) — the #510 symptom; the batched path scales throughput instead (TPOT ratio 1.9x). TTFT at c=8 improves 566 -> 326 ms as decode no longer serializes the GPU.

## Test Env

GH200 (aarch64, sm_90), single GPU, A/B at the same base commit. 27B hf_golden_gate (short + long) 3/3 green on the batched path.  Route log asserts the batched path is active exactly once.

## Type of Change

- [x] Optimisation (non-breaking change which fixes an issue)

