### PR TITLE
chore: clear the clippy backlog outside the linted lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,8 +249,20 @@ jobs:
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libibverbs-dev
 
+      # Clippy lints only the packages named here; dependencies are compiled, not linted.
+      # openinfer-cupti is out: building it needs CUPTI headers the toolkit above omits.
       - name: Run Qwen3 CUDA Clippy
-        run: cargo clippy --release --locked -p openinfer-server --all-targets -- -D warnings
+        run: >-
+          cargo clippy --release --locked
+          -p openinfer-server
+          -p openinfer-qwen3
+          -p openinfer-core
+          -p openinfer-kernels
+          -p openinfer-kv-cache
+          -p openinfer-kv-offload
+          -p openinfer-sample
+          -p openinfer-bench
+          --all-targets -- -D warnings
         env:
           CUDA_PATH: /usr/local/cuda
           OPENINFER_CUDA_SM: "80"

--- a/openinfer-core/src/cuda_graph/dump.rs
+++ b/openinfer-core/src/cuda_graph/dump.rs
@@ -468,6 +468,8 @@ fn dot_escape(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Write as _;
+
     use super::{
         GraphDescription, GraphEdge, GraphNode, GraphNodeKind, communicate, demangle, dot_escape,
         format_driver_api_version,
@@ -516,9 +518,10 @@ mod tests {
             .stderr(std::process::Stdio::piped())
             .spawn()
             .expect("spawn pipe stress child");
-        let input = (0..2_048)
-            .map(|index| format!("line_{index:04}_{}\n", "x".repeat(96)))
-            .collect::<String>();
+        let mut input = String::new();
+        for index in 0..2_048 {
+            let _ = writeln!(input, "line_{index:04}_{}", "x".repeat(96));
+        }
 
         let output = communicate(child, input.clone(), "pipe stress child")
             .expect("communicate with pipe stress child");

--- a/openinfer-deepseek-v2-lite/src/bin/dsv2_lite_ep2_decode_attribution.rs
+++ b/openinfer-deepseek-v2-lite/src/bin/dsv2_lite_ep2_decode_attribution.rs
@@ -130,7 +130,7 @@ fn main() -> Result<()> {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
         }
-        fs::write(&path, format!("{text}\n"))
+        fs::write(path, format!("{text}\n"))
             .with_context(|| format!("write {}", path.display()))?;
         eprintln!("wrote {}", path.display());
     }

--- a/openinfer-deepseek-v2-lite/src/model.rs
+++ b/openinfer-deepseek-v2-lite/src/model.rs
@@ -429,11 +429,10 @@ fn load_bf16_tensor_host(
     );
     Ok(tensor
         .data()
-        .chunks_exact(std::mem::size_of::<bf16>())
-        .map(|bytes| {
-            let bits = u16::from_le_bytes([bytes[0], bytes[1]]);
-            bf16::from_bits(bits).to_f32()
-        })
+        .as_chunks::<{ std::mem::size_of::<bf16>() }>()
+        .0
+        .iter()
+        .map(|bytes| bf16::from_bits(u16::from_le_bytes(*bytes)).to_f32())
         .collect())
 }
 

--- a/openinfer-deepseek-v2-lite/src/runtime/moe/tests.rs
+++ b/openinfer-deepseek-v2-lite/src/runtime/moe/tests.rs
@@ -78,10 +78,13 @@ fn device_router_matches_host_softmax_topk_rule() {
     let logits = gate_logits_host(&config, &hidden_host, &gate_host_f32);
     let expected = topk_softmax_routes(&config, &logits, hidden.seq_len);
 
-    for token in 0..hidden.seq_len {
-        for route in 0..config.num_experts_per_token {
+    for (token, expected_routes) in expected.iter().enumerate().take(hidden.seq_len) {
+        for (route, &(expected_idx, expected_weight)) in expected_routes
+            .iter()
+            .enumerate()
+            .take(config.num_experts_per_token)
+        {
             let offset = token * config.num_experts_per_token + route;
-            let (expected_idx, expected_weight) = expected[token][route];
             assert_eq!(got_idx[offset], expected_idx as i32);
             assert_close(got_weight[offset], expected_weight, 1.0e-6);
         }
@@ -170,7 +173,7 @@ fn router_logits_rejects_inflated_hidden_metadata() {
 
     let err = dsv2_lite_router_logits_into(&ctx, &hidden, &gate, &mut logits)
         .expect_err("inflated hidden metadata must fail before CUDA launch");
-    assert_error_contains(err, "router hidden backing buffer too small");
+    assert_error_contains(&err, "router hidden backing buffer too small");
 }
 
 #[test]
@@ -199,7 +202,7 @@ fn router_logits_rejects_inflated_gate_metadata() {
 
     let err = dsv2_lite_router_logits_into(&ctx, &hidden, &gate, &mut logits)
         .expect_err("inflated gate metadata must fail before CUDA launch");
-    assert_error_contains(err, "router gate backing buffer too small");
+    assert_error_contains(&err, "router gate backing buffer too small");
 }
 
 #[test]
@@ -235,7 +238,7 @@ fn router_topk_rejects_inflated_hidden_metadata() {
         },
     )
     .expect_err("inflated hidden metadata must fail before CUDA launch");
-    assert_error_contains(err, "router hidden backing buffer too small");
+    assert_error_contains(&err, "router hidden backing buffer too small");
 }
 
 #[test]
@@ -264,7 +267,7 @@ fn route_row_accumulation_rejects_inflated_rows_metadata() {
         &mut out,
     )
     .expect_err("inflated rows metadata must fail before CUDA launch");
-    assert_error_contains(err, "route rows backing buffer too small");
+    assert_error_contains(&err, "route rows backing buffer too small");
 }
 
 #[test]
@@ -302,7 +305,7 @@ fn fixed_expert_accumulate_rejects_inflated_output_metadata() {
         &mut accum,
     )
     .expect_err("inflated expert output metadata must fail before CUDA launch");
-    assert_error_contains(err, "fixed-expert output backing buffer too small");
+    assert_error_contains(&err, "fixed-expert output backing buffer too small");
 }
 
 #[test]
@@ -331,7 +334,7 @@ fn kv_norm_rejects_inflated_input_metadata() {
 
     let err = dsv2_lite_kv_norm_into(&ctx, &kv_a, &norm_weight, 2, 1.0e-6, &mut compressed)
         .expect_err("inflated kv_a metadata must fail before CUDA launch");
-    assert_error_contains(err, "kv norm kv_a backing buffer too small");
+    assert_error_contains(&err, "kv norm kv_a backing buffer too small");
 }
 
 #[test]
@@ -360,7 +363,7 @@ fn kv_norm_rejects_inflated_output_metadata() {
 
     let err = dsv2_lite_kv_norm_into(&ctx, &kv_a, &norm_weight, 2, 1.0e-6, &mut compressed)
         .expect_err("inflated compressed metadata must fail before CUDA launch");
-    assert_error_contains(err, "kv norm compressed backing buffer too small");
+    assert_error_contains(&err, "kv norm compressed backing buffer too small");
 }
 
 #[test]
@@ -399,7 +402,7 @@ fn decode_attention_rejects_inflated_q_metadata() {
         &mut out,
     )
     .expect_err("inflated q metadata must fail before CUDA launch");
-    assert_error_contains(err, "attention q backing buffer too small");
+    assert_error_contains(&err, "attention q backing buffer too small");
 }
 
 #[test]
