### PR TITLE
fix(ci): enforce warning-free Clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2026-07-10
           components: rustfmt
 
       - name: Check formatting
@@ -49,7 +49,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2026-07-10
 
       - name: Check locked Cargo metadata
         run: cargo metadata --locked --no-deps --format-version 1
@@ -86,7 +86,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2026-07-10
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -99,6 +99,44 @@ jobs:
 
       - name: Run unit tests
         run: cargo test --release --locked -p ${{ matrix.package }} --lib
+
+  cpu-clippy:
+    name: CPU Clippy
+    runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: nightly-2026-07-10
+          components: clippy
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+        with:
+          version: "v0.16.0"
+
+      - name: Install protobuf compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Run CPU Clippy
+        run: >-
+          cargo clippy --release --locked
+          -p openinfer-build
+          -p openinfer-engine
+          -p openinfer-vllm-support
+          -p openinfer-vllm-frontend
+          -p openinfer-sim
+          -p kvbm-logical
+          --all-targets -- -D warnings
 
   simulated-frontend-e2e:
     name: Simulated frontend E2E
@@ -116,7 +154,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2026-07-10
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -147,7 +185,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2026-07-10
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -168,6 +206,51 @@ jobs:
 
       - name: Compile default Qwen3 targets
         run: cargo check --release --locked -p openinfer-server --all-targets
+        env:
+          CUDA_PATH: /usr/local/cuda
+          OPENINFER_CUDA_SM: "80"
+          OPENINFER_NVCC_JOBS: "2"
+
+  qwen3-cuda-clippy:
+    name: Qwen3 CUDA Clippy (sm_80)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: nightly-2026-07-10
+          components: clippy
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+        with:
+          version: "v0.16.0"
+
+      - name: Install CUDA toolkit
+        uses: Jimver/cuda-toolkit@v0.2.35
+        with:
+          cuda: "13.0.2"
+          linux-local-args: '["--toolkit"]'
+          method: network
+          sub-packages: '["nvcc", "nvrtc-dev", "cudart-dev"]'
+          non-cuda-sub-packages: '["libcublas-dev", "libcurand-dev"]'
+
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libibverbs-dev
+
+      - name: Run Qwen3 CUDA Clippy
+        run: cargo clippy --release --locked -p openinfer-server --all-targets -- -D warnings
         env:
           CUDA_PATH: /usr/local/cuda
           OPENINFER_CUDA_SM: "80"

