### PR TITLE
perf(glm52): indexer weights_proj via min-latency GEMV, drop last per-step cublas splitK plan

### DIFF
--- a/openinfer-glm52/src/indexer.rs
+++ b/openinfer-glm52/src/indexer.rs
@@ -20,7 +20,7 @@
 //!   |
 //! hidden[6144]
 //!   +-- wk (fp8 linear) -> k_raw[128]
-//!   +-- weights_proj (bf16 GEMM) -> weights[32]
+//!   +-- weights_proj (bf16 min-latency GEMV) -> weights[32]
 //!   +-- k quant + cache write (glm52_indexer_k_quant_and_cache)
 //!   |
 //!   +-- DeepGEMM paged MQA logits (fuses per-head ReLU + weighting)
@@ -37,11 +37,11 @@ use openinfer_kernels::ops::{
     GLM52_GEMV_MMA_SCRATCH_FLOATS_PER_ROW, GLM52_INDEXER_HEAD_DIM, GLM52_INDEXER_TOPK,
     Glm52DeepGemmMqaLogitsShape, Glm52IndexerCacheInsert, Glm52IndexerCacheLayout,
     Glm52IndexerLocalTopKToSlots, Glm52IndexerTopK, Glm52MoeQuantShape, bf16_bytes_to_f32_into,
-    gemm_strided_batched_bf16, glm52_deepgemm_paged_mqa_logits_launch,
-    glm52_deepgemm_paged_mqa_metadata_launch, glm52_flashinfer_topk_2048_launch,
-    glm52_fp8_per_token_group_quant_bf16_launch, glm52_indexer_k_quant_and_cache_launch,
-    glm52_indexer_local_topk_to_slots_launch, glm52_indexer_rope_launch,
-    glm52_indexer_weights_fold_launch, layer_norm_into,
+    glm52_deepgemm_paged_mqa_logits_launch, glm52_deepgemm_paged_mqa_metadata_launch,
+    glm52_flashinfer_topk_2048_launch, glm52_fp8_per_token_group_quant_bf16_launch,
+    glm52_indexer_k_quant_and_cache_launch, glm52_indexer_local_topk_to_slots_launch,
+    glm52_indexer_rope_launch, glm52_indexer_weights_fold_launch,
+    glm52_indexer_weights_proj_launch, layer_norm_into,
 };
 use openinfer_kernels::tensor::DeviceContext;
 
@@ -65,7 +65,7 @@ const K_NORM_EPS: f32 = 1.0e-6;
 pub(crate) struct Glm52IndexerLayerWeights {
     wq_b: ProjWeight,              // [32*128, 2048]
     wk: ProjWeight,                // [128, 6144]
-    weights_proj: CudaSlice<bf16>, // [32, 6144] — bf16 GEMM (transformers _keep_in_fp32_modules)
+    weights_proj: CudaSlice<bf16>, // [32, 6144] — bf16 GEMV (transformers _keep_in_fp32_modules)
     k_norm_w: CudaSlice<f32>,      // [128] — LayerNorm gamma (f32 for FlashInfer)
     k_norm_b: CudaSlice<f32>,      // [128] — LayerNorm beta  (f32 for FlashInfer)
 }
@@ -398,30 +398,17 @@ pub(crate) fn glm52_indexer_forward_into(
         Some(&mut s.gemv_partial),
         &mut s.k_raw,
     )?; // [T, 128]