@@ -435,7 +438,7 @@ fn decode_attention_rejects_inflated_output_metadata() {
         &mut out,
     )
     .expect_err("inflated out metadata must fail before CUDA launch");
-    assert_error_contains(err, "attention out backing buffer too small");
+    assert_error_contains(&err, "attention out backing buffer too small");
 }
 
 #[test]
@@ -657,7 +660,7 @@ fn assert_close(got: f32, expected: f32, tolerance: f32) {
     );
 }
 
-fn assert_error_contains(err: anyhow::Error, needle: &str) {
+fn assert_error_contains(err: &anyhow::Error, needle: &str) {
     let message = err.to_string();
     assert!(
         message.contains(needle),

--- a/openinfer-deepseek-v2-lite/src/scheduler.rs
+++ b/openinfer-deepseek-v2-lite/src/scheduler.rs
@@ -422,7 +422,7 @@ impl MixedRequestScheduler {
             Ok(next_tokens) => {
                 retire_rows_with_error(
                     states,
-                    format!(
+                    &format!(
                         "DeepSeek-V2-Lite batched decode returned {} rows for {} active requests",
                         next_tokens.len(),
                         group_size
@@ -435,7 +435,7 @@ impl MixedRequestScheduler {
             Err(err) => {
                 retire_rows_with_error(
                     states,
-                    format!(
+                    &format!(
                         "DeepSeek-V2-Lite batched decode failed for {} active requests: {err}",
                         group_size
                     ),
@@ -509,13 +509,13 @@ fn apply_decoded_tokens_to_rows(
 
 fn retire_rows_with_error(
     states: Vec<ActiveRequestState>,
-    message: String,
+    message: &str,
     active_remaining: &mut usize,
     pending_queue_size: usize,
 ) {
     for state in states {
         *active_remaining = active_remaining.saturating_sub(1);
-        state.emit_error(message.clone(), *active_remaining, pending_queue_size);
+        state.emit_error(message.to_string(), *active_remaining, pending_queue_size);
     }
 }
 

--- a/openinfer-deepseek-v2-lite/src/scheduler/tests.rs
+++ b/openinfer-deepseek-v2-lite/src/scheduler/tests.rs
@@ -273,10 +273,11 @@ fn send_scheduled_returns_trace_when_client_is_closed() {
     let scheduled = send_scheduled(&pending).expect_err("send should fail");
 
     assert_eq!(
-        scheduled.queued_at_unix_s,
+        scheduled.queued_at_unix_s.to_bits(),
         pending
             .queued_at_unix_s
             .unwrap_or(scheduled.scheduled_at_unix_s)
+            .to_bits()
     );
     assert!(scheduled.scheduled_at_unix_s > 0.0);
 }
@@ -394,7 +395,7 @@ fn batch_decode_error_retires_all_active_requests() {
     ];
 
     let mut active_remaining = 2;
-    retire_rows_with_error(active, "batch failed".to_string(), &mut active_remaining, 0);
+    retire_rows_with_error(active, "batch failed", &mut active_remaining, 0);
     assert_eq!(active_remaining, 0);
 
     match recv_event(&mut first_rx) {
@@ -434,12 +435,7 @@ fn subgroup_decode_error_retires_only_group_rows() {
     let third = active_state("third", third_tx, 3, 2, 13, &config);
 
     let mut active_remaining = 3;
-    retire_rows_with_error(
-        vec![first, third],
-        "group failed".to_string(),
-        &mut active_remaining,
-        0,
-    );
+    retire_rows_with_error(vec![first, third], "group failed", &mut active_remaining, 0);
     assert_eq!(active_remaining, 1);
 
     match recv_event(&mut first_rx) {
@@ -466,7 +462,7 @@ fn cross_group_terminal_accounting_uses_shared_active_remaining() {
     let mut active_remaining = 3;
     retire_rows_with_error(
         vec![first, second],
-        "group failed".to_string(),
+        "group failed",
         &mut active_remaining,
         0,
     );

--- a/openinfer-deepseek-v2-lite/tests/e2e_ep2.rs
+++ b/openinfer-deepseek-v2-lite/tests/e2e_ep2.rs
@@ -635,13 +635,18 @@ fn run_mixed_serving_generation(model_path: &Path, model_path_label: &str) -> Re
         "mixed-serving output drift on {model_path_label}: actual={actual:?} expected={expected:?}"
     );
 
-    run_mixed_serving_position_fallback(&handle, fallback_encoded, fallback_expected, &mut actual)?;
+    run_mixed_serving_position_fallback(
+        &handle,
+        fallback_encoded,
+        &fallback_expected,
+        &mut actual,
+    )?;
 
     run_mixed_serving_rejection_isolation(
         &handle,
         isolation_id,
         isolation_prompt_tokens,
-        isolation_expected.tokens,
+        &isolation_expected.tokens,
         isolation_expected.finish_reason,
         &mut actual,
     )?;
@@ -673,7 +678,7 @@ fn run_mixed_serving_generation(model_path: &Path, model_path_label: &str) -> Re
 fn run_mixed_serving_position_fallback(
     handle: &openinfer_engine::engine::EngineHandle,
     encoded_cases: Vec<(String, Vec<u32>, usize, bool)>,
-    expected: Vec<(String, Vec<u32>, FinishReason)>,
+    expected: &[(String, Vec<u32>, FinishReason)],
     actual: &mut Vec<(String, Vec<u32>, FinishReason)>,
 ) -> Result<()> {
     let mut requests = Vec::with_capacity(encoded_cases.len());
@@ -744,7 +749,7 @@ fn run_mixed_serving_rejection_isolation(
     handle: &openinfer_engine::engine::EngineHandle,
     valid_id: &str,
     valid_prompt_tokens: Vec<u32>,
-    expected_tokens: Vec<u32>,
+    expected_tokens: &[u32],
     expected_finish_reason: FinishReason,
     actual: &mut Vec<(String, Vec<u32>, FinishReason)>,
 ) -> Result<()> {

--- a/openinfer-glm52/src/dspark.rs
+++ b/openinfer-glm52/src/dspark.rs
@@ -696,9 +696,9 @@ impl Glm52DsparkModel {
                 context_projection!();
                 for l in 0..DSPARK_LAYERS {
                     layer_prolog!(l);
-                    for i in 0..active {
-                        state_prep!(l, i, &mut *states[i]);
-                        state_dynamic!(l, i, &mut *states[i]);
+                    for (i, state) in states.iter_mut().enumerate().take(active) {
+                        state_prep!(l, i, &mut **state);
+                        state_dynamic!(l, i, &mut **state);
                     }
                     layer_tail!(l);
                 }

--- a/openinfer-glm52/src/dspark_slot.rs
+++ b/openinfer-glm52/src/dspark_slot.rs
@@ -4,10 +4,13 @@
 
 use anyhow::{Result, ensure};
 use cudarc::driver::CudaSlice;
+use half::bf16;
 
 use openinfer_kernels::tensor::{DeviceContext, HiddenStates};
 
-use super::*;
+use super::{
+    DSPARK_LAYERS, DSPARK_QKV_DIM, GLM52_DSPARK_BLOCK, GLM52_DSPARK_CONTEXT_DIM, GLM52_HIDDEN,
+};
 
 pub(super) struct DsparkLayerKv {
     pub(super) k: HiddenStates,

--- a/openinfer-glm52/src/dspark_smoke.rs
+++ b/openinfer-glm52/src/dspark_smoke.rs
@@ -54,7 +54,7 @@ fn bench_propose(
 
     let mut times_ms = Vec::with_capacity(ITERS);
     for round in 0..WARMUP + ITERS {
-        for state in states.iter_mut() {
+        for state in &mut states {
             state.append_captured_row(ctx, &captured, 0)?;
         }
         // Each round drains 1 pending row into committed, so the anchor sits
@@ -247,6 +247,7 @@ fn dspark_propose_graph_parity() -> Result<()> {
 #[test]
 #[ignore = "GPU isolation test — needs a CUDA device with ~11 GB free VRAM"]
 fn dspark_propose_batched_slot_isolation() -> Result<()> {
+    type SlotDrafts = Vec<[u32; GLM52_DSPARK_DRAFTS]>;
     const ROUNDS: usize = 6;
     let _env = ENV_LOCK.lock().unwrap();
     let ctx = DeviceContext::new()?;
@@ -277,12 +278,7 @@ fn dspark_propose_batched_slot_isolation() -> Result<()> {
     };
     let cap_a = captured_row(3)?;
 
-    let run = |cap_b_salt: u32,
-               anchor_b_base: u32|
-     -> Result<(
-        Vec<[u32; GLM52_DSPARK_DRAFTS]>,
-        Vec<[u32; GLM52_DSPARK_DRAFTS]>,
-    )> {
+    let run = |cap_b_salt: u32, anchor_b_base: u32| -> Result<(SlotDrafts, SlotDrafts)> {
         let cap_b = captured_row(cap_b_salt)?;
         let mut scratch = Glm52DsparkScratch::new(&ctx, cache_len)?;
         let mut a = Glm52DsparkSlotState::new(&ctx, cache_len)?;

--- a/openinfer-glm52/src/fp8.rs
+++ b/openinfer-glm52/src/fp8.rs
@@ -36,8 +36,10 @@ pub(crate) fn e4m3_to_f32(b: u8) -> f32 {
 }
 
 pub(crate) fn bytes_to_f32(b: &[u8]) -> Vec<f32> {
-    b.chunks_exact(4)
-        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+    b.as_chunks::<4>()
+        .0
+        .iter()
+        .map(|c| f32::from_le_bytes(*c))
         .collect()
 }
 

--- a/openinfer-glm52/src/moe_tp.rs
+++ b/openinfer-glm52/src/moe_tp.rs
@@ -744,12 +744,19 @@ mod tests {
             // slice blocks 0..2 = gate blocks 2r..2r+2; 2..4 = up (same rows).
             for b in 0..4 {
                 let expect = (2 * rank + b % 2) as f32;
-                assert_eq!(read_f32(&s.w13_scale, b * 48), expect, "rank {rank} b {b}");
+                assert_eq!(
+                    read_f32(&s.w13_scale, b * 48).to_bits(),
+                    expect.to_bits(),
+                    "rank {rank} b {b}"
+                );
             }
             for row in [0usize, 47] {
                 for b in 0..2 {
                     let expect = (2 * rank + b) as f32;
-                    assert_eq!(read_f32(&s.w2_scale, row * 2 + b), expect);
+                    assert_eq!(
+                        read_f32(&s.w2_scale, row * 2 + b).to_bits(),
+                        expect.to_bits()
+                    );
                 }
             }
         }

--- a/openinfer-glm52/src/oracle/indexer.rs
+++ b/openinfer-glm52/src/oracle/indexer.rs
@@ -138,8 +138,10 @@ fn indexer_oracle_gate() -> Result<()> {
     // safetensors data() is a byte view into the mmap with no alignment
     // guarantee — decode per element instead of casting the pointer.
     let bf16_vec = |data: &[u8]| -> Vec<bf16> {
-        data.chunks_exact(2)
-            .map(|b| bf16::from_le_bytes([b[0], b[1]]))
+        data.as_chunks::<2>()
+            .0
+            .iter()
+            .map(|b| bf16::from_le_bytes(*b))
             .collect()
     };
 
@@ -178,8 +180,10 @@ fn indexer_oracle_gate() -> Result<()> {
         "topk size mismatch"
     );
     let topk_all: Vec<i32> = topk_data
-        .chunks_exact(4)
-        .map(|b| i32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|b| i32::from_le_bytes(*b))
         .collect();
     let oracle_topk: &[i32] =
         &topk_all[position * GLM52_INDEXER_TOPK..(position + 1) * GLM52_INDEXER_TOPK];

--- a/openinfer-glm52/src/oracle/mla.rs
+++ b/openinfer-glm52/src/oracle/mla.rs
@@ -325,8 +325,10 @@ fn diff_against_dump(outputs: &[f32], dump: &Path) -> Result<()> {
     let oracle: Vec<f32> = st
         .tensor("o")?
         .data()
-        .chunks_exact(2)
-        .map(|c| bf16::from_le_bytes([c[0], c[1]]).to_f32())
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|c| bf16::from_le_bytes(*c).to_f32())
         .collect();
     ensure!(
         oracle.len() == outputs.len(),

--- a/openinfer-glm52/src/oracle/tp8_ar.rs
+++ b/openinfer-glm52/src/oracle/tp8_ar.rs
@@ -203,7 +203,7 @@ fn tp8_ar_brick_gate() -> Result<()> {
     }
 
     let timings: Vec<f64> = all.iter().map(|(_, us)| *us).collect();
-    let worst = timings.iter().cloned().fold(0.0f64, f64::max);
+    let worst = timings.iter().copied().fold(0.0f64, f64::max);
     println!("tp8_ar standalone: per-rank us/layer = {timings:.3?}, worst {worst:.2}");
     ensure!(
         worst <= 10.0,

--- a/openinfer-qwen3/src/dflash.rs
+++ b/openinfer-qwen3/src/dflash.rs
@@ -872,7 +872,7 @@ mod tests {
             .expect("DFlash config should match target");
 
         assert_eq!(dflash.block_size, 16);
-        assert_eq!(dflash.mask_token_id, 151669);
+        assert_eq!(dflash.mask_token_id, 151_669);
         assert_eq!(dflash.target_layer_ids, vec![1, 9, 17, 25, 33]);
 
         // Pin the memory reservation the KV budget bills against. The per-token

--- a/openinfer-qwen3/src/executor/remote_fetch.rs
+++ b/openinfer-qwen3/src/executor/remote_fetch.rs
@@ -92,8 +92,8 @@ mod tests {
 
     type Action = RemoteFetchAction<u32>;
 
-    fn ready(lease: Option<u32>, num_blocks: usize) -> Result<QueryView<u32>, ()> {
-        Ok(QueryView::Ready { lease, num_blocks })
+    fn ready(lease: Option<u32>, num_blocks: usize) -> QueryView<u32> {
+        QueryView::Ready { lease, num_blocks }
     }
 
     /// Past the deadline the request prefills from scratch and, critically,
@@ -120,7 +120,7 @@ mod tests {
     /// the request just prefills from scratch.
     #[test]
     fn zero_hit_prefills_from_scratch() {
-        let action = remote_fetch_action(false, || ready(None, 0), usize::MAX, 0);
+        let action = remote_fetch_action(false, || Ok::<_, ()>(ready(None, 0)), usize::MAX, 0);
         assert_eq!(action, Action::Scratch);
     }
 
@@ -135,28 +135,28 @@ mod tests {
     /// for release — the type makes dropping it silently unrepresentable.
     #[test]
     fn budget_guard_releases_the_lease() {
-        let action = remote_fetch_action(false, || ready(Some(7), 10), 12, 3);
+        let action = remote_fetch_action(false, || Ok::<_, ()>(ready(Some(7), 10)), 12, 3);
         assert_eq!(action, Action::Release(7));
     }
 
     /// `reserve_floor > available_blocks` must saturate, not underflow.
     #[test]
     fn budget_guard_saturates_when_floor_exceeds_available() {
-        let action = remote_fetch_action(false, || ready(Some(7), 1), 2, 5);
+        let action = remote_fetch_action(false, || Ok::<_, ()>(ready(Some(7), 1)), 2, 5);
         assert_eq!(action, Action::Release(7));
     }
 
     /// Exactly-at-budget reserves and loads: the guard is strict-less-than.
     #[test]
     fn exact_budget_boundary_loads() {
-        let action = remote_fetch_action(false, || ready(Some(7), 9), 12, 3);
+        let action = remote_fetch_action(false, || Ok::<_, ()>(ready(Some(7), 9)), 12, 3);
         assert_eq!(action, Action::Load(7, 9));
     }
 
     /// The normal path: leased hit within budget starts the H2D load.
     #[test]
     fn leased_hit_within_budget_loads() {
-        let action = remote_fetch_action(false, || ready(Some(42), 4), 64, 8);
+        let action = remote_fetch_action(false, || Ok::<_, ()>(ready(Some(42), 4)), 64, 8);
         assert_eq!(action, Action::Load(42, 4));
     }
 }

--- a/openinfer-qwen3/tests/dflash_speculative_gate.rs
+++ b/openinfer-qwen3/tests/dflash_speculative_gate.rs
@@ -311,7 +311,7 @@ fn check_lossless(
         eprintln!("  [diag] prompt {i} matched={matched}");
         eprintln!(
             "  [diag] context+gen base ids {:?} = {:?}",
-            &base_ids,
+            base_ids,
             tokenizer.decode(&base_ids, false).unwrap_or_default()
         );
         eprintln!(
@@ -400,7 +400,9 @@ fn dflash_speculative_greedy_matches_plain_greedy() {
     let (Some(model_path), Some(draft_path)) = (target_path_or_skip(), draft_path_or_skip()) else {
         return;
     };
-    let _gpu = GPU.lock().unwrap_or_else(|p| p.into_inner());
+    let _gpu = GPU
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
 
     let prompts = [
         "The capital of France is",
@@ -493,16 +495,19 @@ fn dflash_speculative_greedy_matches_plain_greedy() {
 /// is only ever captured/replayed at the maximal shape) it stays lossless.
 #[test]
 fn dflash_short_then_long_verify_capture_is_lossless() {
-    let (Some(model_path), Some(draft_path)) = (target_path_or_skip(), draft_path_or_skip()) else {
-        return;
-    };
-    let _gpu = GPU.lock().unwrap_or_else(|p| p.into_inner());
-
     // << block_size (16): the poison request's only verify step is a short
     // truncated span, capturing the bucket-bs=1 graph at total_tokens far below
     // the full span. The fewer valid rows, the sooner a full-span replay hits the
     // stale tail — so the victim diverges early, well clear of its token budget.
     const POISON_MAX_TOKENS: usize = 4;
+
+    let (Some(model_path), Some(draft_path)) = (target_path_or_skip(), draft_path_or_skip()) else {
+        return;
+    };
+    let _gpu = GPU
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
     let poison_prompt = "Hello, world! Tell me a story.";
     let victim_prompt = "Q: What is 17 multiplied by 23? A: Let's think step by step.";
 
@@ -578,7 +583,9 @@ fn dflash_concurrent_heterogeneous_is_lossless() {
     let (Some(model_path), Some(draft_path)) = (target_path_or_skip(), draft_path_or_skip()) else {
         return;
     };
-    let _gpu = GPU.lock().unwrap_or_else(|p| p.into_inner());
+    let _gpu = GPU
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
 
     // Distinct prompts with staggered budgets: at any tick the in-flight batch
     // mixes full and near-budget (truncated) verify spans.
@@ -658,10 +665,14 @@ fn dflash_concurrent_heterogeneous_is_lossless() {
 /// panicked mid-prefill when the draft allocated KV past its own max positions.
 #[test]
 fn dflash_request_in_draft_headroom_is_rejected_not_panicked() {
+    const BLOCK_SIZE: usize = 16; // DFlash drafter block size.
+
     let (Some(model_path), Some(draft_path)) = (target_path_or_skip(), draft_path_or_skip()) else {
         return;
     };
-    let _gpu = GPU.lock().unwrap_or_else(|p| p.into_inner());
+    let _gpu = GPU
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
 
     // Read the real context window so the boundary is exact regardless of the
     // checkpoint, then size the request to sit inside the draft's final in-fill
@@ -673,7 +684,6 @@ fn dflash_request_in_draft_headroom_is_rejected_not_panicked() {
     let max_pos = config["max_position_embeddings"]
         .as_u64()
         .expect("max_position_embeddings") as usize;
-    const BLOCK_SIZE: usize = 16; // DFlash drafter block size.
     let prompt_len = 16usize;
     // total in (max_pos - BLOCK_SIZE, max_pos]: clears the target check, trips
     // the DFlash admission cap (max_pos - BLOCK_SIZE).

--- a/openinfer-qwen3/tests/hf_golden_gate.rs
+++ b/openinfer-qwen3/tests/hf_golden_gate.rs
@@ -185,8 +185,10 @@ fn as_i32(st: &SafeTensors, name: &str) -> (Vec<i32>, Vec<usize>) {
     assert_eq!(t.dtype(), Dtype::I32, "{name} must be i32");
     let v = t
         .data()
-        .chunks_exact(4)
-        .map(|b| i32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|b| i32::from_le_bytes(*b))
         .collect();
     (v, t.shape().to_vec())
 }
@@ -197,8 +199,10 @@ fn as_f32(st: &SafeTensors, name: &str) -> Vec<f32> {
         .unwrap_or_else(|e| panic!("golden missing {name}: {e}"));
     assert_eq!(t.dtype(), Dtype::F32, "{name} must be f32");
     t.data()
-        .chunks_exact(4)
-        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|b| f32::from_le_bytes(*b))
         .collect()
 }
 

--- a/openinfer-qwen3/tests/lora_golden_gate.rs
+++ b/openinfer-qwen3/tests/lora_golden_gate.rs
@@ -68,8 +68,10 @@ fn as_i32(st: &SafeTensors, name: &str) -> (Vec<i32>, Vec<usize>) {
     assert_eq!(t.dtype(), Dtype::I32, "{name} must be i32");
     let v = t
         .data()
-        .chunks_exact(4)
-        .map(|b| i32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|b| i32::from_le_bytes(*b))
         .collect();
     (v, t.shape().to_vec())
 }
@@ -80,8 +82,10 @@ fn as_f32(st: &SafeTensors, name: &str) -> Vec<f32> {
         .unwrap_or_else(|e| panic!("golden missing {name}: {e}"));
     assert_eq!(t.dtype(), Dtype::F32, "{name} must be f32");
     t.data()
-        .chunks_exact(4)
-        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|b| f32::from_le_bytes(*b))
         .collect()
 }
 

--- a/openinfer-qwen35-4b/src/scheduler.rs
+++ b/openinfer-qwen35-4b/src/scheduler.rs
@@ -110,15 +110,12 @@ pub fn start_with_capacity(
         })
         .expect("failed to spawn Qwen3.5 scheduler thread");
 
-    let startup = match startup_rx.recv() {
-        Ok(startup) => startup,
-        Err(_) => {
-            let panic_note = match join_handle.join() {
-                Err(panic) => format!(" (thread panicked: {})", panic_message(panic.as_ref())),
-                Ok(()) => String::new(),
-            };
-            anyhow::bail!("Qwen3.5 scheduler exited during startup{panic_note}");
-        }
+    let Ok(startup) = startup_rx.recv() else {
+        let panic_note = match join_handle.join() {
+            Err(panic) => format!(" (thread panicked: {})", panic_message(panic.as_ref())),
+            Ok(()) => String::new(),
+        };
+        anyhow::bail!("Qwen3.5 scheduler exited during startup{panic_note}");
     };
     if let Err(err) = startup {
         let _ = join_handle.join();
@@ -348,7 +345,7 @@ fn prefill_batch(
     // Scope the borrows of `chunk` to the executor call so the error path can
     // move `chunk` into `fail_chunk`.
     let result = {
-        let window_refs: Vec<&[u32]> = chunk.windows.iter().map(|w| w.as_slice()).collect();
+        let window_refs: Vec<&[u32]> = chunk.windows.iter().map(Vec::as_slice).collect();
         let mut rec_refs: Vec<&mut RecurrentState> = chunk.recs.iter_mut().collect();
         model.batch_prefill_logits(&window_refs, &mut chunk.kvs, &mut rec_refs)
     };
@@ -435,7 +432,7 @@ fn unified_step_sched(
     // Scope the borrows of `chunk` / `active` to the executor call so the error
     // and decode-processing paths can use them afterwards.
     let result = {
-        let window_refs: Vec<&[u32]> = chunk.windows.iter().map(|w| w.as_slice()).collect();
+        let window_refs: Vec<&[u32]> = chunk.windows.iter().map(Vec::as_slice).collect();
         let mut rec_refs: Vec<&mut RecurrentState> = chunk.recs.iter_mut().collect();
         let decode_tokens: Vec<u32> = active.iter().map(|r| r.last_token).collect();
         let mut decode_kv_refs: Vec<&mut KvState> = active.iter_mut().map(|r| &mut r.kv).collect();

--- a/openinfer-qwen35-4b/tests/e2e_scheduler.rs
+++ b/openinfer-qwen35-4b/tests/e2e_scheduler.rs
@@ -196,7 +196,7 @@ fn collect_generation(
 }
 
 fn concurrent_params(case_idx: usize) -> SamplingParams {
-    if case_idx % 2 == 0 {
+    if case_idx.is_multiple_of(2) {
         SamplingParams::default()
     } else {
         SamplingParams {

--- a/openinfer-qwen35-4b/tests/hf_golden_gate.rs
+++ b/openinfer-qwen35-4b/tests/hf_golden_gate.rs
@@ -238,8 +238,10 @@ fn as_i32(st: &SafeTensors, name: &str) -> (Vec<i32>, Vec<usize>) {
     assert_eq!(t.dtype(), Dtype::I32, "{name} must be i32");
     let v = t
         .data()
-        .chunks_exact(4)
-        .map(|b| i32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|b| i32::from_le_bytes(*b))
         .collect();
     (v, t.shape().to_vec())
 }
@@ -250,8 +252,10 @@ fn as_f32(st: &SafeTensors, name: &str) -> Vec<f32> {
         .unwrap_or_else(|e| panic!("golden missing {name}: {e}"));
     assert_eq!(t.dtype(), Dtype::F32, "{name} must be f32");
     t.data()
-        .chunks_exact(4)
-        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|b| f32::from_le_bytes(*b))
         .collect()
 }
 


### PR DESCRIPTION
## Description

Name every CUDA-side crate in the lane (nine now, `-D warnings`), and clear the warnings they surface. The lane needs no new CI dependency: those crates were already being compiled by it.

## Still warning

Three lints are left in place, all in model crates whose hardware this change cannot exercise:

| crate | lint | why it stays |
| --- | --- | --- |
| `openinfer-deepseek-v2-lite` | `large_enum_variant` (`runtime/graph_probe.rs`) | boxing a variant that holds CUDA-graph scratch changes host layout; graph capture is exactly the class of bug a compile cannot catch, and EP2 needs two GPUs |
| `openinfer-deepseek-v2-lite` | `struct_excessive_bools` (`runtime/types.rs`) | same crate, same reason to keep the diff out of it |
| `openinfer-glm52` | `fn_params_excessive_bools` (`scheduler/plan.rs`) | 8-GPU crate, untested here |

## Verification — Single GPU (sm_89, x86_64)

- The nine-crate lane passes `-D warnings` at `OPENINFER_CUDA_SM=80`, the value CI uses.
- `cargo fmt --all --check` passes.
- Feature-gated crates linted with their toolchains present (Triton for qwen35, TileLang + NCCL + SM 90 for glm52 / kimi): `openinfer-qwen35-4b` and `openinfer-kimi-k2` are warning-free; `openinfer-deepseek-v2-lite` and `openinfer-glm52` report exactly the three warnings listed above and nothing else.
- `openinfer-qwen3` (67) and `openinfer-core` (27) unit tests pass, as does `openinfer-deepseek-v2-lite`'s lib suite and the qwen3 `batch_invariance_endtoend` gate.