### PR TITLE
perf(glm52): GB300 split-K table + fused reduce-SwiGLU for the batched GEMV chain

### DIFF
--- a/docs/models/glm52/ep4-gb300.md
+++ b/docs/models/glm52/ep4-gb300.md
@@ -1,6 +1,6 @@
 # GLM5.2 EP4 on GB300
 
-> **TL;DR:** DP4/EP4 (`--moe-topo ep4`) brings the EP high-throughput layout to 4×GB300: 64 whole routed experts per rank (~188 GiB weights/rank of 284 GiB), a second DeepEP shim instantiation (`glm52_ep4_deepep_*`), and a new **weight-only routed-expert chain** replacing the sm_90a-only DeepGEMM masked GEMMs — bf16 recv rows × on-the-fly fp8 dequant on `mma.m16n8k16`, running directly on the DeepEP aligned receive layout (no activation re-quant, no masked relayout, no output remap). Bring-up gates green 2026-07-12: 4-bucket whole-step graph capture, greedy byte-determinism ×2, 8-way concurrent greedy (per-shape identical), sampled fallback, **layer-6 EP4 oracle 63/64 × 4 buckets** (after fixing the FlashMLA sm100 UE8M0 KV-scale contract — see lessons doc — which also un-broke attention accuracy for every heads-64 GLM5.2 path on GB300). First numbers (untuned): bs=1 TPOT `23.1 ms`; **c=32 output `559 tok/s`, TPOT p50 `39.05 ms` / p99 `39.18 ms`**. Needs `EP_DISABLE_GIN=1` on NIC-less nodes.
+> **TL;DR:** DP4/EP4 (`--moe-topo ep4`) brings the EP high-throughput layout to 4×GB300: 64 whole routed experts per rank (~188 GiB weights/rank of 284 GiB), a second DeepEP shim instantiation (`glm52_ep4_deepep_*`), and a new **weight-only routed-expert chain** replacing the sm_90a-only DeepGEMM masked GEMMs — bf16 recv rows × on-the-fly fp8 dequant on `mma.m16n8k16`, running directly on the DeepEP aligned receive layout (no activation re-quant, no masked relayout, no output remap). Bring-up gates green 2026-07-12: 4-bucket whole-step graph capture, greedy byte-determinism ×2, 8-way concurrent greedy (per-shape identical), sampled fallback, **layer-6 EP4 oracle 63/64 × 4 buckets** (after fixing the FlashMLA sm100 UE8M0 KV-scale contract — see lessons doc — which also un-broke attention accuracy for every heads-64 GLM5.2 path on GB300). First numbers (untuned): bs=1 TPOT `23.1 ms`; **c=32 output `559 tok/s`, TPOT p50 `39.05 ms` / p99 `39.18 ms`**. GEMV chain right-sized 2026-07-13 (GB300 split-K table + fused reduce-SwiGLU): b8 step p50 `40.68→40.03 ms`, b1 flat — falsified attempts documented below. Needs `EP_DISABLE_GIN=1` on NIC-less nodes.
 >
 > **Last touched:** 2026-07
 
@@ -169,6 +169,55 @@ efficiency); (3) a2a is only 19% — overlap work exists but is not the
 headline; (4) remember DP4 replicates all attention/shared weights per rank
 (every rank re-reads ~700 MB/layer-equivalent each step) — that is the
 structural reason EP wants large global batch.
