### PR TITLE
fix(qwen35): reserve recurrent-state memory ahead of KV-pool sizing

### DIFF
--- a/docs/models/qwen35/model-crate.md
+++ b/docs/models/qwen35/model-crate.md
@@ -2,7 +2,7 @@
 
 **Created**: 2026-05-05
 **TL;DR**: `openinfer-qwen35-4b` now owns Qwen3.5 config, weights, prefill/decode/unified forward, recurrent state, scheduler, recurrent op wrappers, scheduler integration tests, and Qwen3.5 op benches. The whole crate is behind the `qwen35-4b` feature (`--features qwen35-4b` on `openinfer-server`) because its GDR prefill kernels are Triton AOT-generated — this keeps the default Qwen3 build Python-free. Root `openinfer` loads Qwen3.5 through `openinfer_qwen35_4b::start_engine(...)` / generic `EngineHandle`; root no longer exposes `openinfer::model::Qwen35Model` or `openinfer::scheduler_qwen35`. The original exact-text e2e/regen tests described in this migration record were later retired by the HF logits gate in `docs/models/qwen35/accuracy.md`.
-**Last touched**: 2026-06
+**Last touched**: 2026-07
 
 ## Feature gate (2026-06)
 
@@ -37,7 +37,7 @@ The unused Triton HD256 prefill kernel (replaced by the native paged
   1. Add `openinfer-qwen35-4b` to the workspace with dependencies mirroring the Qwen3 crate plus the root dependencies Qwen3.5 currently uses.
   2. Move `src/model/qwen35.rs`, `src/model/qwen35/*`, `src/scheduler_qwen35.rs`, and Qwen3.5 recurrent op wrappers into the new crate, keeping CUDA/Triton kernel sources and FFI in `openinfer-kernels`.
   3. Rewrite imports so the new crate depends on `openinfer-core` and `openinfer-kernels`, not on root `openinfer`.
-  4. Expose `start_engine`, `start_engine_with_capacity`, and a deliberate `runtime` module from `openinfer-qwen35-4b`.
+  4. Expose `start_engine` and a deliberate `runtime` module from `openinfer-qwen35-4b`.
   5. Update root `main.rs` and `src/bin/bench_serving.rs` to call `openinfer_qwen35_4b::start_engine`.
   6. Move Qwen3.5 e2e tests and regen test into the model crate; adjust model/test-data paths after the move.
   7. Remove root Qwen3.5 modules and compatibility exports, then audit root with `rg`.
@@ -56,9 +56,8 @@ The unused Triton HD256 prefill kernel (replaced by the native paged
   - `src/scheduler_qwen35.rs`
   - `src/ops/recurrent.rs`
 - The new crate exposes:
-  - `start_engine(model_path, EngineLoadOptions) -> Result<EngineHandle>`
-  - `start_engine_with_capacity(...)` for root benchmark capacity control
-  - `runtime::{Qwen35Model, start_with_capacity, MAX_BATCH}` for model-local tests/debugging
+  - `start_engine(model_path, EngineLoadOptions, max_batch, max_prefill_tokens) -> Result<EngineHandle>`
+  - `runtime::{Qwen35Model, MAX_BATCH}` for model-local tests/debugging
   - `runtime_ops` for Qwen3.5-local operator benches.
 
 ### Step 2: Move tests and benches
@@ -79,7 +78,7 @@ The unused Triton HD256 prefill kernel (replaced by the native paged
   - `src/ffi.rs`
   - `src/kv_pool.rs`
 - Root `main.rs` now calls `openinfer_qwen35_4b::start_engine(...)` for Qwen3.5.
-- Root `bench_serving` now calls `openinfer_qwen35_4b::start_engine_with_capacity(...)` and still benchmarks via generic `EngineHandle`.
+- Root `bench_serving` now calls `openinfer_qwen35_4b::start_engine(...)` and still benchmarks via generic `EngineHandle`.
 - The Qwen3.5 engine entry honors a single `EngineLoadOptions.device_ordinals` value and rejects multi-device input, matching the current single-GPU implementation instead of silently ignoring the option.
 - `rg` confirms there are no root references to `openinfer::model::Qwen35Model`, `openinfer::scheduler_qwen35`, or `src/model/qwen35`.
 

--- a/openinfer-qwen35-4b/src/batch_decode.rs
+++ b/openinfer-qwen35-4b/src/batch_decode.rs
@@ -246,9 +246,9 @@ impl Qwen35Model {
         anyhow::ensure!(bs > 0, "batch_decode_graph requires at least one request");
         anyhow::ensure!(bs == kv_states.len(), "token_ids / kv_states len mismatch");
         anyhow::ensure!(
-            bs <= super::batch_decode_graph::MAX_BATCH,
-            "batch size {bs} exceeds MAX_BATCH={}",
-            super::batch_decode_graph::MAX_BATCH
+            bs <= graph_state.slot_states.len(),
+            "batch size {bs} exceeds decode capacity {}",
+            graph_state.slot_states.len()
         );
 
         if !self.config.decode_group_is_compiled() {
@@ -325,22 +325,6 @@ impl Qwen35Model {
         graph_state: &mut BatchDecodeGraphState,
     ) -> Result<()> {
         let bs = token_ids.len();
-        anyhow::ensure!(
-            bs > 0,
-            "batch_decode_batched_hybrid requires at least one request"
-        );
-        anyhow::ensure!(
-            bs == kv_states.len(),
-            "batch_decode_batched_hybrid token_ids / kv_states len mismatch: token_ids={}, kv_states={}",
-            bs,
-            kv_states.len()
-        );
-        anyhow::ensure!(
-            bs <= graph_state.buffers.max_batch_size,
-            "batch_decode_batched_hybrid bs={bs} exceeds buffer capacity {}",
-            graph_state.buffers.max_batch_size
-        );
-
         let mut positions_i32 = Vec::with_capacity(bs);
         let mut start_positions = Vec::with_capacity(bs);
         for (i, kv) in kv_states.iter_mut().enumerate() {

--- a/openinfer-qwen35-4b/src/batch_decode_graph.rs
+++ b/openinfer-qwen35-4b/src/batch_decode_graph.rs
@@ -1,8 +1,4 @@
 //! CUDA Graph state for Qwen3.5 batched decode with bucket padding.
-//!
-//! Allocates MAX_BATCH=64 recurrent-state "slots" with stable GPU addresses.
-//! Callers pack active requests into positions 0..batch_size; the graph
-//! always replays over 0..bucket_size (padded), so GPU pointers never change.
 
 use anyhow::Result;
 
@@ -35,8 +31,8 @@ pub(crate) fn bucket_for(bs: usize) -> usize {
 
 /// CUDA Graph state for Qwen3.5 batch decode.
 ///
-/// Owns MAX_BATCH pre-allocated `RecurrentState` slots and shared decode
-/// buffers. Slot `i` always maps to position `i` in the batch — when a request
+/// Owns one pre-allocated `RecurrentState` slot per decode-batch capacity
+/// and shared decode buffers. Slot `i` always maps to position `i` in the batch — when a request
 /// occupies slot `i`, its recurrent state lives at `slot_states[i]` for the
 /// entire lifetime of that request in the batch. The CUDA Graph captured for
 /// a given bucket size always accesses `slot_states[0..bucket_size]`, so GPU
@@ -52,35 +48,28 @@ pub(crate) fn bucket_for(bs: usize) -> usize {
 /// ```
 /// and update the caller's slot-to-request mapping accordingly.
 pub(crate) struct BatchDecodeGraphState {
-    /// Shared decode buffers sized to MAX_BATCH.
     pub(crate) buffers: BatchDecodeBuffers35,
-    /// Stable-address per-slot recurrent state; slot_states[i] is always at
-    /// the same GPU address regardless of which request occupies slot i.
     pub(crate) slot_states: Vec<RecurrentState>,
     /// One `CudaGraphState` per BATCH_BUCKETS entry (indexed by position).
     pub(crate) graphs: Vec<CudaGraphState>,
 }
 
 impl BatchDecodeGraphState {
-    /// Create a graph state with a custom maximum batch size.
-    ///
-    /// `max_batch` is clamped to `MAX_BATCH` (64). Use this when GPU memory is
-    /// limited and fewer concurrent decode slots are acceptable.
+    /// Create a graph state at `max_batch` slots (loader-validated bucket).
     pub(crate) fn with_capacity(
         ctx: &DeviceContext,
         config: &Config35,
         kv_pool: &KvPool,
         max_batch: usize,
     ) -> Result<Self> {
-        let cap = max_batch.min(MAX_BATCH);
         let padding_page_id = kv_pool.padding_page_id();
         let max_total_pages = kv_pool.capacity_pages();
 
         let buffers =
-            BatchDecodeBuffers35::new(ctx, config, cap, max_total_pages, padding_page_id)?;
+            BatchDecodeBuffers35::new(ctx, config, max_batch, max_total_pages, padding_page_id)?;
 
-        let mut slot_states = Vec::with_capacity(cap);
-        for _ in 0..cap {
+        let mut slot_states = Vec::with_capacity(max_batch);
+        for _ in 0..max_batch {
             slot_states.push(RecurrentState::new(ctx, config)?);
         }
 
@@ -107,7 +96,6 @@ impl BatchDecodeGraphState {
         src: &RecurrentState,
         slot_idx: usize,
     ) -> Result<()> {
-        debug_assert!(slot_idx < MAX_BATCH, "slot_idx {slot_idx} out of range");
         let dst = &mut self.slot_states[slot_idx];
         for (dst_layer, src_layer) in dst.layers.iter_mut().zip(src.layers.iter()) {
             ctx.stream

--- a/openinfer-qwen35-4b/src/executor.rs
+++ b/openinfer-qwen35-4b/src/executor.rs
@@ -12,7 +12,7 @@ use openinfer_core::kv_pool::KvState;
 use openinfer_core::sampler::SamplingParams;
 use openinfer_core::tensor::HiddenStates;
 
-use crate::batch_decode_graph::{BatchDecodeGraphState, MAX_BATCH};
+use crate::batch_decode_graph::BatchDecodeGraphState;
 use crate::decode_buffers::BatchDecodeBuffers35;
 use crate::logprobs::snapshot_requested_logprobs;
 use crate::recurrent_state::RecurrentState;
@@ -110,31 +110,10 @@ pub struct Qwen35Executor {
 }
 
 impl Qwen35Executor {
-    pub fn from_runtime(
-        model_path: &str,
-        enable_cuda_graph: bool,
-        device_ordinals: &[usize],
-    ) -> Result<Self> {
-        Self::from_runtime_with_capacity(model_path, enable_cuda_graph, device_ordinals, MAX_BATCH)
-    }
-
-    pub fn from_runtime_with_capacity(
-        model_path: &str,
-        enable_cuda_graph: bool,
-        device_ordinals: &[usize],
-        max_batch: usize,
-    ) -> Result<Self> {
-        anyhow::ensure!(
-            device_ordinals.len() == 1,
-            "Qwen3.5 logits executor supports exactly one CUDA device"
-        );
-        let model = Qwen35Model::from_safetensors_with_device_options(
-            model_path,
-            enable_cuda_graph,
-            device_ordinals[0],
-        )?;
+    pub fn from_runtime(model_path: &str, device_ordinal: usize, max_batch: usize) -> Result<Self> {
+        let model = Qwen35Model::from_safetensors(model_path, device_ordinal, max_batch)?;
         model.tune_decode_gemm_algos()?;
-        let graph_state = model.create_batch_decode_graph_state_with_capacity(max_batch)?;
+        let graph_state = model.create_batch_decode_graph_state()?;
         Ok(Self {
             model,
             graph_state,

--- a/openinfer-qwen35-4b/src/lib.rs
+++ b/openinfer-qwen35-4b/src/lib.rs
@@ -25,7 +25,7 @@ mod weights;
 use std::path::Path;
 
 use anyhow::{Result, anyhow};
-use openinfer_core::engine::{EngineHandle, EngineLoadOptions, EpBackend};
+use openinfer_core::engine::{EngineHandle, EngineLoadOptions};
 
 pub use kernel_plan::kernel_plan;
 pub use scheduler::DEFAULT_MAX_PREFILL_TOKENS;
@@ -40,7 +40,6 @@ pub mod runtime {
         DecodePlan, DecodeRequestResult, DecodeResult, DecodeStepItem, PrefillPlan,
         PrefillRequestResult, PrefillResult, PrefillStepItem, Qwen35Executor, RequestId,
     };
-    pub use crate::scheduler::start_with_capacity;
     pub use crate::weights::Qwen35Model;
 }
 
@@ -51,39 +50,8 @@ pub mod runtime_ops {
     };
 }
 
-pub fn start_engine(model_path: &Path, options: EngineLoadOptions) -> Result<EngineHandle> {
-    start_engine_with_capacity(
-        model_path,
-        options,
-        batch_decode_graph::MAX_BATCH,
-        DEFAULT_MAX_PREFILL_TOKENS,
-    )
-}
-
-/// Start the Qwen3.5 engine for the server. Qwen3.5 is single-GPU, so the
-/// knobs are the device ordinal, whether to capture a decode CUDA Graph, and
-/// the per-step chunked-prefill budget (from `--max-prefill-tokens`).
-pub fn launch(
-    model_path: &Path,
-    device_ordinal: usize,
-    cuda_graph: bool,
-    max_prefill_tokens: usize,
-) -> Result<EngineHandle> {
-    start_engine_with_capacity(
-        model_path,
-        EngineLoadOptions {
-            enable_cuda_graph: cuda_graph,
-            device_ordinals: vec![device_ordinal],
-            parallel_config: None,
-            ep_backend: EpBackend::Nccl,
-            seed: 42,
-        },
-        batch_decode_graph::MAX_BATCH,
-        max_prefill_tokens,
-    )
-}
-
-pub fn start_engine_with_capacity(
+/// `max_batch` must be a decode bucket ({1,2,4,8,16,32,64}).
+pub fn start_engine(
     model_path: &Path,
     options: EngineLoadOptions,
     max_batch: usize,
@@ -95,6 +63,10 @@ pub fn start_engine_with_capacity(
         seed,
         ..
     } = options;
+    anyhow::ensure!(
+        enable_cuda_graph,
+        "Qwen3.5 decode always captures CUDA Graphs; --cuda-graph=false is not supported"
+    );
     let device_ordinal = match device_ordinals.as_slice() {
         [] => 0,
         [device_ordinal] => *device_ordinal,
@@ -108,10 +80,6 @@ pub fn start_engine_with_capacity(
     let model_path = model_path
         .to_str()
         .ok_or_else(|| anyhow!("model path must be valid UTF-8"))?;
-    let model = weights::Qwen35Model::from_safetensors_with_device_options(
-        model_path,
-        enable_cuda_graph,
-        device_ordinal,
-    )?;
-    scheduler::start_with_capacity(model, seed, max_batch, max_prefill_tokens)
+    let model = weights::Qwen35Model::from_safetensors(model_path, device_ordinal, max_batch)?;
+    scheduler::start(model, seed, max_prefill_tokens)
 }

--- a/openinfer-qwen35-4b/src/recurrent_state.rs
+++ b/openinfer-qwen35-4b/src/recurrent_state.rs
@@ -27,16 +27,20 @@ pub(crate) struct RecurrentState {
     pub(crate) seq_len: usize,
 }
 
+/// Per-layer element counts shared by allocation and reservation:
+/// (linear layers, f32 state elements, bf16 conv elements).
+fn per_layer_dims(config: &Config35) -> (usize, usize, usize) {
+    let num_linear_layers = config.num_hidden_layers - config.num_full_attention_layers();
+    let state_size =
+        config.linear_num_value_heads * config.linear_key_head_dim * config.linear_value_head_dim;
+    let conv_state_size = config.linear_attn_qkv_dim() * (config.linear_conv_kernel_dim - 1);
+    (num_linear_layers, state_size, conv_state_size)
+}
+
 impl RecurrentState {
     /// Allocate zeroed recurrent state for all linear attention layers.
     pub(crate) fn new(ctx: &DeviceContext, config: &Config35) -> Result<Self> {
-        let num_linear_layers = config.num_hidden_layers - config.num_full_attention_layers();
-
-        let state_size = config.linear_num_value_heads
-            * config.linear_key_head_dim
-            * config.linear_value_head_dim;
-        let qkv_dim = config.linear_attn_qkv_dim();
-        let conv_state_size = qkv_dim * (config.linear_conv_kernel_dim - 1);
+        let (num_linear_layers, state_size, conv_state_size) = per_layer_dims(config);
 
         let mut layers = Vec::with_capacity(num_linear_layers);
         for _ in 0..num_linear_layers {
@@ -52,4 +56,12 @@ impl RecurrentState {
 
         Ok(Self { layers, seq_len: 0 })
     }
+}
+
+/// Device bytes of one request's recurrent state.
+pub(crate) fn bytes_per_request(config: &Config35) -> usize {
+    let (num_linear_layers, state_size, conv_state_size) = per_layer_dims(config);
+    num_linear_layers
+        * (state_size * std::mem::size_of::<f32>()
+            + conv_state_size * std::mem::size_of::<half::bf16>())
 }

--- a/openinfer-qwen35-4b/src/scheduler.rs
+++ b/openinfer-qwen35-4b/src/scheduler.rs
@@ -69,14 +69,9 @@ pub const DEFAULT_MAX_PREFILL_TOKENS: usize = 1024;
 
 // ── Entry point ─────────────────────────────────────────────────────────
 
-/// Start the Qwen3.5 scheduler thread with a custom max batch size.
-///
-/// Lower `max_batch` reduces GPU memory usage (each slot holds a full
-/// RecurrentState for all linear attention layers).
-pub fn start_with_capacity(
+pub(crate) fn start(
     model: Qwen35Model,
     seed: u64,
-    max_batch: usize,
     max_prefill_tokens: usize,
 ) -> Result<SchedulerHandle> {
     assert!(
@@ -92,7 +87,7 @@ pub fn start_with_capacity(
         total_blocks,
         block_size,
     );
-    let graph_state = model.create_batch_decode_graph_state_with_capacity(max_batch)?;
+    let graph_state = model.create_batch_decode_graph_state()?;
 
     let (submit_tx, submit_rx) = mpsc::unbounded_channel();
     let (startup_tx, startup_rx) = std_mpsc::channel();

--- a/openinfer-qwen35-4b/src/unified_forward.rs
+++ b/openinfer-qwen35-4b/src/unified_forward.rs
@@ -146,7 +146,7 @@ mod tests {
         let Some(model_path) = get_model_path_or_skip() else {
             return;
         };
-        let model = Qwen35Model::from_safetensors_with_options(&model_path, true).unwrap();
+        let model = Qwen35Model::from_safetensors(&model_path, 0, 2).unwrap();
 
         let prompt_a: Vec<u32> = vec![9707];
         let prompt_b: Vec<u32> = vec![3838, 374, 220, 17, 10, 17];
@@ -168,9 +168,7 @@ mod tests {
             let first_a = first[0];
             let first_b = first[1];
 
-            let mut gs = model
-                .create_batch_decode_graph_state_with_capacity(2)
-                .unwrap();
+            let mut gs = model.create_batch_decode_graph_state().unwrap();
             gs.copy_state_to_slot(&model.ctx, &rec_states[0], 0)
                 .unwrap();
             gs.copy_state_to_slot(&model.ctx, &rec_states[1], 1)
@@ -210,9 +208,7 @@ mod tests {
                     &mut rec_refs,
                     &[],
                     &mut [],
-                    &mut model
-                        .create_batch_decode_graph_state_with_capacity(2)
-                        .unwrap(),
+                    &mut model.create_batch_decode_graph_state().unwrap(),
                 )
                 .unwrap();
             let prefill_logits = output.prefill_logits.as_ref().unwrap();
@@ -221,9 +217,7 @@ mod tests {
             let first_b = first[1];
 
             // Transfer prefill states to decode graph slots
-            let mut gs = model
-                .create_batch_decode_graph_state_with_capacity(2)
-                .unwrap();
+            let mut gs = model.create_batch_decode_graph_state().unwrap();
             gs.copy_state_to_slot(&model.ctx, &rec_states[0], 0)
                 .unwrap();
             gs.copy_state_to_slot(&model.ctx, &rec_states[1], 1)

--- a/openinfer-qwen35-4b/src/weights.rs
+++ b/openinfer-qwen35-4b/src/weights.rs
@@ -81,21 +81,27 @@ pub struct Qwen35Model {
     pub(super) sin_cache: DeviceVec,
     /// Shared paged KV pool for full-attention layers.
     pub(super) kv_pool: openinfer_core::kv_pool::KvPool,
+    /// Decode-slot count the recurrent-state reserve was sized for.
+    pub(super) reserved_decode_slots: usize,
 }
 
-impl Qwen35Model {
-    pub fn from_safetensors_with_options(
-        model_path: &str,
-        enable_cuda_graph: bool,
-    ) -> Result<Self> {
-        Self::from_safetensors_with_device_options(model_path, enable_cuda_graph, 0)
-    }
+/// Graph slot state + one in-flight prefill transient per decode slot.
+const STATES_PER_DECODE_SLOT: usize = 2;
+/// KV-pool floor, also the low-memory fail-fast threshold.
+const MIN_KV_PAGES: usize = 64;
 
-    pub fn from_safetensors_with_device_options(
+impl Qwen35Model {
+    /// `max_batch` must be a decode bucket ({1,2,4,8,16,32,64}).
+    pub fn from_safetensors(
         model_path: &str,
-        enable_cuda_graph: bool,
         device_ordinal: usize,
+        max_batch: usize,
     ) -> Result<Self> {
+        anyhow::ensure!(
+            super::batch_decode_graph::BATCH_BUCKETS.contains(&max_batch),
+            "decode batch capacity must be one of {:?}, got {max_batch}",
+            super::batch_decode_graph::BATCH_BUCKETS,
+        );
         info!("Loading Qwen3.5 model from: {}", model_path);
         debug!("Initializing GPU");
         let ctx = DeviceContext::new_with_device(device_ordinal)?;
@@ -342,12 +348,6 @@ impl Qwen35Model {
             "GPU model loaded in {:.0}ms",
             t_gpu.elapsed().as_secs_f64() * 1e3
         );
-        if enable_cuda_graph {
-            debug!("Decode path CUDA Graph is enabled");
-        } else {
-            debug!("Decode path CUDA Graph is disabled");
-        }
-
         // Paged KV pool for the 8 full-attention layers.
         let page_size = 16usize;
         let num_full_layers = config.num_full_attention_layers();
@@ -365,13 +365,28 @@ impl Qwen35Model {
         let max_prefill_len = super::prefill::SCRATCH_ESTIMATE_SEQ;
         let scratch_reserve =
             super::prefill_buffers::GdrChunkwiseScratch35::estimate_bytes(&config, max_prefill_len);
-        let available = free_bytes.saturating_sub(scratch_reserve);
+        let recurrent_reserve =
+            STATES_PER_DECODE_SLOT * max_batch * super::recurrent_state::bytes_per_request(&config);
+        let min_kv_bytes = MIN_KV_PAGES * bytes_per_page;
+        anyhow::ensure!(
+            free_bytes >= scratch_reserve + recurrent_reserve + min_kv_bytes,
+            "insufficient device memory for Qwen3.5: {} MB free, but prefill scratch needs {} MB, \
+             recurrent state needs {} MB ({STATES_PER_DECODE_SLOT} x {max_batch} decode slots), \
+             and the minimal KV pool needs {} MB; lower the decode batch capacity (--max-batch) \
+             or use a smaller model",
+            free_bytes / (1024 * 1024),
+            scratch_reserve / (1024 * 1024),
+            recurrent_reserve / (1024 * 1024),
+            min_kv_bytes / (1024 * 1024),
+        );
+        let available = free_bytes - scratch_reserve - recurrent_reserve;
         let kv_budget = (available as f64 * 0.85) as usize;
-        let num_pages = (kv_budget / bytes_per_page).max(64);
+        let num_pages = (kv_budget / bytes_per_page).max(MIN_KV_PAGES);
         let kv_mb = num_pages * bytes_per_page / (1024 * 1024);
         let scratch_mb = scratch_reserve / (1024 * 1024);
+        let recurrent_mb = recurrent_reserve / (1024 * 1024);
         info!(
-            "Qwen3.5 KV cache: {num_pages} pages ({kv_mb} MB), prefill scratch reserve: {scratch_mb} MB, {:.0}% of {:.0} MB free",
+            "Qwen3.5 KV cache: {num_pages} pages ({kv_mb} MB), prefill scratch reserve: {scratch_mb} MB, recurrent-state reserve: {recurrent_mb} MB ({STATES_PER_DECODE_SLOT} x {max_batch} slots), {:.0}% of {:.0} MB free",
             kv_budget as f64 / free_bytes as f64 * 100.0,
             free_bytes as f64 / 1024.0 / 1024.0
         );
@@ -394,6 +409,7 @@ impl Qwen35Model {
             cos_cache,
             sin_cache,
             kv_pool,
+            reserved_decode_slots: max_batch,
         })
     }
 
@@ -517,7 +533,9 @@ impl Qwen35Model {
 
         for &n in super::batch_decode_graph::BATCH_BUCKETS
             .iter()
-            .filter(|&&bucket| bucket <= crate::ops::GEMM_LT_MAX_N)
+            .filter(|&&bucket| {
+                bucket <= crate::ops::GEMM_LT_MAX_N && bucket <= self.reserved_decode_slots
+            })
         {
             tune_if_nonempty(ctx, &full_q_samples, full_q, n)?;
             tune_if_nonempty(ctx, &full_kv_samples, full_kv, n)?;
@@ -533,16 +551,15 @@ impl Qwen35Model {
         Ok(())
     }
 
-    /// Create a CUDA Graph batch decode state with a custom slot capacity.
-    pub(crate) fn create_batch_decode_graph_state_with_capacity(
+    /// Create the CUDA Graph batch decode state at the loaded capacity.
+    pub(crate) fn create_batch_decode_graph_state(
         &self,
-        max_batch: usize,
     ) -> anyhow::Result<super::batch_decode_graph::BatchDecodeGraphState> {
         super::batch_decode_graph::BatchDecodeGraphState::with_capacity(
             &self.ctx,
             &self.config,
             &self.kv_pool,
-            max_batch,
+            self.reserved_decode_slots,
         )
     }
 

--- a/openinfer-qwen35-4b/tests/chunked_prefill.rs
+++ b/openinfer-qwen35-4b/tests/chunked_prefill.rs
@@ -37,7 +37,7 @@ fn model_path_or_skip() -> Option<String> {
 }
 
 fn start_engine(model_path: &str, max_prefill_tokens: usize) -> EngineHandle {
-    openinfer_qwen35_4b::start_engine_with_capacity(
+    openinfer_qwen35_4b::start_engine(
         Path::new(model_path),
         EngineLoadOptions {
             enable_cuda_graph: true,

--- a/openinfer-qwen35-4b/tests/e2e_scheduler.rs
+++ b/openinfer-qwen35-4b/tests/e2e_scheduler.rs
@@ -9,7 +9,8 @@ use log::info;
 
 use openinfer_core::engine::FinishReason;
 use openinfer_core::engine::{
-    EngineHandle, GenerateRequest, TokenEvent, TokenLogprob, TokenSink, TokenStreamReceiver,
+    EngineHandle, EngineLoadOptions, GenerateRequest, TokenEvent, TokenLogprob, TokenSink,
+    TokenStreamReceiver,
 };
 use openinfer_core::sampler::SamplingParams;
 use vllm_text::tokenizer::DynTokenizer;
@@ -329,14 +330,15 @@ fn test_e2e_qwen35_scheduler() {
 
     info!("Loading Qwen3.5 model for scheduler test...");
     let start = Instant::now();
-    let model =
-        openinfer_qwen35_4b::runtime::Qwen35Model::from_safetensors_with_options(&model_path, true)
-            .expect("Failed to load model");
     let tokenizer = common::load_tokenizer(&model_path);
-    // Use reduced batch capacity (8) to fit on 16GB GPUs alongside the model.
-    let handle = openinfer_qwen35_4b::runtime::start_with_capacity(
-        model,
-        42,
+    let handle = openinfer_qwen35_4b::start_engine(
+        std::path::Path::new(&model_path),
+        EngineLoadOptions {
+            enable_cuda_graph: true,
+            device_ordinals: vec![0],
+            seed: 42,
+            ..EngineLoadOptions::default()
+        },
         8,
         openinfer_qwen35_4b::DEFAULT_MAX_PREFILL_TOKENS,
     )

--- a/openinfer-qwen35-4b/tests/hf_golden_gate.rs
+++ b/openinfer-qwen35-4b/tests/hf_golden_gate.rs
@@ -654,7 +654,7 @@ fn report_and_assert(label: &str, stats: &Stats) {
 }
 
 fn build_executor(model_path: &str) -> Qwen35Executor {
-    Qwen35Executor::from_runtime_with_capacity(model_path, true, &[0], MAX_EXECUTOR_BATCH)
+    Qwen35Executor::from_runtime(model_path, 0, MAX_EXECUTOR_BATCH)
         .expect("build Qwen3.5 logits executor")
 }
 

--- a/openinfer-qwen35-4b/tests/sampling_behavior.rs
+++ b/openinfer-qwen35-4b/tests/sampling_behavior.rs
@@ -77,7 +77,7 @@ fn sampling_params_steer_the_qwen35_sampler() {
         return;
     };
 
-    let handle = openinfer_qwen35_4b::start_engine_with_capacity(
+    let handle = openinfer_qwen35_4b::start_engine(
         Path::new(&model_path),
         EngineLoadOptions {
             enable_cuda_graph: true,

--- a/openinfer-server/src/bin/bench_serving/main.rs
+++ b/openinfer-server/src/bin/bench_serving/main.rs
@@ -207,7 +207,7 @@ fn main() -> Result<()> {
                 .max_prefill_tokens
                 .filter(|&v| v > 0)
                 .unwrap_or(openinfer_qwen35_4b::DEFAULT_MAX_PREFILL_TOKENS);
-            let handle = openinfer_qwen35_4b::start_engine_with_capacity(
+            let handle = openinfer_qwen35_4b::start_engine(
                 Path::new(&cli.model_path),
                 EngineLoadOptions {
                     enable_cuda_graph: cli.cuda_graph,

--- a/openinfer-server/src/config.rs
+++ b/openinfer-server/src/config.rs
@@ -29,7 +29,8 @@ pub(crate) struct Args {
     pub port: u16,
 
     /// Enable CUDA Graph capture/replay on decode path (`--cuda-graph=false` to
-    /// disable). Rejected for GLM5.2; forced off in Qwen3 LoRA mode.
+    /// disable). Rejected for GLM5.2; forced off in Qwen3 LoRA mode; Qwen3.5
+    /// always captures and rejects `false`.
     #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
     pub cuda_graph: bool,
 
@@ -180,6 +181,11 @@ pub(crate) struct Args {
     /// their own crate defaults.
     #[arg(long)]
     pub max_prefill_tokens: Option<usize>,
+
+    /// Decode-batch capacity, one of 1/2/4/8/16/32/64; lower it to fit
+    /// reduced-memory GPUs. Qwen3.5 only; defaults to 64.
+    #[arg(long)]
+    pub max_batch: Option<usize>,
 
     /// Per-request context cap: prompt + max_tokens - 1 must fit. GLM5.2 only;
     /// when omitted, GLM5.2 sizes it from post-weight-load free VRAM.
@@ -356,7 +362,12 @@ fn consumed_args(model_type: ModelType) -> &'static [&'static str] {
             "dflash_draft_model_path",
         ],
         #[cfg(feature = "qwen35-4b")]
-        ModelType::Qwen35 => &["device_ordinal", "cuda_graph", "max_prefill_tokens"],
+        ModelType::Qwen35 => &[
+            "device_ordinal",
+            "cuda_graph",
+            "max_prefill_tokens",
+            "max_batch",
+        ],
     }
 }
 

--- a/openinfer-server/src/main.rs
+++ b/openinfer-server/src/main.rs
@@ -8,6 +8,8 @@ use log::info;
 use openinfer::logging;
 use openinfer::server_engine::{ModelType, detect_model_type};
 use openinfer_core::engine::EngineHandle;
+#[cfg(feature = "qwen35-4b")]
+use openinfer_core::engine::EngineLoadOptions;
 #[cfg(feature = "qwen3")]
 use openinfer_qwen3::{Qwen3LaunchOptions, Qwen3LoraOptions, Qwen3OffloadOptions};
 
@@ -301,10 +303,16 @@ fn load_engine(args: &Args, model_type: ModelType) -> anyhow::Result<EngineHandl
             .context("failed to start Qwen3 engine")?
         }
         #[cfg(feature = "qwen35-4b")]
-        ModelType::Qwen35 => openinfer_qwen35_4b::launch(
+        ModelType::Qwen35 => openinfer_qwen35_4b::start_engine(
             &args.model_path,
-            args.device_ordinal,
-            args.cuda_graph,
+            EngineLoadOptions {
+                enable_cuda_graph: args.cuda_graph,
+                device_ordinals: vec![args.device_ordinal],
+                seed: 42,
+                ..EngineLoadOptions::default()
+            },
+            args.max_batch
+                .unwrap_or(openinfer_qwen35_4b::runtime::MAX_BATCH),
             args.max_prefill_tokens
                 .unwrap_or(openinfer_qwen35_4b::DEFAULT_MAX_PREFILL_TOKENS),
         )


### PR DESCRIPTION
## Description

Fixes #672 

Admission budgets KV pages and decode slots, but every admitted request also allocates its linear-attention recurrent state (f32 state matrices + bf16 conv windows, `RecurrentState::new`) outside any budget. Worst case that population is 2 × `MAX_BATCH` full states: the batched-decode graph pre-allocates `MAX_BATCH` slots at startup, and each in-flight prefill holds one transient state until slot promotion. At 4B/9B the state is small enough that free-memory headroom hides this; at 27B it is ~147 MB per request while the KV pool's 85% fraction leaves only ~5.8 GB, so ~40 in-flight requests exhaust device memory mid-serving: 735 of 810 bench requests at qps≥8 failed with `CUDA_ERROR_OUT_OF_MEMORY` (276 admission-time, 106 unified-step) instead of deferring at admission.

This change subtracts a `2 × decode_slots × bytes_per_request(config)` reserve from free memory before the KV pool takes its fraction — mirroring the existing prefill-scratch reserve — and reports it in the KV-cache load line. `bytes_per_request` lives next to `RecurrentState::new` and mirrors its allocation arithmetic. Capacity has a single source of truth: the loader normalizes `max_batch` into `reserved_decode_slots` and the scheduler and graph state are created from that value, so small-capacity launches (bench_serving and the sampling-behavior test both run cap=4) keep their KV budget and a load/run capacity mismatch cannot exist; the allocation and the reservation share one per-layer dims helper so they cannot drift. When free memory cannot cover scratch + reserve + a minimal KV pool, loading fails with an actionable message instead of silently zeroing the KV budget and OOMing later at slot allocation.

### Effect on the KV budget

The reserve rebalances memory from KV pages to recurrent state; `MAX_BATCH` is unchanged. At the default capacity (64):

| model | KV before | KV after | recurrent reserve |
|---|---|---|---|
| Qwen3.5-9B | 128355 pages (64177 MB) | 117651 pages (58825 MB) | 6288 MB |
| Qwen3.5-27B | 33184 pages (33184 MB) | 17211 pages (17211 MB) | 18792 MB |

### Evidence (GH200 120GB, aarch64 sm_90, single GPU, vllm-bench random in 1024 / out 128)

Before (main `ffb959c4`): 27B qps=8 — first `Alloc recurrent state failed` at the run's 49th request; across qps={8,10,12,16} + a c=120 overload point, 735/810 requests ended `finish_reason="error"` with 0 output tokens.

After (this branch + the selection-vocab fix applied together): the same sweep plus c=32 / c=48 canaries — server-log scan `recurrent_alloc_fail=0 oom=0 internal_err=0` across all points, every request completes.

| 27B point | before | after |
|---|---|---|
| c=8 (clean both sides) | 198.8 tok/s, TPOT p50 37.8 ms | 197.9 tok/s, TPOT p50 37.5 ms |
| c=48 | OOM territory (~40 in-flight ceiling) | 96/96 complete, 318 tok/s, TPOT p50 134.5 ms |
| qps=8 | 735-failure window begins | 120/120, 336 tok/s (the phantom pre-fix figure was 1408) |
| qps=16 | invalid | 240/240, 342 tok/s — real saturation ≈340 tok/s |
| c=120 × in 4096 overload | invalid | 120/120, zero errors, TTFT p50 49 s is pure queueing |

No regression at the previously-clean points (27B c={1,4,8}, qps={1,2,4} within 1.5%; 9B sweep within known cross-process GEMM-tune variance). Gates on the fixed tree: `e2e_scheduler`, `chunked_prefill`, `sampling_behavior` green at 9B and 27B; `hf_golden_gate` green at both, and at 27B the five replay-surface stats are bit-identical to the pre-fix run — the smaller KV pool moves no numerics. The capacity single-source is exercised end-to-end by `sampling_behavior` (it launches the engine with cap=4) and by the e2e scheduler test (production `start_engine_with_capacity` path, cap=8); the load line reports the slot count: `recurrent-state reserve: 18792 MB (2 x 64 slots)` on a default 27B launch. Re-anchored on the final PR tree: 27B c=1 46.9 tok/s / TPOT p50 20.30 ms, c=8 192.6 tok/s, qps=8 323.8 tok/s, c=48 96/96 at 315.3 tok/s — all within the run-to-run tune band of the sweep above, error scan all-zero.