-    // weights_proj: bf16 GEMM (transformers keeps weights_proj in fp32 via
-    // _keep_in_fp32_modules; checkpoint stores bf16, so bf16 GEMM is the
-    // closest match without a dedicated f32 GEMM path).
-    // cuBLAS column-major: weights [32, 6144] row-major = [6144, 32]^T,
-    // hidden [T, 6144] row-major = [6144, T] col-major. So m=32, n=T, k=6144,
-    // op_a=T, op_b=N; the col-major [32, T] output IS the row-major [T, 32]
-    // layout the fold consumes.
-    gemm_strided_batched_bf16(
+    // weights_proj: bf16 in/out (transformers keeps it fp32 via
+    // _keep_in_fp32_modules; the checkpoint stores bf16). Min-latency GEMV,
+    // [T, 32] row-major out — the layout the fold consumes.
+    glm52_indexer_weights_proj_launch(
         ctx,
-        true,        // transpose_a: weights [32, 6144] row-major → col-major
-        false,       // transpose_b: hidden [6144, T] col-major
-        INDEX_HEADS, // m = 32
-        t,           // n = batch rows
-        HIDDEN,      // k = 6144
-        &w.weights_proj,
-        HIDDEN, // lda = k (row stride of transposed weights)
-        0,      // stride_a (batch=1, unused)
         hidden.data(),
-        HIDDEN, // ldb = k
-        0,      // stride_b
+        &w.weights_proj,
+        t,
+        INDEX_HEADS,
+        HIDDEN,
         &mut s.weights_bf16,
-        INDEX_HEADS, // ldc = m
-        0,           // stride_c
-        1,           // batch
     )?;
     // ---- k LayerNorm (eps=1e-6, with bias), one CTA per row ----
     layer_norm_into(

--- a/openinfer-glm52/src/model/mod.rs
+++ b/openinfer-glm52/src/model/mod.rs
@@ -147,6 +147,11 @@ const _: () = assert!(
         <= openinfer_kernels::ops::GLM52_DEEPGEMM_MASKED_CAP
 );
 
+// The min-latency GEMV (router logits, indexer weights_proj) dispatches
+// tokens 1..=8; a bucket bump must extend glm52_min_gemv.cuh first.
+const _: () =
+    assert!(GLM52_MAX_BATCH_PER_RANK <= openinfer_kernels::ops::GLM52_MIN_GEMV_MAX_TOKENS);
+
 // The decode feed kernel runs one 32-thread block (`glm52_decode_feed.cu`);
 // a batch-cap bump past it must widen the kernel, not silently truncate.
 const _: () = assert!(GLM52_MAX_BATCH_PER_RANK <= 32);

--- a/openinfer-kernels/csrc/glm52/glm52_indexer.cu
+++ b/openinfer-kernels/csrc/glm52/glm52_indexer.cu
@@ -9,6 +9,7 @@
 // int32 index-remap: page = block_table[t, off//bs]; slot = page*bs + off%bs.
 
 #include "../common.cuh"
+#include "glm52_min_gemv.cuh"
 
 #include <cfloat>
 #include <cuda.h>
@@ -208,6 +209,21 @@ CUresult glm52_indexer_k_quant_and_cache_cuda(
       k, indexer_cache, slot_mapping, tokens, cache_block_size,
       cache_block_stride_bytes);
   return consume_last_cuda_error();
+}
+
+// weights_proj [32, 6144] x hidden [tokens, 6144] -> bf16 [tokens, 32];
+// min-latency GEMV replaces the cublas splitK plan (4 graph nodes/call).
+CUresult glm52_indexer_weights_proj_cuda(const __nv_bfloat16* hidden,
+                                         const __nv_bfloat16* weights_proj,
+                                         __nv_bfloat16* out, int tokens,
+                                         int heads, int hidden_dim,
+                                         cudaStream_t stream) {
+  if (hidden == nullptr || weights_proj == nullptr || out == nullptr ||
+      heads != 32 || hidden_dim != glm52_min_gemv::kHidden) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  return map_cuda_error(glm52_min_gemv::launch_tokens<32, __nv_bfloat16>(
+      out, hidden, weights_proj, tokens, stream));
 }
 
 CUresult glm52_indexer_local_topk_to_slots_cuda(

--- a/openinfer-kernels/csrc/glm52/glm52_min_gemv.cuh
+++ b/openinfer-kernels/csrc/glm52/glm52_min_gemv.cuh
@@ -1,0 +1,125 @@
+// Min-latency bf16 GEMV for skinny decode-side projections, adapted from
+// TRT-LLM dsv3MinLatencyKernels dsv3RouterGemm.cu (Apache-2.0) via
+// SGLang/vLLM. One block per output row, fixed f32 reduction order
+// (deterministic); replaces cublas splitK plans that cost 4 whole-step-graph
+// nodes per call (GEMM + splitKreduce + workspace alloc/free).
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+// GLM5.2 (FP8 + FlashMLA) cannot run below Hopper; refuse the target.
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 900)
+#error "GLM5.2 kernels require sm_90+ (check OPENINFER_CUDA_SM / detected GPU targets)"
+#endif
+
+namespace glm52_min_gemv {
+
+constexpr int kHidden = 6144;
+constexpr int kMaxTokens = 8;  // = GLM52_MAX_BATCH_PER_RANK
+
+// out[token * kNumRows + row] = dot(hidden[token], weight[row]); weight is
+// row-major [kNumRows, kHidden].
+template <int kNumTokens, int kNumRows, typename OutT>
+__global__ __launch_bounds__(128, 1) void kernel(
+    OutT* __restrict__ out, const __nv_bfloat16* __restrict__ hidden,
+    const __nv_bfloat16* __restrict__ weight) {
+  constexpr int kBlockSize = 128;
+  constexpr int kVpt = 8;  // bf16 per uint4 vector load
+  constexpr int kWarpSize = 32;
+  constexpr int kNumWarps = kBlockSize / kWarpSize;
+  constexpr int kElemsPerIter = kVpt * kBlockSize;
+  constexpr int kIters = kHidden / kElemsPerIter;
+  static_assert(kHidden % kElemsPerIter == 0);
+
+  const int row = blockIdx.x;
+  const int tid = threadIdx.x;
+  const __nv_bfloat16* w_row = weight + static_cast<size_t>(row) * kHidden;
+
+  float acc[kNumTokens] = {};
+  __shared__ float sm_reduction[kNumTokens][kNumWarps];
+
+  cudaGridDependencySynchronize();
+
+  for (int ki = 0; ki < kIters; ++ki) {
+    const int k_base = ki * kElemsPerIter + tid * kVpt;
+    const uint4 w_vec = *reinterpret_cast<const uint4*>(w_row + k_base);
+    const __nv_bfloat16* w_bf16 = reinterpret_cast<const __nv_bfloat16*>(&w_vec);
+#pragma unroll
+    for (int m = 0; m < kNumTokens; ++m) {
+      const uint4 h_vec = *reinterpret_cast<const uint4*>(
+          hidden + static_cast<size_t>(m) * kHidden + k_base);
+      const __nv_bfloat16* h_bf16 =
+          reinterpret_cast<const __nv_bfloat16*>(&h_vec);
+#pragma unroll
+      for (int k = 0; k < kVpt; ++k) {
+        acc[m] += __bfloat162float(h_bf16[k]) * __bfloat162float(w_bf16[k]);
+      }
+    }
+  }
+
+  const int warp_id = tid / kWarpSize;
+  const int lane_id = tid % kWarpSize;
+#pragma unroll
+  for (int m = 0; m < kNumTokens; ++m) {
+    float sum = acc[m];
+    sum += __shfl_xor_sync(0xffffffff, sum, 16);
+    sum += __shfl_xor_sync(0xffffffff, sum, 8);
+    sum += __shfl_xor_sync(0xffffffff, sum, 4);
+    sum += __shfl_xor_sync(0xffffffff, sum, 2);
+    sum += __shfl_xor_sync(0xffffffff, sum, 1);
+    if (lane_id == 0) sm_reduction[m][warp_id] = sum;
+  }
+  __syncthreads();
+
+  if (tid == 0) {
+#pragma unroll
+    for (int m = 0; m < kNumTokens; ++m) {
+      float final_sum = 0.0f;
+#pragma unroll
+      for (int w = 0; w < kNumWarps; ++w) final_sum += sm_reduction[m][w];
+      out[m * kNumRows + row] = static_cast<OutT>(final_sum);
+    }
+  }
+  // Fence-free like upstream TRT-LLM: dependents can only consume after
+  // their cudaGridDependencySynchronize, which orders on our full completion.
+  cudaTriggerProgrammaticLaunchCompletion();
+}
+
+template <int kNumTokens, int kNumRows, typename OutT>
+cudaError_t launch(OutT* out, const __nv_bfloat16* hidden,
+                   const __nv_bfloat16* weight, cudaStream_t stream) {
+  // PSS needs cc >= 9.0 — a build invariant here (see the #error above).
+  cudaLaunchConfig_t config = {};
+  config.gridDim = kNumRows;
+  config.blockDim = 128;
+  config.dynamicSmemBytes = 0;
+  config.stream = stream;
+  cudaLaunchAttribute attrs[1];
+  attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+  attrs[0].val.programmaticStreamSerializationAllowed = 1;
+  config.numAttrs = 1;
+  config.attrs = attrs;
+  return cudaLaunchKernelEx(&config, kernel<kNumTokens, kNumRows, OutT>, out,
+                            hidden, weight);
+}
+
+// Runtime dispatch over 1..=kMaxTokens.
+template <int kNumRows, typename OutT>
+cudaError_t launch_tokens(OutT* out, const __nv_bfloat16* hidden,
+                          const __nv_bfloat16* weight, int tokens,
+                          cudaStream_t stream) {
+  switch (tokens) {
+    case 1: return launch<1, kNumRows>(out, hidden, weight, stream);
+    case 2: return launch<2, kNumRows>(out, hidden, weight, stream);
+    case 3: return launch<3, kNumRows>(out, hidden, weight, stream);
+    case 4: return launch<4, kNumRows>(out, hidden, weight, stream);
+    case 5: return launch<5, kNumRows>(out, hidden, weight, stream);
+    case 6: return launch<6, kNumRows>(out, hidden, weight, stream);
+    case 7: return launch<7, kNumRows>(out, hidden, weight, stream);
+    case 8: return launch<8, kNumRows>(out, hidden, weight, stream);
+    default: return cudaErrorInvalidValue;
+  }
+}
+
+}  // namespace glm52_min_gemv

--- a/openinfer-kernels/csrc/glm52/glm52_router.cu
+++ b/openinfer-kernels/csrc/glm52/glm52_router.cu
@@ -1,13 +1,9 @@
 #include "../common.cuh"
+#include "glm52_min_gemv.cuh"
 
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <math_constants.h>
-
-// GLM5.2 (FP8 + FlashMLA) cannot run below Hopper; refuse the target.
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 900)
-#error "GLM5.2 kernels require sm_90+ (check OPENINFER_CUDA_SM / detected GPU targets)"
-#endif
 
 namespace {
 
@@ -15,9 +11,6 @@ constexpr int kGlm52Experts = 256;
 // One thread per expert; threads past n_experts only idled (512 was inherited).
 constexpr int kRouterSelectThreads = kGlm52Experts;
 constexpr int kGlm52Topk = 8;
-constexpr int kGlm52Hidden = 6144;
-// = GLM52_MAX_BATCH_PER_RANK; prefill/dspark spans ride the decode buckets.
-constexpr int kRouterGemvMaxTokens = 8;
 
 __device__ __forceinline__ bool better_router_choice(float value, int expert,
                                                      float best_value,
@@ -100,125 +93,16 @@ CUresult consume_last_cuda_error() {
   return map_cuda_error(err);
 }
 
-// Adapted from TRT-LLM dsv3MinLatencyKernels dsv3RouterGemm.cu (Apache-2.0)
-// via SGLang/vLLM. One block per expert row, fixed f32 reduction order
-// (deterministic); replaces the 4-node-per-layer cublas splitK plan.
-template <int kNumTokens>
-__global__ __launch_bounds__(128, 1) void glm52_router_logits_gemv_kernel(
-    float* __restrict__ out, const __nv_bfloat16* __restrict__ hidden,
-    const __nv_bfloat16* __restrict__ gate_weight) {
-  constexpr int kBlockSize = 128;
-  constexpr int kVpt = 8;  // bf16 per uint4 vector load
-  constexpr int kWarpSize = 32;
-  constexpr int kNumWarps = kBlockSize / kWarpSize;
-  constexpr int kElemsPerIter = kVpt * kBlockSize;
-  constexpr int kIters = kGlm52Hidden / kElemsPerIter;
-  static_assert(kGlm52Hidden % kElemsPerIter == 0);
-
-  const int expert = blockIdx.x;
-  const int tid = threadIdx.x;
-  const __nv_bfloat16* w_row =
-      gate_weight + static_cast<size_t>(expert) * kGlm52Hidden;
-
-  float acc[kNumTokens] = {};
-  __shared__ float sm_reduction[kNumTokens][kNumWarps];
-
-  cudaGridDependencySynchronize();
-
-  for (int ki = 0; ki < kIters; ++ki) {
-    const int k_base = ki * kElemsPerIter + tid * kVpt;
-    const uint4 w_vec = *reinterpret_cast<const uint4*>(w_row + k_base);
-    const __nv_bfloat16* w_bf16 = reinterpret_cast<const __nv_bfloat16*>(&w_vec);
-#pragma unroll
-    for (int m = 0; m < kNumTokens; ++m) {
-      const uint4 h_vec = *reinterpret_cast<const uint4*>(
-          hidden + static_cast<size_t>(m) * kGlm52Hidden + k_base);
-      const __nv_bfloat16* h_bf16 =
-          reinterpret_cast<const __nv_bfloat16*>(&h_vec);
-#pragma unroll
-      for (int k = 0; k < kVpt; ++k) {
-        acc[m] += __bfloat162float(h_bf16[k]) * __bfloat162float(w_bf16[k]);
-      }
-    }
-  }
-
-  const int warp_id = tid / kWarpSize;
-  const int lane_id = tid % kWarpSize;
-#pragma unroll
-  for (int m = 0; m < kNumTokens; ++m) {
-    float sum = acc[m];
-    sum += __shfl_xor_sync(0xffffffff, sum, 16);
-    sum += __shfl_xor_sync(0xffffffff, sum, 8);
-    sum += __shfl_xor_sync(0xffffffff, sum, 4);
-    sum += __shfl_xor_sync(0xffffffff, sum, 2);
-    sum += __shfl_xor_sync(0xffffffff, sum, 1);
-    if (lane_id == 0) sm_reduction[m][warp_id] = sum;
-  }
-  __syncthreads();
-
-  if (tid == 0) {
-#pragma unroll
-    for (int m = 0; m < kNumTokens; ++m) {
-      float final_sum = 0.0f;
-#pragma unroll
-      for (int w = 0; w < kNumWarps; ++w) final_sum += sm_reduction[m][w];
-      out[m * kGlm52Experts + expert] = final_sum;
-    }
-  }
-  // Fence-free like upstream TRT-LLM: dependents can only consume after
-  // their cudaGridDependencySynchronize, which orders on our full completion.
-  cudaTriggerProgrammaticLaunchCompletion();
-}
-
-template <int kNumTokens>
-cudaError_t launch_router_logits_gemv(float* logits,
-                                      const __nv_bfloat16* hidden,
-                                      const __nv_bfloat16* gate_weight,
-                                      cudaStream_t stream) {
-  // PSS needs cc >= 9.0 — a build invariant here (see the #error above).
-  cudaLaunchConfig_t config = {};
-  config.gridDim = kGlm52Experts;
-  config.blockDim = 128;
-  config.dynamicSmemBytes = 0;
-  config.stream = stream;
-  cudaLaunchAttribute attrs[1];
-  attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
-  attrs[0].val.programmaticStreamSerializationAllowed = 1;
-  config.numAttrs = 1;
-  config.attrs = attrs;
-  return cudaLaunchKernelEx(&config,
-                            glm52_router_logits_gemv_kernel<kNumTokens>,
-                            logits, hidden, gate_weight);
-}
-
 CUresult glm52_router_logits_gemm(const __nv_bfloat16* hidden,
                                   const __nv_bfloat16* gate_weight,
                                   float* logits, int padded_tokens,
                                   int hidden_dim, int n_experts,
                                   cudaStream_t stream) {
-  if (hidden_dim != kGlm52Hidden || n_experts != kGlm52Experts ||
-      padded_tokens < 1 || padded_tokens > kRouterGemvMaxTokens) {
+  if (hidden_dim != glm52_min_gemv::kHidden || n_experts != kGlm52Experts) {
     return CUDA_ERROR_INVALID_VALUE;
   }
-  cudaError_t err = cudaSuccess;
-  switch (padded_tokens) {
-#define GLM52_ROUTER_GEMV_CASE(N)                                     \
-  case N:                                                             \
-    err = launch_router_logits_gemv<N>(logits, hidden, gate_weight, stream); \
-    break;
-    GLM52_ROUTER_GEMV_CASE(1)
-    GLM52_ROUTER_GEMV_CASE(2)
-    GLM52_ROUTER_GEMV_CASE(3)
-    GLM52_ROUTER_GEMV_CASE(4)
-    GLM52_ROUTER_GEMV_CASE(5)
-    GLM52_ROUTER_GEMV_CASE(6)
-    GLM52_ROUTER_GEMV_CASE(7)
-    GLM52_ROUTER_GEMV_CASE(8)
-#undef GLM52_ROUTER_GEMV_CASE
-    default:
-      return CUDA_ERROR_INVALID_VALUE;
-  }
-  return map_cuda_error(err);
+  return map_cuda_error(glm52_min_gemv::launch_tokens<kGlm52Experts, float>(
+      logits, hidden, gate_weight, padded_tokens, stream));
 }
 
 }  // namespace

--- a/openinfer-kernels/src/ffi/glm52/indexer.rs
+++ b/openinfer-kernels/src/ffi/glm52/indexer.rs
@@ -14,6 +14,16 @@ unsafe extern "C" {
         stream: CUstream,
     ) -> CUresult;
 
+    pub fn glm52_indexer_weights_proj_cuda(
+        hidden: *const Half,
+        weights_proj: *const Half,
+        out: *mut Half,
+        tokens: i32,
+        heads: i32,
+        hidden_dim: i32,
+        stream: CUstream,
+    ) -> CUresult;
+
     pub fn glm52_indexer_local_topk_to_slots_cuda(
         global_slots: *mut i32,
         topk_lens: *mut i32,

--- a/openinfer-kernels/src/ops/glm52/indexer.rs
+++ b/openinfer-kernels/src/ops/glm52/indexer.rs
@@ -221,6 +221,62 @@ pub fn glm52_indexer_local_topk_to_slots_launch(
         .map_err(|err| anyhow!("GLM5.2 indexer local_topk_to_slots launch failed: {err}"))
 }
 
+/// Token bound baked into `glm52_min_gemv.cuh`'s `launch_tokens` switch.
+pub const GLM52_MIN_GEMV_MAX_TOKENS: usize = 8;
+
+/// weights_proj min-latency GEMV: `out[t, h] = dot(hidden[t], weights[h])`,
+/// bf16 in/out with fixed-order f32 accumulation. Replaces the cublas splitK
+/// plan (GEMM + splitKreduce + workspace alloc/free per call).
+pub fn glm52_indexer_weights_proj_launch(
+    ctx: &DeviceContext,
+    hidden: &CudaSlice<bf16>,
+    weights_proj: &CudaSlice<bf16>,
+    tokens: usize,
+    heads: usize,
+    hidden_dim: usize,
+    out: &mut CudaSlice<bf16>,
+) -> Result<()> {
+    ensure!(
+        (1..=GLM52_MIN_GEMV_MAX_TOKENS).contains(&tokens),
+        "GLM5.2 indexer weights_proj tokens {tokens} outside 1..={GLM52_MIN_GEMV_MAX_TOKENS}"
+    );
+    ensure!(
+        hidden.len() >= tokens * hidden_dim,
+        "GLM5.2 indexer weights_proj hidden too small: have {}, need {}",
+        hidden.len(),
+        tokens * hidden_dim
+    );
+    ensure!(
+        weights_proj.len() >= heads * hidden_dim,
+        "GLM5.2 indexer weights_proj weights too small: have {}, need {}",
+        weights_proj.len(),
+        heads * hidden_dim
+    );
+    ensure!(
+        out.len() >= tokens * heads,
+        "GLM5.2 indexer weights_proj out too small: have {}, need {}",
+        out.len(),
+        tokens * heads
+    );
+    let (h_ptr, _g0) = hidden.device_ptr(&ctx.stream);
+    let (w_ptr, _g1) = weights_proj.device_ptr(&ctx.stream);
+    let (o_ptr, _g2) = out.device_ptr_mut(&ctx.stream);
+    let result = unsafe {
+        ffi::glm52_indexer_weights_proj_cuda(
+            h_ptr as *const ffi::Half,
+            w_ptr as *const ffi::Half,
+            o_ptr as *mut ffi::Half,
+            tokens as i32,
+            heads as i32,
+            hidden_dim as i32,
+            ctx.stream.cu_stream(),
+        )
+    };
+    result
+        .result()
+        .map_err(|err| anyhow!("GLM5.2 indexer weights_proj launch failed: {err}"))
+}
+
 /// Fold the per-head `weights_proj` output (bf16) with the per-head q quant
 /// scale and the two attention scale constants into f32 weights for the
 /// DeepGEMM MQA logits kernel: `out[h] = weights[h] * q_scale[h] *

--- a/openinfer-kernels/tests/glm52_router_smoke.rs
+++ b/openinfer-kernels/tests/glm52_router_smoke.rs
@@ -27,7 +27,7 @@ impl Lcg {
             .0
             .wrapping_mul(6_364_136_223_846_793_005)
             .wrapping_add(1_442_695_040_888_963_407);
-        (self.0 >> 33) as u32
+        (self.0 >> 32) as u32
     }
     fn unit_f32(&mut self) -> f32 {
         (self.next_u32() as f32 / u32::MAX as f32) * 2.0 - 1.0

--- a/openinfer-kernels/tests/glm52_weights_proj_smoke.rs
+++ b/openinfer-kernels/tests/glm52_weights_proj_smoke.rs
@@ -1,0 +1,78 @@
+//! Device gate for the GLM5.2 indexer weights_proj min-latency GEMV (which
+//! replaced the cublas splitK plan): bf16 [tokens,6144] x [32,6144]^T ->
+//! bf16 [tokens,32], checked against an f64 host reference at every
+//! dispatched tokens count (1..=8).
+
+#![cfg(feature = "glm52")]
+
+use half::bf16;
+use openinfer_kernels::ops::{GLM52_MIN_GEMV_MAX_TOKENS, glm52_indexer_weights_proj_launch};
+use openinfer_kernels::tensor::DeviceContext;
+
+const HIDDEN: usize = 6144;
+const HEADS: usize = 32;
+
+struct Lcg(u64);
+impl Lcg {
+    fn next_u32(&mut self) -> u32 {
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        (self.0 >> 32) as u32
+    }
+    fn unit_f32(&mut self) -> f32 {
+        (self.next_u32() as f32 / u32::MAX as f32) * 2.0 - 1.0
+    }
+}
+
+#[test]
+fn weights_proj_gemv_matches_host_reference() {
+    let Ok(ctx) = DeviceContext::new() else {
+        eprintln!("skipping: no CUDA device");
+        return;
+    };
+    let mut w_rng = Lcg(0x1d78_2026_0713);
+    let mut h_rng = Lcg(0x9e37_79b9_7f4a_7c15);
+    let weights: Vec<bf16> = (0..HEADS * HIDDEN)
+        .map(|_| bf16::from_f32(w_rng.unit_f32() * 0.05))
+        .collect();
+    let weights_dev = ctx.stream.clone_htod(&weights).expect("weights H2D");
+
+    for tokens in 1..=GLM52_MIN_GEMV_MAX_TOKENS {
+        // 0.25 scale keeps |dot| ~ 1: bf16 half-ulp 3.9e-3 vs the 8e-3 assert.
+        let hidden: Vec<bf16> = (0..tokens * HIDDEN)
+            .map(|_| bf16::from_f32(h_rng.unit_f32() * 0.25))
+            .collect();
+        let hidden_dev = ctx.stream.clone_htod(&hidden).expect("hidden H2D");
+        let mut out_dev = ctx
+            .stream
+            .alloc_zeros::<bf16>(tokens * HEADS)
+            .expect("out alloc");
+        glm52_indexer_weights_proj_launch(
+            &ctx,
+            &hidden_dev,
+            &weights_dev,
+            tokens,
+            HEADS,
+            HIDDEN,
+            &mut out_dev,
+        )
+        .expect("weights_proj launch");
+        let out = ctx.stream.clone_dtoh(&out_dev).expect("out D2H");
+
+        let mut max_err = 0.0f64;
+        for t in 0..tokens {
+            for h in 0..HEADS {
+                let mut acc = 0.0f64;
+                for k in 0..HIDDEN {
+                    acc += f64::from(hidden[t * HIDDEN + k].to_f32())
+                        * f64::from(weights[h * HIDDEN + k].to_f32());
+                }
+                let err = (f64::from(out[t * HEADS + h].to_f32()) - acc).abs();
+                max_err = max_err.max(err);
+            }
+        }
+        assert!(max_err < 8e-3, "tokens={tokens}: max err {max_err}");
+    }
+}


### PR DESCRIPTION
## What

Replace the last per-step cublas users in the GLM5.2 decode graph — the indexer `weights_proj` GEMM (`[32,6144] x [6144,tokens<=8]`, 21 call sites: 3 dense layers + every 4th MoE layer) — with the min-latency GEMV introduced for the router in #664.

Each cublas call costs 4 graph nodes at decode row counts (nvjet splitK GEMM + `splitKreduce` + workspace `mem_alloc`/`mem_free`); the GEMV is 1 node.

## How

- Hoist the router GEMV into a shared `glm52_min_gemv.cuh` template, parameterized on output rows and output dtype (`float` logits for the router, `bf16 [T,32]` for the indexer — bit-identical layout to the old cublas `ldc=32` output, consumed by `indexer_weights_fold`). One block per output row, uint4 bf16 loads, fixed f32 reduction order, PDL launch attributes. The router path is instruction-identical to #664. Hopper benefits identically; the `#error` floor stays at `__CUDA_ARCH__ >= 900`.
- Delete the cublas call site in `openinfer-glm52/src/indexer.rs`. `gemm_strided_batched_bf16` itself stays: the bookend lm-head and MLA decode still use it at non-decode shapes.
- `GLM52_MAX_BATCH_PER_RANK <= GLM52_MIN_GEMV_MAX_TOKENS` is now a compile-time assert, so a future bucket bump fails at build, not with `CUDA_ERROR_INVALID_VALUE` at runtime.
- Fix the smoke-test LCG: `state >> 33` emitted only 31 bits, making `unit_f32` all-negative — every dot product biased to ~+77, which saturated the router smoke's sigmoid to 1.0 across all 256 experts. **The merged #664 gate was exercising degenerate data until this fix.** Both smokes now draw full 32-bit outputs; the weights_proj test checks against an f64 host reference at every dispatched token count (1..=8), data scaled so bf16 output rounding (half-ulp 3.9e-3) has real slack under the 8e-3 assert.

## Measurements (GB300 tray, EP4, buckets 1+8, 96 steps, same-session A/B)

| | main (#664) | this PR |
|---|---|---|
| bucket-1 p50 / p99 | 22.72 / 22.90 ms | **22.62 / 22.76 ms** |
| bucket-8 p50 / p99 | 40.79 / 82.62 ms | 40.80 / 82.33 ms |
| bucket-1 graph kernel nodes | 2625 | **2604** (−42 splitK, +21 GEMV) |
| `mem_alloc` / `mem_free` nodes | 21 / 21 | **0 / 0** |
| `splitKreduce` kernels | 21 | 0 |

Fresh-binary identity verified by kernel names in the graph dot (96 `min_gemv` nodes = 75 router + 21 weights_proj). bucket-8 p99 ~2× bimodal tail is pre-existing at every EP width ≥8 and tracked separately. The 21 indexer `memcpy` nodes are a separate follow-up.

## Gates

- `glm52_weights_proj_smoke` (new), `glm52_router_smoke`, `glm52_indexer_smoke` — green on GB300 (sm_103) + 5090 (sm_120)
- `layer_moe_ep4_oracle_gate` — 63/64 probes within tol, same tie-flip allowance as baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
