### PR TITLE
fix(qwen35): restrict token selection to the frontend-decodable vocab

### DIFF
--- a/openinfer-core/src/ops.rs
+++ b/openinfer-core/src/ops.rs
@@ -32,13 +32,13 @@ pub use openinfer_kernels::ops::{
 #[cfg(not(feature = "kernel-call-trace"))]
 pub use openinfer_kernels::ops::{
     embedding_batch, fused_add_rms_norm_batch_into, gemm_into, gemm_rows_into,
-    gemm_token_range_into_checked, qk_norm_rope_batch_decode_into, rms_norm_batch_into,
-    silu_mul_fused_batch_into,
+    gemm_rows_into_checked, gemm_token_range_into_checked, qk_norm_rope_batch_decode_into,
+    rms_norm_batch_into, silu_mul_fused_batch_into,
 };
 pub use paged_plan::PrefillPagedPlan;
 #[cfg(feature = "kernel-call-trace")]
 pub use traced::{
     embedding_batch, fused_add_rms_norm_batch_into, gemm_into, gemm_rows_into,
-    gemm_token_range_into_checked, qk_norm_rope_batch_decode_into, rms_norm_batch_into,
-    silu_mul_fused_batch_into,
+    gemm_rows_into_checked, gemm_token_range_into_checked, qk_norm_rope_batch_decode_into,
+    rms_norm_batch_into, silu_mul_fused_batch_into,
 };

--- a/openinfer-core/src/ops/traced.rs
+++ b/openinfer-core/src/ops/traced.rs
@@ -54,6 +54,18 @@ pub fn gemm_rows_into(
     x: &HiddenStates,
     out: &mut HiddenStates,
 ) {
+    gemm_rows_into_checked(ctx, weight, row_offset, num_rows, x, out)
+        .expect("GEMM row-range launch failed");
+}
+
+pub fn gemm_rows_into_checked(
+    ctx: &DeviceContext,
+    weight: &DeviceMatrix,
+    row_offset: usize,
+    num_rows: usize,
+    x: &HiddenStates,
+    out: &mut HiddenStates,
+) -> Result<()> {
     if call_trace::is_enabled() {
         let label = call_trace::current_label("gemm_rows");
         call_trace::record_call(gemm_rows_call::<OutDim>(
@@ -65,7 +77,7 @@ pub fn gemm_rows_into(
             x.seq_len,
         ));
     }
-    openinfer_kernels::ops::gemm_rows_into(ctx, weight, row_offset, num_rows, x, out);
+    openinfer_kernels::ops::gemm_rows_into_checked(ctx, weight, row_offset, num_rows, x, out)
 }
 
 pub fn gemm_into(

--- a/openinfer-qwen35-4b/src/batch_decode.rs
+++ b/openinfer-qwen35-4b/src/batch_decode.rs
@@ -503,12 +503,14 @@ impl Qwen35Model {
             eps,
             &mut bufs.normed,
         )?;
-        ops::gemm_into(
+        ops::gemm_rows_into_checked(
             &self.ctx,
             self.output_projection(),
+            0,
+            self.config.selection_vocab,
             &bufs.normed,
             &mut bufs.logits,
-        );
+        )?;
         debug_assert_eq!(bufs.logits.seq_len, padded_bs);
 
         Ok(())
@@ -577,12 +579,14 @@ impl Qwen35Model {
             eps,
             &mut bufs.normed,
         )?;
-        ops::gemm_into(
+        ops::gemm_rows_into_checked(
             &self.ctx,
             self.output_projection(),
+            0,
+            self.config.selection_vocab,
             &bufs.normed,
             &mut bufs.logits,
-        );
+        )?;
         debug_assert_eq!(bufs.logits.seq_len, bs);
         Ok(())
     }

--- a/openinfer-qwen35-4b/src/config.rs
+++ b/openinfer-qwen35-4b/src/config.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
+use log::warn;
 use serde::Deserialize;
+use std::collections::HashSet;
 use std::fs;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -76,6 +78,9 @@ pub(crate) struct Config35 {
 
     /// `false` requires a top-level `lm_head.weight`; `true` reuses `embed_tokens`.
     pub(crate) tie_word_embeddings: bool,
+
+    /// Token-selection width: `vocab_size` bounded to the frontend-decodable vocab.
+    pub(crate) selection_vocab: usize,
 }
 
 /// Head dims baked into the kernels; head counts are runtime parameters.
@@ -179,6 +184,7 @@ impl Config35 {
             max_position_embeddings,
             layer_types,
             tie_word_embeddings,
+            selection_vocab: t.vocab_size,
         };
         Ok(config)
     }
@@ -226,6 +232,86 @@ impl Config35 {
     }
 }
 
