### PR TITLE
feat(glm52): export per-rank scheduler metrics

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 
 | Path | TL;DR |
 | --- | --- |
+| `models/glm52/dp-scheduler-metrics.md` | GLM5.2 maps logical scheduler partitions onto vLLM EngineCore identities: 8 rank-local running/waiting/KV series for EP8/DP8, 1 for TP8; 8x H200 endpoint gates and matched serving A/B passed without an upstream vLLM change. |
 | `models/glm52/moe-tp8-low-latency.md` | `--moe-topo tp8`: bucket-1 decode MoE runs TP8-sharded phase-split kernels + LL packet AG/RS instead of the EP8 DeepEP chain — measured solo ITL 19.23 → 15.27 ms (1.26×), 8-concurrent 1.17×, on 8×H200. TP8+MTP span mapping on top: solo DSpark span-8 rides the bucket-8 shape — code 186 tok/s (2.5–2.9× over both baselines), prose 106, ~25 ms rounds; solo prefill 8 tok/step. Launch-time config; EP8 stays the high-throughput default. |
 | `models/glm52/vllm-speculative-pd-audit.md` | For model-based speculators with their own KV (including EAGLE/EAGLE3 and DFlash/DSpark), vLLM NIXL P/D runs the drafter on P and transfers draft KV with target KV; on a full hit D restores both and replays only the last prompt token. EAGLE3/MTP gates exist, but DSpark/GLM5.2 P/D is untested. |
 | `models/glm52/pegaflow-offload-pd.md` | GLM5.2 target-only P/D uses the existing 99 target arenas plus vLLM hash/layout compatibility. Stateful speculative P/D is separate: vLLM transfers drafter KV too; OpenInfer must measure explicit DSpark suffix cold-start against an 80-KiB/token draft-KV handoff. Pins pegaflow-core v0.23.2 rev d46fd16. |

--- a/docs/models/glm52/dp-scheduler-metrics.md
+++ b/docs/models/glm52/dp-scheduler-metrics.md
@@ -1,0 +1,148 @@
+# GLM5.2 DP scheduler metrics
+
+**TL;DR:** GLM5.2 now maps each logical scheduler partition to vLLM's existing EngineCore identity: EP8/DP8 exposes eight rank-local running/waiting/KV series and uses frontend least-load routing, while TP8 exposes one series. Endpoint-level gates passed on 8x H200, and a matched three-run serving A/B found no measurable regression; upstream vLLM required no change.
+
+Last touched: 2026-07
+
+## Preparation
+
+### Request and acceptance boundary
+
+Expose the GLM5.2 scheduler gauges already supported by the vLLM Rust frontend:
+
+- `num_running_reqs`
+- `num_waiting_reqs`
+- `kv_cache_usage`
+
+The representation must match the real scheduling topology. EP8/DP8 must expose eight rank-local scheduler series; TP8 has one logical rank and must expose one series. Validate the result on 8x H200, measure matched performance before review, and submit the OpenInfer change as a PR. An upstream vLLM change is allowed only when the existing frontend cannot express this topology, and must be reviewed separately before implementation.
+
+### Sources read
+
+- `docs/index.md`
+- `docs/subsystems/frontend/prometheus-metrics.md`
+- `docs/models/glm52/dp8-scheduler.md`
+- `docs/models/glm52/serving-status.md`
+- `docs/conventions/bench-regression.md`
+- `openinfer-engine/src/engine.rs`
+- `openinfer-vllm-frontend/src/{lib,bridge}.rs`
+- `openinfer-glm52/src/{lib,scheduler/mod,scheduler/admission}.rs`
+- vLLM latest `main` at public commit `c241c7a2b015f8168d1c75e80cee15e45c18ba94` (2026-07-10), especially its Rust engine-core client, metrics recorder, Python DP coordinator, EngineCore, scheduler, and metrics logger
+- The vLLM revision pinned by this workspace, confirming the required multi-engine routing and per-engine metrics mechanisms are already available to OpenInfer
+
+### Findings
+
+vLLM DP8 already has the desired model:
+
+1. It launches eight EngineCore instances.
+2. Each EngineCore owns one scheduler, waiting queue, and KV manager.
+3. Each engine emits one `SchedulerStats`; the enclosing output carries `engine_index`.
+4. The frontend registers `engine=0..7`, records eight Prometheus series, and routes new requests using a least-load score based on waiting and running counts.
+5. Aggregated text logging sums running/waiting and averages KV usage, but Prometheus retains the eight rank-local series.
+
+No upstream vLLM change is required. OpenInfer is the mismatch:
+
+- The local frontend config hard-codes `engine_count=1`.
+- The bridge hard-codes `engine_index=0` and reports `data_parallel_size=1`.
+- GLM5.2 chooses a rank inside its coordinator from one global pending queue.
+- GLM5.2 exposes no load watches.
+
+Sending eight stats-only batches while keeping one registered engine would not work: the frontend drops stats for unknown engine indexes. Directly writing Prometheus families would also leave request routing and waiting ownership inconsistent. The truthful integration is to register the logical DP ranks as the engines the frontend already knows how to route.
+
+### Invariants
+
+- EP8/DP8 registers exactly eight engine identities; TP8 registers exactly one.
+- A request selected for frontend engine `r` remains bound to logical rank `r`; the coordinator cannot silently reassign it.
+- Each rank owns its waiting count, running count, KV used blocks, and KV total blocks.
+- `sum(num_waiting_reqs)` equals the coordinator's total queued requests; `sum(num_running_reqs)` equals occupied request slots.
+- KV usage is `rank_used_blocks / rank_total_blocks`, never a fleet average presented as a rank value.
+- TP8's eight mirrored workers remain one scheduler partition and one KV series.
+- The central coordinator still chooses global step shapes and drives every worker in lock-step; only request ownership moves to the existing frontend least-load boundary.
+- Direct `EngineHandle` callers without a selected DP rank retain deterministic least-load placement.
+- Other model lines remain single-engine unless they explicitly opt into partitioned registration.
+- An engine-count mismatch between the frontend declaration and the resolved handle fails startup rather than degrading to aggregate metrics.
+
+## Implementation
+
+1. The shared engine contract carries explicit scheduler partitions:
+   - a request may carry an optional target DP rank;
+   - an `EngineHandle` may publish one load watch per partition;
+   - existing single-engine constructors and callers remain the one-partition case.
+2. The local vLLM bridge supports multiple engine identities:
+   - accept a launch-time engine count without waiting for model loading, preserving concurrent tokenizer/model startup;
+   - start one bridge identity per partition on the shared transport;
+   - use that identity for requests, outputs, ready metadata, and its rank-local stats watch;
+   - validate the handle exposes the declared number of partitions.
+   - supervise the output sender and scheduler-stats publisher as part of the bridge lifecycle; a closed load feed, output failure, or scheduler-submit failure tears down the endpoint instead of leaving a registered but unusable rank.
+   - keep request validation failures local: malformed public request extensions receive a terminal error, while transport, output, scheduler-submit, and load-feed failures remain endpoint-fatal.
+3. The GLM5.2 coordinator owns one pending queue per logical rank:
+   - HTTP requests arrive already bound by the vLLM frontend's least-load choice;
+   - direct unbound requests are assigned once at intake;
+   - admission stays FIFO within a rank and preserves full-lifetime KV reservation;
+   - global step planning continues over all rank slots.
+4. The coordinator publishes one snapshot per logical rank at idle and every scheduler boundary. KV usage comes from that rank's pool and excludes its reserved padding block.
+5. Focused tests prove:
+   - eight bridge identities produce eight independent stats series;
+   - rank-bound requests are not reassigned;
+   - running/waiting sums are exact across queue/admit/finish transitions;
+   - KV accounting is per pool;
+   - TP8 exposes one partition;
+   - scheduler metrics update live and return to zero, while a closed rank-local load feed fails the endpoint;
+   - a malformed request extension rejects only that request and a following valid request still completes;
+   - single-engine model behavior is unchanged.
+6. The endpoint refuses to start when the declared engine count and the resolved handle's scheduler partition count disagree.
+
+The public HTTP surface remains one endpoint. The eight EP8 identities are internal routing and metrics identities connected through the existing shared vLLM transport; they are not eight HTTP servers.
+
+## Validation
+
+### Release gates
+
+- `openinfer-engine`: 10 passed.
+- `openinfer-vllm-frontend`: 22 passed.
+- CPU frontend E2E, including live per-engine series, closed-feed lifecycle, request-local validation failure, and fail-fast topology mismatch coverage: 9 passed.
+- `openinfer-glm52`: 56 passed, 14 hardware oracle tests ignored by their explicit annotations.
+- GLM5.2-enabled server release check and release build passed.
+
+### 8x H200 endpoint gates
+
+EP8/DP8 exposed exactly eight series for each requested gauge, labelled `engine="0"` through `engine="7"`:
+
+| Workload state | Per-engine evidence |
+| --- | --- |
+| Idle | running=0, waiting=0, KV=0 for all eight engines |
+| One long request | engine 0 running=1 and KV=0.011538; the other seven remained zero |
+| Eight concurrent requests | every engine running=1 and KV=0.009615 |
+| 72 concurrent requests | every engine running=8 and waiting=1; KV stayed rank-local |
+| Drained | all 72 requests succeeded; all three gauges returned to zero on every engine |
+
+TP8 exposed exactly one `engine="0"` series. A long request moved it to running=1 and KV=0.019231, then both returned to zero. This confirms the eight mirrored GPU workers remain one logical scheduler/KV partition.
+
+A 10 Hz diagnostic trace across 451 busy samples observed no rank-routing skew: the maximum difference between any two engines' running+waiting counts was one, and no sample queued while the 64-request workload was at its configured concurrency limit.
+
+### Performance A/B
+
+The performance gate used vllm-bench `cfa8044c` against the real OpenAI completions endpoint on the same 8x H200 host. Each run used 256 requests, exact 64-token inputs, exact 256-token outputs, concurrency 64, 16 warmups, seed 20260710, greedy sampling, and EOS suppression. Both variants completed 768/768 measured requests across three runs.
+
+| Three-run median, steady state | Main baseline | Per-rank metrics | Delta |
+| --- | ---: | ---: | ---: |
+| Output throughput | 1268.58 tok/s | 1264.82 tok/s | -0.30% |
+| TPOT p50 | 41.76 ms | 41.35 ms | -0.97% |
+| TTFT p50 | 2353.64 ms | 2349.74 ms | -0.17% |
+| TTFT p99 | 2378.98 ms | 2373.87 ms | -0.21% |
+
+The throughput delta is below run-to-run noise, while token latency is unchanged to slightly lower. One candidate run had four late completions; an additional instrumented run completed normally at 1269.89 tok/s and the per-engine trace stayed balanced, so the isolated tail was not attributed to the change. vllm-bench's coarse top-level `max_concurrent_requests=128` was not used: its inclusive one-second buckets overlap adjacent 64-request waves, while its exact steady-state event window correctly reported 64.
+
+## Execution log
+
+- 2026-07-10: plan approved. Implementation started on `feat/glm52-metrics`; upstream vLLM remains unchanged.
+- 2026-07-10: local release gates passed, followed by EP8 and TP8 endpoint validation on 8x H200.
+- 2026-07-10: matched three-run serving A/B passed the no-regression gate; evidence recorded before review.
+- 2026-07-10: review found that detached bridge output/stats tasks could fail without unregistering their engine identity. The bridge now supervises both tasks and the CPU E2E drives live snapshots, verifies drain-to-zero, and proves a closed load feed tears down the endpoint.
+- 2026-07-10: follow-up review found request validation and infrastructure errors shared one propagation path. Malformed request extensions now terminate only their request; an E2E proves the endpoint accepts the next valid request.
+- 2026-07-10: final toxic review passed after both findings were fixed; release tests, targeted `-D warnings` lint gates, formatting, and diff checks are green.
+
+## Debrief
+
+The important boundary is scheduler ownership, not endpoint count. EP8 has eight independent admission queues and KV pools even though clients see one HTTP endpoint, so it needs eight `SchedulerStats` identities. TP8 has one request stream mirrored across eight workers, so it needs one identity. Reusing vLLM's EngineCore registry keeps routing, request ownership, and Prometheus labels consistent; adding metrics as a separate aggregation layer would have made those three views disagree.
+
+No upstream vLLM change was needed. Its pinned Rust frontend already provides per-engine registration, frontend-local in-flight least-load routing, scheduler-stat gauges, and explicit DP-rank routing. OpenInfer only needed to expose its real logical partitions to that contract.

--- a/docs/subsystems/frontend/prometheus-metrics.md
+++ b/docs/subsystems/frontend/prometheus-metrics.md
@@ -1,6 +1,6 @@
 # Prometheus /metrics via the vLLM frontend
 
-**TL;DR:** `/metrics` works out of the box for the Qwen3 line — request histograms (TTFT/ITL/queue time, token counters) are derived by the upstream frontend from the `Queued`/`Scheduled` events and `PrefillStats` the bridge already sends; engine gauges (`num_requests_running/waiting`, `kv_cache_usage_perc`) ride the scheduler's `LoadSnapshot` watch, forwarded by the bridge as stats-only batches. Anything not listed below reads 0 by design, not by accident.
+**TL;DR:** `/metrics` exposes request histograms for every model and engine gauges for schedulers that publish `LoadSnapshot`: Qwen3 uses one engine, GLM5.2 EP8/DP8 uses eight rank-local engines, and GLM5.2 TP8 uses one logical engine. The bridge forwards each partition's stats under the same identity the vLLM frontend uses for least-load routing.
 
 Last touched: 2026-07
 
@@ -9,14 +9,21 @@ Last touched: 2026-07
 Two independent paths feed the upstream Prometheus registry (`vllm-metrics`, served by `vllm-server` at `/metrics` with its HTTP middleware counters):
 
 1. **Per-request path (works for every model crate).** The bridge stamps each request's first output with `Queued`/`Scheduled` timestamps and `PrefillStats` (prompt/computed/cached token split). The upstream `RequestMetricsTracker` turns those into `time_to_first_token_seconds`, `inter_token_latency_seconds`, `request_queue_time_seconds`, `prompt_tokens_total`, `generation_tokens_total`, `request_success_total`, `prompt_tokens_by_source_total`, … unconditionally — `disable_log_stats` only gates the periodic *text* logger, not Prometheus.
