### PR TITLE
ci(workflows): split CPU and CUDA checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   rust-format:
@@ -85,6 +87,9 @@ jobs:
         with:
           toolchain: nightly
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
       - name: Install protobuf compiler
         if: matrix.needs_protobuf
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
@@ -106,6 +111,9 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Install protobuf compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
@@ -130,6 +138,9 @@ jobs:
         with:
           toolchain: nightly
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
       - name: Install CUDA toolkit
         uses: Jimver/cuda-toolkit@v0.2.35
         with:
@@ -137,7 +148,7 @@ jobs:
           linux-local-args: '["--toolkit"]'
           method: network
           sub-packages: '["nvcc", "nvrtc-dev", "cudart-dev"]'
-          non-cuda-sub-packages: '["libcublas-dev"]'
+          non-cuda-sub-packages: '["libcublas-dev", "libcurand-dev"]'
 
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libibverbs-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTC_WRAPPER: sccache
-  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   rust-format:
@@ -59,6 +57,9 @@ jobs:
   cpu-unit-tests:
     name: CPU unit tests (${{ matrix.package }})
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     strategy:
       fail-fast: false
       matrix:
@@ -89,6 +90,8 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
+        with:
+          version: "v0.16.0"
 
       - name: Install protobuf compiler
         if: matrix.needs_protobuf
@@ -100,6 +103,9 @@ jobs:
   simulated-frontend-e2e:
     name: Simulated frontend E2E
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
 
     steps:
       - name: Checkout
@@ -114,6 +120,8 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
+        with:
+          version: "v0.16.0"
 
       - name: Install protobuf compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
@@ -125,6 +133,9 @@ jobs:
     name: Qwen3 CUDA compile (sm_80)
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
 
     steps:
       - name: Checkout
@@ -140,6 +151,8 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
+        with:
+          version: "v0.16.0"
 
       - name: Install CUDA toolkit
         uses: Jimver/cuda-toolkit@v0.2.35

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,29 +10,141 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
-  cpu-checks:
-    name: CPU checks
+  rust-format:
+    name: Rust formatting
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
-          components: rustfmt, clippy
-
-      - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+          components: rustfmt
 
       - name: Check formatting
         run: cargo fmt --all --check
 
+  cargo-metadata:
+    name: Locked Cargo metadata
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: nightly
+
       - name: Check locked Cargo metadata
         run: cargo metadata --locked --no-deps --format-version 1
 
-      - name: Run simulated frontend e2e tests
-        run: cargo test --release -p openinfer-sim --test frontend_e2e
+  cpu-unit-tests:
+    name: CPU unit tests (${{ matrix.package }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: openinfer-build
+            needs_protobuf: false
+          - package: openinfer-engine
+            needs_protobuf: false
+          - package: openinfer-vllm-support
+            needs_protobuf: false
+          - package: openinfer-vllm-frontend
+            needs_protobuf: true
+          - package: openinfer-sim
+            needs_protobuf: true
+          - package: kvbm-logical
+            needs_protobuf: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: nightly
+
+      - name: Install protobuf compiler
+        if: matrix.needs_protobuf
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Run unit tests
+        run: cargo test --release --locked -p ${{ matrix.package }} --lib
+
+  simulated-frontend-e2e:
+    name: Simulated frontend E2E
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: nightly
+
+      - name: Install protobuf compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Run simulated frontend E2E tests
+        run: cargo test --release --locked -p openinfer-sim --test frontend_e2e
+
+  qwen3-cuda-compile:
+    name: Qwen3 CUDA compile (sm_80)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: nightly
+
+      - name: Install CUDA toolkit
+        uses: Jimver/cuda-toolkit@v0.2.35
+        with:
+          cuda: "13.0.2"
+          linux-local-args: '["--toolkit"]'
+          method: network
+          sub-packages: '["nvcc", "nvrtc-dev", "cudart-dev"]'
+          non-cuda-sub-packages: '["libcublas-dev"]'
+
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libibverbs-dev
+
+      - name: Compile default Qwen3 targets
+        run: cargo check --release --locked -p openinfer-server --all-targets
+        env:
+          CUDA_PATH: /usr/local/cuda
+          OPENINFER_CUDA_SM: "80"
+          OPENINFER_NVCC_JOBS: "2"


### PR DESCRIPTION
## Summary

- split formatting, locked metadata, CPU unit tests, simulated frontend E2E, and Qwen3 CUDA compilation into independently reported CI jobs
- run CPU unit tests as a fail-fast-disabled matrix across six CPU-safe crates
- compile the default Qwen3 server on a CPU-only runner with a minimal CUDA 13.0.2 toolkit and an explicit `sm_80` target
- cache Rust compilation through sccache's GitHub Actions backend while leaving direct nvcc compilation uncached
- keep Clippy out of this change until the warning baseline is clean; follow-up is tracked in #326

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml`
- `cargo fmt --all --check`
- `cargo metadata --locked --no-deps --format-version 1`
- 535 CPU unit tests across the six matrix packages
- 5 simulated frontend E2E tests
- `CUDA_VISIBLE_DEVICES='' OPENINFER_CUDA_SM=80 OPENINFER_NVCC_JOBS=2 cargo check --release --locked -p openinfer-server --all-targets` (86.8s locally)

### GitHub-hosted runner results

Both the cold-cache run and a same-commit warm-cache rerun passed all jobs. Selected cold → warm job times:

| Job | Cold | Warm |
| --- | ---: | ---: |
| `openinfer-vllm-frontend` unit tests | 5m04s | 2m15s |
| `openinfer-sim` unit tests | 5m06s | 2m16s |
| simulated frontend E2E | 5m42s | 2m55s |
| Qwen3 CUDA compile | 5m26s | 5m42s |

The Rust-heavy CPU jobs benefit from warm sccache. The workflow remains CUDA-bound because `openinfer-kernels/build.rs` invokes nvcc directly, outside `RUSTC_WRAPPER`.