--- a/openinfer-kv-offload/src/engine.rs
+++ b/openinfer-kv-offload/src/engine.rs
@@ -829,7 +829,7 @@ impl OffloadEngine {
         let (done_tx, done_rx) = oneshot::channel();
         let (handles, prev_done) = {
             let mut barrier = self.write_barrier.lock().expect("write_barrier poisoned");
-            let handles: Vec<JoinHandle<()>> = barrier.pending_saves.drain(..).collect();
+            let handles = std::mem::take(&mut barrier.pending_saves);
             let prev_done = barrier.prev_flush_done.replace(done_rx);
             (handles, prev_done)
         };

--- a/openinfer-qwen3/src/config.rs
+++ b/openinfer-qwen3/src/config.rs
@@ -38,13 +38,13 @@ pub(crate) struct Config {
     pub(crate) stop_token_ids: Vec<u32>,
 }
 
-/// Resolved drafter config, shared by DFlash and DSpark (DSpark = DFlash backbone
-/// + a Markov head + an optional confidence head). `markov_rank == 0` is plain
-/// DFlash. Two on-disk schemas are normalized into this in `from_file`:
-/// our `Qwen3-4B-DFlash-b16` nests `dflash_config: {mask_token_id,
-/// target_layer_ids}` and puts `rope_theta` at the top level; DeepSpec's
-/// `dflash_/dspark_*_block7` put those fields flat and nest `rope_theta` under
-/// `rope_parameters`.
+/// Resolved drafter config shared by DFlash and DSpark. DSpark extends the
+/// DFlash backbone with a Markov head and an optional confidence head;
+/// `markov_rank == 0` is plain DFlash. Two on-disk schemas are normalized into
+/// this in `from_file`: our `Qwen3-4B-DFlash-b16` nests
+/// `dflash_config: {mask_token_id, target_layer_ids}` and puts `rope_theta` at
+/// the top level, while DeepSpec's `dflash_/dspark_*_block7` put those fields
+/// flat and nest `rope_theta` under `rope_parameters`.
 #[derive(Clone, Debug)]
 pub(crate) struct DFlashConfig {
     pub(crate) hidden_size: usize,
@@ -322,7 +322,7 @@ impl DFlashConfig {
             target.vocab_size
         );
         anyhow::ensure!(
-            self.rope_theta == target.rope_theta,
+            self.rope_theta.to_bits() == target.rope_theta.to_bits(),
             "DFlash rope_theta {} does not match target {}",
             self.rope_theta,
             target.rope_theta

--- a/openinfer-qwen3/src/dflash.rs
+++ b/openinfer-qwen3/src/dflash.rs
@@ -567,7 +567,7 @@ impl DFlashDraftModel {
                 .context
                 .ensure_capacity(ctx, self.config.hidden_size, context_len)?;
             state.pending_context.activate_for_read();
-            self.project_context_into(ctx, &state.pending_context.buffer, &mut state.context)?;
+            self.project_context_into(ctx, &state.pending_context.buffer, &mut state.context);
             state.pending_context.clear();
         }
 
@@ -752,7 +752,7 @@ impl DFlashDraftModel {
         for (i, state) in states.iter_mut().enumerate() {
             state.committed_len += context_lens[i];
         }
-        self.compute_logits_with_target_head_into(target, scratch)?;
+        self.compute_logits_with_target_head_into(target, scratch);
         Ok(&scratch.logits)
     }
 
@@ -798,7 +798,7 @@ impl DFlashDraftModel {
         ctx: &DeviceContext,
         context_features: &HiddenStates,
         context: &mut DFlashContextScratch,
-    ) -> Result<()> {
+    ) {
         ops::gemm_into(
             ctx,
             &self.fc,
@@ -812,14 +812,13 @@ impl DFlashDraftModel {
             self.config.rms_norm_eps,
             &mut context.context_hidden,
         );
-        Ok(())
     }
 
     fn compute_logits_with_target_head_into(
         &self,
         target: &Qwen3Model,
         scratch: &mut DFlashBatchScratch,
-    ) -> Result<()> {
+    ) {
         let ctx = target.device_ctx();
         ops::rms_norm_batch_into(
             ctx,
@@ -834,7 +833,6 @@ impl DFlashDraftModel {
             &scratch.logits_normed,
             &mut scratch.logits,
         );
-        Ok(())
     }
 }
 

--- a/openinfer-qwen3/src/dspark.rs
+++ b/openinfer-qwen3/src/dspark.rs
@@ -138,10 +138,11 @@ impl MarkovHead {
     /// Bytes occupied by the Markov head weights + sample scratch, for the memory
     /// reservation. `0` when the head is disabled.
     pub(crate) fn reservation_bytes(config: &DFlashConfig, max_decode_batch_size: usize) -> usize {
+        const BF16: usize = 2;
+
         if !config.uses_markov_head() {
             return 0;
         }
-        const BF16: usize = 2;
         let vocab = config.vocab_size;
         let rank = config.markov_rank;
         let weights = 2 * vocab * rank * BF16;

--- a/openinfer-qwen3/src/executor.rs
+++ b/openinfer-qwen3/src/executor.rs
@@ -490,7 +490,7 @@ fn execute_step_on_lane(
                 let mut event: cudarc::driver::sys::CUevent = std::ptr::null_mut();
                 unsafe {
                     cudarc::driver::sys::cuEventCreate(
-                        &mut event,
+                        &raw mut event,
                         cudarc::driver::sys::CUevent_flags_enum::CU_EVENT_DISABLE_TIMING as u32,
                     );
                     cudarc::driver::sys::cuEventRecord(event, prefill_stream.0);
@@ -577,6 +577,8 @@ fn tune_decode_gemm_algos(
     max_prefill_tokens: usize,
     run_envelope_check: bool,
 ) -> Result<()> {
+    use openinfer_kernels::ops::{NumericPolicy, numeric_policy};
+
     let ctx = model.device_ctx();
     let hidden = model.config().hidden_size;
     let vocab = model.config().vocab_size;
@@ -584,7 +586,6 @@ fn tune_decode_gemm_algos(
     let kv_dim = model.local_kv_dim();
     let intermediate = model.local_intermediate_size();
 
-    use openinfer_kernels::ops::{NumericPolicy, numeric_policy};
     if numeric_policy() == NumericPolicy::Pin {
         // Eager pin before capture: the lazy pin-workspace alloc is illegal mid-capture.
         crate::batch_decode_buffers::warmup_decode_projection_pins(
@@ -1118,6 +1119,10 @@ impl Qwen3Executor {
         )
     }
 
+    #[allow(
+        clippy::needless_pass_by_value,
+        reason = "executor construction is a one-shot ownership boundary"
+    )]
     pub fn from_runtime_with_lora_options(
         model_path: &str,
         enable_cuda_graph: bool,
@@ -1466,9 +1471,8 @@ impl Qwen3Executor {
         // engine-entry guard. launch_gemm_pin also bails on the resulting stream override, but only mid
         // graph-capture/replay (a hot-path failure) — rejecting here moves it to a safe point.
         anyhow::ensure!(
-            !(openinfer_kernels::ops::numeric_policy()
-                == openinfer_kernels::ops::NumericPolicy::Pin
-                && !matches!(overlap, crate::DecodeOverlap::Off)),
+            openinfer_kernels::ops::numeric_policy() != openinfer_kernels::ops::NumericPolicy::Pin
+                || matches!(overlap, crate::DecodeOverlap::Off),
             "--batch-invariant (NumericPolicy::Pin) is not compatible with decode-overlap: the stream override would force the pinned GEMM to bail at runtime"
         );
         // Overlap's split-concurrent decode stream uses the group-limited decode
@@ -2729,13 +2733,11 @@ impl ModelExecutor for Qwen3Executor {
         }
 
         // Ask worker to sync + sample the prefill result.
-        let rx = match self.primary.resolve_prefill() {
-            Ok(rx) => rx,
-            Err(_) => return None,
+        let Ok(rx) = self.primary.resolve_prefill() else {
+            return None;
         };
-        let result = match rx.recv() {
-            Ok(Ok(r)) => r,
-            _ => return None,
+        let Ok(Ok(result)) = rx.recv() else {
+            return None;
         };
 
         // Apply prefill results (KV commit)

--- a/openinfer-qwen3/src/executor/dflash_lane.rs
+++ b/openinfer-qwen3/src/executor/dflash_lane.rs
@@ -307,7 +307,7 @@ impl LocalQwen3Lane {
             // already predict the first draft, giving all `block_size` drafts —
             // a one-token-longer span. This is a checkpoint property, not a markov
             // one: a `markov_rank == 0` DeepSpec checkpoint is still anchor-first.
-            let drafts_start = if model.anchor_first() { 0 } else { 1 };
+            let drafts_start = usize::from(!model.anchor_first());
             let mut outputs = Vec::with_capacity(requests.len());
             for (i, req) in requests.iter().enumerate() {
                 let block = &sampled[i * block_size..(i + 1) * block_size];

--- a/openinfer-qwen3/src/executor/spec.rs
+++ b/openinfer-qwen3/src/executor/spec.rs
@@ -173,7 +173,7 @@ impl Qwen3Executor {
     /// via RAII); the reverse order here just mirrors schedule order and is
     /// cosmetic.
     fn revert_speculative_schedules(&mut self, request_ids: &[RequestId]) {
-        for request_id in request_ids.iter().rev().copied() {
+        for &request_id in request_ids.iter().rev() {
             let Some(rkv) = self.request_kvs.get_mut(&request_id) else {
                 log::warn!(
                     "missing RequestKv while reverting speculative schedule for {request_id:?}"

--- a/openinfer-qwen3/src/green_ctx.rs
+++ b/openinfer-qwen3/src/green_ctx.rs
@@ -78,7 +78,7 @@ fn query_total_sm(device: CUdevice) -> Result<u32> {
         unsafe {
             sys::cuDeviceGetDevResource(
                 device,
-                &mut sm_res,
+                &raw mut sm_res,
                 sys::CUdevResourceType::CU_DEV_RESOURCE_TYPE_SM,
             )
         },
@@ -93,7 +93,7 @@ fn create_primary_stream() -> Result<CUstream> {
     check_cu(
         unsafe {
             sys::cuStreamCreate(
-                &mut stream,
+                &raw mut stream,
                 sys::CUstream_flags::CU_STREAM_NON_BLOCKING as u32,
             )
         },
@@ -137,7 +137,7 @@ impl OverlapStreams {
             unsafe {
                 sys::cuDeviceGetDevResource(
                     device,
-                    &mut sm_res,
+                    &raw mut sm_res,
                     sys::CUdevResourceType::CU_DEV_RESOURCE_TYPE_SM,
                 )
             },
@@ -151,10 +151,10 @@ impl OverlapStreams {
         check_cu(
             unsafe {
                 sys::cuDevSmResourceSplitByCount(
-                    &mut probe_grp,
-                    &mut nb,
-                    &sm_res,
-                    &mut probe_rem,
+                    &raw mut probe_grp,
+                    &raw mut nb,
+                    &raw const sm_res,
+                    &raw mut probe_rem,
                     0,
                     1,
                 )
@@ -179,10 +179,10 @@ impl OverlapStreams {
         check_cu(
             unsafe {
                 sys::cuDevSmResourceSplitByCount(
-                    &mut grp_decode,
-                    &mut nb,
-                    &sm_res,
-                    &mut grp_prefill,
+                    &raw mut grp_decode,
+                    &raw mut nb,
+                    &raw const sm_res,
+                    &raw mut grp_prefill,
                     0,
                     sm_for_decode,
                 )
@@ -196,11 +196,13 @@ impl OverlapStreams {
         let mut desc_decode: sys::CUdevResourceDesc = ptr::null_mut();
         let mut desc_prefill: sys::CUdevResourceDesc = ptr::null_mut();
         check_cu(
-            unsafe { sys::cuDevResourceGenerateDesc(&mut desc_decode, &mut grp_decode, 1) },
+            unsafe { sys::cuDevResourceGenerateDesc(&raw mut desc_decode, &raw mut grp_decode, 1) },
             "cuDevResourceGenerateDesc (decode)",
         )?;
         check_cu(
-            unsafe { sys::cuDevResourceGenerateDesc(&mut desc_prefill, &mut grp_prefill, 1) },
+            unsafe {
+                sys::cuDevResourceGenerateDesc(&raw mut desc_prefill, &raw mut grp_prefill, 1)
+            },
             "cuDevResourceGenerateDesc (prefill)",
         )?;
 
@@ -209,7 +211,7 @@ impl OverlapStreams {
         check_cu(
             unsafe {
                 sys::cuGreenCtxCreate(
-                    &mut gctx_decode,
+                    &raw mut gctx_decode,
                     desc_decode,
                     device,
                     sys::CUgreenCtxCreate_flags::CU_GREEN_CTX_DEFAULT_STREAM as u32,
@@ -220,7 +222,7 @@ impl OverlapStreams {
         check_cu(
             unsafe {
                 sys::cuGreenCtxCreate(
-                    &mut gctx_prefill,
+                    &raw mut gctx_prefill,
                     desc_prefill,
                     device,
                     sys::CUgreenCtxCreate_flags::CU_GREEN_CTX_DEFAULT_STREAM as u32,
@@ -232,11 +234,11 @@ impl OverlapStreams {
         let mut ctx_decode: sys::CUcontext = ptr::null_mut();
         let mut ctx_prefill: sys::CUcontext = ptr::null_mut();
         check_cu(
-            unsafe { sys::cuCtxFromGreenCtx(&mut ctx_decode, gctx_decode) },
+            unsafe { sys::cuCtxFromGreenCtx(&raw mut ctx_decode, gctx_decode) },
             "cuCtxFromGreenCtx (decode)",
         )?;
         check_cu(
-            unsafe { sys::cuCtxFromGreenCtx(&mut ctx_prefill, gctx_prefill) },
+            unsafe { sys::cuCtxFromGreenCtx(&raw mut ctx_prefill, gctx_prefill) },
             "cuCtxFromGreenCtx (prefill)",
         )?;
 
@@ -251,7 +253,7 @@ impl OverlapStreams {
         let mut prefill_stream: CUstream = ptr::null_mut();
         let r1 = unsafe {
             sys::cuGreenCtxStreamCreate(
-                &mut decode_stream,
+                &raw mut decode_stream,
                 gctx_decode,
                 sys::CUstream_flags::CU_STREAM_NON_BLOCKING as u32,
                 0,
@@ -259,7 +261,7 @@ impl OverlapStreams {
         };
         let r2 = unsafe {
             sys::cuGreenCtxStreamCreate(
-                &mut prefill_stream,
+                &raw mut prefill_stream,
                 gctx_prefill,
                 sys::CUstream_flags::CU_STREAM_NON_BLOCKING as u32,
                 0,

--- a/openinfer-qwen3/src/lib.rs
+++ b/openinfer-qwen3/src/lib.rs
@@ -198,6 +198,10 @@ pub fn probe_model(model_path: &Path) -> Result<Option<ModelInfo>> {
 /// exclusion — and dispatches to the right low-level entry.
 /// That policy lives with the model instead of leaking into the server.
 #[derive(Clone, Debug)]
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "these launch flags are independent server options, not states"
+)]
 pub struct Qwen3LaunchOptions {
     /// CUDA device for single-GPU loads (ignored when `tp_size > 1`).
     pub device_ordinal: usize,
@@ -225,6 +229,10 @@ pub struct Qwen3LaunchOptions {
 }
 
 /// Start the Qwen3 engine from server-facing [`Qwen3LaunchOptions`].
+#[allow(
+    clippy::needless_pass_by_value,
+    reason = "launch is a one-shot ownership boundary used by external worker threads"
+)]
 pub fn launch(model_path: &Path, options: Qwen3LaunchOptions) -> Result<EngineHandle> {
     let device_ordinals = if options.tp_size == 1 {
         vec![options.device_ordinal]
@@ -267,8 +275,8 @@ pub fn launch(model_path: &Path, options: Qwen3LaunchOptions) -> Result<EngineHa
         "DFlash speculative decoding cannot be combined with LoRA serving"
     );
     anyhow::ensure!(
-        !(options.dflash_draft_model_path.is_some()
-            && !matches!(options.decode_overlap, DecodeOverlap::Off)),
+        options.dflash_draft_model_path.is_none()
+            || matches!(options.decode_overlap, DecodeOverlap::Off),
         "DFlash speculative decoding cannot be combined with decode overlap \
          (--decode-overlap): the speculative path never takes the unified overlap \
          route, so the overlap streams would only waste VRAM the drafter needs"

--- a/openinfer-qwen3/src/lora.rs
+++ b/openinfer-qwen3/src/lora.rs
@@ -632,7 +632,9 @@ fn tensor_to_bf16(tensor: &TensorView<'_>, name: &str) -> Result<Vec<bf16>> {
             );
             Ok(tensor
                 .data()
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|bytes| bf16::from_bits(u16::from_le_bytes([bytes[0], bytes[1]])))
                 .collect())
         }
@@ -643,7 +645,9 @@ fn tensor_to_bf16(tensor: &TensorView<'_>, name: &str) -> Result<Vec<bf16>> {
             );
             Ok(tensor
                 .data()
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|bytes| {
                     let value = f16::from_bits(u16::from_le_bytes([bytes[0], bytes[1]]));
                     bf16::from_f32(value.to_f32())
@@ -657,7 +661,9 @@ fn tensor_to_bf16(tensor: &TensorView<'_>, name: &str) -> Result<Vec<bf16>> {
             );
             Ok(tensor
                 .data()
-                .chunks_exact(4)
+                .as_chunks::<4>()
+                .0
+                .iter()
                 .map(|bytes| {
                     bf16::from_f32(f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
                 })

--- a/openinfer-qwen3/src/scheduler.rs
+++ b/openinfer-qwen3/src/scheduler.rs
@@ -1215,10 +1215,7 @@ fn failure_targets_for(
         self::plan::ExecutionPlan::Prefill { pending } => {
             targets.extend(pending.iter().map(pending_failure_target));
         }
-        self::plan::ExecutionPlan::Decode => {
-            targets.extend(active.iter().map(active_failure_target));
-        }
-        self::plan::ExecutionPlan::SpeculativeDecode => {
+        self::plan::ExecutionPlan::Decode | self::plan::ExecutionPlan::SpeculativeDecode => {
             targets.extend(active.iter().map(active_failure_target));
         }
         self::plan::ExecutionPlan::Unified { pending } => {

--- a/openinfer-qwen3/src/speculative.rs
+++ b/openinfer-qwen3/src/speculative.rs
@@ -49,6 +49,7 @@ impl VerifyStepItem {
     }
 }
 
+#[derive(Clone, Copy)]
 pub(crate) struct VerifyPlan<'a> {
     pub requests: &'a [VerifyStepItem],
 }
@@ -88,6 +89,7 @@ impl DraftStepItem {
     }
 }
 
+#[derive(Clone, Copy)]
 pub(crate) struct DraftPlan<'a> {
     pub requests: &'a [DraftStepItem],
 }

--- a/openinfer-qwen3/src/unified_forward.rs
+++ b/openinfer-qwen3/src/unified_forward.rs
@@ -227,7 +227,7 @@ impl Qwen3Model {
             .chain(decode_views.iter())
             .map(openinfer_kv_cache::KvView::last_page_len)
             .collect();
-        let mut start_positions = prefill_start_positions.clone();
+        let mut start_positions = prefill_start_positions;
         start_positions.extend_from_slice(&decode_positions);
         let mut seq_lens = prefill_seq_lens.clone();
         seq_lens.extend(std::iter::repeat_n(1, num_decode_reqs));

--- a/openinfer-qwen3/src/verify_graph.rs
+++ b/openinfer-qwen3/src/verify_graph.rs
@@ -127,7 +127,7 @@ impl VerifyGraphBuffers {
             graphs: BATCH_BUCKETS
                 .iter()
                 .map(|_| {
-                    (0..model.config().num_hidden_layers + 1)
+                    (0..=model.config().num_hidden_layers)
                         .map(|_| CudaGraphState::new())
                         .collect()
                 })
@@ -290,8 +290,8 @@ impl Qwen3Model {
                 let result = (|| -> Result<()> {
                     segs[0].run_or_capture(ctx, || self.verify_seg_embed_pre(bufs))?;
                     self.verify_attn(0, kv_buffer, layout, bufs)?;
-                    for i in 1..num_layers {
-                        segs[i].run_or_capture(ctx, || {
+                    for (i, segment) in segs.iter_mut().enumerate().take(num_layers).skip(1) {
+                        segment.run_or_capture(ctx, || {
                             self.verify_seg_post_pre(i, capture_layer_ids, bufs)
                         })?;
                         self.verify_attn(i, kv_buffer, layout, bufs)?;

--- a/openinfer-qwen3/src/weights.rs
+++ b/openinfer-qwen3/src/weights.rs
@@ -926,10 +926,10 @@ impl Qwen3Model {
     #[cfg(feature = "kernel-call-trace")]
     pub(crate) fn kv_budget(&self) -> KvBudget {
         let geometry = self.kv_budget_geometry(DEFAULT_KV_PAGE_SIZE);
-        let bytes_per_block = self.kv_bytes_per_block(&geometry);
+        let bytes_per_block = Self::kv_bytes_per_block(&geometry);
         let (free_bytes, _) = cudarc::driver::result::mem_get_info().expect("cuMemGetInfo failed");
         let kv_budget_bytes = (free_bytes as f64 * 0.85) as usize;
-        self.kv_budget_from_bytes(
+        Self::kv_budget_from_bytes(
             geometry,
             bytes_per_block,
             0,
@@ -948,7 +948,7 @@ impl Qwen3Model {
     ) -> Result<KvBudget> {
         let memory_options = memory_options.validate()?;
         let geometry = self.kv_budget_geometry(memory_options.page_size);
-        let bytes_per_block = self.kv_bytes_per_block(&geometry);
+        let bytes_per_block = Self::kv_bytes_per_block(&geometry);
         let (initial_free_bytes, total_bytes) = mem_info_bytes()?;
         let requested_bytes =
             (total_bytes as f64 * memory_options.gpu_memory_utilization).ceil() as usize;
@@ -1063,7 +1063,7 @@ impl Qwen3Model {
             memory_options.kv_cache_memory_margin_bytes / (1024 * 1024),
             kv_budget_bytes / (1024 * 1024),
         );
-        Ok(self.kv_budget_from_bytes(
+        Ok(Self::kv_budget_from_bytes(
             geometry,
             bytes_per_block,
             dflash_kv_bytes_per_token,
@@ -1084,7 +1084,7 @@ impl Qwen3Model {
         }
     }
 
-    fn kv_bytes_per_block(&self, geometry: &KvBudget) -> usize {
+    fn kv_bytes_per_block(geometry: &KvBudget) -> usize {
         let layout = openinfer_kv_cache::KvLayout::new(
             geometry.num_layers,
             geometry.num_kv_heads,
@@ -1095,7 +1095,6 @@ impl Qwen3Model {
     }
 
     fn kv_budget_from_bytes(
-        &self,
         mut geometry: KvBudget,
         bytes_per_block: usize,
         dflash_kv_bytes_per_token: usize,

--- a/openinfer-server/src/bin/bench_serving/exec.rs
+++ b/openinfer-server/src/bin/bench_serving/exec.rs
@@ -172,7 +172,7 @@ impl BenchModel for SchedulerBenchModel {
         _rng: &mut StdRng,
     ) -> GenTimings {
         run_timed(prompt_tokens, max_new_tokens, |toks, n, cb| {
-            run_scheduler_stream(&self.handle, None, toks.to_vec(), *sampling, n, |id| cb(id))?;
+            run_scheduler_stream(&self.handle, None, toks.to_vec(), *sampling, n, &mut *cb)?;
             Ok(())
         })
     }
@@ -197,7 +197,7 @@ impl BenchModel for SchedulerBenchModel {
                         toks.to_vec(),
                         sampling,
                         n,
-                        |id| cb(id),
+                        &mut *cb,
                     )?;
                     Ok(())
                 })

--- a/openinfer-server/src/bin/bench_serving/main.rs
+++ b/openinfer-server/src/bin/bench_serving/main.rs
@@ -46,11 +46,11 @@ mod render;
 mod report;
 mod runners;
 mod snapshot;
-use cli::*;
-use exec::*;
-use metrics::*;
-use runners::*;
-use snapshot::*;
+use cli::{Cli, Command};
+use exec::{BenchModel, SchedulerBenchModel};
+use metrics::dur_ms;
+use runners::{emit_report, run_command};
+use snapshot::{run_compare, run_snapshot};
 
 fn command_seed(cli: &Cli) -> u64 {
     match &cli.command {

--- a/openinfer-server/src/bin/bench_serving/runners.rs
+++ b/openinfer-server/src/bin/bench_serving/runners.rs
@@ -15,12 +15,25 @@ use rand::SeedableRng;
 use rand::rngs::StdRng;
 use vllm_text::tokenizer::DynTokenizer;
 
-use crate::cli::*;
-use crate::exec::*;
-use crate::metrics::*;
-use crate::prompt::*;
-use crate::render::*;
-use crate::report::*;
+use crate::cli::{Cli, Command, CurveArgs, MatrixArgs, OutputFormat, RequestArgs, RunArgs};
+use crate::exec::{BenchModel, GenTimings};
+use crate::metrics::{
+    aggregate_tok_s, dur_ms, generated_token_trace, summarize_counts, summarize_durations,
+};
+use crate::prompt::{
+    SYNTHETIC_PATTERN, SYNTHETIC_TOKEN_HI, SYNTHETIC_TOKEN_LO, resolve_prompt_input,
+    synthetic_prompt_tokens, synthetic_random_prompt,
+};
+use crate::render::{
+    push_table, render_curve_meta, render_curve_table, render_decode_meta, render_decode_table,
+    render_duration_table, render_matrix_meta, render_matrix_table, render_mixed_text,
+    render_prefill_meta, render_prefill_table, render_request_meta, render_request_summary,
+};
+use crate::report::{
+    BenchReport, CurveReport, CurveWindow, CurveWorkload, GeneratedTokenTrace, MatrixCell,
+    MatrixReport, MatrixWorkload, RequestIterationTiming, RequestMetrics, RequestReport,
+    RequestWorkload, RunInfo,
+};
 
 pub(crate) const DEFAULT_REQUEST_PROMPT: &str = "Tell me a story";
 pub(crate) const DEFAULT_CURVE_PROMPT_LEN: usize = 512;

--- a/openinfer-server/src/bin/bench_serving/snapshot.rs
+++ b/openinfer-server/src/bin/bench_serving/snapshot.rs
@@ -10,12 +10,12 @@ use comfy_table::{Cell, CellAlignment};
 use log::info;
 use openinfer::server_engine::ModelType;
 
-use crate::cli::*;
-use crate::exec::*;
-use crate::prompt::*;
-use crate::render::*;
-use crate::report::*;
-use crate::runners::*;
+use crate::cli::{Cli, CompareArgs, MixedArgs, RunArgs, SnapshotArgs};
+use crate::exec::BenchModel;
+use crate::prompt::synthetic_prompt_tokens;
+use crate::render::{key_cell, new_table, numeric_cell, push_table};
+use crate::report::{BenchReport, SnapshotMixedItl, SnapshotProfile, SnapshotReport};
+use crate::runners::{build_request_metrics, measure_timings};
 
 pub(crate) const SNAPSHOT_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../bench_snapshots");
 pub(crate) const SNAPSHOT_PREFILL_OUTPUT_LEN: usize = 1;
@@ -404,7 +404,9 @@ pub(crate) fn render_comparison(
     }
 
     if let (Some(cm), Some(bm)) = (&current.mixed_itl, &baseline.mixed_itl) {
-        if cm.config.inj_prompt_len == bm.config.inj_prompt_len && cm.config.qps == bm.config.qps {
+        if cm.config.inj_prompt_len == bm.config.inj_prompt_len
+            && cm.config.qps.to_bits() == bm.config.qps.to_bits()
+        {
             let ml = format!("(inj {}@{})", cm.config.inj_prompt_len, cm.config.qps);
             for (stat, cur, base) in [
                 ("p50", cm.itl.all.p50_ms, bm.itl.all.p50_ms),

--- a/openinfer-vllm-frontend/src/bridge/tests.rs
+++ b/openinfer-vllm-frontend/src/bridge/tests.rs
@@ -489,7 +489,7 @@ async fn load_snapshots_become_stats_only_batches() {
     };
     let stats = batch.scheduler_stats.expect("scheduler stats");
     assert_eq!(stats.num_running_reqs, 0);
-    assert_eq!(stats.kv_cache_usage, 0.0);
+    assert_eq!(stats.kv_cache_usage.to_bits(), 0.0_f64.to_bits());
 
     shutdown.cancel();
     task.await.expect("stats task exits on shutdown");

--- a/openinfer-vllm-frontend/src/wire.rs
+++ b/openinfer-vllm-frontend/src/wire.rs
@@ -190,7 +190,7 @@ mod tests {
 
         // Greedy lowering zeroes min_p along with the rest.
         params.temperature = 0.0;
-        assert_eq!(convert_sampling(&params).min_p, 0.0);
+        assert_eq!(convert_sampling(&params).min_p.to_bits(), 0.0_f32.to_bits());
     }
 
     #[test]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2026-07-10"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

- pin the Rust nightly so Clippy results do not drift underneath CI
- resolve the current CPU and default Qwen3 Clippy findings without changing public API ownership contracts
- add independent CPU and CUDA Qwen3 Clippy jobs with `-D warnings` and pinned sccache

## Validation

- `cargo clippy --release --locked -p openinfer-build -p openinfer-engine -p openinfer-vllm-support -p openinfer-vllm-frontend -p openinfer-sim -p kvbm-logical --all-targets -- -D warnings`
- `CUDA_VISIBLE_DEVICES='' CUDA_PATH=/usr/local/cuda OPENINFER_CUDA_SM=80 OPENINFER_NVCC_JOBS=4 cargo clippy --release --locked -p openinfer-server --all-targets -- -D warnings`
- CPU unit suite: 535 passed
- simulated frontend E2E: 5 passed
- Qwen3 library suite: 67 passed
- Qwen3 batch-invariance API boundary: 3 passed
- `actionlint` v1.7.12

Closes #326