+
+## b8 GEMV-chain right-sizing (2026-07-13, branch `feat/glm52-b8-gemv-chain`)
+
+The bucket-8 step spends ~7.6 ms/step in the batched weight-only GEMV family
+(vs ~1.8 ms roofline). Two shipped changes, gated on this box (locked clocks,
+`glm52_step_bench --buckets 8` / `--buckets 1`, 60 steps):
+
+| config | b8 p50 / p99 | b1 p50 / p99 |
+| --- | --- | --- |
+| main (a2d0a8c) | 40.68 / 41.6 | 22.62 / 22.7 |
+| + GB300 split-K table + fused reduce-SwiGLU | **40.03 / 41.31** | 22.57 / 22.68 |
+
+- **GB300 batch-8 split-K table** (`mma_config`, gated on
+  `arch_is_blackwell()`): every whitelisted shape re-swept on GB300 sm_103
+  over the full (KSPLIT × NTILES) grid with a standalone harness (one
+  `.cu` compiling the production kernel at every template instantiation,
+  locked clocks, 512-iteration medians) — pair-time winners like q_a 48/2
+  (8.1→7.1 µs) and kv_a 16/1 (6.7→5.5 µs). Hopper tables untouched. The
+  H200 picks do NOT transfer (the wall is bytes-in-flight per SM, an arch
+  property). Attribution: this table is the bulk of the −0.65 ms; the
+  SwiGLU fusion below is ~−0.15 ms of it.
+- **Fused reduce-SwiGLU** (`glm52_gemv_reduce_silu_mul`): the packed gate|up
+  mma path stops at its f32 k-slice partials and the SwiGLU absorbs the
+  fixed-order reduce — bit-identical (sums round to bf16 before the SiLU),
+  one launch instead of two, and the `[rows, 2*inter]` bf16 round-trip
+  disappears. Wins because silu's grid (rows × inter/256 ≈ 64 blocks) can
+  host the reduce work.
+
+**Falsified on this box (don't repeat):**
+
+- *reduce→RMSNorm fusion* (q_a norm + post-attn add+norm absorbing the
+  reduce; bit-identical impl, oracle green): b8 40.03→40.84/40.72 — norm
+  kernels are block-per-row (grid = 8 blocks on ~148 SMs), so the
+  ksplit=16-48 slice reduction collapses onto 8 latency-bound blocks. A
+  fusion only wins when the consumer's grid can host the producer's
+  parallelism.
+- *Five structural GEMV alternatives*, all measured slower or unavailable:
+  smem-act + deep prefetch (occupancy backfire), `__launch_bounds__(128,8)`
+  (register spills), cp.async staging (`__syncthreads` tax), Triton split-K
+  (o_proj 36.8 vs 22.8 µs — the H200 1.3× win does not transfer), DeepGEMM
+  fp8 masked (does not exist on SM100; its "fp8" masked entry is an alias
+  to fp8×fp4). A pure-read control at the shipping grid geometry reaches
+  6.4-6.8 TB/s, so the kernel is at its W8A16 structural optimum — the
+  remaining gap is the cvt+mma issue chain under register-squeezed
+  occupancy.
+
+Deeper levers (W4A8 weights, DeepEP protocol tax ~4.4 ms/step, masked-mma
+small-bucket right-sizing) are roadmap items — issue #668 carries the full
+profile data.
 
 ## Pitfalls
 

--- a/openinfer-glm52/src/fp8.rs
+++ b/openinfer-glm52/src/fp8.rs
@@ -15,7 +15,8 @@ use half::bf16;
 
 use openinfer_kernels::ops::{
     GLM52_GEMV_MMA_SCRATCH_FLOATS_PER_ROW, glm52_fp8_weight_only_gemv_launch,
-    glm52_fp8_weight_only_gemv_pair_launch, glm52_silu_and_mul_bf16_launch,
+    glm52_fp8_weight_only_gemv_pair_launch, glm52_fp8_weight_only_gemv_partials_launch,
+    glm52_gemv_reduce_silu_mul_launch, glm52_silu_and_mul_bf16_launch,
 };
 use openinfer_kernels::tensor::DeviceContext;
 
@@ -356,16 +357,34 @@ pub(crate) fn fp8_mlp_into(
         "GLM5.2 fp8_mlp scratch sized for intermediate {} but weights have {intermediate}",
         s.intermediate
     );
-    fp8_linear_into(
+    // The gate|up projection stops at its f32 k-slice partials when the
+    // (rows, shape) routes to the mma path, and the SwiGLU absorbs the
+    // fixed-order reduce (one launch instead of two, bit-identical); the
+    // register-tile rows keep the bf16 GEMV -> standalone SwiGLU pair.
+    let ksplit = glm52_fp8_weight_only_gemv_partials_launch(
         ctx,
-        gate_up,
         s.rows,
+        gate_up.n,
+        gate_up.k,
         input,
-        Some(&mut s.gemv_partial),
+        &gate_up.weight,
+        &gate_up.scale,
+        &mut s.gemv_partial,
         &mut s.gate_up,
     )?;
-    // bf16 SwiGLU (no route weight, no activation quant) -> bf16 down input.
-    glm52_silu_and_mul_bf16_launch(ctx, s.rows, intermediate, &s.gate_up, &mut s.silu_out)?;
+    if ksplit == 0 {
+        // bf16 SwiGLU (no route weight, no activation quant) -> bf16 down input.
+        glm52_silu_and_mul_bf16_launch(ctx, s.rows, intermediate, &s.gate_up, &mut s.silu_out)?;
+    } else {
+        glm52_gemv_reduce_silu_mul_launch(
+            ctx,
+            s.rows,
+            intermediate,
+            ksplit,
+            &s.gemv_partial,
+            &mut s.silu_out,
+        )?;
+    }
     fp8_linear_into(
         ctx,
         down,

--- a/openinfer-kernels/csrc/glm52/glm52_moe_gemv.cu
+++ b/openinfer-kernels/csrc/glm52/glm52_moe_gemv.cu
@@ -424,12 +424,40 @@ __global__ void glm52_gemv_batched_mma_reduce_kernel(
   out[i] = __float2bfloat16(v);
 }
 
-// (ksplit, ntiles) per (batch, whitelisted shape); ksplit == 0 keeps the
-// register tile. Measured winners ONLY, jz-38 H200 2026-07-05 (see block
-// comment) — an explicit per-shape table so a future whitelist addition lands
-// on the register tile until someone measures it into here.
+// (ksplit, ntiles) per (arch, batch, whitelisted shape); ksplit == 0 keeps the
+// register tile. Measured winners ONLY — Hopper table from jz-38 H200
+// 2026-07-05, Blackwell batch-8 table from GB300 sm_103 locked-clock sweep
+// 2026-07-13 (KSPLIT x NTILES grid, /work/gemv_mma_sweep.cu). Batch-4 has not
+// been re-swept on Blackwell and keeps the Hopper picks.
 struct MmaConfig { int ksplit; int ntiles; };
+
+bool arch_is_blackwell() {
+  static const bool blackwell = [] {
+    int device = 0;
+    int major = 0;
+    if (cudaGetDevice(&device) != cudaSuccess ||
+        cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor,
+                               device) != cudaSuccess) {
+      return false;
+    }
+    return major >= 10;
+  }();
+  return blackwell;
+}
+
 MmaConfig mma_config(int batch, int n, int k) {
+  if (batch == 8 && arch_is_blackwell()) {
+    if (n == 2048  && k == 6144)  return {48, 2};  // q_a / shared gate,up
+    if (n == 16384 && k == 2048)  return {4, 1};   // q_b
+    if (n == 576   && k == 6144)  return {16, 1};  // kv_a
+    if (n == 6144  && k == 16384) return {16, 2};  // o_proj
+    if (n == 24576 && k == 6144)  return {8, 2};   // dense gate|up
+    if (n == 6144  && k == 12288) return {16, 2};  // dense down
+    if (n == 4096  && k == 6144)  return {16, 2};  // shared gate|up
+    if (n == 6144  && k == 2048)  return {16, 2};  // shared down
+    if (n == 4096  && k == 2048)  return {16, 1};  // indexer wq_b
+    if (n == 128   && k == 6144)  return {48, 1};  // indexer wk
+  }
   if (batch == 8) {
     if (n == 2048  && k == 6144)  return {16, 2};  // q_a / shared gate,up
     if (n == 16384 && k == 2048)  return {8, 4};   // q_b
@@ -458,7 +486,8 @@ CUresult launch_gemv_batched_mma(const __nv_bfloat16* activation,
                                  const unsigned char* weight,
                                  const float* weight_scale, __nv_bfloat16* out,
                                  float* scratch, size_t scratch_floats, int n,
-                                 int k, cudaStream_t stream) {
+                                 int k, cudaStream_t stream,
+                                 bool skip_reduce = false) {
   if (n % 16 != 0 || k % (128 * KSPLIT) != 0 || (n / 16) % NTILES != 0 ||
       scratch == nullptr || (size_t)KSPLIT * BATCH * n > scratch_floats) {
     return CUDA_ERROR_INVALID_VALUE;
@@ -468,10 +497,12 @@ CUresult launch_gemv_batched_mma(const __nv_bfloat16* activation,
   glm52_gemv_batched_mma_kernel<BATCH, KSPLIT, NTILES>
       <<<grid, kMmaWarps * kWarpSize, 0, stream>>>(activation, weight,
                                                    weight_scale, scratch, n, k);
-  const int rthreads = 256;
-  glm52_gemv_batched_mma_reduce_kernel<BATCH, KSPLIT>
-      <<<(BATCH * n + rthreads - 1) / rthreads, rthreads, 0, stream>>>(scratch,
-                                                                       out, n);
+  if (!skip_reduce) {
+    const int rthreads = 256;
+    glm52_gemv_batched_mma_reduce_kernel<BATCH, KSPLIT>
+        <<<(BATCH * n + rthreads - 1) / rthreads, rthreads, 0, stream>>>(
+            scratch, out, n);
+  }
   return consume_last_cuda_error();
 }
 
@@ -487,6 +518,33 @@ __global__ void glm52_silu_and_mul_bf16_kernel(
   const __nv_bfloat16* up = gate + inter;
   const float g = __bfloat162float(gate[col]);
   const float u = __bfloat162float(up[col]);
+  const float sg = 1.0f / (1.0f + expf(-g));
+  output[(size_t)row * inter + col] = __float2bfloat16(g * sg * u);
+}
+
+// Fixed-order k-slice reduce fused with the SwiGLU: `partial` is the packed
+// gate|up mma scratch ([ksplit, rows, 2*inter] f32). Each of the two sums is
+// rounded to bf16 before the SiLU math — bit-identical to the standalone
+// reduce -> silu pair this replaces, one launch instead of two. ksplit is a
+// runtime loop bound: the kernel is bandwidth-trivial and shared across every
+// per-shape split factor.
+__global__ void glm52_gemv_reduce_silu_mul_kernel(
+    const float* __restrict__ partial,       // [ksplit, rows, 2*inter]
+    __nv_bfloat16* __restrict__ output,      // [rows, inter]
+    int rows, int inter, int ksplit) {
+  const int row = blockIdx.x;
+  const int col = blockIdx.y * blockDim.x + threadIdx.x;
+  if (row >= rows || col >= inter) return;
+  const size_t slice = (size_t)rows * 2 * inter;
+  const size_t base = (size_t)row * (2 * inter);
+  float g = partial[base + col];
+  float u = partial[base + inter + col];
+  for (int s = 1; s < ksplit; ++s) {
+    g += partial[(size_t)s * slice + base + col];
+    u += partial[(size_t)s * slice + base + inter + col];
+  }
+  g = __bfloat162float(__float2bfloat16(g));
+  u = __bfloat162float(__float2bfloat16(u));
   const float sg = 1.0f / (1.0f + expf(-g));
   output[(size_t)row * inter + col] = __float2bfloat16(g * sg * u);
 }
@@ -614,18 +672,32 @@ CUresult glm52_fp8_weight_only_gemv_pair_cuda(
 // one buffer per stream, never shared across the ctx/aux overlap). Batches
 // that stay on the register tile ignore it; an mma-routed launch with a
 // null/short buffer fails INVALID_VALUE instead of racing.
-CUresult glm52_fp8_weight_only_gemv_batched_cuda(
+//
+// `partials_only`: an mma-routed launch stops after the mma kernel, leaves the
+// f32 k-slice partials in `scratch`, and reports the ksplit via `ksplit_out`
+// so a fused consumer (reduce+SwiGLU below) can take over the fixed-order
+// reduction. Non-mma paths write bf16 `out` as usual and report ksplit 0.
+static CUresult gemv_batched_dispatch(
     const __nv_bfloat16* activation, const unsigned char* weight,
     const float* weight_scale, __nv_bfloat16* out, float* scratch,
-    size_t scratch_floats, int batch, int n, int k, cudaStream_t stream) {
+    size_t scratch_floats, int batch, int n, int k, cudaStream_t stream,
+    bool partials_only, int* ksplit_out) {
   if (activation == nullptr || weight == nullptr || weight_scale == nullptr ||
       out == nullptr || !aligned16(activation) ||
       !whitelisted_linear_shape(n, k)) {
     return CUDA_ERROR_INVALID_VALUE;
   }
+  if (ksplit_out != nullptr) *ksplit_out = 0;
   if (batch == 1) {
     return fp8_weight_only_gemv(activation, weight, weight_scale, out, n, k,
                                 stream);
+  }
+#define GLM52_MMA_CASE(BATCH_, KS_, NT_)                                     \
+  if (cfg.ksplit == (KS_) && cfg.ntiles == (NT_)) {                         \
+    if (partials_only && ksplit_out != nullptr) *ksplit_out = (KS_);        \
+    return launch_gemv_batched_mma<BATCH_, KS_, NT_>(                       \
+        activation, weight, weight_scale, out, scratch, scratch_floats, n,  \
+        k, stream, partials_only);                                          \
   }
   switch (batch) {
     case kBatchedGemvBatch2: {
@@ -639,11 +711,7 @@ CUresult glm52_fp8_weight_only_gemv_batched_cuda(
     }
     case kBatchedGemvBatch4: {
       const MmaConfig cfg = mma_config(batch, n, k);
-      if (cfg.ksplit == 16 && cfg.ntiles == 2) {
-        return launch_gemv_batched_mma<kBatchedGemvBatch4, 16, 2>(
-            activation, weight, weight_scale, out, scratch, scratch_floats, n,
-            k, stream);
-      }
+      GLM52_MMA_CASE(kBatchedGemvBatch4, 16, 2)
       if (!valid_tiling(n, k, kBatchedWarps * kBatchedRows))
         return CUDA_ERROR_INVALID_VALUE;
       const dim3 grid(1, n / (kBatchedWarps * kBatchedRows), 1);
@@ -656,21 +724,14 @@ CUresult glm52_fp8_weight_only_gemv_batched_cuda(
     case kBatchedGemvBatchFull: {
       // Every whitelisted shape runs the tensor-core path at batch 8.
       const MmaConfig cfg = mma_config(batch, n, k);
-      if (cfg.ksplit == 16 && cfg.ntiles == 2) {
-        return launch_gemv_batched_mma<kBatchedGemvBatchFull, 16, 2>(
-            activation, weight, weight_scale, out, scratch, scratch_floats, n,
-            k, stream);
-      }
-      if (cfg.ksplit == 8 && cfg.ntiles == 4) {
-        return launch_gemv_batched_mma<kBatchedGemvBatchFull, 8, 4>(
-            activation, weight, weight_scale, out, scratch, scratch_floats, n,
-            k, stream);
-      }
-      if (cfg.ksplit == 8 && cfg.ntiles == 1) {
-        return launch_gemv_batched_mma<kBatchedGemvBatchFull, 8, 1>(
-            activation, weight, weight_scale, out, scratch, scratch_floats, n,
-            k, stream);
-      }
+      GLM52_MMA_CASE(kBatchedGemvBatchFull, 16, 2)
+      GLM52_MMA_CASE(kBatchedGemvBatchFull, 8, 4)
+      GLM52_MMA_CASE(kBatchedGemvBatchFull, 8, 1)
+      GLM52_MMA_CASE(kBatchedGemvBatchFull, 48, 2)
+      GLM52_MMA_CASE(kBatchedGemvBatchFull, 48, 1)
+      GLM52_MMA_CASE(kBatchedGemvBatchFull, 16, 1)
+      GLM52_MMA_CASE(kBatchedGemvBatchFull, 8, 2)
+      GLM52_MMA_CASE(kBatchedGemvBatchFull, 4, 1)
       if (!valid_tiling(n, k, kBatchedWarps * kBatchedRows))
         return CUDA_ERROR_INVALID_VALUE;
       const dim3 grid(1, n / (kBatchedWarps * kBatchedRows), 1);
@@ -684,6 +745,30 @@ CUresult glm52_fp8_weight_only_gemv_batched_cuda(
       return CUDA_ERROR_INVALID_VALUE;
   }
   return consume_last_cuda_error();
+#undef GLM52_MMA_CASE
+}
+
+CUresult glm52_fp8_weight_only_gemv_batched_cuda(
+    const __nv_bfloat16* activation, const unsigned char* weight,
+    const float* weight_scale, __nv_bfloat16* out, float* scratch,
+    size_t scratch_floats, int batch, int n, int k, cudaStream_t stream) {
+  return gemv_batched_dispatch(activation, weight, weight_scale, out, scratch,
+                               scratch_floats, batch, n, k, stream,
+                               /*partials_only=*/false, nullptr);
+}
+
+// Partials-producing twin of the batched GEMV: mma-routed shapes stop at the
+// f32 k-slice partials (`*ksplit_out` > 0, bf16 `out` untouched); everything
+// else behaves exactly like the plain entry and reports `*ksplit_out` == 0.
+CUresult glm52_fp8_weight_only_gemv_partials_cuda(
+    const __nv_bfloat16* activation, const unsigned char* weight,
+    const float* weight_scale, __nv_bfloat16* out, float* scratch,
+    size_t scratch_floats, int batch, int n, int k, cudaStream_t stream,
+    int* ksplit_out) {
+  if (ksplit_out == nullptr) return CUDA_ERROR_INVALID_VALUE;
+  return gemv_batched_dispatch(activation, weight, weight_scale, out, scratch,
+                               scratch_floats, batch, n, k, stream,
+                               /*partials_only=*/true, ksplit_out);
 }
 
 CUresult glm52_silu_and_mul_bf16_cuda(
@@ -696,6 +781,20 @@ CUresult glm52_silu_and_mul_bf16_cuda(
   const dim3 grid(rows, (inter + threads - 1) / threads, 1);
   glm52_silu_and_mul_bf16_kernel<<<grid, threads, 0, stream>>>(input, output, rows,
                                                                inter);
+  return consume_last_cuda_error();
+}
+
+CUresult glm52_gemv_reduce_silu_mul_cuda(
+    const float* partial, __nv_bfloat16* output, int rows, int inter,
+    int ksplit, cudaStream_t stream) {
+  if (partial == nullptr || output == nullptr || rows <= 0 || inter <= 0 ||
+      ksplit < 1) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  const int threads = 256;
+  const dim3 grid(rows, (inter + threads - 1) / threads, 1);
+  glm52_gemv_reduce_silu_mul_kernel<<<grid, threads, 0, stream>>>(
+      partial, output, rows, inter, ksplit);
   return consume_last_cuda_error();
 }
 

--- a/openinfer-kernels/csrc/glm52/glm52_moe_gemv.cu
+++ b/openinfer-kernels/csrc/glm52/glm52_moe_gemv.cu
@@ -425,13 +425,16 @@ __global__ void glm52_gemv_batched_mma_reduce_kernel(
 }
 
 // (ksplit, ntiles) per (arch, batch, whitelisted shape); ksplit == 0 keeps the
-// register tile. Measured winners ONLY — Hopper table from jz-38 H200
-// 2026-07-05, Blackwell batch-8 table from GB300 sm_103 locked-clock sweep
-// 2026-07-13 (KSPLIT x NTILES grid, /work/gemv_mma_sweep.cu). Batch-4 has not
-// been re-swept on Blackwell and keeps the Hopper picks.
+// register tile. Measured winners ONLY — Hopper table from an 8xH200
+// locked-clock sweep 2026-07-05, Blackwell batch-8 table from a GB300 sm_103
+// locked-clock sweep 2026-07-13 (full KSPLIT x NTILES grid per shape; method
+// in docs/models/glm52/). Batch-4 has not been re-swept on Blackwell and
+// keeps the Hopper picks.
 struct MmaConfig { int ksplit; int ntiles; };
 
 bool arch_is_blackwell() {
+  // Config selection only — on a failed attribute query fall back to the
+  // Hopper table (still correct everywhere) instead of failing the launch.
   static const bool blackwell = [] {
     int device = 0;
     int major = 0;
@@ -712,6 +715,10 @@ static CUresult gemv_batched_dispatch(
     case kBatchedGemvBatch4: {
       const MmaConfig cfg = mma_config(batch, n, k);
       GLM52_MMA_CASE(kBatchedGemvBatch4, 16, 2)
+      // A table entry whose (ksplit, ntiles) has no case above is a config/
+      // dispatch drift — crash at capture, never silently take the register
+      // tile (the sweep winner would quietly not run).
+      if (cfg.ksplit != 0) return CUDA_ERROR_INVALID_VALUE;
       if (!valid_tiling(n, k, kBatchedWarps * kBatchedRows))
         return CUDA_ERROR_INVALID_VALUE;
       const dim3 grid(1, n / (kBatchedWarps * kBatchedRows), 1);
@@ -722,7 +729,8 @@ static CUresult gemv_batched_dispatch(
       break;
     }
     case kBatchedGemvBatchFull: {
-      // Every whitelisted shape runs the tensor-core path at batch 8.
+      // Table shapes route to the tensor-core path; anything off-table (e.g.
+      // the attention-TP shard shapes) keeps the register tile below.
       const MmaConfig cfg = mma_config(batch, n, k);
       GLM52_MMA_CASE(kBatchedGemvBatchFull, 16, 2)
       GLM52_MMA_CASE(kBatchedGemvBatchFull, 8, 4)
@@ -732,6 +740,8 @@ static CUresult gemv_batched_dispatch(
       GLM52_MMA_CASE(kBatchedGemvBatchFull, 16, 1)
       GLM52_MMA_CASE(kBatchedGemvBatchFull, 8, 2)
       GLM52_MMA_CASE(kBatchedGemvBatchFull, 4, 1)
+      // See the batch-4 arm: an uninstantiated table entry must crash here.
+      if (cfg.ksplit != 0) return CUDA_ERROR_INVALID_VALUE;
       if (!valid_tiling(n, k, kBatchedWarps * kBatchedRows))
         return CUDA_ERROR_INVALID_VALUE;
       const dim3 grid(1, n / (kBatchedWarps * kBatchedRows), 1);

--- a/openinfer-kernels/src/ffi/glm52.rs
+++ b/openinfer-kernels/src/ffi/glm52.rs
@@ -290,6 +290,29 @@ unsafe extern "C" {
         inter: i32,
         stream: CUstream,
     ) -> CUresult;
+
+    pub fn glm52_fp8_weight_only_gemv_partials_cuda(
+        activation: *const Half,
+        weight: *const u8,
+        weight_scale: *const f32,
+        out: *mut Half,
+        scratch: *mut f32,
+        scratch_floats: usize,
+        batch: i32,
+        n: i32,
+        k: i32,
+        stream: CUstream,
+        ksplit_out: *mut i32,
+    ) -> CUresult;
+
+    pub fn glm52_gemv_reduce_silu_mul_cuda(
+        partial: *const f32,
+        output: *mut Half,
+        rows: i32,
+        inter: i32,
+        ksplit: i32,
+        stream: CUstream,
+    ) -> CUresult;
 }
 
 macro_rules! declare_tp_ffi {

--- a/openinfer-kernels/src/ops/glm52/moe_gemv.rs
+++ b/openinfer-kernels/src/ops/glm52/moe_gemv.rs
@@ -48,7 +48,49 @@ pub fn glm52_silu_and_mul_bf16_launch(
 /// size their buffer as `rows * GLM52_GEMV_MMA_SCRATCH_FLOATS_PER_ROW` — one
 /// constant instead of mirroring the CUDA-side per-shape config table; the
 /// launcher still guards the exact requirement and rejects a short buffer.
+/// (The Blackwell table's larger splits only apply to small n — 48 × 2048
+/// stays well inside this budget; the CUDA-side guard is the invariant.)
 pub const GLM52_GEMV_MMA_SCRATCH_FLOATS_PER_ROW: usize = 16 * 24576;
+
+/// Fused fixed-order k-slice reduce + `SiLU(gate) * up`: consumes the f32
+/// partials a [`glm52_fp8_weight_only_gemv_partials_launch`] left in scratch
+/// for a packed gate|up projection. Bit-identical to the standalone
+/// reduce -> silu pair (both sums round to bf16 before the SiLU math).
+pub fn glm52_gemv_reduce_silu_mul_launch(
+    ctx: &DeviceContext,
+    rows: usize,
+    inter: usize,
+    ksplit: usize,
+    partial: &CudaSlice<f32>,
+    output: &mut CudaSlice<bf16>,
+) -> Result<()> {
+    ensure!(
+        rows > 0 && inter > 0 && ksplit >= 1,
+        "GLM5.2 reduce-SiLU needs positive rows/inter/ksplit, got {rows}/{inter}/{ksplit}"
+    );
+    ensure!(
+        partial.len() >= ksplit * rows * 2 * inter && output.len() >= rows * inter,
+        "GLM5.2 reduce-SiLU buffers too small: partial {} (need {}), out {} (need {})",
+        partial.len(),
+        ksplit * rows * 2 * inter,
+        output.len(),
+        rows * inter
+    );
+    let (p_ptr, _p) = partial.device_ptr(&ctx.stream);
+    let (out_ptr, _o) = output.device_ptr_mut(&ctx.stream);
+    unsafe {
+        ffi::glm52_gemv_reduce_silu_mul_cuda(
+            p_ptr as *const f32,
+            out_ptr as *mut ffi::Half,
+            rows as i32,
+            inter as i32,
+            ksplit as i32,
+            ctx.stream.cu_stream(),
+        )
+    }
+    .result()
+    .map_err(|err| anyhow!("GLM5.2 reduce-SiLU launch failed: {err}"))
+}
 
 /// Plain weight-only fp8 GEMV (bs=1): `out[n] = deq(weight[n,k]) @ activation[k]`
 /// with the bf16 activation read directly (no activation quant, no scale
@@ -124,6 +166,71 @@ pub fn glm52_fp8_weight_only_gemv_launch(
     }
     .result()
     .map_err(|err| anyhow!("GLM5.2 linear GEMV launch failed for rows={rows}, n={n}, k={k}: {err}"))
+}
+
+/// Partials-producing twin of [`glm52_fp8_weight_only_gemv_launch`]: when the
+/// (batch, shape) routes to the tensor-core mma path, the launch stops at the
+/// f32 k-slice partials in `scratch` and returns the split factor (`out` is
+/// untouched); otherwise it behaves exactly like the plain launch and returns
+/// 0. Callers pair a non-zero return with a fused reduce consumer.
+#[allow(clippy::too_many_arguments)]
+pub fn glm52_fp8_weight_only_gemv_partials_launch(
+    ctx: &DeviceContext,
+    rows: usize,
+    n: usize,
+    k: usize,
+    activation: &CudaSlice<bf16>,
+    weight: &CudaSlice<u8>,
+    scale_bytes: &CudaSlice<u8>,
+    scratch: &mut CudaSlice<f32>,
+    out: &mut CudaSlice<bf16>,
+) -> Result<usize> {
+    ensure!(
+        rows > 0 && n > 0 && k > 0,
+        "GLM5.2 linear GEMV needs positive rows/n/k, got {rows}/{n}/{k}"
+    );
+    let scale_len = n.div_ceil(FP8_BLOCK) * k.div_ceil(FP8_BLOCK) * 4;
+    ensure!(
+        weight.len() >= n * k
+            && scale_bytes.len() >= scale_len
+            && activation.len() >= rows * k
+            && out.len() >= rows * n,
+        "GLM5.2 linear GEMV buffers too small: w {} (need {}), scale {} (need {scale_len}), act {} (need {}), out {} (need {})",
+        weight.len(),
+        n * k,
+        scale_bytes.len(),
+        activation.len(),
+        rows * k,
+        out.len(),
+        rows * n
+    );
+    let (act_ptr, _a) = activation.device_ptr(&ctx.stream);
+    let (w_ptr, _w) = weight.device_ptr(&ctx.stream);
+    let (s_ptr, _s) = scale_bytes.device_ptr(&ctx.stream);
+    let (out_ptr, _o) = out.device_ptr_mut(&ctx.stream);
+    let scr_floats = scratch.len();
+    let (scr_ptr, _scr) = scratch.device_ptr_mut(&ctx.stream);
+    let mut ksplit: i32 = 0;
+    unsafe {
+        ffi::glm52_fp8_weight_only_gemv_partials_cuda(
+            act_ptr as *const ffi::Half,
+            w_ptr as *const u8,
+            s_ptr as *const f32,
+            out_ptr as *mut ffi::Half,
+            scr_ptr as *mut f32,
+            scr_floats,
+            rows as i32,
+            n as i32,
+            k as i32,
+            ctx.stream.cu_stream(),
+            &mut ksplit,
+        )
+    }
+    .result()
+    .map_err(|err| {
+        anyhow!("GLM5.2 linear GEMV (partials) launch failed for rows={rows}, n={n}, k={k}: {err}")
+    })?;
+    Ok(ksplit as usize)
 }
 
 /// MLA's bs=1 q_a and kv_a projections in one graph node. The two weights and

--- a/openinfer-kernels/src/ops/glm52/moe_gemv.rs
+++ b/openinfer-kernels/src/ops/glm52/moe_gemv.rs
@@ -115,6 +115,69 @@ pub fn glm52_fp8_weight_only_gemv_launch(
     scratch: Option<&mut CudaSlice<f32>>,
     out: &mut CudaSlice<bf16>,
 ) -> Result<()> {
+    gemv_batched_launch(
+        ctx,
+        rows,
+        n,
+        k,
+        activation,
+        weight,
+        scale_bytes,
+        scratch,
+        out,
+        None,
+    )
+    .map(|_| ())
+}
+
+/// Partials-producing twin of [`glm52_fp8_weight_only_gemv_launch`]: when the
+/// (batch, shape) routes to the tensor-core mma path, the launch stops at the
+/// f32 k-slice partials in `scratch` and returns the split factor (`out` is
+/// untouched); otherwise it behaves exactly like the plain launch and returns
+/// 0. Callers pair a non-zero return with a fused reduce consumer.
+#[allow(clippy::too_many_arguments)]
+pub fn glm52_fp8_weight_only_gemv_partials_launch(
+    ctx: &DeviceContext,
+    rows: usize,
+    n: usize,
+    k: usize,
+    activation: &CudaSlice<bf16>,
+    weight: &CudaSlice<u8>,
+    scale_bytes: &CudaSlice<u8>,
+    scratch: &mut CudaSlice<f32>,
+    out: &mut CudaSlice<bf16>,
+) -> Result<usize> {
+    let mut ksplit: i32 = 0;
+    gemv_batched_launch(
+        ctx,
+        rows,
+        n,
+        k,
+        activation,
+        weight,
+        scale_bytes,
+        Some(scratch),
+        out,
+        Some(&mut ksplit),
+    )?;
+    Ok(ksplit as usize)
+}
+
+/// Shared body of the two entry points above: validation, pointer extraction,
+/// and the FFI call (plain when `ksplit_out` is `None`, partials otherwise).
+#[allow(clippy::too_many_arguments)]
+fn gemv_batched_launch(
+    ctx: &DeviceContext,
+    rows: usize,
+    n: usize,
+    k: usize,
+    activation: &CudaSlice<bf16>,
+    weight: &CudaSlice<u8>,
+    scale_bytes: &CudaSlice<u8>,
+    scratch: Option<&mut CudaSlice<f32>>,
+    out: &mut CudaSlice<bf16>,
+    ksplit_out: Option<&mut i32>,
+) -> Result<()> {
     ensure!(
         rows > 0 && n > 0 && k > 0,
         "GLM5.2 linear GEMV needs positive rows/n/k, got {rows}/{n}/{k}"
@@ -150,87 +213,39 @@ pub fn glm52_fp8_weight_only_gemv_launch(
     // rows 4/8 the tensor-core mma path on winning shapes (deterministic per
     // bucket, not bit-identical to m=1). The CUDA side whitelists the
     // supported batches — a drifted GLM52_DECODE_BUCKETS crashes here.
-    unsafe {
-        ffi::glm52_fp8_weight_only_gemv_batched_cuda(
-            act_ptr as *const ffi::Half,
-            w_ptr as *const u8,
-            s_ptr as *const f32,
-            out_ptr as *mut ffi::Half,
-            scr_ptr,
-            scr_floats,
-            rows as i32,
-            n as i32,
-            k as i32,
-            ctx.stream.cu_stream(),
-        )
+    match ksplit_out {
+        None => unsafe {
+            ffi::glm52_fp8_weight_only_gemv_batched_cuda(
+                act_ptr as *const ffi::Half,
+                w_ptr as *const u8,
+                s_ptr as *const f32,
+                out_ptr as *mut ffi::Half,
+                scr_ptr,
+                scr_floats,
+                rows as i32,
+                n as i32,
+                k as i32,
+                ctx.stream.cu_stream(),
+            )
+        },
+        Some(ksplit) => unsafe {
+            ffi::glm52_fp8_weight_only_gemv_partials_cuda(
+                act_ptr as *const ffi::Half,
+                w_ptr as *const u8,
+                s_ptr as *const f32,
+                out_ptr as *mut ffi::Half,
+                scr_ptr,
+                scr_floats,
+                rows as i32,
+                n as i32,
+                k as i32,
+                ctx.stream.cu_stream(),
+                ksplit,
+            )
+        },
     }
     .result()
     .map_err(|err| anyhow!("GLM5.2 linear GEMV launch failed for rows={rows}, n={n}, k={k}: {err}"))
-}
-
-/// Partials-producing twin of [`glm52_fp8_weight_only_gemv_launch`]: when the
-/// (batch, shape) routes to the tensor-core mma path, the launch stops at the
-/// f32 k-slice partials in `scratch` and returns the split factor (`out` is
-/// untouched); otherwise it behaves exactly like the plain launch and returns
-/// 0. Callers pair a non-zero return with a fused reduce consumer.
-#[allow(clippy::too_many_arguments)]
-pub fn glm52_fp8_weight_only_gemv_partials_launch(
-    ctx: &DeviceContext,
-    rows: usize,
-    n: usize,
-    k: usize,
-    activation: &CudaSlice<bf16>,
-    weight: &CudaSlice<u8>,
-    scale_bytes: &CudaSlice<u8>,
-    scratch: &mut CudaSlice<f32>,
-    out: &mut CudaSlice<bf16>,
-) -> Result<usize> {
-    ensure!(
-        rows > 0 && n > 0 && k > 0,
-        "GLM5.2 linear GEMV needs positive rows/n/k, got {rows}/{n}/{k}"
-    );
-    let scale_len = n.div_ceil(FP8_BLOCK) * k.div_ceil(FP8_BLOCK) * 4;
-    ensure!(
-        weight.len() >= n * k
-            && scale_bytes.len() >= scale_len
-            && activation.len() >= rows * k
-            && out.len() >= rows * n,
-        "GLM5.2 linear GEMV buffers too small: w {} (need {}), scale {} (need {scale_len}), act {} (need {}), out {} (need {})",
-        weight.len(),
-        n * k,
-        scale_bytes.len(),
-        activation.len(),
-        rows * k,
-        out.len(),
-        rows * n
-    );
-    let (act_ptr, _a) = activation.device_ptr(&ctx.stream);
-    let (w_ptr, _w) = weight.device_ptr(&ctx.stream);
-    let (s_ptr, _s) = scale_bytes.device_ptr(&ctx.stream);
-    let (out_ptr, _o) = out.device_ptr_mut(&ctx.stream);
-    let scr_floats = scratch.len();
-    let (scr_ptr, _scr) = scratch.device_ptr_mut(&ctx.stream);
-    let mut ksplit: i32 = 0;
-    unsafe {
-        ffi::glm52_fp8_weight_only_gemv_partials_cuda(
-            act_ptr as *const ffi::Half,
-            w_ptr as *const u8,
-            s_ptr as *const f32,
-            out_ptr as *mut ffi::Half,
-            scr_ptr as *mut f32,
-            scr_floats,
-            rows as i32,
-            n as i32,
-            k as i32,
-            ctx.stream.cu_stream(),
-            &mut ksplit,
-        )
-    }
-    .result()
-    .map_err(|err| {
-        anyhow!("GLM5.2 linear GEMV (partials) launch failed for rows={rows}, n={n}, k={k}: {err}")
-    })?;
-    Ok(ksplit as usize)
 }
 
 /// MLA's bs=1 q_a and kv_a projections in one graph node. The two weights and


### PR DESCRIPTION
## Summary

Right-sizes the GLM5.2 batched weight-only GEMV chain for GB300 (sm_103) EP4 decode:

1. **GB300 batch-8 split-K table** (`mma_config`): every whitelisted decode shape re-swept on GB300 over the full (KSPLIT × NTILES) grid with a locked-clock standalone harness. The H200 picks do not transfer (the wall is bytes-in-flight per SM, an arch property) — e.g. q_a moves 16/2 → 48/2 (8.1 → 7.1 µs pair), kv_a 16/2 → 16/1 (6.7 → 5.5 µs). Gated on `arch_is_blackwell()`; Hopper tables byte-for-byte untouched.
2. **Fused reduce-SwiGLU** (`glm52_gemv_reduce_silu_mul`): the packed gate|up mma path stops at its f32 k-slice partials and the SwiGLU absorbs the fixed-order reduce — bit-identical (both sums round to bf16 before the SiLU math), one launch instead of two, and the `[rows, 2*inter]` bf16 round-trip disappears. Wired through `fp8_mlp_into` (dense MLP + MoE shared expert).
3. A `mma_config` entry whose (ksplit, ntiles) has no instantiated dispatch case now fails the launch at capture instead of silently falling back to the register tile.

## Measured (4×GB300, EP4, locked clocks, `glm52_step_bench` 60 steps)

| config | b8 step p50 / p99 (ms) | b1 step p50 / p99 (ms) |
| --- | --- | --- |
| main | 40.68 / 41.6 | 22.62 / 22.7 |
| this PR | **40.03 / 41.31** | 22.57 / 22.68 |

Attribution: the split-K table is the bulk of the −0.65 ms; the SwiGLU fusion contributes ~−0.15 ms (per-site launch + bf16 round-trip removal). Correctness: dense-layer, EP4 full-layer, and bookend oracle gates green on GB300 at the perf commit (the follow-up commit only adds a host-side dispatch-drift guard, a Rust wrapper dedupe, and docs; a re-gate at the final SHA is queued and will be posted as a comment).

Hopper note: sm_90 keeps its measured tables, but bucket-4/8 graphs now route gate|up through the fused epilogue there too — bit-identical numerics and strictly fewer bytes, not re-benched on H200.

## Falsified along the way (documented in `docs/models/glm52/ep4-gb300.md`)

- reduce→RMSNorm fusion (q_a norm + post-attn add+norm absorbing the reduce): bit-identical impl, oracle green, but b8 regressed 40.03 → 40.84/40.72 — norm kernels are block-per-row (grid = 8 blocks), so the ksplit=16-48 reduction collapses onto 8 latency-bound blocks. Reverted; a fusion only wins when the consumer's grid can host the producer's parallelism.
- Five structural GEMV alternatives (smem staging, launch-bounds squeeze, cp.async, Triton split-K, DeepGEMM masked fp8) all measured slower or unavailable on SM100; a pure-read control at the shipping grid geometry reaches 6.4-6.8 TB/s, so the kernel is at its W8A16 structural optimum. Deeper levers are tracked in #668.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
