### PR TITLE
chore(deps): remove unused direct dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3389,7 +3389,6 @@ dependencies = [
  "openinfer-comm-fabric-lib",
  "openinfer-comm-logging-lib",
  "openinfer-comm-p2p-all-to-all",
- "openinfer-comm-thread-lib",
  "openinfer-comm-torch-lib",
  "parking_lot",
  "postcard",
@@ -3436,7 +3435,6 @@ dependencies = [
  "parking_lot",
  "safetensors",
  "serde_json",
- "tokio",
 ]
 
 [[package]]
@@ -3480,7 +3478,6 @@ dependencies = [
  "crossbeam-channel",
  "cudarc",
  "half",
- "libc",
  "log",
  "memmap2",
  "openinfer-comm",
@@ -3532,7 +3529,6 @@ dependencies = [
  "cc",
  "cudarc",
  "half",
- "log",
  "openinfer-build",
  "serde",
  "tvm-ffi",
@@ -3569,7 +3565,6 @@ dependencies = [
  "anyhow",
  "cudarc",
  "dynamo-kv-hashing",
- "dynamo-tokens",
  "half",
  "kvbm-logical",
  "openinfer-kernels",
@@ -3580,7 +3575,6 @@ dependencies = [
 name = "openinfer-kv-offload"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "cudarc",
  "half",
  "log",
@@ -3603,7 +3597,6 @@ dependencies = [
  "half",
  "hex",
  "log",
- "memmap2",
  "openinfer-bench",
  "openinfer-core",
  "openinfer-cupti",
@@ -3631,7 +3624,6 @@ dependencies = [
  "anyhow",
  "criterion 0.8.2",
  "cudarc",
- "fastrace",
  "half",
  "log",
  "openinfer-core",
@@ -3666,13 +3658,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "colored",
  "comfy-table",
  "cudarc",
- "fastrace",
- "half",
  "log",
- "logforth",
  "openinfer-core",
  "openinfer-deepseek-v2-lite",
  "openinfer-deepseek-v4",

--- a/openinfer-comm/crates/openinfer-comm-python-ext/Cargo.toml
+++ b/openinfer-comm/crates/openinfer-comm-python-ext/Cargo.toml
@@ -24,7 +24,6 @@ hw-rdma = [
 cuda-lib = { path = "../openinfer-comm-cuda-lib", package = "openinfer-comm-cuda-lib" }
 fabric-lib = { path = "../openinfer-comm-fabric-lib", package = "openinfer-comm-fabric-lib" }
 logging-lib = { path = "../openinfer-comm-logging-lib", package = "openinfer-comm-logging-lib" }
-thread-lib = { path = "../openinfer-comm-thread-lib", package = "openinfer-comm-thread-lib" }
 torch-lib = { path = "../openinfer-comm-torch-lib", package = "openinfer-comm-torch-lib" }
 p2p-all-to-all = { path = "../openinfer-comm-p2p-all-to-all", package = "openinfer-comm-p2p-all-to-all" }
 

--- a/openinfer-core/Cargo.toml
+++ b/openinfer-core/Cargo.toml
@@ -18,7 +18,6 @@ memmap2 = { workspace = true }
 parking_lot = { workspace = true }
 safetensors = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["sync"] }
 
 [features]
 default = []

--- a/openinfer-deepseek-v4/Cargo.toml
+++ b/openinfer-deepseek-v4/Cargo.toml
@@ -29,7 +29,6 @@ clap = { workspace = true }
 crossbeam-channel = { workspace = true }
 cudarc = { workspace = true, features = ["nccl"] }
 half = { workspace = true }
-libc = { workspace = true }
 log = { workspace = true }
 memmap2 = { workspace = true }
 openinfer-comm = { workspace = true, optional = true }

--- a/openinfer-kernels/Cargo.toml
+++ b/openinfer-kernels/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2024"
 anyhow = { workspace = true }
 cudarc = { workspace = true }
 half = { workspace = true }
-log = { workspace = true }
 serde = { workspace = true }
 tvm-ffi = { version = "0.1.0-alpha.0", optional = true }
 

--- a/openinfer-kv-cache/Cargo.toml
+++ b/openinfer-kv-cache/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2024"
 [dependencies]
 openinfer-kernels = { workspace = true }
 kvbm-logical = { workspace = true }
-dynamo-tokens = { workspace = true }
 dynamo-kv-hashing = { workspace = true }
 anyhow = { workspace = true }
 cudarc = { workspace = true }

--- a/openinfer-kv-offload/Cargo.toml
+++ b/openinfer-kv-offload/Cargo.toml
@@ -17,7 +17,6 @@ edition = "2024"
 pegaflow-core = { git = "https://github.com/novitalabs/pegaflow.git", rev = "d46fd1653154f3f895ff23e995b6efbf4e3e1e9a", default-features = false, features = ["rdma"] }
 openinfer-kv-cache = { workspace = true }
 cudarc = { workspace = true }
-anyhow = { workspace = true }
 half = { workspace = true }
 log = { workspace = true }
 tokio = { workspace = true }

--- a/openinfer-qwen3/Cargo.toml
+++ b/openinfer-qwen3/Cargo.toml
@@ -22,7 +22,6 @@ fastrace = { workspace = true }
 half = { workspace = true }
 hex = { workspace = true, optional = true }
 log = { workspace = true }
-memmap2 = { workspace = true }
 rand = { workspace = true }
 safetensors = { workspace = true }
 serde = { workspace = true }

--- a/openinfer-qwen35-4b/Cargo.toml
+++ b/openinfer-qwen35-4b/Cargo.toml
@@ -11,7 +11,6 @@ openinfer-kernels = { workspace = true }
 openinfer-sample = { workspace = true }
 anyhow = { workspace = true }
 cudarc = { workspace = true }
-fastrace = { workspace = true }
 half = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }

--- a/openinfer-server/Cargo.toml
+++ b/openinfer-server/Cargo.toml
@@ -35,13 +35,9 @@ openinfer-vllm-frontend = { workspace = true }
 openinfer-vllm-support = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
-colored = { workspace = true }
 comfy-table = { workspace = true }
 cudarc = { workspace = true }
-fastrace = { workspace = true }
-half = { workspace = true }
 log = { workspace = true }
-logforth = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 tokio-util = { workspace = true }


### PR DESCRIPTION
## Summary
- Remove unused direct dependency declarations reported by cargo-machete.
- Keep transitive dependencies such as vllm-metrics, which are still pulled by upstream vLLM crates.
- Update Cargo.lock to match the manifest cleanup.

## Validation
- cargo machete
- cargo check -p openinfer-server --release
- cargo check --release -p openinfer-qwen35-4b -p openinfer-deepseek-v4 -p openinfer-comm-python-ext --lib

## Notes
- cargo check --release --workspace --lib was attempted but requires OPENINFER_NCCL_ROOT for the openinfer-kernels moe path; this is unrelated to the dependency cleanup.