### PR TITLE
test(qwen3): chunk the split-KV gate prefill within the pin envelope

### DIFF
--- a/openinfer-qwen3/src/executor.rs
+++ b/openinfer-qwen3/src/executor.rs
@@ -107,6 +107,14 @@ impl PrefillStepItem {
         self
     }
 
+    /// Cap the prompt tokens forwarded per `execute_prefill` call; re-issue the
+    /// item until its result is `completed` to prefill a long prompt in chunks.
+    #[must_use]
+    pub fn with_chunk_budget(mut self, chunk_budget: usize) -> Self {
+        self.chunk_budget = chunk_budget;
+        self
+    }
+
     /// Prompt tokens forwarded this step.
     fn as_slice(&self) -> &[u32] {
         &self.prompt_tokens[self.chunk_start..self.chunk_start + self.chunk_tokens]

--- a/openinfer-qwen3/tests/batch_invariance_decode_splitkv_graph.rs
+++ b/openinfer-qwen3/tests/batch_invariance_decode_splitkv_graph.rs
@@ -27,6 +27,10 @@ fn model_path_or_skip() -> Option<String> {
     Some(p)
 }
 
+// A_LEN/B_LEN exceed the pin's serve-N ceiling, so prefill chunked within the
+// verified envelope, as the scheduler does — the gate is about decode split-KV.
+const PREFILL_CHUNK: usize = 1024;
+
 fn pitem(id: RequestId, prompt: Vec<u32>) -> PrefillStepItem {
     PrefillStepItem::new(
         id,
@@ -36,6 +40,22 @@ fn pitem(id: RequestId, prompt: Vec<u32>) -> PrefillStepItem {
         LOGPROBS,
         false,
     )
+}
+
+fn prefill_chunked(ex: &mut Qwen3Executor, id: RequestId, prompt: &[u32]) -> u32 {
+    let item = pitem(id, prompt.to_vec()).with_chunk_budget(PREFILL_CHUNK);
+    loop {
+        let pr = ex
+            .execute_prefill(PrefillPlan {
+                sample_seed: 0,
+                requests: std::slice::from_ref(&item),
+                echo: false,
+            })
+            .expect("prefill chunk");
+        if pr.requests[0].completed {
+            break pr.requests[0].first_token;
+        }
+    }
 }
 
 fn filler(len: usize, stride: u32) -> Vec<u32> {
@@ -53,30 +73,12 @@ fn a_decode_cobatched_with(
     let id_a = RequestId::new(1);
     let id_b = RequestId::new(2);
     // Prefill A alone (batch 1); A's KV is identical regardless of B's length.
-    let pr_a = ex
-        .execute_prefill(PrefillPlan {
-            sample_seed: 0,
-            requests: &[pitem(id_a, a_prompt.to_vec())],
-            echo: false,
-        })
-        .expect("prefill A");
-    let a_first = pr_a.requests[0].first_token;
-    let pr_b = ex
-        .execute_prefill(PrefillPlan {
-            sample_seed: 0,
-            requests: &[pitem(id_b, b_prompt.to_vec())],
-            echo: false,
-        })
-        .expect("prefill B");
+    let a_first = prefill_chunked(ex, id_a, a_prompt);
+    let b_first = prefill_chunked(ex, id_b, b_prompt);
     // Decode A+B together (batch 2, A row 0); B's KV length sets the batch max_seq_len.
     let ditems = vec![
         DecodeStepItem::new(id_a, a_first, SamplingParams::default(), LOGPROBS),
-        DecodeStepItem::new(
-            id_b,
-            pr_b.requests[0].first_token,
-            SamplingParams::default(),
-            LOGPROBS,
-        ),
+        DecodeStepItem::new(id_b, b_first, SamplingParams::default(), LOGPROBS),
     ];
     let dr = ex
         .execute_decode(DecodePlan {


### PR DESCRIPTION
## Description

Refs #435 

The `batch_invariance_decode_splitkv_graph` gate prefilled its two prompts (A_LEN / B_LEN) in a single `execute_prefill` call under the batch-invariant Pin. On Dual-GH200 (aarch64, sm_90) this failed deterministically: `launch_gemm_pin` bails because the pinned cuBLASLt algo cannot serve N in one shot once N exceeds an arch-dependent ceiling (its workspace grows with N, bounded by the 128 MB pin buffer), and A_LEN/B_LEN sit above it. This chunks the gate's prefill within the verified pin envelope — the way the scheduler already does — so the gate exercises decode split-KV rather than the pin's serve-N ceiling.

Production is protected on two sides the gate bypassed:

- `verify_pin_envelope` runs at executor construction and refuses to start unless the pinned algo can serve every N up to `max_prefill_tokens + max_bucket - 1`.
- the scheduler chunks every prefill to `max_prefill_tokens`.

The gate builds with the default `max_prefill_tokens` (so the envelope self-check passes) but then calls `execute_prefill` on the whole prompt directly, going around both — so N exceeds the verified ceiling and the pin bails. No production path prefills an over-ceiling prompt in one shot.

## Test Env

Full 19-gate qwen3 matrix green on both architectures, 0 failed:

- Dual-GH200 (aarch64, sm_90): `batch_invariance_decode_splitkv_graph` now passes (58.4s); it was previously the only red gate.
- Single GPU (sm_89, x86_64): green.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)