### PR TITLE
fix(qwen3): fail loud at the --batch-invariant envelope boundary

### DIFF
--- a/docs/models/qwen3/model-crate.md
+++ b/docs/models/qwen3/model-crate.md
@@ -1,8 +1,12 @@
 # Qwen3-4B Model Crate
 
 **Created**: 2026-05-03
-**Last touched**: 2026-06
+**Last touched**: 2026-07
 **TL;DR**: `crates/openinfer-qwen3` now owns Qwen3 config, weights, execution, scheduler, tests, benches, and kernel plan. Root `openinfer` loads Qwen3 through a generic `EngineHandle` and no longer contains `Qwen3Model`, `Qwen3Executor`, `ModelRuntimeConfig`, root Qwen3 tests, or `src/model/qwen3/*`. The old `ModelForward` path has been removed; decode length-limit now emits the final token before `Finished`. Long-context `bs=1` TPOT was traced to non-partition FlashInfer paged decode under-filling the GPU; Qwen3 runtime gates FlashInfer split-K decode on `padded_bs<=32` (the `seq_len>=1024` gate was dropped in #437) with a 64-token chunk floor (`Tuned` capped at 64 chunks; opt-in `--batch-invariant` pins a fixed 160-token split), cutting 4k/64 serving steady TPOT from about `11.7ms` to `6.46ms` on RTX 5090. Qwen3 now keeps a single model-crate bench entry: `qwen3_kernel_snapshot`, a JSON snapshot runner with warm/cold-L2 latency, default-on CUPTI counters, and compare. Correctness/truth is intentionally out of this snapshot for now.
+
+## Determinism scope
+
+`--batch-invariant` is scoped to one process, one toolchain, and one GPU. The cuBLASLt algo is re-tuned on every boot and cached per executor thread (`thread_local`), so it does not promise stability across cuBLAS or driver versions; startup logging records the pinned `splitk` and `reduction_scheme` per `(M,K)`. The builder rejects decode-overlap, DFlash speculative decoding, LoRA, and tensor parallelism.
 
 ## Preparation
 

--- a/docs/models/qwen3/tp-design.md
+++ b/docs/models/qwen3/tp-design.md
@@ -56,6 +56,7 @@ The first TP milestone does not aim to do the following:
 - preserve current CUDA Graph behavior from day one
 - introduce vocab-parallel embedding or vocab-parallel `lm_head` in the first pass
 - optimize every path for peak throughput before the basic design is proven correct
+- serve `--batch-invariant`, which the builder rejects for `tp_size > 1`: the prefill and unified all-reduces are eager and unbucketed, so NCCL can pick a different algorithm and protocol as the message size moves with batch composition, and that reduction order has never been audited
 
 ## Simplifications Allowed In First Pass
 

--- a/openinfer-kernels/csrc/shared/linear.cu
+++ b/openinfer-kernels/csrc/shared/linear.cu
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <map>
 
 static constexpr int CUBLAS_STATUS_ERROR_OFFSET = 100000;
@@ -57,6 +58,7 @@ static constexpr int GEMM_LT_UNTUNED = -1;
 // Keyed on {M,K} only (g_lt_plans uses {M,N,K}): one cublasLt algo chosen at rep_n, reused for every N.
 static constexpr int GEMM_LT_PIN_UNTUNED = -1;     // no pinned plan for {M,K}
 static constexpr int GEMM_LT_PIN_UNSUPPORTED = -2; // pinned algo cannot serve this N
+static constexpr int GEMM_LT_PIN_NONDET = -3;      // reduction scheme outside cublasLtReductionScheme_t
 struct LtPinPlan {
   cublasLtMatmulDesc_t op = nullptr;
   cublasLtMatrixLayout_t a = nullptr; // [K, M], independent of N
@@ -529,7 +531,7 @@ int gemm_lt_tune_cuda(const __nv_bfloat16 *const *Ws, int num_ws, int M, int N, 
 }
 
 // Pin one cublasLt algo for (M,K) at rep_n (heuristic top, no timing → deterministic), keyed {M,K}.
-int gemm_lt_pin_tune_cuda(int M, int rep_n, int K) {
+int gemm_lt_pin_tune_cuda(int M, int rep_n, int K, int *out_splitk, int *out_reduction_scheme) {
   // Dropped before any check, so every failure below leaves {M,K} unpinned and lt_pin_run reports
   // PIN_UNTUNED instead of serving the plan this call was meant to replace.
   const std::array<int, 2> key{M, K};
@@ -538,9 +540,11 @@ int gemm_lt_pin_tune_cuda(int M, int rep_n, int K) {
     lt_pin_destroy(existing->second);
     g_lt_pin_plans.erase(existing);
   }
-  if (M <= 0 || rep_n <= 0 || K <= 0) {
+  if (M <= 0 || rep_n <= 0 || K <= 0 || out_splitk == nullptr || out_reduction_scheme == nullptr) {
     return static_cast<int>(cudaErrorInvalidValue);
   }
+  *out_splitk = 0;
+  *out_reduction_scheme = 0;
   int rc = ensure_lt_resources();
   if (rc == static_cast<int>(cudaSuccess)) {
     rc = ensure_lt_pin_workspace();
@@ -578,6 +582,30 @@ int gemm_lt_pin_tune_cuda(int M, int rep_n, int K) {
   }
 
   plan.algo = results[0].algo;
+  int32_t splitk = 0;
+  uint32_t reduction_scheme = 0;
+  size_t written = 0;
+  status = cublasLtMatmulAlgoConfigGetAttribute(
+      &plan.algo, CUBLASLT_ALGO_CONFIG_SPLITK_NUM, &splitk, sizeof(splitk), &written);
+  if (status == CUBLAS_STATUS_SUCCESS) {
+    status = cublasLtMatmulAlgoConfigGetAttribute(&plan.algo,
+                                                  CUBLASLT_ALGO_CONFIG_REDUCTION_SCHEME,
+                                                  &reduction_scheme, sizeof(reduction_scheme),
+                                                  &written);
+  }
+  *out_splitk = static_cast<int>(splitk);
+  *out_reduction_scheme = static_cast<int>(reduction_scheme);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    lt_pin_destroy(plan);
+    return cublas_status_to_error(status);
+  }
+  if (reduction_scheme != static_cast<uint32_t>(CUBLASLT_REDUCTION_SCHEME_NONE) &&
+      reduction_scheme != static_cast<uint32_t>(CUBLASLT_REDUCTION_SCHEME_INPLACE) &&
+      reduction_scheme != static_cast<uint32_t>(CUBLASLT_REDUCTION_SCHEME_COMPUTE_TYPE) &&
+      reduction_scheme != static_cast<uint32_t>(CUBLASLT_REDUCTION_SCHEME_OUTPUT_TYPE)) {
+    lt_pin_destroy(plan);
+    return GEMM_LT_PIN_NONDET;
+  }
   g_lt_pin_plans.emplace(key, plan);
   return static_cast<int>(cudaSuccess);
 }

--- a/openinfer-kernels/src/ffi/shared.rs
+++ b/openinfer-kernels/src/ffi/shared.rs
@@ -210,7 +210,13 @@ unsafe extern "C" {
     ) -> i32;
 
     // Batch-invariant pinned-algo path (csrc/shared/linear.cu).
-    pub fn gemm_lt_pin_tune_cuda(M: i32, rep_n: i32, K: i32) -> i32;
+    pub fn gemm_lt_pin_tune_cuda(
+        M: i32,
+        rep_n: i32,
+        K: i32,
+        out_splitk: *mut i32,
+        out_reduction_scheme: *mut i32,
+    ) -> i32;
     pub fn gemm_lt_pin_check_cuda(M: i32, N: i32, K: i32) -> i32;
 
     pub fn gemm_lt_pin_cuda(

--- a/openinfer-kernels/src/ops.rs
+++ b/openinfer-kernels/src/ops.rs
@@ -48,8 +48,9 @@ pub use embedding::{
 pub use glm52::*;
 #[cfg(feature = "kimi-k2")]
 pub use kimi_k2::*;
+pub(crate) use linear::ensure_tuned_policy;
 pub use linear::{
-    GEMM_LT_MAX_N, NumericPolicy, gemm, gemm_graphsafe_into_checked,
+    GEMM_LT_MAX_N, NumericPolicy, PinAlgoConfig, gemm, gemm_graphsafe_into_checked,
     gemm_graphsafe_ref_into_checked, gemm_into, gemm_into_checked, gemm_lt_pin_check,
     gemm_lt_pin_into_checked, gemm_lt_pin_tune, gemm_lt_pin_warmup, gemm_lt_tune, gemm_per_token,
     gemm_per_token_into_checked, gemm_rows_into, gemm_rows_into_checked, gemm_strided_batched_bf16,

--- a/openinfer-kernels/src/ops/linear.rs
+++ b/openinfer-kernels/src/ops/linear.rs
@@ -150,21 +150,59 @@ pub fn gemm_lt_tune(
 /// Mirrors the GEMM_LT_PIN_* sentinels in csrc/shared/linear.cu.
 const GEMM_LT_PIN_UNTUNED: i32 = -1;
 const GEMM_LT_PIN_UNSUPPORTED: i32 = -2;
+const GEMM_LT_PIN_NONDET: i32 = -3;
+
+#[derive(Clone, Copy, Debug)]
+pub struct PinAlgoConfig {
+    pub splitk: i32,
+    pub reduction_scheme: i32,
+}
+
+impl PinAlgoConfig {
+    pub fn reduction_scheme_name(self) -> &'static str {
+        match self.reduction_scheme {
+            0 => "none",
+            1 => "inplace",
+            2 => "compute_type",
+            4 => "output_type",
+            _ => "unknown",
+        }
+    }
+}
 
 /// Pin one cublasLt algo for `(num_rows, cols)`, selected by the heuristic at `rep_n` (shape-only),
 /// reused for every N. Run on the GEMM-issuing thread (the plan cache is thread-local).
-pub fn gemm_lt_pin_tune(num_rows: usize, rep_n: usize, cols: usize) -> Result<()> {
-    let status = unsafe { ffi::gemm_lt_pin_tune_cuda(num_rows as i32, rep_n as i32, cols as i32) };
-    if status != 0 {
-        bail!(
+pub fn gemm_lt_pin_tune(num_rows: usize, rep_n: usize, cols: usize) -> Result<PinAlgoConfig> {
+    let mut splitk = 0;
+    let mut reduction_scheme = 0;
+    let status = unsafe {
+        ffi::gemm_lt_pin_tune_cuda(
+            num_rows as i32,
+            rep_n as i32,
+            cols as i32,
+            &raw mut splitk,
+            &raw mut reduction_scheme,
+        )
+    };
+    match status {
+        0 => Ok(PinAlgoConfig {
+            splitk,
+            reduction_scheme,
+        }),
+        GEMM_LT_PIN_NONDET => bail!(
+            "cublasLt pin tuning selected an unknown reduction scheme: m={}, k={}, reduction_scheme={}",
+            num_rows,
+            cols,
+            reduction_scheme
+        ),
+        s => bail!(
             "cublasLt pin tuning failed: status={}, m={}, rep_n={}, k={}",
-            status,
+            s,
             num_rows,
             rep_n,
             cols
-        );
+        ),
     }
-    Ok(())
 }
 
 /// Run the pinned `(rows, cols)` algo at this N. `Ok(false)` = algo can't serve this N; bails if
@@ -571,6 +609,16 @@ pub fn numeric_policy() -> NumericPolicy {
     }
 }
 
+/// NUMERIC_POLICY defaults to Tuned; only qwen3 sets Pin/PerToken, so typed GEMM (kimi) never fires this.
+pub(crate) fn ensure_tuned_policy(m: usize, n: usize, k: usize) -> Result<()> {
+    let policy = numeric_policy();
+    ensure!(
+        policy == NumericPolicy::Tuned,
+        "typed GEMM is not covered by the batch-invariant pin: policy={policy:?}, m={m}, n={n}, k={k}"
+    );
+    Ok(())
+}
+
 /// Count of projection GEMMs served by the pinned algo: process-global, mixed across prefill +
 /// decode + unified and across TP ranks. Under `Pin` a GEMM either serves (counted here) or
 /// `launch_gemm_pin` bails — there is no silent per-token fallback. Decode counts the graph
@@ -596,7 +644,7 @@ pub fn reset_numeric_policy_counters() {
 const PIN_REP_N: i32 = 32;
 
 /// Pin one `(num_rows, cols)` algo at the canonical `PIN_REP_N`, reused for all N.
-pub fn gemm_lt_pin_warmup(num_rows: usize, cols: usize) -> Result<()> {
+pub fn gemm_lt_pin_warmup(num_rows: usize, cols: usize) -> Result<PinAlgoConfig> {
     gemm_lt_pin_tune(num_rows, PIN_REP_N as usize, cols)
 }
 

--- a/openinfer-kernels/src/typed_ops.rs
+++ b/openinfer-kernels/src/typed_ops.rs
@@ -614,6 +614,7 @@ fn launch_gemm(
     graphsafe: bool,
     ctx: &DeviceContext,
 ) -> Result<()> {
+    crate::ops::ensure_tuned_policy(m, n, k)?;
     unsafe {
         let status = if graphsafe {
             ffi::gemm_graphsafe_cuda(
@@ -658,6 +659,7 @@ fn launch_gemm_per_token(
     k: usize,
     ctx: &DeviceContext,
 ) -> Result<()> {
+    crate::ops::ensure_tuned_policy(m, batch, k)?;
     unsafe {
         let status = ffi::gemm_per_token_cuda(
             w_ptr,

--- a/openinfer-qwen3/src/batch_decode_buffers.rs
+++ b/openinfer-qwen3/src/batch_decode_buffers.rs
@@ -3,6 +3,7 @@
 use anyhow::Result;
 
 use cudarc::driver::CudaSlice;
+use log::info;
 
 use openinfer_core::cuda_graph::CudaGraphState;
 use openinfer_core::tensor::{DeviceContext, HiddenStates};
@@ -85,7 +86,12 @@ pub(crate) fn warmup_decode_projection_pins(
     vocab: usize,
 ) -> Result<()> {
     for (m, k) in decode_projection_pin_shapes(hidden, q_dim, kv_dim, intermediate, vocab) {
-        gemm_lt_pin_warmup(m, k)?;
+        let config = gemm_lt_pin_warmup(m, k)?;
+        info!(
+            "Qwen3 GEMM pin: m={m}, k={k}, splitk={}, reduction_scheme={}",
+            config.splitk,
+            config.reduction_scheme_name()
+        );
     }
     Ok(())
 }

--- a/openinfer-qwen3/src/lib.rs
+++ b/openinfer-qwen3/src/lib.rs
@@ -414,6 +414,7 @@ fn start_engine_with_offload_inner(
         decode_overlap,
         batch_invariant,
         dflash_draft_model_path.is_some(),
+        device_ordinals.len(),
     )?;
     apply_batch_invariant_policy(batch_invariant);
     let dflash_draft_model_path = dflash_draft_model_path
@@ -458,7 +459,12 @@ pub fn start_engine_with_lora_control(
     let model_path = model_path
         .to_str()
         .ok_or_else(|| anyhow::anyhow!("model path must be valid UTF-8"))?;
-    ensure_batch_invariant_supported(decode_overlap, batch_invariant, false)?;
+    ensure_batch_invariant_supported(
+        decode_overlap,
+        batch_invariant,
+        false,
+        device_ordinals.len(),
+    )?;
     if batch_invariant {
         anyhow::bail!(
             "--batch-invariant is not supported with LoRA: the decode-GEMM pin warms and self-checks \
@@ -496,10 +502,16 @@ fn ensure_batch_invariant_supported(
     decode_overlap: DecodeOverlap,
     batch_invariant: bool,
     dflash: bool,
+    world_size: usize,
 ) -> Result<()> {
     if batch_invariant && !matches!(decode_overlap, DecodeOverlap::Off) {
         anyhow::bail!(
             "--batch-invariant is not compatible with --decode-overlap; the stream override would force the pinned GEMM to bail at runtime"
+        );
+    }
+    if batch_invariant && world_size > 1 {
+        anyhow::bail!(
+            "--batch-invariant is not supported with tensor parallelism: world_size={world_size} has unverified cross-rank reduction order"
         );
     }
     if batch_invariant && dflash {

--- a/openinfer-server/src/config.rs
+++ b/openinfer-server/src/config.rs
@@ -372,6 +372,9 @@ impl Args {
                 "--batch-invariant is not supported with DFlash speculative decoding; enable one at a time"
             );
         }
+        if self.batch_invariant && self.tp_size > 1 {
+            bail!("--batch-invariant is not supported with --tp-size > 1; enable one at a time");
+        }
         if provided.contains("decode_sm_pct")
             && !matches!(self.decode_overlap, CliDecodeOverlap::GreenCtx)
         {


### PR DESCRIPTION
## Description

Fixes #628 

**1. `typed_ops` GEMMs no longer bypass the numeric-policy gate.** `ops::linear::launch_gemm` opens with `match numeric_policy()`, so under `Pin` a projection GEMM is either served by the pinned algo or fails loud. `typed_ops` has a same-named private twin that reads the policy under no circumstances: it calls `cublasGemmEx` with `CUBLAS_GEMM_DEFAULT_TENSOR_OP` directly, not even the `gemm_lt_tune` plan cache. Both of its launchers now go through one shared `ensure_tuned_policy`, which bails unless the policy is `Tuned`.

This is unreachable in any supported process today, and the fix does not make it reachable. `NUMERIC_POLICY` defaults to `Tuned`; only qwen3 ever writes `Pin`; qwen3 never touches `typed_ops` (whose only consumer is the Kimi-K2 runner, directly and through the `typed_pipeline!` macro). That chain is the whole reason the bypass has never bitten, and it was written down nowhere. It is now a doc comment on the guard, and the guard turns a silent bypass into a startup error the day someone breaks the chain.

**2. `--batch-invariant` is rejected under tensor parallelism.** `ensure_batch_invariant_supported` never saw the TP world size, so the combination booted and armed the pin. It is now rejected at the engine boundary (the load-bearing guard, reachable by any library consumer of `start_engine_with_offload`) and again at the CLI, matching how decode-overlap is rejected at both layers.

The reduction order under TP has never been audited. Since #611 the decode all-reduce runs inside graphs captured per `(bucket, attention_path)`, while the prefill and unified all-reduces are eager with message sizes that vary continuously with batch composition. NCCL selects algorithm and protocol by message size, so batch composition can move the reduction order — the axis `--batch-invariant` exists to close. The honest status is *unaudited*, not *known broken*, and that is what the error text and `tp-design.md` now say.

**3. The pinned algo's numeric configuration is read back and logged.** `gemm_lt_pin_tune` pinned `results[0].algo` and never looked at what it pinned. The two attributes that decide the K-reduction, `CUBLASLT_ALGO_CONFIG_SPLITK_NUM` and `CUBLASLT_ALGO_CONFIG_REDUCTION_SCHEME`, are baked into the pinned algo and replayed at every N — `lt_pin_run` reuses `plan.algo`, `plan.op` and `plan.a` verbatim and rebuilds only the B/C layouts — which is precisely why the pin works. 

Selection is unchanged: the heuristic's first result is still what gets pinned, and `cublasLtMatmulAlgoConfigGetAttribute` is a getter. What is new is one startup line per pinned `(M,K)`, and a boot-time bail if the scheme is outside `cublasLtReductionScheme_t`'s documented set. 

## Before and after

Measured on Single GPU (sm_89, x86_64). 

`--batch-invariant --tp-size 2`, on base:

```
INFO openinfer_qwen3 Qwen3 numeric policy: Pin (--batch-invariant=true)
...
Error: 0: failed to start Qwen3 engine
       1: Failed to set CUDA device 1: cudaError=101
```

Zero rejections at any layer. The pin is armed under TP, and the run ends only because this box has one GPU. With this branch:

```
$ openinfer --model-path <qwen3-4b> --batch-invariant --tp-size 2
Error: --batch-invariant is not supported with --tp-size > 1; enable one at a time
$ echo $?
1
```

Single-GPU `--batch-invariant` still boots, so the reject does not over-fire.

The new startup log, on the same GPU:

```
Qwen3 numeric policy: Pin (--batch-invariant=true)
Qwen3 GEMM pin: m=4096,   k=2560, splitk=2, reduction_scheme=output_type
Qwen3 GEMM pin: m=1024,   k=2560, splitk=8, reduction_scheme=output_type
Qwen3 GEMM pin: m=2560,   k=4096, splitk=3, reduction_scheme=output_type
Qwen3 GEMM pin: m=9728,   k=2560, splitk=1, reduction_scheme=none
Qwen3 GEMM pin: m=2560,   k=9728, splitk=3, reduction_scheme=output_type
Qwen3 GEMM pin: m=151936, k=2560, splitk=1, reduction_scheme=none
```

Four of the six pinned shapes really do use split-K, and every one of them reduces through `OUTPUT_TYPE` — partials to workspace, summed by a separate kernel in a fixed order. That is the property the pin depends on, and until now nobody could see it. These values are specific to this GPU and this cuBLAS version.

The block prints twice per boot, once from the memory-profile thread and once from the serving worker. The pin cache is `thread_local`, so each thread pins independently.

## Tests

None added. The TP reject is observable end to end from the CLI.

Single GPU (sm_89, x86_64).

`batch_invariance_decode_gemm_graph` and `batch_invariance_endtoend` are green on both, unchanged: 83.6s / 27.2s on base, 82.0s / 27.2s here. 



## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)