### PR TITLE
feat(qwen3): export decode CUDA graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ and [Co-locating Prefill and Decode on One GPU](https://open-infer.org/blog/gree
 ### Prerequisites
 
 - Rust (2024 edition), CUDA Toolkit (nvcc, cuBLAS), CUDA-capable GPU
-- NVIDIA driver R535 (CUDA 12.2) or newer; driver symbols resolve lazily at call time, so the `cuda-12090` cudarc feature does not raise the driver floor
+- NVIDIA driver R545 (CUDA 12.3) or newer; `cuFuncGetName` sets this floor, while per-symbol lazy loading keeps the `cuda-12090` cudarc binding from requiring a CUDA 12.9 driver
 - The default build (Qwen3-4B / 8B) is pure Rust + CUDA — no Python at all
 - Python 3 + Triton for `qwen35-4b` feature builds (build-time only — no Python at runtime)
 - TileLang for `deepseek-v4` feature builds (build-time only)

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 
 | Path | TL;DR |
 | --- | --- |
+| `models/qwen3/cuda-graph-png.md` | `--dump-graph-png PATH` exports the live Qwen3 rank-0, batch-1 SplitKv decode graph as an unfolded detailed DOT and a 192-DPI folded PNG; Qwen3-4B yields 507 kernels and 506 edges, with CUDA Driver API 12.3 as the repository floor. |
 | `models/qwen3/serving-performance.md` | **Authoritative Qwen3 serving perf numbers** (4B + 8B QPS sweep vs vLLM 0.24.0, footprint, DSpark/DFlash spec decode, warm prefix-cache TTFT, KV offload). All data reproducible via `tools/bench/run_serving_bench.sh`. |
 | `models/qwen3/serving-perf-5090.md` | Tuning history behind the serving numbers: unified-step attention fusion, batched step tail (#345), chunked prefill, cuBLAS 12.9 N=1025 cliff, cublasLt per-shape tuning, split-KV ≤bs32. Latest data lives in `serving-performance.md`. |
 | `models/qwen3/decode-attention.md` | Decode attention path (`NonPartition` vs `SplitKv`) is chosen by **batch (CTA-vs-SM), not context**: the old `max_seq_len>=1024` gate stranded bs=1 mid-context decode on the SM-starved NonPartition kernel — a tpot hump peaking ~ctx800, cliff-dropping at ctx1024. Removing it flattens bs=1 tpot (5090 −16% / 5070 Ti −7.5% @ctx800); kept `padded_bs<=32` (bs≤8 wins big, bs16 even, bs32 <1% loss). Also records the SplitKv chunk-size/grid policy (`Tuned` adaptive vs `Pin`/`PerToken` fixed-split batch-invariance, #435/#438). Two-card A/B + CUDA-graph capture + golden-gate verified. |

--- a/docs/models/qwen3/cuda-graph-png.md
+++ b/docs/models/qwen3/cuda-graph-png.md
@@ -1,0 +1,99 @@
+# Qwen3 decode CUDA Graph PNG export
+
+> **TL;DR:** `--dump-graph-png PATH` now exports the live Qwen3 rank-0,
+> batch-1 SplitKv decode graph during startup: an unfolded detailed `.dot` for
+> LLM/script inspection and a 192-DPI Cairo PNG that folds repeated physical
+> layers for human browsing. Qwen3-4B produced 507 kernel nodes and 506 edges;
+> kernel naming sets the repository driver floor at CUDA Driver API 12.3.
+>
+> **Last touched:** 2026-07
+
+## Preparation
+
+- **Read**:
+  - `docs/index.md` — located the Qwen3 model, decode-attention, and kernel-report records.
+  - `docs/models/qwen3/model-crate.md` — established that Qwen3 owns its decode graph and kernel plan rather than exposing model details through the server.
+  - `docs/subsystems/kernels/kernel-op-reports.md` — established the existing distinction between semantic `KernelCall` reports and physical kernel execution.
+  - `openinfer-core/src/cuda_graph.rs` — confirmed `CudaGraphState` retains the source `CUgraph` after capture and is the correct graph-inspection boundary.
+  - `openinfer-qwen3/src/batch_decode.rs` and `batch_decode_buffers.rs` — confirmed graph identity is `(bucket, attention_path, stream cache)`; batch 1 deterministically selects SplitKv.
+  - `openinfer-qwen3/src/unified_forward.rs`, `weights.rs`, and `executor.rs` — confirmed single-GPU memory profiling captures a temporary graph, while TP startup pre-captures live graphs; the export must explicitly target the live batch-1 graph instead of relying on capture order.
+  - `openinfer-server/src/config.rs` and `main.rs` — located CLI validation and the server-to-`Qwen3LaunchOptions` handoff.
+  - CUDA 13.3 headers and the main workspace's locked cudarc 0.19.7 bindings — confirmed availability of `cuGraphGetNodes`, `cuGraphGetEdges`, `cuGraphNodeGetType`, `cuGraphKernelNodeGetParams`, and `cuFuncGetName`.
+- **Relevant history**:
+  - `docs/models/qwen3/decode-attention.md` records that batch 1 uses the SplitKv path; choosing batch 1 is therefore a semantic choice, not merely a smaller launch shape.
+  - The local `cuda_graph_demo*` experiment proved that CUDA kernel parameters plus Graphviz produce a readable physical DAG, while verbose handles and default attributes are noise.
+- **Plan**:
+  1. Add `--dump-graph-png PATH` to the server CLI, accept it only for Qwen3 with CUDA Graph enabled, and validate Graphviz availability before model loading.
+  2. Thread the optional output path through `Qwen3LaunchOptions` to the Qwen3 executor startup boundary without changing normal serving behavior.
+  3. Reuse Qwen3's live decode buffers to capture the rank-0, batch-1, SplitKv, full-SM graph during startup; TP reuses its existing sweep, while TP1 performs only this requested pre-capture.
+  4. Inspect `CUgraph` directly through the CUDA Driver API and build one node/edge model. Emit a detailed `.dot` sidecar for LLM consumption (full demangled name, raw symbol, launch shape, node type, all edges), then render the requested PNG from a compact human label view of the same graph. Rust generates DOT; Graphviz owns layout/rendering.
+  5. Build in release mode, launch `/data/models/Qwen3-4B` on the local RTX 5070 Ti with the new flag, inspect the real PNG, and verify the server reaches readiness without the flag changing inference behavior.
+  6. Record actual node/edge counts and rendering pitfalls, then complete this document's execution log and debrief.
+- **Risks / open questions**:
+  - A 36-layer physical DAG may be too tall for convenient PNG browsing. This first slice preserves every node; repeated-layer folding is intentionally deferred until the real output demonstrates the need.
+  - `dot` and C++ demangling are diagnostic-tool dependencies only. Missing tools must fail before the expensive model load rather than silently emit a degraded graph.
+  - Existing untracked `cuda_graph_demo*` files belong to the ongoing visual experiment and will not be overwritten or removed by this task.
+
+## Execution Log
+
+### Step 1: Review gate and output contract
+
+- User approved the batch-1/rank-0 scope.
+- Added the explicit two-audience contract: detailed `.dot` for LLMs and compact `.png` for humans, both sharing the same graph-node IDs.
+- Result: approved; implementation started.
+
+### Step 2: CLI, live-graph plumbing, and CUDA graph inspection
+
+- Added `--dump-graph-png PATH` to `openinfer-server`; model applicability and CUDA-Graph/LoRA exclusions fail before engine loading.
+- Added `Qwen3LaunchOptions::dump_graph_png` and routed it through the Qwen3 scheduler to a rank-0 worker command.
+- Single GPU pre-captures only the requested live batch-1 graph; TP reuses the completed startup sweep and reads rank 0's existing batch-1 graph.
+- Added direct `CUgraph` inspection in `openinfer-core` via `cuGraphGetNodes`, `cuGraphGetEdges`, `cuGraphNodeGetType`, `cuGraphKernelNodeGetParams_v2`, and `cuFuncGetName`.
+- Detailed `.dot` retains full demangled/raw names and launch shapes; the PNG uses compact labels from the same node IDs and is rendered by external Graphviz.
+- Commands: `cargo fmt --all`; `git diff --check`; `cargo check --release -p openinfer-core -p openinfer-qwen3 -p openinfer-server`.
+- Result: release check passed on sm_120; no new dependency and no Python path.
+
+### Step 3: Real Qwen3-4B export and repeated-layer folding
+
+- Built `openinfer-server` in release mode and launched:
+  `LD_LIBRARY_PATH=/data/opt/nccl-2.30.4/lib target/release/openinfer --model-path /data/models/Qwen3-4B --dump-graph-png qwen3_4b_decode.png --port 18080`.
+- The live batch-1 SplitKv graph contained 507 kernel nodes and 506 edges. The server reached scheduler and HTTP readiness after the export.
+- The first unfolded PNG was `470x32767`: Graphviz hit its practical raster-height ceiling, making the image unusable even though the DOT was correct.
+- The physical graph is a linear chain with a 14-kernel block repeated 36 times between a two-node prologue and the final LM-head GEMV. Added topology/signature-based repeated-run detection to fold only the PNG view; the detailed DOT remains all 507 nodes and 506 edges.
+- Human labels identify cuBLAS GEMV directly instead of exposing the unhelpful demangled leaf `kernel<…>`.
+- Result: the compact 96-DPI image became `693x1525` while preserving a representative 14-kernel layer and an explicit `×36` boundary.
+
+### Step 4: Raster quality and final validation
+
+- User review found the default Graphviz raster text blurry. Rendering now requires the Cairo PNG backend and uses 192 DPI.
+- Final artifacts from the real model are `qwen3_4b_decode.dot` (319 KiB, 507 full raw/demangled symbols) and `qwen3_4b_decode.png` (336 KiB, `1386x3050`). Graphviz successfully reparsed the detailed DOT.
+- Validation passed:
+  - `cargo test --release -p openinfer-core cuda_graph::dump::tests` — 4 passed.
+  - `cargo test --release -p openinfer-server config::tests::qwen3_` — 4 passed.
+  - `cargo test --release -p openinfer-qwen3 --lib` — 67 passed.
+  - `cargo clippy --release -p openinfer-core -p openinfer-qwen3 -p openinfer-server -- -D warnings`.
+  - `cargo fmt --all --check`; `git diff --check`; `dot -Tdot qwen3_4b_decode.dot -o /dev/null`.
+- Error/resolution: the first strict Clippy run rejected implicit Rust borrows passed to CUDA FFI and a local constant placed after statements. Switched the CUDA output parameters to explicit raw pointers and moved the constant before statements; the rerun passed.
+
+### Step 5: PR preparation and artifact cleanup
+
+- Backed up the reviewed high-DPI image to `/tmp/qwen3_4b_decode.png`; after final validation its SHA-256 is `462cd42e58cd4f4b2cbe688f30d8c696b5f79bdda63b06c657d94a4b5651143c`.
+- Removed all repository-root experiment sources, scripts, binaries, DOT files, and PNG files, including the Qwen3-4B output pair. Only implementation, tests, and documentation remain in the worktree.
+- The starting branch name was unrelated (`perf/glm52-fuse-decode-feed-rope`) but contained no commits ahead of `origin/main`; the worktree was migrated to the dedicated `feat/qwen3-cuda-graph-dump` branch after refreshing the mainline.
+
+### Step 6: Submission review fixes
+
+- The required `toxic-reviewer` pass traced CLI → Qwen launch → scheduler → rank worker → captured graph → CUDA Driver API and requested changes before submission.
+- `cuFuncGetName` requires CUDA Driver API 12.3. At the user's direction, raised the documented repository floor from R535/CUDA 12.2 to R545/CUDA 12.3 and added a pre-load `cuDriverGetVersion` diagnostic so older drivers return a clear error instead of panicking in cudarc's lazy symbol loader.
+- Renamed `shared_mem_bytes`/`smem` to `dynamic_shared_mem_bytes`/`dynamic_smem`; `CUDA_KERNEL_NODE_PARAMS.sharedMemBytes` does not include statically allocated shared memory.
+- Removed Qwen3 presentation metadata from `openinfer-core`: the Qwen3 executor now supplies the graph title to the reusable renderer.
+- Extended the existing TP2 CUDA Graph integration test to request an export when Graphviz Cairo and `c++filt` are available, then assert that the PNG and detailed DOT contain the expected data. External renderer absence is the only reason to disable export coverage; every validation/export error otherwise fails the test. The test compiled and skipped its GPU body on the single-GPU development host.
+- Added the missing CLI test for rejecting graph export with LoRA.
+- Rebuilt and reran the real single-GPU Qwen3-4B export into `/tmp`; the server reached HTTP readiness and the detailed DOT retained 507 nodes/506 edges with the corrected dynamic-shared-memory field.
+- `cargo test --release --workspace --lib` first exposed the documented missing `OPENINFER_NCCL_ROOT`; after rerunning with `/data/opt/nccl-2.30.4`, the all-model build completed and tests advanced through 493 `kvbm-logical` cases before the unrelated `openinfer-comm-cuda-lib::test_gdr::gdr_copy_flag_GPU` failed because this host cannot create a GDRCopy handle. All Qwen3/core/server tests in this change's scope passed.
+
+## Debrief
+
+- **Outcome:** one CLI argument produces both audiences' views from the same captured graph. The `.dot` is the source of truth; the PNG is a derived, folded projection.
+- **Design boundary:** CUDA exposes kernel symbols and launch configuration (`grid`, `block`, dynamic shared memory) but not tensor shapes or semantic model roles. Those belong in a later kernel-plan enrichment pass rather than being guessed during graph capture.
+- **Operational behavior:** CUDA Driver API older than 12.3, missing Graphviz Cairo or `c++filt`, a non-PNG path, disabled CUDA Graph, or LoRA mode fails before model loading. Normal serving does not capture or render this diagnostic graph unless the flag is present.
+- **Next action:** use the detailed DOT as the physical-execution input when a semantic Qwen3/GLM kernel-plan annotator is built; keep model tensor metadata separate and join it by stable execution order or explicit runtime annotations.

--- a/openinfer-core/src/cuda_graph.rs
+++ b/openinfer-core/src/cuda_graph.rs
@@ -10,6 +10,10 @@ use cudarc::driver::sys::{self, CUgraph, CUgraphExec};
 
 use crate::tensor::{DeviceContext, active_cu_stream};
 
+mod dump;
+
+pub use dump::{CudaGraphDumpSummary, validate_graph_dump_request};
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CudaGraphPhase {
     BeforeBeginCapture,

--- a/openinfer-core/src/cuda_graph/dump.rs
+++ b/openinfer-core/src/cuda_graph/dump.rs
@@ -1,0 +1,667 @@
+use std::collections::HashMap;
+use std::ffi::CStr;
+use std::fmt::Write as _;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result, ensure};
+use cudarc::driver::sys::{self, CUgraphNode};
+
+use super::{CudaGraphState, check};
+
+#[derive(Clone, Debug)]
+pub struct CudaGraphDumpSummary {
+    pub nodes: usize,
+    pub edges: usize,
+    pub kernels: usize,
+    pub dot_path: PathBuf,
+    pub png_path: PathBuf,
+}
+
+struct GraphDescription {
+    nodes: Vec<GraphNode>,
+    edges: Vec<(usize, usize)>,
+}
+
+struct GraphNode {
+    kind: GraphNodeKind,
+}
+
+#[derive(Clone, Copy)]
+struct RepeatedRun {
+    start: usize,
+    width: usize,
+    repetitions: usize,
+}
+
+enum GraphNodeKind {
+    Kernel {
+        raw_symbol: String,
+        demangled: String,
+        grid: [u32; 3],
+        block: [u32; 3],
+        dynamic_shared_mem_bytes: u32,
+    },
+    Other {
+        node_type: String,
+    },
+}
+
+pub fn validate_graph_dump_request(png_path: &Path) -> Result<()> {
+    ensure!(
+        png_path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("png")),
+        "--dump-graph-png expects a .png output path, got {}",
+        png_path.display()
+    );
+    let parent = png_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent).with_context(|| {
+        format!(
+            "create CUDA Graph dump output directory {}",
+            parent.display()
+        )
+    })?;
+    require_graph_dump_driver()?;
+    require_tool("dot", &["-Tpng:cairo"], "Graphviz Cairo PNG renderer")?;
+    require_tool("c++filt", &["--version"], "C++ demangler")?;
+    Ok(())
+}
+
+fn require_graph_dump_driver() -> Result<()> {
+    const MIN_DRIVER_API_VERSION: i32 = 12_030;
+
+    let mut version = 0i32;
+    check(
+        unsafe { sys::cuDriverGetVersion(&raw mut version) },
+        "cuDriverGetVersion",
+    )?;
+    ensure!(
+        version >= MIN_DRIVER_API_VERSION,
+        "--dump-graph-png requires CUDA driver API 12.3 or newer for kernel names; found {}",
+        format_driver_api_version(version)
+    );
+    Ok(())
+}
+
+fn format_driver_api_version(version: i32) -> String {
+    format!("{}.{}", version / 1000, version % 1000 / 10)
+}
+
+fn require_tool(program: &str, args: &[&str], description: &str) -> Result<()> {
+    let output = Command::new(program)
+        .args(args)
+        .output()
+        .with_context(|| format!("{description} `{program}` is required for CUDA Graph export"))?;
+    ensure!(
+        output.status.success(),
+        "{description} `{program}` check failed: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+    Ok(())
+}
+
+impl CudaGraphState {
+    pub fn dump_png(&self, png_path: &Path, title: &str) -> Result<CudaGraphDumpSummary> {
+        ensure!(
+            self.is_captured(),
+            "CUDA graph dump requested before capture"
+        );
+        let graph = self.inspect()?;
+        let dot_path = png_path.with_extension("dot");
+        std::fs::write(&dot_path, graph.detailed_dot())
+            .with_context(|| format!("write detailed CUDA Graph DOT to {}", dot_path.display()))?;
+        render_png(&graph.human_dot(title), png_path)?;
+        Ok(CudaGraphDumpSummary {
+            nodes: graph.nodes.len(),
+            edges: graph.edges.len(),
+            kernels: graph
+                .nodes
+                .iter()
+                .filter(|node| matches!(&node.kind, GraphNodeKind::Kernel { .. }))
+                .count(),
+            dot_path,
+            png_path: png_path.to_path_buf(),
+        })
+    }
+
+    fn inspect(&self) -> Result<GraphDescription> {
+        let handles = graph_nodes(self.graph)?;
+        let handle_to_index: HashMap<usize, usize> = handles
+            .iter()
+            .enumerate()
+            .map(|(index, &handle)| (handle as usize, index))
+            .collect();
+        let raw_kinds = handles
+            .iter()
+            .map(|&handle| inspect_node(handle))
+            .collect::<Result<Vec<_>>>()?;
+        let symbols = raw_kinds
+            .iter()
+            .filter_map(|kind| match kind {
+                RawNodeKind::Kernel { raw_symbol, .. } => Some(raw_symbol.as_str()),
+                RawNodeKind::Other { .. } => None,
+            })
+            .collect::<Vec<_>>();
+        let demangled = demangle(&symbols)?;
+        let mut demangled = demangled.into_iter();
+        let nodes = raw_kinds
+            .into_iter()
+            .map(|kind| GraphNode {
+                kind: match kind {
+                    RawNodeKind::Kernel {
+                        raw_symbol,
+                        grid,
+                        block,
+                        dynamic_shared_mem_bytes,
+                    } => GraphNodeKind::Kernel {
+                        raw_symbol,
+                        demangled: demangled
+                            .next()
+                            .expect("one demangled name per kernel node"),
+                        grid,
+                        block,
+                        dynamic_shared_mem_bytes,
+                    },
+                    RawNodeKind::Other { node_type } => GraphNodeKind::Other { node_type },
+                },
+            })
+            .collect();
+        let edges = graph_edges(self.graph)?
+            .into_iter()
+            .map(|(from, to)| {
+                let from = handle_to_index
+                    .get(&(from as usize))
+                    .copied()
+                    .context("CUDA graph edge source is absent from the node list")?;
+                let to = handle_to_index
+                    .get(&(to as usize))
+                    .copied()
+                    .context("CUDA graph edge destination is absent from the node list")?;
+                Ok((from, to))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(GraphDescription { nodes, edges })
+    }
+}
+
+enum RawNodeKind {
+    Kernel {
+        raw_symbol: String,
+        grid: [u32; 3],
+        block: [u32; 3],
+        dynamic_shared_mem_bytes: u32,
+    },
+    Other {
+        node_type: String,
+    },
+}
+
+fn graph_nodes(graph: sys::CUgraph) -> Result<Vec<CUgraphNode>> {
+    let mut count = 0usize;
+    check(
+        unsafe { sys::cuGraphGetNodes(graph, std::ptr::null_mut(), &raw mut count) },
+        "cuGraphGetNodes(count)",
+    )?;
+    let mut nodes = vec![std::ptr::null_mut(); count];
+    check(
+        unsafe { sys::cuGraphGetNodes(graph, nodes.as_mut_ptr(), &raw mut count) },
+        "cuGraphGetNodes(nodes)",
+    )?;
+    nodes.truncate(count);
+    Ok(nodes)
+}
+
+fn graph_edges(graph: sys::CUgraph) -> Result<Vec<(CUgraphNode, CUgraphNode)>> {
+    let mut count = 0usize;
+    check(
+        unsafe {
+            sys::cuGraphGetEdges(
+                graph,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &raw mut count,
+            )
+        },
+        "cuGraphGetEdges(count)",
+    )?;
+    let mut from = vec![std::ptr::null_mut(); count];
+    let mut to = vec![std::ptr::null_mut(); count];
+    check(
+        unsafe { sys::cuGraphGetEdges(graph, from.as_mut_ptr(), to.as_mut_ptr(), &raw mut count) },
+        "cuGraphGetEdges(edges)",
+    )?;
+    Ok(from.into_iter().zip(to).take(count).collect())
+}
+
+fn inspect_node(node: CUgraphNode) -> Result<RawNodeKind> {
+    let mut node_type = std::mem::MaybeUninit::uninit();
+    check(
+        unsafe { sys::cuGraphNodeGetType(node, node_type.as_mut_ptr()) },
+        "cuGraphNodeGetType",
+    )?;
+    let node_type = unsafe { node_type.assume_init() };
+    if node_type != sys::CUgraphNodeType::CU_GRAPH_NODE_TYPE_KERNEL {
+        return Ok(RawNodeKind::Other {
+            node_type: format!("{node_type:?}")
+                .trim_start_matches("CU_GRAPH_NODE_TYPE_")
+                .to_ascii_lowercase(),
+        });
+    }
+
+    let mut params = std::mem::MaybeUninit::<sys::CUDA_KERNEL_NODE_PARAMS>::zeroed();
+    check(
+        unsafe { sys::cuGraphKernelNodeGetParams_v2(node, params.as_mut_ptr()) },
+        "cuGraphKernelNodeGetParams",
+    )?;
+    let params = unsafe { params.assume_init() };
+    ensure!(
+        !params.func.is_null(),
+        "CUDA graph kernel node has no CUfunction"
+    );
+    let mut name = std::ptr::null();
+    check(
+        unsafe { sys::cuFuncGetName(&raw mut name, params.func) },
+        "cuFuncGetName",
+    )?;
+    ensure!(!name.is_null(), "cuFuncGetName returned a null name");
+    let raw_symbol = unsafe { CStr::from_ptr(name) }
+        .to_str()
+        .context("CUDA kernel name is not UTF-8")?
+        .to_owned();
+    Ok(RawNodeKind::Kernel {
+        raw_symbol,
+        grid: [params.gridDimX, params.gridDimY, params.gridDimZ],
+        block: [params.blockDimX, params.blockDimY, params.blockDimZ],
+        dynamic_shared_mem_bytes: params.sharedMemBytes,
+    })
+}
+
+fn demangle(symbols: &[&str]) -> Result<Vec<String>> {
+    if symbols.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut child = Command::new("c++filt")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("spawn C++ demangler `c++filt`")?;
+    {
+        let stdin = child.stdin.as_mut().context("open c++filt stdin")?;
+        for symbol in symbols {
+            writeln!(stdin, "{symbol}").context("write symbol to c++filt")?;
+        }
+    }
+    let output = child.wait_with_output().context("wait for c++filt")?;
+    ensure!(
+        output.status.success(),
+        "c++filt failed: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+    let names = String::from_utf8(output.stdout)
+        .context("c++filt output is not UTF-8")?
+        .lines()
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    ensure!(
+        names.len() == symbols.len(),
+        "c++filt returned {} names for {} symbols",
+        names.len(),
+        symbols.len()
+    );
+    Ok(names)
+}
+
+fn render_png(dot: &str, png_path: &Path) -> Result<()> {
+    let mut child = Command::new("dot")
+        .args(["-Tpng:cairo", "-Gdpi=192", "-o"])
+        .arg(png_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("spawn Graphviz `dot`")?;
+    child
+        .stdin
+        .as_mut()
+        .context("open Graphviz stdin")?
+        .write_all(dot.as_bytes())
+        .context("write clean CUDA Graph DOT to Graphviz")?;
+    let output = child.wait_with_output().context("wait for Graphviz")?;
+    ensure!(
+        output.status.success(),
+        "Graphviz failed to render {}: {}",
+        png_path.display(),
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+    Ok(())
+}
+
+impl GraphDescription {
+    fn detailed_dot(&self) -> String {
+        let mut dot = String::from("digraph cuda_graph_detailed {\n");
+        dot.push_str("  graph [rankdir=TB];\n  node [shape=box];\n");
+        for (index, node) in self.nodes.iter().enumerate() {
+            let label = match &node.kind {
+                GraphNodeKind::Kernel {
+                    raw_symbol,
+                    demangled,
+                    grid,
+                    block,
+                    dynamic_shared_mem_bytes,
+                } => format!(
+                    "id={index}\\ntype=kernel\\nname={}\\nraw_symbol={}\\ngrid={}\\nblock={}\\ndynamic_shared_mem_bytes={dynamic_shared_mem_bytes}",
+                    dot_escape(demangled),
+                    dot_escape(raw_symbol),
+                    dims(*grid),
+                    dims(*block),
+                ),
+                GraphNodeKind::Other { node_type } => {
+                    format!("id={index}\\ntype={}", dot_escape(node_type))
+                }
+            };
+            let _ = writeln!(dot, "  n{index} [label=\"{label}\"];");
+        }
+        for &(from, to) in &self.edges {
+            let _ = writeln!(dot, "  n{from} -> n{to};");
+        }
+        dot.push_str("}\n");
+        dot
+    }
+
+    fn human_dot(&self, title: &str) -> String {
+        let mut indegree = vec![0usize; self.nodes.len()];
+        let mut outdegree = vec![0usize; self.nodes.len()];
+        for &(from, to) in &self.edges {
+            outdegree[from] += 1;
+            indegree[to] += 1;
+        }
+
+        let mut dot = String::from("digraph cuda_graph {\n");
+        let _ = writeln!(
+            dot,
+            "  graph [rankdir=TB, bgcolor=\"white\", pad=0.2, nodesep=0.25, ranksep=0.35, fontname=\"Helvetica\", label=\"{}\", labelloc=t, fontsize=18];",
+            dot_escape(title)
+        );
+        dot.push_str(
+            "  node [shape=box, style=\"rounded,filled\", color=\"#374151\", \
+             fontname=\"Helvetica\", fontsize=10, margin=\"0.12,0.08\"];\n",
+        );
+        dot.push_str("  edge [color=\"#6B7280\", arrowsize=0.6];\n");
+        if let Some((order, repeated)) = self.repeated_linear_run() {
+            let first_end = repeated.start + repeated.width;
+            let repeated_end = repeated.start + repeated.width * repeated.repetitions;
+            for &index in &order[..repeated.start] {
+                self.write_human_node(&mut dot, index, indegree[index], outdegree[index]);
+            }
+            let _ = writeln!(
+                dot,
+                "  subgraph cluster_repeated {{\n    label=\"Repeated physical block ×{} · {} kernels/instance\";\n    color=\"#9CA3AF\";\n    style=\"rounded,dashed\";",
+                repeated.repetitions, repeated.width
+            );
+            for &index in &order[repeated.start..first_end] {
+                self.write_human_node(&mut dot, index, indegree[index], outdegree[index]);
+            }
+            dot.push_str("  }\n");
+            for &index in &order[repeated_end..] {
+                self.write_human_node(&mut dot, index, indegree[index], outdegree[index]);
+            }
+
+            let visible_order = order[..first_end]
+                .iter()
+                .chain(order[repeated_end..].iter())
+                .copied()
+                .collect::<Vec<_>>();
+            for pair in visible_order.windows(2) {
+                let label = if pair[0] == order[first_end - 1] {
+                    format!(" [label=\"after ×{}\", fontsize=9]", repeated.repetitions)
+                } else {
+                    String::new()
+                };
+                let _ = writeln!(dot, "  n{} -> n{}{};", pair[0], pair[1], label);
+            }
+        } else {
+            for index in 0..self.nodes.len() {
+                self.write_human_node(&mut dot, index, indegree[index], outdegree[index]);
+            }
+            for &(from, to) in &self.edges {
+                let _ = writeln!(dot, "  n{from} -> n{to};");
+            }
+        }
+        dot.push_str("}\n");
+        dot
+    }
+
+    fn write_human_node(&self, dot: &mut String, index: usize, indegree: usize, outdegree: usize) {
+        let fill = node_color(indegree, outdegree);
+        let label = match &self.nodes[index].kind {
+            GraphNodeKind::Kernel {
+                demangled,
+                grid,
+                block,
+                dynamic_shared_mem_bytes,
+                ..
+            } => format!(
+                "{}\\ngrid={} block={} dynamic_smem={}",
+                dot_escape(&compact_kernel_name(demangled)),
+                dims(*grid),
+                dims(*block),
+                dynamic_shared_mem_bytes,
+            ),
+            GraphNodeKind::Other { node_type } => dot_escape(&node_type.to_ascii_uppercase()),
+        };
+        let _ = writeln!(dot, "  n{index} [fillcolor=\"{fill}\", label=\"{label}\"];");
+    }
+
+    fn repeated_linear_run(&self) -> Option<(Vec<usize>, RepeatedRun)> {
+        let order = self.linear_order()?;
+        let signatures = order
+            .iter()
+            .map(|&index| self.nodes[index].signature())
+            .collect::<Vec<_>>();
+        let mut best = None::<RepeatedRun>;
+        for start in 0..signatures.len() {
+            let max_width = (signatures.len() - start) / 3;
+            for width in 2..=max_width {
+                let pattern = &signatures[start..start + width];
+                let mut repetitions = 1usize;
+                while start + (repetitions + 1) * width <= signatures.len()
+                    && signatures[start + repetitions * width..start + (repetitions + 1) * width]
+                        == *pattern
+                {
+                    repetitions += 1;
+                }
+                if repetitions < 3 {
+                    continue;
+                }
+                let candidate = RepeatedRun {
+                    start,
+                    width,
+                    repetitions,
+                };
+                let better = best.is_none_or(|current| {
+                    let covered = candidate.width * candidate.repetitions;
+                    let current_covered = current.width * current.repetitions;
+                    covered > current_covered
+                        || (covered == current_covered
+                            && candidate.repetitions > current.repetitions)
+                });
+                if better {
+                    best = Some(candidate);
+                }
+            }
+        }
+        let repeated = best?;
+        (repeated.width * repeated.repetitions >= self.nodes.len() / 2).then_some((order, repeated))
+    }
+
+    fn linear_order(&self) -> Option<Vec<usize>> {
+        if self.nodes.is_empty() || self.edges.len() + 1 != self.nodes.len() {
+            return None;
+        }
+        let mut indegree = vec![0usize; self.nodes.len()];
+        let mut next = vec![None; self.nodes.len()];
+        for &(from, to) in &self.edges {
+            indegree[to] += 1;
+            if indegree[to] > 1 || next[from].replace(to).is_some() {
+                return None;
+            }
+        }
+        let roots = indegree
+            .iter()
+            .enumerate()
+            .filter_map(|(index, &degree)| (degree == 0).then_some(index))
+            .collect::<Vec<_>>();
+        if roots.len() != 1 {
+            return None;
+        }
+        let mut order = Vec::with_capacity(self.nodes.len());
+        let mut cursor = Some(roots[0]);
+        while let Some(index) = cursor {
+            order.push(index);
+            cursor = next[index];
+        }
+        (order.len() == self.nodes.len()).then_some(order)
+    }
+}
+
+impl GraphNode {
+    fn signature(&self) -> String {
+        match &self.kind {
+            GraphNodeKind::Kernel {
+                raw_symbol,
+                grid,
+                block,
+                dynamic_shared_mem_bytes,
+                ..
+            } => format!(
+                "kernel|{raw_symbol}|{}|{}|{dynamic_shared_mem_bytes}",
+                dims(*grid),
+                dims(*block)
+            ),
+            GraphNodeKind::Other { node_type } => format!("other|{node_type}"),
+        }
+    }
+}
+
+fn dims(dims: [u32; 3]) -> String {
+    format!("({},{},{})", dims[0], dims[1], dims[2])
+}
+
+fn node_color(indegree: usize, outdegree: usize) -> &'static str {
+    if indegree == 0 {
+        "#DCEEFF"
+    } else if outdegree == 0 {
+        "#E8DEFF"
+    } else if indegree > 1 {
+        "#FFE8C2"
+    } else if outdegree > 1 {
+        "#E3F6E8"
+    } else {
+        "#F5F5F5"
+    }
+}
+
+fn compact_kernel_name(name: &str) -> String {
+    const MAX_CHARS: usize = 72;
+
+    if name.contains("internal::gemvx::kernel") {
+        return "cuBLAS GEMV".to_owned();
+    }
+    let signature = name.rsplit_once('(').map_or(name, |(name, _)| name);
+    let mut compact = String::with_capacity(signature.len());
+    let mut template_depth = 0usize;
+    for ch in signature.chars() {
+        match ch {
+            '<' => {
+                if template_depth == 0 {
+                    compact.push_str("<…>");
+                }
+                template_depth += 1;
+            }
+            '>' if template_depth > 0 => template_depth -= 1,
+            _ if template_depth == 0 => compact.push(ch),
+            _ => {}
+        }
+    }
+    let leaf = compact.rsplit("::").next().unwrap_or(&compact);
+    if leaf.chars().count() <= MAX_CHARS {
+        return leaf.to_owned();
+    }
+    let prefix = leaf.chars().take(MAX_CHARS - 1).collect::<String>();
+    format!("{prefix}…")
+}
+
+fn dot_escape(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        GraphDescription, GraphNode, GraphNodeKind, compact_kernel_name, dot_escape,
+        format_driver_api_version,
+    };
+
+    #[test]
+    fn compact_name_drops_namespace_signature_and_template_body() {
+        assert_eq!(
+            compact_kernel_name("flashinfer::BatchDecodeKernel<128, foo::Bar>(float*, int)"),
+            "BatchDecodeKernel<…>"
+        );
+        assert_eq!(
+            compact_kernel_name(
+                "std::enable_if<true, void>::type internal::gemvx::kernel<int>(int)"
+            ),
+            "cuBLAS GEMV"
+        );
+    }
+
+    #[test]
+    fn dot_label_escaping_preserves_graph_syntax() {
+        assert_eq!(dot_escape("a\\b\n\"c\""), "a\\\\b\\n\\\"c\\\"");
+    }
+
+    #[test]
+    fn formats_cuda_driver_api_version() {
+        assert_eq!(format_driver_api_version(12_020), "12.2");
+        assert_eq!(format_driver_api_version(12_030), "12.3");
+        assert_eq!(format_driver_api_version(13_000), "13.0");
+    }
+
+    #[test]
+    fn human_dot_folds_a_repeated_linear_block() {
+        let kernel = |name: &str| GraphNode {
+            kind: GraphNodeKind::Kernel {
+                raw_symbol: name.to_string(),
+                demangled: format!("{name}()"),
+                grid: [1, 1, 1],
+                block: [32, 1, 1],
+                dynamic_shared_mem_bytes: 0,
+            },
+        };
+        let names = ["head", "a", "b", "a", "b", "a", "b", "tail"];
+        let graph = GraphDescription {
+            nodes: names.into_iter().map(kernel).collect(),
+            edges: (0..7).map(|index| (index, index + 1)).collect(),
+        };
+
+        let dot = graph.human_dot("test graph");
+
+        assert!(dot.contains("label=\"test graph\""));
+        assert!(dot.contains("Repeated physical block ×3 · 2 kernels/instance"));
+        assert!(dot.contains("n0 -> n1"));
+        assert!(dot.contains("n2 -> n7 [label=\"after ×3\""));
+        assert!(!dot.contains("n3 [fillcolor"));
+    }
+}

--- a/openinfer-dynamo-backend/src/engine.rs
+++ b/openinfer-dynamo-backend/src/engine.rs
@@ -145,6 +145,7 @@ impl OpeninferBackend {
             device_ordinal: args.device_ordinal,
             tp_size: 1,
             cuda_graph: !args.no_cuda_graph,
+            dump_graph_png: None,
             offload: Qwen3OffloadOptions::disabled(),
             // Keep the prefix cache on: it is both a single-worker win and the
             // source of the KV store/remove events published to the router for

--- a/openinfer-qwen3/src/executor.rs
+++ b/openinfer-qwen3/src/executor.rs
@@ -1,7 +1,8 @@
 use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 use std::thread;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use crossbeam_channel as channel;
 
 use crate::batch_decode::DecodeGraphUse;
@@ -9,6 +10,7 @@ use crate::batch_decode_buffers::{BATCH_BUCKETS, BatchDecodeBuffers};
 use crate::config::{Config, TensorParallelConfig};
 use crate::weights::{KvBudget, ModelRuntimeConfig, Qwen3MemoryOptions, Qwen3Model};
 use crate::{Qwen3LoraOptions, Qwen3OffloadOptions};
+use openinfer_core::cuda_graph::CudaGraphDumpSummary;
 use openinfer_core::engine::{
     LoadLoraAdapterRequest, TokenEvent, TokenLogprob, TokenSink, UnloadLoraAdapterRequest,
     panic_message,
@@ -1013,6 +1015,10 @@ enum PrefetchPhase {
 const REMOTE_FETCH_DEADLINE: std::time::Duration = std::time::Duration::from_secs(15);
 
 impl Qwen3Executor {
+    pub(crate) fn dump_decode_graph_png(&self, png_path: &Path) -> Result<CudaGraphDumpSummary> {
+        self.primary.dump_decode_graph_png(png_path.to_path_buf())
+    }
+
     pub(crate) fn single(
         model: Qwen3Model,
         offload_opts: &Qwen3OffloadOptions,
@@ -2957,6 +2963,26 @@ impl LocalQwen3Lane {
         Ok(())
     }
 
+    fn dump_decode_graph_png(&mut self, png_path: &Path) -> Result<CudaGraphDumpSummary> {
+        let bucket_idx = 0;
+        let bucket = BATCH_BUCKETS[bucket_idx];
+        let attention_path = BatchDecodeBuffers::attention_path(bucket);
+        let graph_idx = BatchDecodeBuffers::graph_index(bucket_idx, attention_path);
+        if !self.bufs.graphs[graph_idx].is_captured() {
+            anyhow::ensure!(
+                !self.model.tp_graph_enabled(),
+                "Qwen3 TP batch-1 graph was not captured by the startup sweep"
+            );
+            self.precapture_decode(bucket_idx, DecodeGraphUse::CaptureOnly)?;
+        }
+        let title = format!("Qwen3 decode CUDA Graph · bs={bucket} · {attention_path:?}");
+        self.bufs.graphs[graph_idx]
+            .dump_png(png_path, &title)
+            .with_context(|| {
+                format!("dump Qwen3 rank-0 batch-{bucket} {attention_path:?} decode CUDA Graph")
+            })
+    }
+
     /// Load the DFlash draft model into this lane (primary rank only). The draft
     /// model is built here on the worker thread because it reads the co-located
     /// target model's embeddings and head.
@@ -3324,6 +3350,10 @@ enum WorkerCommand {
         phase: PrecapturePhase,
         resp: channel::Sender<Result<()>>,
     },
+    DumpDecodeGraph {
+        png_path: PathBuf,
+        resp: channel::Sender<Result<CudaGraphDumpSummary>>,
+    },
     Shutdown,
 }
 
@@ -3440,6 +3470,10 @@ impl RankWorker {
                                     let result = lane.precapture_phase(phase);
                                     let _ = resp.send(result);
                                 }
+                                WorkerCommand::DumpDecodeGraph { png_path, resp } => {
+                                    let result = lane.dump_decode_graph_png(&png_path);
+                                    let _ = resp.send(result);
+                                }
                                 WorkerCommand::Shutdown => break,
                             }
                         }
@@ -3491,6 +3525,19 @@ impl RankWorker {
             })
             .map_err(|_| anyhow::anyhow!("worker channel closed on precapture {phase:?}"))?;
         Ok(resp_rx)
+    }
+
+    fn dump_decode_graph_png(&self, png_path: PathBuf) -> Result<CudaGraphDumpSummary> {
+        let (resp_tx, resp_rx) = channel::bounded(1);
+        self.tx
+            .send(WorkerCommand::DumpDecodeGraph {
+                png_path,
+                resp: resp_tx,
+            })
+            .map_err(|_| anyhow::anyhow!("worker channel closed on CUDA Graph dump"))?;
+        resp_rx
+            .recv()
+            .map_err(|_| anyhow::anyhow!("worker dropped CUDA Graph dump response"))?
     }
 
     /// Ask the worker to sync its in-flight prefill and return the result.

--- a/openinfer-qwen3/src/lib.rs
+++ b/openinfer-qwen3/src/lib.rs
@@ -210,6 +210,9 @@ pub struct Qwen3LaunchOptions {
     /// Whether the user requested CUDA Graph. LoRA serving forces it off;
     /// under tensor parallelism every decode graph is pre-captured at startup.
     pub cuda_graph: bool,
+    /// Export the live rank-0, batch-1 SplitKv decode graph during startup.
+    /// The requested PNG gets a detailed sibling `.dot` for LLM inspection.
+    pub dump_graph_png: Option<PathBuf>,
     pub offload: Qwen3OffloadOptions,
     pub no_prefix_cache: bool,
     pub max_prefill_tokens: usize,
@@ -249,6 +252,17 @@ pub fn launch(model_path: &Path, options: Qwen3LaunchOptions) -> Result<EngineHa
     } else {
         options.cuda_graph
     };
+    if let Some(path) = &options.dump_graph_png {
+        anyhow::ensure!(
+            enable_cuda_graph,
+            "Qwen3 graph export requires CUDA Graph enabled"
+        );
+        anyhow::ensure!(
+            options.lora.is_none(),
+            "Qwen3 graph export is not supported with LoRA serving"
+        );
+        openinfer_core::cuda_graph::validate_graph_dump_request(path)?;
+    }
     let engine = EngineLoadOptions {
         enable_cuda_graph,
         enable_prefill_profile: false,
@@ -302,7 +316,7 @@ pub fn launch(model_path: &Path, options: Qwen3LaunchOptions) -> Result<EngineHa
                 options.batch_invariant,
             )
         }
-        None => start_engine_with_offload(
+        None => start_engine_with_offload_inner(
             model_path,
             engine,
             options.offload,
@@ -313,6 +327,7 @@ pub fn launch(model_path: &Path, options: Qwen3LaunchOptions) -> Result<EngineHa
             options.batch_invariant,
             options.dflash_draft_model_path.as_deref(),
             options.enable_kv_events,
+            options.dump_graph_png.as_deref(),
         ),
     }
 }
@@ -357,6 +372,35 @@ pub fn start_engine_with_offload(
     dflash_draft_model_path: Option<&Path>,
     enable_kv_events: bool,
 ) -> Result<EngineHandle> {
+    start_engine_with_offload_inner(
+        model_path,
+        options,
+        offload_options,
+        no_prefix_cache,
+        max_prefill_tokens,
+        memory_options,
+        decode_overlap,
+        batch_invariant,
+        dflash_draft_model_path,
+        enable_kv_events,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn start_engine_with_offload_inner(
+    model_path: &Path,
+    options: EngineLoadOptions,
+    offload_options: Qwen3OffloadOptions,
+    no_prefix_cache: bool,
+    max_prefill_tokens: usize,
+    memory_options: Qwen3MemoryOptions,
+    decode_overlap: DecodeOverlap,
+    batch_invariant: bool,
+    dflash_draft_model_path: Option<&Path>,
+    enable_kv_events: bool,
+    dump_graph_png: Option<&Path>,
+) -> Result<EngineHandle> {
     let EngineLoadOptions {
         enable_cuda_graph,
         device_ordinals,
@@ -390,6 +434,7 @@ pub fn start_engine_with_offload(
         decode_overlap,
         dflash_draft_model_path,
         enable_kv_events,
+        dump_graph_png,
     )
 }
 

--- a/openinfer-qwen3/src/scheduler.rs
+++ b/openinfer-qwen3/src/scheduler.rs
@@ -11,6 +11,7 @@ mod plan;
 mod resolve;
 
 use std::collections::{HashSet, VecDeque};
+use std::path::Path;
 use std::thread;
 
 use anyhow::Result;
@@ -151,6 +152,7 @@ pub(crate) fn start_qwen3(
     decode_overlap: crate::DecodeOverlap,
     dflash_draft_model_path: Option<&str>,
     enable_kv_events: bool,
+    dump_graph_png: Option<&Path>,
 ) -> Result<EngineHandle> {
     let mut executor = Qwen3Executor::from_runtime_with_lora_options(
         model_path,
@@ -163,6 +165,17 @@ pub(crate) fn start_qwen3(
         memory_options,
         enable_kv_events,
     )?;
+    if let Some(path) = dump_graph_png {
+        let summary = executor.dump_decode_graph_png(path)?;
+        info!(
+            "Qwen3 decode CUDA Graph exported: nodes={}, kernels={}, edges={}, dot={}, png={}",
+            summary.nodes,
+            summary.kernels,
+            summary.edges,
+            summary.dot_path.display(),
+            summary.png_path.display()
+        );
+    }
     executor.set_no_prefix_cache(no_prefix_cache);
     executor.enable_decode_overlap(decode_overlap)?;
     // Speculative decoding loads its draft model after the target is up (the

--- a/openinfer-qwen3/tests/dflash_speculative_gate.rs
+++ b/openinfer-qwen3/tests/dflash_speculative_gate.rs
@@ -104,6 +104,7 @@ fn launch_options(draft: Option<PathBuf>) -> Qwen3LaunchOptions {
         device_ordinal: 0,
         tp_size: 1,
         cuda_graph: true,
+        dump_graph_png: None,
         offload: Qwen3OffloadOptions::disabled(),
         // The speculative engine forces the prefix cache off; match it on the
         // baseline so both take the same cold prefill path.

--- a/openinfer-qwen3/tests/dflash_speculative_perf.rs
+++ b/openinfer-qwen3/tests/dflash_speculative_perf.rs
@@ -56,6 +56,7 @@ fn launch_options(draft: Option<PathBuf>) -> Qwen3LaunchOptions {
         device_ordinal: 0,
         tp_size: 1,
         cuda_graph: true,
+        dump_graph_png: None,
         offload: Qwen3OffloadOptions::disabled(),
         no_prefix_cache: true,
         max_prefill_tokens: DEFAULT_MAX_PREFILL_TOKENS,

--- a/openinfer-qwen3/tests/tp_concurrent_decode.rs
+++ b/openinfer-qwen3/tests/tp_concurrent_decode.rs
@@ -1,9 +1,11 @@
-//! TP=2 launch with CUDA Graph on — decode replays the graphs pre-captured at
-//! startup, so this gates both the sweep and graph-on concurrent serving.
+//! TP=2 launch with CUDA Graph on — when rendering tools are available, startup
+//! dumps rank 0's pre-captured bs1 graph, then decode replays captured graphs
+//! under concurrent serving.
 //! The drain loop polls with a deadline so a deadlock fails instead of wedging the run.
 
 use std::mem::ManuallyDrop;
 use std::path::Path;
+use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 use openinfer_core::engine::{GenerateRequest, TokenEvent, TokenSink};
@@ -39,8 +41,21 @@ fn cuda_device_count() -> usize {
     cudarc::driver::CudaContext::device_count().map_or(0, |n| n.max(0) as usize)
 }
 
+fn graph_render_tools_available() -> bool {
+    let succeeds = |program: &str, args: &[&str]| {
+        Command::new(program)
+            .args(args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
+    };
+    succeeds("dot", &["-Tpng:cairo"]) && succeeds("c++filt", &["--version"])
+}
+
 #[test]
-fn tp2_concurrent_decode_completes() {
+fn tp2_graph_dump_when_available_and_concurrent_decode_complete() {
     let Some(model_path) = model_path_or_skip() else {
         return;
     };
@@ -49,11 +64,21 @@ fn tp2_concurrent_decode_completes() {
         eprintln!("skipping tp2 concurrent decode: needs >=2 GPUs, have {gpus}");
         return;
     }
+    let dump_dir = tempfile::tempdir().expect("create graph dump directory");
+    let dump_png = dump_dir.path().join("tp2-decode.png");
+    let dump_enabled = graph_render_tools_available();
+    if dump_enabled {
+        openinfer_core::cuda_graph::validate_graph_dump_request(&dump_png)
+            .expect("validate TP graph export request");
+    } else {
+        eprintln!("TP graph export coverage disabled: Graphviz Cairo or c++filt unavailable");
+    }
 
     let options = Qwen3LaunchOptions {
         device_ordinal: 0,
         tp_size: 2,
         cuda_graph: true,
+        dump_graph_png: dump_enabled.then(|| dump_png.clone()),
         offload: Qwen3OffloadOptions::disabled(),
         no_prefix_cache: false,
         max_prefill_tokens: DEFAULT_MAX_PREFILL_TOKENS,
@@ -75,6 +100,14 @@ fn tp2_concurrent_decode_completes() {
     let handle = ManuallyDrop::new(
         openinfer_qwen3::launch(Path::new(&model_path), options).expect("launch tp2 engine"),
     );
+    if dump_enabled {
+        let dump_dot = dump_png.with_extension("dot");
+        assert!(dump_png.is_file(), "TP graph PNG was not exported");
+        assert!(dump_dot.is_file(), "TP graph DOT was not exported");
+        let dot = std::fs::read_to_string(&dump_dot).expect("read TP graph DOT");
+        assert!(dot.contains("dynamic_shared_mem_bytes="));
+        assert!(dot.contains(" -> "), "TP graph DOT has no dependency edges");
+    }
 
     let tokenizer = common::load_tokenizer(&model_path);
     // Submit all up front so they coexist in the engine and form real decode batches.

--- a/openinfer-server/src/config.rs
+++ b/openinfer-server/src/config.rs
@@ -33,6 +33,13 @@ pub(crate) struct Args {
     #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
     pub cuda_graph: bool,
 
+    /// Dump the live Qwen3 rank-0, batch-1 SplitKv decode CUDA Graph during
+    /// startup. Writes a detailed sibling `.dot` for LLM inspection and a
+    /// compact Graphviz-rendered PNG at this path. Requires CUDA driver API
+    /// 12.3 or newer for kernel-name inspection.
+    #[arg(long)]
+    pub dump_graph_png: Option<PathBuf>,
+
     /// Enable Qwen3 LoRA serving mode.
     #[arg(long, default_value_t = false)]
     pub enable_lora: bool,
@@ -262,6 +269,7 @@ fn consumed_args(model_type: ModelType) -> &'static [&'static str] {
         #[cfg(feature = "qwen3")]
         ModelType::Qwen3 => &[
             "cuda_graph",
+            "dump_graph_png",
             "enable_lora",
             "lora_modules",
             "max_loras",
@@ -345,6 +353,14 @@ impl Args {
         }
         if self.batch_invariant && self.enable_lora {
             bail!("--batch-invariant is not supported with --enable-lora; enable one at a time");
+        }
+        if self.dump_graph_png.is_some() && !self.cuda_graph {
+            bail!("--dump-graph-png requires --cuda-graph=true");
+        }
+        if self.dump_graph_png.is_some() && self.enable_lora {
+            bail!(
+                "--dump-graph-png is not supported with --enable-lora (LoRA disables CUDA Graph)"
+            );
         }
         if self.batch_invariant && !matches!(self.decode_overlap, CliDecodeOverlap::Off) {
             bail!(
@@ -480,7 +496,7 @@ fn parse_lora_module_fields(name: &str, path: &str) -> Result<LoraModule, String
 mod tests {
     use super::*;
 
-    #[cfg(feature = "glm52")]
+    #[cfg(any(feature = "glm52", feature = "qwen3"))]
     fn parse_with_provided(argv: &[&str]) -> (Args, BTreeSet<String>) {
         use clap::FromArgMatches;
         let matches = Args::command()
@@ -573,6 +589,49 @@ mod tests {
     #[test]
     fn qwen3_lora_default_rank_is_64() {
         assert_eq!(Qwen3LoraOptions::default().max_lora_rank, 64);
+    }
+
+    #[cfg(feature = "qwen3")]
+    #[test]
+    fn qwen3_accepts_graph_png_dump() {
+        let (args, provided) =
+            parse_with_provided(&["openinfer", "--dump-graph-png", "decode.png"]);
+        args.validate(ModelType::Qwen3, &provided)
+            .expect("Qwen3 should accept a graph PNG dump with CUDA Graph enabled");
+    }
+
+    #[cfg(feature = "qwen3")]
+    #[test]
+    fn qwen3_graph_png_dump_requires_cuda_graph() {
+        let (args, provided) = parse_with_provided(&[
+            "openinfer",
+            "--dump-graph-png",
+            "decode.png",
+            "--cuda-graph=false",
+        ]);
+        let error = args
+            .validate(ModelType::Qwen3, &provided)
+            .expect_err("graph dump without CUDA Graph should be rejected");
+        assert!(error.to_string().contains("requires --cuda-graph=true"));
+    }
+
+    #[cfg(feature = "qwen3")]
+    #[test]
+    fn qwen3_graph_png_dump_rejects_lora() {
+        let (args, provided) = parse_with_provided(&[
+            "openinfer",
+            "--dump-graph-png",
+            "decode.png",
+            "--enable-lora",
+        ]);
+        let error = args
+            .validate(ModelType::Qwen3, &provided)
+            .expect_err("graph dump with LoRA should be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("not supported with --enable-lora")
+        );
     }
 
     #[cfg(feature = "qwen3")]

--- a/openinfer-server/src/main.rs
+++ b/openinfer-server/src/main.rs
@@ -210,6 +210,7 @@ fn load_engine(args: &Args, model_type: ModelType) -> anyhow::Result<EngineHandl
                     device_ordinal: args.device_ordinal,
                     tp_size: args.tp_size,
                     cuda_graph: args.cuda_graph,
+                    dump_graph_png: args.dump_graph_png.clone(),
                     offload,
                     no_prefix_cache: args.no_prefix_cache,
                     max_prefill_tokens: args


### PR DESCRIPTION
## Summary

- add --dump-graph-png for the live Qwen3 rank-0, batch-1 SplitKv decode graph
- emit an unfolded DOT with full kernel symbols and launch metadata plus a folded 192-DPI Cairo PNG for human inspection
- validate CUDA Driver API 12.3, Graphviz Cairo, and c++filt before model loading; document R545/CUDA 12.3 as the driver floor
- cover CLI rejection paths and the TP rank-0 export path

## Validation

- cargo test --release -p openinfer-core cuda_graph::dump::tests (4 passed)
- cargo test --release -p openinfer-server config::tests::qwen3_ (4 passed)
- cargo test --release -p openinfer-qwen3 --lib (67 passed)
- OPENINFER_TEST_MODEL_PATH=/data/models/Qwen3-4B cargo test --release -p openinfer-qwen3 --test tp_concurrent_decode -- --nocapture (compiled; GPU body skipped on the one-GPU host)
- cargo clippy --release -p openinfer-core -p openinfer-qwen3 -p openinfer-server -- -D warnings
- real Qwen3-4B launch on RTX 5070 Ti exported 507 kernel nodes / 506 edges and reached HTTP readiness

## Environment note

The all-workspace lib build completed after setting OPENINFER_NCCL_ROOT=/data/opt/nccl-2.30.4. Its test run later failed in the unrelated openinfer-comm-cuda-lib GDRCopy hardware test because this host cannot create a GDRCopy handle.