### PR TITLE
fix(qwen3): re-enable CUDA Graph under TP via startup decode-graph pre-capture

### DIFF
--- a/docs/models/qwen3/tp-design.md
+++ b/docs/models/qwen3/tp-design.md
@@ -735,7 +735,7 @@ The next practical steps should be:
 
 - keep the current TP path stable and avoid reopening the earlier decode append bug
 - further unify the `tp=1` and `tp>1` scheduler / executor flow now that both paths are real and runnable
-- defer TP-specific CUDA Graph work until after that runtime shape is cleaner and more stable
+- keep the TP decode-graph startup pre-capture (every reachable bucket graph is captured in lock-step at init, so TP `batch_decode` steps are pure replay; mixed prefill+decode steps stay on the eager unified path) aligned with any bucket/attention-path changes
 - then revisit vocab-side replication only after the execution and correctness story is stable
 
 So the right reading of the current status is:
@@ -743,7 +743,8 @@ So the right reading of the current status is:
 - the architecture direction is validated
 - the TP path is real and runnable
 - the implementation is still a first-pass runtime bring-up, not the final production shape
-- TP-specific CUDA Graph support should still be treated as follow-up work rather than a solved part of the current baseline
+- TP CUDA Graph is now served via startup pre-capture (#498): every reachable (bucket, attention-path) decode graph is captured per rank at init while the ranks are trivially in lock-step, after every rank worker has spawned — uniform captured-ness across ranks is an invariant established at construction, not a runtime property
+- the sweep is two-phase per bucket (dual-GPU measured requirement, not a nicety): every rank records + instantiates + uploads the bucket's graph before any rank launches it, because a launched captured collective spins on its peers while capture/instantiate/upload contend process-wide driver locks — overlapping the two deadlocks the driver; for the same reason the TP memory profile's decode exercise runs eager, and the NCCL warmup runs one eager all-reduce per bucket size (connections are established per size-selected algorithm)
 
 The core bar for this milestone is straightforward:
 
@@ -754,7 +755,6 @@ The core bar for this milestone is straightforward:
 The following questions are intentionally deferred until after the first TP milestone is proven:
 
 - how far to push throughput optimization in the first TP implementation
-- when to restore or redesign CUDA Graph support for TP paths
 - when to shard vocab-facing weights instead of replicating them
 - whether later multi-GPU support should expand first toward larger dense models, MoE, or broader serving topology work
 

--- a/openinfer-core/src/cuda_graph.rs
+++ b/openinfer-core/src/cuda_graph.rs
@@ -96,6 +96,25 @@ impl CudaGraphState {
         self.run_or_capture_synchronized(ctx, |_| {}, kernels)
     }
 
+    /// Capture, instantiate, and upload — no launch — so a later
+    /// [`Self::launch_captured`] is a pure enqueue (an un-uploaded exec uploads
+    /// implicitly on first launch). Async; synchronize before launching.
+    pub fn capture_only<F>(&mut self, ctx: &DeviceContext, kernels: F) -> Result<()>
+    where
+        F: FnOnce() -> Result<()>,
+    {
+        anyhow::ensure!(
+            !self.is_captured(),
+            "capture_only on an already-captured graph would leak the live exec"
+        );
+        let stream = active_cu_stream(ctx);
+        self.capture_and_instantiate(ctx, stream, &mut |_| {}, kernels)?;
+        check(
+            unsafe { sys::cuGraphUpload(self.exec, stream) },
+            "cuGraphUpload",
+        )
+    }
+
     pub fn run_or_capture_synchronized<F, S>(
         &mut self,
         ctx: &DeviceContext,
@@ -118,6 +137,28 @@ impl CudaGraphState {
             return Ok(());
         }
 
+        self.capture_and_instantiate(ctx, stream, &mut synchronize, kernels)?;
+
+        synchronize(CudaGraphPhase::BeforeLaunch);
+        check(
+            unsafe { sys::cuGraphLaunch(self.exec, stream) },
+            "cuGraphLaunch first launch",
+        )?;
+        synchronize(CudaGraphPhase::AfterLaunch);
+        Ok(())
+    }
+
+    fn capture_and_instantiate<F, S>(
+        &mut self,
+        ctx: &DeviceContext,
+        stream: sys::CUstream,
+        synchronize: &mut S,
+        kernels: F,
+    ) -> Result<()>
+    where
+        F: FnOnce() -> Result<()>,
+        S: FnMut(CudaGraphPhase),
+    {
         debug!("Capturing CUDA Graph for decode path...");
         synchronize(CudaGraphPhase::BeforeBeginCapture);
         check(
@@ -159,13 +200,6 @@ impl CudaGraphState {
         self.ctx_anchor = Some(ctx.ctx.clone());
         synchronize(CudaGraphPhase::AfterEndCapture);
         debug!("CUDA Graph captured successfully");
-
-        synchronize(CudaGraphPhase::BeforeLaunch);
-        check(
-            unsafe { sys::cuGraphLaunch(self.exec, stream) },
-            "cuGraphLaunch first launch",
-        )?;
-        synchronize(CudaGraphPhase::AfterLaunch);
         Ok(())
     }
 }

--- a/openinfer-qwen3/src/batch_decode.rs
+++ b/openinfer-qwen3/src/batch_decode.rs
@@ -42,6 +42,20 @@ macro_rules! trace_decode_kv_len {
     ($kv_len:expr, $body:block) => {{ $body }};
 }
 
+/// How a `batch_decode` call interacts with the per-bucket CUDA graphs.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum DecodeGraphUse {
+    /// Replay if captured, lazily capture otherwise (single-GPU serving).
+    Serve,
+    /// Eager kernels even with graphs enabled; the TP memory profile uses it to
+    /// avoid an uncoordinated capture (see [`PrecapturePhase`]).
+    Eager,
+    /// Record + instantiate + upload, no launch (the TP sweep's `Capture`).
+    CaptureOnly,
+    /// Replay only; error if never captured (the TP sweep's `Launch`).
+    Replay,
+}
+
 impl Qwen3Model {
     /// Batch decode step: N requests, 1 new token each, one forward pass.
     ///
@@ -57,6 +71,7 @@ impl Qwen3Model {
         kv_buffer: &CudaSlice<bf16>,
         layout: &KvLayout,
         bufs: &mut BatchDecodeBuffers,
+        graph_use: DecodeGraphUse,
     ) -> Result<()> {
         let bs = token_ids.len();
         assert_eq!(bs, kv_views.len());
@@ -71,7 +86,12 @@ impl Qwen3Model {
         );
         let lora_slots = self.decode_lora_slots(lora_adapters)?;
         let use_lora = lora_slots.is_some();
-        let use_cuda_graph = self.enable_cuda_graph && lora_slots.is_none();
+        let graphs_available = self.enable_cuda_graph && lora_slots.is_none();
+        anyhow::ensure!(
+            graphs_available || matches!(graph_use, DecodeGraphUse::Serve | DecodeGraphUse::Eager),
+            "batch_decode {graph_use:?} requires CUDA graphs enabled and no LoRA rows"
+        );
+        let use_cuda_graph = graphs_available && graph_use != DecodeGraphUse::Eager;
 
         // Derive positions from views (seq_len - 1 = position of the new token)
         let mut positions: Vec<i32> = kv_views.iter().map(|v| (v.seq_len() - 1) as i32).collect();
@@ -118,7 +138,8 @@ impl Qwen3Model {
             } else {
                 std::mem::take(&mut bufs.graphs)
             };
-            let result = graphs[graph_idx].run_or_capture(&self.ctx, || {
+            let graph = &mut graphs[graph_idx];
+            let kernels = || {
                 trace_decode_kv_len!(trace_kv_len, {
                     self.batch_decode_kernels(
                         kv_buffer,
@@ -129,7 +150,13 @@ impl Qwen3Model {
                         bufs,
                     )
                 })
-            });
+            };
+            let result = match graph_use {
+                DecodeGraphUse::Serve => graph.run_or_capture(&self.ctx, kernels),
+                DecodeGraphUse::CaptureOnly => graph.capture_only(&self.ctx, kernels),
+                DecodeGraphUse::Replay => graph.launch_captured(&self.ctx),
+                DecodeGraphUse::Eager => unreachable!("use_cuda_graph excludes Eager"),
+            };
             if on_split_stream {
                 bufs.graphs_split = graphs;
             } else {

--- a/openinfer-qwen3/src/batch_decode_trace.rs
+++ b/openinfer-qwen3/src/batch_decode_trace.rs
@@ -113,6 +113,7 @@ pub fn trace_decode_kernel_calls(
             kv_mgr.buffer().buffer(),
             &layout,
             &mut bufs,
+            crate::batch_decode::DecodeGraphUse::Serve,
         )
     })?;
     Ok(calls)

--- a/openinfer-qwen3/src/executor.rs
+++ b/openinfer-qwen3/src/executor.rs
@@ -4,6 +4,7 @@ use std::thread;
 use anyhow::Result;
 use crossbeam_channel as channel;
 
+use crate::batch_decode::DecodeGraphUse;
 use crate::batch_decode_buffers::{BATCH_BUCKETS, BatchDecodeBuffers};
 use crate::config::{Config, TensorParallelConfig};
 use crate::weights::{KvBudget, ModelRuntimeConfig, Qwen3MemoryOptions, Qwen3Model};
@@ -331,6 +332,12 @@ fn execute_step_on_lane(
             kv_views,
             sample_seed,
         } => {
+            // Under TP, replay is only safe once the sweep captured every graph;
+            // reaching here without it would be a mid-serving capture (#481).
+            anyhow::ensure!(
+                !lane.model.tp_graph_enabled() || lane.precapture_complete,
+                "TP decode with CUDA Graph requires the startup pre-capture sweep"
+            );
             let token_ids: Vec<u32> = requests.iter().map(|req| req.token_id).collect();
             let lora_adapters: Vec<Option<&str>> = requests
                 .iter()
@@ -1133,13 +1140,6 @@ impl Qwen3Executor {
             "KV block events are only supported on the single-GPU path; got {} devices",
             device_ordinals.len()
         );
-        anyhow::ensure!(
-            !enable_cuda_graph || device_ordinals.len() == 1,
-            "CUDA Graph is not supported under tensor parallelism (the captured decode \
-             graph would record NCCL collectives with no cross-rank capture alignment); \
-             got {} devices",
-            device_ordinals.len()
-        );
         // The store cursor announces a block as cacheable the moment it is
         // registered, assuming GPU-resident reuse. With KV offload on, a block
         // can be evicted to the host tier and restored under a different lineage
@@ -1262,6 +1262,9 @@ impl Qwen3Executor {
             )?);
         }
 
+        // Each comm is built on its rank's compute stream — the same stream
+        // decode capture runs on — so its all-reduces land inside the captured
+        // graph; a comm on any other stream would execute them eagerly instead.
         let streams = models
             .iter()
             .map(|m| m.device_ctx().stream.clone())
@@ -1305,6 +1308,80 @@ impl Qwen3Executor {
                 RankWorker::spawn(index + 1, lane)
             })
             .collect::<Result<Vec<_>>>()?;
+
+        // Pre-capture every reachable decode graph now (see [`PrecapturePhase`]):
+        // after every RankWorker is spawned (each launch blocks on its peers) and
+        // exactly once (a mid-serving re-run is the #481 capture window).
+        // Uncompiled GQA groups reroute decode to the eager unified path and skip it.
+        if enable_cuda_graph && metadata.config.decode_group_is_compiled() {
+            // NCCL has no device timeout, so a desynced sweep wedges forever;
+            // this watchdog aborts on the deadline. abort() not exit() — exit's
+            // cudart atexit teardown takes the same wedged driver lock — and it
+            // disarms only on the explicit success send (drop-on-error stays armed).
+            let (sweep_done_tx, sweep_done_rx) = channel::bounded::<()>(1);
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(600);
+            thread::Builder::new()
+                .name("qwen3-tp-precapture-watchdog".into())
+                .spawn(move || {
+                    if sweep_done_rx.recv_deadline(deadline).is_ok() {
+                        return;
+                    }
+                    // A sender drop (error path) can wake us early; stay armed
+                    // to the deadline before deciding startup is wedged.
+                    std::thread::sleep(deadline.saturating_duration_since(std::time::Instant::now()));
+                    eprintln!(
+                        "qwen3 TP decode graph pre-capture did not complete within 600s — NCCL wedge suspected, aborting"
+                    );
+                    log::error!(
+                        "qwen3 TP decode graph pre-capture did not complete within 600s — NCCL wedge suspected, aborting"
+                    );
+                    std::process::abort();
+                })
+                .map_err(|e| anyhow::anyhow!("failed to spawn pre-capture watchdog: {e}"))?;
+            let started = std::time::Instant::now();
+            let run_phase = |phase: PrecapturePhase| -> Result<()> {
+                let pending = std::iter::once(&primary)
+                    .chain(workers.iter())
+                    .map(|worker| worker.precapture(phase))
+                    .collect::<Result<Vec<_>>>()?;
+                let ranks = pending.len();
+                for (rank, recv) in pending.into_iter().enumerate() {
+                    let outcome = recv.recv().map_err(|_| {
+                        anyhow::anyhow!(
+                            "tensor-parallel rank {rank} dropped during graph pre-capture {phase:?}"
+                        )
+                    });
+                    if let Err(e) = outcome.and_then(|r| {
+                        r.map_err(|e| {
+                            anyhow::anyhow!(
+                                "tensor-parallel rank {rank} graph pre-capture {phase:?} failed: {e:#}"
+                            )
+                        })
+                    }) {
+                        // Peers past this rank may be wedged in an unpaired
+                        // collective; name them so the wedge is attributable.
+                        log::error!(
+                            "graph pre-capture aborting in {phase:?}; ranks {:?} were not yet collected and may be wedged in NCCL collectives",
+                            (rank + 1..ranks).collect::<Vec<_>>()
+                        );
+                        return Err(e);
+                    }
+                }
+                Ok(())
+            };
+            run_phase(PrecapturePhase::Warmup)?;
+            for bucket_idx in 0..BATCH_BUCKETS.len() {
+                run_phase(PrecapturePhase::Capture { bucket_idx })?;
+                run_phase(PrecapturePhase::Launch { bucket_idx })?;
+            }
+            run_phase(PrecapturePhase::Finalize)?;
+            let _ = sweep_done_tx.send(());
+            log::info!(
+                "TP decode graph pre-capture: {} buckets per rank captured in {:.2}s",
+                BATCH_BUCKETS.len(),
+                started.elapsed().as_secs_f64()
+            );
+        }
 
         Ok(Self {
             metadata,
@@ -1394,6 +1471,13 @@ impl Qwen3Executor {
             "decode-overlap is unsupported for GQA group size {}/{}: no compiled decode kernel",
             self.metadata.config.num_attention_heads,
             self.metadata.config.num_key_value_heads,
+        );
+        // TP decode graphs are pre-captured on the compute stream only; a split
+        // decode stream would route capture into the graphs_split cache with no
+        // cross-rank alignment (and the streams below are built on device 0).
+        anyhow::ensure!(
+            self.workers.is_empty() || matches!(overlap, crate::DecodeOverlap::Off),
+            "decode-overlap is unsupported under tensor parallelism"
         );
         let device_ordinal = 0; // single-GPU path
         self.overlap = crate::green_ctx::OverlapStreams::create(device_ordinal, overlap)?;
@@ -2717,10 +2801,13 @@ struct DFlashMeta {
 }
 
 struct LocalQwen3Lane {
+    /// Before `model` on purpose: NCCL comm teardown polls until every graph
+    /// that recorded its collectives is destroyed, so these graphs must drop
+    /// before `model.tp_comm`.
+    bufs: BatchDecodeBuffers,
     model: Qwen3Model,
     kv_buffer: KvBuffer,
     layout: KvLayout,
-    bufs: BatchDecodeBuffers,
     sample_scratch: openinfer_sample::SampleScratch,
     /// Request-local decode steps handed to `select_batch`, reused across
     /// steps to keep the sampling hot path allocation-free. All zeros until
@@ -2740,6 +2827,11 @@ struct LocalQwen3Lane {
     verify_bufs: Option<VerifyGraphBuffers>,
     /// KV pool block count — the worst-case page-list bound for `verify_bufs`.
     total_blocks: usize,
+    /// Shared dead page backing both production padding rows and the sweep's
+    /// synthetic rows.
+    padding_block_id: i32,
+    /// Set by the sweep's `Finalize`; arms the TP replay fail-loud in serving.
+    precapture_complete: bool,
 }
 
 /// Stored state for an async prefill that was launched but not yet synced.
@@ -2802,7 +2894,57 @@ impl LocalQwen3Lane {
             dflash: None,
             verify_bufs: None,
             total_blocks,
+            padding_block_id,
+            precapture_complete: false,
         })
+    }
+
+    /// One phase of the TP startup sweep ([`PrecapturePhase`]). Synthetic rows
+    /// are token 0 at position 0 over the shared padding page; outputs unused.
+    fn precapture_phase(&mut self, phase: PrecapturePhase) -> Result<()> {
+        match phase {
+            PrecapturePhase::Warmup => self.model.warmup_tp_collective(),
+            PrecapturePhase::Capture { bucket_idx } => {
+                self.precapture_decode(bucket_idx, DecodeGraphUse::CaptureOnly)
+            }
+            PrecapturePhase::Launch { bucket_idx } => {
+                self.precapture_decode(bucket_idx, DecodeGraphUse::Replay)
+            }
+            PrecapturePhase::Finalize => {
+                for (bucket_idx, &bucket) in BATCH_BUCKETS.iter().enumerate() {
+                    let path = BatchDecodeBuffers::attention_path(bucket);
+                    let graph_idx = BatchDecodeBuffers::graph_index(bucket_idx, path);
+                    anyhow::ensure!(
+                        self.bufs.graphs[graph_idx].is_captured(),
+                        "TP decode graph pre-capture left bucket {bucket} ({path:?}) uncaptured"
+                    );
+                }
+                self.precapture_complete = true;
+                Ok(())
+            }
+        }
+    }
+
+    fn precapture_decode(&mut self, bucket_idx: usize, graph_use: DecodeGraphUse) -> Result<()> {
+        let bucket = BATCH_BUCKETS[bucket_idx];
+        let token_ids = vec![0u32; bucket];
+        let kv_views: Vec<KvView> = (0..bucket)
+            .map(|_| KvView::new(vec![self.padding_block_id], 1, self.layout.page_size))
+            .collect();
+        let lora_adapters: Vec<Option<&str>> = vec![None; bucket];
+        self.model.batch_decode(
+            &token_ids,
+            &kv_views,
+            &lora_adapters,
+            self.kv_buffer.buffer(),
+            &self.layout,
+            &mut self.bufs,
+            graph_use,
+        )?;
+        // Capture acks only after the async cuGraphUpload lands; Launch acks
+        // only after the collectives drained.
+        self.model.device_ctx().stream.synchronize()?;
+        Ok(())
     }
 
     /// Load the DFlash draft model into this lane (primary rank only). The draft
@@ -3027,6 +3169,7 @@ impl LocalQwen3Lane {
             self.kv_buffer.buffer(),
             &self.layout,
             &mut self.bufs,
+            DecodeGraphUse::Serve,
         )
     }
 
@@ -3165,7 +3308,33 @@ enum WorkerCommand {
         request_id: RequestId,
         resp: channel::Sender<Result<()>>,
     },
+    /// Startup-only (TP + CUDA Graph): one phase of the decode-graph
+    /// pre-capture sweep. See [`LocalQwen3Lane::precapture_phase`].
+    Precapture {
+        phase: PrecapturePhase,
+        resp: channel::Sender<Result<()>>,
+    },
     Shutdown,
+}
+
+/// One controller-barriered phase of the TP decode-graph pre-capture sweep.
+///
+/// Capture and launch are separate phases because a captured collective's first
+/// launch blocks on its peers: overlapping that with a peer still in capture/
+/// instantiate/upload (which contend driver locks and allocate device memory)
+/// deadlocks the driver. So every rank finishes capturing a bucket before any
+/// rank launches it.
+#[derive(Clone, Copy, Debug)]
+enum PrecapturePhase {
+    /// One eager all-reduce per bucket message size, so the size-selected NCCL
+    /// algorithm connects before any `cuStreamBeginCapture` records it.
+    Warmup,
+    /// Record + instantiate + upload one bucket; no launch, no cross-rank dependency.
+    Capture { bucket_idx: usize },
+    /// Launch one bucket (pure enqueue after `Capture`) + sync; collectives pair across ranks.
+    Launch { bucket_idx: usize },
+    /// Verify every graph captured, mark the lane serve-ready.
+    Finalize,
 }
 
 enum WorkerStepOutcome {
@@ -3257,6 +3426,10 @@ impl RankWorker {
                                     lane.drop_dflash_request(request_id);
                                     let _ = resp.send(Ok(()));
                                 }
+                                WorkerCommand::Precapture { phase, resp } => {
+                                    let result = lane.precapture_phase(phase);
+                                    let _ = resp.send(result);
+                                }
                                 WorkerCommand::Shutdown => break,
                             }
                         }