+/// Schema kept identical to the pinned vLLM frontend; unread fields exist for
+/// payload type-checking.
+#[allow(dead_code)]
+#[derive(Deserialize)]
+struct AddedTokenConfig {
+    #[serde(default)]
+    id: Option<u32>,
+    content: String,
+    #[serde(default)]
+    single_word: bool,
+    #[serde(default)]
+    lstrip: bool,
+    #[serde(default)]
+    rstrip: bool,
+    #[serde(default)]
+    normalized: bool,
+    #[serde(default)]
+    special: bool,
+}
+
+#[derive(Deserialize)]
+struct TokenizerJsonIds {
+    model: TokenizerModelIds,
+    #[serde(default)]
+    added_tokens: Vec<AddedTokenConfig>,
+}
+
+#[derive(Deserialize)]
+struct TokenizerModelIds {
+    vocab: std::collections::HashMap<String, u32>,
+}
+
+#[derive(Deserialize)]
+struct TokenizerConfigIds {
+    #[serde(default)]
+    added_tokens_decoder: std::collections::HashMap<String, AddedTokenConfig>,
+}
+
+/// Width of the frontend-decodable id space, mirroring the pinned frontend's
+/// merge: `tokenizer.json` vocab and added_tokens (fatal on parse failure -
+/// the frontend cannot serve without it) plus `tokenizer_config.json`
+/// added_tokens_decoder (whole-file typed parse; failure drops all decoder
+/// tokens with a warning, unparseable keys are skipped per entry). The ids
+/// must form a dense prefix - a row-range selection bound cannot mask holes -
+/// so a sparse id space fails the load instead of silently truncating the
+/// output space.
+pub(crate) fn tokenizer_effective_vocab(model_path: &str) -> Result<usize> {
+    let path = format!("{}/tokenizer.json", model_path);
+    let content =
+        fs::read_to_string(&path).map_err(|e| anyhow::anyhow!("cannot read {path}: {e}"))?;
+    let tj: TokenizerJsonIds =
+        serde_json::from_str(&content).map_err(|e| anyhow::anyhow!("cannot parse {path}: {e}"))?;
+    anyhow::ensure!(!tj.model.vocab.is_empty(), "{path} model.vocab is empty");
+    let mut ids: HashSet<u32> = tj.model.vocab.into_values().collect();
+    ids.extend(tj.added_tokens.iter().filter_map(|t| t.id));
+
+    let config_path = format!("{}/tokenizer_config.json", model_path);
+    if let Ok(text) = fs::read_to_string(&config_path) {
+        match serde_json::from_str::<TokenizerConfigIds>(&text) {
+            Ok(cfg) => ids.extend(
+                cfg.added_tokens_decoder
+                    .keys()
+                    .filter_map(|k| k.parse::<u32>().ok()),
+            ),
+            Err(e) => warn!(
+                "cannot parse {config_path}: {e}; skipping its added tokens like the frontend does"
+            ),
+        }
+    }
+
+    let width = ids.len();
+    let max_id = *ids.iter().max().expect("vocab checked non-empty") as usize;
+    anyhow::ensure!(
+        max_id + 1 == width,
+        "tokenizer id space is not dense (max id {max_id}, {width} distinct ids); \
+         a row-range selection bound cannot mask holes"
+    );
+    Ok(width)
+}
+
 #[cfg(test)]
 mod tests {
     use super::Config35;
@@ -257,5 +343,44 @@ mod tests {
 }"#;
         std::fs::write(dir.path().join("config.json"), json).unwrap();
         Config35::from_file(dir.path().to_str().unwrap()).expect("48 value heads must load");
+    }
+
+    #[test]
+    fn effective_vocab_is_the_dense_decodable_width() {
+        let dir = tempfile::tempdir().unwrap();
+        let json = r#"{
+  "model": { "vocab": { "a": 0, "b": 1, "c": 2 } },
+  "added_tokens": [ { "id": 3, "content": "<x>" } ]
+}"#;
+        std::fs::write(dir.path().join("tokenizer.json"), json).unwrap();
+        let cfg = r#"{ "added_tokens_decoder": { "4": { "content": "<z>" }, "5": { "content": "<w>" }, "x": { "content": "<bad-key>" } } }"#;
+        std::fs::write(dir.path().join("tokenizer_config.json"), cfg).unwrap();
+        assert_eq!(
+            super::tokenizer_effective_vocab(dir.path().to_str().unwrap()).unwrap(),
+            6
+        );
+    }
+
+    #[test]
+    fn effective_vocab_fails_on_a_sparse_id_space() {
+        let dir = tempfile::tempdir().unwrap();
+        let json = r#"{ "model": { "vocab": { "a": 0, "b": 1 } } }"#;
+        std::fs::write(dir.path().join("tokenizer.json"), json).unwrap();
+        let cfg = r#"{ "added_tokens_decoder": { "5": { "content": "<z>" } } }"#;
+        std::fs::write(dir.path().join("tokenizer_config.json"), cfg).unwrap();
+        assert!(super::tokenizer_effective_vocab(dir.path().to_str().unwrap()).is_err());
+    }
+
+    #[test]
+    fn one_invalid_decoder_entry_drops_all_decoder_tokens() {
+        let dir = tempfile::tempdir().unwrap();
+        let json = r#"{ "model": { "vocab": { "a": 0, "b": 1 } } }"#;
+        std::fs::write(dir.path().join("tokenizer.json"), json).unwrap();
+        let cfg = r#"{ "added_tokens_decoder": { "2": { "content": "<z>" }, "3": { "content": "<w>", "special": "not-a-bool" } } }"#;
+        std::fs::write(dir.path().join("tokenizer_config.json"), cfg).unwrap();
+        assert_eq!(
+            super::tokenizer_effective_vocab(dir.path().to_str().unwrap()).unwrap(),
+            2
+        );
     }
 }

