### PR TITLE
feat(glm52): export decode CUDA graphs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 
 | Path | TL;DR |
 | --- | --- |
+| `models/glm52/cuda-graph-png.md` | `--dump-graph-png PATH` exports GLM5.2 rank 0's live EP8 bucket-1 or TP8 bucket-8 whole-step graph as a complete DOT and readable folded PNG, preserving PDL metadata and omitting DSpark work when the drafter is off. |
 | `models/glm52/dp-scheduler-metrics.md` | GLM5.2 maps logical scheduler partitions onto vLLM EngineCore identities: 8 rank-local running/waiting/KV series for EP8/DP8, 1 for TP8; 8x H200 endpoint gates and matched serving A/B passed without an upstream vLLM change. |
 | `models/glm52/moe-tp8-low-latency.md` | `--moe-topo tp8`: bucket-1 decode MoE runs TP8-sharded phase-split kernels + LL packet AG/RS instead of the EP8 DeepEP chain — measured solo ITL 19.23 → 15.27 ms (1.26×), 8-concurrent 1.17×, on 8×H200. TP8+MTP span mapping on top: solo DSpark span-8 rides the bucket-8 shape — code 186 tok/s (2.5–2.9× over both baselines), prose 106, ~25 ms rounds; solo prefill 8 tok/step. Launch-time config; EP8 stays the high-throughput default. |
 | `models/glm52/vllm-speculative-pd-audit.md` | For model-based speculators with their own KV (including EAGLE/EAGLE3 and DFlash/DSpark), vLLM NIXL P/D runs the drafter on P and transfers draft KV with target KV; on a full hit D restores both and replays only the last prompt token. EAGLE3/MTP gates exist, but DSpark/GLM5.2 P/D is untested. |

--- a/docs/models/glm52/cuda-graph-png.md
+++ b/docs/models/glm52/cuda-graph-png.md
@@ -1,0 +1,185 @@
+# GLM5.2 decode CUDA Graph PNG export
+
+> **TL;DR:** `--dump-graph-png PATH` now exports GLM5.2 rank 0's live,
+> pre-captured whole-step graph: EP8 and TP4 use bucket 1; TP8 uses its fixed
+> bucket 8. On 8×H200, DSpark-off exports contain 3,144/2,986 nodes and
+> 399/21 PDL edges respectively, with a complete DOT and readable folded PNG.
+>
+> **Last touched:** 2026-07
+
+## Preparation
+
+- **Read**:
+  - `docs/index.md` — located the existing Qwen3 graph exporter and the GLM5.2 whole-step graph and TP8 topology records.
+  - `docs/models/qwen3/cuda-graph-png.md` — established the existing CLI contract: early dependency validation, one complete detailed DOT, and one folded 192-DPI Cairo PNG from the same live graph.
+  - `docs/models/glm52/whole-step-decode-graph.md` — established that every GLM5.2 per-rank whole-step graph covers embed through device argmax, is pre-captured before serving, and currently contains about 2,000 nodes.
+  - `openinfer-core/src/cuda_graph.rs` and `openinfer-core/src/cuda_graph/dump.rs` — confirmed `CudaGraphState` retains the source `CUgraph`, already exposes the model-agnostic inspector/renderer, and fails if asked to dump an uncaptured graph.
+  - `openinfer-glm52/src/lib.rs` — confirmed GLM5.2 launches eight physical workers in either the default DP8/EP8 topology or the mirrored TP8 MoE topology, and identified the launch boundary where dump dependencies can fail before weight loading.
+  - `openinfer-glm52/src/model/mod.rs` — confirmed each decode bucket owns its own persistent `CudaGraphState`; EP8 has buckets 1/2/4/8, while TP8 serves only the fixed bucket-8 shape.
+  - `openinfer-glm52/src/scheduler/mod.rs` — confirmed all required bucket graphs are pre-captured across all ranks before the coordinator accepts requests, providing a safe point to export rank 0 without running an extra model step.
+  - `openinfer-glm52/src/runner.rs` — located the rank-local command boundary needed to inspect the graph on the CUDA-context-owning worker thread.
+  - `openinfer-server/src/config.rs` and `openinfer-server/src/main.rs` — located model-specific CLI applicability, validation tests, and the server-to-`Glm52LaunchOptions` handoff.
+- **Relevant history**:
+  - `docs/models/qwen3/cuda-graph-png.md` records that an unfolded 507-node graph exceeded Graphviz's practical PNG height; GLM5.2's roughly 2,000-node branched graph must be judged from a real render rather than assumed readable.
+  - `docs/models/glm52/whole-step-decode-graph.md` records fork/join event nodes and collective kernels inside the graph, so Qwen3's linear repeated-run folding may not recognize the 78-layer GLM5.2 body.
+- **Plan**:
+  1. Generalize the server help/applicability tests and thread the optional PNG path through `Glm52LaunchOptions`, validating the `.png` path, CUDA driver, Graphviz Cairo renderer, and demangler before loading the checkpoint.
+  2. Add one rank-local graph-dump command and a narrow `Glm52RankModel` accessor. After the existing all-rank pre-capture completes, export rank 0 bucket 1 for EP8 or rank 0 bucket 8 for TP8; normal serving and graph capture stay unchanged when the flag is absent.
+  3. Reuse the shared complete-DOT exporter. Render real EP8 and TP8 graphs on 8×H200; if the PNG is not readable, extend the shared renderer to fold repeated branched layer subgraphs while preserving every physical node and edge in the DOT sidecar.
+  4. Add CPU-side CLI/model-contract coverage, then run release formatting, checks, tests, and Clippy for `openinfer-core`, `openinfer-glm52`, and `openinfer-server` with the GLM5.2 feature.
+  5. On 8×H200, launch both EP8 and TP8 with the flag, verify startup reaches readiness, validate the detailed DOT with Graphviz, inspect PNG dimensions/content, and run one request on each topology. Record sanitized node/edge/kernel counts and artifacts without internal hostnames or private paths.
+  6. Measure dump-disabled versus dump-enabled startup/serving behavior before the required `toxic-reviewer` pass. Address every correctness or performance objection until the change is ready for review, then complete the execution log and debrief.
+- **Risks / open questions**:
+  - The shared renderer currently folds only a repeated linear run. GLM5.2 has layer-internal branches, so readable PNG output may require a topology-aware repeated-DAG folding algorithm.
+  - Export must run on the rank worker that owns the CUDA context; moving the raw graph handle to the coordinator would violate the existing ownership boundary.
+  - TP8 has no bucket-1 graph. Calling its bucket-8 shape "batch 1" would be misleading even though it represents one mirrored logical rank, so the artifact title and log must state both topology and physical bucket.
+
+## Execution Log
+
+### Step 1: Review gate and execution target
+
+- User approved execution and authorized validation on an 8×H200 development host.
+- Internal host aliases and private paths remain outside repository documentation and future GitHub text.
+- Result: approved; implementation started.
+
+### Step 2: First live EP8 export and graph-inspection fixes
+
+- The first 8×H200 EP8 export reached serving readiness and produced a valid
+  detailed graph with 3,149 nodes, 2,933 kernels, and 3,339 edges.
+- The graph contains 399 programmatic-dependent-launch edges. The legacy edge
+  query rejected this graph with `CUDA_ERROR_LOSSY_QUERY`, so inspection now
+  uses the CUDA 12.3 edge-v2 API and records ports plus dependency type in the
+  detailed DOT. The human view distinguishes non-default dependencies.
+- Feeding roughly 3,000 symbols to `c++filt` exposed a pipe deadlock: the
+  parent filled stdin while the child filled stdout. Input now runs on a
+  writer thread while the parent drains output, with a stream larger than one
+  pipe covered by a regression test.
+- Exact repeated-DAG folding reduced the physical graph to six repeated blocks,
+  but the first PNG still reached Graphviz's 32,767-pixel raster-height limit.
+  Inspection showed five DSpark hidden-state copies in a launch that did not
+  request a drafter. The user clarified the runtime contract: without
+  `--dspark-path`, the live graph itself must omit DSpark work rather than the
+  PNG hiding it.
+
+### Step 3: Make DSpark capture launch-configured
+
+- The launch-time DSpark decision now reaches rank-model construction.
+  Per-bucket capture storage is optional: ordinary decode allocates no DSpark
+  capture row and submits no capture copies; DSpark launches retain both.
+- Attempting to read captured context from a model built without DSpark fails
+  explicitly instead of returning an unrelated buffer.
+- Local release validation: GLM5.2/server feature check passed; GLM5.2 library
+  tests passed 57/57 with 14 hardware tests intentionally ignored.
+- Live 8×H200 EP8 validation passed without a drafter: 3,144 nodes, 2,928
+  kernels, 3,334 edges, zero `copy_hidden_rows_kernel` nodes, and all 399
+  programmatic dependencies retained. The detailed DOT reparsed successfully,
+  an HTTP completion returned 200, and the folded PNG shrank from the raster
+  ceiling to 2,611×11,538. Removing the five unused capture copies restored a
+  162-node four-layer macroblock repeated 17 times.
+
+### Step 4: TP8 live export
+
+- User authorized the previously deferred TP8 run. Validation uses rank 0's
+  fixed physical bucket-8 graph and keeps DSpark disabled.
+- Live 8×H200 validation passed: 2,986 nodes, 2,770 kernels, 3,026
+  edges, zero `copy_hidden_rows_kernel` nodes, and 21 programmatic
+  dependencies. The detailed DOT reparsed successfully, an HTTP completion
+  returned 200, and the PNG is 3,045×11,911.
+- The title identifies `MoE TP8`, `mirrored`, and physical bucket 8; it does
+  not call this a batch-1 graph. Export took about 1.69 seconds after
+  pre-capture; total TP8 startup was 167.5 seconds, dominated by the known
+  all-layer expert-slice load.
+- Result: passed; the service was stopped and all GPU processes released after
+  copying the artifact.
+
+### Step 5: Renderer correctness review
+
+- The required post-measurement review accepted CUDA-context ownership,
+  pre-capture/export teardown, PDL metadata, DSpark gating, and topology/bucket
+  selection, then found three renderer defects before handoff.
+- Repeated blocks now require a real, identical dependency boundary between
+  adjacent copies. Identical but disconnected parallel subgraphs are not
+  presented as a sequential `×N` block.
+- Candidate selection now preserves the primitive period instead of rewarding
+  a larger opaque bundle. A 14-kernel body repeated 36 times remains `14×36`,
+  preserving the established Qwen3 output contract.
+- Graphviz and `c++filt` share one subprocess communication path that writes
+  stdin while draining stdout/stderr. A test moves more than one pipe of data
+  in both output streams to prevent the startup deadlock from returning.
+- Human rendering moved into its own module, GLM5.2 graph pre-capture/export
+  moved out of the scheduler body, and the captured layer-step body moved out
+  of `model/mod.rs`. All touched files are below the project's 1,000-line
+  ceiling.
+- Post-fix 8×H200 exports preserved the measured graph structure and image
+  dimensions: EP8 remained 3,144 nodes/3,334 edges/399 PDL at 2,611×11,538;
+  TP8 remained 2,986 nodes/3,026 edges/21 PDL at 3,045×11,911. Both detailed
+  DOT files reparsed with Graphviz, both one-token requests returned HTTP 200,
+  and both graphs still contained zero DSpark copy kernels.
+- Release validation passed for `openinfer-core` (27/27, including all 12 graph
+  tests), GLM5.2 library tests (57/57, 14 hardware tests ignored), server
+  graph-CLI tests (4/4), the GLM5.2/server feature check, formatting, diff
+  whitespace, and strict
+  `openinfer-core` Clippy. Strict GLM5.2 Clippy remains blocked by seven
+  unrelated existing lints outside this change.
+
+### Step 5b: TP4 live export after the TP4-serving rebase
+
+- Rebasing onto the merged GLM5.2 TP4/GB300 serving path (`#637`) re-based the
+  extracted step body and scheduler graph module on the generalized
+  tensor-replicated runtime: the export bucket now keys on the full-bucket
+  contract rather than mirroring (EP8 and TP4 have a true bucket-1 graph; TP8
+  keeps its fixed bucket 8), and the exported step body carries the TP4
+  vocabulary-parallel greedy tail.
+- 4×GB300 TP4 live export: bucket-1 graph at 2,547 nodes / 2,334 kernels /
+  2,587 edges, complete DOT reparsed with Graphviz, 2,171×17,098 PNG, and the
+  greedy HTTP smoke unchanged. The DSpark-off graph contains the 75 TP4
+  MoE eight-row bridge copies (one per MoE layer — a legitimate serving use of
+  the same copy kernel) and zero DSpark aux-capture copies.
+
+### Step 6: Review handoff
+
+- Three post-measurement review passes reached Ready for Review after fixing
+  renderer semantics, subprocess communication, Qwen period compatibility,
+  and every file-size violation introduced or exposed by this work.
+- The publication scope contains implementation, tests, and living docs. The
+  two rendered PNGs remain untracked local artifacts because they are for
+  visual inspection rather than repository assets.
+
+## Performance Work
+
+No optimization claim is made. A same-build, same-cap EP8 A/B on 8×H200 makes
+the opt-in diagnostic cost explicit:
+
+| metric | no dump | `--dump-graph-png` | delta |
+|---|---:|---:|---:|
+| `Engine loaded` | 73.207 s | 75.841 s | +2.634 s |
+| identical one-token request, server wall | 20.423 ms | 20.442 ms | +0.019 ms |
+
+The enabled run spent 1.139 seconds inspecting/folding/rendering after graph
+pre-capture. The remaining startup delta is primarily the enabled path waiting
+for pre-capture before publishing the engine; without a dump, pre-capture can
+finish behind frontend startup. The request delta is noise-sized, consistent
+with export having no serving-time branch.
+
+## Debrief
+
+The opt-in export now follows the same caller contract for Qwen3 and GLM5.2,
+while model-specific code selects the only graph that the chosen topology can
+actually serve. CUDA inspection remains on the rank worker that owns the
+context; the coordinator only requests export after the all-rank pre-capture
+barrier and reports success or tears every worker down on failure.
+
+The live graph, not merely its rendering, follows launch configuration:
+without `--dspark-path`, no capture buffer is allocated and no hidden-state
+copy is submitted. The detailed DOT is the lossless artifact, including PDL
+ports and dependency types. The PNG is a verified projection: it folds only
+topologically identical, sequential repeated DAGs and preserves primitive
+periods such as Qwen3's 14-kernel layer.
+
+The measured cost is diagnostic startup work, not a decode optimization:
+same-build EP8 startup increased by 2.634 seconds, while the observed
+one-token serving delta was 0.019 ms. The two user-facing PNGs remain local
+artifacts and must not be included in a code commit.
+
+Next action: review the published pull request; there is no known
+implementation or validation blocker.

--- a/docs/models/glm52/dspark-mtp.md
+++ b/docs/models/glm52/dspark-mtp.md
@@ -53,7 +53,8 @@ The engine is decode-only ("prompt tokens ride the decode path one position at a
 New step surface (contained): allow repeated slots with strictly increasing per-slot positions,
 per-row block-table gather for bucket 8, and an **aux-hidden capture buffer** — 5 dtod copies of
 the residual stream after layers {8,23,39,55,70} into a pre-allocated `[8, 30720]` buffer inside
-the whole-step graph (~480 KB/step; pointer-stable, graph-safe).
+the whole-step graph (~480 KB/step; pointer-stable, graph-safe). The buffer and copy nodes exist
+only when `--dspark-path` is present; ordinary decode graphs contain neither.
 
 ## Round cadence (M3)
 

--- a/openinfer-core/src/cuda_graph/dump.rs
+++ b/openinfer-core/src/cuda_graph/dump.rs
@@ -3,12 +3,14 @@ use std::ffi::CStr;
 use std::fmt::Write as _;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Output, Stdio};
 
 use anyhow::{Context, Result, ensure};
 use cudarc::driver::sys::{self, CUgraphNode};
 
 use super::{CudaGraphState, check};