-2. **Engine-gauge path (needs a `LoadSnapshot` watch).** The scheduler publishes `LoadSnapshot { kv_used_blocks, kv_total_blocks, num_running_reqs, num_waiting_reqs }` at the top of every loop iteration; the bridge's `publish_scheduler_stats` task forwards each snapshot as a stats-only `RequestBatchOutputs` whose `SchedulerStats` the frontend records (`num_requests_running`, `num_requests_waiting`, `kv_cache_usage_perc`). The watch coalesces to ≤1 message per scheduler step, and the scheduler's final idle publish settles the gauges back to 0. Measured cost: TPOT 10.6387 ms (main) vs 10.6395 ms (branch) over 828 tokens — noise.
+2. **Engine-gauge path (needs one `LoadSnapshot` watch per scheduler partition).** The scheduler publishes `LoadSnapshot { kv_used_blocks, kv_total_blocks, num_running_reqs, num_waiting_reqs }` at scheduler boundaries; one bridge identity per partition forwards its snapshot as a stats-only `RequestBatchOutputs`. The enclosing `engine_index` is both the routing identity and the Prometheus `engine` label. Watches coalesce to ≤1 message per scheduler step, and the scheduler's final idle publish settles the gauges back to 0.
+
+For a single-partition model, `EngineHandle::with_load_watch` keeps the original one-engine contract. A partitioned scheduler uses `with_load_watches`, and the frontend launch declares the same engine count; a mismatch fails startup. GLM5.2 EP8 therefore registers engines 0–7, each bound to its own pending queue and KV pool. TP8 registers only engine 0 because its eight workers mirror one logical request stream.
+
+Measured cost is noise in both covered configurations:
+
+- Qwen3 TPOT: 10.6387 ms (main) vs 10.6395 ms (metrics branch) over 828 tokens.
+- GLM5.2 EP8, three-run median at concurrency 64: 1268.58 vs 1264.82 output tok/s (-0.30%); TPOT p50 41.76 vs 41.35 ms.
 
 ## What deliberately reads zero (state at capture time)
 
 - `prefix_cache_queries/hits` and the by-reason waiting split (`reason="deferred"` is driven by a skipped-request counter we don't report; all waiting shows as `reason="capacity"`).
 - Spec-decode counters, per-GPU FLOPs/bytes estimates, KV-block residency histograms, cudagraph stats — the bridge sends `SchedulerStats::default()` for these fields.
-- Every model crate whose scheduler doesn't publish a `LoadSnapshot` watch (qwen35, deepseek, kimi, glm52) gets path 1 only; its engine gauges are absent, not lying-zero — the bridge skips the stats task when `EngineHandle::load_watch()` is `None`.
+- Every model crate whose scheduler doesn't publish a `LoadSnapshot` watch (qwen35, deepseek, kimi) gets path 1 only; its engine gauges are absent, not lying-zero — the bridge skips the stats task for that partition when no watch exists.
 
 ## Next step
 
-Wire `LoadSnapshot` publishing into the qwen35 scheduler (the other schedulers can follow the same recipe), and report real prefix-cache query/hit counters instead of zeros.
+Wire `LoadSnapshot` publishing into the qwen35 scheduler (the other schedulers can follow the same recipe), and report real prefix-cache query/hit counters instead of zeros. A future partitioned model must expose its logical scheduler partitions instead of averaging them behind engine 0.

--- a/openinfer-deepseek-v2-lite/tests/e2e_ep2.rs
+++ b/openinfer-deepseek-v2-lite/tests/e2e_ep2.rs
@@ -612,6 +612,7 @@ fn run_mixed_serving_generation(model_path: &Path, model_path_label: &str) -> Re
         let req = GenerateRequest {
             request_id: Some(id.clone()),
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens,
             params: SamplingParams {
                 ignore_eos,
@@ -687,6 +688,7 @@ fn run_mixed_serving_position_fallback(
         let req = GenerateRequest {
             request_id: Some(id.clone()),
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens,
             params: SamplingParams {
                 ignore_eos,
@@ -755,6 +757,7 @@ fn run_mixed_serving_rejection_isolation(
     let invalid_req = GenerateRequest {
         request_id: Some("mixed-invalid-logprobs".to_string()),
         queued_at_unix_s: None,
+        data_parallel_rank: None,
         prompt_tokens: vec![1, 2, 3],
         params: SamplingParams::default(),
         max_tokens: 4,
@@ -768,6 +771,7 @@ fn run_mixed_serving_rejection_isolation(
     let valid_req = GenerateRequest {
         request_id: Some(valid_id.to_string()),
         queued_at_unix_s: None,
+        data_parallel_rank: None,
         prompt_tokens: valid_prompt_tokens,
         params: SamplingParams::default(),
         max_tokens: 6,

--- a/openinfer-deepseek-v4/src/e2e_runner.rs
+++ b/openinfer-deepseek-v4/src/e2e_runner.rs
@@ -209,6 +209,7 @@ fn generate_text(
         .submit(GenerateRequest {
             request_id: None,
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens,
             params: SamplingParams::default(),
             max_tokens,

--- a/openinfer-dynamo-backend/src/engine.rs
+++ b/openinfer-dynamo-backend/src/engine.rs
@@ -284,6 +284,7 @@ impl LLMEngine for OpeninferBackend {
         let req = GenerateRequest {
             request_id: Some(ctx.id().to_string()),
             queued_at_unix_s: request.request_timestamp_ms.map(|ms| ms / 1000.0),
+            data_parallel_rank: None,
             prompt_tokens: request.token_ids,
             params,
             max_tokens,

--- a/openinfer-engine/src/engine.rs
+++ b/openinfer-engine/src/engine.rs
@@ -69,6 +69,9 @@ pub enum FinishReason {
 pub struct GenerateRequest {
     pub request_id: Option<String>,
     pub queued_at_unix_s: Option<f64>,
+    /// Logical data-parallel rank selected by the frontend. `None` leaves
+    /// placement to the model scheduler (the direct `EngineHandle` path).
+    pub data_parallel_rank: Option<usize>,
     pub prompt_tokens: Vec<u32>,
     pub params: SamplingParams,
     pub max_tokens: usize,
@@ -391,9 +394,10 @@ pub struct EngineHandle {
     /// KV pool capacity in blocks + block size, or `None` if the engine did not
     /// report it. See [`KvCapacity`].
     kv_capacity: Option<KvCapacity>,
-    /// Live KV-load feed, or `None` if the engine did not wire one. Each clone
-    /// of the handle holds its own receiver; `watch` fans out to all of them.
-    load_watch: Option<watch::Receiver<LoadSnapshot>>,
+    /// One optional live-load feed per scheduler partition. A normal engine
+    /// has one partition; a data-parallel engine exposes one per logical DP
+    /// rank. Each handle clone owns cloned receivers and `watch` fans out.
+    load_watches: Vec<Option<watch::Receiver<LoadSnapshot>>>,
     /// Block store/remove feed for a cache-aware router, or `None` if not wired.
     /// `mpsc` (every event matters — unlike the coalescing load feed), so the
     /// single receiver is handed out exactly once via [`Self::take_kv_events`];
@@ -448,7 +452,7 @@ impl EngineHandle {
             }),
             servable_len: None,
             kv_capacity: None,
-            load_watch: None,
+            load_watches: vec![None],
             kv_events: None,
         }
     }
@@ -478,16 +482,42 @@ impl EngineHandle {
 
     #[must_use]
     pub fn with_load_watch(mut self, load_watch: watch::Receiver<LoadSnapshot>) -> Self {
-        self.load_watch = Some(load_watch);
+        self.load_watches = vec![Some(load_watch)];
         self
     }
 
-    /// A receiver for the engine's live KV load, if it wired one. Awaiting
+    /// Attach one load feed per logical scheduler partition.
+    ///
+    /// The vector is also the engine's frontend-visible DP topology, so an
+    /// empty vector is an invalid engine rather than a single partition with
+    /// missing metrics.
+    #[must_use]
+    pub fn with_load_watches(mut self, load_watches: Vec<watch::Receiver<LoadSnapshot>>) -> Self {
+        assert!(
+            !load_watches.is_empty(),
+            "an engine must expose at least one scheduler partition"
+        );
+        self.load_watches = load_watches.into_iter().map(Some).collect();
+        self
+    }
+
+    /// Number of logical scheduler partitions exposed to the frontend.
+    pub fn scheduler_partition_count(&self) -> usize {
+        self.load_watches.len()
+    }
+
+    /// A receiver for one partition's live load, if it wired one. Awaiting
     /// [`watch::Receiver::changed`] wakes once per scheduler step under load and
     /// stays quiet when idle, so a consumer republishes on real change rather
-    /// than polling. `None` if the engine reported no load feed.
+    /// than polling. `None` if the partition does not report a load feed or the
+    /// index is outside the engine topology.
+    pub fn load_watch_for(&self, partition: usize) -> Option<watch::Receiver<LoadSnapshot>> {
+        self.load_watches.get(partition)?.clone()
+    }
+
+    /// Single-partition compatibility accessor.
     pub fn load_watch(&self) -> Option<watch::Receiver<LoadSnapshot>> {
-        self.load_watch.clone()
+        self.load_watch_for(0)
     }
 
     #[must_use]
@@ -668,6 +698,39 @@ mod tests {
         let (command_tx, _command_rx) = mpsc::unbounded_channel::<EngineCommand>();
         let handle = EngineHandle::new_with_command_channel(command_tx);
         assert!(handle.supports_lora_control());
+    }
+
+    #[test]
+    fn load_watches_define_scheduler_partitions() {
+        let (submit_tx, _submit_rx) = mpsc::unbounded_channel::<GenerateRequest>();
+        let (_load_tx0, load_rx0) = watch::channel(LoadSnapshot {
+            num_running_reqs: 1,
+            ..LoadSnapshot::default()
+        });
+        let (_load_tx1, load_rx1) = watch::channel(LoadSnapshot {
+            num_waiting_reqs: 2,
+            ..LoadSnapshot::default()
+        });
+        let handle = EngineHandle::new(submit_tx).with_load_watches(vec![load_rx0, load_rx1]);
+
+        assert_eq!(handle.scheduler_partition_count(), 2);
+        assert_eq!(
+            handle
+                .load_watch_for(0)
+                .expect("rank 0 watch")
+                .borrow()
+                .num_running_reqs,
+            1
+        );
+        assert_eq!(
+            handle
+                .load_watch_for(1)
+                .expect("rank 1 watch")
+                .borrow()
+                .num_waiting_reqs,
+            2
+        );
+        assert!(handle.load_watch_for(2).is_none());
     }
 
     #[test]

--- a/openinfer-glm52/src/lib.rs
+++ b/openinfer-glm52/src/lib.rs
@@ -35,14 +35,14 @@ use std::{collections::BTreeSet, path::Path, time::Instant};
 
 use anyhow::{Result, ensure};
 use bytesize::ByteSize;
-use openinfer_core::engine::EngineHandle;
+use openinfer_core::engine::{EngineHandle, KvCapacity, LoadSnapshot};
 use openinfer_kv_offload::{HostConfig, KvArena, OffloadEngine, OffloadHost};
 use runner::{Glm52RankPlacement, Glm52RankWorker};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use weights::{GLM52_EP_RANKS, Glm52RankLoadBundle, Glm52WeightManifest};
 
 use crate::config::GLM52_MAX_CONTEXT;
-use crate::model::{GLM52_MODEL_LEN_ALIGN, glm52_arena_bytes};
+use crate::model::{GLM52_MODEL_LEN_ALIGN, glm52_arena_bytes, glm52_pool_blocks};
 
 pub use config::{
     GLM52_DENSE_LAYERS, GLM52_HIDDEN, GLM52_INDEX_TOPK, GLM52_LAYERS, GLM52_MOE_LAYERS,
@@ -429,6 +429,20 @@ fn start_engine(
             return Err(err);
         }
     };
+    let logical_ranks = if moe_topo == Glm52MoeTopo::Tp8 {
+        1
+    } else {
+        loaded.workers.len()
+    };
+    let kv_total_blocks = glm52_pool_blocks(max_model_len) - 1;
+    let (load_txs, load_rxs): (Vec<_>, Vec<_>) = (0..logical_ranks)
+        .map(|_| {
+            watch::channel(LoadSnapshot {
+                kv_total_blocks: kv_total_blocks as u64,
+                ..LoadSnapshot::default()
+            })
+        })
+        .unzip();
     let (submit_tx, submit_rx) = mpsc::unbounded_channel();
     let coord_handle = std::thread::Builder::new()
         .name("glm52-coord".into())
@@ -442,6 +456,7 @@ fn start_engine(
                 no_prefix_cache,
                 offload,
                 moe_topo,
+                load_txs,
             );
         })
         .map_err(|err| anyhow::anyhow!("failed to spawn GLM5.2 coordinator: {err}"))?;
@@ -450,7 +465,13 @@ fn start_engine(
     // requests the scheduler would reject (same contract as qwen3/dsv2-lite).
     let servable_len = u32::try_from(max_model_len)
         .expect("max_model_len is bounded by GLM52_MAX_CONTEXT and fits u32");
-    Ok(EngineHandle::new_with_join_handle(submit_tx, coord_handle).with_servable_len(servable_len))
+    Ok(EngineHandle::new_with_join_handle(submit_tx, coord_handle)
+        .with_servable_len(servable_len)
+        .with_kv_capacity(KvCapacity {
+            total_blocks: kv_total_blocks,
+            block_size: GLM52_MODEL_LEN_ALIGN,
+        })
+        .with_load_watches(load_rxs))
 }
 
 /// Load the DSpark drafter on every rank (rank-local, ~3.8 GB bf16 each —

--- a/openinfer-glm52/src/scheduler/admission.rs
+++ b/openinfer-glm52/src/scheduler/admission.rs
@@ -1,11 +1,12 @@
 //! Request intake and slot placement: [`validate_request`] fast-rejects at
 //! the door (past it, a bad value only surfaces inside a collective and tears
-//! the engine down), [`admission_target`] picks the least-loaded rank with
-//! pool budget for the request's full [`lifetime_blocks`] reservation.
+//! the engine down), then binds every request to one rank queue. HTTP requests
+//! arrive with the vLLM frontend's DP choice; direct requests are placed once
+//! using the same waiting-weighted least-load policy.
+
+use std::collections::VecDeque;
 
 use openinfer_core::engine::{GenerateRequest, TokenEvent, unix_now_s};
-
-use crate::model::GLM52_MAX_BATCH_PER_RANK;
 
 use super::PAGE;
 
@@ -70,66 +71,71 @@ pub(super) fn lifetime_blocks(prompt_tokens: usize, max_tokens: usize) -> usize 
     (prompt_tokens + max_tokens).div_ceil(PAGE)
 }
 
-/// Where the next queued request goes: among the ranks with a free slot AND
-/// enough unreserved pool pages for the request's full lifetime, the
-/// least-loaded one (ties → lowest rank id), its lowest free slot. `None`
-/// when no rank can take it — the queue holds (a request that fits the pool
-/// geometry always fits an EMPTY rank, so FCFS deferral never livelocks).
-/// Least-loaded-first keeps occupancy balanced, which keeps the fleet in the
-/// cheap 1-row bucket until concurrency exceeds the rank count.
-///
-/// `committed[rank]` = Σ active requests' [`lifetime_blocks`];
-/// `usable[rank]` = pool blocks minus the reserved padding page. The
-/// reservation is conservative: prefix-cache hits share pages between
-/// requests, but each holder reserves them in full — over-reserving can only
-/// defer admission, never strand a decode.
-pub(super) fn admission_target(
-    occupied: &[[bool; GLM52_MAX_BATCH_PER_RANK]],
-    committed: &[usize],
-    usable: &[usize],
-    need_blocks: usize,
-) -> Option<(usize, usize)> {
-    let (rank, row) = occupied
+/// Pick a rank for a direct, unbound request. Waiting carries the same 4x
+/// weight as vLLM's DP load balancer; ties go to the lowest rank. Frontend
+/// requests bypass this function because their selected engine index is the
+/// rank assignment.
+fn least_loaded_rank(running: &[usize], pending: &[VecDeque<GenerateRequest>]) -> usize {
+    assert_eq!(running.len(), pending.len());
+    running
         .iter()
         .enumerate()
-        .filter(|(rank, row)| {
-            committed[*rank] + need_blocks <= usable[*rank] && row.iter().any(|&o| !o)
-        })
-        .min_by_key(|(rank, row)| (row.iter().filter(|&&o| o).count(), *rank))?;
-    let slot = row.iter().position(|&o| !o)?;
-    Some((rank, slot))
+        .min_by_key(|&(rank, &running)| (running + pending[rank].len() * 4, rank))
+        .map(|(rank, _)| rank)
+        .expect("GLM5.2 must expose at least one logical rank")
 }
 
-/// Fast-reject invalid requests at intake (Scheduled → Rejected, the same
-/// event order the bs=1 coordinator emitted); valid ones queue for a rank.
+fn reject(req: &GenerateRequest, message: String) {
+    let prompt_tokens = req.prompt_tokens.len();
+    let queued_at_unix_s = req.queued_at_unix_s.unwrap_or_else(unix_now_s);
+    let _ = req.token_tx.send(TokenEvent::Scheduled {
+        queued_at_unix_s,
+        scheduled_at_unix_s: unix_now_s(),
+        prompt_tokens,
+        cached_tokens: 0,
+    });
+    let _ = req.token_tx.send(TokenEvent::Rejected {
+        message,
+        prompt_tokens,
+        completion_tokens: 0,
+    });
+}
+
+/// Fast-reject invalid requests at intake (Scheduled → Rejected), otherwise
+/// bind the request to exactly one rank queue. The binding is permanent so
+/// frontend `engine_index`, metrics labels, and actual KV ownership agree.
 pub(super) fn intake(
     req: GenerateRequest,
-    pending: &mut std::collections::VecDeque<GenerateRequest>,
+    pending: &mut [VecDeque<GenerateRequest>],
+    running: &[usize],
     max_model_len: usize,
 ) {
     if let Err(message) = validate_request(&req, max_model_len) {
-        let prompt_tokens = req.prompt_tokens.len();
-        let queued_at_unix_s = req.queued_at_unix_s.unwrap_or_else(unix_now_s);
-        let _ = req.token_tx.send(TokenEvent::Scheduled {
-            queued_at_unix_s,
-            scheduled_at_unix_s: unix_now_s(),
-            prompt_tokens,
-            cached_tokens: 0,
-        });
-        let _ = req.token_tx.send(TokenEvent::Rejected {
-            message,
-            prompt_tokens,
-            completion_tokens: 0,
-        });
+        reject(&req, message);
         return;
     }
-    pending.push_back(req);
+    let rank = match req.data_parallel_rank {
+        Some(rank) if rank < pending.len() => rank,
+        Some(rank) => {
+            reject(
+                &req,
+                format!(
+                    "GLM5.2 data_parallel_rank {rank} is outside 0..{}",
+                    pending.len()
+                ),
+            );
+            return;
+        }
+        None => least_loaded_rank(running, pending),
+    };
+    pending[rank].push_back(req);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::scheduler::testkit::{request, sampled};
+    use openinfer_sample::SamplingParams;
 
     #[test]
     fn malformed_sampling_params_die_at_intake() {
@@ -179,54 +185,40 @@ mod tests {
         assert!(validate_request(&req, 4096).is_ok());
     }
 
-    fn occ(counts: &[usize]) -> Vec<[bool; GLM52_MAX_BATCH_PER_RANK]> {
-        counts
-            .iter()
-            .map(|&c| std::array::from_fn(|slot| slot < c))
-            .collect()
-    }
-
-    /// `admission_target` with an unconstrained pool budget — the pure
-    /// occupancy-placement behavior.
-    fn target(occupied: &[[bool; GLM52_MAX_BATCH_PER_RANK]]) -> Option<(usize, usize)> {
-        let committed = vec![0usize; occupied.len()];
-        let usable = vec![usize::MAX; occupied.len()];
-        admission_target(occupied, &committed, &usable, 1)
-    }
-
     #[test]
-    fn admission_prefers_least_loaded_rank_then_lowest_slot() {
-        // Empty fleet: rank 0, slot 0.
-        assert_eq!(target(&occ(&[0, 0, 0])), Some((0, 0)));
-        // Rank 1 is the least loaded.
-        assert_eq!(target(&occ(&[2, 1, 2])), Some((1, 1)));
-        // Tie between ranks 0 and 2 → lowest rank id.
-        assert_eq!(target(&occ(&[1, 2, 1])), Some((0, 1)));
-        // A hole in the middle of a rank's slots is reused first.
-        let mut holey = occ(&[3, 3]);
-        holey[1][1] = false;
-        assert_eq!(target(&holey), Some((1, 1)));
-        // Full fleet: no target.
-        assert_eq!(target(&occ(&[GLM52_MAX_BATCH_PER_RANK; 2])), None);
-    }
+    fn intake_keeps_frontend_binding_and_load_balances_direct_requests() {
+        let mut pending: Vec<VecDeque<GenerateRequest>> = (0..3).map(|_| VecDeque::new()).collect();
 
-    #[test]
-    fn admission_respects_the_pool_budget() {
-        // Rank 0 has free slots but its pool is fully reserved; rank 1 (more
-        // loaded but with budget) takes the request. No rank fits → defer.
-        let occupied = occ(&[1, 2]);
+        let mut bound = request(vec![10], SamplingParams::default(), 4);
+        bound.data_parallel_rank = Some(2);
+        intake(bound, &mut pending, &[0, 0, 0], 4096);
         assert_eq!(
-            admission_target(&occupied, &[90, 40], &[100, 100], 20),
-            Some((1, 2))
+            pending.iter().map(VecDeque::len).collect::<Vec<_>>(),
+            [0, 0, 1]
+        );
+
+        intake(
+            request(vec![11], SamplingParams::default(), 4),
+            &mut pending,
+            &[2, 1, 2],
+            4096,
         );
         assert_eq!(
-            admission_target(&occupied, &[90, 90], &[100, 100], 20),
-            None
+            pending.iter().map(VecDeque::len).collect::<Vec<_>>(),
+            [0, 1, 1]
         );
-        // Exact fit admits.
+
+        // Rank 1's queued request adds a 4x waiting penalty, so the next
+        // direct request goes to the lower-rank member of the 2/2 tie.
+        intake(
+            request(vec![12], SamplingParams::default(), 4),
+            &mut pending,
+            &[2, 1, 2],
+            4096,
+        );
         assert_eq!(
-            admission_target(&occupied, &[80, 90], &[100, 100], 20),
-            Some((0, 1))
+            pending.iter().map(VecDeque::len).collect::<Vec<_>>(),
+            [1, 1, 1]
         );
     }
 

--- a/openinfer-glm52/src/scheduler/contract_tests.rs
+++ b/openinfer-glm52/src/scheduler/contract_tests.rs
@@ -3,16 +3,93 @@
 //! real [`BlockPool`] — a schedule failure in serving tears the whole EP8
 //! engine down, so the full-lifetime reservation must be proven tight here.
 
-use openinfer_core::engine::FinishReason;
+use std::collections::VecDeque;
+
+use openinfer_core::engine::{FinishReason, GenerateRequest, LoadSnapshot, TokenSink};
 use openinfer_kv_cache::BlockPool;
+use openinfer_sample::SamplingParams;
 
 use crate::model::GLM52_MAX_BATCH_PER_RANK;
 
-use super::PAGE;
 use super::admission::lifetime_blocks;
 use super::slot::GLM52_DSPARK_EP8_SPAN_DRAFTS;
 use super::slot::{Glm52SlotState, Glm52StepOutcome};
-use super::testkit::EOS;
+use super::testkit::{EOS, request};
+use super::{ActiveRequest, PAGE, RankSlots, admit_from_queue, publish_load};
+
+#[test]
+fn load_snapshots_keep_rank_ownership() {
+    let pools = vec![
+        BlockPool::new(PAGE, 8).expect("rank 0 pool"),
+        BlockPool::new(PAGE, 8).expect("rank 1 pool"),
+    ];
+    let mut slots: Vec<RankSlots> = (0..2).map(|_| std::array::from_fn(|_| None)).collect();
+
+    let req = request(vec![10, 11], SamplingParams::default(), 4);
+    let state = Glm52SlotState::new(req.prompt_tokens.clone(), req.max_tokens, true, 0);
+    let mut kv = pools[0].new_request(req.prompt_tokens.clone(), req.max_tokens, None);
+    kv.schedule_prefill(1, &pools[0])
+        .expect("rank 0 owns one live KV block");
+    slots[0][0] = Some(ActiveRequest { req, state, kv });
+
+    let mut pending: Vec<VecDeque<GenerateRequest>> = (0..2).map(|_| VecDeque::new()).collect();
+    pending[1].push_back(request(vec![20], SamplingParams::default(), 4));
+    pending[1].push_back(request(vec![21], SamplingParams::default(), 4));
+
+    let channels: Vec<_> = (0..2)
+        .map(|_| tokio::sync::watch::channel(LoadSnapshot::default()))
+        .collect();
+    let load_txs: Vec<_> = channels.iter().map(|(tx, _)| tx.clone()).collect();
+    let load_rxs: Vec<_> = channels.into_iter().map(|(_, rx)| rx).collect();
+    publish_load(&load_txs, &pools, &slots, &pending);
+
+    let rank0 = *load_rxs[0].borrow();
+    assert_eq!(rank0.num_running_reqs, 1);
+    assert_eq!(rank0.num_waiting_reqs, 0);
+    assert_eq!(rank0.kv_total_blocks, 7);
+    assert_eq!(rank0.kv_used_blocks, 1);
+
+    let rank1 = *load_rxs[1].borrow();
+    assert_eq!(rank1.num_running_reqs, 0);
+    assert_eq!(rank1.num_waiting_reqs, 2);
+    assert_eq!(rank1.kv_total_blocks, 7);
+    assert_eq!(rank1.kv_used_blocks, 0);
+}
+
+#[test]
+fn admission_never_moves_a_rank_bound_request() {
+    let pools = vec![
+        BlockPool::new(PAGE, 8).expect("rank 0 pool"),
+        BlockPool::new(PAGE, 8).expect("rank 1 pool"),
+    ];
+    let mut slots: Vec<RankSlots> = (0..2).map(|_| std::array::from_fn(|_| None)).collect();
+    let mut pending: Vec<VecDeque<GenerateRequest>> = (0..2).map(|_| VecDeque::new()).collect();
+    let mut req = request(vec![10], SamplingParams::default(), 4);
+    req.data_parallel_rank = Some(1);
+    let (token_tx, _token_rx) = TokenSink::standalone();
+    req.token_tx = token_tx;
+    pending[1].push_back(req);
+    let mut pending_resets = vec![Vec::new(), Vec::new()];
+    let mut slots_changed = false;
+
+    admit_from_queue(
+        &mut pending,
+        &mut slots,
+        &pools,
+        &[7, 7],
+        None,
+        false,
+        false,
+        &mut pending_resets,
+        &mut slots_changed,
+    )
+    .expect("admission");
+
+    assert!(slots[0].iter().all(Option::is_none));
+    assert!(slots[1][0].is_some());
+    assert!(pending.iter().all(VecDeque::is_empty));
+    assert!(slots_changed);
+}
 
 /// Drive one request end to end through the coordinator's exact
 /// schedule/apply sequence against `pool` — the offline replica of the

--- a/openinfer-glm52/src/scheduler/load.rs
+++ b/openinfer-glm52/src/scheduler/load.rs
@@ -1,0 +1,40 @@
+//! Rank-local scheduler load snapshots exported to the frontend.
+
+use std::collections::VecDeque;
+
+use openinfer_core::engine::{GenerateRequest, LoadSnapshot};
+use openinfer_kv_cache::BlockPool;
+use tokio::sync::watch;
+
+use super::RankSlots;
+
+pub(super) fn running_counts(slots: &[RankSlots]) -> Vec<usize> {
+    slots
+        .iter()
+        .map(|rank_slots| rank_slots.iter().flatten().count())
+        .collect()
+}
+
+pub(super) fn pending_is_empty(pending: &[VecDeque<GenerateRequest>]) -> bool {
+    pending.iter().all(VecDeque::is_empty)
+}
+
+/// Publish one truthful scheduler snapshot per logical DP rank. Cached pages
+/// that kvbm can evict count as available; the reserved padding page is
+/// excluded from both used and total.
+pub(super) fn publish_load(
+    load_txs: &[watch::Sender<LoadSnapshot>],
+    pools: &[BlockPool],
+    slots: &[RankSlots],
+    pending: &[VecDeque<GenerateRequest>],
+) {
+    for (rank, load_tx) in load_txs.iter().enumerate() {
+        let kv_total_blocks = pools[rank].total_blocks() - 1;
+        load_tx.send_replace(LoadSnapshot {
+            kv_used_blocks: kv_total_blocks.saturating_sub(pools[rank].available_blocks()) as u64,
+            kv_total_blocks: kv_total_blocks as u64,
+            num_running_reqs: slots[rank].iter().flatten().count() as u64,
+            num_waiting_reqs: pending[rank].len() as u64,
+        });
+    }
+}

--- a/openinfer-glm52/src/scheduler/mod.rs
+++ b/openinfer-glm52/src/scheduler/mod.rs
@@ -21,13 +21,13 @@
 //! `GLM52_DECODE_BUCKETS` covering the hungriest rank's row demand, so the
 //! fleet pays for prefill only while someone is prefilling and returns to the
 //! cheap 1-row bucket for pure decode. Requests join and leave slots at step
-//! boundaries (continuous batching) — admission is least-loaded rank first,
-//! so decode-only fleets leave the 1-row bucket only past `GLM52_EP_RANKS`
-//! concurrent requests.
+//! boundaries (continuous batching). The vLLM frontend assigns HTTP requests
+//! least-load-first to rank-owned queues, so decode-only fleets leave the
+//! 1-row bucket only past `GLM52_EP_RANKS` concurrent requests.
 //!
 //! The per-request decisions (what to feed next, what a step's output means)
 //! live in [`Glm52SlotState`] as pure data transitions, and the
-//! admission/step-shape decisions in [`admission_target`] /
+//! admission/step-shape decisions in [`intake`] /
 //! [`plan_step_shapes`] as pure functions over the occupancy and feed wants;
 //! the coordinator is a thin shell that moves tokens between channels and the
 //! rank workers.
@@ -35,19 +35,22 @@
 mod admission;
 #[cfg(test)]
 mod contract_tests;
+mod load;
 mod offload;
 mod plan;
 mod slot;
 #[cfg(test)]
 mod testkit;
 
+use std::collections::VecDeque;
+
 use anyhow::Context as _;
 
-use openinfer_core::engine::{GenerateRequest, TokenEvent, unix_now_s};
+use openinfer_core::engine::{GenerateRequest, LoadSnapshot, TokenEvent, unix_now_s};
 use openinfer_kv_cache::{BlockPool, RequestKv};
 use openinfer_kv_offload::OffloadEngine;
 use openinfer_sample::mix_seed;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 
 use crate::model::{
     GLM52_DECODE_BUCKETS, GLM52_MAX_BATCH_PER_RANK, GLM52_MODEL_LEN_ALIGN, Glm52StepKv,
@@ -55,8 +58,11 @@ use crate::model::{
 };
 use crate::runner::{Glm52RankWorker, Glm52StepFlags};
 
-use admission::{admission_target, intake, lifetime_blocks};
-use plan::{collect_sampling_rows, feed_wants, launch_ahead_flags, occupancy, plan_step_shapes};
+use admission::{intake, lifetime_blocks};
+use load::{pending_is_empty, publish_load, running_counts};
+use plan::{
+    collect_sampling_rows, feed_wants, launch_ahead_flags, padding_step_kv, plan_step_shapes,
+};
 use slot::{GLM52_PADDING_STEP, Glm52SlotState, Glm52StepOutcome};
 
 /// The KV page size (== the FlashMLA page / index-K block / model-len
@@ -95,26 +101,6 @@ enum SpanKind {
     Speculative,
 }
 
-/// The all-padding-rows step KV: every page-table entry is the pool's
-/// padding page, every write slot points into it (padding rows sit at
-/// position 0, inside the page).
-fn padding_step_kv(
-    bucket: usize,
-    table_width: usize,
-    padding_page: i32,
-    inputs: &[(u32, usize); GLM52_MAX_BATCH_PER_RANK],
-) -> Glm52StepKv {
-    let pages = vec![padding_page; bucket * table_width].into_boxed_slice();
-    let mut slot_mapping = [0i64; GLM52_MAX_BATCH_PER_RANK];
-    for (row, slot) in slot_mapping.iter_mut().enumerate().take(bucket) {
-        *slot = padding_page as i64 * PAGE as i64 + (inputs[row].1 % PAGE) as i64;
-    }
-    Glm52StepKv {
-        pages,
-        slot_mapping,
-    }
-}
-
 /// DP8 coordinator: admits up to `GLM52_MAX_BATCH_PER_RANK` requests per rank
 /// (least-loaded rank with pool budget first) and drives all ranks in
 /// lock-step. Consumes the workers — and the offload engines: they hold the
@@ -132,6 +118,7 @@ pub(crate) fn run_dp8_coordinator(
     no_prefix_cache: bool,
     offload: Option<Vec<OffloadEngine>>,
     moe_topo: crate::Glm52MoeTopo,
+    load_txs: Vec<watch::Sender<LoadSnapshot>>,
 ) {
     // TP8 replicated topology: ONE logical rank drives 8 mirrored executors.
     // Every worker receives the identical step (inputs, shape, KV, seed) and
@@ -140,6 +127,11 @@ pub(crate) fn run_dp8_coordinator(
     // and draft joins.
     let mirrored = moe_topo == crate::Glm52MoeTopo::Tp8;
     let logical_ranks = if mirrored { 1 } else { workers.len() };
+    assert_eq!(
+        load_txs.len(),
+        logical_ranks,
+        "one GLM5.2 load feed is required per logical rank"
+    );
     // Verify-span draft budget: EP8 feeds 3 (the measured bucket-4 optimum);
     // the tp8 full-bucket shape always computes 8 rows, so it feeds the
     // drafter's full proposal.
@@ -189,7 +181,8 @@ pub(crate) fn run_dp8_coordinator(
     // slot, or a new one was admitted into it). Flushed with each step's
     // Draft commands; the handler is idempotent, so duplicates are harmless.
     let mut pending_resets: Vec<Vec<usize>> = (0..logical_ranks).map(|_| Vec::new()).collect();
-    let mut pending = std::collections::VecDeque::<GenerateRequest>::new();
+    let mut pending: Vec<VecDeque<GenerateRequest>> =
+        (0..logical_ranks).map(|_| VecDeque::new()).collect();
     let mut channel_open = true;
     let all_idle = |slots: &[RankSlots]| {
         slots
@@ -222,20 +215,21 @@ pub(crate) fn run_dp8_coordinator(
 
     'serve: loop {
         // Intake: block when fully idle, otherwise drain what's queued.
-        if channel_open && all_idle(&slots) && pending.is_empty() {
+        if channel_open && all_idle(&slots) && pending_is_empty(&pending) {
+            publish_load(&load_txs, &pools, &slots, &pending);
             match submit_rx.blocking_recv() {
-                Some(req) => intake(req, &mut pending, max_model_len),
+                Some(req) => intake(req, &mut pending, &running_counts(&slots), max_model_len),
                 None => channel_open = false,
             }
         }
         while channel_open {
             match submit_rx.try_recv() {
-                Ok(req) => intake(req, &mut pending, max_model_len),
+                Ok(req) => intake(req, &mut pending, &running_counts(&slots), max_model_len),
                 Err(mpsc::error::TryRecvError::Empty) => break,
                 Err(mpsc::error::TryRecvError::Disconnected) => channel_open = false,
             }
         }
-        if !channel_open && all_idle(&slots) && pending.is_empty() {
+        if !channel_open && all_idle(&slots) && pending_is_empty(&pending) {
             break;
         }
 
@@ -256,6 +250,7 @@ pub(crate) fn run_dp8_coordinator(
             fail_step(&mut slots, &err);
             break 'serve;
         }
+        publish_load(&load_txs, &pools, &slots, &pending);
         if all_idle(&slots) {
             continue;
         }
@@ -269,7 +264,7 @@ pub(crate) fn run_dp8_coordinator(
             &shapes,
             leased_shapes.as_deref(),
             slots_changed,
-            pending.is_empty(),
+            pending_is_empty(&pending),
             dspark_enabled,
             offload.is_some(),
             &slots,
@@ -355,7 +350,7 @@ pub(crate) fn run_dp8_coordinator(
     }
 
     // Also fail whatever never got a slot.
-    for req in pending {
+    for req in pending.into_iter().flatten() {
         let _ = req.token_tx.send(TokenEvent::Error {
             message: "GLM5.2 engine shut down before the request was scheduled".to_owned(),
             prompt_tokens: req.prompt_tokens.len(),
@@ -443,14 +438,15 @@ fn precapture_step_graphs(
     Ok(())
 }
 
-/// Admission: fill free slots from the queue, least-loaded rank (with pool
-/// budget for the request's full lifetime) first. New requests join the
-/// lock-step at the next step boundary (their prefill rides decode alongside
-/// everyone else's rows). An `Err` is a kvbm invariant break — the caller
-/// fails the step (the affected request was already answered here).
+/// Admission: fill each rank's free slots from its own FIFO queue while its
+/// full-lifetime KV budget permits. The frontend already selected the rank;
+/// admission must never move the request or its metrics/KV ownership diverge.
+/// New requests join the lock-step at the next step boundary. An `Err` is a
+/// kvbm invariant break — the caller fails the step (the affected request was
+/// already answered here).
 #[allow(clippy::too_many_arguments)]
 fn admit_from_queue(
-    pending: &mut std::collections::VecDeque<GenerateRequest>,
+    pending: &mut [VecDeque<GenerateRequest>],
     slots: &mut [RankSlots],
     pools: &[BlockPool],
     usable_blocks: &[usize],
@@ -460,93 +456,98 @@ fn admit_from_queue(
     pending_resets: &mut [Vec<usize>],
     slots_changed: &mut bool,
 ) -> anyhow::Result<()> {
-    while let Some(front) = pending.front() {
-        let need_blocks = lifetime_blocks(front.prompt_tokens.len(), front.max_tokens);
-        let committed: Vec<usize> = slots
-            .iter()
-            .map(|rank_slots| {
-                rank_slots
-                    .iter()
-                    .flatten()
-                    .map(|active| {
-                        lifetime_blocks(active.req.prompt_tokens.len(), active.req.max_tokens)
-                    })
-                    .sum()
-            })
-            .collect();
-        // Pages pinned by in-flight release saves are physically
-        // unallocatable until their D2H lands — hide them from the
-        // full-lifetime budget so admission defers instead of promising
-        // pages a later `schedule_prefill` cannot get (which would
-        // fail_step the whole engine).
-        let usable: Vec<usize> = match offload {
-            Some(offload) => usable_blocks
+    assert_eq!(pending.len(), slots.len());
+    let mut committed: Vec<usize> = slots
+        .iter()
+        .map(|rank_slots| {
+            rank_slots
                 .iter()
-                .zip(offload)
-                .map(|(&usable, rank)| usable.saturating_sub(rank.pinned_blocks()))
-                .collect(),
-            None => usable_blocks.to_vec(),
-        };
-        let Some((rank, slot)) =
-            admission_target(&occupancy(slots), &committed, &usable, need_blocks)
-        else {
-            break;
-        };
-        let req = pending.pop_front().expect("checked non-empty");
-        // The client left while the request sat in the queue — admitting
-        // it would burn a slot (and whole global steps) on a dead sink.
-        if req.token_tx.is_closed() {
-            continue;
-        }
-        let mut kv = pools[rank].new_request(req.prompt_tokens.clone(), req.max_tokens, None);
-        // Host-tier restore first, so the single GPU prefix match below sees
-        // the union of HBM-resident and freshly-restored blocks. The probe
-        // stays alive across the match: it holds the committed blocks, and
-        // dropping it earlier would open an eviction window between commit
-        // and re-match.
-        let _restored_hold = offload.filter(|_| prefix_cache_enabled).map(|offload| {
-            offload::restore_host_prefix(&offload[rank].engine, &pools[rank], &req.prompt_tokens)
-        });
-        let cached_tokens = if prefix_cache_enabled {
-            match kv.match_and_add_prefix(&pools[rank]) {
-                Ok(cached) => cached,
-                Err(err) => {
-                    // A fresh request failing to match is a kvbm state
-                    // invariant break — crash early, don't serve on a
-                    // pool whose bookkeeping already lied once. This
-                    // request is already out of `pending` and never
-                    // reaches a slot, so fail it explicitly (fail_step
-                    // and the shutdown sweep can't see it).
-                    let err = err.context("GLM5.2 prefix match at admission");
-                    let _ = req.token_tx.send(TokenEvent::Error {
-                        message: format!("{err:#}"),
-                        prompt_tokens: req.prompt_tokens.len(),
-                        completion_tokens: 0,
-                    });
-                    return Err(err);
-                }
+                .flatten()
+                .map(|active| {
+                    lifetime_blocks(active.req.prompt_tokens.len(), active.req.max_tokens)
+                })
+                .sum()
+        })
+        .collect();
+    // Pages pinned by in-flight release saves are physically unallocatable
+    // until their D2H lands. Hide them from each rank's full-lifetime budget
+    // so admission defers instead of promising pages a later schedule cannot
+    // get (which would fail the whole engine).
+    let usable: Vec<usize> = match offload {
+        Some(offload) => usable_blocks
+            .iter()
+            .zip(offload)
+            .map(|(&usable, rank)| usable.saturating_sub(rank.pinned_blocks()))
+            .collect(),
+        None => usable_blocks.to_vec(),
+    };
+
+    for rank in 0..slots.len() {
+        while let Some(slot) = slots[rank].iter().position(Option::is_none) {
+            let Some(front) = pending[rank].front() else {
+                break;
+            };
+            let need_blocks = lifetime_blocks(front.prompt_tokens.len(), front.max_tokens);
+            if committed[rank] + need_blocks > usable[rank] {
+                break;
             }
-        } else {
-            0
-        };
-        let queued_at_unix_s = req.queued_at_unix_s.unwrap_or_else(unix_now_s);
-        let _ = req.token_tx.send(TokenEvent::Scheduled {
-            queued_at_unix_s,
-            scheduled_at_unix_s: unix_now_s(),
-            prompt_tokens: req.prompt_tokens.len(),
-            cached_tokens,
-        });
-        let state = Glm52SlotState::new(
-            req.prompt_tokens.clone(),
-            req.max_tokens,
-            req.params.ignore_eos,
-            cached_tokens,
-        );
-        if dspark_enabled {
-            pending_resets[rank].push(slot);
+
+            let req = pending[rank].pop_front().expect("checked non-empty");
+            // The client left while the request sat in the queue — admitting
+            // it would burn a slot (and whole global steps) on a dead sink.
+            if req.token_tx.is_closed() {
+                continue;
+            }
+            let mut kv = pools[rank].new_request(req.prompt_tokens.clone(), req.max_tokens, None);
+            // Host-tier restore first, so the GPU prefix match sees the union
+            // of HBM-resident and freshly-restored blocks. The probe stays
+            // alive across the match to close the eviction window.
+            let _restored_hold = offload.filter(|_| prefix_cache_enabled).map(|offload| {
+                offload::restore_host_prefix(
+                    &offload[rank].engine,
+                    &pools[rank],
+                    &req.prompt_tokens,
+                )
+            });
+            let cached_tokens = if prefix_cache_enabled {
+                match kv.match_and_add_prefix(&pools[rank]) {
+                    Ok(cached) => cached,
+                    Err(err) => {
+                        // The request is already out of `pending` and never
+                        // reaches a slot, so fail it explicitly before the
+                        // engine-fatal invariant error propagates.
+                        let err = err.context("GLM5.2 prefix match at admission");
+                        let _ = req.token_tx.send(TokenEvent::Error {
+                            message: format!("{err:#}"),
+                            prompt_tokens: req.prompt_tokens.len(),
+                            completion_tokens: 0,
+                        });
+                        return Err(err);
+                    }
+                }
+            } else {
+                0
+            };
+            let queued_at_unix_s = req.queued_at_unix_s.unwrap_or_else(unix_now_s);
+            let _ = req.token_tx.send(TokenEvent::Scheduled {
+                queued_at_unix_s,
+                scheduled_at_unix_s: unix_now_s(),
+                prompt_tokens: req.prompt_tokens.len(),
+                cached_tokens,
+            });
+            let state = Glm52SlotState::new(
+                req.prompt_tokens.clone(),
+                req.max_tokens,
+                req.params.ignore_eos,
+                cached_tokens,
+            );
+            if dspark_enabled {
+                pending_resets[rank].push(slot);
+            }
+            slots[rank][slot] = Some(ActiveRequest { req, state, kv });
+            committed[rank] += need_blocks;
+            *slots_changed = true;
         }
-        slots[rank][slot] = Some(ActiveRequest { req, state, kv });
-        *slots_changed = true;
     }
     Ok(())
 }

--- a/openinfer-glm52/src/scheduler/plan.rs
+++ b/openinfer-glm52/src/scheduler/plan.rs
@@ -7,11 +7,29 @@
 use openinfer_sample::SamplingParams;
 
 use crate::config::GLM52_VOCAB;
-use crate::model::{GLM52_DECODE_BUCKETS, GLM52_MAX_BATCH_PER_RANK, Glm52StepShape};
+use crate::model::{GLM52_DECODE_BUCKETS, GLM52_MAX_BATCH_PER_RANK, Glm52StepKv, Glm52StepShape};
 use crate::runner::{Glm52RowSample, Glm52StepFlags};
 
 use super::slot::Glm52SlotState;
 use super::{PAGE, RankSlots};
+
+/// Build the all-padding step KV used while pre-capturing graph buckets.
+pub(super) fn padding_step_kv(
+    bucket: usize,
+    table_width: usize,
+    padding_page: i32,
+    inputs: &[(u32, usize); GLM52_MAX_BATCH_PER_RANK],
+) -> Glm52StepKv {
+    let pages = vec![padding_page; bucket * table_width].into_boxed_slice();
+    let mut slot_mapping = [0i64; GLM52_MAX_BATCH_PER_RANK];
+    for (row, slot) in slot_mapping.iter_mut().enumerate().take(bucket) {
+        *slot = padding_page as i64 * PAGE as i64 + (inputs[row].1 % PAGE) as i64;
+    }
+    Glm52StepKv {
+        pages,
+        slot_mapping,
+    }
+}
 
 /// Every rank's forward shape for one step, decided together from the same
 /// feed-want snapshot (`wants[rank][slot]` = rows that slot can usefully
@@ -216,13 +234,6 @@ pub(super) fn feed_wants(slots: &[RankSlots]) -> Vec<[usize; GLM52_MAX_BATCH_PER
                     .map_or(0, |active| active.state.feed_want())
             })
         })
-        .collect()
-}
-
-pub(super) fn occupancy(slots: &[RankSlots]) -> Vec<[bool; GLM52_MAX_BATCH_PER_RANK]> {
-    slots
-        .iter()
-        .map(|rank_slots| std::array::from_fn(|slot| rank_slots[slot].is_some()))
         .collect()
 }
 

--- a/openinfer-glm52/src/scheduler/testkit.rs
+++ b/openinfer-glm52/src/scheduler/testkit.rs
@@ -42,6 +42,7 @@ pub(super) fn request(
     GenerateRequest {
         request_id: None,
         queued_at_unix_s: None,
+        data_parallel_rank: None,
         prompt_tokens: prompt,
         params,
         max_tokens,

--- a/openinfer-kimi-k2/src/batch_decode_trace.rs
+++ b/openinfer-kimi-k2/src/batch_decode_trace.rs
@@ -121,6 +121,7 @@ pub fn trace_runtime_decode_kernel_calls(
             engine.submit(GenerateRequest {
                 request_id: Some(format!("kimi-trace-{request_idx}")),
                 queued_at_unix_s: None,
+                data_parallel_rank: None,
                 prompt_tokens: vec![0_u32; prompt_len],
                 params: SamplingParams {
                     temperature: 0.0,

--- a/openinfer-kimi-k2/src/runner/scheduler.rs
+++ b/openinfer-kimi-k2/src/runner/scheduler.rs
@@ -759,6 +759,7 @@ mod tests {
         let req = GenerateRequest {
             request_id: None,
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens,
             params: SamplingParams::default(),
             max_tokens,

--- a/openinfer-kimi-k2/src/runner/scheduler/dp.rs
+++ b/openinfer-kimi-k2/src/runner/scheduler/dp.rs
@@ -1096,6 +1096,7 @@ mod tests {
         GenerateRequest {
             request_id: None,
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens,
             params: SamplingParams::default(),
             max_tokens,

--- a/openinfer-kimi-k2/tests/vllm_golden_gate.rs
+++ b/openinfer-kimi-k2/tests/vllm_golden_gate.rs
@@ -185,8 +185,10 @@ fn as_i32(st: &SafeTensors, name: &str) -> (Vec<i32>, Vec<usize>) {
     assert_eq!(t.dtype(), Dtype::I32, "{name} must be i32");
     let v = t
         .data()
-        .chunks_exact(4)
-        .map(|b| i32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|bytes| i32::from_le_bytes(*bytes))
         .collect();
     (v, t.shape().to_vec())
 }
@@ -198,8 +200,10 @@ fn as_f32(st: &SafeTensors, name: &str) -> (Vec<f32>, Vec<usize>) {
     assert_eq!(t.dtype(), Dtype::F32, "{name} must be f32");
     let v = t
         .data()
-        .chunks_exact(4)
-        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|bytes| f32::from_le_bytes(*bytes))
         .collect();
     (v, t.shape().to_vec())
 }
@@ -326,6 +330,7 @@ fn submit(
         .submit(openinfer_core::engine::GenerateRequest {
             request_id: Some(label.clone()),
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens: prompt.to_vec(),
             params: SamplingParams {
                 temperature: 0.0,

--- a/openinfer-qwen3/src/scheduler/tests.rs
+++ b/openinfer-qwen3/src/scheduler/tests.rs
@@ -758,6 +758,7 @@ fn request(
         GenerateRequest {
             request_id: None,
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens: vec![1; prompt_len],
             params: SamplingParams::default(),
             max_tokens,

--- a/openinfer-qwen3/tests/cached_tokens_usage.rs
+++ b/openinfer-qwen3/tests/cached_tokens_usage.rs
@@ -44,6 +44,7 @@ fn run_and_capture_cached(handle: &EngineHandle, prompt_tokens: Vec<u32>) -> usi
         .submit(GenerateRequest {
             request_id: None,
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens,
             params: SamplingParams::default(),
             max_tokens: 4,

--- a/openinfer-qwen3/tests/context_window.rs
+++ b/openinfer-qwen3/tests/context_window.rs
@@ -55,6 +55,7 @@ fn generate_text(
         .submit(GenerateRequest {
             request_id: None,
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens,
             params: SamplingParams::default(),
             max_tokens,
@@ -105,6 +106,7 @@ fn oversized_prompt_is_rejected_with_context_length_error() {
         .submit(GenerateRequest {
             request_id: None,
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens,
             params: SamplingParams::default(),
             max_tokens: 8,

--- a/openinfer-qwen3/tests/context_window_in_window.rs
+++ b/openinfer-qwen3/tests/context_window_in_window.rs
@@ -70,6 +70,7 @@ fn in_window_prompt_past_old_rope_table_is_served() {
         .submit(GenerateRequest {
             request_id: None,
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens,
             params: SamplingParams::default(),
             max_tokens: 1,

--- a/openinfer-qwen3/tests/dflash_speculative_gate.rs
+++ b/openinfer-qwen3/tests/dflash_speculative_gate.rs
@@ -144,6 +144,7 @@ fn generate(
         .submit(GenerateRequest {
             request_id: None,
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens,
             params: SamplingParams::default(),
             max_tokens,
@@ -186,6 +187,7 @@ fn generate_concurrent(handle: &EngineHandle, requests: Vec<(Vec<u32>, usize)>) 
                 .submit(GenerateRequest {
                     request_id: None,
                     queued_at_unix_s: None,
+                    data_parallel_rank: None,
                     prompt_tokens,
                     params: SamplingParams::default(),
                     max_tokens,
@@ -238,6 +240,7 @@ fn prefill_next(handle: &EngineHandle, context: Vec<u32>, logprobs: usize) -> St
         .submit(GenerateRequest {
             request_id: None,
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens: context,
             params: SamplingParams::default(),
             max_tokens: 1,
@@ -687,6 +690,7 @@ fn dflash_request_in_draft_headroom_is_rejected_not_panicked() {
         .submit(GenerateRequest {
             request_id: None,
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens: vec![100u32; prompt_len],
             params: SamplingParams::default(),
             max_tokens,

--- a/openinfer-qwen3/tests/dflash_speculative_perf.rs
+++ b/openinfer-qwen3/tests/dflash_speculative_perf.rs
@@ -83,6 +83,7 @@ fn timed_generate(handle: &EngineHandle, prompt_tokens: Vec<u32>) -> (usize, Dur
         .submit(GenerateRequest {
             request_id: None,
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens,
             params: SamplingParams {
                 ignore_eos: true,

--- a/openinfer-qwen3/tests/lora_smoke.rs
+++ b/openinfer-qwen3/tests/lora_smoke.rs
@@ -95,6 +95,7 @@ fn generate_tokens(
         .submit(GenerateRequest {
             request_id: None,
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens,
             params: SamplingParams::default(),
             max_tokens,

--- a/openinfer-qwen3/tests/sampling_behavior.rs
+++ b/openinfer-qwen3/tests/sampling_behavior.rs
@@ -47,6 +47,7 @@ fn generate(handle: &EngineHandle, prompt_tokens: Vec<u32>, params: SamplingPara
         .submit(GenerateRequest {
             request_id: None,
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens,
             params,
             max_tokens: GENERATED_TOKENS,

--- a/openinfer-qwen3/tests/scheduler_robustness.rs
+++ b/openinfer-qwen3/tests/scheduler_robustness.rs
@@ -58,6 +58,7 @@ fn generate_text(
         .submit(GenerateRequest {
             request_id: None,
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens,
             params: SamplingParams::default(),
             max_tokens,
@@ -126,6 +127,7 @@ fn scheduler_survives_consumer_drop() {
         .submit(GenerateRequest {
             request_id: None,
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens,
             params: SamplingParams::default(),
             max_tokens: 10,

--- a/openinfer-qwen3/tests/tp_concurrent_decode.rs
+++ b/openinfer-qwen3/tests/tp_concurrent_decode.rs
@@ -120,6 +120,7 @@ fn tp2_graph_dump_when_available_and_concurrent_decode_complete() {
                 .submit(GenerateRequest {
                     request_id: None,
                     queued_at_unix_s: None,
+                    data_parallel_rank: None,
                     prompt_tokens,
                     params: SamplingParams::default(),
                     max_tokens: 24 + (i % 4) * 24,

--- a/openinfer-qwen35-4b/src/scheduler/tests.rs
+++ b/openinfer-qwen35-4b/src/scheduler/tests.rs
@@ -6,6 +6,7 @@ fn send_rejection_reports_kv_lifetime_request_tokens() {
     let req = SchedulerRequest {
         request_id: Some("too-large".to_string()),
         queued_at_unix_s: None,
+        data_parallel_rank: None,
         prompt_tokens: vec![1; 16],
         params: SamplingParams::default(),
         max_tokens: 65,
@@ -40,6 +41,7 @@ fn send_rejection_reports_context_window_limit() {
     let req = SchedulerRequest {
         request_id: Some("too-long".to_string()),
         queued_at_unix_s: None,
+        data_parallel_rank: None,
         prompt_tokens: vec![1; 16],
         params: SamplingParams::default(),
         max_tokens: 17,

--- a/openinfer-qwen35-4b/tests/chunked_prefill.rs
+++ b/openinfer-qwen35-4b/tests/chunked_prefill.rs
@@ -58,6 +58,7 @@ fn generate(handle: &EngineHandle, prompt_tokens: Vec<u32>) -> (Vec<u32>, Finish
         .submit(GenerateRequest {
             request_id: None,
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens,
             params: SamplingParams {
                 ignore_eos: true,

--- a/openinfer-qwen35-4b/tests/e2e_scheduler.rs
+++ b/openinfer-qwen35-4b/tests/e2e_scheduler.rs
@@ -125,6 +125,7 @@ fn generate_tokens_with_logprobs(
         .submit(GenerateRequest {
             request_id: None,
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens,
             params: SamplingParams::default(),
             max_tokens,
@@ -214,6 +215,7 @@ fn expect_context_window_rejection(handle: &EngineHandle, max_context_tokens: us
         .submit(GenerateRequest {
             request_id: Some("over-context-window".to_string()),
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens: vec![1; max_context_tokens],
             params: SamplingParams::default(),
             max_tokens: 1,
@@ -439,6 +441,7 @@ fn test_e2e_qwen35_scheduler() {
                 .submit(GenerateRequest {
                     request_id: None,
                     queued_at_unix_s: None,
+                    data_parallel_rank: None,
                     prompt_tokens,
                     params: concurrent_params(case_idx),
                     max_tokens: case.max_new_tokens,
@@ -478,6 +481,7 @@ fn test_e2e_qwen35_scheduler() {
                 .submit(GenerateRequest {
                     request_id: Some(name.to_string()),
                     queued_at_unix_s: None,
+                    data_parallel_rank: None,
                     prompt_tokens,
                     params: SamplingParams::default(),
                     max_tokens: 8,
@@ -518,6 +522,7 @@ fn test_e2e_qwen35_scheduler() {
             .submit(GenerateRequest {
                 request_id: None,
                 queued_at_unix_s: None,
+                data_parallel_rank: None,
                 prompt_tokens,
                 params: SamplingParams::default(),
                 max_tokens: 10,

--- a/openinfer-qwen35-4b/tests/sampling_behavior.rs
+++ b/openinfer-qwen35-4b/tests/sampling_behavior.rs
@@ -47,6 +47,7 @@ fn generate(handle: &EngineHandle, prompt_tokens: Vec<u32>, params: SamplingPara
         .submit(GenerateRequest {
             request_id: None,
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens,
             params,
             max_tokens: GENERATED_TOKENS,

--- a/openinfer-server/src/bin/bench_serving/decode.rs
+++ b/openinfer-server/src/bin/bench_serving/decode.rs
@@ -280,6 +280,7 @@ fn measure_decode_stream(
         .submit(SchedulerRequest {
             request_id: Some(request_id),
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens,
             params,
             max_tokens,

--- a/openinfer-server/src/bin/bench_serving/exec.rs
+++ b/openinfer-server/src/bin/bench_serving/exec.rs
@@ -125,6 +125,7 @@ pub(crate) fn run_scheduler_stream(
         .submit(SchedulerRequest {
             request_id,
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens,
             params,
             max_tokens,

--- a/openinfer-server/src/bin/glm52_step_bench.rs
+++ b/openinfer-server/src/bin/glm52_step_bench.rs
@@ -206,6 +206,7 @@ fn run_stream(
         .submit(SchedulerRequest {
             request_id: Some(request_id),
             queued_at_unix_s: None,
+            data_parallel_rank: None,
             prompt_tokens,
             params,
             max_tokens,

--- a/openinfer-server/src/main.rs
+++ b/openinfer-server/src/main.rs
@@ -50,6 +50,11 @@ async fn main() -> anyhow::Result<()> {
     let lora_modules = args.lora_modules.clone();
     let enable_lora = args.enable_lora;
     let port = args.port;
+    let frontend_engine_count = match model_type {
+        #[cfg(feature = "glm52")]
+        ModelType::Glm52 if args.moe_topo != "tp8" => args.dp_size.unwrap_or(8),
+        _ => 1,
+    };
     let engine_load = tokio::task::spawn_blocking(move || -> anyhow::Result<EngineHandle> {
         load_engine(&args, model_type)
     });
@@ -89,12 +94,13 @@ async fn main() -> anyhow::Result<()> {
                 anyhow::Ok(handle)
             }
         };
-        openinfer::vllm_frontend::serve(
+        openinfer::vllm_frontend::serve_with_engine_count(
             engine,
             &model_path,
             served_model_name.into_iter().collect(),
             port,
             None,
+            frontend_engine_count,
             shutdown,
         )
         .await

--- a/openinfer-sim/src/lib.rs
+++ b/openinfer-sim/src/lib.rs
@@ -187,6 +187,7 @@ mod tests {
             GenerateRequest {
                 request_id: Some("req-1".to_string()),
                 queued_at_unix_s: Some(1.0),
+                data_parallel_rank: None,
                 prompt_tokens: vec![7, 9],
                 params: SamplingParams::default(),
                 max_tokens: 3,

--- a/openinfer-sim/tests/frontend_e2e.rs
+++ b/openinfer-sim/tests/frontend_e2e.rs
@@ -3,21 +3,27 @@ use std::net::TcpListener;
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow, bail};
+use openinfer_engine::engine::LoadSnapshot;
 use openinfer_sim::{SimulatedEngineConfig, start_engine};
 use reqwest::Client;
 use serde_json::{Value, json};
 use tempfile::TempDir;
+use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 const MODEL_NAME: &str = "openinfer-sim-e2e";
+const METRICS_MODEL_NAME: &str = "openinfer-sim-e2e-metrics";
+const CLOSED_FEED_MODEL_NAME: &str = "openinfer-sim-e2e-closed-feed";
 const SERVER_START_ATTEMPTS: usize = 5;
 
 struct SimServer {
     base_url: String,
+    model_name: String,
     shutdown: CancellationToken,
     task: JoinHandle<Result<()>>,
+    load_txs: Vec<watch::Sender<LoadSnapshot>>,
     _model_dir: TempDir,
 }
 
@@ -27,25 +33,55 @@ impl SimServer {
     }
 
     async fn spawn_with_lora_routes() -> Result<Self> {
-        Self::spawn_with_model_dir_and_lora_routes(model_dir_with_minimal_metadata()?, true).await
+        Self::spawn_with_model_dir_and_lora_routes(
+            model_dir_with_minimal_metadata()?,
+            true,
+            1,
+            MODEL_NAME,
+        )
+        .await
+    }
+
+    async fn spawn_partitioned() -> Result<Self> {
+        Self::spawn_with_model_dir_and_lora_routes(
+            model_dir_with_minimal_metadata()?,
+            false,
+            2,
+            METRICS_MODEL_NAME,
+        )
+        .await
+    }
+
+    async fn spawn_with_closed_load_feed() -> Result<Self> {
+        Self::spawn_with_model_dir_and_lora_routes(
+            model_dir_with_minimal_metadata()?,
+            false,
+            2,
+            CLOSED_FEED_MODEL_NAME,
+        )
+        .await
     }
 
     async fn spawn_with_model_dir(model_dir: TempDir) -> Result<Self> {
-        Self::spawn_with_model_dir_and_lora_routes(model_dir, false).await
+        Self::spawn_with_model_dir_and_lora_routes(model_dir, false, 1, MODEL_NAME).await
     }
 
     async fn spawn_with_model_dir_and_lora_routes(
         model_dir: TempDir,
         enable_lora_routes: bool,
+        engine_count: usize,
+        model_name: &str,
     ) -> Result<Self> {
         let mut last_error = None;
         for attempt in 1..=SERVER_START_ATTEMPTS {
-            match Self::spawn_once(&model_dir, enable_lora_routes).await {
+            match Self::spawn_once(&model_dir, enable_lora_routes, engine_count, model_name).await {
                 Ok(started) => {
                     return Ok(Self {
                         base_url: started.base_url,
+                        model_name: started.model_name,
                         shutdown: started.shutdown,
                         task: started.task,
+                        load_txs: started.load_txs,
                         _model_dir: model_dir,
                     });
                 }
@@ -64,12 +100,28 @@ impl SimServer {
             })
     }
 
-    async fn spawn_once(model_dir: &TempDir, enable_lora_routes: bool) -> Result<StartedSimServer> {
+    async fn spawn_once(
+        model_dir: &TempDir,
+        enable_lora_routes: bool,
+        engine_count: usize,
+        model_name: &str,
+    ) -> Result<StartedSimServer> {
         let port = reserve_loopback_port()?;
         let base_url = format!("http://127.0.0.1:{port}");
         let shutdown = CancellationToken::new();
-        let engine = start_engine(SimulatedEngineConfig::new(0.0, 1000.0, 0.0, 1)?);
+        let mut engine = start_engine(SimulatedEngineConfig::new(0.0, 1000.0, 0.0, 1)?);
+        let load_txs = if engine_count > 1 {
+            let (load_txs, load_watches) = (0..engine_count)
+                .map(|_| watch::channel(LoadSnapshot::default()))
+                .unzip();
+            engine = engine.with_load_watches(load_watches);
+            load_txs
+        } else {
+            Vec::new()
+        };
         let server_shutdown = shutdown.clone();
+        let served_model_name = model_name.to_string();
+        let started_model_name = served_model_name.clone();
         let model_path = model_dir.path().to_string_lossy().into_owned();
         let model_path_buf = model_dir.path().to_path_buf();
         let mut task = tokio::spawn(async move {
@@ -77,7 +129,7 @@ impl SimServer {
                 openinfer_vllm_frontend::serve_model_with_lora_routes(
                     engine,
                     model_path,
-                    vec![MODEL_NAME.to_string()],
+                    vec![served_model_name],
                     Vec::new(),
                     port,
                     128,
@@ -85,12 +137,13 @@ impl SimServer {
                 )
                 .await
             } else {
-                openinfer_vllm_frontend::serve(
+                openinfer_vllm_frontend::serve_with_engine_count(
                     std::future::ready(Ok(engine)),
                     &model_path_buf,
-                    vec![MODEL_NAME.to_string()],
+                    vec![served_model_name],
                     port,
                     Some(128),
+                    engine_count,
                     server_shutdown,
                 )
                 .await
@@ -117,9 +170,20 @@ impl SimServer {
 
         Ok(StartedSimServer {
             base_url,
+            model_name: started_model_name,
             shutdown,
             task,
+            load_txs,
         })
+    }
+
+    fn publish_load(&self, partition: usize, snapshot: LoadSnapshot) -> Result<()> {
+        let sender = self
+            .load_txs
+            .get(partition)
+            .ok_or_else(|| anyhow!("sim frontend has no load feed for partition {partition}"))?;
+        let _ = sender.send_replace(snapshot);
+        Ok(())
     }
 
     async fn shutdown(self) -> Result<()> {
@@ -133,8 +197,10 @@ impl SimServer {
 
 struct StartedSimServer {
     base_url: String,
+    model_name: String,
     shutdown: CancellationToken,
     task: JoinHandle<Result<()>>,
+    load_txs: Vec<watch::Sender<LoadSnapshot>>,
 }
 
 fn empty_model_dir() -> Result<TempDir> {
@@ -165,11 +231,204 @@ async fn simulated_engine_serves_openai_completions_over_http() -> Result<()> {
     let server = SimServer::spawn().await?;
     let client = test_client()?;
 
-    assert_models_endpoint(&client, &server.base_url).await?;
-    assert_non_streaming_completion_has_output(&client, &server.base_url).await?;
-    assert_streaming_completion_emits_done(&client, &server.base_url).await?;
+    assert_models_endpoint(&client, &server.base_url, &server.model_name).await?;
+    assert_non_streaming_completion_has_output(&client, &server.base_url, &server.model_name)
+        .await?;
+    assert_streaming_completion_emits_done(&client, &server.base_url, &server.model_name).await?;
 
     server.shutdown().await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn one_http_endpoint_exports_per_engine_scheduler_metrics() -> Result<()> {
+    let server = SimServer::spawn_partitioned().await?;
+    let client = test_client()?;
+
+    assert_non_streaming_completion_has_output(&client, &server.base_url, &server.model_name)
+        .await?;
+    wait_for_metrics(
+        &client,
+        &server.base_url,
+        &[
+            ("vllm:num_requests_running", "0", 0.0),
+            ("vllm:num_requests_running", "1", 0.0),
+            ("vllm:num_requests_waiting", "0", 0.0),
+            ("vllm:num_requests_waiting", "1", 0.0),
+            ("vllm:kv_cache_usage_perc", "0", 0.0),
+            ("vllm:kv_cache_usage_perc", "1", 0.0),
+        ],
+        &server.model_name,
+    )
+    .await?;
+
+    server.publish_load(
+        0,
+        LoadSnapshot {
+            kv_used_blocks: 25,
+            kv_total_blocks: 100,
+            num_running_reqs: 1,
+            num_waiting_reqs: 0,
+        },
+    )?;
+    server.publish_load(
+        1,
+        LoadSnapshot {
+            kv_used_blocks: 50,
+            kv_total_blocks: 100,
+            num_running_reqs: 0,
+            num_waiting_reqs: 2,
+        },
+    )?;
+    wait_for_metrics(
+        &client,
+        &server.base_url,
+        &[
+            ("vllm:num_requests_running", "0", 1.0),
+            ("vllm:num_requests_waiting", "1", 2.0),
+            ("vllm:kv_cache_usage_perc", "0", 0.25),
+            ("vllm:kv_cache_usage_perc", "1", 0.5),
+        ],
+        &server.model_name,
+    )
+    .await?;
+
+    server.publish_load(
+        0,
+        LoadSnapshot {
+            kv_used_blocks: 75,
+            kv_total_blocks: 100,
+            num_running_reqs: 3,
+            num_waiting_reqs: 4,
+        },
+    )?;
+    server.publish_load(
+        1,
+        LoadSnapshot {
+            kv_used_blocks: 25,
+            kv_total_blocks: 100,
+            num_running_reqs: 5,
+            num_waiting_reqs: 6,
+        },
+    )?;
+    wait_for_metrics(
+        &client,
+        &server.base_url,
+        &[
+            ("vllm:num_requests_running", "0", 3.0),
+            ("vllm:num_requests_running", "1", 5.0),
+            ("vllm:num_requests_waiting", "0", 4.0),
+            ("vllm:num_requests_waiting", "1", 6.0),
+            ("vllm:kv_cache_usage_perc", "0", 0.75),
+            ("vllm:kv_cache_usage_perc", "1", 0.25),
+        ],
+        &server.model_name,
+    )
+    .await?;
+
+    server.publish_load(0, LoadSnapshot::default())?;
+    server.publish_load(1, LoadSnapshot::default())?;
+    wait_for_metrics(
+        &client,
+        &server.base_url,
+        &[
+            ("vllm:num_requests_running", "0", 0.0),
+            ("vllm:num_requests_running", "1", 0.0),
+            ("vllm:num_requests_waiting", "0", 0.0),
+            ("vllm:num_requests_waiting", "1", 0.0),
+            ("vllm:kv_cache_usage_perc", "0", 0.0),
+            ("vllm:kv_cache_usage_perc", "1", 0.0),
+        ],
+        &server.model_name,
+    )
+    .await?;
+
+    server.shutdown().await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn closed_scheduler_load_feed_stops_the_endpoint() -> Result<()> {
+    let mut server = SimServer::spawn_with_closed_load_feed().await?;
+    drop(server.load_txs.remove(0));
+
+    let service_result = tokio::time::timeout(Duration::from_secs(10), &mut server.task)
+        .await
+        .context("frontend did not stop after a scheduler load feed closed")?
+        .context("sim frontend task panicked")?;
+    let error = service_result.expect_err("closed scheduler load feed must fail the endpoint");
+    let message = format!("{error:#}");
+    if !message.contains("scheduler load feed closed") {
+        bail!("closed scheduler load feed returned unexpected error: {message}");
+    }
+
+    Ok(())
+}
+
+async fn wait_for_metrics(
+    client: &Client,
+    base_url: &str,
+    expected: &[(&str, &str, f64)],
+    model_name: &str,
+) -> Result<()> {
+    let metrics_url = format!("{base_url}/metrics");
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let mut last_metrics = String::new();
+    loop {
+        if tokio::time::Instant::now() >= deadline {
+            bail!("timed out waiting for scheduler metrics at {metrics_url}:\n{last_metrics}");
+        }
+
+        if let Ok(response) = client.get(&metrics_url).send().await {
+            if let Ok(response) = response.error_for_status() {
+                if let Ok(metrics) = response.text().await {
+                    let all_found = expected.iter().all(|(metric, engine, expected_value)| {
+                        metrics.lines().any(|line| {
+                            line.starts_with(metric)
+                                && line.contains(&format!("engine=\"{engine}\""))
+                                && line.contains(&format!("model_name=\"{model_name}\""))
+                                && line
+                                    .rsplit_once(' ')
+                                    .and_then(|(_, value)| value.parse::<f64>().ok())
+                                    .is_some_and(|value| (value - expected_value).abs() < 1e-9)
+                        })
+                    });
+                    if all_found {
+                        return Ok(());
+                    }
+                    last_metrics = metrics;
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn frontend_rejects_engine_partition_mismatch() -> Result<()> {
+    let model_dir = model_dir_with_minimal_metadata()?;
+    let port = reserve_loopback_port()?;
+    let engine = start_engine(SimulatedEngineConfig::new(0.0, 1000.0, 0.0, 1)?);
+    let result = tokio::time::timeout(
+        Duration::from_secs(10),
+        openinfer_vllm_frontend::serve_with_engine_count(
+            std::future::ready(Ok(engine)),
+            model_dir.path(),
+            vec![MODEL_NAME.to_string()],
+            port,
+            Some(128),
+            2,
+            CancellationToken::new(),
+        ),
+    )
+    .await
+    .context("partition-mismatch server did not stop")?;
+    let error = result.expect_err("one scheduler partition cannot register as two engines");
+    if !error
+        .to_string()
+        .contains("declared 2 engines but the resolved handle exposes 1 scheduler partitions")
+    {
+        bail!("unexpected partition-mismatch error: {error:#}");
+    }
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -206,8 +465,33 @@ async fn non_streaming_completion_returns_nonempty_output_for_positive_max_token
     let server = SimServer::spawn().await?;
     let client = test_client()?;
 
-    assert_non_streaming_completion_has_output(&client, &server.base_url).await?;
+    assert_non_streaming_completion_has_output(&client, &server.base_url, &server.model_name)
+        .await?;
 
+    server.shutdown().await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn invalid_lora_xarg_rejects_only_its_request() -> Result<()> {
+    let server = SimServer::spawn().await?;
+    let client = test_client()?;
+    let mut body = completion_body(&server.model_name, false);
+    body["vllm_xargs"] = json!({ "openinfer_lora_adapter": 123 });
+
+    let response = client
+        .post(format!("{}/v1/completions", server.base_url))
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(body.to_string())
+        .send()
+        .await?;
+    let status = response.status();
+    let response_body = response.text().await?;
+    if status.is_success() {
+        bail!("invalid openinfer_lora_adapter unexpectedly succeeded: {response_body}");
+    }
+
+    assert_non_streaming_completion_has_output(&client, &server.base_url, &server.model_name)
+        .await?;
     server.shutdown().await
 }
 
@@ -216,7 +500,7 @@ async fn streaming_completion_emits_terminal_done() -> Result<()> {
     let server = SimServer::spawn().await?;
     let client = test_client()?;
 
-    assert_streaming_completion_emits_done(&client, &server.base_url).await?;
+    assert_streaming_completion_emits_done(&client, &server.base_url, &server.model_name).await?;
 
     server.shutdown().await
 }
@@ -248,7 +532,7 @@ async fn simulated_frontend_metadata_contract_is_executable() -> Result<()> {
     Ok(())
 }
 
-async fn assert_models_endpoint(client: &Client, base_url: &str) -> Result<()> {
+async fn assert_models_endpoint(client: &Client, base_url: &str, model_name: &str) -> Result<()> {
     let models: Value = client
         .get(format!("{base_url}/v1/models"))
         .send()
@@ -259,15 +543,19 @@ async fn assert_models_endpoint(client: &Client, base_url: &str) -> Result<()> {
     let advertised = models["data"]
         .as_array()
         .ok_or_else(|| anyhow!("/v1/models response has no data array"))?;
-    if !advertised.iter().any(|model| model["id"] == MODEL_NAME) {
-        bail!("/v1/models did not advertise {MODEL_NAME}: {models}");
+    if !advertised.iter().any(|model| model["id"] == model_name) {
+        bail!("/v1/models did not advertise {model_name}: {models}");
     }
 
     Ok(())
 }
 
-async fn assert_non_streaming_completion_has_output(client: &Client, base_url: &str) -> Result<()> {
-    let completion: Value = post_completion(client, base_url, false).await?;
+async fn assert_non_streaming_completion_has_output(
+    client: &Client,
+    base_url: &str,
+    model_name: &str,
+) -> Result<()> {
+    let completion: Value = post_completion(client, base_url, model_name, false).await?;
     let text = completion["choices"][0]["text"]
         .as_str()
         .ok_or_else(|| anyhow!("non-streaming completion has no text: {completion}"))?;
@@ -278,8 +566,12 @@ async fn assert_non_streaming_completion_has_output(client: &Client, base_url: &
     Ok(())
 }
 
-async fn assert_streaming_completion_emits_done(client: &Client, base_url: &str) -> Result<()> {
-    let stream = post_completion_stream(client, base_url).await?;
+async fn assert_streaming_completion_emits_done(
+    client: &Client,
+    base_url: &str,
+    model_name: &str,
+) -> Result<()> {
+    let stream = post_completion_stream(client, base_url, model_name).await?;
     if !stream.lines().any(|line| line.trim() == "data: [DONE]") {
         bail!("streaming completion did not emit terminal data: [DONE]: {stream}");
     }
@@ -287,11 +579,16 @@ async fn assert_streaming_completion_emits_done(client: &Client, base_url: &str)
     Ok(())
 }
 
-async fn post_completion(client: &Client, base_url: &str, stream: bool) -> Result<Value> {
+async fn post_completion(
+    client: &Client,
+    base_url: &str,
+    model_name: &str,
+    stream: bool,
+) -> Result<Value> {
     let response = client
         .post(format!("{base_url}/v1/completions"))
         .header(reqwest::header::CONTENT_TYPE, "application/json")
-        .body(completion_body(stream).to_string())
+        .body(completion_body(model_name, stream).to_string())
         .send()
         .await?
         .error_for_status()?;
@@ -301,11 +598,15 @@ async fn post_completion(client: &Client, base_url: &str, stream: bool) -> Resul
         .context("failed to parse non-streaming completion response")
 }
 
-async fn post_completion_stream(client: &Client, base_url: &str) -> Result<String> {
+async fn post_completion_stream(
+    client: &Client,
+    base_url: &str,
+    model_name: &str,
+) -> Result<String> {
     client
         .post(format!("{base_url}/v1/completions"))
         .header(reqwest::header::CONTENT_TYPE, "application/json")
-        .body(completion_body(true).to_string())
+        .body(completion_body(model_name, true).to_string())
         .send()
         .await?
         .error_for_status()?
@@ -321,9 +622,9 @@ fn test_client() -> Result<Client> {
         .context("failed to build HTTP test client")
 }
 
-fn completion_body(stream: bool) -> Value {
+fn completion_body(model_name: &str, stream: bool) -> Value {
     json!({
-        "model": MODEL_NAME,
+        "model": model_name,
         "prompt": [1, 2],
         "max_tokens": 3,
         "temperature": 0.0,

--- a/openinfer-vllm-frontend/src/bridge.rs
+++ b/openinfer-vllm-frontend/src/bridge.rs
@@ -35,13 +35,14 @@ use crate::wire::{
     to_wire_position_logprobs,
 };
 
-const ENGINE_INDEX: u32 = 0;
-
 pub(crate) struct LocalEngineBridge {
     pub(crate) input_address: String,
     pub(crate) output_address: String,
     pub(crate) handle: EngineHandle,
     pub(crate) max_model_len: u32,
+    pub(crate) engine_index: u32,
+    pub(crate) data_parallel_size: u32,
+    pub(crate) load_watch: Option<watch::Receiver<LoadSnapshot>>,
 }
 
 impl LocalEngineBridge {
@@ -49,7 +50,7 @@ impl LocalEngineBridge {
         wait_for_ipc_endpoint(&self.input_address, &shutdown).await?;
         wait_for_ipc_endpoint(&self.output_address, &shutdown).await?;
 
-        let engine_id = EngineId::from_engine_index(ENGINE_INDEX);
+        let engine_id = EngineId::from_engine_index(self.engine_index);
         let mut socket_options = SocketOptions::default();
         socket_options.peer_identity(PeerIdentity::try_from(engine_id)?);
 
@@ -85,14 +86,15 @@ impl LocalEngineBridge {
             dtype: ModelDtype::BFloat16,
             vllm_version: "openinfer-local-bridge".to_string(),
             world_size: 1,
-            data_parallel_size: 1,
+            data_parallel_size: u64::from(self.data_parallel_size),
             kv_cache_size_tokens,
             kv_cache_max_concurrency,
         };
         info!(
-            "local engine KV capacity: {kv_capacity:?} -> \
+            "local engine {} KV capacity: {kv_capacity:?} -> \
              kv_cache_size_tokens={kv_cache_size_tokens:?} \
-             kv_cache_max_concurrency={kv_cache_max_concurrency:?}"
+             kv_cache_max_concurrency={kv_cache_max_concurrency:?}",
+            self.engine_index
         );
         input
             .send(ZmqMessage::from(encode_msgpack(&ready)?))
@@ -111,7 +113,8 @@ impl LocalEngineBridge {
             })?;
 
         let (output_tx, output_rx) = mpsc::unbounded_channel();
-        let output_task = tokio::spawn(output_loop(output, output_rx));
+        let mut child_tasks = tokio::task::JoinSet::new();
+        child_tasks.spawn(async move { ("output sender", output_loop(output, output_rx).await) });
 
         // Republish the scheduler's load snapshots as stats-only output
         // batches so the frontend's Prometheus gauges (scheduler_running,
@@ -120,13 +123,18 @@ impl LocalEngineBridge {
         // scheduler publishes a final drained snapshot before parking idle, so
         // the gauges settle to zero instead of freezing at the last busy
         // value. Engines without a load watch simply publish no stats.
-        let stats_task = self.handle.load_watch().map(|load_rx| {
-            tokio::spawn(publish_scheduler_stats(
-                load_rx,
-                output_tx.clone(),
-                shutdown.clone(),
-            ))
-        });
+        if let Some(load_rx) = self.load_watch.clone() {
+            let engine_index = self.engine_index;
+            let stats_output_tx = output_tx.clone();
+            let stats_shutdown = shutdown.clone();
+            child_tasks.spawn(async move {
+                (
+                    "scheduler stats publisher",
+                    publish_scheduler_stats(engine_index, load_rx, stats_output_tx, stats_shutdown)
+                        .await,
+                )
+            });
+        }
 
         // One shared channel carries every request's token events, tagged by
         // request id; this loop is the sole consumer. Per-request state lives
@@ -136,33 +144,59 @@ impl LocalEngineBridge {
         let mut streams: HashMap<RequestTag, RequestStreamState> = HashMap::new();
 
         info!(
-            "local vLLM engine bridge connected: input={}, output={}, max_model_len={}",
-            self.input_address, self.output_address, self.max_model_len
+            "local vLLM engine {} bridge connected: input={}, output={}, max_model_len={}",
+            self.engine_index, self.input_address, self.output_address, self.max_model_len
         );
 
-        loop {
+        let run_result = loop {
             tokio::select! {
-                () = shutdown.cancelled() => break,
+                biased;
+                () = shutdown.cancelled() => break Ok(()),
+                joined = child_tasks.join_next(), if !child_tasks.is_empty() => {
+                    if shutdown.is_cancelled() {
+                        break Ok(());
+                    }
+                    break match joined {
+                        Some(Ok((name, Ok(())))) => {
+                            Err(anyhow::anyhow!("local engine {name} exited unexpectedly"))
+                        }
+                        Some(Ok((name, Err(error)))) => {
+                            Err(error).with_context(|| format!("local engine {name} failed"))
+                        }
+                        Some(Err(error)) => {
+                            Err(anyhow::anyhow!("local engine child task panicked: {error}"))
+                        }
+                        None => Err(anyhow::anyhow!("local engine child task set became empty")),
+                    };
+                }
                 Some(first) = event_rx.recv() => {
-                    if let Err(error) =
-                        dispatch_burst(first, &mut event_rx, &mut streams, &output_tx)
+                    if let Err(error) = dispatch_burst(
+                        self.engine_index,
+                        first,
+                        &mut event_rx,
+                        &mut streams,
+                        &output_tx,
+                    )
                     {
-                        warn!("local engine bridge output failed: {error:#}");
+                        break Err(error).context("failed to dispatch local engine output");
                     }
                 }
                 recv = input.recv() => {
-                    let message = recv.context("failed to receive local engine request")?;
+                    let message = match recv.context("failed to receive local engine request") {
+                        Ok(message) => message,
+                        Err(error) => break Err(error),
+                    };
                     if let Err(error) = self.handle_message(
                         message,
                         &event_tx,
                         &output_tx,
                         &mut streams,
                     ) {
-                        warn!("local engine bridge request failed: {error:#}");
+                        break Err(error).context("failed to handle local engine request");
                     }
                 }
             }
-        }
+        };
 
         // Cancel every in-flight request so the scheduler retires them on its
         // next emit instead of pushing into a channel no one drains.
@@ -170,12 +204,10 @@ impl LocalEngineBridge {
             state.abort(RequestAbortReason::Cancelled);
         }
         drop(output_tx);
-        if let Some(task) = stats_task {
-            task.abort();
-        }
-        output_task.abort();
+        child_tasks.abort_all();
+        while child_tasks.join_next().await.is_some() {}
 
-        Ok(())
+        run_result
     }
 
     fn handle_message(
@@ -231,7 +263,7 @@ impl LocalEngineBridge {
                     String,
                     rmpv::Value,
                 ) = rmp_serde::from_slice(&frames[1])?;
-                send_utility_response(output_tx, call_id, &method_name)
+                send_utility_response(self.engine_index, output_tx, call_id, &method_name)
             }
             other => bail!("unsupported local engine request type frame: {other:?}"),
         }
@@ -253,6 +285,7 @@ impl LocalEngineBridge {
         let Some(prompt_tokens) = prompt_token_ids else {
             warn!("request {request_id} dropped: missing prompt_token_ids");
             send_terminal_output(
+                self.engine_index,
                 output_tx,
                 request_id,
                 EngineCoreFinishReason::Error,
@@ -265,6 +298,7 @@ impl LocalEngineBridge {
         let Some(sampling_params) = sampling_params else {
             warn!("request {request_id} dropped: missing sampling_params");
             send_terminal_output(
+                self.engine_index,
                 output_tx,
                 request_id,
                 EngineCoreFinishReason::Error,
@@ -281,6 +315,7 @@ impl LocalEngineBridge {
         if let Some(unsupported) = crate::wire::unsupported_sampling(&sampling_params) {
             warn!("request {request_id} rejected: unsupported sampling params: {unsupported}");
             send_terminal_output(
+                self.engine_index,
                 output_tx,
                 request_id,
                 EngineCoreFinishReason::Error,
@@ -290,6 +325,23 @@ impl LocalEngineBridge {
             )?;
             return Ok(());
         }
+        let lora_adapter = match lora_adapter_from_sampling_params(&sampling_params) {
+            Ok(adapter) => adapter,
+            Err(error) => {
+                let message = error.to_string();
+                warn!("request {request_id} rejected: {message}");
+                send_terminal_output(
+                    self.engine_index,
+                    output_tx,
+                    request_id,
+                    EngineCoreFinishReason::Error,
+                    Some(StopReason::Text(message)),
+                    None,
+                    None,
+                )?;
+                return Ok(());
+            }
+        };
 
         let tag: RequestTag = Arc::from(request_id.as_str());
         let abort_reason = Arc::new(AtomicU8::new(RequestAbortReason::None as u8));
@@ -298,10 +350,11 @@ impl LocalEngineBridge {
             .submit(GenerateRequest {
                 request_id: Some(request_id),
                 queued_at_unix_s: Some(request.arrival_time),
+                data_parallel_rank: Some(self.engine_index as usize),
                 prompt_tokens,
                 params: convert_sampling(&sampling_params),
                 max_tokens: sampling_params.max_tokens as usize,
-                lora_adapter: lora_adapter_from_sampling_params(&sampling_params)?,
+                lora_adapter,
                 token_tx,
                 logprobs: requested_logprobs(&sampling_params),
                 echo: false,
@@ -346,6 +399,7 @@ impl RequestStreamState {
 /// whole burst as a single `EngineCoreOutputs` — collapsing what used to be N
 /// per-request ZMQ messages per step into one.
 fn dispatch_burst(
+    engine_index: u32,
     first: (RequestTag, TokenEvent),
     event_rx: &mut TokenStreamReceiver,
     streams: &mut HashMap<RequestTag, RequestStreamState>,
@@ -396,7 +450,7 @@ fn dispatch_burst(
     send_outputs(
         output_tx,
         RequestBatchOutputs {
-            engine_index: ENGINE_INDEX,
+            engine_index,
             outputs,
             finished_requests: (!finished_requests.is_empty()).then_some(finished_requests),
             timestamp: now_secs_f64(),
@@ -510,12 +564,15 @@ fn reduce_request(
 /// Forward every scheduler load snapshot as a stats-only output batch; the
 /// frontend records it into the shared Prometheus registry. Sends the current
 /// snapshot up front so the gauges initialize before the first step, then one
-/// message per watch change until shutdown or either channel closes.
+/// message per watch change until shutdown. Losing either output or scheduler
+/// load feed is fatal because keeping that engine registered would leave stale
+/// metrics and a request-routing black hole.
 async fn publish_scheduler_stats(
+    engine_index: u32,
     mut load_rx: watch::Receiver<LoadSnapshot>,
     output_tx: mpsc::UnboundedSender<EngineCoreOutputs>,
     shutdown: CancellationToken,
-) {
+) -> Result<()> {
     loop {
         let snapshot = *load_rx.borrow_and_update();
         let stats = SchedulerStats {
@@ -529,21 +586,18 @@ async fn publish_scheduler_stats(
             ..SchedulerStats::default()
         };
         let outputs = RequestBatchOutputs {
-            engine_index: ENGINE_INDEX,
+            engine_index,
             scheduler_stats: Some(Box::new(stats)),
             timestamp: now_secs_f64(),
             ..Default::default()
         }
         .into();
-        if send_outputs(&output_tx, outputs).is_err() {
-            return;
-        }
+        send_outputs(&output_tx, outputs).context("failed to publish scheduler stats")?;
         tokio::select! {
-            () = shutdown.cancelled() => return,
+            biased;
+            () = shutdown.cancelled() => return Ok(()),
             changed = load_rx.changed() => {
-                if changed.is_err() {
-                    return;
-                }
+                changed.context("scheduler load feed closed")?;
             }
         }
     }
@@ -563,6 +617,7 @@ async fn output_loop(
 }
 
 fn send_terminal_output(
+    engine_index: u32,
     output_tx: &mpsc::UnboundedSender<EngineCoreOutputs>,
     request_id: String,
     finish_reason: EngineCoreFinishReason,
@@ -573,7 +628,7 @@ fn send_terminal_output(
     send_outputs(
         output_tx,
         RequestBatchOutputs {
-            engine_index: ENGINE_INDEX,
+            engine_index,
             outputs: vec![engine_output(
                 request_id.clone(),
                 Vec::new(),
@@ -592,6 +647,7 @@ fn send_terminal_output(
 }
 
 fn send_utility_response(
+    engine_index: u32,
     output_tx: &mpsc::UnboundedSender<EngineCoreOutputs>,
     call_id: UtilityCallId,
     method_name: &str,
@@ -607,7 +663,7 @@ fn send_utility_response(
     send_outputs(
         output_tx,
         UtilityCallOutput {
-            engine_index: ENGINE_INDEX,
+            engine_index,
             timestamp: now_secs_f64(),
             output: UtilityOutput {
                 call_id,

--- a/openinfer-vllm-frontend/src/bridge/tests.rs
+++ b/openinfer-vllm-frontend/src/bridge/tests.rs
@@ -60,6 +60,7 @@ impl Demux {
         match self.event_rx.try_recv() {
             Ok(first) => {
                 dispatch_burst(
+                    0,
                     first,
                     &mut self.event_rx,
                     &mut self.streams,
@@ -466,6 +467,7 @@ async fn load_snapshots_become_stats_only_batches() {
     let (output_tx, mut output_rx) = mpsc::unbounded_channel();
     let shutdown = CancellationToken::new();
     let task = tokio::spawn(publish_scheduler_stats(
+        7,
         load_rx,
         output_tx,
         shutdown.clone(),
@@ -477,6 +479,7 @@ async fn load_snapshots_become_stats_only_batches() {
     };
     assert!(batch.outputs.is_empty());
     assert!(batch.finished_requests.is_none());
+    assert_eq!(batch.engine_index, 7);
     let stats = batch.scheduler_stats.expect("scheduler stats");
     assert_eq!(stats.num_running_reqs, 2);
     assert_eq!(stats.num_waiting_reqs, 1);
@@ -492,5 +495,7 @@ async fn load_snapshots_become_stats_only_batches() {
     assert_eq!(stats.kv_cache_usage.to_bits(), 0.0_f64.to_bits());
 
     shutdown.cancel();
-    task.await.expect("stats task exits on shutdown");
+    task.await
+        .expect("stats task exits on shutdown")
+        .expect("stats publisher shuts down cleanly");
 }

--- a/openinfer-vllm-frontend/src/lib.rs
+++ b/openinfer-vllm-frontend/src/lib.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Result, ensure};
 use axum::Router;
 use log::warn;
 use serde::Deserialize;
@@ -56,6 +56,31 @@ pub async fn serve(
     max_model_len: Option<u32>,
     shutdown: CancellationToken,
 ) -> Result<()> {
+    serve_with_engine_count(
+        engine,
+        model_path,
+        served_model_name,
+        port,
+        max_model_len,
+        1,
+        shutdown,
+    )
+    .await
+}
+
+/// Serve one HTTP endpoint backed by `engine_count` frontend-visible engine
+/// identities. Data-parallel model lines use one identity per scheduler
+/// partition; ordinary model lines call [`serve`] and get the single-engine
+/// case.
+pub async fn serve_with_engine_count(
+    engine: impl Future<Output = Result<EngineHandle>> + Send + 'static,
+    model_path: &Path,
+    served_model_name: Vec<String>,
+    port: u16,
+    max_model_len: Option<u32>,
+    engine_count: usize,
+    shutdown: CancellationToken,
+) -> Result<()> {
     serve_model_on_host(
         engine,
         model_path.to_string_lossy().into_owned(),
@@ -63,6 +88,7 @@ pub async fn serve(
         "0.0.0.0".to_string(),
         port,
         resolve_max_model_len(model_path, max_model_len),
+        engine_count,
         shutdown,
     )
     .await
@@ -91,6 +117,7 @@ pub async fn serve_model_with_lora_routes(
         "0.0.0.0".to_string(),
         port,
         max_model_len,
+        1,
         shutdown,
         move |router| {
             let lora_router = lora_routes(handle.clone(), Arc::clone(&adapter_names));
@@ -113,6 +140,7 @@ async fn serve_model_on_host(
     host: String,
     port: u16,
     max_model_len: u32,
+    engine_count: usize,
     shutdown: CancellationToken,
 ) -> Result<()> {
     serve_model_on_host_with_router_extension(
@@ -122,6 +150,7 @@ async fn serve_model_on_host(
         host,
         port,
         max_model_len,
+        engine_count,
         shutdown,
         |router| router,
     )
@@ -135,12 +164,16 @@ async fn serve_model_on_host_with_router_extension<F>(
     host: String,
     port: u16,
     max_model_len: u32,
+    engine_count: usize,
     shutdown: CancellationToken,
     extend_router: F,
 ) -> Result<()>
 where
     F: FnOnce(Router) -> Router,
 {
+    ensure!(engine_count > 0, "frontend engine_count must be positive");
+    let data_parallel_size = u32::try_from(engine_count)
+        .map_err(|_| anyhow::anyhow!("frontend engine_count {engine_count} exceeds u32"))?;
     let namespace = local_ipc_namespace()?;
     let input_address = ipc_endpoint(&namespace, "input.sock");
     let output_address = ipc_endpoint(&namespace, "output.sock");
@@ -166,15 +199,63 @@ where
                     return Err(error);
                 }
             };
+            let actual_partitions = handle.scheduler_partition_count();
+            if actual_partitions != engine_count {
+                server_shutdown.cancel();
+                anyhow::bail!(
+                    "frontend declared {engine_count} engines but the resolved handle exposes \
+                     {actual_partitions} scheduler partitions"
+                );
+            }
             let servable_limit = handle.servable_len().map(|cap| max_model_len.min(cap));
-            let bridge = LocalEngineBridge {
-                input_address,
-                output_address,
-                handle,
-                max_model_len: servable_limit.unwrap_or(max_model_len),
-            };
-            if let Err(error) = bridge.run(bridge_shutdown).await {
-                warn!("local vLLM engine bridge exited: {error:#}");
+            let max_model_len = servable_limit.unwrap_or(max_model_len);
+            let mut bridges = tokio::task::JoinSet::new();
+            for engine_index in 0..engine_count {
+                let bridge = LocalEngineBridge {
+                    input_address: input_address.clone(),
+                    output_address: output_address.clone(),
+                    handle: handle.clone(),
+                    max_model_len,
+                    engine_index: engine_index as u32,
+                    data_parallel_size,
+                    load_watch: handle.load_watch_for(engine_index),
+                };
+                let shutdown = bridge_shutdown.clone();
+                bridges.spawn(async move { (engine_index, bridge.run(shutdown).await) });
+            }
+            drop(handle);
+
+            let mut bridge_error = None;
+            while let Some(joined) = bridges.join_next().await {
+                match joined {
+                    Ok((_, Ok(()))) if bridge_shutdown.is_cancelled() => {}
+                    Ok((engine_index, Ok(()))) => {
+                        bridge_error = Some(anyhow::anyhow!(
+                            "local vLLM engine {engine_index} bridge exited unexpectedly"
+                        ));
+                        break;
+                    }
+                    Ok((engine_index, Err(error))) => {
+                        bridge_error = Some(
+                            error
+                                .context(format!("local vLLM engine {engine_index} bridge failed")),
+                        );
+                        break;
+                    }
+                    Err(error) => {
+                        bridge_error = Some(anyhow::anyhow!(
+                            "local vLLM engine bridge task panicked: {error}"
+                        ));
+                        break;
+                    }
+                }
+            }
+            if let Some(error) = bridge_error {
+                server_shutdown.cancel();
+                bridge_shutdown.cancel();
+                bridges.abort_all();
+                while bridges.join_next().await.is_some() {}
+                return Err(error);
             }
             Ok(())
         }
@@ -185,7 +266,7 @@ where
             input_address,
             output_address,
             engine_start_index: 0,
-            engine_count: 1,
+            engine_count,
             // The in-process bridge registers once the engine future resolves,
             // so this bounds the whole engine load (multi-GPU MoE models take
             // minutes, cold starts longer). Load *failure* already cancels the


### PR DESCRIPTION
## Summary

- expose GLM5.2's real scheduler topology through the existing vLLM EngineCore contract: EP8/DP8 registers eight rank-local engine identities, while TP8 registers one logical engine
- bind frontend least-load placement to rank-owned pending queues and export rank-local running, waiting, and KV-cache usage gauges
- fail startup on topology mismatches and tear down the endpoint when an output, scheduler, or load-feed path fails, while keeping malformed user requests request-local
- preserve the single-engine API for all other model lines; no upstream vLLM change is required

## Validation

- all pre-commit hooks passed, including release all-target Clippy and the Kimi-K2 `-D warnings` gate
- `openinfer-engine`: 10 passed
- `openinfer-vllm-frontend`: 22 passed
- CPU frontend E2E: 9 passed, including live per-engine updates, drain-to-zero, closed-feed teardown, topology mismatch, and malformed-request isolation
- `openinfer-glm52`: 56 passed, 14 explicitly hardware-gated tests ignored
- release GLM5.2 server build passed
- 8x H200 EP8 endpoint exposed exactly `engine="0"` through `engine="7"`; at 72 concurrent requests every engine reported running=8 and waiting=1, all requests succeeded, and all gauges drained to zero
- 8x H200 TP8 endpoint exposed only `engine="0"`; its gauges moved under load and returned to zero

## Performance

Matched three-run vllm-bench A/B on the same 8x H200 host, using 256 requests/run, exact 64-token inputs, exact 256-token outputs, concurrency 64, and 16 warmups:

| Three-run median | Main | This PR | Delta |
| --- | ---: | ---: | ---: |
| Output throughput | 1268.58 tok/s | 1264.82 tok/s | -0.30% |
| TPOT p50 | 41.76 ms | 41.35 ms | -0.97% |
| TTFT p50 | 2353.64 ms | 2349.74 ms | -0.17% |
| TTFT p99 | 2378.98 ms | 2373.87 ms | -0.21% |

All 768/768 measured requests completed for both variants. The throughput delta is within run-to-run noise and latency did not regress.

## Local test limitation

A full workspace library-test run reached the existing hardware-only GDR test and failed because the local host could not create a GDR handle. The targeted release gates above passed, and this change does not modify the communication crate.