--- a/openinfer-qwen35-4b/src/decode_buffers.rs
+++ b/openinfer-qwen35-4b/src/decode_buffers.rs
@@ -93,7 +93,7 @@ impl BatchDecodeBuffers35 {
             gate_up_out: HiddenStates::zeros(ctx, 2 * config.intermediate_size, bs)?,
             act_out: HiddenStates::zeros(ctx, config.intermediate_size, bs)?,
             mlp_out: HiddenStates::zeros(ctx, h, bs)?,
-            logits: HiddenStates::zeros(ctx, config.vocab_size, bs)?,
+            logits: HiddenStates::zeros(ctx, config.selection_vocab, bs)?,
 
             q_full: HiddenStates::zeros(ctx, q_proj_dim, bs)?,
             q_attn: HiddenStates::zeros(ctx, q_dim, bs)?,
@@ -124,7 +124,7 @@ impl BatchDecodeBuffers35 {
             kv_tile_indices_d: ctx.stream.alloc_zeros(bs)?,
             kv_chunk_size_d: ctx.stream.alloc_zeros(bs)?,
 
-            sample: openinfer_sample::SampleScratch::new(ctx, config.vocab_size, bs)?,
+            sample: openinfer_sample::SampleScratch::new(ctx, config.selection_vocab, bs)?,
             steps: Vec::new(),
 
             padding_page_id,

--- a/openinfer-qwen35-4b/src/kernel_plan.rs
+++ b/openinfer-qwen35-4b/src/kernel_plan.rs
@@ -157,7 +157,7 @@ pub static KERNEL_PLAN: KernelPlan = KernelPlan {
                 },
                 KernelOp {
                     id: "lm_head_prefill",
-                    rust: "prefill::batch_last_hidden_logits -> ops::gemm (output_projection)",
+                    rust: "prefill::batch_last_hidden_logits -> ops::gemm_rows_into_checked (output_projection, selection_vocab rows)",
                     backend: "cuBLAS",
                     notes: "LM head: untied lm_head.weight when the config unties embeddings, else embed_tokens (one cuBLAS GEMM over request rows)",
                 },
@@ -274,7 +274,7 @@ pub static KERNEL_PLAN: KernelPlan = KernelPlan {
                 },
                 KernelOp {
                     id: "lm_head_decode",
-                    rust: "batch_decode::{batch_decode_kernels_graph,batch_decode_batched_hybrid_kernels} -> ops::gemm_into (output_projection)",
+                    rust: "batch_decode::{batch_decode_kernels_graph,batch_decode_batched_hybrid_kernels} -> ops::gemm_rows_into (output_projection, selection_vocab rows)",
                     backend: "cuBLAS",
                     notes: "LM head: untied lm_head.weight when configured, else embed_tokens; logits rows are dense 0..active_bs",
                 },

--- a/openinfer-qwen35-4b/src/ops.rs
+++ b/openinfer-qwen35-4b/src/ops.rs
@@ -3,7 +3,7 @@
 pub(crate) use openinfer_core::ops::PrefillPagedPlan;
 pub(crate) use openinfer_core::ops::{
     GEMM_LT_MAX_N, add_batch, add_batch_into, embedding_batch, extract_vec, extract_vec_into, gemm,
-    gemm_into, gemm_lt_tune, paged_attention_batch_decode_hd256_into,
+    gemm_into, gemm_lt_tune, gemm_rows_into_checked, paged_attention_batch_decode_hd256_into,
     paged_attention_batch_decode_via_prefill_hd256_into,
     qk_norm_partial_rope_batched_decode_hd256_into, rms_norm_gated_batch_into,
     silu_mul_fused_batch_into, write_vec_into,

--- a/openinfer-qwen35-4b/src/prefill.rs
+++ b/openinfer-qwen35-4b/src/prefill.rs
@@ -110,7 +110,15 @@ impl Qwen35Model {
             self.config.rms_norm_eps,
             &mut normed,
         )?;
-        let logits = ops::gemm(&self.ctx, self.output_projection(), &normed)?;
+        let mut logits = HiddenStates::zeros(&self.ctx, self.config.selection_vocab, n)?;
+        ops::gemm_rows_into_checked(
+            &self.ctx,
+            self.output_projection(),
+            0,
+            self.config.selection_vocab,
+            &normed,
+            &mut logits,
+        )?;
         debug_assert_eq!(logits.seq_len, n);
         Ok(logits)
     }

--- a/openinfer-qwen35-4b/src/unified_forward.rs
+++ b/openinfer-qwen35-4b/src/unified_forward.rs
@@ -25,7 +25,7 @@ pub(crate) struct UnifiedStepOutput {
 impl Qwen35Model {
     /// Prefill `n` prompts sequentially, updating each request's KV and recurrent state.
     ///
-    /// Returns batched last-token logits `[vocab_size, n]` in request order.
+    /// Returns batched last-token logits `[selection_vocab, n]` in request order.
     /// Requests are independent — there is no cross-request batching in the prefill pass.
     pub(crate) fn batch_prefill_logits(
         &self,
@@ -61,7 +61,7 @@ impl Qwen35Model {
     ///
     /// Either `prefill_prompts` or `decode_tokens` may be empty (but not both).
     ///
-    /// Prefill logits are returned as `[vocab_size, n_prefill]` in request order.
+    /// Prefill logits are returned as `[selection_vocab, n_prefill]` in request order.
     /// Decode logits remain in `graph_state.buffers.logits`; callers sample from
     /// that batched buffer directly to avoid per-request extraction.
     pub(crate) fn unified_step(
@@ -133,7 +133,7 @@ mod tests {
         let params = vec![openinfer_core::sampler::SamplingParams::default(); rows];
         let params_refs: Vec<&openinfer_core::sampler::SamplingParams> = params.iter().collect();
         let mut scratch =
-            openinfer_sample::SampleScratch::new(&model.ctx, model.config.vocab_size, rows)
+            openinfer_sample::SampleScratch::new(&model.ctx, model.config.selection_vocab, rows)
                 .unwrap();
         let steps = vec![0u64; params_refs.len()];
         openinfer_sample::select_batch(&model.ctx, logits, &params_refs, &steps, 0, &mut scratch)

--- a/openinfer-qwen35-4b/src/weights.rs
+++ b/openinfer-qwen35-4b/src/weights.rs
@@ -100,7 +100,7 @@ impl Qwen35Model {
         debug!("Initializing GPU");
         let ctx = DeviceContext::new_with_device(device_ordinal)?;
 
-        let config = Config35::from_file(model_path)?;
+        let mut config = Config35::from_file(model_path)?;
         debug!(
             "Config: hidden_size={}, num_layers={}, full_attn={}, linear_attn={}, max_position_embeddings={}",
             config.hidden_size,
@@ -109,6 +109,20 @@ impl Qwen35Model {
             config.num_hidden_layers - config.num_full_attention_layers(),
             config.max_position_embeddings
         );
+        let effective_vocab = super::config::tokenizer_effective_vocab(model_path)?;
+        anyhow::ensure!(
+            effective_vocab <= config.vocab_size,
+            "tokenizer defines ids up to {} but checkpoint vocab_size is {}",
+            effective_vocab - 1,
+            config.vocab_size,
+        );
+        if effective_vocab < config.vocab_size {
+            config.selection_vocab = effective_vocab;
+            info!(
+                "output projection: selection bounded to decodable vocab {} (checkpoint pads to {})",
+                effective_vocab, config.vocab_size
+            );
+        }
 
         let (shard_paths, weight_map) = load_shard_info_fixed(model_path)?;
         debug!("Loading {} safetensor shard(s)", shard_paths.len());
@@ -421,7 +435,7 @@ impl Qwen35Model {
     pub(crate) fn tune_decode_gemm_algos(&self) -> Result<()> {
         let ctx = &self.ctx;
         let hidden = self.config.hidden_size;
-        let vocab = self.config.vocab_size;
+        let vocab = self.config.selection_vocab;
         let full_q = self.config.full_attn_q_proj_dim();
         let full_kv = self.config.full_attn_kv_dim();
         let linear_qkv = self.config.linear_attn_qkv_dim();


### PR DESCRIPTION
## Description

Fixes #673 

Qwen3.5 checkpoints pad `vocab_size` past the tokenizer's serialized vocab: `tokenizer.json` across the line defines ids up to 248069 while `vocab_size` is 248320. Every id in the padded tail is a legal argmax output — the rows exist in the output projection — but the frontend cannot detokenize them: the stream fails with `decoding failed: unknown token ID` and the engine aborts the request. Observed once in 800+ random-prompt bench requests on Qwen3.5-9B. HF transformers decodes such ids to an empty string and continues, so this was an availability gap unique to our serving path.

At load, the selection width mirrors the pinned frontend's merge with its exact failure semantics: `tokenizer.json` vocab and added_tokens through the same typed added-token schema and u32 id contract (fatal on parse failure — the frontend cannot serve without it), plus `tokenizer_config.json` `added_tokens_decoder` as a whole-file typed parse where any invalid entry drops all decoder tokens with a warning and unparseable numeric keys are skipped per entry (248077 across the Qwen3.5 line vs the padded 248320). All three output-projection sites go through the checked row-range GEMM so launch failures keep flowing to the scheduler as `Result`s. The merged ids must form a dense prefix — a row-range bound cannot mask holes — so a sparse id space fails the load instead of silently truncating the model's output space; the published artifacts are dense 0..=248076. The output-projection GEMMs run over that row prefix via the existing checked row-range GEMM, and the logits arena plus sampling scratch are sized with the same width. Weights stay untouched, so tied and untied checkpoints take the same path with no extra memory or copies.

The parsed width is additionally validated against the checkpoint `vocab_size`; a missing `tokenizer_config.json` only shrinks the bound, which is the safe direction. Unit tests pin the merge arithmetic, the sparse-id-space failure, the all-or-nothing decoder drop, and the per-entry key skip.

### Semantics

The cutoff is the frontend-decodable vocab (248077 across the line), so nothing the frontend could render is masked — including the audio/TTS placeholder ids (248070–248076) that live only in `added_tokens_decoder`. Every generated special token sits far below the cutoff (`<tool_response>` 248066/67, `<think>`/`</think>` 248068/69). Prompt-side ids are unaffected: embeddings keep the full width. Teacher-forced logprobs shift by the padded tail's softmax mass, which is negligible for real text — the size-keyed golden gates stay green (below). A greedy divergence vs HF is only possible at steps where HF's top-1 lands in the padded tail, which is exactly the failure this PR removes.

### Evidence (GH200 120GB, aarch64 sm_90, single GPU)

- Load line on every size, tied and untied alike: `output projection: selection bounded to decodable vocab 248077 (checkpoint pads to 248320)`.
- Bounded-GEMM path validated on the final tree at 4B (tied) and 9B/27B (untied): `hf_golden_gate` green at all three sizes (4B mean 0.018–0.026 / max 0.190; 9B mean 0.020–0.023 / max 0.138; 27B bit-identical to the pre-change run across all five replay surfaces, mean 0.020–0.022 / max 0.206), `e2e_scheduler` / `chunked_prefill` / `sampling_behavior` green at 4B, serving probe returns coherent greedy output (`<think>` still generates) and a well-formed tool call with `unknown_token=0`.
- Perf anchors on the final tree within the tune band: 9B c=1 126.4 tok/s / TTFT p50 50.6 ms / TPOT p50 7.58 ms, qps=8 701 tok/s; 27B c=1 46.9 / c=8 192.6 / qps=8 323.8 / c=48 315.3 tok/s, error scans all-zero.
- Full 9B + 27B sweeps (c={1,4,8}, qps={1,2,4,8,10,12,16}, long-context in 4097, c=120 overload; 27B additionally c=32/48): server-log scan `unknown_token=0` everywhere; throughput/latency at previously-clean points within noise (27B within 1.5%; 9B within known cross-process GEMM-tune variance).
- HF greedy comparison (6 prompts): same match pattern as the pre-fix run (9B 5/6, 27B 4/6, flips at the same positions).
- Gates on the fixed tree: `hf_golden_gate` green at 9B (mean 0.018–0.024, max 0.122) and 27B (bit-identical stats to pre-fix); `e2e_scheduler`, `chunked_prefill`, `sampling_behavior` green at both sizes; config unit tests 3/3.