+
+mod render;
 
 #[derive(Clone, Debug)]
 pub struct CudaGraphDumpSummary {
@@ -21,7 +23,7 @@ pub struct CudaGraphDumpSummary {
 
 struct GraphDescription {
     nodes: Vec<GraphNode>,
-    edges: Vec<(usize, usize)>,
+    edges: Vec<GraphEdge>,
 }
 
 struct GraphNode {
@@ -29,10 +31,25 @@ struct GraphNode {
 }
 
 #[derive(Clone, Copy)]
-struct RepeatedRun {
-    start: usize,
-    width: usize,
-    repetitions: usize,
+struct GraphEdge {
+    from: usize,
+    to: usize,
+    from_port: u8,
+    to_port: u8,
+    dependency_type: u8,
+}
+
+impl GraphEdge {
+    #[cfg(test)]
+    fn ordinary(from: usize, to: usize) -> Self {
+        Self {
+            from,
+            to,
+            from_port: 0,
+            to_port: 0,
+            dependency_type: 0,
+        }
+    }
 }
 
 enum GraphNodeKind {
@@ -174,7 +191,7 @@ impl CudaGraphState {
             .collect();
         let edges = graph_edges(self.graph)?
             .into_iter()
-            .map(|(from, to)| {
+            .map(|(from, to, data)| {
                 let from = handle_to_index
                     .get(&(from as usize))
                     .copied()
@@ -183,7 +200,13 @@ impl CudaGraphState {
                     .get(&(to as usize))
                     .copied()
                     .context("CUDA graph edge destination is absent from the node list")?;
-                Ok((from, to))
+                Ok(GraphEdge {
+                    from,
+                    to,
+                    from_port: data.from_port,
+                    to_port: data.to_port,
+                    dependency_type: data.type_,
+                })
             })
             .collect::<Result<Vec<_>>>()?;
         Ok(GraphDescription { nodes, edges })
@@ -217,12 +240,15 @@ fn graph_nodes(graph: sys::CUgraph) -> Result<Vec<CUgraphNode>> {
     Ok(nodes)
 }
 
-fn graph_edges(graph: sys::CUgraph) -> Result<Vec<(CUgraphNode, CUgraphNode)>> {
+fn graph_edges(
+    graph: sys::CUgraph,
+) -> Result<Vec<(CUgraphNode, CUgraphNode, sys::CUgraphEdgeData)>> {
     let mut count = 0usize;
     check(
         unsafe {
-            sys::cuGraphGetEdges(
+            sys::cuGraphGetEdges_v2(
                 graph,
+                std::ptr::null_mut(),
                 std::ptr::null_mut(),
                 std::ptr::null_mut(),
                 &raw mut count,
@@ -232,11 +258,34 @@ fn graph_edges(graph: sys::CUgraph) -> Result<Vec<(CUgraphNode, CUgraphNode)>> {
     )?;
     let mut from = vec![std::ptr::null_mut(); count];
     let mut to = vec![std::ptr::null_mut(); count];
+    let mut data = vec![
+        sys::CUgraphEdgeData {
+            from_port: 0,
+            to_port: 0,
+            type_: 0,
+            reserved: [0; 5],
+        };
+        count
+    ];
     check(
-        unsafe { sys::cuGraphGetEdges(graph, from.as_mut_ptr(), to.as_mut_ptr(), &raw mut count) },
+        unsafe {
+            sys::cuGraphGetEdges_v2(
+                graph,
+                from.as_mut_ptr(),
+                to.as_mut_ptr(),
+                data.as_mut_ptr(),
+                &raw mut count,
+            )
+        },
         "cuGraphGetEdges(edges)",
     )?;
-    Ok(from.into_iter().zip(to).take(count).collect())
+    Ok(from
+        .into_iter()
+        .zip(to)
+        .zip(data)
+        .take(count)
+        .map(|((from, to), data)| (from, to, data))
+        .collect())
 }
 
 fn inspect_node(node: CUgraphNode) -> Result<RawNodeKind> {
@@ -286,19 +335,17 @@ fn demangle(symbols: &[&str]) -> Result<Vec<String>> {
     if symbols.is_empty() {
         return Ok(Vec::new());
     }
-    let mut child = Command::new("c++filt")
+    let child = Command::new("c++filt")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .context("spawn C++ demangler `c++filt`")?;
-    {
-        let stdin = child.stdin.as_mut().context("open c++filt stdin")?;
-        for symbol in symbols {
-            writeln!(stdin, "{symbol}").context("write symbol to c++filt")?;
-        }
+    let mut input = String::new();
+    for symbol in symbols {
+        writeln!(input, "{symbol}").expect("writing to a String cannot fail");
     }
-    let output = child.wait_with_output().context("wait for c++filt")?;
+    let output = communicate(child, input, "c++filt")?;
     ensure!(
         output.status.success(),
         "c++filt failed: {}",
@@ -319,7 +366,7 @@ fn demangle(symbols: &[&str]) -> Result<Vec<String>> {
 }
 
 fn render_png(dot: &str, png_path: &Path) -> Result<()> {
-    let mut child = Command::new("dot")
+    let child = Command::new("dot")
         .args(["-Tpng:cairo", "-Gdpi=192", "-o"])
         .arg(png_path)
         .stdin(Stdio::piped())
@@ -327,13 +374,7 @@ fn render_png(dot: &str, png_path: &Path) -> Result<()> {
         .stderr(Stdio::piped())
         .spawn()
         .context("spawn Graphviz `dot`")?;
-    child
-        .stdin
-        .as_mut()
-        .context("open Graphviz stdin")?
-        .write_all(dot.as_bytes())
-        .context("write clean CUDA Graph DOT to Graphviz")?;
-    let output = child.wait_with_output().context("wait for Graphviz")?;
+    let output = communicate(child, dot.to_owned(), "Graphviz")?;
     ensure!(
         output.status.success(),
         "Graphviz failed to render {}: {}",
@@ -341,6 +382,27 @@ fn render_png(dot: &str, png_path: &Path) -> Result<()> {
         String::from_utf8_lossy(&output.stderr).trim()
     );
     Ok(())
+}
+
+fn communicate(mut child: Child, input: String, program: &'static str) -> Result<Output> {
+    let mut stdin = child
+        .stdin
+        .take()
+        .with_context(|| format!("open {program} stdin"))?;
+    // Whole-step graphs are larger than an OS pipe. Feed stdin concurrently
+    // while `wait_with_output` drains stdout/stderr, so neither side can fill
+    // a pipe while waiting for the other side to make progress.
+    let writer = std::thread::spawn(move || stdin.write_all(input.as_bytes()));
+    let output = child
+        .wait_with_output()
+        .with_context(|| format!("wait for {program}"))?;
+    let write_result = writer
+        .join()
+        .map_err(|_| anyhow::anyhow!("{program} stdin writer panicked"))?;
+    if output.status.success() {
+        write_result.with_context(|| format!("write input to {program}"))?;
+    }
+    Ok(output)
 }
 
 impl GraphDescription {
@@ -368,185 +430,19 @@ impl GraphDescription {
             };
             let _ = writeln!(dot, "  n{index} [label=\"{label}\"];");
         }
-        for &(from, to) in &self.edges {
-            let _ = writeln!(dot, "  n{from} -> n{to};");
-        }
-        dot.push_str("}\n");
-        dot
-    }
-
-    fn human_dot(&self, title: &str) -> String {
-        let mut indegree = vec![0usize; self.nodes.len()];
-        let mut outdegree = vec![0usize; self.nodes.len()];
-        for &(from, to) in &self.edges {
-            outdegree[from] += 1;
-            indegree[to] += 1;
-        }
-
-        let mut dot = String::from("digraph cuda_graph {\n");
-        let _ = writeln!(
-            dot,
-            "  graph [rankdir=TB, bgcolor=\"white\", pad=0.2, nodesep=0.25, ranksep=0.35, fontname=\"Helvetica\", label=\"{}\", labelloc=t, fontsize=18];",
-            dot_escape(title)
-        );
-        dot.push_str(
-            "  node [shape=box, style=\"rounded,filled\", color=\"#374151\", \
-             fontname=\"Helvetica\", fontsize=10, margin=\"0.12,0.08\"];\n",
-        );
-        dot.push_str("  edge [color=\"#6B7280\", arrowsize=0.6];\n");
-        if let Some((order, repeated)) = self.repeated_linear_run() {
-            let first_end = repeated.start + repeated.width;
-            let repeated_end = repeated.start + repeated.width * repeated.repetitions;
-            for &index in &order[..repeated.start] {
-                self.write_human_node(&mut dot, index, indegree[index], outdegree[index]);
-            }
+        for edge in &self.edges {
             let _ = writeln!(
                 dot,
-                "  subgraph cluster_repeated {{\n    label=\"Repeated physical block ×{} · {} kernels/instance\";\n    color=\"#9CA3AF\";\n    style=\"rounded,dashed\";",
-                repeated.repetitions, repeated.width
+                "  n{} -> n{} [label=\"from_port={}\\nto_port={}\\ndependency_type={}\"];",
+                edge.from,
+                edge.to,
+                edge.from_port,
+                edge.to_port,
+                dependency_type_name(edge.dependency_type),
             );
-            for &index in &order[repeated.start..first_end] {
-                self.write_human_node(&mut dot, index, indegree[index], outdegree[index]);
-            }
-            dot.push_str("  }\n");
-            for &index in &order[repeated_end..] {
-                self.write_human_node(&mut dot, index, indegree[index], outdegree[index]);
-            }
-
-            let visible_order = order[..first_end]
-                .iter()
-                .chain(order[repeated_end..].iter())
-                .copied()
-                .collect::<Vec<_>>();
-            for pair in visible_order.windows(2) {
-                let label = if pair[0] == order[first_end - 1] {
-                    format!(" [label=\"after ×{}\", fontsize=9]", repeated.repetitions)
-                } else {
-                    String::new()
-                };
-                let _ = writeln!(dot, "  n{} -> n{}{};", pair[0], pair[1], label);
-            }
-        } else {
-            for index in 0..self.nodes.len() {
-                self.write_human_node(&mut dot, index, indegree[index], outdegree[index]);
-            }
-            for &(from, to) in &self.edges {
-                let _ = writeln!(dot, "  n{from} -> n{to};");
-            }
         }
         dot.push_str("}\n");
         dot
-    }
-
-    fn write_human_node(&self, dot: &mut String, index: usize, indegree: usize, outdegree: usize) {
-        let fill = node_color(indegree, outdegree);
-        let label = match &self.nodes[index].kind {
-            GraphNodeKind::Kernel {
-                demangled,
-                grid,
-                block,
-                dynamic_shared_mem_bytes,
-                ..
-            } => format!(
-                "{}\\ngrid={} block={} dynamic_smem={}",
-                dot_escape(&compact_kernel_name(demangled)),
-                dims(*grid),
-                dims(*block),
-                dynamic_shared_mem_bytes,
-            ),
-            GraphNodeKind::Other { node_type } => dot_escape(&node_type.to_ascii_uppercase()),
-        };
-        let _ = writeln!(dot, "  n{index} [fillcolor=\"{fill}\", label=\"{label}\"];");
-    }
-
-    fn repeated_linear_run(&self) -> Option<(Vec<usize>, RepeatedRun)> {
-        let order = self.linear_order()?;
-        let signatures = order
-            .iter()
-            .map(|&index| self.nodes[index].signature())
-            .collect::<Vec<_>>();
-        let mut best = None::<RepeatedRun>;
-        for start in 0..signatures.len() {
-            let max_width = (signatures.len() - start) / 3;
-            for width in 2..=max_width {
-                let pattern = &signatures[start..start + width];
-                let mut repetitions = 1usize;
-                while start + (repetitions + 1) * width <= signatures.len()
-                    && signatures[start + repetitions * width..start + (repetitions + 1) * width]
-                        == *pattern
-                {
-                    repetitions += 1;
-                }
-                if repetitions < 3 {
-                    continue;
-                }
-                let candidate = RepeatedRun {
-                    start,
-                    width,
-                    repetitions,
-                };
-                let better = best.is_none_or(|current| {
-                    let covered = candidate.width * candidate.repetitions;
-                    let current_covered = current.width * current.repetitions;
-                    covered > current_covered
-                        || (covered == current_covered
-                            && candidate.repetitions > current.repetitions)
-                });
-                if better {
-                    best = Some(candidate);
-                }
-            }
-        }
-        let repeated = best?;
-        (repeated.width * repeated.repetitions >= self.nodes.len() / 2).then_some((order, repeated))
-    }
-
-    fn linear_order(&self) -> Option<Vec<usize>> {
-        if self.nodes.is_empty() || self.edges.len() + 1 != self.nodes.len() {
-            return None;
-        }
-        let mut indegree = vec![0usize; self.nodes.len()];
-        let mut next = vec![None; self.nodes.len()];
-        for &(from, to) in &self.edges {
-            indegree[to] += 1;
-            if indegree[to] > 1 || next[from].replace(to).is_some() {
-                return None;
-            }
-        }
-        let roots = indegree
-            .iter()
-            .enumerate()
-            .filter_map(|(index, &degree)| (degree == 0).then_some(index))
-            .collect::<Vec<_>>();
-        if roots.len() != 1 {
-            return None;
-        }
-        let mut order = Vec::with_capacity(self.nodes.len());
-        let mut cursor = Some(roots[0]);
-        while let Some(index) = cursor {
-            order.push(index);
-            cursor = next[index];
-        }
-        (order.len() == self.nodes.len()).then_some(order)
-    }
-}
-
-impl GraphNode {
-    fn signature(&self) -> String {
-        match &self.kind {
-            GraphNodeKind::Kernel {
-                raw_symbol,
-                grid,
-                block,
-                dynamic_shared_mem_bytes,
-                ..
-            } => format!(
-                "kernel|{raw_symbol}|{}|{}|{dynamic_shared_mem_bytes}",
-                dims(*grid),
-                dims(*block)
-            ),
-            GraphNodeKind::Other { node_type } => format!("other|{node_type}"),
-        }
     }
 }
 
@@ -554,48 +450,12 @@ fn dims(dims: [u32; 3]) -> String {
     format!("({},{},{})", dims[0], dims[1], dims[2])
 }
 
-fn node_color(indegree: usize, outdegree: usize) -> &'static str {
-    if indegree == 0 {
-        "#DCEEFF"
-    } else if outdegree == 0 {
-        "#E8DEFF"
-    } else if indegree > 1 {
-        "#FFE8C2"
-    } else if outdegree > 1 {
-        "#E3F6E8"
-    } else {
-        "#F5F5F5"
+fn dependency_type_name(dependency_type: u8) -> String {
+    match dependency_type {
+        0 => "default".to_owned(),
+        1 => "programmatic".to_owned(),
+        other => format!("unknown({other})"),
     }
-}
-
-fn compact_kernel_name(name: &str) -> String {
-    const MAX_CHARS: usize = 72;
-
-    if name.contains("internal::gemvx::kernel") {
-        return "cuBLAS GEMV".to_owned();
-    }
-    let signature = name.rsplit_once('(').map_or(name, |(name, _)| name);
-    let mut compact = String::with_capacity(signature.len());
-    let mut template_depth = 0usize;
-    for ch in signature.chars() {
-        match ch {
-            '<' => {
-                if template_depth == 0 {
-                    compact.push_str("<…>");
-                }
-                template_depth += 1;
-            }
-            '>' if template_depth > 0 => template_depth -= 1,
-            _ if template_depth == 0 => compact.push(ch),
-            _ => {}
-        }
-    }
-    let leaf = compact.rsplit("::").next().unwrap_or(&compact);
-    if leaf.chars().count() <= MAX_CHARS {
-        return leaf.to_owned();
-    }
-    let prefix = leaf.chars().take(MAX_CHARS - 1).collect::<String>();
-    format!("{prefix}…")
 }
 
 fn dot_escape(value: &str) -> String {
@@ -609,23 +469,9 @@ fn dot_escape(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        GraphDescription, GraphNode, GraphNodeKind, compact_kernel_name, dot_escape,
+        GraphDescription, GraphEdge, GraphNode, GraphNodeKind, communicate, demangle, dot_escape,
         format_driver_api_version,
     };
-
-    #[test]
-    fn compact_name_drops_namespace_signature_and_template_body() {
-        assert_eq!(
-            compact_kernel_name("flashinfer::BatchDecodeKernel<128, foo::Bar>(float*, int)"),
-            "BatchDecodeKernel<…>"
-        );
-        assert_eq!(
-            compact_kernel_name(
-                "std::enable_if<true, void>::type internal::gemvx::kernel<int>(int)"
-            ),
-            "cuBLAS GEMV"
-        );
-    }
 
     #[test]
     fn dot_label_escaping_preserves_graph_syntax() {
@@ -640,28 +486,69 @@ mod tests {
     }
 
     #[test]
-    fn human_dot_folds_a_repeated_linear_block() {
-        let kernel = |name: &str| GraphNode {
-            kind: GraphNodeKind::Kernel {
-                raw_symbol: name.to_string(),
-                demangled: format!("{name}()"),
-                grid: [1, 1, 1],
-                block: [32, 1, 1],
-                dynamic_shared_mem_bytes: 0,
+    fn demangle_drains_output_larger_than_a_pipe() {
+        if std::process::Command::new("c++filt")
+            .arg("--version")
+            .output()
+            .is_err()
+        {
+            return;
+        }
+        let symbols = (0..2_048)
+            .map(|index| format!("plain_symbol_{index:04}_{}", "x".repeat(96)))
+            .collect::<Vec<_>>();
+        let refs = symbols.iter().map(String::as_str).collect::<Vec<_>>();
+
+        let names = demangle(&refs).expect("large c++filt stream");
+
+        assert_eq!(names, symbols);
+    }
+
+    #[test]
+    fn subprocess_communication_drains_stdout_and_stderr() {
+        let child = std::process::Command::new("sh")
+            .args([
+                "-c",
+                "while IFS= read -r line; do printf '%s\\n' \"$line\"; printf '%s\\n' \"$line\" >&2; done",
+            ])
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn pipe stress child");
+        let input = (0..2_048)
+            .map(|index| format!("line_{index:04}_{}\n", "x".repeat(96)))
+            .collect::<String>();
+
+        let output = communicate(child, input.clone(), "pipe stress child")
+            .expect("communicate with pipe stress child");
+
+        assert_eq!(output.stdout, input.as_bytes());
+        assert_eq!(output.stderr, input.as_bytes());
+    }
+
+    #[test]
+    fn dot_preserves_programmatic_edge_metadata() {
+        let node = || GraphNode {
+            kind: GraphNodeKind::Other {
+                node_type: "empty".to_owned(),
             },
         };
-        let names = ["head", "a", "b", "a", "b", "a", "b", "tail"];
         let graph = GraphDescription {
-            nodes: names.into_iter().map(kernel).collect(),
-            edges: (0..7).map(|index| (index, index + 1)).collect(),
+            nodes: vec![node(), node()],
+            edges: vec![GraphEdge {
+                from: 0,
+                to: 1,
+                from_port: 1,
+                to_port: 0,
+                dependency_type: 1,
+            }],
         };
 
-        let dot = graph.human_dot("test graph");
+        let detailed = graph.detailed_dot();
+        let human = graph.human_dot("programmatic edge");
 
-        assert!(dot.contains("label=\"test graph\""));
-        assert!(dot.contains("Repeated physical block ×3 · 2 kernels/instance"));
-        assert!(dot.contains("n0 -> n1"));
-        assert!(dot.contains("n2 -> n7 [label=\"after ×3\""));
-        assert!(!dot.contains("n3 [fillcolor"));
+        assert!(detailed.contains("from_port=1\\nto_port=0\\ndependency_type=programmatic"));
+        assert!(human.contains("style=dashed, label=\"programmatic · port 1→0\""));
     }
 }

--- a/openinfer-core/src/cuda_graph/dump/render.rs
+++ b/openinfer-core/src/cuda_graph/dump/render.rs
@@ -1,0 +1,596 @@
+use std::collections::HashSet;
+use std::fmt::Write as _;
+
+use super::{GraphDescription, GraphNode, GraphNodeKind, dependency_type_name, dims, dot_escape};
+
+const MAX_VISIBLE_REPEAT_WIDTH: usize = 32;
+
+#[derive(Clone, Copy)]
+struct RepeatedRun {
+    start: usize,
+    width: usize,
+    repetitions: usize,
+}
+
+impl RepeatedRun {
+    fn end(self) -> usize {
+        self.start + self.width * self.repetitions
+    }
+
+    fn display_cost(self) -> usize {
+        if self.width <= MAX_VISIBLE_REPEAT_WIDTH {
+            self.width
+        } else {
+            1
+        }
+    }
+
+    fn saved_nodes(self) -> usize {
+        self.width * self.repetitions - self.display_cost()
+    }
+}
+
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+enum HumanNodeId {
+    Original(usize),
+    RepeatedSummary(usize),
+}
+
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+struct HumanEdge {
+    from: HumanNodeId,
+    to: HumanNodeId,
+    from_port: u8,
+    to_port: u8,
+    dependency_type: u8,
+    after_repetitions: Option<usize>,
+}
+
+impl GraphDescription {
+    pub(super) fn human_dot(&self, title: &str) -> String {
+        let mut indegree = vec![0usize; self.nodes.len()];
+        let mut outdegree = vec![0usize; self.nodes.len()];
+        for edge in &self.edges {
+            outdegree[edge.from] += 1;
+            indegree[edge.to] += 1;
+        }
+
+        let mut dot = String::from("digraph cuda_graph {\n");
+        let _ = writeln!(
+            dot,
+            "  graph [rankdir=TB, bgcolor=\"white\", pad=0.2, nodesep=0.25, ranksep=0.35, fontname=\"Helvetica\", label=\"{}\", labelloc=t, fontsize=18];",
+            dot_escape(title)
+        );
+        dot.push_str(
+            "  node [shape=box, style=\"rounded,filled\", color=\"#374151\", \
+             fontname=\"Helvetica\", fontsize=10, margin=\"0.12,0.08\"];\n",
+        );
+        dot.push_str("  edge [color=\"#6B7280\", arrowsize=0.6];\n");
+        let repeated = self.repeated_dag_runs();
+        let mut cursor = 0usize;
+        for (run_index, &run) in repeated.iter().enumerate() {
+            for index in cursor..run.start {
+                self.write_human_node(&mut dot, index, indegree[index], outdegree[index]);
+            }
+            self.write_repeated_run(&mut dot, run_index, run, &indegree, &outdegree);
+            cursor = run.end();
+        }
+        for index in cursor..self.nodes.len() {
+            self.write_human_node(&mut dot, index, indegree[index], outdegree[index]);
+        }
+
+        let mut written = HashSet::new();
+        for edge in &self.edges {
+            let from_run = run_membership(edge.from, &repeated);
+            let to_run = run_membership(edge.to, &repeated);
+            if matches!((from_run, to_run), (Some((left, left_copy, _)), Some((right, right_copy, _))) if left == right && left_copy != right_copy)
+            {
+                continue;
+            }
+            let projected = HumanEdge {
+                from: project_node(edge.from, from_run, &repeated),
+                to: project_node(edge.to, to_run, &repeated),
+                from_port: edge.from_port,
+                to_port: edge.to_port,
+                dependency_type: edge.dependency_type,
+                after_repetitions: from_run.and_then(|(run_index, copy, _)| {
+                    let run = repeated[run_index];
+                    (copy + 1 == run.repetitions
+                        && to_run.is_none_or(|(to_run_index, _, _)| to_run_index != run_index))
+                    .then_some(run.repetitions)
+                }),
+            };
+            if projected.from != projected.to && written.insert(projected) {
+                write_human_edge(&mut dot, projected);
+            }
+        }
+        dot.push_str("}\n");
+        dot
+    }
+
+    fn write_human_node(&self, dot: &mut String, index: usize, indegree: usize, outdegree: usize) {
+        let fill = node_color(indegree, outdegree);
+        let label = match &self.nodes[index].kind {
+            GraphNodeKind::Kernel {
+                demangled,
+                grid,
+                block,
+                dynamic_shared_mem_bytes,
+                ..
+            } => format!(
+                "{}\\ngrid={} block={} dynamic_smem={}",
+                dot_escape(&compact_kernel_name(demangled)),
+                dims(*grid),
+                dims(*block),
+                dynamic_shared_mem_bytes,
+            ),
+            GraphNodeKind::Other { node_type } => dot_escape(&node_type.to_ascii_uppercase()),
+        };
+        let _ = writeln!(dot, "  n{index} [fillcolor=\"{fill}\", label=\"{label}\"];");
+    }
+
+    fn write_repeated_run(
+        &self,
+        dot: &mut String,
+        run_index: usize,
+        run: RepeatedRun,
+        indegree: &[usize],
+        outdegree: &[usize],
+    ) {
+        let kernels = self.nodes[run.start..run.start + run.width]
+            .iter()
+            .filter(|node| matches!(&node.kind, GraphNodeKind::Kernel { .. }))
+            .count();
+        let instance_description = if kernels == run.width {
+            format!("{} kernels/instance", run.width)
+        } else {
+            format!("{} nodes/instance · {kernels} kernels/instance", run.width)
+        };
+        let _ = writeln!(
+            dot,
+            "  subgraph cluster_repeated_{run_index} {{\n    label=\"Repeated physical block ×{} · {instance_description}\";\n    color=\"#9CA3AF\";\n    style=\"rounded,dashed\";",
+            run.repetitions,
+        );
+        if run.width <= MAX_VISIBLE_REPEAT_WIDTH {
+            for index in run.start..run.start + run.width {
+                self.write_human_node(dot, index, indegree[index], outdegree[index]);
+            }
+        } else {
+            let _ = writeln!(
+                dot,
+                "    r{run_index} [shape=component, fillcolor=\"#F3F4F6\", label=\"Folded repeated subgraph\\n{} nodes and {kernels} kernels per instance\\nphysical repetitions ×{}\"];",
+                run.width, run.repetitions,
+            );
+        }
+        dot.push_str("  }\n");
+    }
+
+    fn repeated_dag_runs(&self) -> Vec<RepeatedRun> {
+        let signatures = self
+            .nodes
+            .iter()
+            .map(GraphNode::signature)
+            .collect::<Vec<_>>();
+        let mut candidates = Vec::new();
+        for start in 0..signatures.len() {
+            let max_width = (signatures.len() - start) / 3;
+            let mut primitive_widths = Vec::new();
+            for width in 2..=max_width {
+                let first = &signatures[start..start + width];
+                if signatures[start + width..start + 2 * width] != *first
+                    || signatures[start + 2 * width..start + 3 * width] != *first
+                {
+                    continue;
+                }
+                let mut repetitions = 3usize;
+                while start + (repetitions + 1) * width <= signatures.len()
+                    && signatures[start + repetitions * width..start + (repetitions + 1) * width]
+                        == *first
+                {
+                    repetitions += 1;
+                }
+                let mut candidate = None;
+                for repetitions in (3..=repetitions).rev() {
+                    let run = RepeatedRun {
+                        start,
+                        width,
+                        repetitions,
+                    };
+                    if self.is_repeated_dag(run) {
+                        candidate = Some(run);
+                        break;
+                    }
+                }
+                let Some(candidate) = candidate else {
+                    continue;
+                };
+                let bundled_primitive = primitive_widths.iter().copied().any(|primitive_width| {
+                    width % primitive_width == 0
+                        && first
+                            .chunks_exact(primitive_width)
+                            .all(|chunk| chunk == &first[..primitive_width])
+                });
+                if bundled_primitive {
+                    continue;
+                }
+                primitive_widths.push(width);
+                candidates.push(candidate);
+            }
+        }
+        let runs = select_non_overlapping_runs(candidates);
+        let saved = runs.iter().map(|run| run.saved_nodes()).sum::<usize>();
+        if saved.saturating_mul(2) >= self.nodes.len() {
+            runs
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn is_repeated_dag(&self, run: RepeatedRun) -> bool {
+        let mut internal = vec![Vec::new(); run.repetitions];
+        let mut boundaries = vec![Vec::new(); run.repetitions - 1];
+        for edge in &self.edges {
+            let from = repeated_node_position(edge.from, run);
+            let to = repeated_node_position(edge.to, run);
+            match (from, to) {
+                (Some((from_copy, from_offset)), Some((to_copy, to_offset)))
+                    if from_copy == to_copy =>
+                {
+                    internal[from_copy].push((
+                        from_offset,
+                        to_offset,
+                        edge.from_port,
+                        edge.to_port,
+                        edge.dependency_type,
+                    ));
+                }
+                (Some((from_copy, from_offset)), Some((to_copy, to_offset)))
+                    if from_copy + 1 == to_copy =>
+                {
+                    boundaries[from_copy].push((
+                        from_offset,
+                        to_offset,
+                        edge.from_port,
+                        edge.to_port,
+                        edge.dependency_type,
+                    ));
+                }
+                (Some(_), Some(_)) => return false,
+                (None, Some((to_copy, _))) if to_copy != 0 => return false,
+                (Some((from_copy, _)), None) if from_copy + 1 != run.repetitions => return false,
+                _ => {}
+            }
+        }
+        for edges in internal.iter_mut().chain(boundaries.iter_mut()) {
+            edges.sort_unstable();
+        }
+        boundaries.iter().all(|edges| !edges.is_empty())
+            && internal.windows(2).all(|pair| pair[0] == pair[1])
+            && boundaries.windows(2).all(|pair| pair[0] == pair[1])
+    }
+}
+
+impl GraphNode {
+    fn signature(&self) -> String {
+        match &self.kind {
+            GraphNodeKind::Kernel {
+                raw_symbol,
+                grid,
+                block,
+                dynamic_shared_mem_bytes,
+                ..
+            } => format!(
+                "kernel|{raw_symbol}|{}|{}|{dynamic_shared_mem_bytes}",
+                dims(*grid),
+                dims(*block)
+            ),
+            GraphNodeKind::Other { node_type } => format!("other|{node_type}"),
+        }
+    }
+}
+
+fn repeated_node_position(index: usize, run: RepeatedRun) -> Option<(usize, usize)> {
+    (run.start..run.end()).contains(&index).then(|| {
+        let offset = index - run.start;
+        (offset / run.width, offset % run.width)
+    })
+}
+
+fn select_non_overlapping_runs(mut candidates: Vec<RepeatedRun>) -> Vec<RepeatedRun> {
+    candidates.sort_unstable_by_key(|run| (run.end(), run.start, run.width, run.repetitions));
+    let mut best_savings = vec![0usize; candidates.len() + 1];
+    let mut take = vec![false; candidates.len()];
+    let mut compatible_count = vec![0usize; candidates.len()];
+    for (index, &candidate) in candidates.iter().enumerate() {
+        let compatible = candidates[..index].partition_point(|run| run.end() <= candidate.start);
+        compatible_count[index] = compatible;
+        let with_candidate = best_savings[compatible] + candidate.saved_nodes();
+        if with_candidate > best_savings[index] {
+            best_savings[index + 1] = with_candidate;
+            take[index] = true;
+        } else {
+            best_savings[index + 1] = best_savings[index];
+        }
+    }
+
+    let mut selected = Vec::new();
+    let mut cursor = candidates.len();
+    while cursor > 0 {
+        let index = cursor - 1;
+        if take[index] {
+            selected.push(candidates[index]);
+            cursor = compatible_count[index];
+        } else {
+            cursor -= 1;
+        }
+    }
+    selected.sort_unstable_by_key(|run| run.start);
+    selected
+}
+
+fn run_membership(index: usize, runs: &[RepeatedRun]) -> Option<(usize, usize, usize)> {
+    runs.iter().enumerate().find_map(|(run_index, &run)| {
+        repeated_node_position(index, run).map(|(copy, offset)| (run_index, copy, offset))
+    })
+}
+
+fn project_node(
+    index: usize,
+    membership: Option<(usize, usize, usize)>,
+    runs: &[RepeatedRun],
+) -> HumanNodeId {
+    let Some((run_index, _, offset)) = membership else {
+        return HumanNodeId::Original(index);
+    };
+    let run = runs[run_index];
+    if run.width <= MAX_VISIBLE_REPEAT_WIDTH {
+        HumanNodeId::Original(run.start + offset)
+    } else {
+        HumanNodeId::RepeatedSummary(run_index)
+    }
+}
+
+fn write_human_edge(dot: &mut String, edge: HumanEdge) {
+    dot.push_str("  ");
+    write_human_node_id(dot, edge.from);
+    dot.push_str(" -> ");
+    write_human_node_id(dot, edge.to);
+    let special = edge.from_port != 0 || edge.to_port != 0 || edge.dependency_type != 0;
+    match (edge.after_repetitions, special) {
+        (None, false) => dot.push_str(";\n"),
+        (Some(repetitions), false) => {
+            let _ = writeln!(dot, " [label=\"after ×{repetitions}\", fontsize=9];");
+        }
+        (after, true) => {
+            let prefix = after
+                .map(|repetitions| format!("after ×{repetitions} · "))
+                .unwrap_or_default();
+            let _ = writeln!(
+                dot,
+                " [color=\"#2563EB\", style=dashed, label=\"{prefix}{} · port {}→{}\", fontsize=8];",
+                dependency_type_name(edge.dependency_type),
+                edge.from_port,
+                edge.to_port,
+            );
+        }
+    }
+}
+
+fn write_human_node_id(dot: &mut String, node: HumanNodeId) {
+    match node {
+        HumanNodeId::Original(index) => {
+            let _ = write!(dot, "n{index}");
+        }
+        HumanNodeId::RepeatedSummary(index) => {
+            let _ = write!(dot, "r{index}");
+        }
+    }
+}
+
+fn node_color(indegree: usize, outdegree: usize) -> &'static str {
+    if indegree == 0 {
+        "#DCEEFF"
+    } else if outdegree == 0 {
+        "#E8DEFF"
+    } else if indegree > 1 {
+        "#FFE8C2"
+    } else if outdegree > 1 {
+        "#E3F6E8"
+    } else {
+        "#F5F5F5"
+    }
+}
+
+fn compact_kernel_name(name: &str) -> String {
+    const MAX_CHARS: usize = 72;
+
+    if name.contains("internal::gemvx::kernel") {
+        return "cuBLAS GEMV".to_owned();
+    }
+    let signature = name.rsplit_once('(').map_or(name, |(name, _)| name);
+    let mut compact = String::with_capacity(signature.len());
+    let mut template_depth = 0usize;
+    for ch in signature.chars() {
+        match ch {
+            '<' => {
+                if template_depth == 0 {
+                    compact.push_str("<…>");
+                }
+                template_depth += 1;
+            }
+            '>' if template_depth > 0 => template_depth -= 1,
+            _ if template_depth == 0 => compact.push(ch),
+            _ => {}
+        }
+    }
+    let leaf = compact.rsplit("::").next().unwrap_or(&compact);
+    if leaf.chars().count() <= MAX_CHARS {
+        return leaf.to_owned();
+    }
+    let prefix = leaf.chars().take(MAX_CHARS - 1).collect::<String>();
+    format!("{prefix}…")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{GraphDescription, GraphEdge, GraphNode, GraphNodeKind};
+    use super::compact_kernel_name;
+
+    fn kernel(name: &str) -> GraphNode {
+        GraphNode {
+            kind: GraphNodeKind::Kernel {
+                raw_symbol: name.to_owned(),
+                demangled: format!("{name}()"),
+                grid: [1, 1, 1],
+                block: [32, 1, 1],
+                dynamic_shared_mem_bytes: 0,
+            },
+        }
+    }
+
+    #[test]
+    fn compact_name_drops_namespace_signature_and_template_body() {
+        assert_eq!(
+            compact_kernel_name("flashinfer::BatchDecodeKernel<128, foo::Bar>(float*, int)"),
+            "BatchDecodeKernel<…>"
+        );
+        assert_eq!(
+            compact_kernel_name(
+                "std::enable_if<true, void>::type internal::gemvx::kernel<int>(int)"
+            ),
+            "cuBLAS GEMV"
+        );
+    }
+
+    #[test]
+    fn human_dot_folds_a_repeated_linear_block() {
+        let names = ["head", "a", "b", "a", "b", "a", "b", "tail"];
+        let graph = GraphDescription {
+            nodes: names.into_iter().map(kernel).collect(),
+            edges: (0..7)
+                .map(|index| GraphEdge::ordinary(index, index + 1))
+                .collect(),
+        };
+
+        let dot = graph.human_dot("test graph");
+
+        assert!(dot.contains("label=\"test graph\""));
+        assert!(dot.contains("Repeated physical block ×3 · 2 kernels/instance"));
+        assert!(dot.contains("n0 -> n1"));
+        assert!(dot.contains("n2 -> n7 [label=\"after ×3\""));
+        assert!(!dot.contains("n3 [fillcolor"));
+    }
+
+    #[test]
+    fn human_dot_folds_a_repeated_branched_dag() {
+        let names = [
+            "head", "fork", "left", "right", "join", "fork", "left", "right", "join", "fork",
+            "left", "right", "join", "tail",
+        ];
+        let mut edges = vec![GraphEdge::ordinary(0, 1)];
+        for start in [1, 5, 9] {
+            edges.extend([
+                GraphEdge::ordinary(start, start + 1),
+                GraphEdge::ordinary(start, start + 2),
+                GraphEdge::ordinary(start + 1, start + 3),
+                GraphEdge::ordinary(start + 2, start + 3),
+            ]);
+        }
+        edges.extend([
+            GraphEdge::ordinary(4, 5),
+            GraphEdge::ordinary(8, 9),
+            GraphEdge::ordinary(12, 13),
+        ]);
+        let graph = GraphDescription {
+            nodes: names.into_iter().map(kernel).collect(),
+            edges,
+        };
+
+        let dot = graph.human_dot("branched graph");
+
+        assert!(dot.contains("Repeated physical block ×3 · 4 kernels/instance"));
+        assert!(dot.contains("n1 -> n2;"));
+        assert!(dot.contains("n1 -> n3;"));
+        assert!(dot.contains("n2 -> n4;"));
+        assert!(dot.contains("n3 -> n4;"));
+        assert!(dot.contains("n4 -> n13 [label=\"after ×3\""));
+        assert!(!dot.contains("n5 [fillcolor"));
+    }
+
+    #[test]
+    fn repeated_signatures_with_different_edges_are_not_folded() {
+        let names = ["head", "a", "b", "a", "b", "a", "b", "tail"];
+        let graph = GraphDescription {
+            nodes: names.into_iter().map(kernel).collect(),
+            edges: vec![
+                GraphEdge::ordinary(0, 1),
+                GraphEdge::ordinary(1, 2),
+                GraphEdge::ordinary(2, 3),
+                GraphEdge::ordinary(3, 5),
+                GraphEdge::ordinary(5, 6),
+                GraphEdge::ordinary(6, 7),
+            ],
+        };
+
+        assert!(graph.repeated_dag_runs().is_empty());
+    }
+
+    #[test]
+    fn disconnected_parallel_copies_are_not_folded_as_a_sequence() {
+        let names = ["head", "a", "b", "a", "b", "a", "b", "tail"];
+        let graph = GraphDescription {
+            nodes: names.into_iter().map(kernel).collect(),
+            edges: vec![
+                GraphEdge::ordinary(0, 1),
+                GraphEdge::ordinary(1, 2),
+                GraphEdge::ordinary(3, 4),
+                GraphEdge::ordinary(5, 6),
+                GraphEdge::ordinary(6, 7),
+            ],
+        };
+
+        assert!(graph.repeated_dag_runs().is_empty());
+    }
+
+    #[test]
+    fn qwen_shape_uses_the_primitive_fourteen_kernel_period() {
+        let mut names = vec!["head".to_owned()];
+        for _ in 0..36 {
+            names.extend((0..14).map(|index| format!("layer_kernel_{index}")));
+        }
+        names.push("tail".to_owned());
+        let graph = GraphDescription {
+            nodes: names.iter().map(|name| kernel(name)).collect(),
+            edges: (0..names.len() - 1)
+                .map(|index| GraphEdge::ordinary(index, index + 1))
+                .collect(),
+        };
+
+        let dot = graph.human_dot("qwen graph");
+
+        assert!(dot.contains("Repeated physical block ×36 · 14 kernels/instance"));
+        assert!(!dot.contains("Folded repeated subgraph"));
+    }
+
+    #[test]
+    fn large_repeated_dag_uses_one_summary_node() {
+        let mut names = vec!["head".to_owned()];
+        for _ in 0..3 {
+            names.extend((0..33).map(|index| format!("layer_{index}")));
+        }
+        names.push("tail".to_owned());
+        let graph = GraphDescription {
+            nodes: names.iter().map(|name| kernel(name)).collect(),
+            edges: (0..names.len() - 1)
+                .map(|index| GraphEdge::ordinary(index, index + 1))
+                .collect(),
+        };
+
+        let dot = graph.human_dot("large graph");
+
+        assert!(dot.contains("Folded repeated subgraph\\n33 nodes and 33 kernels per instance"));
+        assert!(dot.contains("n0 -> r0;"));
+        assert!(dot.contains("r0 -> n100 [label=\"after ×3\""));
+        assert!(!dot.contains("n1 [fillcolor"));
+    }
+}

--- a/openinfer-glm52/src/lib.rs
+++ b/openinfer-glm52/src/lib.rs
@@ -31,7 +31,11 @@ mod scheduler;
 mod scratch;
 mod weights;
 
-use std::{collections::BTreeSet, path::Path, time::Instant};
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+    time::Instant,
+};
 
 use anyhow::{Context as _, Result, ensure};
 use bytesize::ByteSize;
@@ -88,6 +92,11 @@ pub struct Glm52LaunchOptions {
     /// four-GPU bring-up target using 16 attention heads per rank and 1/4
     /// intermediate MoE slices.
     pub moe_topo: Glm52MoeTopo,
+    /// Export rank 0's already pre-captured whole-step decode graph during
+    /// startup. EP8 and TP4 export bucket 1; TP8 exports its fixed bucket 8.
+    /// The requested PNG gets a complete sibling `.dot` for machine
+    /// inspection.
+    pub dump_graph_png: Option<PathBuf>,
 }
 
 /// Launch-time MoE sharding topology (the expert slab is repacked during
@@ -227,7 +236,11 @@ pub fn launch(model_path: &Path, options: Glm52LaunchOptions) -> Result<EngineHa
         no_prefix_cache,
         kv_offload,
         moe_topo,
+        dump_graph_png,
     } = options;
+    if let Some(path) = &dump_graph_png {
+        openinfer_core::cuda_graph::validate_graph_dump_request(path)?;
+    }
     match moe_topo {
         Glm52MoeTopo::Ep8 | Glm52MoeTopo::Tp8 => {
             ensure!(
@@ -279,6 +292,7 @@ pub fn launch(model_path: &Path, options: Glm52LaunchOptions) -> Result<EngineHa
         no_prefix_cache,
         kv_offload,
         moe_topo,
+        dump_graph_png,
     )
 }
 
@@ -448,7 +462,9 @@ fn start_engine(
     no_prefix_cache: bool,
     kv_offload: Option<Glm52KvOffloadOptions>,
     moe_topo: Glm52MoeTopo,
+    dump_graph_png: Option<PathBuf>,
 ) -> Result<EngineHandle> {
+    let dspark_enabled = dspark_path.is_some();
     let startup = validate_startup(model_path, options, moe_topo)?;
     let loaded = load_rank_weights_to_gpu(model_path, &startup, moe_topo)?;
     log::info!(
@@ -466,11 +482,8 @@ fn start_engine(
         .copied()
         .min()
         .expect("at least one rank loaded");
-    let budget = derive_max_model_len(
-        requested_max_model_len,
-        min_free_vram_bytes,
-        dspark_path.is_some(),
-    )?;
+    let budget =
+        derive_max_model_len(requested_max_model_len, min_free_vram_bytes, dspark_enabled)?;
     let max_model_len = budget.max_model_len;
     log::info!(
         "GLM5.2 max_model_len={max_model_len} ({}): min rank free VRAM {} after weights, \
@@ -483,7 +496,7 @@ fn start_engine(
         ByteSize(min_free_vram_bytes as u64),
         ByteSize(budget.arena_bytes as u64),
         model::GLM52_MAX_BATCH_PER_RANK,
-        if dspark_path.is_some() {
+        if dspark_enabled {
             " (dspark lane included)"
         } else {
             ""
@@ -502,29 +515,27 @@ fn start_engine(
     // down, and the launch error surfaces only after the ~100 s DeepEP
     // device timeout. The TP8 LL rendezvous rejecting a topology (poison
     // pill, NVLink probe) is a real failure landing exactly in this window.
-    let rank_arenas = match build_rank_models(&loaded.workers, max_model_len, moe_topo) {
-        Ok(rank_arenas) => rank_arenas,
-        Err(err) => {
-            for worker in &loaded.workers {
-                let _ = worker.request_shutdown();
+    let rank_arenas =
+        match build_rank_models(&loaded.workers, max_model_len, moe_topo, dspark_enabled) {
+            Ok(rank_arenas) => rank_arenas,
+            Err(err) => {
+                for worker in &loaded.workers {
+                    let _ = worker.request_shutdown();
+                }
+                return Err(err);
             }
-            return Err(err);
-        }
-    };
-    let post_comm_startup = || -> Result<(bool, Option<Vec<OffloadEngine>>)> {
-        let dspark_enabled = if let Some(dspark_path) = dspark_path {
-            load_dspark_drafters(&loaded.workers, dspark_path)?;
-            true
-        } else {
-            false
         };
+    let post_comm_startup = || -> Result<Option<Vec<OffloadEngine>>> {
+        if let Some(dspark_path) = dspark_path {
+            load_dspark_drafters(&loaded.workers, dspark_path)?;
+        }
         ensure_post_build_headroom(&loaded.workers)?;
         let offload = kv_offload
             .map(|opts| build_offload_engines(&opts, rank_arenas, &startup.device_ordinals))
             .transpose()?;
-        Ok((dspark_enabled, offload))
+        Ok(offload)
     };
-    let (dspark_enabled, offload) = match post_comm_startup() {
+    let offload = match post_comm_startup() {
         Ok(started) => started,
         Err(err) => {
             for worker in &loaded.workers {
@@ -544,6 +555,13 @@ fn start_engine(
         })
         .unzip();
     let (submit_tx, submit_rx) = mpsc::unbounded_channel();
+    let (graph_dump_request, graph_dump_response) = match dump_graph_png {
+        Some(path) => {
+            let (response_tx, response_rx) = crossbeam_channel::bounded(1);
+            (Some((path, response_tx)), Some(response_rx))
+        }
+        None => (None, None),
+    };
     let coord_handle = std::thread::Builder::new()
         .name("glm52-coord".into())
         .spawn(move || {
@@ -557,9 +575,39 @@ fn start_engine(
                 offload,
                 moe_topo,
                 load_txs,
+                graph_dump_request,
             );
         })
         .map_err(|err| anyhow::anyhow!("failed to spawn GLM5.2 coordinator: {err}"))?;
+    if let Some(response) = graph_dump_response {
+        let Ok(dump_result) = response.recv() else {
+            drop(submit_tx);
+            coord_handle.join().map_err(|_| {
+                anyhow::anyhow!("GLM5.2 coordinator panicked before reporting graph export")
+            })?;
+            return Err(anyhow::anyhow!(
+                "GLM5.2 coordinator exited before reporting CUDA Graph export"
+            ));
+        };
+        let summary = match dump_result {
+            Ok(summary) => summary,
+            Err(err) => {
+                drop(submit_tx);
+                coord_handle.join().map_err(|_| {
+                    anyhow::anyhow!("GLM5.2 coordinator panicked after graph export failure")
+                })?;
+                return Err(err.context("GLM5.2 CUDA Graph export failed"));
+            }
+        };
+        log::info!(
+            "GLM5.2 decode CUDA Graph exported: nodes={}, kernels={}, edges={}, dot={}, png={}",
+            summary.nodes,
+            summary.kernels,
+            summary.edges,
+            summary.dot_path.display(),
+            summary.png_path.display()
+        );
+    }
     // Publish the launch-time cap so the frontend clamps its config.json
     // max_position_embeddings (1M) at the API boundary instead of admitting
     // requests the scheduler would reject (same contract as qwen3/dsv2-lite).
@@ -637,11 +685,12 @@ fn build_rank_models(
     workers: &[Glm52RankWorker],
     max_model_len: usize,
     moe_topo: Glm52MoeTopo,
+    dspark_enabled: bool,
 ) -> Result<Vec<Vec<KvArena>>> {
     let build_started = Instant::now();
     let responses = workers
         .iter()
-        .map(|worker| worker.build_model_async(max_model_len, moe_topo))
+        .map(|worker| worker.build_model_async(max_model_len, moe_topo, dspark_enabled))
         .collect::<Result<Vec<_>>>()?;
     let mut rank_arenas = Vec::with_capacity(responses.len());
     for (rank, response) in responses.into_iter().enumerate() {

--- a/openinfer-glm52/src/model/mod.rs
+++ b/openinfer-glm52/src/model/mod.rs
@@ -19,14 +19,13 @@
 use anyhow::{Context as _, Result, ensure};
 use cudarc::driver::{CudaSlice, CudaStream, DevicePtr as _, PinnedHostSlice};
 use half::bf16;
+use openinfer_core::cuda_graph::CudaGraphDumpSummary;
 use openinfer_core::cuda_graph::CudaGraphState;
 use openinfer_kernels::ops::{
     GLM52_FLASHMLA_SPARSE_BYTES_PER_TOKEN, GLM52_FLASHMLA_SPARSE_PAGE_SIZE,
     GLM52_FLASHMLA_SPARSE_TOPK, GLM52_GEMV_MMA_SCRATCH_FLOATS_PER_ROW, Glm52FlashMlaSparseDecode,
-    Glm52IndexerCacheLayout, add_into, argmax_bf16_split_into, copy_hidden_rows_raw_into,
-    embedding_rows_into, glm52_flashmla_sparse_decode_num_sm_parts,
-    glm52_fp8_weight_only_gemv_launch, glm52_vocab_parallel_pack_launch,
-    glm52_vocab_parallel_unpack_launch, rms_norm_rows_into,
+    Glm52IndexerCacheLayout, embedding_rows_into, glm52_flashmla_sparse_decode_num_sm_parts,
+    glm52_fp8_weight_only_gemv_launch,
 };
 use openinfer_kernels::tensor::{DeviceContext, DeviceMatrix, DeviceVec, HiddenStatesRef};
 use openinfer_kv_offload::KvArena;
@@ -34,29 +33,26 @@ use openinfer_sample::{
     BatchSamplingRow, BatchSamplingScratch, effectively_greedy, gpu_sample_batch_into, mix_seed,
 };
 
-use crate::bookend::{glm52_embed_into, glm52_final_norm_into, glm52_lm_head_into};
+use crate::bookend::glm52_lm_head_into;
 use crate::config::{
-    GLM52_HIDDEN, GLM52_INDEX_HEAD_DIM, GLM52_INDEX_TOPK, GLM52_LAYERS, GLM52_RMS_EPS,
-    GLM52_ROPE_HALF, GLM52_SM_SCALE, GLM52_VOCAB, glm52_layer_has_full_indexer,
+    GLM52_HIDDEN, GLM52_INDEX_HEAD_DIM, GLM52_INDEX_TOPK, GLM52_LAYERS, GLM52_ROPE_HALF,
+    GLM52_SM_SCALE, GLM52_VOCAB, glm52_layer_has_full_indexer,
 };
-use crate::dense::glm52_dense_mlp_forward_into;
 use crate::indexer::Glm52IndexerScratch;
-use crate::layer::{
-    Glm52DecodeStep, Glm52DecoderLayerWeights, Glm52LayerCaches, Glm52LayerMlp,
-    glm52_layer_attention_half, glm52_layer_finish, glm52_layer_finish_fused,
-};
+use crate::layer::{Glm52DecodeStep, Glm52DecoderLayerWeights, Glm52LayerCaches};
 use crate::mla_decode::{
     Glm52MlaSchedMetadata, glm52_mla_backend_preflight, glm52_select_mla_backend,
 };
-use crate::moe_decode::run_router_into;
-use crate::moe_ep8::{Glm52MoeEp8LayerWeights, Glm52MoeEp8State, glm52_moe_ep8_routed_forward};
+use crate::moe_ep8::Glm52MoeEp8State;
 use crate::moe_tp::Glm52MoeTpRank;
 use crate::scratch::Glm52DecodeScratch;
 use crate::weights::{Glm52RankGpuWeights, retype_owned};
 
 mod build;
 mod launch_ahead;
+mod step_body;
 use launch_ahead::Glm52SpeculatedStep;
+use step_body::run_step_body;
 
 /// The per-rank slot count and the largest decode bucket. A slot is a batch
 /// lane (and the draft lane's state key), not a cache region — KV pages come
@@ -308,6 +304,34 @@ struct Glm52BucketState {
 /// same fixed-order transport to gather vocabulary-shard top-1 candidates.
 const VOCAB_AR_SLOT: usize = GLM52_LAYERS;
 impl Glm52RankModel {
+    /// Export one already pre-captured whole-step bucket graph. The scheduler
+    /// selects the topology's serving shape; this method only enforces that
+    /// the requested bucket belongs to this model and is ready for replay.
+    pub(crate) fn dump_decode_graph_png(
+        &self,
+        bucket: usize,
+        png_path: &std::path::Path,
+        title: &str,
+    ) -> Result<CudaGraphDumpSummary> {
+        let state = self
+            .buckets
+            .iter()
+            .find(|state| state.rows == bucket)
+            .with_context(|| {
+                format!(
+                    "GLM5.2 graph dump bucket {bucket} is not a member of {GLM52_DECODE_BUCKETS:?}"
+                )
+            })?;
+        ensure!(
+            state.graph.is_captured(),
+            "GLM5.2 bucket-{bucket} graph dump requested before pre-capture"
+        );
+        state
+            .graph
+            .dump_png(png_path, title)
+            .with_context(|| format!("dump GLM5.2 rank-0 bucket-{bucket} decode CUDA Graph"))
+    }
+
     /// The token embedding table — the DSpark draft's block embedding reuses
     /// it (the draft checkpoint's copy is byte-identical and not loaded).
     pub(crate) fn embed(&self) -> &DeviceMatrix {
@@ -338,7 +362,12 @@ impl Glm52RankModel {
                     "GLM5.2 capture bucket {bucket} is not a member of {GLM52_DECODE_BUCKETS:?}"
                 )
             })?;
-        Ok(state.scratch.captured.data())
+        Ok(state
+            .scratch
+            .captured
+            .as_ref()
+            .context("GLM5.2 DSpark context capture is disabled")?
+            .data())
     }
 
     /// The per-layer cache arenas this rank registers with the KV offload
@@ -394,6 +423,7 @@ impl Glm52RankModel {
         max_model_len: usize,
         moe_topo: crate::Glm52MoeTopo,
         attn_shard: Option<usize>,
+        dspark_enabled: bool,
     ) -> Result<Self> {
         ensure!(
             moe_topo.uses_tensor_replicated_moe() == attn_shard.is_some(),
@@ -553,6 +583,7 @@ impl Glm52RankModel {
                     mqa_shape,
                     mla_heads,
                     mla_backend,
+                    dspark_enabled,
                 )?,
                 graph: CudaGraphState::new(),
                 block_table: bucket_table,
@@ -993,276 +1024,4 @@ impl Glm52RankModel {
         bucket.graph = graph;
         result
     }
-}
-
-/// The captured region of one decode step: embed → 78 layers → lm_head →
-/// device argmax over the step's `batch` rows (read from the attend plan —
-/// the single source of truth for the step's row count). Shared verbatim by
-/// both batch buckets; only the plan, scratch, block table, and
-/// `global_tokens` differ per shape.
-#[allow(clippy::too_many_arguments)]
-fn run_step_body(
-    ctx: &DeviceContext,
-    aux: &DeviceContext,
-    mut ep8: Option<&mut Glm52MoeEp8State>,
-    mut tp: Option<&mut Glm52MoeTpRank>,
-    layers: &[Glm52DecoderLayerWeights],
-    caches: &mut [Glm52LayerCaches],
-    embed: &DeviceMatrix,
-    final_norm: &DeviceVec,
-    lm_head: &DeviceMatrix,
-    vocab_start: usize,
-    token_ids: &CudaSlice<u32>,
-    step: &Glm52DecodeStep<'_>,
-    s: &mut Glm52DecodeScratch,
-    global_tokens: usize,
-) -> Result<()> {
-    let batch = step.mla_sched.batch();
-    // TP8 step head: advance the shared LL epoch exactly once per replayed
-    // step that runs TP8 kernels (all TP8 layers of the step share the tag;
-    // per-layer slot regions alternate parity across steps).
-    if let Some(rank) = tp.as_deref_mut() {
-        if !rank.slices.is_empty() {
-            rank.state.advance_epoch(ctx)?;
-        }
-    }
-    glm52_embed_into(ctx, embed, token_ids, &mut s.hidden)?;
-    // Layer 0's input norm is standalone (the embedding is the residual);
-    // every later layer's input norm is fused into the previous layer's
-    // closing add (`glm52_layer_finish_fused`).
-    rms_norm_rows_into(
-        ctx,
-        s.hidden.data(),
-        &layers[0].input_ln,
-        GLM52_RMS_EPS,
-        GLM52_HIDDEN,
-        batch,
-        s.layer.normed.data_mut(),
-    )?;
-    let mut carry_ready = false;
-    for (layer, (weights, cache)) in layers.iter().zip(caches.iter_mut()).enumerate() {
-        let parity = layer % 2;
-        // Attention-TP: a head-sharded layer's o_proj partial crosses the AR
-        // brick inside the attention half; the layer index is its AR slot.
-        let tp_ar = if weights.mla.heads == crate::config::GLM52_HEADS {
-            None
-        } else {
-            let rank = tp
-                .as_deref_mut()
-                .context("GLM5.2 sharded attention without TP state")?;
-            Some((&mut rank.state, layer))
-        };
-        glm52_layer_attention_half(
-            ctx,
-            Some(aux),
-            weights,
-            cache,
-            step,
-            s,
-            &mut carry_ready,
-            parity,
-            layer == 0,
-            tp_ar,
-        )
-        .with_context(|| format!("GLM5.2 layer {layer} attention half"))?;
-        let mut tp_padded_mlp = false;
-        match &weights.mlp {
-            Glm52LayerMlp::Dense(dense) => glm52_dense_mlp_forward_into(
-                ctx,
-                dense,
-                s.layer.normed2.data(),
-                &mut s.dense_mlp,
-                s.layer.mlp_out.data_mut(),
-            )?,
-            Glm52LayerMlp::MoeEp8(moe) => {
-                let ep8 = ep8
-                    .as_deref_mut()
-                    .context("GLM5.2 EP8 MoE layer reached without DeepEP state")?;
-                glm52_moe_ep8_layer(ctx, aux, ep8, moe, s, batch, global_tokens)
-                    .with_context(|| format!("GLM5.2 layer {layer} EP8 MoE"))?;
-            }
-            Glm52LayerMlp::MoeTp(router) => {
-                let (state, slot, bank) = tp
-                    .as_deref_mut()
-                    .and_then(|rank| rank.layer_bank(layer))
-                    .with_context(|| {
-                        format!("GLM5.2 TP8 layer {layer} has no slice bank — loader drifted")
-                    })?;
-                // Every rank routes all rows locally — bit-identical across
-                // ranks (same kernel, same replicated normed2), so the
-                // kernel's union and prob table need no routing exchange.
-                run_router_into(ctx, router, s.layer.normed2.data(), &mut s.router)?;
-                if batch == GLM52_MAX_BATCH_PER_RANK {
-                    state.forward(
-                        ctx,
-                        slot,
-                        bank,
-                        s.layer.normed2.data(),
-                        &s.router.route.topk_idx,
-                        &s.router.route.topk_weight,
-                        s.layer.mlp_out.data_mut(),
-                    )?;
-                } else {
-                    // TP4 keeps the proven eight-row MoE ABI while allowing
-                    // every other layer component to use bucket 1/2/4.
-                    copy_hidden_rows_raw_into(
-                        ctx,
-                        s.layer.normed2.data(),
-                        GLM52_HIDDEN,
-                        &mut s.tp_normed2,
-                        GLM52_HIDDEN,
-                        0,
-                        batch,
-                    )?;
-                    state.forward(
-                        ctx,
-                        slot,
-                        bank,
-                        &s.tp_normed2,
-                        &s.router.route.topk_idx,
-                        &s.router.route.topk_weight,
-                        &mut s.tp_mlp_out,
-                    )?;
-                    // The active rows are the contiguous prefix. The closing
-                    // residual/norm reads them directly from the padded output.
-                    tp_padded_mlp = true;
-                }
-            }
-        }
-        if layer + 1 < layers.len() {
-            glm52_layer_finish_fused(ctx, s, parity, &layers[layer + 1].input_ln, tp_padded_mlp)?;
-        } else {
-            glm52_layer_finish(ctx, s, parity, tp_padded_mlp)?;
-        }
-        // DSpark aux-hidden capture: after layer L's closing add the residual
-        // stream lives in `attn[parity]` (updated in place by the fused
-        // add+norm; none of the capture layers is the last layer, which lands
-        // in `s.hidden` instead). Recorded into the step graph — pointer-
-        // stable, ~60 KB/row per step.
-        if let Some(feature) = crate::dspark::GLM52_DSPARK_AUX_LAYERS
-            .iter()
-            .position(|&aux| aux == layer)
-        {
-            copy_hidden_rows_raw_into(
-                ctx,
-                s.layer.attn[parity].data(),
-                GLM52_HIDDEN,
-                s.captured.data_mut(),
-                crate::dspark::GLM52_DSPARK_CONTEXT_DIM,
-                feature * GLM52_HIDDEN,
-                batch,
-            )?;
-        }
-    }
-
-    glm52_final_norm_into(ctx, &s.hidden, final_norm, &mut s.final_normed)?;
-    glm52_lm_head_into(ctx, &s.final_normed, lm_head, &mut s.logits)?;
-    // Device greedy argmax per row (same semantics as a host scan: lowest
-    // index wins ties, NaN never wins) — the step's egress shrinks from the
-    // full vocab rows to 6 bytes per row, and the kernel chain ends on-device
-    // (the graph boundary). Two-stage: per-4096-tile partials in parallel,
-    // then one finalize block per row — bit-identical to the single-block
-    // scan (the partials carry global indices, same total order), and each
-    // row's result is independent of its slot-mates.
-    argmax_bf16_split_into(
-        ctx,
-        s.logits.data(),
-        batch,
-        lm_head.rows,
-        &mut s.argmax_partial_values,
-        &mut s.argmax_partial_indices,
-        &mut s.argmax_values,
-        &mut s.argmax_indices,
-    )?;
-
-    if let Some(rank) = tp {
-        ensure!(
-            lm_head.rows * rank.state.ranks() == GLM52_VOCAB
-                && vocab_start == rank.state.rank() * lm_head.rows,
-            "GLM5.2 vocab shard [{vocab_start}..{}) does not match TP rank {}/{}",
-            vocab_start + lm_head.rows,
-            rank.state.rank(),
-            rank.state.ranks()
-        );
-        glm52_vocab_parallel_pack_launch(
-            ctx,
-            &s.argmax_values,
-            &s.argmax_indices,
-            s.layer.ar_partial.data_mut(),
-            batch,
-            rank.state.rank(),
-            vocab_start,
-        )?;
-        rank.state.attn_ar_launch(
-            ctx,
-            VOCAB_AR_SLOT,
-            batch,
-            s.layer.ar_partial.data(),
-            s.layer.attn[0].data_mut(),
-        )?;
-        glm52_vocab_parallel_unpack_launch(
-            ctx,
-            s.layer.attn[0].data(),
-            &mut s.argmax_values,
-            &mut s.argmax_indices,
-            batch,
-            rank.state.ranks(),
-        )?;
-    } else {
-        ensure!(
-            lm_head.rows == GLM52_VOCAB && vocab_start == 0,
-            "GLM5.2 non-TP decode received a sharded vocabulary head"
-        );
-    }
-    Ok(())
-}
-
-/// One layer's EP8 MoE half: shared expert forked to the aux stream, routed
-/// path through router + DeepEP dispatch/grouped-GEMM/combine, joined by the
-/// closing add into `mlp_out`. The events recorded here during capture
-/// become graph edges; replay keeps the parallel branches.
-fn glm52_moe_ep8_layer(
-    ctx: &DeviceContext,
-    aux: &DeviceContext,
-    ep8: &mut Glm52MoeEp8State,
-    moe: &Glm52MoeEp8LayerWeights,
-    s: &mut Glm52DecodeScratch,
-    batch: usize,
-    global_tokens: usize,
-) -> Result<()> {
-    // Fork: the shared expert only needs `normed2`, so it runs on the aux
-    // stream concurrently with the routed path's dispatch/grouped-GEMM/
-    // combine — the cooperative collectives occupy a fixed SM slice and
-    // mostly wait on peers, leaving the rest of the GPU free.
-    let normed_ready = ctx.stream.record_event(None)?;
-    aux.stream.wait(&normed_ready)?;
-    moe.shared.forward_into(
-        aux,
-        s.layer.normed2.data(),
-        &mut s.shared_mlp,
-        s.layer.shared_out.data_mut(),
-    )?;
-    let shared_done = aux.stream.record_event(None)?;
-
-    run_router_into(ctx, &moe.router, s.layer.normed2.data(), &mut s.router)?;
-    let dispatched = glm52_moe_ep8_routed_forward(
-        ctx,
-        ep8,
-        &moe.bank,
-        Some((s.layer.normed2.data(), &s.router.route, batch)),
-        global_tokens,
-    )?;
-    ensure!(
-        dispatched,
-        "EP8 MoE returned no combined output for the dispatched rows"
-    );
-    // Join: the closing add consumes both branches.
-    ctx.stream.wait(&shared_done)?;
-    add_into(
-        ctx,
-        ep8.combined(),
-        s.layer.shared_out.data(),
-        batch * GLM52_HIDDEN,
-        s.layer.mlp_out.data_mut(),
-    )
 }

--- a/openinfer-glm52/src/model/step_body.rs
+++ b/openinfer-glm52/src/model/step_body.rs
@@ -1,0 +1,298 @@
+//! Captured GLM5.2 whole-step forward body.
+
+use anyhow::{Context as _, Result, ensure};
+use cudarc::driver::CudaSlice;
+use openinfer_kernels::ops::{
+    add_into, argmax_bf16_split_into, copy_hidden_rows_raw_into, glm52_vocab_parallel_pack_launch,
+    glm52_vocab_parallel_unpack_launch, rms_norm_rows_into,
+};
+use openinfer_kernels::tensor::{DeviceContext, DeviceMatrix, DeviceVec};
+
+use crate::bookend::{glm52_embed_into, glm52_final_norm_into, glm52_lm_head_into};
+use crate::config::{GLM52_HIDDEN, GLM52_RMS_EPS, GLM52_VOCAB};
+use crate::dense::glm52_dense_mlp_forward_into;
+use crate::layer::{
+    Glm52DecodeStep, Glm52DecoderLayerWeights, Glm52LayerCaches, Glm52LayerMlp,
+    glm52_layer_attention_half, glm52_layer_finish, glm52_layer_finish_fused,
+};
+use crate::moe_decode::run_router_into;
+use crate::moe_ep8::{Glm52MoeEp8LayerWeights, Glm52MoeEp8State, glm52_moe_ep8_routed_forward};
+use crate::moe_tp::Glm52MoeTpRank;
+use crate::scratch::Glm52DecodeScratch;
+
+use super::{GLM52_MAX_BATCH_PER_RANK, VOCAB_AR_SLOT};
+
+/// The captured region of one decode step: embed → 78 layers → lm_head →
+/// device argmax over the step's `batch` rows (read from the attend plan —
+/// the single source of truth for the step's row count). Shared verbatim by
+/// every batch bucket; only the plan, scratch, block table, and
+/// `global_tokens` differ per shape.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn run_step_body(
+    ctx: &DeviceContext,
+    aux: &DeviceContext,
+    mut ep8: Option<&mut Glm52MoeEp8State>,
+    mut tp: Option<&mut Glm52MoeTpRank>,
+    layers: &[Glm52DecoderLayerWeights],
+    caches: &mut [Glm52LayerCaches],
+    embed: &DeviceMatrix,
+    final_norm: &DeviceVec,
+    lm_head: &DeviceMatrix,
+    vocab_start: usize,
+    token_ids: &CudaSlice<u32>,
+    step: &Glm52DecodeStep<'_>,
+    s: &mut Glm52DecodeScratch,
+    global_tokens: usize,
+) -> Result<()> {
+    let batch = step.mla_sched.batch();
+    // TP8 step head: advance the shared LL epoch exactly once per replayed
+    // step that runs TP8 kernels (all TP8 layers of the step share the tag;
+    // per-layer slot regions alternate parity across steps).
+    if let Some(rank) = tp.as_deref_mut()
+        && !rank.slices.is_empty()
+    {
+        rank.state.advance_epoch(ctx)?;
+    }
+    glm52_embed_into(ctx, embed, token_ids, &mut s.hidden)?;
+    // Layer 0's input norm is standalone (the embedding is the residual);
+    // every later layer's input norm is fused into the previous layer's
+    // closing add (`glm52_layer_finish_fused`).
+    rms_norm_rows_into(
+        ctx,
+        s.hidden.data(),
+        &layers[0].input_ln,
+        GLM52_RMS_EPS,
+        GLM52_HIDDEN,
+        batch,
+        s.layer.normed.data_mut(),
+    )?;
+    let mut carry_ready = false;
+    for (layer, (weights, cache)) in layers.iter().zip(caches.iter_mut()).enumerate() {
+        let parity = layer % 2;
+        // Attention-TP: a head-sharded layer's o_proj partial crosses the AR
+        // brick inside the attention half; the layer index is its AR slot.
+        let tp_ar = if weights.mla.heads == crate::config::GLM52_HEADS {
+            None
+        } else {
+            let rank = tp
+                .as_deref_mut()
+                .context("GLM5.2 sharded attention without TP state")?;
+            Some((&mut rank.state, layer))
+        };
+        glm52_layer_attention_half(
+            ctx,
+            Some(aux),
+            weights,
+            cache,
+            step,
+            s,
+            &mut carry_ready,
+            parity,
+            layer == 0,
+            tp_ar,
+        )
+        .with_context(|| format!("GLM5.2 layer {layer} attention half"))?;
+        let mut tp_padded_mlp = false;
+        match &weights.mlp {
+            Glm52LayerMlp::Dense(dense) => glm52_dense_mlp_forward_into(
+                ctx,
+                dense,
+                s.layer.normed2.data(),
+                &mut s.dense_mlp,
+                s.layer.mlp_out.data_mut(),
+            )?,
+            Glm52LayerMlp::MoeEp8(moe) => {
+                let ep8 = ep8
+                    .as_deref_mut()
+                    .context("GLM5.2 EP8 MoE layer reached without DeepEP state")?;
+                glm52_moe_ep8_layer(ctx, aux, ep8, moe, s, batch, global_tokens)
+                    .with_context(|| format!("GLM5.2 layer {layer} EP8 MoE"))?;
+            }
+            Glm52LayerMlp::MoeTp(router) => {
+                let (state, slot, bank) = tp
+                    .as_deref_mut()
+                    .and_then(|rank| rank.layer_bank(layer))
+                    .with_context(|| {
+                        format!("GLM5.2 TP8 layer {layer} has no slice bank — loader drifted")
+                    })?;
+                // Every rank routes all rows locally — bit-identical across
+                // ranks (same kernel, same replicated normed2), so the
+                // kernel's union and prob table need no routing exchange.
+                run_router_into(ctx, router, s.layer.normed2.data(), &mut s.router)?;
+                if batch == GLM52_MAX_BATCH_PER_RANK {
+                    state.forward(
+                        ctx,
+                        slot,
+                        bank,
+                        s.layer.normed2.data(),
+                        &s.router.route.topk_idx,
+                        &s.router.route.topk_weight,
+                        s.layer.mlp_out.data_mut(),
+                    )?;
+                } else {
+                    // TP4 keeps the proven eight-row MoE ABI while allowing
+                    // every other layer component to use bucket 1/2/4.
+                    copy_hidden_rows_raw_into(
+                        ctx,
+                        s.layer.normed2.data(),
+                        GLM52_HIDDEN,
+                        &mut s.tp_normed2,
+                        GLM52_HIDDEN,
+                        0,
+                        batch,
+                    )?;
+                    state.forward(
+                        ctx,
+                        slot,
+                        bank,
+                        &s.tp_normed2,
+                        &s.router.route.topk_idx,
+                        &s.router.route.topk_weight,
+                        &mut s.tp_mlp_out,
+                    )?;
+                    // The active rows are the contiguous prefix. The closing
+                    // residual/norm reads them directly from the padded output.
+                    tp_padded_mlp = true;
+                }
+            }
+        }
+        if layer + 1 < layers.len() {
+            glm52_layer_finish_fused(ctx, s, parity, &layers[layer + 1].input_ln, tp_padded_mlp)?;
+        } else {
+            glm52_layer_finish(ctx, s, parity, tp_padded_mlp)?;
+        }
+        // DSpark aux-hidden capture: after layer L's closing add the residual
+        // stream lives in `attn[parity]` (updated in place by the fused
+        // add+norm; none of the capture layers is the last layer, which lands
+        // in `s.hidden` instead). Recorded into the step graph — pointer-
+        // stable, ~60 KB/row per step — only when the drafter was requested
+        // at launch (otherwise neither the buffer nor the copy nodes exist).
+        if let (Some(feature), Some(captured)) = (
+            crate::dspark::GLM52_DSPARK_AUX_LAYERS
+                .iter()
+                .position(|&aux| aux == layer),
+            s.captured.as_mut(),
+        ) {
+            copy_hidden_rows_raw_into(
+                ctx,
+                s.layer.attn[parity].data(),
+                GLM52_HIDDEN,
+                captured.data_mut(),
+                crate::dspark::GLM52_DSPARK_CONTEXT_DIM,
+                feature * GLM52_HIDDEN,
+                batch,
+            )?;
+        }
+    }
+
+    glm52_final_norm_into(ctx, &s.hidden, final_norm, &mut s.final_normed)?;
+    glm52_lm_head_into(ctx, &s.final_normed, lm_head, &mut s.logits)?;
+    // Device greedy argmax per row (same semantics as a host scan: lowest
+    // index wins ties, NaN never wins) — the step's egress shrinks from the
+    // full vocab rows to 6 bytes per row, and the kernel chain ends on-device
+    // (the graph boundary). Two-stage: per-4096-tile partials in parallel,
+    // then one finalize block per row — bit-identical to the single-block
+    // scan (the partials carry global indices, same total order), and each
+    // row's result is independent of its slot-mates.
+    argmax_bf16_split_into(
+        ctx,
+        s.logits.data(),
+        batch,
+        lm_head.rows,
+        &mut s.argmax_partial_values,
+        &mut s.argmax_partial_indices,
+        &mut s.argmax_values,
+        &mut s.argmax_indices,
+    )?;
+
+    if let Some(rank) = tp {
+        ensure!(
+            lm_head.rows * rank.state.ranks() == GLM52_VOCAB
+                && vocab_start == rank.state.rank() * lm_head.rows,
+            "GLM5.2 vocab shard [{vocab_start}..{}) does not match TP rank {}/{}",
+            vocab_start + lm_head.rows,
+            rank.state.rank(),
+            rank.state.ranks()
+        );
+        glm52_vocab_parallel_pack_launch(
+            ctx,
+            &s.argmax_values,
+            &s.argmax_indices,
+            s.layer.ar_partial.data_mut(),
+            batch,
+            rank.state.rank(),
+            vocab_start,
+        )?;
+        rank.state.attn_ar_launch(
+            ctx,
+            VOCAB_AR_SLOT,
+            batch,
+            s.layer.ar_partial.data(),
+            s.layer.attn[0].data_mut(),
+        )?;
+        glm52_vocab_parallel_unpack_launch(
+            ctx,
+            s.layer.attn[0].data(),
+            &mut s.argmax_values,
+            &mut s.argmax_indices,
+            batch,
+            rank.state.ranks(),
+        )?;
+    } else {
+        ensure!(
+            lm_head.rows == GLM52_VOCAB && vocab_start == 0,
+            "GLM5.2 non-TP decode received a sharded vocabulary head"
+        );
+    }
+    Ok(())
+}
+
+/// One layer's EP8 MoE half: shared expert forked to the aux stream, routed
+/// path through router + DeepEP dispatch/grouped-GEMM/combine, joined by the
+/// closing add into `mlp_out`. The events recorded here during capture
+/// become graph edges; replay keeps the parallel branches.
+fn glm52_moe_ep8_layer(
+    ctx: &DeviceContext,
+    aux: &DeviceContext,
+    ep8: &mut Glm52MoeEp8State,
+    moe: &Glm52MoeEp8LayerWeights,
+    s: &mut Glm52DecodeScratch,
+    batch: usize,
+    global_tokens: usize,
+) -> Result<()> {
+    // Fork: the shared expert only needs `normed2`, so it runs on the aux
+    // stream concurrently with the routed path's dispatch/grouped-GEMM/
+    // combine — the cooperative collectives occupy a fixed SM slice and
+    // mostly wait on peers, leaving the rest of the GPU free.
+    let normed_ready = ctx.stream.record_event(None)?;
+    aux.stream.wait(&normed_ready)?;
+    moe.shared.forward_into(
+        aux,
+        s.layer.normed2.data(),
+        &mut s.shared_mlp,
+        s.layer.shared_out.data_mut(),
+    )?;
+    let shared_done = aux.stream.record_event(None)?;
+
+    run_router_into(ctx, &moe.router, s.layer.normed2.data(), &mut s.router)?;
+    let dispatched = glm52_moe_ep8_routed_forward(
+        ctx,
+        ep8,
+        &moe.bank,
+        Some((s.layer.normed2.data(), &s.router.route, batch)),
+        global_tokens,
+    )?;
+    ensure!(
+        dispatched,
+        "EP8 MoE returned no combined output for the dispatched rows"
+    );
+    // Join: the closing add consumes both branches.
+    ctx.stream.wait(&shared_done)?;
+    add_into(
+        ctx,
+        ep8.combined(),
+        s.layer.shared_out.data(),
+        batch * GLM52_HIDDEN,
+        s.layer.mlp_out.data_mut(),
+    )
+}

--- a/openinfer-glm52/src/oracle/layer.rs
+++ b/openinfer-glm52/src/oracle/layer.rs
@@ -466,7 +466,7 @@ fn run_layer_prefill(
     let mqa_shape =
         Glm52IndexerScratch::decode_shape(1, index_cache_layout, index_blocks, NUM_SMS, oracle_ctx);
     let mut scratch =
-        Glm52DecodeScratch::new(ctx, &contract, mqa_shape, crate::config::GLM52_HEADS)?;
+        Glm52DecodeScratch::new(ctx, &contract, mqa_shape, crate::config::GLM52_HEADS, false)?;
 
     let mut outputs = Vec::with_capacity(oracle_ctx * HIDDEN);
     for position in 0..oracle_ctx {

--- a/openinfer-glm52/src/oracle/layer_ep8.rs
+++ b/openinfer-glm52/src/oracle/layer_ep8.rs
@@ -193,7 +193,7 @@ fn run_layer_prefill_ep8(
     let mqa_shape =
         Glm52IndexerScratch::decode_shape(1, index_cache_layout, index_blocks, NUM_SMS, oracle_ctx);
     let mut scratch =
-        Glm52DecodeScratch::new(ctx, &contract, mqa_shape, crate::config::GLM52_HEADS)?;
+        Glm52DecodeScratch::new(ctx, &contract, mqa_shape, crate::config::GLM52_HEADS, false)?;
 
     let mut outputs = Vec::with_capacity(oracle_ctx * HIDDEN);
     for position in 0..oracle_ctx {

--- a/openinfer-glm52/src/oracle/layer_tp8.rs
+++ b/openinfer-glm52/src/oracle/layer_tp8.rs
@@ -211,7 +211,7 @@ fn run_layer_prefill_tp8(
     let mqa_shape =
         Glm52IndexerScratch::decode_shape(1, index_cache_layout, index_blocks, NUM_SMS, oracle_ctx);
     let mut scratch =
-        Glm52DecodeScratch::new(ctx, &contract, mqa_shape, crate::config::GLM52_HEADS)?;
+        Glm52DecodeScratch::new(ctx, &contract, mqa_shape, crate::config::GLM52_HEADS, false)?;
     let mut router_scratch = Glm52RouterScratch::new(ctx, 1)?;
 
     // 8-row staging for the replicated kernel (rows 1..8 stay zero).

--- a/openinfer-glm52/src/runner.rs
+++ b/openinfer-glm52/src/runner.rs
@@ -7,6 +7,7 @@ use std::{
 
 use anyhow::{Context as _, Result, ensure};
 use crossbeam_channel::{Receiver, Sender, bounded, unbounded};
+use openinfer_core::cuda_graph::CudaGraphDumpSummary;
 use openinfer_kv_offload::KvArena;
 
 use crate::dspark::{
@@ -105,6 +106,7 @@ enum Glm52RankCommand {
     BuildModel {
         max_model_len: usize,
         moe_topo: crate::Glm52MoeTopo,
+        dspark_enabled: bool,
         resp: Sender<Result<Vec<KvArena>>>,
     },
     /// Collective: create the DeepEP context (barriers across ranks). Issued
@@ -161,6 +163,15 @@ enum Glm52RankCommand {
         appends: Vec<(usize, usize)>,
         proposals: Vec<(usize, u32, usize)>,
         resp: Sender<Result<Vec<[u32; GLM52_DSPARK_DRAFTS]>>>,
+    },
+    /// Rank-local inspection of an already pre-captured whole-step graph.
+    /// This command stays on the worker so CUDA graph handles never cross the
+    /// thread/context ownership boundary.
+    DumpDecodeGraph {
+        bucket: usize,
+        png_path: PathBuf,
+        title: String,
+        resp: Sender<Result<CudaGraphDumpSummary>>,
     },
     Shutdown,
 }
@@ -226,12 +237,14 @@ impl Glm52RankWorker {
         &self,
         max_model_len: usize,
         moe_topo: crate::Glm52MoeTopo,
+        dspark_enabled: bool,
     ) -> Result<Receiver<Result<Vec<KvArena>>>> {
         let (resp_tx, resp_rx) = bounded(1);
         self.tx
             .send(Glm52RankCommand::BuildModel {
                 max_model_len,
                 moe_topo,
+                dspark_enabled,
                 resp: resp_tx,
             })
             .map_err(|_| anyhow::anyhow!("GLM5.2 rank worker channel closed"))?;
@@ -313,6 +326,24 @@ impl Glm52RankWorker {
                 resets,
                 appends,
                 proposals,
+                resp: resp_tx,
+            })
+            .map_err(|_| anyhow::anyhow!("GLM5.2 rank worker channel closed"))?;
+        Ok(resp_rx)
+    }
+
+    pub(crate) fn dump_decode_graph_async(
+        &self,
+        bucket: usize,
+        png_path: PathBuf,
+        title: String,
+    ) -> Result<Receiver<Result<CudaGraphDumpSummary>>> {
+        let (resp_tx, resp_rx) = bounded(1);
+        self.tx
+            .send(Glm52RankCommand::DumpDecodeGraph {
+                bucket,
+                png_path,
+                title,
                 resp: resp_tx,
             })
             .map_err(|_| anyhow::anyhow!("GLM5.2 rank worker channel closed"))?;
@@ -455,6 +486,7 @@ impl Glm52RankThreadState {
         &mut self,
         max_model_len: usize,
         moe_topo: crate::Glm52MoeTopo,
+        dspark_enabled: bool,
     ) -> Result<Vec<KvArena>> {
         let mut weights = self
             .loaded
@@ -469,6 +501,7 @@ impl Glm52RankThreadState {
             moe_topo
                 .uses_tensor_replicated_moe()
                 .then_some(self.placement.rank),
+            dspark_enabled,
         )?);
         let arenas = model.kv_arenas(&dev_ctx.stream)?;
         let aux_ctx = self.ctx.auxiliary_device_context("decode aux")?;
@@ -697,6 +730,19 @@ impl Glm52RankThreadState {
             seed,
         )
     }
+
+    fn dump_decode_graph(
+        &self,
+        bucket: usize,
+        png_path: &Path,
+        title: &str,
+    ) -> Result<CudaGraphDumpSummary> {
+        let runtime = self
+            .runtime
+            .as_ref()
+            .context("GLM5.2 graph dump before build_model")?;
+        runtime.model.dump_decode_graph_png(bucket, png_path, title)
+    }
 }
 
 fn rank_worker_loop(rx: &Receiver<Glm52RankCommand>, mut state: Glm52RankThreadState) {
@@ -712,9 +758,10 @@ fn rank_worker_loop(rx: &Receiver<Glm52RankCommand>, mut state: Glm52RankThreadS
             Glm52RankCommand::BuildModel {
                 max_model_len,
                 moe_topo,
+                dspark_enabled,
                 resp,
             } => {
-                let _ = resp.send(state.build_model(max_model_len, moe_topo));
+                let _ = resp.send(state.build_model(max_model_len, moe_topo, dspark_enabled));
             }
             Glm52RankCommand::SetupComm {
                 unique_id,
@@ -734,6 +781,14 @@ fn rank_worker_loop(rx: &Receiver<Glm52RankCommand>, mut state: Glm52RankThreadS
                 resp,
             } => {
                 let _ = resp.send(state.step(&inputs, shape, &kv, flags, &sampling, seed));
+            }
+            Glm52RankCommand::DumpDecodeGraph {
+                bucket,
+                png_path,
+                title,
+                resp,
+            } => {
+                let _ = resp.send(state.dump_decode_graph(bucket, &png_path, &title));
             }
             Glm52RankCommand::LoadDspark { path, resp } => {
                 let _ = resp.send(state.load_dspark(&path));

--- a/openinfer-glm52/src/scheduler/contract_tests.rs
+++ b/openinfer-glm52/src/scheduler/contract_tests.rs
@@ -12,10 +12,25 @@ use openinfer_sample::SamplingParams;
 use crate::model::GLM52_MAX_BATCH_PER_RANK;
 
 use super::admission::lifetime_blocks;
+use super::graph::graph_dump_bucket;
 use super::slot::GLM52_DSPARK_EP8_SPAN_DRAFTS;
 use super::slot::{Glm52SlotState, Glm52StepOutcome};
 use super::testkit::{EOS, request};
 use super::{ActiveRequest, PAGE, RankSlots, admit_from_queue, publish_load};
+
+#[test]
+fn graph_dump_uses_a_serving_shape_for_each_topology() {
+    assert_eq!(
+        graph_dump_bucket(false),
+        1,
+        "EP8 and TP4 have a true bucket-1 graph"
+    );
+    assert_eq!(
+        graph_dump_bucket(true),
+        GLM52_MAX_BATCH_PER_RANK,
+        "full-bucket TP8 only captures its fixed bucket-8 shape"
+    );
+}
 
 #[test]
 fn load_snapshots_keep_rank_ownership() {

--- a/openinfer-glm52/src/scheduler/graph.rs
+++ b/openinfer-glm52/src/scheduler/graph.rs
@@ -1,0 +1,112 @@
+use std::path::PathBuf;
+
+use anyhow::Context as _;
+use openinfer_core::cuda_graph::CudaGraphDumpSummary;
+use openinfer_kv_cache::BlockPool;
+
+use crate::Glm52MoeTopo;
+use crate::model::{GLM52_DECODE_BUCKETS, GLM52_MAX_BATCH_PER_RANK, Glm52StepShape};
+use crate::runner::{Glm52RankWorker, Glm52StepFlags};
+
+use super::plan::padding_step_kv;
+use super::slot::GLM52_PADDING_STEP;
+
+pub(super) type GraphDumpRequest = (
+    PathBuf,
+    crossbeam_channel::Sender<anyhow::Result<CudaGraphDumpSummary>>,
+);
+
+/// Pre-capture every whole-step bucket graph while the ranks are idle and
+/// trivially in lock-step. Launch-ahead speculation requires captured-ness
+/// to be UNIFORM across ranks — a lazily capturing rank would skip the
+/// speculative replay the others enqueued and desync the collectives — and
+/// pre-capturing also removes the old mid-serving capture stall. Every row
+/// is a padding write into the pool's padding page.
+pub(super) fn precapture_step_graphs(
+    workers: &[Glm52RankWorker],
+    pools: &[BlockPool],
+    table_width: usize,
+    mirrored: bool,
+    full_bucket: bool,
+) -> anyhow::Result<()> {
+    // TP8 serves exactly one shape. EP8 and TP4 capture every bucket; TP4 is
+    // still mirrored, but only its MoE subgraph pads to eight rows.
+    let capture_bucket = |bucket: usize| !full_bucket || bucket == GLM52_MAX_BATCH_PER_RANK;
+    for &bucket in GLM52_DECODE_BUCKETS
+        .iter()
+        .filter(|&&bucket| capture_bucket(bucket))
+    {
+        let mut shape = Glm52StepShape {
+            bucket,
+            slots: [0; GLM52_MAX_BATCH_PER_RANK],
+            active_rows: 0,
+        };
+        for (slot, dst) in shape.slots.iter_mut().enumerate().take(bucket) {
+            *dst = slot as u8;
+        }
+        let inputs =
+            [(GLM52_PADDING_STEP.token, GLM52_PADDING_STEP.position); GLM52_MAX_BATCH_PER_RANK];
+        let flags = Glm52StepFlags::plain();
+        let responses = workers
+            .iter()
+            .enumerate()
+            .map(|(rank, worker)| {
+                let pool = &pools[if mirrored { 0 } else { rank }];
+                let kv = padding_step_kv(bucket, table_width, pool.padding_block_id(), &inputs);
+                worker.step_async(inputs, shape, kv, flags, Vec::new(), 0)
+            })
+            .collect::<anyhow::Result<Vec<_>>>()
+            .context("GLM5.2 graph pre-capture submit")?;
+        for (rank, response) in responses.into_iter().enumerate() {
+            response
+                .recv()
+                .map_err(|_| anyhow::anyhow!("rank dropped its pre-capture response"))
+                .and_then(|result| result)
+                .with_context(|| {
+                    format!("GLM5.2 graph pre-capture (bucket {bucket}) on rank {rank}")
+                })?;
+        }
+    }
+    log::info!(
+        "GLM5.2 whole-step graphs pre-captured: {} buckets",
+        GLM52_DECODE_BUCKETS
+            .iter()
+            .filter(|&&bucket| capture_bucket(bucket))
+            .count()
+    );
+    Ok(())
+}
+
+/// Export rank 0's serving graph after the all-rank pre-capture barrier.
+/// EP8 and TP4 have a true bucket-1 graph; TP8 always executes the mirrored
+/// full-bucket shape.
+pub(super) fn dump_rank0_decode_graph(
+    workers: &[Glm52RankWorker],
+    moe_topo: Glm52MoeTopo,
+    full_bucket: bool,
+    png_path: PathBuf,
+) -> anyhow::Result<CudaGraphDumpSummary> {
+    let rank0 = workers
+        .first()
+        .context("GLM5.2 graph export requires rank 0")?;
+    let bucket = graph_dump_bucket(full_bucket);
+    let topology = match moe_topo {
+        Glm52MoeTopo::Ep8 => "DP8/EP8",
+        Glm52MoeTopo::Tp8 => "MoE TP8 · mirrored",
+        Glm52MoeTopo::Tp4 => "MoE TP4 · mirrored",
+    };
+    let title =
+        format!("GLM5.2 whole-step decode CUDA Graph · rank 0 · {topology} · bucket {bucket}");
+    rank0
+        .dump_decode_graph_async(bucket, png_path, title)?
+        .recv()
+        .map_err(|_| anyhow::anyhow!("GLM5.2 rank 0 dropped its graph export response"))?
+}
+
+pub(super) fn graph_dump_bucket(full_bucket: bool) -> usize {
+    if full_bucket {
+        GLM52_MAX_BATCH_PER_RANK
+    } else {
+        1
+    }
+}

--- a/openinfer-glm52/src/scheduler/mod.rs
+++ b/openinfer-glm52/src/scheduler/mod.rs
@@ -35,6 +35,7 @@
 mod admission;
 #[cfg(test)]
 mod contract_tests;
+mod graph;
 mod load;
 mod offload;
 mod plan;
@@ -44,8 +45,6 @@ mod testkit;
 
 use std::collections::VecDeque;
 
-use anyhow::Context as _;
-
 use openinfer_core::engine::{GenerateRequest, LoadSnapshot, TokenEvent, unix_now_s};
 use openinfer_kv_cache::{BlockPool, RequestKv};
 use openinfer_kv_offload::OffloadEngine;
@@ -53,16 +52,15 @@ use openinfer_sample::mix_seed;
 use tokio::sync::{mpsc, watch};
 
 use crate::model::{
-    GLM52_DECODE_BUCKETS, GLM52_MAX_BATCH_PER_RANK, GLM52_MODEL_LEN_ALIGN, Glm52StepKv,
-    Glm52StepShape, glm52_pool_blocks, glm52_table_width,
+    GLM52_MAX_BATCH_PER_RANK, GLM52_MODEL_LEN_ALIGN, Glm52StepKv, Glm52StepShape,
+    glm52_pool_blocks, glm52_table_width,
 };
 use crate::runner::{Glm52RankWorker, Glm52StepFlags};
 
 use admission::{intake, lifetime_blocks};
+use graph::{GraphDumpRequest, dump_rank0_decode_graph, precapture_step_graphs};
 use load::{pending_is_empty, publish_load, running_counts};
-use plan::{
-    collect_sampling_rows, feed_wants, launch_ahead_flags, padding_step_kv, plan_step_shapes,
-};
+use plan::{collect_sampling_rows, feed_wants, launch_ahead_flags, plan_step_shapes};
 use slot::{GLM52_PADDING_STEP, Glm52SlotState, Glm52StepOutcome};
 
 /// The KV page size (== the FlashMLA page / index-K block / model-len
@@ -119,6 +117,7 @@ pub(crate) fn run_dp8_coordinator(
     offload: Option<Vec<OffloadEngine>>,
     moe_topo: crate::Glm52MoeTopo,
     load_txs: Vec<watch::Sender<LoadSnapshot>>,
+    graph_dump_request: Option<GraphDumpRequest>,
 ) {
     // Tensor-replicated topology: ONE logical rank drives mirrored executors.
     // Every worker receives the identical step (inputs, shape, KV, seed) and
@@ -200,11 +199,29 @@ pub(crate) fn run_dp8_coordinator(
     // workers' sequential Drop joins them (the same collective-teardown
     // contract as the exit path).
     if let Err(err) = precapture_step_graphs(&workers, &pools, table_width, mirrored, full_bucket) {
+        if let Some((_, response)) = graph_dump_request {
+            let _ = response.send(Err(anyhow::anyhow!("{err:#}")));
+        }
         log::error!("GLM5.2 graph pre-capture failed: {err:#}");
         for worker in &workers {
             let _ = worker.request_shutdown();
         }
         return;
+    }
+    if let Some((png_path, response)) = graph_dump_request {
+        match dump_rank0_decode_graph(&workers, moe_topo, full_bucket, png_path) {
+            Ok(summary) => {
+                let _ = response.send(Ok(summary));
+            }
+            Err(err) => {
+                log::error!("GLM5.2 CUDA Graph export failed: {err:#}");
+                let _ = response.send(Err(err));
+                for worker in &workers {
+                    let _ = worker.request_shutdown();
+                }
+                return;
+            }
+        }
     }
 
     // The step shapes that carried the last launch-ahead lease, and whether
@@ -382,66 +399,6 @@ pub(crate) fn run_dp8_coordinator(
         let _ = worker.request_shutdown();
     }
     drop(workers);
-}
-
-/// Pre-capture every whole-step bucket graph while the ranks are idle and
-/// trivially in lock-step. Launch-ahead speculation requires captured-ness
-/// to be UNIFORM across ranks — a lazily capturing rank would skip the
-/// speculative replay the others enqueued and desync the collectives — and
-/// pre-capturing also removes the old mid-serving capture stall. Every row
-/// is a padding write into the pool's padding page.
-fn precapture_step_graphs(
-    workers: &[Glm52RankWorker],
-    pools: &[BlockPool],
-    table_width: usize,
-    mirrored: bool,
-    full_bucket: bool,
-) -> anyhow::Result<()> {
-    // TP8 serves exactly one shape. EP8 and TP4 capture every bucket; TP4 is
-    // still mirrored, but only its MoE subgraph pads to eight rows.
-    let capture_bucket = |bucket: usize| !full_bucket || bucket == GLM52_MAX_BATCH_PER_RANK;
-    for &bucket in GLM52_DECODE_BUCKETS
-        .iter()
-        .filter(|&&bucket| capture_bucket(bucket))
-    {
-        let mut shape = Glm52StepShape {
-            bucket,
-            slots: [0; GLM52_MAX_BATCH_PER_RANK],
-            active_rows: 0,
-        };
-        for (slot, dst) in shape.slots.iter_mut().enumerate().take(bucket) {
-            *dst = slot as u8;
-        }
-        let inputs =
-            [(GLM52_PADDING_STEP.token, GLM52_PADDING_STEP.position); GLM52_MAX_BATCH_PER_RANK];
-        let flags = Glm52StepFlags::plain();
-        let responses = workers
-            .iter()
-            .enumerate()
-            .map(|(rank, worker)| {
-                let pool = &pools[if mirrored { 0 } else { rank }];
-                let kv = padding_step_kv(bucket, table_width, pool.padding_block_id(), &inputs);
-                worker.step_async(inputs, shape, kv, flags, Vec::new(), 0)
-            })
-            .collect::<anyhow::Result<Vec<_>>>()
-            .context("GLM5.2 graph pre-capture submit")?;
-        for (rank, resp) in responses.into_iter().enumerate() {
-            resp.recv()
-                .map_err(|_| anyhow::anyhow!("rank dropped its pre-capture response"))
-                .and_then(|r| r)
-                .with_context(|| {
-                    format!("GLM5.2 graph pre-capture (bucket {bucket}) on rank {rank}")
-                })?;
-        }
-    }
-    log::info!(
-        "GLM5.2 whole-step graphs pre-captured: {} buckets",
-        GLM52_DECODE_BUCKETS
-            .iter()
-            .filter(|&&bucket| capture_bucket(bucket))
-            .count()
-    );
-    Ok(())
 }
 
 /// Admission: fill each rank's free slots from its own FIFO queue while its

--- a/openinfer-glm52/src/scratch.rs
+++ b/openinfer-glm52/src/scratch.rs
@@ -58,11 +58,12 @@ pub(crate) struct Glm52DecodeScratch {
     /// The residual stream: embed writes it, every layer reads and rewrites
     /// it, the final norm consumes it.
     pub(crate) hidden: Rows<GLM52_HIDDEN>,
-    /// DSpark aux-hidden capture: each row's residual stream after the
+    /// Optional DSpark aux-hidden capture: each row's residual stream after the
     /// [`crate::dspark::GLM52_DSPARK_AUX_LAYERS`] layers, concatenated per row
-    /// (`[tokens, 5 * GLM52_HIDDEN]`). Written inside the captured step graph
-    /// (5 strided row copies), read by the draft lane between steps.
-    pub(crate) captured: Rows<GLM52_DSPARK_CONTEXT_DIM>,
+    /// (`[tokens, 5 * GLM52_HIDDEN]`). Present only when the drafter was
+    /// requested at launch; otherwise neither the buffer nor its five graph
+    /// copy nodes exist.
+    pub(crate) captured: Option<Rows<GLM52_DSPARK_CONTEXT_DIM>>,
     pub(crate) final_normed: Rows<GLM52_HIDDEN>,
     pub(crate) logits: Rows<GLM52_VOCAB>,
     /// Device greedy argmax outputs: each row's top logit bf16 value (for the
@@ -82,6 +83,7 @@ impl Glm52DecodeScratch {
         contract: &Glm52FlashMlaSparseDecode,
         mqa_shape: Glm52DeepGemmMqaLogitsShape,
         mla_heads: usize,
+        dspark_enabled: bool,
     ) -> Result<Self> {
         Self::new_for_backend(
             ctx,
@@ -89,6 +91,7 @@ impl Glm52DecodeScratch {
             mqa_shape,
             mla_heads,
             Glm52MlaBackend::FlashMlaFp8Ds,
+            dspark_enabled,
         )
     }
 
@@ -98,6 +101,7 @@ impl Glm52DecodeScratch {
         mqa_shape: Glm52DeepGemmMqaLogitsShape,
         mla_heads: usize,
         mla_backend: Glm52MlaBackend,
+        dspark_enabled: bool,
     ) -> Result<Self> {
         let tokens = contract.batch_size;
         anyhow::ensure!(
@@ -125,7 +129,9 @@ impl Glm52DecodeScratch {
                 .alloc_zeros::<bf16>(GLM52_TP_TOKENS * GLM52_HIDDEN)?,
             layer: Glm52LayerScratch::new(ctx, tokens)?,
             hidden: Rows::zeros(ctx, tokens)?,
-            captured: Rows::zeros(ctx, tokens)?,
+            captured: dspark_enabled
+                .then(|| Rows::zeros(ctx, tokens))
+                .transpose()?,
             final_normed: Rows::zeros(ctx, tokens)?,
             logits: Rows::zeros(ctx, tokens)?,
             argmax_partial_values: ctx

--- a/openinfer-server/src/bin/glm52_step_bench.rs
+++ b/openinfer-server/src/bin/glm52_step_bench.rs
@@ -105,6 +105,7 @@ fn main() -> Result<()> {
             no_prefix_cache: false,
             kv_offload: None,
             moe_topo,
+            dump_graph_png: None,
         },
     )
     .context("failed to start GLM5.2 engine")?;

--- a/openinfer-server/src/config.rs
+++ b/openinfer-server/src/config.rs
@@ -33,10 +33,11 @@ pub(crate) struct Args {
     #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
     pub cuda_graph: bool,
 
-    /// Dump the live Qwen3 rank-0, batch-1 SplitKv decode CUDA Graph during
-    /// startup. Writes a detailed sibling `.dot` for LLM inspection and a
-    /// compact Graphviz-rendered PNG at this path. Requires CUDA driver API
-    /// 12.3 or newer for kernel-name inspection.
+    /// Dump a live rank-0 decode CUDA Graph during startup. Qwen3 exports its
+    /// batch-1 SplitKv graph; GLM5.2 exports EP8 bucket 1 or the fixed TP8
+    /// bucket 8 selected by `--moe-topo`. Writes a complete sibling `.dot` for
+    /// machine inspection and a folded Graphviz PNG at this path. Requires
+    /// CUDA driver API 12.3 or newer for kernel-name inspection.
     #[arg(long)]
     pub dump_graph_png: Option<PathBuf>,
 
@@ -259,6 +260,7 @@ fn consumed_args(model_type: ModelType) -> &'static [&'static str] {
             "kv_offload_host_gib",
             "kv_offload_hugepages",
             "moe_topo",
+            "dump_graph_png",
         ],
         #[cfg(feature = "kimi-k2")]
         ModelType::KimiK2 => &["tp_size", "dp_size", "ep_backend", "cuda_graph"],
@@ -656,6 +658,15 @@ mod tests {
 
         assert!(error.contains("--max-lora-rank must be one of"));
         assert!(error.contains("16"));
+    }
+
+    #[cfg(feature = "glm52")]
+    #[test]
+    fn glm52_accepts_graph_png_dump() {
+        let (args, provided) =
+            parse_with_provided(&["openinfer", "--dump-graph-png", "decode.png"]);
+        args.validate(ModelType::Glm52, &provided)
+            .expect("GLM5.2 should accept a graph PNG dump");
     }
 
     #[cfg(feature = "glm52")]

--- a/openinfer-server/src/main.rs
+++ b/openinfer-server/src/main.rs
@@ -145,6 +145,7 @@ fn load_engine(args: &Args, model_type: ModelType) -> anyhow::Result<EngineHandl
                             use_hugepages: args.kv_offload_hugepages,
                         }),
                     moe_topo,
+                    dump_graph_png: args.dump_graph_png.clone(),
                 },
             )
             .context("failed to start GLM5.2 engine")?


### PR DESCRIPTION
## Summary

- extend `--dump-graph-png PATH` to GLM5.2, exporting rank 0 bucket 1 for EP8 and the fixed bucket 8 for mirrored TP8
- preserve CUDA programmatic-dependent-launch ports and dependency types in the complete DOT sidecar, while rendering a readable folded PNG from exact repeated DAGs
- allocate and capture DSpark hidden-state copies only when `--dspark-path` is enabled
- keep graph inspection on the CUDA-context-owning rank worker and fail startup cleanly on pre-capture or export errors
- split graph rendering, scheduler graph setup, and the captured model step body into focused submodules

## Validation

- `cargo test --release -p openinfer-core --lib`: 27 passed
- `cargo test --release -p openinfer-glm52 --lib`: 57 passed, 14 hardware tests ignored
- server graph CLI tests: 4 passed
- release GLM5.2/server feature check and H200-target release build passed
- strict `openinfer-core` Clippy, formatting, diff checks, and all pre-commit hooks passed
- strict GLM5.2 Clippy remains blocked by seven unrelated existing lints
- three post-measurement review passes reached Ready for Review

### 8× H200 live export

| topology | physical bucket | nodes | kernels | edges | PDL edges | PNG |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| EP8 | 1 | 3,144 | 2,928 | 3,334 | 399 | 2,611×11,538 |
| TP8 mirrored | 8 | 2,986 | 2,770 | 3,026 | 21 | 3,045×11,911 |

Both detailed DOT files reparsed with Graphviz, both one-token HTTP requests returned 200, and both DSpark-off graphs contained zero `copy_hidden_rows_kernel` nodes.

## Performance Work

This is an opt-in diagnostic feature, not a decode optimization. Same-build EP8 A/B:

| metric | no dump | graph dump | delta |
| --- | ---: | ---: | ---: |
| engine startup | 73.207 s | 75.841 s | +2.634 s |
| identical one-token request | 20.423 ms | 20.442 ms | +0.019 ms |

The request delta is noise-sized. The enabled run spent 1.139 seconds inspecting, folding, and rendering after pre-capture; the rest of the startup delta comes primarily from waiting for pre-capture before engine publication.