@@ -3294,6 +3467,19 @@ impl RankWorker {
                 resp: resp_tx,
             })
             .map_err(|_| anyhow::anyhow!("tensor-parallel worker step channel closed"))?;
+        Ok(resp_rx)
+    }
+
+    /// Start one sweep phase; returns the ack receiver. The controller fans a
+    /// phase out to all ranks before collecting acks so their collectives pair.
+    fn precapture(&self, phase: PrecapturePhase) -> Result<channel::Receiver<Result<()>>> {
+        let (resp_tx, resp_rx) = channel::bounded(1);
+        self.tx
+            .send(WorkerCommand::Precapture {
+                phase,
+                resp: resp_tx,
+            })
+            .map_err(|_| anyhow::anyhow!("worker channel closed on precapture {phase:?}"))?;
         Ok(resp_rx)
     }
 

--- a/openinfer-qwen3/src/lib.rs
+++ b/openinfer-qwen3/src/lib.rs
@@ -194,8 +194,8 @@ pub fn probe_model(model_path: &Path) -> Result<Option<ModelInfo>> {
 /// Server-facing launch knobs for the Qwen3 engine.
 ///
 /// The binary maps raw CLI flags into this struct; [`launch`] then owns the
-/// Qwen3 startup policy — the TP→device mapping and the LoRA↔CUDA-Graph and
-/// TP↔CUDA-Graph exclusions — and dispatches to the right low-level entry.
+/// Qwen3 startup policy — the TP→device mapping and the LoRA↔CUDA-Graph
+/// exclusion — and dispatches to the right low-level entry.
 /// That policy lives with the model instead of leaking into the server.
 #[derive(Clone, Debug)]
 pub struct Qwen3LaunchOptions {
@@ -203,8 +203,8 @@ pub struct Qwen3LaunchOptions {
     pub device_ordinal: usize,
     /// Tensor-parallel world size; `> 1` uses devices `0..tp_size`.
     pub tp_size: usize,
-    /// Whether the user requested CUDA Graph. LoRA serving and tensor
-    /// parallelism force it off.
+    /// Whether the user requested CUDA Graph. LoRA serving forces it off;
+    /// under tensor parallelism every decode graph is pre-captured at startup.
     pub cuda_graph: bool,
     pub offload: Qwen3OffloadOptions,
     pub no_prefix_cache: bool,
@@ -232,16 +232,10 @@ pub fn launch(model_path: &Path, options: Qwen3LaunchOptions) -> Result<EngineHa
         (0..options.tp_size).collect()
     };
     // LoRA serving repoints adapter weights between steps, which a captured
-    // decode graph bakes in; under TP the graph would capture each layer's
-    // NCCL all-reduces with nothing aligning capture across ranks.
+    // decode graph bakes in.
     let enable_cuda_graph = if options.lora.is_some() {
         if options.cuda_graph {
             warn!("Qwen3: CUDA Graph is disabled while LoRA serving is enabled");
-        }
-        false
-    } else if options.tp_size > 1 {
-        if options.cuda_graph {
-            warn!("Qwen3: CUDA Graph is disabled under tensor parallelism");
         }
         false
     } else {
@@ -262,6 +256,12 @@ pub fn launch(model_path: &Path, options: Qwen3LaunchOptions) -> Result<EngineHa
             options.no_prefix_cache
         );
     }
+    // Also rejected at enable_decode_overlap (the load-bearing guard); failing
+    // here saves the full TP model load + graph pre-capture before the error.
+    anyhow::ensure!(
+        options.tp_size == 1 || matches!(options.decode_overlap, DecodeOverlap::Off),
+        "decode-overlap is unsupported under tensor parallelism"
+    );
     anyhow::ensure!(
         !(options.dflash_draft_model_path.is_some() && options.lora.is_some()),
         "DFlash speculative decoding cannot be combined with LoRA serving"

--- a/openinfer-qwen3/src/unified_forward.rs
+++ b/openinfer-qwen3/src/unified_forward.rs
@@ -60,7 +60,14 @@ impl Qwen3Model {
         // sample. The synthetic views are short, but the pre-allocated decode
         // arena and graph state are the same serving objects used later. Skip it
         // for uncompiled-group models: the unified sample below bounds their KV.
+        // Eager under TP: ranks profile uncoordinated, so an in-profile capture
+        // would hit the same deadlock the sweep avoids (see `PrecapturePhase`).
         if self.config.decode_group_is_compiled() {
+            let graph_use = if self.tensor_parallel.world_size > 1 {
+                crate::batch_decode::DecodeGraphUse::Eager
+            } else {
+                crate::batch_decode::DecodeGraphUse::Serve
+            };
             self.batch_decode(
                 &decode_tokens,
                 &decode_views,
@@ -68,6 +75,7 @@ impl Qwen3Model {
                 kv_buffer.buffer(),
                 &layout,
                 decode_bufs,
+                graph_use,
             )?;
             mark_peak()?;
         }

--- a/openinfer-qwen3/src/weights.rs
+++ b/openinfer-qwen3/src/weights.rs
@@ -620,7 +620,9 @@ impl Qwen3Model {
         };
 
         if model.enable_cuda_graph {
-            debug!("Decode path CUDA Graph is enabled (captures on first decode step)");
+            debug!(
+                "Decode path CUDA Graph is enabled (single GPU captures on first decode step; TP pre-captures every bucket at startup)"
+            );
         } else {
             debug!("Decode path CUDA Graph is disabled");
         }
@@ -662,6 +664,31 @@ impl Qwen3Model {
 
     pub(crate) fn attach_tp_comm(&mut self, comm: Comm) {
         self.tp_comm = Some(comm);
+    }
+
+    /// Whether decode steps replay pre-captured graphs that record NCCL
+    /// collectives — i.e. CUDA Graph on a tensor-parallel model.
+    pub(crate) fn tp_graph_enabled(&self) -> bool {
+        self.enable_cuda_graph && self.tp_comm.is_some()
+    }
+
+    /// Force NCCL connect before any capture records a collective (lazy connect
+    /// inside `cuStreamBeginCapture` is the classic hazard). NCCL >= 2.22
+    /// connects per size-selected algorithm, so warm one all-reduce at every
+    /// bucket's message size. No-op without a TP communicator.
+    pub(crate) fn warmup_tp_collective(&self) -> Result<()> {
+        if let Some(comm) = &self.tp_comm {
+            let buckets = crate::batch_decode_buffers::BATCH_BUCKETS;
+            let max_elems = buckets.last().unwrap() * self.config.hidden_size;
+            let mut scratch = self.ctx.stream.alloc_zeros::<bf16>(max_elems)?;
+            for &bucket in buckets {
+                let mut view = scratch.slice_mut(0..bucket * self.config.hidden_size);
+                comm.all_reduce_in_place(&mut view, &ReduceOp::Sum)
+                    .map_err(|e| anyhow::anyhow!("nccl warm-up all-reduce failed: {e:?}"))?;
+            }
+            self.ctx.stream.synchronize()?;
+        }
+        Ok(())
     }
 
     pub(crate) fn install_lora_adapter(

--- a/openinfer-qwen3/tests/hf_golden_gate.rs
+++ b/openinfer-qwen3/tests/hf_golden_gate.rs
@@ -654,12 +654,23 @@ fn pega_logprobs_match_hf_golden_within_bf16_tolerance() {
 
     // TP=2: the same eager suite sharded over two GPUs. Same golden, same
     // tolerances — a reduction-order, shard-offset, or all-reduce bug drifts
-    // logits far past the bf16 noise floor. Eager-only: TP CUDA-graph support
-    // is deferred follow-up work (docs/models/qwen3/tp-design.md).
+    // logits far past the bf16 noise floor.
     let gpus = cuda_device_count();
     if gpus < 2 {
         eprintln!("skipping hf_golden_gate TP=2 pass: {gpus} CUDA device(s) visible, need 2");
         return;
     }
     run_eager_suite(&golden, &model_path, &[0, 1], "tp2 ");
+
+    // TP=2, graph on: replay the pre-captured decode graphs against the same
+    // golden, so a bad shard, pointer, or collective in a capture drifts logits.
+    if decode_group_compiled(&model_path) {
+        let mut ex = Qwen3Executor::from_runtime(&model_path, true, &[0, 1])
+            .expect("build cuda-graph TP executor");
+        ex.set_prefix_cache_enabled(false);
+        for n in BUCKET_STRADDLES {
+            let (batched, _) = run(&golden, &mut ex, &all[..n], true);
+            report_and_assert(&format!("tp2 batched cuda-graph ({n} padded)"), &batched);
+        }
+    }
 }

--- a/openinfer-qwen3/tests/tp_concurrent_decode.rs
+++ b/openinfer-qwen3/tests/tp_concurrent_decode.rs
@@ -1,4 +1,5 @@
-//! TP=2 launch with CUDA Graph requested — guards `launch` disabling CUDA Graph under TP.
+//! TP=2 launch with CUDA Graph on — decode replays the graphs pre-captured at
+//! startup, so this gates both the sweep and graph-on concurrent serving.
 //! The drain loop polls with a deadline so a deadlock fails instead of wedging the run.
 
 use std::mem::ManuallyDrop;


### PR DESCRIPTION
## Description

Fixes #498.

Re-enables CUDA Graph decode under `--tp-size > 1` for qwen3. #496 guarded CUDA graph off under TP after the #481 hang; this removes both guards and makes graph-on TP serving the working path.

The issue proposed three runtime mechanisms: a dedicated capture stream, a CPU barrier before capture, and a per-bucket all-ranks-captured replay gate. Each defends against divergence the TP step protocol already excludes — the graph key is a pure function of the broadcast `StepCommand` (the controller picks the bucket and clones one command to every rank) and the step lock already prevents any rank from starting step N+1 before all ranks finish N, so under lazy capture every rank hits a bucket's first capture on the same global step. The dedicated capture stream would also conflict with the stream-binding invariant documented in `cuda_graph.rs`: a graph is tied to the stream it was captured on, so capturing on a non-decode stream silently strips the Green Context SM partition from `graphs_split`.

What actually broke in #481 is narrower: mid-serving capture overlaps the previous step's eager NCCL tail. Removing the mid-serving capture window removes the bug. So this takes the shape glm52 has shipped since #570 — pre-capture every reachable `(bucket, attention-path)` decode graph at startup, per rank, right after all rank workers spawn, while the ranks are trivially in lock-step and no eager collectives are in flight. Uniform captured-ness across ranks becomes an invariant established at construction rather than a property maintained at runtime. Serving decode-only steps (`batch_decode`) are then pure replay; mixed prefill+decode steps keep running the eager unified path, which never captures. The single-GPU lazy-capture path keeps its behaviour: `openinfer-core` gains one additive method (`capture_only`, which records + instantiates + uploads without launching), and `run_or_capture` is unchanged.

Supporting pieces: an eager warm-up collective per rank before the first capture (NCCL lazy connect must stay outside `cuStreamBeginCapture`, and since NCCL >= 2.22 connects per size-selected algorithm the warm-up runs one all-reduce per bucket message size); a fail-loud check in the serving decode arm so a missed shape can never lazily capture under TP; decode-overlap rejected under TP (the `graphs_split` cache has no cross-rank alignment story); and lane buffers dropping before the model so captured graphs are destroyed before the NCCL communicator (NCCL >= 2.26 comm teardown polls until referencing graphs are gone).

The first sweep fused capture + instantiate + first-launch per bucket (the single-GPU `run_or_capture` shape) and deadlocked on two GPUs: the launched rank's captured all-reduce spins on its peer while the peer is still inside capture/instantiate driver calls that hold the process-wide driver lock — and the first launch of a never-uploaded exec performs the implicit upload, which is more of the same. The sweep is therefore two-phase per bucket under a controller barrier: every rank records + instantiates + `cuGraphUpload`s the bucket's graph before any rank launches it, and the launch phase is a pure enqueue + sync. NCCL has no device-side timeout, so a startup watchdog turns a wedged sweep into a loud `abort()` (not `exit()`, which would re-enter the same driver lock in cudart teardown); separately, a rank that errors mid-sweep fails startup and logs which peers were not yet collected and may still be wedged. Applying the same reasoning backward, the TP memory-profile decode exercise now runs eager instead of lazily capturing per rank uncoordinated.

## Measured — Dual-GH200 (aarch64, sm_90), Qwen3-4B, tp-size 2

Startup pre-capture covers all 36 `(bucket, attention-path)` graphs per rank in 0.74s; graph-exec residency costs ~500 MiB per GPU over the eager server. Because the TP memory profile now runs the decode exercise eager (above), that residency lands after profiling rather than inside the profiled KV budget — measured, graph-on used 88002 MiB against a profiled 87552 MiB request, so it draws ~500 MiB from the 0.90-utilization headroom rather than OOMing. Budgeting the TP graph-exec into the profile (and correcting the `--gpu-memory-utilization` help text, which still says profiling accounts for CUDA-graph capture — true single-GPU, not under TP) is a small follow-up, not a blocker here.

Graph-on vs eager serving (`vllm bench serve`, random 128 in / 256 out):

| concurrency | mean TPOT (ms) graph / eager | output tok/s graph / eager |
|---|---|---|
| 1 | 5.77 / 6.35 | 173 / 156 |
| 4 | 5.79 / 6.38 | 642 / 595 |
| 8 | 5.92 / 6.48 | 1206 / 1092 |

Decode TPOT improves ~9% and throughput 8-11% across concurrencies.

## Testing

- `tests/tp_concurrent_decode.rs` passes graph-on with assertions unchanged (the #496 acceptance gate), 13.3s on two GH200s — the first exercise of NCCL collectives under `cuStreamBeginCapture` on this stack.
- `hf_golden_gate` gains a graph-on TP=2 pass (`from_runtime(true, [0, 1])` — the startup sweep captures each rank's decode graphs, serving replays them) checked against the HF golden at the same tolerances as the eager TP suite. The graph-on TP logits match: worst head delta 0.375 / 0.162 at the straddle buckets, inside the eager TP suite's 0.375 noise floor. This closes the "TP CUDA-graph deferred" note the golden gate carried.
- Single-GPU regression: `hf_golden_gate` (single-GPU eager + graph passes) and the workspace lib suite green on sm_89; clippy clean (no new warnings vs base).
- Both #496 guards deleted.
- Everything above ran on this branch rebased onto `main`, so the numbers are the merge target, not a stale base.



## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)