### PR TITLE
feat(qwen3): sampled-verify speculative decoding — lift the greedy-only gate (#512)

### DIFF
--- a/openinfer-qwen3/src/executor.rs
+++ b/openinfer-qwen3/src/executor.rs
@@ -521,14 +521,18 @@ fn execute_step_on_lane(
                 Ok(WorkerStepOutcome::Ack)
             }
         }
-        StepCommand::SpeculativeVerify { requests, kv_views } => {
+        StepCommand::SpeculativeVerify {
+            requests,
+            kv_views,
+            sample_seed,
+        } => {
             // One target forward over each request's K+1 draft span with a
             // speculative KV view. The fixed-buffer verify path computes all-
-            // position logits (accept_greedy needs the target's posterior at
-            // each span position) and captures the target hidden states (at the
-            // DFlash layers) to seed the next draft — all into reused,
+            // position logits (accept_prefix_match needs the target's committed
+            // token at each span position) and captures the target hidden states
+            // (at the DFlash layers) to seed the next draft — all into reused,
             // pointer-stable scratch (`VerifyGraphBuffers`).
-            let result = lane.execute_dflash_verify(requests, kv_views)?;
+            let result = lane.execute_dflash_verify(requests, kv_views, *sample_seed)?;
             Ok(WorkerStepOutcome::SpeculativeVerify(result))
         }
         StepCommand::SpeculativeDraft { requests } => Ok(WorkerStepOutcome::SpeculativeDraft(
@@ -3351,6 +3355,7 @@ impl LocalQwen3Lane {
         &mut self,
         requests: &[VerifyStepItem],
         kv_views: &[KvView],
+        sample_seed: u64,
     ) -> Result<VerifyResult> {
         let capture_layer_ids = self.dflash_capture_layer_ids().ok_or_else(|| {
             anyhow::anyhow!("DFlash verify requested but no draft model is loaded")
@@ -3390,10 +3395,18 @@ impl LocalQwen3Lane {
                 &mut bufs,
             )?;
 
-            let total_tokens: usize = requests.iter().map(|req| req.as_slice().len()).sum();
-            let greedy = SamplingParams::default();
-            let params: Vec<&SamplingParams> = vec![&greedy; total_tokens];
-            let target_tokens = self.select_step_tokens(bufs.all_logits(), &params, 0)?;
+            // One committed token per span row, each row governed by ITS
+            // request's params — argmax rows batch through the fused path,
+            // sampled rows ride the regular batched sampler (sampled-verify,
+            // #512). Steps stay zeroed exactly like the plain-decode call:
+            // when sampling-parity 1b wires request-local decode steps
+            // through, verify rows must move with it (row k of a span is the
+            // request's step `completion + k`) or seeded replay breaks.
+            let params: Vec<&SamplingParams> = requests
+                .iter()
+                .flat_map(|req| std::iter::repeat_n(&req.params, req.as_slice().len()))
+                .collect();
+            let target_tokens = self.select_step_tokens(bufs.all_logits(), &params, sample_seed)?;
             let request_results = build_verify_results(requests, &target_tokens)?;
             self.record_verify_dflash_context(
                 requests,
@@ -3501,10 +3514,13 @@ enum StepCommand {
     },
     /// Speculative verify: one target forward over each request's `K + 1` draft
     /// span (with a speculative KV view), capturing target hidden states for the
-    /// next draft round. Greedy argmax per position drives [`accept_greedy`].
+    /// next draft round. Each position selects the request's *committed* token —
+    /// argmax for greedy rows, a regular sample for non-greedy rows — and the
+    /// tokens drive [`accept_prefix_match`] (sampled-verify, #512).
     SpeculativeVerify {
         requests: Vec<VerifyStepItem>,
         kv_views: Vec<KvView>,
+        sample_seed: u64,
     },
     /// Speculative draft: roll the DFlash draft model forward one block per
     /// request. Uses the draft's own KV — no target KV views.

--- a/openinfer-qwen3/src/executor/dflash_lane.rs
+++ b/openinfer-qwen3/src/executor/dflash_lane.rs
@@ -217,13 +217,6 @@ impl LocalQwen3Lane {
             !requests.is_empty(),
             "DFlash draft requested without active requests"
         );
-        for req in requests {
-            anyhow::ensure!(
-                req.params.is_greedy(),
-                "DFlash draft currently supports greedy sampling only"
-            );
-        }
-
         // Take the lane out of `self` so the draft forward (which borrows
         // `dflash.model`/`dflash.scratch`) and the argmax (which borrows
         // `self.sample_scratch`) don't collide on a `self` borrow.

--- a/openinfer-qwen3/src/executor/dflash_prefill.rs
+++ b/openinfer-qwen3/src/executor/dflash_prefill.rs
@@ -1,17 +1,17 @@
 //! DFlash prefill-capture eligibility predicates.
 //!
 //! A request can seed the DFlash draft only if its prefill produces clean target
-//! hidden states: greedy, no LoRA, no prefix-cache hit, no echo, no logprobs.
+//! hidden states: no LoRA, no prefix-cache hit, no echo, no logprobs. Sampling
+//! params are irrelevant here — the prompt's hidden states are
+//! sampling-independent, and sampled-verify (#512) speculates the full
+//! sampling surface, so capture is as valid for a sampled request as for a
+//! greedy one.
 
 use super::{PrefillStepItem, RequestId};
 
 /// Whether a prefill request is eligible to capture DFlash target context.
 pub(super) fn dflash_prefill_supported(req: &PrefillStepItem) -> bool {
-    req.lora_adapter.is_none()
-        && req.cached_tokens == 0
-        && req.logprobs == 0
-        && !req.echo
-        && req.params.is_greedy()
+    req.lora_adapter.is_none() && req.cached_tokens == 0 && req.logprobs == 0 && !req.echo
 }
 
 /// Eligible AND continuous: either the first chunk, or a later chunk whose

--- a/openinfer-qwen3/src/executor/spec.rs
+++ b/openinfer-qwen3/src/executor/spec.rs
@@ -27,10 +27,6 @@ impl Qwen3Executor {
                 req.request_id
             );
             anyhow::ensure!(
-                req.params.is_greedy(),
-                "speculative verification currently supports greedy sampling only"
-            );
-            anyhow::ensure!(
                 self.dflash_ready_requests.contains(&req.request_id),
                 "speculative verification requested before DFlash state is ready for {:?}",
                 req.request_id
@@ -70,6 +66,7 @@ impl Qwen3Executor {
         let step = StepCommand::SpeculativeVerify {
             requests: plan.requests.to_vec(),
             kv_views,
+            sample_seed: plan.sample_seed,
         };
         let outcome = match self.run_step(&step) {
             Ok(outcome) => outcome,
@@ -146,10 +143,6 @@ impl Qwen3Executor {
             "speculative draft requested but no draft model is loaded"
         );
         for req in plan.requests {
-            anyhow::ensure!(
-                req.params.is_greedy(),
-                "speculative draft currently supports greedy sampling only"
-            );
             anyhow::ensure!(
                 self.dflash_ready_requests.contains(&req.request_id),
                 "speculative draft requested before DFlash state is ready for {:?}",

--- a/openinfer-qwen3/src/scheduler/plan.rs
+++ b/openinfer-qwen3/src/scheduler/plan.rs
@@ -66,7 +66,7 @@ pub(super) fn build_next_plan(
     let needs_dflash_capture = speculative
         && pending
             .iter()
-            .any(|r| r.lora_adapter.is_none() && r.logprobs == 0 && r.params.is_greedy());
+            .any(|r| r.lora_adapter.is_none() && r.logprobs == 0);
     if !pending.is_empty() && have_active && !needs_prompt_logprobs && !needs_dflash_capture {
         Some(ExecutionPlan::Unified { pending })
     } else if !pending.is_empty() {
@@ -124,6 +124,7 @@ pub(super) fn execute_plan(
             let verify_requests = build_speculative_verify_items(active, &draft.requests);
             let mut verify = executor.execute_speculative_verify(VerifyPlan {
                 requests: &verify_requests,
+                sample_seed: rand::RngExt::random(rng),
             })?;
             verify.requests.sort_by_key(|result| result.request_id);
             Ok(ExecutionArtifacts::SpeculativeDecode { verify })
@@ -151,8 +152,11 @@ pub(super) fn execute_plan(
 }
 
 /// All-or-nothing: speculate the whole active batch only when every request is
-/// draft-ready and greedy (no LoRA, no logprobs). A single non-ready request
-/// falls the batch back to plain decode rather than running a mixed step.
+/// draft-ready (no LoRA, no logprobs). A single non-ready request falls the
+/// batch back to plain decode rather than running a mixed step. Sampling
+/// params are NOT a gate: sampled-verify (#512) runs the regular sampler over
+/// the verify rows, so the full surface — temperature/top_k/top_p/min_p/seed —
+/// rides the speculative path.
 pub(super) fn should_speculative_decode(
     executor: &impl ModelExecutor,
     active: &[ActiveRequestState],
@@ -163,14 +167,13 @@ pub(super) fn should_speculative_decode(
             executor.speculative_request_ready(req.request_id)
                 && req.lora_adapter.is_none()
                 && req.logprobs == 0
-                && req.params.is_greedy()
         })
 }
 
 fn build_speculative_draft_items(active: &[ActiveRequestState]) -> Vec<DraftStepItem> {
     active
         .iter()
-        .map(|r| DraftStepItem::new(r.request_id, r.last_token, r.params))
+        .map(|r| DraftStepItem::new(r.request_id, r.last_token))
         .collect()
 }
 
@@ -354,7 +357,7 @@ mod tests {
             ),
             "active + pending echo-only request (no logprobs) can use unified"
         );
-        // Under DFlash speculation, an eligible (greedy) pending must capture its
+        // Under DFlash speculation, an eligible pending must capture its
         // target context during prefill — the unified forward skips that capture,
         // so route it to a dedicated prefill step rather than let DFlash silently
         // no-op for it.
@@ -365,19 +368,46 @@ mod tests {
             ),
             "spec + active + eligible pending routes to prefill so the drafter context is captured"
         );
-        // A non-greedy pending needs no draft capture, so unified fusion is still
-        // fine even under speculation.
-        let mut sampled = pending();
-        sampled.params = SamplingParams {
-            temperature: 1.0,
-            ..SamplingParams::default()
-        };
+        // Sampled-verify (#512): a non-greedy pending speculates too, so it
+        // needs the same capture — Prefill, not Unified (which would silently
+        // never make it draft-ready). This covers min_p and seeded params as
+        // well; nothing on the sampling surface opts a request out.
+        for params in [
+            SamplingParams {
+                temperature: 1.0,
+                ..SamplingParams::default()
+            },
+            SamplingParams {
+                temperature: 0.8,
+                min_p: 0.05,
+                ..SamplingParams::default()
+            },
+            SamplingParams {
+                temperature: 0.8,
+                seed: Some(42),
+                ..SamplingParams::default()
+            },
+        ] {
+            let mut sampled = pending();
+            sampled.params = params;
+            assert!(
+                matches!(
+                    build_next_plan(true, vec![sampled], true),
+                    Some(ExecutionPlan::Prefill { pending }) if pending.len() == 1
+                ),
+                "spec + active + sampled pending routes to prefill for draft capture"
+            );
+        }
+        // A LoRA pending never speculates, so no capture is needed and unified
+        // fusion is still fine under speculation.
+        let mut lora = pending();
+        lora.lora_adapter = Some("adapter".to_string());
         assert!(
             matches!(
-                build_next_plan(true, vec![sampled], true),
+                build_next_plan(true, vec![lora], true),
                 Some(ExecutionPlan::Unified { pending }) if pending.len() == 1
             ),
-            "spec + active + non-greedy pending (no capture needed) can still use unified"
+            "spec + active + LoRA pending (never speculates, no capture) can use unified"
         );
     }
 }

--- a/openinfer-qwen3/src/speculative.rs
+++ b/openinfer-qwen3/src/speculative.rs
@@ -14,10 +14,14 @@
 //! today and is kept concrete; a proposer trait is deferred until a second
 //! implementation (n-gram / EAGLE) validates the shape.
 //!
-//! What is *not* generic yet: [`accept_greedy`] returns argmax-based acceptance,
-//! which is the *greedy* rule. Sampling-correct acceptance would need the target
-//! and draft distributions, touching both the verify path and the proposer — so
-//! it is left until a sampling method actually lands.
+//! Acceptance is [`accept_prefix_match`] for greedy and sampled requests alike
+//! (#512, the sampled-verify mechanism GLM5.2 landed in #589): the verify
+//! forward selects one *committed* token per span position — the fused argmax
+//! for a greedy request, a regular per-row sample from the target distribution
+//! for a non-greedy one — and the accepted prefix is simply the drafts that
+//! match those tokens. For a deterministic (one-hot) draft this is lossless
+//! speculative sampling: every committed token is a true sample from the
+//! target distribution; acceptance only decides how many ride one step.
 
 use anyhow::Result;
 
@@ -52,6 +56,9 @@ impl VerifyStepItem {
 #[derive(Clone, Copy)]
 pub(crate) struct VerifyPlan<'a> {
     pub requests: &'a [VerifyStepItem],
+    /// Engine step seed for the verify rows' sampler pass (same contract as
+    /// decode: fresh per step; seeded rows re-mix their own request seed).
+    pub sample_seed: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -72,19 +79,20 @@ pub(crate) struct VerifyResult {
 }
 
 /// One request's draft request: the proposer continues from `current_token`.
+/// Deliberately carries no sampling params — the draft rollout is argmax
+/// regardless of the request's sampler; sampled-verify applies the request's
+/// params on the verify side only.
 #[derive(Clone)]
 pub(crate) struct DraftStepItem {
     pub(crate) request_id: RequestId,
     pub(crate) current_token: u32,
-    pub(crate) params: SamplingParams,
 }
 
 impl DraftStepItem {
-    pub(crate) fn new(request_id: RequestId, current_token: u32, params: SamplingParams) -> Self {
+    pub(crate) fn new(request_id: RequestId, current_token: u32) -> Self {
         Self {
             request_id,
             current_token,
-            params,
         }
     }
 }
@@ -105,14 +113,15 @@ pub(crate) struct DraftResult {
     pub requests: Vec<DraftRequestResult>,
 }
 
-/// Greedy speculative acceptance — the shared seam every method reuses.
+/// Speculative acceptance — the shared seam every method and sampler reuses.
 ///
 /// * `proposed` — the `K` candidate tokens from the proposer.
-/// * `target_argmax` — the target model's greedy token at each of the `K + 1`
-///   verify positions. `target_argmax[i]` is the model's prediction *after*
-///   consuming verify input `i`; `target_argmax[0]` follows the last confirmed
-///   token and `target_argmax[K]` is the model's own continuation after the
-///   whole candidate run.
+/// * `target_tokens` — the target model's *committed* token at each of the
+///   `K + 1` verify positions: the argmax for a greedy request, the sampled
+///   token for a non-greedy one. `target_tokens[i]` is the model's pick
+///   *after* consuming verify input `i`; `target_tokens[0]` follows the last
+///   confirmed token and `target_tokens[K]` is the model's own continuation
+///   after the whole candidate run.
 ///
 /// Returns the longest accepted prefix of `proposed` followed by exactly one
 /// model token (the correction at the first divergence, or the bonus
@@ -121,36 +130,36 @@ pub(crate) struct DraftResult {
 /// # Panics
 /// Panics (debug builds) if `target_argmax.len() != proposed.len() + 1`.
 #[must_use]
-pub(crate) fn accept_greedy(proposed: &[u32], target_argmax: &[u32]) -> Vec<u32> {
+pub(crate) fn accept_prefix_match(proposed: &[u32], target_tokens: &[u32]) -> Vec<u32> {
     debug_assert_eq!(
-        target_argmax.len(),
+        target_tokens.len(),
         proposed.len() + 1,
-        "verify must produce one greedy token per candidate plus a bonus"
+        "verify must produce one committed token per candidate plus a bonus"
     );
-    let n = num_accepted(proposed, target_argmax);
+    let n = num_accepted(proposed, target_tokens);
     let mut committed = Vec::with_capacity(n + 1);
     committed.extend_from_slice(&proposed[..n]);
     // The model's own token at the first divergence (or the bonus continuation
     // when the whole run was accepted). `n <= proposed.len() < target_argmax.len()`
     // so this index is always valid.
-    committed.push(target_argmax[n]);
+    committed.push(target_tokens[n]);
     committed
 }
 
 /// Length of the accepted prefix: leading drafts whose token matches the
-/// target's argmax.
-fn num_accepted(proposed: &[u32], target_argmax: &[u32]) -> usize {
+/// target's committed pick.
+fn num_accepted(proposed: &[u32], target_tokens: &[u32]) -> usize {
     let mut i = 0;
-    while i < proposed.len() && proposed[i] == target_argmax[i] {
+    while i < proposed.len() && proposed[i] == target_tokens[i] {
         i += 1;
     }
     i
 }
 
-/// Batched greedy acceptance over a verify forward's flattened per-position
-/// argmax. `target_tokens` is the concatenation of each request's `K + 1`
+/// Batched acceptance over a verify forward's flattened per-position committed
+/// tokens. `target_tokens` is the concatenation of each request's `K + 1`
 /// posterior columns, in `requests` order. Each request applies the shared
-/// [`accept_greedy`] over its own span.
+/// [`accept_prefix_match`] over its own span.
 pub(crate) fn build_verify_results(
     requests: &[VerifyStepItem],
     target_tokens: &[u32],
@@ -171,8 +180,8 @@ pub(crate) fn build_verify_results(
         );
         let posterior = &target_tokens[offset..end];
         // proposed = the K drafts (span minus the leading confirmed token);
-        // posterior = the K + 1 argmax columns. accept_greedy ties them together.
-        let accepted_tokens = accept_greedy(&req.token_ids[1..], posterior);
+        // posterior = the K + 1 argmax columns. accept_prefix_match ties them together.
+        let accepted_tokens = accept_prefix_match(&req.token_ids[1..], posterior);
         outputs.push(VerifyRequestResult {
             request_id: req.request_id,
             matched_draft_tokens: accepted_tokens.len() - 1,
@@ -196,7 +205,10 @@ mod tests {
     fn accepts_full_run_plus_bonus() {
         let proposed = [10u32, 11, 12];
         let argmax = [10u32, 11, 12, 13];
-        assert_eq!(accept_greedy(&proposed, &argmax), vec![10, 11, 12, 13]);
+        assert_eq!(
+            accept_prefix_match(&proposed, &argmax),
+            vec![10, 11, 12, 13]
+        );
         assert_eq!(num_accepted(&proposed, &argmax), 3);
     }
 
@@ -204,7 +216,7 @@ mod tests {
     fn accepts_prefix_then_correction() {
         let proposed = [10u32, 11, 99];
         let argmax = [10u32, 11, 22, 33];
-        assert_eq!(accept_greedy(&proposed, &argmax), vec![10, 11, 22]);
+        assert_eq!(accept_prefix_match(&proposed, &argmax), vec![10, 11, 22]);
         assert_eq!(num_accepted(&proposed, &argmax), 2);
     }
 
@@ -212,7 +224,7 @@ mod tests {
     fn rejects_first_candidate_commits_one() {
         let proposed = [10u32, 11, 12];
         let argmax = [7u32, 8, 9, 10];
-        assert_eq!(accept_greedy(&proposed, &argmax), vec![7]);
+        assert_eq!(accept_prefix_match(&proposed, &argmax), vec![7]);
         assert_eq!(num_accepted(&proposed, &argmax), 0);
     }
 
@@ -220,7 +232,7 @@ mod tests {
     fn empty_proposal_commits_model_token() {
         let proposed: [u32; 0] = [];
         let argmax = [42u32];
-        assert_eq!(accept_greedy(&proposed, &argmax), vec![42]);
+        assert_eq!(accept_prefix_match(&proposed, &argmax), vec![42]);
         assert_eq!(num_accepted(&proposed, &argmax), 0);
     }
 
@@ -228,7 +240,7 @@ mod tests {
     fn always_commits_at_least_one_token() {
         let proposed = [1u32, 2];
         let argmax = [9u32, 9, 9];
-        assert!(!accept_greedy(&proposed, &argmax).is_empty());
+        assert!(!accept_prefix_match(&proposed, &argmax).is_empty());
     }
 
     #[test]

--- a/openinfer-qwen3/tests/dflash_sampled_equivalence.rs
+++ b/openinfer-qwen3/tests/dflash_sampled_equivalence.rs
@@ -1,0 +1,606 @@
+//! Sampled speculative decoding must be *distribution-lossless* (#512).
+//!
+//! Sampled-verify (the #589 mechanism) commits only tokens the verify pass
+//! sampled from the target model's own distribution — spec-on and spec-off
+//! differ in *how* tokens are produced, never in *what law* they follow. Token-by-token
+//! equality is meaningless for sampled decoding (each run is a fresh draw), so
+//! the gate is statistical: for a fixed prompt set and representative sampling
+//! configs, generate many independent runs per arm and compare the per-position
+//! marginal token distributions.
+//!
+//! Test: at every (config, prompt, position) cell, a two-sample permutation
+//! test on the max studentized per-token frequency difference (max-z; TV is
+//! reported as the effect size) between the arms' token histograms
+//! (1,999 permutations, seeded — deterministic), then Benjamini–Hochberg FDR
+//! at q = 0.05 across all cells. Gate: **zero rejected cells**. The max
+//! per-cell TV is reported as the effect-size readout. `ignore_eos` keeps every
+//! run exactly `POSITIONS` long so the position marginals are uncensored (EOS
+//! is then an ordinary token the histograms still compare).
+//!
+//! The machinery has teeth: `permutation_gate_detects_bias` (pure CPU, always
+//! runs) rejects a deliberately biased synthetic sampler, and the
+//! `..._null_check` GPU test runs spec-on vs spec-on, which must pass — so a
+//! failure of the main gate means a real distribution shift, not harness noise.
+//!
+//! Runs the two engines sequentially (spec-off arm dropped before the
+//! speculative engine loads) so only one Qwen3-4B is resident at a time.
+//!
+//! Requires a CUDA GPU, Qwen3-4B weights, and the DFlash drafter. Set
+//! `OPENINFER_TEST_MODEL_PATH` (target) and `OPENINFER_DFLASH_TEST_MODEL_PATH`
+//! (drafter); skips cleanly when either is absent. Knobs:
+//! `OPENINFER_EQ_RUNS` (default 256 per arm), `OPENINFER_EQ_BATCH` (default
+//! 16 concurrent identical requests per wave — the arms see the same batch
+//! shapes), `OPENINFER_EQ_OUT` (optional JSON dump of every token matrix, for
+//! offline scrutiny).
+
+use std::collections::HashMap;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use openinfer_core::engine::{EngineHandle, GenerateRequest, TokenEvent, TokenSink};
+use openinfer_core::sampler::SamplingParams;
+use openinfer_qwen3::{
+    DEFAULT_KV_CACHE_MEMORY_MARGIN_BYTES, DEFAULT_KV_PAGE_SIZE, DEFAULT_MAX_PREFILL_TOKENS,
+    DecodeOverlap, Qwen3LaunchOptions, Qwen3MemoryOptions, Qwen3OffloadOptions,
+};
+use rand::rngs::StdRng;
+use rand::{RngExt, SeedableRng};
+
+mod common;
+
+const MODEL_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../models/Qwen3-4B");
+const DRAFT_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../models/Qwen3-4B-DFlash-b16");
+
+/// Positions compared per run; also the exact run length (`ignore_eos`).
+const POSITIONS: usize = 32;
+/// Permutations per cell; p-values resolve down to 1/2000.
+const PERMUTATIONS: usize = 1999;
+/// BH false-discovery rate across all (config, prompt, position) cells.
+const FDR_Q: f64 = 0.05;
+
+/// Checked-in prompt set (reproducibility): sharegpt-flavored variety — chat,
+/// instruction, code, math, structured output, free-form continuation.
+const PROMPTS: [&str; 8] = [
+    "Tell me about the history of the Roman Empire.",
+    "Write a Python function that merges two sorted lists into one sorted list.",
+    "What are the main differences between TCP and UDP?",
+    "Summarize the plot of Romeo and Juliet in three sentences.",
+    "If a train travels 120 km in 1.5 hours, what is its average speed? Explain step by step.",
+    "List five common causes of memory leaks in C++ programs, one per line.",
+    "The old lighthouse keeper looked out at the storm and",
+    "Explain how photosynthesis works to a ten-year-old.",
+];
+
+/// Representative sampling configs: pure top-p, pure top-k, combined, and a
+/// min_p config — sampled-verify (#512) admits the full sampling surface, so
+/// min_p rides the speculative path and belongs in the equivalence matrix.
+/// `(temperature, top_k, top_p, min_p)`. Seeded requests get the *stronger*
+/// determinism gate (`dflash_sampled_seeded_determinism`) instead.
+const CONFIGS: [(f32, i32, f32, f32); 4] = [
+    (0.8, -1, 0.95, 0.0),
+    (1.0, 50, 1.0, 0.0),
+    (0.7, 20, 0.9, 0.0),
+    (0.8, -1, 1.0, 0.05),
+];
+
+/// Serialize engine-holding test bodies — one engine resident at a time.
+static GPU: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn target_path_or_skip() -> Option<String> {
+    match std::env::var("OPENINFER_TEST_MODEL_PATH") {
+        Ok(path) => Some(path),
+        Err(_) if Path::new(MODEL_PATH).join("config.json").exists() => {
+            Some(MODEL_PATH.to_string())
+        }
+        Err(_) => {
+            eprintln!(
+                "skipping sampled-equivalence gate: {MODEL_PATH}/config.json missing; set OPENINFER_TEST_MODEL_PATH"
+            );
+            None
+        }
+    }
+}
+
+fn draft_path_or_skip() -> Option<String> {
+    match std::env::var("OPENINFER_DFLASH_TEST_MODEL_PATH") {
+        Ok(path) => Some(path),
+        Err(_) if Path::new(DRAFT_PATH).join("config.json").exists() => {
+            Some(DRAFT_PATH.to_string())
+        }
+        Err(_) => {
+            eprintln!(
+                "skipping sampled-equivalence gate: {DRAFT_PATH}/config.json missing; set OPENINFER_DFLASH_TEST_MODEL_PATH"
+            );
+            None
+        }
+    }
+}
+
+fn env_knob(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn launch_options(draft: Option<PathBuf>) -> Qwen3LaunchOptions {
+    Qwen3LaunchOptions {
+        device_ordinal: 0,
+        tp_size: 1,
+        cuda_graph: true,
+        dump_graph_png: None,
+        offload: Qwen3OffloadOptions::disabled(),
+        // The speculative engine forces the prefix cache off; match it on the
+        // baseline so both arms take the same cold prefill path.
+        no_prefix_cache: true,
+        max_prefill_tokens: DEFAULT_MAX_PREFILL_TOKENS,
+        memory: Qwen3MemoryOptions::new(
+            0.85,
+            DEFAULT_KV_CACHE_MEMORY_MARGIN_BYTES,
+            DEFAULT_KV_PAGE_SIZE,
+        )
+        .validate()
+        .expect("valid memory options"),
+        lora: None,
+        decode_overlap: DecodeOverlap::Off,
+        batch_invariant: false,
+        dflash_draft_model_path: draft,
+        enable_kv_events: false,
+    }
+}
+
+fn sampling(cfg: (f32, i32, f32, f32)) -> SamplingParams {
+    SamplingParams {
+        temperature: cfg.0,
+        top_k: cfg.1,
+        top_p: cfg.2,
+        min_p: cfg.3,
+        // Fixed-length runs: position marginals stay uncensored, and EOS is
+        // compared as an ordinary token.
+        ignore_eos: true,
+        ..SamplingParams::default()
+    }
+}
+
+/// One wave of `n` identical concurrent requests; returns each run's tokens.
+/// Concurrency makes the engine form real batches — the serving shape both
+/// arms are supposed to be equivalent under — and the two arms see the same
+/// wave sizes so batch-composition numerics cancel out of the comparison.
+fn sample_wave(
+    handle: &EngineHandle,
+    prompt_tokens: &[u32],
+    params: &SamplingParams,
+    n: usize,
+) -> Vec<Vec<u32>> {
+    let receivers: Vec<_> = (0..n)
+        .map(|_| {
+            let (token_tx, rx) = TokenSink::standalone();
+            handle
+                .submit(GenerateRequest {
+                    request_id: None,
+                    queued_at_unix_s: None,
+                    data_parallel_rank: None,
+                    prompt_tokens: prompt_tokens.to_vec(),
+                    params: *params,
+                    max_tokens: POSITIONS,
+                    lora_adapter: None,
+                    token_tx,
+                    logprobs: 0,
+                    echo: false,
+                })
+                .expect("submit failed");
+            rx
+        })
+        .collect();
+
+    receivers
+        .into_iter()
+        .map(|mut rx| {
+            let mut tokens = Vec::with_capacity(POSITIONS);
+            loop {
+                match rx.blocking_recv().map(|(_, event)| event) {
+                    Some(TokenEvent::Token { id, .. }) => tokens.push(id),
+                    Some(TokenEvent::Scheduled { .. } | TokenEvent::PromptTokens { .. }) => {}
+                    Some(TokenEvent::Finished { .. }) => break,
+                    Some(TokenEvent::Error { message, .. }) => {
+                        panic!("generation failed: {message}")
+                    }
+                    Some(TokenEvent::Rejected { message, .. }) => {
+                        panic!("generation rejected: {message}")
+                    }
+                    None => panic!("scheduler channel closed without Finished"),
+                }
+            }
+            assert_eq!(
+                tokens.len(),
+                POSITIONS,
+                "ignore_eos run must be exactly {POSITIONS} tokens"
+            );
+            tokens
+        })
+        .collect()
+}
+
+/// `runs` independent generations for every (config, prompt), in waves of
+/// `batch`. Indexed `[config][prompt][run][position]`.
+fn collect_arm(
+    handle: &EngineHandle,
+    encoded: &[Vec<u32>],
+    runs: usize,
+    batch: usize,
+) -> Vec<Vec<Vec<Vec<u32>>>> {
+    CONFIGS
+        .iter()
+        .map(|&cfg| {
+            let params = sampling(cfg);
+            encoded
+                .iter()
+                .map(|prompt_tokens| {
+                    let mut rows = Vec::with_capacity(runs);
+                    while rows.len() < runs {
+                        let n = batch.min(runs - rows.len());
+                        rows.extend(sample_wave(handle, prompt_tokens, &params, n));
+                    }
+                    rows
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// Total-variation distance between the empirical distributions of two token
+/// samples: `0.5 * Σ_tok |p_a(tok) - p_b(tok)|`.
+fn tv_distance(a: &[u32], b: &[u32]) -> f64 {
+    let mut counts: HashMap<u32, (usize, usize)> = HashMap::new();
+    for &t in a {
+        counts.entry(t).or_default().0 += 1;
+    }
+    for &t in b {
+        counts.entry(t).or_default().1 += 1;
+    }
+    let (na, nb) = (a.len() as f64, b.len() as f64);
+    0.5 * counts
+        .values()
+        .map(|&(ca, cb)| (ca as f64 / na - cb as f64 / nb).abs())
+        .sum::<f64>()
+}
+
+/// Max studentized per-token frequency difference between the two samples.
+/// This is the permutation test's statistic — chosen over total variation
+/// because the realistic sampled-verify bug shifts mass toward ONE token per
+/// position (accepting the draft's argmax when it shouldn't), and a max-z is
+/// an order of magnitude more sensitive to a single-token shift than TV
+/// (standalone power check: 10% mass onto a 5%-base-rate token at n=256/arm —
+/// TV permutation detects 11/64 synthetic cells after BH, max-z detects 47).
+fn max_z(a: &[u32], b: &[u32]) -> f64 {
+    let mut counts: HashMap<u32, (usize, usize)> = HashMap::new();
+    for &t in a {
+        counts.entry(t).or_default().0 += 1;
+    }
+    for &t in b {
+        counts.entry(t).or_default().1 += 1;
+    }
+    let (na, nb) = (a.len() as f64, b.len() as f64);
+    counts
+        .values()
+        .map(|&(ca, cb)| {
+            let (pa, pb) = (ca as f64 / na, cb as f64 / nb);
+            let pooled = (ca + cb) as f64 / (na + nb);
+            let se = (pooled * (1.0 - pooled) * (1.0 / na + 1.0 / nb)).sqrt();
+            (pa - pb).abs() / se.max(1e-12)
+        })
+        .fold(0.0f64, f64::max)
+}
+
+/// Two-sample permutation test (max-z statistic; TV reported as effect size).
+/// Returns `(observed_tv, p)` with the add-one estimate
+/// `p = (1 + #{null ≥ obs}) / (1 + PERMUTATIONS)`, unbiased under
+/// exchangeability (exactly the H0 "same sampling law").
+fn permutation_test(a: &[u32], b: &[u32], rng: &mut StdRng) -> (f64, f64) {
+    let observed = max_z(a, b);
+    let mut pool: Vec<u32> = a.iter().chain(b.iter()).copied().collect();
+    let mut at_least = 0usize;
+    for _ in 0..PERMUTATIONS {
+        // Partial Fisher–Yates: shuffle the first |a| slots, split, re-measure.
+        for i in 0..a.len() {
+            let j = rng.random_range(i..pool.len());
+            pool.swap(i, j);
+        }
+        if max_z(&pool[..a.len()], &pool[a.len()..]) >= observed {
+            at_least += 1;
+        }
+    }
+    let p = (1 + at_least) as f64 / (1 + PERMUTATIONS) as f64;
+    (tv_distance(a, b), p)
+}
+
+/// Benjamini–Hochberg: which of `pvals` are rejected at FDR `q`.
+fn bh_rejections(pvals: &[f64], q: f64) -> Vec<bool> {
+    let m = pvals.len();
+    let mut order: Vec<usize> = (0..m).collect();
+    order.sort_by(|&i, &j| pvals[i].total_cmp(&pvals[j]));
+    let mut cutoff = None;
+    for (rank, &idx) in order.iter().enumerate() {
+        if pvals[idx] <= q * (rank + 1) as f64 / m as f64 {
+            cutoff = Some(rank);
+        }
+    }
+    let mut rejected = vec![false; m];
+    if let Some(k) = cutoff {
+        for &idx in &order[..=k] {
+            rejected[idx] = true;
+        }
+    }
+    rejected
+}
+
+struct Cell {
+    config: usize,
+    prompt: usize,
+    position: usize,
+    tv: f64,
+    p: f64,
+}
+
+/// Compare two collected arms cell by cell; returns every cell's TV and p.
+fn compare_arms(arm_a: &[Vec<Vec<Vec<u32>>>], arm_b: &[Vec<Vec<Vec<u32>>>]) -> Vec<Cell> {
+    // Seeded: the verdict is a pure function of the collected tokens.
+    let mut rng = StdRng::seed_from_u64(0x512_512);
+    let mut cells = Vec::new();
+    for (c, (pa, pb)) in arm_a.iter().zip(arm_b).enumerate() {
+        for (i, (rows_a, rows_b)) in pa.iter().zip(pb).enumerate() {
+            for t in 0..POSITIONS {
+                let col_a: Vec<u32> = rows_a.iter().map(|r| r[t]).collect();
+                let col_b: Vec<u32> = rows_b.iter().map(|r| r[t]).collect();
+                let (tv, p) = permutation_test(&col_a, &col_b, &mut rng);
+                cells.push(Cell {
+                    config: c,
+                    prompt: i,
+                    position: t,
+                    tv,
+                    p,
+                });
+            }
+        }
+    }
+    cells
+}
+
+/// Gate on the compared cells: BH-FDR, zero rejections. Prints the readout.
+fn assert_equivalent(cells: &[Cell], label: &str) {
+    let pvals: Vec<f64> = cells.iter().map(|c| c.p).collect();
+    let rejected = bh_rejections(&pvals, FDR_Q);
+    let max_tv = cells.iter().map(|c| c.tv).fold(0.0f64, f64::max);
+    let min_p = pvals.iter().copied().fold(1.0f64, f64::min);
+    eprintln!(
+        "{label}: {} cells, max TV {max_tv:.4}, min p {min_p:.4}, BH rejections {}",
+        cells.len(),
+        rejected.iter().filter(|&&r| r).count()
+    );
+    let failures: Vec<String> = cells
+        .iter()
+        .zip(&rejected)
+        .filter(|&(_, &r)| r)
+        .map(|(c, _)| {
+            format!(
+                "config {} prompt {} position {}: TV {:.4}, p {:.4}",
+                c.config, c.prompt, c.position, c.tv, c.p
+            )
+        })
+        .collect();
+    assert!(
+        failures.is_empty(),
+        "{label}: {} cells rejected at FDR {FDR_Q}:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}
+
+/// Optional raw dump for offline scrutiny (`OPENINFER_EQ_OUT`).
+fn dump_json(path: &str, arms: [(&str, &[Vec<Vec<Vec<u32>>>]); 2]) {
+    let mut out = String::from("{");
+    for (a, (name, arm)) in arms.iter().enumerate() {
+        if a > 0 {
+            out.push(',');
+        }
+        out.push_str(&format!("\"{name}\":["));
+        for (c, per_prompt) in arm.iter().enumerate() {
+            if c > 0 {
+                out.push(',');
+            }
+            out.push('[');
+            for (i, rows) in per_prompt.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push('[');
+                for (r, row) in rows.iter().enumerate() {
+                    if r > 0 {
+                        out.push(',');
+                    }
+                    out.push_str(&format!(
+                        "[{}]",
+                        row.iter().map(u32::to_string).collect::<Vec<_>>().join(",")
+                    ));
+                }
+                out.push(']');
+            }
+            out.push(']');
+        }
+        out.push(']');
+    }
+    out.push('}');
+    std::fs::File::create(path)
+        .and_then(|mut f| f.write_all(out.as_bytes()))
+        .unwrap_or_else(|err| panic!("failed to write {path}: {err}"));
+    eprintln!("raw token matrices dumped to {path}");
+}
+
+/// Main gate: sampled spec-on vs spec-off statistical equivalence.
+#[test]
+#[ignore = "GPU equivalence gate — needs Qwen3-4B + DFlash weights and ~20 GiB VRAM headroom"]
+fn dflash_sampled_equivalence_gate() {
+    let _gpu = GPU.lock().unwrap();
+    let (Some(model_path), Some(draft_path)) = (target_path_or_skip(), draft_path_or_skip()) else {
+        return;
+    };
+    let runs = env_knob("OPENINFER_EQ_RUNS", 256);
+    let batch = env_knob("OPENINFER_EQ_BATCH", 16);
+
+    let tokenizer = common::load_tokenizer(&model_path);
+    let encoded: Vec<Vec<u32>> = PROMPTS
+        .iter()
+        .map(|p| tokenizer.encode(p, false).expect("encode failed"))
+        .collect();
+
+    // Arm A: plain decode (no draft model loaded — the spec path cannot run).
+    let spec_off = {
+        let handle = openinfer_qwen3::launch(Path::new(&model_path), launch_options(None))
+            .expect("failed to start spec-off engine");
+        let arm = collect_arm(&handle, &encoded, runs, batch);
+        drop(handle);
+        std::thread::sleep(Duration::from_secs(2));
+        arm
+    };
+
+    // Arm B: DFlash speculative engine; sampled requests ride chain rejection.
+    let spec_on = {
+        let handle = openinfer_qwen3::launch(
+            Path::new(&model_path),
+            launch_options(Some(PathBuf::from(&draft_path))),
+        )
+        .expect("failed to start speculative engine");
+        let arm = collect_arm(&handle, &encoded, runs, batch);
+        drop(handle);
+        arm
+    };
+
+    if let Ok(path) = std::env::var("OPENINFER_EQ_OUT") {
+        dump_json(&path, [("spec_off", &spec_off), ("spec_on", &spec_on)]);
+    }
+
+    let cells = compare_arms(&spec_off, &spec_on);
+    assert_equivalent(&cells, "sampled equivalence spec-off vs spec-on");
+}
+
+/// Null check: two independent spec-on collections must pass the same gate.
+/// If this fails, the harness (not the engine) is flagging noise as signal.
+#[test]
+#[ignore = "GPU null check — needs Qwen3-4B + DFlash weights"]
+fn dflash_sampled_equivalence_null_check() {
+    let _gpu = GPU.lock().unwrap();
+    let (Some(model_path), Some(draft_path)) = (target_path_or_skip(), draft_path_or_skip()) else {
+        return;
+    };
+    let runs = env_knob("OPENINFER_EQ_RUNS", 256);
+    let batch = env_knob("OPENINFER_EQ_BATCH", 16);
+
+    let tokenizer = common::load_tokenizer(&model_path);
+    let encoded: Vec<Vec<u32>> = PROMPTS
+        .iter()
+        .map(|p| tokenizer.encode(p, false).expect("encode failed"))
+        .collect();
+
+    let handle = openinfer_qwen3::launch(
+        Path::new(&model_path),
+        launch_options(Some(PathBuf::from(&draft_path))),
+    )
+    .expect("failed to start speculative engine");
+    let first = collect_arm(&handle, &encoded, runs, batch);
+    let second = collect_arm(&handle, &encoded, runs, batch);
+    drop(handle);
+
+    let cells = compare_arms(&first, &second);
+    assert_equivalent(&cells, "null check spec-on vs spec-on");
+}
+
+/// Seeded requests get a byte-exact gate rather than a statistical one
+/// (glm52's M4 doc: byte gates are for determinism): the same seeded request
+/// submitted twice to the SAME spec-on engine must reproduce its tokens
+/// exactly — seeded sampling is a pure function of (seed, step, distribution)
+/// and c1 keeps the batch shape (hence the logits) deterministic.
+#[test]
+#[ignore = "GPU seeded-determinism gate — needs Qwen3-4B + DFlash weights"]
+fn dflash_sampled_seeded_determinism() {
+    let _gpu = GPU.lock().unwrap();
+    let (Some(model_path), Some(draft_path)) = (target_path_or_skip(), draft_path_or_skip()) else {
+        return;
+    };
+    let tokenizer = common::load_tokenizer(&model_path);
+    let handle = openinfer_qwen3::launch(
+        Path::new(&model_path),
+        launch_options(Some(PathBuf::from(&draft_path))),
+    )
+    .expect("failed to start speculative engine");
+
+    for (i, prompt) in PROMPTS.iter().enumerate() {
+        let tokens = tokenizer.encode(prompt, false).expect("encode failed");
+        let params = SamplingParams {
+            seed: Some(0xC0FFEE + i as u64),
+            ..sampling(CONFIGS[0])
+        };
+        let first = sample_wave(&handle, &tokens, &params, 1);
+        let second = sample_wave(&handle, &tokens, &params, 1);
+        assert_eq!(
+            first, second,
+            "prompt {i}: a seeded spec-on request must replay byte-identically"
+        );
+    }
+    drop(handle);
+}
+
+/// The statistical machinery must *detect* a real shift: a synthetic sampler
+/// with a 10% probability mass moved to one token must be rejected, and an
+/// identical-law pair must pass. Pure CPU — always runs.
+#[test]
+fn permutation_gate_detects_bias() {
+    let mut rng = StdRng::seed_from_u64(7);
+    let n = 256;
+    // Unbiased law: uniform over 20 tokens. Biased law: token 0 absorbs an
+    // extra 10% of the mass (TV = 0.095 from uniform).
+    let draw_unbiased = |rng: &mut StdRng| -> u32 { rng.random_range(0..20u32) };
+    let draw_biased = |rng: &mut StdRng| -> u32 {
+        if rng.random_range(0.0..1.0f64) < 0.10 {
+            0
+        } else {
+            rng.random_range(0..20u32)
+        }
+    };
+
+    // 64 same-law cells must produce zero BH rejections…
+    let mut same_cells = Vec::new();
+    let mut test_rng = StdRng::seed_from_u64(0x512_512);
+    for _ in 0..64 {
+        let a: Vec<u32> = (0..n).map(|_| draw_unbiased(&mut rng)).collect();
+        let b: Vec<u32> = (0..n).map(|_| draw_unbiased(&mut rng)).collect();
+        let (_, p) = permutation_test(&a, &b, &mut test_rng);
+        same_cells.push(p);
+    }
+    let same_rejected = bh_rejections(&same_cells, FDR_Q);
+    assert_eq!(
+        same_rejected.iter().filter(|&&r| r).count(),
+        0,
+        "same-law cells must not be rejected"
+    );
+
+    // …while 64 biased cells must be overwhelmingly rejected.
+    let mut biased_cells = Vec::new();
+    for _ in 0..64 {
+        let a: Vec<u32> = (0..n).map(|_| draw_unbiased(&mut rng)).collect();
+        let b: Vec<u32> = (0..n).map(|_| draw_biased(&mut rng)).collect();
+        let (_, p) = permutation_test(&a, &b, &mut test_rng);
+        biased_cells.push(p);
+    }
+    let biased_rejected = bh_rejections(&biased_cells, FDR_Q)
+        .iter()
+        .filter(|&&r| r)
+        .count();
+    // Measured 47/64 with the max-z statistic at these exact sizes; 36 leaves
+    // RNG-stream margin while still failing hard if the statistic regresses
+    // (the TV statistic this replaced detected only 11/64 here).
+    assert!(
+        biased_rejected >= 36,
+        "a 10%-mass shift must be detected in most cells (got {biased_rejected}/64)"
+    );
+}

--- a/openinfer-qwen3/tests/dflash_sampled_equivalence.rs
+++ b/openinfer-qwen3/tests/dflash_sampled_equivalence.rs
@@ -34,6 +34,7 @@
 //! offline scrutiny).
 
 use std::collections::HashMap;
+use std::fmt::Write as _;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -83,6 +84,9 @@ const CONFIGS: [(f32, i32, f32, f32); 4] = [
     (0.7, 20, 0.9, 0.0),
     (0.8, -1, 1.0, 0.05),
 ];
+
+/// One config's collected tokens: `[prompt][run][position]`.
+type ConfigTokens = Vec<Vec<Vec<u32>>>;
 
 /// Serialize engine-holding test bodies — one engine resident at a time.
 static GPU: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -229,7 +233,7 @@ fn collect_arm(
     encoded: &[Vec<u32>],
     runs: usize,
     batch: usize,
-) -> Vec<Vec<Vec<Vec<u32>>>> {
+) -> Vec<ConfigTokens> {
     CONFIGS
         .iter()
         .map(|&cfg| {
@@ -344,7 +348,7 @@ struct Cell {
 }
 
 /// Compare two collected arms cell by cell; returns every cell's TV and p.
-fn compare_arms(arm_a: &[Vec<Vec<Vec<u32>>>], arm_b: &[Vec<Vec<Vec<u32>>>]) -> Vec<Cell> {
+fn compare_arms(arm_a: &[ConfigTokens], arm_b: &[ConfigTokens]) -> Vec<Cell> {
     // Seeded: the verdict is a pure function of the collected tokens.
     let mut rng = StdRng::seed_from_u64(0x512_512);
     let mut cells = Vec::new();
@@ -398,13 +402,13 @@ fn assert_equivalent(cells: &[Cell], label: &str) {
 }
 
 /// Optional raw dump for offline scrutiny (`OPENINFER_EQ_OUT`).
-fn dump_json(path: &str, arms: [(&str, &[Vec<Vec<Vec<u32>>>]); 2]) {
+fn dump_json(path: &str, arms: [(&str, &[ConfigTokens]); 2]) {
     let mut out = String::from("{");
     for (a, (name, arm)) in arms.iter().enumerate() {
         if a > 0 {
             out.push(',');
         }
-        out.push_str(&format!("\"{name}\":["));
+        let _ = write!(out, "\"{name}\":[");
         for (c, per_prompt) in arm.iter().enumerate() {
             if c > 0 {
                 out.push(',');
@@ -419,10 +423,11 @@ fn dump_json(path: &str, arms: [(&str, &[Vec<Vec<Vec<u32>>>]); 2]) {
                     if r > 0 {
                         out.push(',');
                     }
-                    out.push_str(&format!(
+                    let _ = write!(
+                        out,
                         "[{}]",
                         row.iter().map(u32::to_string).collect::<Vec<_>>().join(",")
-                    ));
+                    );
                 }
                 out.push(']');
             }
@@ -537,7 +542,7 @@ fn dflash_sampled_seeded_determinism() {
     for (i, prompt) in PROMPTS.iter().enumerate() {
         let tokens = tokenizer.encode(prompt, false).expect("encode failed");
         let params = SamplingParams {
-            seed: Some(0xC0FFEE + i as u64),
+            seed: Some(0x00C0_FFEE + i as u64),
             ..sampling(CONFIGS[0])
         };
         let first = sample_wave(&handle, &tokens, &params, 1);

--- a/openinfer-sample/tests/select_batch.rs
+++ b/openinfer-sample/tests/select_batch.rs
@@ -325,3 +325,61 @@ fn seeded_rows_replay_independent_of_batch_position() {
     assert_ne!(a[2], c[0], "step must advance the seeded stream");
     assert_ne!(a[2], d[0], "seed must select a distinct stream");
 }
+
+/// Latency micro-benchmark for the verify-round sampler cost (#512): span-17
+/// rows at Qwen3 vocab, greedy argmax vs sampled paths. Not a correctness
+/// gate — prints per-call microseconds; run with --nocapture.
+#[test]
+#[ignore = "GPU latency probe — run manually with --nocapture"]
+fn select_batch_span17_latency_probe() {
+    let ctx = DeviceContext::new().unwrap();
+    let vocab = 151_936;
+    let rows = 17;
+    let logits: Vec<Vec<f32>> = (0..rows)
+        .map(|r| {
+            (0..vocab)
+                .map(|v| (((v * 2_654_435_761 + r * 97) % 1000) as f32) / 50.0)
+                .collect()
+        })
+        .collect();
+    let arena = make_arena(&ctx, &logits);
+    let mut scratch = SampleScratch::new(&ctx, vocab, rows).unwrap();
+
+    let cases: Vec<(&str, SamplingParams)> = vec![
+        ("greedy", SamplingParams::default()),
+        (
+            "t0.8_topp0.95",
+            SamplingParams {
+                temperature: 0.8,
+                top_p: 0.95,
+                ..SamplingParams::default()
+            },
+        ),
+        (
+            "t0.7_topk20_topp0.9",
+            SamplingParams {
+                temperature: 0.7,
+                top_k: 20,
+                top_p: 0.9,
+                ..SamplingParams::default()
+            },
+        ),
+    ];
+    for (name, p) in cases {
+        let params = vec![p; rows];
+        let param_refs = refs(&params);
+        let steps = vec![0u64; rows];
+        for _ in 0..20 {
+            select_batch(&ctx, &arena, &param_refs, &steps, 7, &mut scratch).unwrap();
+        }
+        ctx.sync().unwrap();
+        let start = std::time::Instant::now();
+        let iters = 200;
+        for i in 0..iters {
+            select_batch(&ctx, &arena, &param_refs, &steps, i as u64, &mut scratch).unwrap();
+        }
+        ctx.sync().unwrap();
+        let us = start.elapsed().as_micros() as f64 / iters as f64;
+        eprintln!("select_batch span17 {name}: {us:.1} us/call");
+    }
+}

--- a/scripts/bench_http_serving.py
+++ b/scripts/bench_http_serving.py
@@ -13,6 +13,7 @@ import concurrent.futures
 import hashlib
 import http.client
 import json
+import random
 import re
 import socket
 import statistics
@@ -421,6 +422,41 @@ def make_prompt(index: int, prompt_words: int) -> str:
         for offset in range(prompt_words)
     ]
     return " ".join(words)
+
+
+def load_prompt_pool(args: argparse.Namespace) -> list[str] | None:
+    """Deterministic prompt pool from a ShareGPT-style JSON (--prompt-file).
+
+    Takes each conversation's first human turn, filters by length, then
+    seed-samples --prompt-count of them — the same protocol as the DSpark/DFlash
+    closing A/Bs (30 ShareGPT first-turn prompts), reproducible via
+    --prompt-seed. Synthetic --prompt-words prompts overstate speculative
+    accept rates (repetitive text drafts too well); use real text for any
+    spec-on number that will be quoted.
+    """
+    path = arg_value(args, "prompt_file", None)
+    if not path:
+        return None
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    lo = int(arg_value(args, "prompt_min_chars", 32))
+    hi = int(arg_value(args, "prompt_max_chars", 2000))
+    firsts = []
+    for item in data:
+        conversations = item.get("conversations") or []
+        if not conversations:
+            continue
+        first = conversations[0]
+        if first.get("from") != "human":
+            continue
+        text = (first.get("value") or "").strip()
+        if lo <= len(text) <= hi:
+            firsts.append(text)
+    count = int(arg_value(args, "prompt_count", 30))
+    if len(firsts) < count:
+        raise SystemExit(f"prompt file has only {len(firsts)} usable first turns, need {count}")
+    rng = random.Random(int(arg_value(args, "prompt_seed", 512)))
+    return rng.sample(firsts, count)
 
 
 def parse_int_list(raw: str) -> list[int]:
@@ -962,16 +998,22 @@ def run_batch(
         request_id_prefix = f"openinfer-bench-{uuid.uuid4().hex}"
         args.request_id_prefix = request_id_prefix
     shapes = workload_shapes(args.prompt_words, args.max_tokens)
+    prompt_pool = load_prompt_pool(args)
     workloads = []
     for idx in range(count):
         global_index = offset + idx
         prompt_words, max_tokens = shapes[global_index % len(shapes)]
+        if prompt_pool is not None:
+            prompt = prompt_pool[global_index % len(prompt_pool)]
+            prompt_words = len(prompt.split())
+        else:
+            prompt = make_prompt(global_index, prompt_words)
         workloads.append(
             (
                 global_index,
                 prompt_words,
                 max_tokens,
-                make_prompt(global_index, prompt_words),
+                prompt,
                 sampling_profile_for(args, global_index),
             )
         )
@@ -1239,6 +1281,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--backend-runtime-version", help="Loaded backend runtime version."
     )
+    parser.add_argument(
+        "--prompt-file",
+        help="ShareGPT-style JSON; first human turns become the prompt pool (overrides --prompt-words)",
+    )
+    parser.add_argument("--prompt-count", type=int, default=30)
+    parser.add_argument("--prompt-seed", type=int, default=512)
+    parser.add_argument("--prompt-min-chars", type=int, default=32)
+    parser.add_argument("--prompt-max-chars", type=int, default=2000)
     parser.add_argument("--temperature", type=float, default=0.0)
     parser.add_argument("--top-k", type=int, default=-1)
     parser.add_argument("--top-p", type=float, default=1.0)

--- a/scripts/bench_http_serving.py
+++ b/scripts/bench_http_serving.py
@@ -1004,7 +1004,18 @@ def run_batch(
         global_index = offset + idx
         prompt_words, max_tokens = shapes[global_index % len(shapes)]
         if prompt_pool is not None:
-            prompt = prompt_pool[global_index % len(prompt_pool)]
+            # Paired design under mixed-greedy-sampled: the profile alternates
+            # by global_index parity, so indexing prompts by global_index //
+            # 2 gives each prompt to BOTH labels (greedy g=2k and sampled
+            # g=2k+1 share prompt k). Indexing by raw global_index would, with
+            # an even pool, permanently assign each prompt to one label and
+            # confound per-label comparisons with prompt content.
+            pidx = (
+                global_index // 2
+                if sampling_mode(args) == "mixed-greedy-sampled"
+                else global_index
+            )
+            prompt = prompt_pool[pidx % len(prompt_pool)]
             prompt_words = len(prompt.split())
         else:
             prompt = make_prompt(global_index, prompt_words)

--- a/scripts/eval_gsm8k_thinking.py
+++ b/scripts/eval_gsm8k_thinking.py
@@ -92,7 +92,13 @@ def main():
     parser.add_argument("--num-fewshot", type=int, default=8)
     parser.add_argument("--max-tokens", type=int, default=4096)
     parser.add_argument("--limit", type=int, default=0, help="0 = all samples")
-    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--seed", type=int, default=1234, help="per-request seed; -1 omits it (engine RNG)")
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        default=0.0,
+        help="sampling temperature (0 = greedy; >0 for sampled-score parity runs)",
+    )
     parser.add_argument("--output", default=None, help="Output JSON path")
     args = parser.parse_args()
 
@@ -117,10 +123,13 @@ def main():
             "prompt": prompt,
             "model": args.model,
             "max_tokens": args.max_tokens,
-            "temperature": 0,
+            "temperature": args.temperature,
             "stop": ["<|im_end|>"],
-            "seed": args.seed,
         }
+        # seed < 0 omits the per-request seed: sampled-parity runs want the
+        # engine RNG (three independent runs per arm), not a fixed replay.
+        if args.seed >= 0:
+            payload["seed"] = args.seed
         resp = requests.post(args.base_url, json=payload)
         resp.raise_for_status()
         result = resp.json()


### PR DESCRIPTION
Implements #512 as re-specified (2026-07-11): qwen3 adopts the **sampled-verify** mechanism GLM5.2 landed in #589, replacing the earlier chain-rejection-sampling plan (#534, closed). No new kernels: the verify forward's per-position token selection simply runs through `openinfer_sample::select_batch` with each request's own params — fused argmax for greedy rows, the regular batched sampler for non-greedy rows — and `accept_prefix_match` (né `accept_greedy`, renamed to match glm52) commits the drafts that match those tokens.

## Why this is lossless (one paragraph)

Every verify row samples its token from the target model's distribution at that position, exactly as a plain decode step would. The draft never influences *which* token is committed — only *how many* positions ride one engine step: acceptance stops at the first position where the target's sample differs from the draft, and that position emits the target's sample itself (full acceptance emits the position-K sample as the bonus). So the emitted stream is, position by position, a stream of true target-distribution samples; speculation is pure latency mechanics. (Known, deliberate trade-off vs full rejection sampling: with a one-hot draft, per-token acceptance is p(draft) instead of min(1, p(draft)) — GLM5.2 measured the end-to-end cost at ≈0 and we take mechanism uniformity; see the M4 notes in `docs/models/glm52/dspark-mtp.md`.)

## What changes

- **Verify token selection** (`executor.rs`): per-request params + the engine step seed (`VerifyPlan.sample_seed`, threaded through `StepCommand::SpeculativeVerify`). Sampling steps stay zeroed exactly like plain decode until sampling-parity 1b wires request-local steps through — verify rows must move with that change (row k = step `completion + k`) or seeded replay breaks; the code comment marks it.
- **The admission funnel loses its greedy gates end to end**: prefill capture eligibility (`dflash_prefill_supported`), scheduler batch admission (`should_speculative_decode`), unified-vs-prefill routing (`needs_dflash_capture`), and the draft/verify entry ensures. The full sampling surface — temperature / top_k / top_p / min_p / seed — rides the speculative path; a mixed greedy+sampled batch keeps speculating. (Capture is sampling-independent: prompt hidden states don't depend on the sampler.)
- **`accept_greedy` → `accept_prefix_match`**, docs updated: same function, now fed committed tokens instead of argmax.

## Evidence

**Statistical equivalence gate** (`tests/dflash_sampled_equivalence.rs`, the merge gate agreed in #534): spec-on vs spec-off, 8 checked-in prompts × 4 configs (pure top_p / pure top_k / combined / min_p) × 32 positions, 512 runs per arm at matching batch shapes; per-cell two-sample permutation test on the max studentized per-token frequency difference (max-z; 1,999 permutations, seeded verdict; TV reported as effect size) with Benjamini–Hochberg FDR at 5% across all cells; gate = zero rejections, max TV reported as effect size.

The gate demonstrably has teeth:
- `permutation_gate_detects_bias` (CPU, always runs): a 10%-mass shift must be BH-rejected in ≥36/64 synthetic cells (measured 47).
- Standalone power sweep (n=256/arm, zipf-200 marginals, mass shifted onto the head token — the worst case for detection; 64 cells per row):

  | shift | cell-level reject % | BH-detected / 64 |
  |---|---|---|
  | 2% | 3.1% | 0 |
  | 5% | 6.2% | 0 |
  | 10% | 43.8% | 18 |
  | 15% | 57.8% | 36 |

  A real acceptance bug hits *every* cell simultaneously (1,024 cells in the full run), so family-level detection at a 10% per-position shift is effectively certain. One property to state precisely: with 1,999 permutations the smallest achievable p-value (5e-4) sits above BH's strictest single-cell threshold (0.05/1024), so the gate cannot reject a *lone* aberrant cell — it fires once ≥11 cells hit the permutation floor together. That is the intended shape: it is a family-level detector for mechanism bugs (which shift every cell), deliberately blind to single-cell sampling flukes. The max-z statistic replaced a first-draft TV statistic after a standalone power check showed TV detecting only 11/64 teeth cells vs max-z's 47/64 — false-positive control is 0/768 same-law cells for both.
- `..._null_check` (GPU): spec-on vs spec-on must pass.
- Seeded requests get the stronger gate: `dflash_sampled_seeded_determinism` — byte-exact replay of a seeded request on the same spec-on engine (glm52 M4 doctrine: statistical gates for distribution, byte gates for determinism).

**Greedy must be invisible**: `dflash_speculative_gate` unchanged and green; lib tests green.

Results on H100 (this PR's head, GPU-pinned single-card runs):

| gate | result |
|---|---|
| statistical equivalence, 512 runs/arm (spec-off vs spec-on) | **1,024 cells, BH rejections 0**; max TV 0.4727, min p 0.0010 — min p sits exactly at the ~1/1024 uniform-null expectation (no excess small p-values) |
| null check, 256 runs/arm (spec-on vs spec-on) | 1,024 cells, BH rejections 0; max TV 0.5547 — the half-sample null shows *more* noise than the real comparison, bracketing it |
| CPU teeth (`permutation_gate_detects_bias`) | 47/64 synthetic biased cells BH-rejected (gate ≥36); 0/768 same-law false positives |
| seeded determinism (byte-exact replay, spec-on) | pass, 8/8 prompts |
| greedy losslessness (`dflash_speculative_gate`) | 4/4 pass — greedy is byte-invisible to this change |
| lib tests | 67/67 |

**Perf** (H100 single card; 30 ShareGPT first-turn prompts seed-512, c1 out200 sequential / c8+c16 out128, `t=0.8 top_p=0.95`; aggregate output tok/s):

| bench | spec-off | spec-on | delta |
|---|---|---|---|
| c1 sampled | 218.7 | **355.1** | **+62%** |
| c1 greedy (ref) | 221.6 | **449.8** | **+103%** |
| c8 sampled | 1663.8 | 1610.1 | −3% |
| c16 sampled | 3180.7 | 2248.6 | −29% |
| c8 mixed (per-label TPOT p50) | greedy 4.76 / sampled 4.76 ms | greedy 9.09 / sampled 9.24 ms | labels within 2% of each other |

Greedy controls at the same concurrencies: c8 1622.7 → 1881.0 (**+16%**), c16 3233.4 → 2741.3 (**−15%**).

The full causal decomposition, from the serving log's per-phase accept telemetry (ShareGPT, same drafter):

| phase | accept rate | tokens/round |
|---|---|---|
| c1 greedy | 0.110 | 2.76 |
| c1 sampled | 0.076 | 2.21 |
| c8 sampled | 0.069 | 2.11 |
| c16 sampled | 0.064 | 2.02 |
| c8 mixed | 0.073 | 2.16 |

- **The c1 sampled-vs-greedy gap is fully explained by acceptance physics, not implementation cost**: tokens/round ratio 2.21/2.76 = 0.80 vs throughput ratio 355/450 = 0.79 — round *cost* is unchanged. This is the per-token `p(draft)` vs argmax-match discount the spec change accepted deliberately; a micro-benchmark of the verify-round sampler (`select_batch_span17_latency_probe`, span 17 × 151,936 vocab) puts the added sampling cost at 102 µs/round for `t=0.8/top_p` (219 µs with top_k+top_p) against a ~5.5 ms round — 2–4%.
- **The c8/c16 losses are the pre-existing H100 concurrency economics, shifted by that same discount**: greedy already loses at c16 (−15%) — H100's plain batched decode is a much stronger baseline than the RTX 5090 the published c8/c16 spec wins were measured on — and the 0.8× tokens/round moves sampled's breakeven one bucket earlier (c8: greedy +16%, sampled −3%). Engaging speculation as a function of batch size is an orthogonal, pre-existing scheduling question; this PR keeps sampled requests at parity with greedy either way (mixed batch: both classes speculate together, TPOT within 2%).
- Accept telemetry doubles as the "sampled requests really speculate" receipt: 2,883 sampled verify rounds at c1 alone, accepted spans up to 13 drafts in one round.

Scope note: "full sampling surface" here is the *engine* path (what `should_speculative_decode` and the verify sampler see). The HTTP bridge separately rejects per-request seeds today (`bridge.rs`: "per-request seed is not supported yet") — a pre-existing frontend gap, orthogonal to this PR; the engine-level seeded contract is what the byte-exact determinism gate exercises.

**GSM8K parity (coarse accuracy gate)** — 8-shot strict-match, 200 samples, `scripts/eval_gsm8k_thinking.py` (grew `--temperature` and seed-omission for these runs):

| | spec-off | spec-on |
|---|---|---|
| greedy | 0.885 | **0.885 (identical)** |
| sampled t=0.8, 3 independent runs | 0.860 / 0.900 / 0.885 — mean 0.882, 95% CI [0.832, 0.932] | 0.880 / 0.900 / 0.855 — mean 0.878, 95% CI [0.822, 0.934] |

Means within 0.4 pp, CIs near-fully overlapping, individual runs interleaved across arms — sampled-score parity holds.

## Follow-ups
- sampling-parity 1b (request-local steps) — verify rows are annotated to move together with decode.
- HTTP-bridge per-request seed support (pre-existing frontend gap; the engine-side contract is already gated).
