### PR TITLE
fix(kernels): drop the pinned algo for a shape whose retune fails

### DIFF
--- a/openinfer-kernels/csrc/shared/linear.cu
+++ b/openinfer-kernels/csrc/shared/linear.cu
@@ -530,6 +530,14 @@ int gemm_lt_tune_cuda(const __nv_bfloat16 *const *Ws, int num_ws, int M, int N, 
 
 // Pin one cublasLt algo for (M,K) at rep_n (heuristic top, no timing → deterministic), keyed {M,K}.
 int gemm_lt_pin_tune_cuda(int M, int rep_n, int K) {
+  // Dropped before any check, so every failure below leaves {M,K} unpinned and lt_pin_run reports
+  // PIN_UNTUNED instead of serving the plan this call was meant to replace.
+  const std::array<int, 2> key{M, K};
+  auto existing = g_lt_pin_plans.find(key);
+  if (existing != g_lt_pin_plans.end()) {
+    lt_pin_destroy(existing->second);
+    g_lt_pin_plans.erase(existing);
+  }
   if (M <= 0 || rep_n <= 0 || K <= 0) {
     return static_cast<int>(cudaErrorInvalidValue);
   }
@@ -570,12 +578,6 @@ int gemm_lt_pin_tune_cuda(int M, int rep_n, int K) {
   }
 
   plan.algo = results[0].algo;
-  const std::array<int, 2> key{M, K};
-  auto existing = g_lt_pin_plans.find(key);
-  if (existing != g_lt_pin_plans.end()) {
-    lt_pin_destroy(existing->second);
-    g_lt_pin_plans.erase(existing);
-  }
   g_lt_pin_plans.emplace(key, plan);
   return static_cast<int>(cudaSuccess);
 }


### PR DESCRIPTION
## Description

Under `--batch-invariant`, `gemm_lt_pin_tune_cuda` pins one cuBLASLt algo per `(M,K)` in a thread-local map, and drops that shape's previous plan only on the success path. Every failure return — a rejected argument, the lazy handle and workspace allocation, a heuristic that yields no algo — leaves the old plan in the map, so `lt_pin_run` goes on serving the plan this call was meant to replace.

The stale plan is not a wrong kernel: `lt_pin_run` still runs `cublasLtMatmulAlgoCheck` against the live N and rejects it if the workspace exceeds the pin budget. The defect is narrower and more awkward. Cache invalidation depends on the caller aborting: the production chain (`warmup_decode_projection_pins` to `gemm_lt_pin_warmup`) propagates the error and engine startup dies, so nobody reads the stale entry. Nothing in the cache enforces that.

Retuning a shape now drops its plan before any check runs. Every failure below — a rejected argument included — leaves the shape unpinned, so `lt_pin_run` returns `PIN_UNTUNED` and `launch_gemm_pin` fails loud. The postcondition becomes unconditional: after a non-zero return, `(M,K)` is not pinned. The success path is then a bare `emplace`, since no entry for that key can exist by then, and the second lookup goes away.

## Verification

Single GPU (sm_89, x86_64).

`batch_invariance_gemm` retunes three representative seam shapes directly through `gemm_lt_pin_tune` and independently checks the baseline, pinned, and per-token arms for cross-N drift over an N sweep that straddles `GEMM_LT_MAX_N`. It asserts the pinned and per-token arms hold `maxΔ == 0`, that the pinned arm actually served the decode buckets, and that the baseline drifted somewhere — without that last one a green pin run would be vacuous.

That test carries a no-CUDA skip branch which still reports `1 passed`, so the run was checked against a forced `CUDA_VISIBLE_DEVICES=""` control: the control prints the skip line, the real run does not.



## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)