### PR TITLE
fix(kernels): drop redundant clone in the glm52 stub nvcc args

### DIFF
--- a/openinfer-kernels/build.rs
+++ b/openinfer-kernels/build.rs
@@ -1515,7 +1515,7 @@ fn main() {
             "-I".to_string(),
             cuda_include.to_string_lossy().to_string(),
         ];
-        nvcc_args.extend(arch_args.clone());
+        nvcc_args.extend(arch_args);
         nvcc_args.extend(["--compiler-options".to_string(), "-fPIC".to_string()]);
         nvcc_tasks.push(NvccTask {
             cu_file: stub_path,


### PR DESCRIPTION
## Why

Main CI is red: the `Qwen3 CUDA Clippy (sm_80)` job fails on every run since #649 merged (ed63986).

#649 deleted the last consumer of `arch_args` after the glm52 TileLang stub branch in `openinfer-kernels/build.rs`, so the `.clone()` at the final use site became `clippy::redundant_clone`, which the nightly clippy gate rejects under `-D warnings`:

```
error: redundant clone
    --> openinfer-kernels/build.rs:1518:35
1518 |         nvcc_args.extend(arch_args.clone());
```

(#649's branch runs showed the same failure three times; it merged with the job red.)

## What

Move `arch_args` instead of cloning it at its last use.

## Verification

`cargo clippy --release --locked -p openinfer-server --all-targets -- -D warnings` (the exact CI command) passes locally on nightly-2026-07-10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)