### PR TITLE
feat(dsv2lite): add retained HTTP serving SLO reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 __pycache__/
 *.py[cod]
 /bench_results/
+/artifacts/bench/
 /docs/private/
 /profile/
 .claude/scheduled_tasks.lock

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Model type is auto-detected from `config.json` — just point `--model-path` at 
 
 DeepSeek support is intentionally narrower than the Qwen paths:
 
-- **DeepSeek-V2-Lite** requires `--features deepseek-v2-lite` and the 2-GPU EP2 path. Its current gate is correctness and attribution only: HF, host-staged, and NCCL are token/text exact for the narrow `Hello`/16-token greedy contract; same-prompt batch and HTTP/vLLM data are diagnostic and do not claim production continuous batching or serving parity. Evidence: [`status.md`](docs/models/deepseek-v2-lite/status.md) and [`hf-accuracy-gate.md`](docs/models/deepseek-v2-lite/hf-accuracy-gate.md).
+- **DeepSeek-V2-Lite** requires `--features deepseek-v2-lite` and the 2-GPU EP2 path. Correctness, direct decode diagnostics, and retained HTTP SLO reports use separate entry points and claim boundaries; see [`benchmarking.md`](docs/models/deepseek-v2-lite/benchmarking.md), [`status.md`](docs/models/deepseek-v2-lite/status.md), and [`hf-accuracy-gate.md`](docs/models/deepseek-v2-lite/hf-accuracy-gate.md).
 
 ## API
 
@@ -327,7 +327,10 @@ cargo test --release --workspace --lib
 OPENINFER_TEST_MODEL_PATH=models/Qwen3-4B cargo test --release -p openinfer-qwen3 --test hf_golden_gate
 OPENINFER_TEST_MODEL_PATH=models/Qwen3.5-4B cargo test --release -p openinfer-qwen35-4b --features qwen35-4b --test hf_golden_gate
 OPENINFER_TEST_MODEL_PATH=models/Qwen3.5-4B cargo test --release -p openinfer-qwen35-4b --features qwen35-4b --test e2e_scheduler
+OPENINFER_TEST_MODEL_PATH=models/DeepSeek-V2-Lite cargo test --release -p openinfer-deepseek-v2-lite --features deepseek-v2-lite --test e2e_ep2 -- --nocapture
 ```
+
+The DeepSeek-V2-Lite E2E is a correctness/integration gate. Direct diagnostics and HTTP SLO report commands live in [`benchmarking.md`](docs/models/deepseek-v2-lite/benchmarking.md).
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,10 +87,12 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 
 | Path | TL;DR |
 | --- | --- |
-| `models/deepseek-v2-lite/status.md` | DeepSeek-V2-Lite EP2 status ledger: HF/host-staged/NCCL exactness, mixed-request serving, #464 trace attribution plus host-staged/NCCL route grouping and NCCL device-router evidence, reliability gates, and retained vLLM boundaries; no broad-workload, parity, or production claim. |
+| `models/deepseek-v2-lite/status.md` | DeepSeek-V2-Lite EP2 status ledger: correctness, direct attribution, lifecycle reliability, and the #466 six-child host-staged/NCCL HTTP SLO report remain separate evidence buckets; no soak, parity, or production claim. |
+| `models/deepseek-v2-lite/benchmarking.md` | Verification ladder and commands for DSV2-Lite correctness, direct decode diagnostics, retained host-staged/NCCL HTTP SLO profiles, and the separate soak/production boundary. |
+| `models/deepseek-v2-lite/roadmap.md` | Single-node EP2 roadmap: #466 retained SLO reporting is an evidence layer; soak, device KV/attention, long-prefill scheduling, and Stable promotion remain separate gates. |
 | `models/deepseek-v2-lite/benchmark-artifact-manifest.md` | Issue #467 implemented: the retained DeepSeek-V2-Lite benchmark matrix emits `artifact_manifest.json` and `regression_summary.json`, with CPU-only summarize-only tests. |
 | `models/deepseek-v2-lite/hf-accuracy-gate.md` | DeepSeek-V2-Lite EP2 HF accuracy gate after PR #149/#150/#274: HF `generate(use_cache=true)`, host-staged EP2, and NCCL EP2 are compared across the committed small case set. |
-| `models/deepseek-v2-lite/decode-attribution-gate.md` | DeepSeek-V2-Lite EP2 decode attribution gate for `Hello`/16-token batch sizes 1/4/8: structured JSON with accuracy hashes, timing/counters, separated NCCL all-reduce smoke, and fail-closed full-decode graph probe evidence for the retained batch-1 shape. |
+| `models/deepseek-v2-lite/decode-attribution-gate.md` | Direct diagnostic benchmark for DeepSeek-V2-Lite EP2 `Hello`/16-token batch sizes 1/4/8: structured timing/counters and graph probes with no HTTP SLO or production claim. |
 | `models/deepseek-v2-lite/source-layout.md` | DeepSeek-V2-Lite runtime layout refactor: `runtime.rs` split by responsibility, HF/host-staged/NCCL EP2 E2E exact on 2x RTX 5090; NCCL CUDA Graph smoke remains a diagnostic blocker on that host, independent of the passed correctness gate. |
 | `models/deepseek-v2-lite/device-resident-nccl-combine.md` | Issue #275 record: NCCL decode combine uses reusable device-resident f32 scratch; current NCCL graph-readiness blockers live in `status.md`. |
 

--- a/docs/models/deepseek-v2-lite/benchmarking.md
+++ b/docs/models/deepseek-v2-lite/benchmarking.md
@@ -1,0 +1,152 @@
+# DeepSeek-V2-Lite Verification And Benchmarking
+
+> **TL;DR:** Use `e2e_ep2` for correctness, `dsv2_lite_ep2_decode_attribution` for direct decode diagnostics, and `bench_dsv2lite_http_slo.py` for retained HTTP SLO evidence. These artifacts answer different questions; none of them alone proves production readiness.
+>
+> Last touched: 2026-07
+
+## Verification Ladder
+
+| Layer | Entry point | Proves | Does not prove |
+| --- | --- | --- | --- |
+| Correctness / integration | `openinfer-deepseek-v2-lite/tests/e2e_ep2.rs` | EP2 load, host-staged/NCCL generation, request isolation, output tokens/text/hashes, route and collective accounting | Latency, throughput, SLO, soak, production readiness |
+| Direct diagnostic | `dsv2_lite_ep2_decode_attribution` | Fixed-shape CPU/CUDA section timing, route/collective counters, graph-readiness diagnostics | HTTP behavior, client pressure, serving SLO |
+| HTTP serving SLO | `scripts/bench_dsv2lite_http_slo.py` over the shared HTTP harness | Streaming TTFT/TPOT/ITL, request/output throughput, failures/timeouts, server trace coverage, output hashes, repeat spread | Direct-kernel attribution, sustained soak, production readiness |
+| Soak / production readiness | Separate sustained-run gate | Memory drift, long-duration tails, recovery and deployment limits | Out of scope for issue #466 |
+
+## Correctness Gate
+
+The following is a remote-GPU template. Replace `MODEL_PATH` and, on Blackwell, select an NCCL runtime that satisfies the startup check.
+
+```bash
+# Template: requires two GPUs and DeepSeek-V2-Lite weights.
+OPENINFER_TEST_MODEL_PATH=MODEL_PATH \
+OPENINFER_DSV2_LITE_EP_BACKEND=host-staged \
+  cargo test --release -p openinfer-deepseek-v2-lite \
+  --features deepseek-v2-lite --test e2e_ep2 -- --nocapture
+
+OPENINFER_TEST_MODEL_PATH=MODEL_PATH \
+OPENINFER_DSV2_LITE_EP_BACKEND=nccl \
+OPENINFER_NCCL_LIB_DIR=NCCL_LIB_DIR \
+  cargo test --release -p openinfer-deepseek-v2-lite \
+  --features deepseek-v2-lite --test e2e_ep2 -- --nocapture
+```
+
+The JSON emitted by this test uses `report_intent=correctness_integration` and carries an explicit no-performance claim boundary. Use the same-host HF comparison in `hf-accuracy-gate.md` for accuracy-sensitive changes.
+
+On `sm_120`, the DSV2-Lite NCCL backend fails before communicator creation when the loaded NCCL is older than `2.26.2`. NCCL 2.26.2 contains NVIDIA's shared-memory fix for recent Blackwell GPUs ([NVIDIA/nccl#1637](https://github.com/NVIDIA/nccl/issues/1637)); older releases can exceed the device/function shared-memory limit when launching collectives. Set `OPENINFER_NCCL_LIB_DIR` or `OPENINFER_NCCL_PYTHON` to select a compatible runtime. This startup floor is specific to `sm_120`, not older GPU architectures.
+
+## Direct Diagnostic Benchmark
+
+This is a remote-GPU template:
+
+```bash
+# Template: direct/in-process diagnostic, no HTTP server involved.
+OPENINFER_DSV2_LITE_EP_BACKEND=nccl \
+OPENINFER_NCCL_LIB_DIR=NCCL_LIB_DIR \
+  cargo run --release -p openinfer-deepseek-v2-lite \
+  --features deepseek-v2-lite \
+  --bin dsv2_lite_ep2_decode_attribution \
+  -- --model-path MODEL_PATH --commit COMMIT --batch-size 8 \
+  --out artifacts/bench/dsv2-lite/direct/nccl-b8.json
+```
+
+The artifact has `kind=deepseek_v2_lite_direct_decode_attribution` plus model, backend, commit, hardware/toolchain, workload, metrics, coverage, output hashes, and `claim_boundary`. Keep `timing`, `by_section`, and `by_gpu_*` as attribution fields. Do not translate them into HTTP TTFT/TPOT or production throughput claims.
+
+## Retained HTTP SLO Profiles
+
+The profile definitions and six-child aggregate gate live in `scripts/bench_dsv2lite_http_slo.py`. The model runner calls the generic `bench_http_sweep.py`, which calls `bench_http_serving.py`; neither generic harness imports model-specific contracts.
+
+| Profile | Workload | Default timeout | Intended use |
+| --- | --- | ---: | --- |
+| `dsv2-lite-short-decode-heavy` | 32 requests, `prompt_words=64`, `max_tokens=64` | 240 s/request | Short decode-heavy SLO rows with at least 30 samples per repeat |
+| `dsv2-lite-mixed-prompt-shape` | 32 alternating `prompt_words=64,512` requests, `max_tokens=64` | 240 s/request | Short/long prompt interaction and trace tails with at least 30 samples per repeat |
+| `dsv2-lite-long-prompt-smoke` | `prompt_words=2048`, `max_tokens=64` | 900 s/request | One explicit long-prompt boundary cell |
+
+`prompt_words` is deterministic prompt-generator input. The artifact records actual server-side prompt-token counts when traces are attached.
+
+Retained profiles lock greedy sampling, ignore-EOS, shape, absolute request deadline, warmup, request count, concurrency, repeats, and full trace coverage. Percentiles use R7 linear interpolation. The aggregate rejects missing traces, failed/time-out requests, duplicate cells, mixed commit/model/backend provenance, backend-version drift, and leaf-artifact SHA mismatches.
+
+`coverage_gate.passed` means the retained report has complete HTTP evidence for the fixed contracts. It is not a numeric latency budget; reports keep `latency_budget.configured=false` until a production budget is ratified.
+
+### Server
+
+Run one backend at a time. These are remote-GPU templates:
+
+```bash
+# Template: host-staged server.
+RUST_LOG=info \
+OPENINFER_DSV2_LITE_EP_BACKEND=host-staged \
+  cargo run --release -p openinfer-server \
+  --features deepseek-v2-lite --bin openinfer -- \
+  --model-path MODEL_PATH --served-model-name DeepSeek-V2-Lite \
+  --port 18000 --cuda-graph=false \
+  > artifacts/bench/dsv2-lite/RUN_ID/host-staged/server.log 2>&1
+
+# Template: NCCL server. Use the verified runtime selector on Blackwell.
+RUST_LOG=info \
+OPENINFER_DSV2_LITE_EP_BACKEND=nccl \
+OPENINFER_NCCL_LIB_DIR=NCCL_LIB_DIR \
+  cargo run --release -p openinfer-server \
+  --features deepseek-v2-lite --bin openinfer -- \
+  --model-path MODEL_PATH --served-model-name DeepSeek-V2-Lite \
+  --port 18000 --cuda-graph=false \
+  > artifacts/bench/dsv2-lite/RUN_ID/nccl/server.log 2>&1
+```
+
+### Sweep
+
+These are remote-GPU templates. Replace metadata/path placeholders; `PROFILE` is one row from the profile table and `PROFILE_SLUG` is the matching output directory name such as `short`, `mixed`, or `long`.
+
+```bash
+# Template: run one retained profile/backend contract.
+python3 scripts/bench_dsv2lite_http_slo.py run \
+  --profile PROFILE --backend BACKEND \
+  --base-url http://127.0.0.1:18000 \
+  --server-log artifacts/bench/dsv2-lite/RUN_ID/BACKEND/server.log \
+  --model-path MODEL_PATH --server-command "SERVER_COMMAND" --commit COMMIT \
+  --model-revision MODEL_REVISION \
+  --server-binary SERVER_BINARY \
+  --out-dir artifacts/bench/dsv2-lite/RUN_ID/BACKEND/PROFILE_SLUG
+
+# Template: combine the six passing backend/profile summaries into one report.
+python3 scripts/bench_dsv2lite_http_slo.py combine \
+  --summary artifacts/bench/dsv2-lite/RUN_ID/host-staged/short/sweep_summary.json \
+  --summary artifacts/bench/dsv2-lite/RUN_ID/host-staged/mixed/sweep_summary.json \
+  --summary artifacts/bench/dsv2-lite/RUN_ID/host-staged/long/sweep_summary.json \
+  --summary artifacts/bench/dsv2-lite/RUN_ID/nccl/short/sweep_summary.json \
+  --summary artifacts/bench/dsv2-lite/RUN_ID/nccl/mixed/sweep_summary.json \
+  --summary artifacts/bench/dsv2-lite/RUN_ID/nccl/long/sweep_summary.json \
+  --out artifacts/bench/dsv2-lite/RUN_ID/retained_slo_report.json
+```
+
+Each `sweep_summary.json` records:
+
+- command, model, source, backend, hardware, and toolchain metadata;
+- workload contract and latency-budget status;
+- TTFT, TPOT, and ITL p50/p95/p99;
+- request throughput and output tokens/s;
+- completed, failed, and timeout counts;
+- active-set, decode-batch, token-timing, and missing-trace coverage;
+- output-hash distribution;
+- repeat median/min/max plus `stable`, `noisy`, `insufficient_repeats`, `benchmark_error`, `failed_or_timeout`, or `startup_failure`.
+
+A cell is `noisy` when repeat spread exceeds 10% of the median for TTFT/TPOT/ITL p95, request throughput, or output-token throughput.
+
+## Local Tooling Gate
+
+These commands were run on 2026-07-13:
+
+```bash
+python3 -m py_compile scripts/bench_http_common.py scripts/bench_http_serving.py scripts/bench_http_sweep.py scripts/bench_dsv2lite_http_slo.py
+python3 -m unittest -v tests/test_bench_http_serving.py tests/test_bench_http_sweep.py tests/test_bench_dsv2lite_http_slo.py
+cargo fmt --all --check
+cargo metadata --locked --no-deps --format-version 1
+```
+
+## Current-Source Evidence
+
+Regenerate the retained report when its profile, schema, or measurement contract changes. The current retained 2x RTX 5090 evidence completed all six host-staged/NCCL children with zero failures/timeouts and full required trace coverage. The gitignored local copy is under `artifacts/bench/dsv2-lite/<run-id>/`; aggregate SHA-256: `a7e677c63d1ce92ad0c069f83acfcc8b381e07d06bed9364ab899adecef8d317`.
+
+## Claim Boundary
+
+A passing retained report is HTTP pressure/SLO evidence for the named backend, model revision, hardware/toolchain, and workload. It can support comparisons between retained runs when their contracts match. It does not establish direct decode attribution, vLLM parity, sustained soak stability, multi-node recovery, or production readiness.

--- a/docs/models/deepseek-v2-lite/decode-attribution-gate.md
+++ b/docs/models/deepseek-v2-lite/decode-attribution-gate.md
@@ -1,8 +1,8 @@
 # DeepSeek-V2-Lite EP2 Decode Attribution Gate
 
-> **TL;DR:** The attribution gate keeps DeepSeek-V2-Lite EP2 on a narrow, repeatable shape: `prompt="Hello"`, `output_len=16`, batch `1/4/8`, host-staged and NCCL backends. Issue #278 adds a fail-closed full decode graph probe for the NCCL batch-1 decode step: readiness is true only after capture, instantiate, replay, and token verification all pass.
+> **TL;DR:** This is a direct diagnostic benchmark for a narrow DeepSeek-V2-Lite EP2 shape: `prompt="Hello"`, `output_len=16`, batch `1/4/8`, host-staged and NCCL. Its timing and graph-readiness fields do not carry an HTTP serving SLO or production-readiness claim.
 
-Last touched: 2026-06
+Last touched: 2026-07
 
 ## Scope
 
@@ -100,6 +100,8 @@ Optional diagnostics:
 
 The top-level report includes:
 
+- `schema_version`, `kind`, model, backend, commit, and hardware/toolchain metadata;
+- `workload` and `metrics`: stable direct-diagnostic contract fields;
 - `accuracy`: generated tokens/text and exact hash status;
 - `timing`: CPU-side section timing for the fixed attribution path;
 - `gpu_timing` and `by_gpu_*`: selected CUDA event sections only;

--- a/docs/models/deepseek-v2-lite/roadmap.md
+++ b/docs/models/deepseek-v2-lite/roadmap.md
@@ -1,0 +1,86 @@
+# DeepSeek-V2-Lite Serving Roadmap
+
+> **TL;DR:** DeepSeek-V2-Lite has single-node EP2 correctness, request-lifecycle reliability, direct diagnostics, and retained HTTP SLO reporting. Production readiness still requires sustained soak, bounded device KV ownership, long-prefill scheduling, and explicit deployment limits.
+>
+> Last touched: 2026-07
+
+## Product Boundary
+
+The target is a stable single-node, two-GPU EP2 serving line. Current roadmap work does not claim multi-node EP, transparent rank-loss recovery, sparse EP, broad API parity, or vLLM parity.
+
+Evidence stays in four buckets:
+
+1. Correctness and integration: HF/host-staged/NCCL exactness, EP accounting, request isolation.
+2. Direct diagnostics: decode attribution, backend timing, CUDA event and graph-readiness probes.
+3. HTTP serving SLO: fixed `/v1/completions` contracts, tails, throughput, failures/timeouts, trace coverage, hashes, repeat spread.
+4. Soak and production readiness: sustained memory/tail drift, recovery, capacity, deployment and support limits.
+
+The first three can be green while the fourth remains open.
+
+## Current Gates
+
+| Gate | State | Source of truth | Boundary |
+| --- | --- | --- | --- |
+| HF and EP2 correctness | Retained | `hf-accuracy-gate.md`, `e2e_ep2.rs` | Correctness only |
+| Direct decode attribution | Retained | `decode-attribution-gate.md` | Direct diagnostic only |
+| HTTP lifecycle reliability | Retained | `status.md`, issue #453 | Failure isolation and recovery scenarios, no long-duration claim |
+| HTTP SLO report | Retained for #466 | `benchmarking.md`, `bench_dsv2lite_http_slo.py` | Fixed host-staged/NCCL HTTP contracts retained; no soak or production claim |
+| Sustained soak | Open | issue #465 | Required before Stable promotion |
+| Long-prefill scheduling | Open | issue #452 | Current long smoke records the boundary; it does not close latency work |
+| Device attention and KV | Open | issue #635 | Required for bounded device lifetime and stronger scaling |
+
+## Issue #466 Position
+
+Issue #466 is an evidence and reporting milestone. It provides named DSV2-Lite profiles for short decode-heavy, mixed prompt-shape, and long-prompt smoke workloads across host-staged and NCCL. The retained JSON carries the model/backend metadata, TTFT/TPOT/ITL tails, throughput, failures/timeouts, trace coverage, output hashes, repeat spread, and an HTTP-only claim boundary.
+
+This closes the missing report layer. It does not optimize latency or throughput and does not close issue #465.
+
+## Sequence
+
+### 1. Retain The Serving Contract
+
+- Keep #466 short/mixed/long profiles stable unless a versioned schema or profile change is reviewed.
+- Run both host-staged and NCCL after scheduler, frontend, trace, or backend changes.
+- Fail retained runs on request failures, timeouts, missing traces, or missing active/decode coverage.
+- Keep startup failures as structured artifacts instead of dropping failed cells.
+
+### 2. Close Sustained Availability
+
+Primary issue: #465.
+
+- Run host-staged and NCCL for ratified short and long durations.
+- Track first/last-quartile tails and throughput, RSS/VRAM drift, active/pending state, terminal reasons, and clean follow-up recovery.
+- Calibrate budgets from retained variance before promoting numeric thresholds to hard gates.
+
+### 3. Move Decode State To The Device
+
+Primary issue: #635.
+
+- Give each request explicit device KV ownership, capacity, retirement, and slot-reuse semantics.
+- Move steady decode attention and compressed KV off the host path.
+- Preserve exact output, cancellation cleanup, stable pointers, eager fallback, and graph diagnostics.
+- Require paired HTTP evidence under #466 contracts before any performance claim.
+
+### 4. Schedule Long Prefill
+
+Primary issue: #452.
+
+- Add bounded prefill work per scheduler step and protect active decode from starvation.
+- Reserve capacity before admission and reject impossible contexts explicitly.
+- Use #466 mixed and long rows as regression evidence, then add issue-specific long-context gates where needed.
+
+### 5. Stable Promotion
+
+Promotion requires all of the following:
+
+- HF/host-staged/NCCL correctness remains green;
+- request and KV capacity are bounded and observable;
+- lifecycle and soak gates recover cleanly with no unexplained drift;
+- short, mixed, and long retained SLO reports pass on the supported hardware/runtime matrix;
+- backend startup failures give actionable version or configuration errors;
+- API, topology, context, sampling, and recovery limits are documented;
+- performance claims use matched repeated HTTP contracts, while direct and profiler data remain diagnostic.
+
+## Deferred Work
+
+Sparse all-to-all, expert replication, prefix caching, KV offload, multi-node EP, and rank restart should start only after current profiles show they are material and the device-KV ownership contract is stable. Host-staged deprecation requires NCCL correctness, SLO, and soak evidence on every supported hardware/runtime row.

--- a/docs/models/deepseek-v2-lite/source-layout.md
+++ b/docs/models/deepseek-v2-lite/source-layout.md
@@ -61,15 +61,15 @@ cargo fmt --all --check
 Both passed.
 
 Remote validation ran on Ubuntu 22.04 with 2x NVIDIA GeForce RTX 5090, driver
-580.105.08, CUDA 12.8, `OPENINFER_CUDA_SM=120`, and
-`OPENINFER_TRITON_PYTHON=/root/autodl-tmp/openinfer-triton-venv/bin/python`.
+580.105.08, CUDA 12.8, `OPENINFER_CUDA_SM=120`, and a configured
+`OPENINFER_TRITON_PYTHON` environment.
 
 Passed gates:
 
 - `cargo check --offline --release -p openinfer-deepseek-v2-lite --features deepseek-v2-lite --lib --tests`
 - HF oracle dump with `tools/accuracy/hf_dump_dsv2_lite_ep2_greedy.py`
 - host-staged `tests/e2e_ep2.rs`
-- NCCL `tests/e2e_ep2.rs` using `LD_LIBRARY_PATH=/root/autodl-tmp/nccl-2.27.7/nvidia/nccl/lib`
+- NCCL `tests/e2e_ep2.rs` using an explicit compatible NCCL library selector
 - `tools/accuracy/compare_dsv2_lite_ep2_outputs.py --require-all-exact`
 - NCCL attribution without graph smoke
 

--- a/docs/models/deepseek-v2-lite/status.md
+++ b/docs/models/deepseek-v2-lite/status.md
@@ -1,6 +1,6 @@
 # DeepSeek-V2-Lite Status And Benchmark Ledger
 
-> **TL;DR:** DeepSeek-V2-Lite has an EP2 correctness contract across HF, host-staged, and NCCL. The current optimization groups repeated expert routes and computes NCCL gate logits on CUDA while preserving the host top-k/softmax rule. Exact token/text hashes are preserved; retained short-shape HTTP A/B shows host-staged and NCCL throughput gains under the documented request contract. This is not a production, broad-workload, or vLLM-parity claim.
+> **TL;DR:** DeepSeek-V2-Lite keeps correctness, direct decode diagnostics, retained HTTP SLO reports, and soak readiness as separate gates. HF/host-staged/NCCL exactness and HTTP lifecycle evidence are retained; issue #466 adds fixed host-staged/NCCL SLO artifacts without claiming production readiness.
 
 Last touched: 2026-07
 
@@ -23,6 +23,7 @@ Last touched: 2026-07
 | Long-shape NCCL collectives | Available | Issue #280 chunks large bf16 dense-exchange and f32 combine all-reduces. The 2026-06-24 2x RTX 5090 NCCL checks preserve HF / host-staged / NCCL exactness and complete 24/64/128-word direct long-shape probes. |
 | HTTP trace and measured MoE throughput optimization | HTTP and direct evidence | Issue #280 logs DeepSeek-V2-Lite `openinfer_http_trace` records and batches same-position decode subgroups. Issue #464 extends phase/decode-step attribution, groups host-staged and NCCL routes by stable `(owner_rank, global_expert)`, and moves the NCCL gate GEMM to a bitwise-matched CUDA logits kernel while keeping host top-k/softmax. Diagnostic serial/host rollback switches remain available for retained A/B and emergency rollback; they are not production tuning knobs. |
 | HTTP reliability lifecycle gate | Available | Issue #453 adds `scripts/bench_dsv2lite_http_reliability.py`, which drives real streaming `/v1/completions` scenarios for client cancel/disconnect, unsupported params, active-cap overload, mixed short/long prompts with adjacent failures, and clean follow-up recovery. The 2026-07-04 2x RTX 5090 host-staged and NCCL runs both passed with terminal trace coverage, stable output hashes, active/pending/decode maxima, and healthy final scheduler baselines. |
+| Retained HTTP serving SLO report | Retained HTTP evidence | Issue #466 adds model-owned short/mixed/long profiles on the shared HTTP benchmark scripts. The current retained run covered all six host-staged/NCCL children with zero failures/timeouts and full trace coverage. This is HTTP pressure/SLO evidence only; command details and the aggregate hash live in `benchmarking.md`. |
 | Retained vLLM comparison matrix | Snapshot complete with clean failed setup rows and supplemental validation rows | The retained matrix for tracking issue #279 keeps HF/host/NCCL correctness, OpenInfer direct diagnostic batch, `vllm bench serve` HTTP pressure, OpenInfer trace rows, and failed setup rows separate. The 2026-06-28 clean full matrix passed HF / host-staged / NCCL correctness plus OpenInfer host-staged/NCCL direct, HTTP pressure, and trace rows; stock vLLM TP2 and TP2+EP2 failed during setup on the target FlashInfer SM120 path. A separate FlashInfer #3633-equivalent validation completed vLLM TP2 and TP2+EP2 under the same HTTP client/workload contract. |
 | vLLM production parity | Not claimed | The vLLM TP2 / TP2+EP2 rows are gap-finding evidence from a documented contract. The supplemental validation run is not serving parity or a stock-install claim. |
 
@@ -44,7 +45,25 @@ The HTTP reliability gate is intentionally separate from the mixed-serving E2E. 
 
 The Rust E2E accepts the known HF-confirmed RTX 5090 and A800 hash pairs for this narrow shape, because the same model snapshot has produced different exact greedy text on those hosts while still matching HF on each host. Do not use the static hash pair list as a substitute for the same-host HF comparison when changing accuracy-sensitive code.
 
+`e2e_ep2.rs` is a correctness/integration gate. Its JSON uses `report_intent=correctness_integration`; timing percentiles, throughput, SLO budgets, and soak claims are intentionally absent. The direct attribution binary and HTTP report commands are mapped in `benchmarking.md`.
+
 ## Benchmark Ledger
+
+### Issue #466 Retained HTTP SLO Report
+
+The retained SLO layer uses model-owned `scripts/bench_dsv2lite_http_slo.py` over the generic `bench_http_serving.py` and `bench_http_sweep.py` harnesses. The model line owns three fixed contracts:
+
+| Contract | Shape | Boundary |
+| --- | --- | --- |
+| short decode-heavy | `prompt_words=64`, `max_tokens=64`, 240 s timeout | Repeated short HTTP pressure/SLO evidence |
+| mixed prompt shape | alternating `prompt_words=64,512`, `max_tokens=64`, 240 s timeout | Mixed-shape tails and trace evidence |
+| long-prompt smoke | `prompt_words=2048`, `max_tokens=64`, 900 s timeout | One long boundary cell, no broad long-context claim |
+
+Every retained profile fixes shape, timeout, request count, concurrency, repeats, greedy sampling, ignore-EOS, and full trace coverage. Repeat summaries report median/min/max and a stable/noisy/failure marker. `benchmarking.md` is the command and artifact-schema source of truth.
+
+On Blackwell (`sm_120`), DSV2-Lite NCCL rejects runtimes older than `2.26.2` before communicator creation and reports how to select a compatible NCCL library. NCCL 2.26.2 is the first upstream release containing NVIDIA's recent-Blackwell shared-memory fix. This floor does not apply to non-SM120 GPUs.
+
+The current-source #466 aggregate is retained under `artifacts/bench/dsv2-lite/<run-id>/` (gitignored). `benchmarking.md` contains the command, artifact fields, aggregate hash, and claim boundary.
 
 ### Retained vLLM TP2/EP2 Matrix
 
@@ -253,6 +272,7 @@ Use these labels consistently:
 | `route-grouped MoE slice` | Separate paired host-staged and NCCL direct/HTTP A/B for the retained #464 shapes, with exact token/text hashes and contribution accumulation in original route order. | Fewer per-row GEMM launches, broad workload scaling, soak/SLO readiness, production EP readiness, or vLLM parity. |
 | `NCCL device logits router slice` | The gate GEMM runs on CUDA with bitwise host-logit coverage; existing host top-k/softmax builds the route plan. | Fully device-resident routing, no routing D2H, general numerical equivalence, or non-NCCL improvement. |
 | `HTTP reliability lifecycle gate` | `/v1/completions` cancel/disconnect/reject/overload/mixed-failure scenarios have terminal reason counts, trace coverage, active/pending/decode maxima, output hashes, and clean follow-up recovery evidence. | Production EP readiness, soak stability, SLO latency, vLLM parity, throughput improvement, sparse dispatch, or multi-node EP support. |
+| `retained HTTP serving SLO` | Named short/mixed/long `/v1/completions` contracts report latency percentiles, throughput, outcomes, full trace coverage, hashes, and repeat spread for one backend/hardware/toolchain. | Direct attribution, sustained soak, production readiness, vLLM parity, or performance outside a matched contract. |
 | `covered NCCL decode graph probe` | Probe-only batch-1 `Hello` decode step captured, instantiated, replayed, and token-verified under CUDA Graph. | Default serving graph coverage, multi-step graph replay, batch `4/8` graph coverage, or performance improvement. |
 | `HTTP concurrency pressure` | `vllm bench serve --max-concurrency N` against an HTTP endpoint. | True OpenInfer batch size unless the engine path proves it. |
 | `vLLM comparison from documented environment` | vLLM TP2 / TP2+EP2 from the retained matrix or the separate FlashInfer-fixed validation. | Stock vLLM install support, OpenInfer serving parity, or production readiness. |
@@ -304,7 +324,7 @@ The next implementation should be chosen from measured evidence:
 5. Keep the #453 HTTP reliability evidence retained.
    - rerun the reliability runner for host-staged and NCCL when scheduler or HTTP lifecycle code changes;
    - keep the JSON artifact hashes and server-log trace coverage in the PR evidence;
-   - keep #452 long/mixed-prompt latency, #465 soak, #466 SLO report, and #467 benchmark manifest separate.
+   - keep #452 long/mixed-prompt latency, #465 soak, the completed #466 SLO report layer, and #467 benchmark manifest separate.
 
 6. Keep MoE internals readable.
    - routing, dispatch, expert execution, and combine should remain distinguishable in code and attribution;

--- a/openinfer-deepseek-v2-lite/src/bin/dsv2_lite_ep2_decode_attribution.rs
+++ b/openinfer-deepseek-v2-lite/src/bin/dsv2_lite_ep2_decode_attribution.rs
@@ -1,6 +1,12 @@
+//! Direct DeepSeek-V2-Lite EP2 decode diagnostic benchmark.
+//!
+//! This binary records in-process attribution and correctness metadata. It does
+//! not exercise HTTP serving or establish serving SLO or production readiness.
+
 use std::{
     env, fs,
     path::{Path, PathBuf},
+    process::Command,
 };
 
 use anyhow::{Context, Result, bail, ensure};
@@ -28,6 +34,7 @@ const EXPECTED_OUTPUT_SHA256_PAIRS: &[(&str, &str, &str)] = &[
 
 struct Cli {
     model_path: String,
+    commit: Option<String>,
     batch_size: usize,
     nccl_graph_smoke: bool,
     full_decode_graph_probe: bool,
@@ -68,7 +75,7 @@ fn main() -> Result<()> {
         },
     )?;
     trace_stage("generator loaded");
-    let (report, probe_status, probe_ready) = if cli.batch_size == 1 {
+    let (mut report, probe_status, probe_ready) = if cli.batch_size == 1 {
         trace_stage("run batch=1 attribution oracle");
         let (result, attribution) =
             generator.generate_greedy_with_attribution(&prompt_tokens, OUTPUT_LEN, false)?;
@@ -123,6 +130,7 @@ fn main() -> Result<()> {
         )?;
         (report, probe_status, probe_ready)
     };
+    attach_report_metadata(&mut report, &cli, &model_path)?;
 
     let text = serde_json::to_string_pretty(&report)?;
     let output_path = cli.out.clone().map(resolve_workspace_path);
@@ -198,9 +206,17 @@ fn single_report(
     Ok(json!({
         "schema": 1,
         "report_type": "deepseek-v2-lite-ep2-decode-attribution",
-        "model": "DeepSeek-V2-Lite",
-        "phase": "decode",
         "backend": &result.stats.ep_backend,
+        "workload": {
+            "batch_size": 1,
+            "prompt": PROMPT,
+            "prompt_token_ids": &prompt_tokens,
+            "output_len": OUTPUT_LEN,
+            "ignore_eos": false,
+            "ep_size": result.stats.ep_size,
+            "device_ordinals": &result.stats.device_ordinals,
+            "cuda_graph": false,
+        },
         "config": {
             "batch_size": 1,
             "prompt": PROMPT,
@@ -229,6 +245,14 @@ fn single_report(
             "decode_token_count": attribution.per_token_decode_us().len(),
             "per_token_decode_us": attribution.per_token_decode_us(),
             "per_token_decode_stats": latency_stats(attribution.per_token_decode_us()),
+        },
+        "metrics": {
+            "total_generation_us": attribution.total_generation_us(),
+            "prefill_next_token_us": attribution.prefill_next_token_us(),
+            "decode_token_count": attribution.per_token_decode_us().len(),
+            "per_token_decode_stats": latency_stats(attribution.per_token_decode_us()),
+            "gpu_sample_count": attribution.gpu_sample_count(),
+            "gpu_timing_failure_count": attribution.gpu_timing_failure_count(),
         },
         "attribution_source": "DeepSeekV2LiteEp2Generator::generate_greedy_with_attribution; CPU sections use host wall-clock timers, and selected GPU/NCCL sections also carry CUDA event timing plus optional NVTX ranges.",
         "gpu_timing": {
@@ -294,9 +318,17 @@ fn batch_report(
     Ok(json!({
         "schema": 1,
         "report_type": "deepseek-v2-lite-ep2-decode-attribution",
-        "model": "DeepSeek-V2-Lite",
-        "phase": "decode",
         "backend": &result.stats.ep_backend,
+        "workload": {
+            "batch_size": result.tokens.len(),
+            "prompt": PROMPT,
+            "prompt_token_ids": prompt_tokens,
+            "output_len": OUTPUT_LEN,
+            "ignore_eos": true,
+            "ep_size": result.stats.ep_size,
+            "device_ordinals": &result.stats.device_ordinals,
+            "cuda_graph": false,
+        },
         "config": {
             "batch_size": result.tokens.len(),
             "prompt": PROMPT,
@@ -332,6 +364,14 @@ fn batch_report(
             "per_token_decode_us": attribution.per_token_decode_us(),
             "per_token_decode_stats": latency_stats(attribution.per_token_decode_us()),
         },
+        "metrics": {
+            "total_generation_us": result.total_generation_us,
+            "prefill_next_token_us_by_row": &result.prefill_next_token_us,
+            "decode_step_count": result.per_token_decode_us.len(),
+            "per_token_decode_stats": latency_stats(attribution.per_token_decode_us()),
+            "gpu_sample_count": attribution.gpu_sample_count(),
+            "gpu_timing_failure_count": attribution.gpu_timing_failure_count(),
+        },
         "attribution_source": "DeepSeekV2LiteEp2Generator::generate_greedy_batch_same_prompt_with_attribution; CPU sections use host wall-clock timers, and selected GPU/NCCL sections also carry CUDA event timing plus optional NVTX ranges.",
         "gpu_timing": {
             "source": "CUDA event timing around selected DeepSeek-V2-Lite EP2 GPU/NCCL stream sections in the explicit batched attribution path",
@@ -359,6 +399,7 @@ fn batch_report(
 
 fn parse_cli() -> Result<Option<Cli>> {
     let mut model_path = "models/DeepSeek-V2-Lite".to_string();
+    let mut commit = None;
     let mut batch_size = 1;
     let mut nccl_graph_smoke = false;
     let mut full_decode_graph_probe = false;
@@ -370,6 +411,9 @@ fn parse_cli() -> Result<Option<Cli>> {
                 model_path = args
                     .next()
                     .context("--model-path requires a path argument")?;
+            }
+            "--commit" => {
+                commit = Some(args.next().context("--commit requires a value")?);
             }
             "--batch-size" => {
                 batch_size = args
@@ -395,12 +439,12 @@ fn parse_cli() -> Result<Option<Cli>> {
             }
             "-h" | "--help" => {
                 println!(
-                    "DeepSeek-V2-Lite EP2 decode attribution gate\n\nUSAGE:\n  dsv2_lite_ep2_decode_attribution [--model-path PATH] [--batch-size N] [--nccl-graph-smoke] [--full-decode-graph-probe] [--out PATH]\n\nThe gate is intentionally fixed to prompt=Hello, output_len=16, with batch-size in 1..=8. Select NCCL with OPENINFER_DSV2_LITE_EP_BACKEND=nccl. Use --nccl-graph-smoke to run a preallocated f32 NCCL all-reduce CUDA Graph capture/replay smoke after attribution. Use --full-decode-graph-probe to request the fail-closed full decode graph readiness probe for the retained batch-size=1 NCCL shape."
+                    "DeepSeek-V2-Lite EP2 decode attribution gate\n\nUSAGE:\n  dsv2_lite_ep2_decode_attribution [--model-path PATH] [--commit COMMIT] [--batch-size N] [--nccl-graph-smoke] [--full-decode-graph-probe] [--out PATH]\n\nThe gate is intentionally fixed to prompt=Hello, output_len=16, with batch-size in 1..=8. Select NCCL with OPENINFER_DSV2_LITE_EP_BACKEND=nccl. Use --nccl-graph-smoke to run a preallocated f32 NCCL all-reduce CUDA Graph capture/replay smoke after attribution. Use --full-decode-graph-probe to request the fail-closed full decode graph readiness probe for the retained batch-size=1 NCCL shape."
                 );
                 return Ok(None);
             }
             other => bail!(
-                "unsupported argument `{other}`; supported flags: --model-path PATH, --batch-size N, --nccl-graph-smoke, --full-decode-graph-probe, --out PATH"
+                "unsupported argument `{other}`; supported flags: --model-path PATH, --commit COMMIT, --batch-size N, --nccl-graph-smoke, --full-decode-graph-probe, --out PATH"
             ),
         }
     }
@@ -410,6 +454,7 @@ fn parse_cli() -> Result<Option<Cli>> {
     );
     Ok(Some(Cli {
         model_path,
+        commit,
         batch_size,
         nccl_graph_smoke,
         full_decode_graph_probe,
@@ -613,6 +658,98 @@ fn sha256_tokens(tokens: &[u32]) -> String {
     hex::encode(hasher.finalize())
 }
 
+fn current_commit() -> Option<String> {
+    command_output(
+        Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(workspace_root()),
+    )
+}
+
+fn resolve_commit(requested: Option<&str>) -> Result<Option<String>> {
+    if let Some(requested) = requested {
+        ensure!(
+            matches!(requested.len(), 12 | 40)
+                && requested.bytes().all(|byte| byte.is_ascii_hexdigit())
+                && requested.bytes().all(|byte| !byte.is_ascii_uppercase()),
+            "--commit must be a 12- or 40-character lowercase Git object id"
+        );
+    }
+    let current = current_commit();
+    ensure!(
+        requested.is_none() || current.is_some(),
+        "--commit requires a Git worktree so the requested revision can be verified"
+    );
+    if let (Some(requested), Some(current)) = (requested, current.as_deref()) {
+        let matches_head = if requested.len() == 12 {
+            current.get(..12) == Some(requested)
+        } else {
+            requested == current
+        };
+        ensure!(
+            matches_head,
+            "--commit {requested} does not match current HEAD {current}"
+        );
+    }
+    Ok(requested.map(str::to_owned).or(current))
+}
+
+fn hardware_toolchain_metadata() -> Value {
+    json!({
+        "gpu": command_output(Command::new("nvidia-smi").args([
+            "--query-gpu=name,driver_version,memory.total,compute_cap",
+            "--format=csv,noheader",
+        ])).map(|value| value.lines().map(str::to_owned).collect::<Vec<_>>()).unwrap_or_default(),
+        "cuda_visible_devices": env::var("CUDA_VISIBLE_DEVICES").ok(),
+        "nvcc_version": command_output(Command::new("nvcc").arg("--version")),
+        "rustc_version": command_output(Command::new("rustc").arg("--version")),
+        "cargo_version": command_output(Command::new("cargo").arg("--version")),
+    })
+}
+
+fn command_output(command: &mut Command) -> Option<String> {
+    let output = command.output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn attach_report_metadata(report: &mut Value, cli: &Cli, model_path: &Path) -> Result<()> {
+    let commit = resolve_commit(cli.commit.as_deref())?;
+    let object = report
+        .as_object_mut()
+        .context("decode attribution report must be a JSON object")?;
+    object.insert("schema_version".to_string(), json!(1));
+    object.insert(
+        "kind".to_string(),
+        json!("deepseek_v2_lite_direct_decode_attribution"),
+    );
+    object.insert("model".to_string(), json!("DeepSeek-V2-Lite"));
+    object.insert("phase".to_string(), json!("decode"));
+    object.insert(
+        "report_intent".to_string(),
+        json!("direct_decode_diagnostic"),
+    );
+    object.insert("commit".to_string(), json!(commit));
+    object.insert(
+        "hardware_toolchain".to_string(),
+        hardware_toolchain_metadata(),
+    );
+    object.insert(
+        "metadata".to_string(),
+        json!({
+            "commit": commit,
+            "model_path": model_path.display().to_string(),
+            "command": env::args().collect::<Vec<_>>(),
+        }),
+    );
+    Ok(())
+}
+
 fn resolve_model_path(raw: &str) -> PathBuf {
     let path = PathBuf::from(raw);
     if path.join("config.json").exists() {
@@ -642,6 +779,23 @@ fn workspace_root() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn explicit_commit_must_match_current_head() {
+        let error = resolve_commit(Some("000000000000"))
+            .expect_err("a retained direct report must reject a forged commit");
+        assert!(error.to_string().contains("does not match current HEAD"));
+    }
+
+    #[test]
+    fn full_commit_cannot_forge_the_current_short_prefix() {
+        let current = current_commit().expect("tests run from a Git worktree");
+        let replacement = if current.ends_with('0') { '1' } else { '0' };
+        let forged = format!("{}{replacement}", &current[..current.len() - 1]);
+        let error = resolve_commit(Some(&forged))
+            .expect_err("a 40-character commit must match the complete HEAD object id");
+        assert!(error.to_string().contains("does not match current HEAD"));
+    }
 
     #[test]
     fn full_decode_graph_probe_gate_allows_not_requested() {

--- a/openinfer-deepseek-v2-lite/src/nccl_backend.rs
+++ b/openinfer-deepseek-v2-lite/src/nccl_backend.rs
@@ -51,6 +51,7 @@ type NcclAllReduce = unsafe extern "C" fn(
     ncclComm_t,
     CUstream,
 ) -> ncclResult_t;
+type NcclGetVersion = unsafe extern "C" fn(*mut c_int) -> ncclResult_t;
 type NcclGetErrorString = unsafe extern "C" fn(ncclResult_t) -> *const c_char;
 
 // Keep the correctness-first NCCL bridge below the long-prompt failure band
@@ -60,6 +61,9 @@ type NcclGetErrorString = unsafe extern "C" fn(ncclResult_t) -> *const c_char;
 // that previously failed in prefill.
 const NCCL_BF16_ALL_REDUCE_MAX_ELEMS_PER_CALL: usize = 64 * 1024;
 const NCCL_F32_ALL_REDUCE_MAX_ELEMS_PER_CALL: usize = 48 * 1024;
+// NCCL 2.26.2 contains NVIDIA's reduced collective-unroll fix for the
+// shared-memory limit on recent sm_120 Blackwell GPUs (NVIDIA/nccl#1637).
+const MIN_SM120_NCCL_VERSION: c_int = 22_602;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct AllReduceChunk {
@@ -129,6 +133,7 @@ struct RawNcclLib {
     group_start: NcclGroupStart,
     group_end: NcclGroupEnd,
     all_reduce: NcclAllReduce,
+    version_code: c_int,
     get_error_string: NcclGetErrorString,
 }
 
@@ -317,6 +322,16 @@ impl NaiveNcclEp2Backend {
             [rank0.device_ordinal, rank1.device_ordinal]
         );
         let lib = Arc::new(RawNcclLib::load()?);
+        let compute_capabilities = [
+            rank0.ctx.compute_capability()?,
+            rank1.ctx.compute_capability()?,
+        ];
+        validate_nccl_version_for_compute_capabilities(lib.version_code, &compute_capabilities)?;
+        log::info!(
+            "DeepSeek-V2-Lite NCCL backend loaded: version={}, version_code={}",
+            format_nccl_version(lib.version_code),
+            lib.version_code
+        );
         let ordinals = [rank0.device_ordinal as i32, rank1.device_ordinal as i32];
         let mut comms = vec![ptr::null_mut(); 2];
         let status = unsafe {
@@ -1342,6 +1357,22 @@ impl RawNcclLib {
     }
 
     unsafe fn from_library(library: Library, source: String) -> Result<Self> {
+        let get_version: NcclGetVersion = unsafe { load_symbol(&library, b"ncclGetVersion\0")? };
+        let get_error_string: NcclGetErrorString =
+            unsafe { load_symbol(&library, b"ncclGetErrorString\0")? };
+        let mut version_code = 0;
+        let status = unsafe { get_version(&raw mut version_code) };
+        if status != ncclResult_t::ncclSuccess {
+            let message = unsafe {
+                let ptr = get_error_string(status);
+                if ptr.is_null() {
+                    format!("{status:?}")
+                } else {
+                    CStr::from_ptr(ptr).to_string_lossy().into_owned()
+                }
+            };
+            bail!("query NCCL version from {source} failed: {message} ({status:?})");
+        }
         Ok(Self {
             comm_init_all: unsafe { load_symbol(&library, b"ncclCommInitAll\0")? },
             comm_count: unsafe { load_symbol(&library, b"ncclCommCount\0")? },
@@ -1350,7 +1381,8 @@ impl RawNcclLib {
             group_start: unsafe { load_symbol(&library, b"ncclGroupStart\0")? },
             group_end: unsafe { load_symbol(&library, b"ncclGroupEnd\0")? },
             all_reduce: unsafe { load_symbol(&library, b"ncclAllReduce\0")? },
-            get_error_string: unsafe { load_symbol(&library, b"ncclGetErrorString\0")? },
+            version_code,
+            get_error_string,
             source,
             _library: library,
         })
@@ -1371,8 +1403,9 @@ impl RawNcclLib {
             }
         };
         bail!(
-            "{context} failed with NCCL library {}: {message} ({status:?})",
-            self.source
+            "{context} failed with NCCL library {} version {}: {message} ({status:?})",
+            self.source,
+            format_nccl_version(self.version_code)
         )
     }
 
@@ -1397,6 +1430,29 @@ impl RawNcclLib {
         self.check(status, context)?;
         Ok(device)
     }
+}
+
+fn validate_nccl_version_for_compute_capabilities(
+    version_code: c_int,
+    compute_capabilities: &[(i32, i32)],
+) -> Result<()> {
+    let has_sm120 = compute_capabilities
+        .iter()
+        .any(|compute_capability| *compute_capability == (12, 0));
+    ensure!(
+        !has_sm120 || version_code >= MIN_SM120_NCCL_VERSION,
+        "DeepSeek-V2-Lite NCCL EP2 on sm_120 requires NCCL >= {}, loaded {}. Set OPENINFER_NCCL_LIB_DIR to a compatible wheel lib directory or OPENINFER_NCCL_PYTHON to its Python executable",
+        format_nccl_version(MIN_SM120_NCCL_VERSION),
+        format_nccl_version(version_code)
+    );
+    Ok(())
+}
+
+fn format_nccl_version(version_code: c_int) -> String {
+    let major = version_code / 10_000;
+    let minor = (version_code % 10_000) / 100;
+    let patch = version_code % 100;
+    format!("{major}.{minor}.{patch}")
 }
 
 fn nccl_library_candidates() -> Vec<String> {
@@ -1477,6 +1533,19 @@ fn python_env_roots() -> Vec<PathBuf> {
 }
 
 fn add_python_env_root(roots: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>, python: &Path) {
+    add_python_env_root_candidate(roots, seen, python);
+    if let Ok(resolved) = fs::canonicalize(python)
+        && resolved != python
+    {
+        add_python_env_root_candidate(roots, seen, &resolved);
+    }
+}
+
+fn add_python_env_root_candidate(
+    roots: &mut Vec<PathBuf>,
+    seen: &mut HashSet<PathBuf>,
+    python: &Path,
+) {
     if python.is_dir() {
         add_pathbuf_once(roots, seen, python.to_path_buf());
         return;

--- a/openinfer-deepseek-v2-lite/src/nccl_backend/tests.rs
+++ b/openinfer-deepseek-v2-lite/src/nccl_backend/tests.rs
@@ -1,8 +1,12 @@
 use std::{collections::HashSet, fs};
 
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
+
 use super::{
     AllReduceChunk, NCCL_BF16_ALL_REDUCE_MAX_ELEMS_PER_CALL,
     NCCL_F32_ALL_REDUCE_MAX_ELEMS_PER_CALL, bf16_all_reduce_chunks, f32_all_reduce_chunks,
+    format_nccl_version, validate_nccl_version_for_compute_capabilities,
 };
 use super::{add_python_env_root, nccl_python_wheel_lib_dirs_from_root};
 
@@ -84,6 +88,33 @@ fn finds_nccl_python_wheel_lib_dir_from_python_executable() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn keeps_symlinked_python_venv_root_before_resolved_root() {
+    let real_root = tempfile::tempdir().expect("create real Python root");
+    let link_root = tempfile::tempdir().expect("create symlink root");
+    let real_bin = real_root.path().join("bin");
+    let link_bin = link_root.path().join("bin");
+    fs::create_dir_all(&real_bin).expect("create real bin dir");
+    fs::create_dir_all(&link_bin).expect("create symlink bin dir");
+    let real_python = real_bin.join("python3.12");
+    fs::write(&real_python, []).expect("create Python marker");
+    let linked_python = link_bin.join("python3");
+    symlink(&real_python, &linked_python).expect("create Python symlink");
+
+    let mut roots = Vec::new();
+    let mut seen = HashSet::new();
+    add_python_env_root(&mut roots, &mut seen, &linked_python);
+
+    assert_eq!(
+        roots,
+        vec![
+            link_root.path().to_path_buf(),
+            real_root.path().to_path_buf()
+        ]
+    );
+}
+
 #[test]
 fn finds_nccl_python_wheel_lib_dir_with_unversioned_soname() {
     let root = tempfile::tempdir().expect("create temp root");
@@ -97,4 +128,33 @@ fn finds_nccl_python_wheel_lib_dir_with_unversioned_soname() {
         nccl_python_wheel_lib_dirs_from_root(root.path()),
         vec![wheel_dir]
     );
+}
+
+#[test]
+fn formats_nccl_version_code() {
+    assert_eq!(format_nccl_version(22_602), "2.26.2");
+    assert_eq!(format_nccl_version(22_707), "2.27.7");
+    assert_eq!(format_nccl_version(22_501), "2.25.1");
+}
+
+#[test]
+fn sm120_rejects_nccl_before_shared_memory_fix() {
+    let error = validate_nccl_version_for_compute_capabilities(22_601, &[(12, 0)])
+        .expect_err("NCCL 2.26.1 predates the sm_120 shared-memory fix");
+    let message = error.to_string();
+    assert!(message.contains("requires NCCL >= 2.26.2"));
+    assert!(message.contains("loaded 2.26.1"));
+    assert!(message.contains("OPENINFER_NCCL_LIB_DIR"));
+}
+
+#[test]
+fn sm120_accepts_nccl_2_26_2() {
+    validate_nccl_version_for_compute_capabilities(22_602, &[(12, 0), (12, 0)])
+        .expect("NCCL 2.26.2 contains the sm_120 shared-memory fix");
+}
+
+#[test]
+fn non_sm120_capabilities_do_not_inherit_the_sm120_floor() {
+    validate_nccl_version_for_compute_capabilities(22_501, &[(8, 0), (10, 0), (12, 1)])
+        .expect("the sm_120 workaround must stay scoped to compute capability 12.0");
 }

--- a/openinfer-deepseek-v2-lite/tests/e2e_ep2.rs
+++ b/openinfer-deepseek-v2-lite/tests/e2e_ep2.rs
@@ -1,3 +1,10 @@
+//! DeepSeek-V2-Lite EP2 correctness and integration gate.
+//!
+//! This test verifies model loading, host-staged/NCCL generation, request-flow
+//! isolation, token/text hashes, and EP route/collective accounting. It does
+//! not measure serving latency, throughput, SLO compliance, soak behavior, or
+//! production readiness; those claims belong to retained benchmark artifacts.
+
 use std::{
     env, fs,
     path::{Path, PathBuf},
@@ -227,6 +234,9 @@ fn run_rust_generation(model_path_label: &str, model_path: &Path) -> Result<()> 
     let matched_output_oracle =
         matched_expected_output_oracle(&result.stats.output_token_sha256, &output_text_sha256);
     let payload = serde_json::json!({
+        "schema_version": 1,
+        "kind": "deepseek_v2_lite_ep2_correctness",
+        "report_intent": "correctness_integration",
         "model_path": model_path_label,
         "gpu_count": 2,
         "ep_size": result.stats.ep_size,
@@ -258,6 +268,7 @@ fn run_rust_generation(model_path_label: &str, model_path: &Path) -> Result<()> 
         "nccl_dense_exchange_elements": result.stats.nccl_dense_exchange_elements,
         "nccl_combine_elements": result.stats.nccl_combine_elements,
         "output_text": &output_text,
+        "claim_boundary": "Correctness and integration evidence for the covered DeepSeek-V2-Lite EP2 generation path. This artifact makes no latency, throughput, serving SLO, soak, or production-readiness claim.",
     });
     let payload_text = serde_json::to_string_pretty(&payload)?;
     if let Ok(path) = env::var(E2E_JSON_OUT_ENV) {
@@ -313,6 +324,9 @@ fn run_case_set_generation(
     }
 
     let payload = serde_json::json!({
+        "schema_version": 1,
+        "kind": "deepseek_v2_lite_ep2_correctness_case_set",
+        "report_intent": "correctness_integration",
         "schema": 2,
         "report_type": "deepseek-v2-lite-ep2-rust-e2e-case-set",
         "model_path": model_path_label,
@@ -325,6 +339,7 @@ fn run_case_set_generation(
         "token_sha256_algorithm": "sha256 over generated token ids encoded as little-endian u32",
         "text_sha256_algorithm": "sha256 over UTF-8 generated text bytes",
         "cases": case_payloads,
+        "claim_boundary": "Correctness and integration evidence for the covered DeepSeek-V2-Lite EP2 case set. This artifact makes no latency, throughput, serving SLO, soak, or production-readiness claim.",
     });
     let payload_text = serde_json::to_string_pretty(&payload)?;
     write_payload_if_requested(&payload_text)?;
@@ -654,6 +669,9 @@ fn run_mixed_serving_generation(model_path: &Path, model_path_label: &str) -> Re
     println!(
         "{}",
         serde_json::to_string_pretty(&serde_json::json!({
+            "schema_version": 1,
+            "kind": "deepseek_v2_lite_ep2_mixed_serving_correctness",
+            "report_intent": "correctness_integration",
             "schema": 1,
             "report_type": "deepseek-v2-lite-ep2-mixed-serving-e2e",
             "model_path": model_path_label,
@@ -670,6 +688,7 @@ fn run_mixed_serving_generation(model_path: &Path, model_path_label: &str) -> Re
                     })
                 })
                 .collect::<Vec<_>>(),
+            "claim_boundary": "Correctness and integration evidence for mixed DeepSeek-V2-Lite EP2 request flow and failure isolation. This artifact makes no latency, throughput, serving SLO, soak, or production-readiness claim.",
         }))?
     );
     Ok(())

--- a/scripts/bench_dsv2lite_http_slo.py
+++ b/scripts/bench_dsv2lite_http_slo.py
@@ -1,0 +1,1122 @@
+#!/usr/bin/env python3
+"""Run and combine retained DeepSeek-V2-Lite HTTP SLO contracts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from bench_http_common import (
+    artifact_command,
+    combined_output_hash,
+    numeric_summary,
+    repeat_noise_marker,
+    value_counts,
+    write_json,
+)
+from bench_http_sweep import verify_summary_leaf_artifacts
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+SWEEP = SCRIPT_DIR / "bench_http_sweep.py"
+BACKENDS = ("host-staged", "nccl")
+PROFILE_SCHEMA_VERSION = 1
+NCCL_VERSION_PATTERNS = (
+    re.compile(
+        r"DeepSeek-V2-Lite NCCL backend loaded: version=([0-9]+\.[0-9]+\.[0-9]+)"
+    ),
+    re.compile(r"NCCL version ([0-9]+\.[0-9]+\.[0-9]+)"),
+)
+REPORT_CLAIM_BOUNDARY = (
+    "Retained HTTP pressure/SLO evidence for the six fixed DeepSeek-V2-Lite "
+    "host-staged/NCCL contracts. This report is not direct decode attribution, "
+    "sustained soak, vLLM parity, multi-node recovery, or production-readiness evidence."
+)
+
+
+@dataclass(frozen=True)
+class SloProfile:
+    name: str
+    description: str
+    prompt_words: tuple[int, ...]
+    max_tokens: tuple[int, ...]
+    num_requests: int
+    concurrency: tuple[int, ...]
+    repeats: int
+    warmup: int
+    timeout_s: float
+    mixed_prompt_shape: bool
+    required_trace_coverage_ratio: float
+    claim_boundary: str
+
+    def workload_contract(self) -> dict[str, Any]:
+        return {
+            "num_requests": self.num_requests,
+            "warmup": self.warmup,
+            "prompt_words": list(self.prompt_words),
+            "temperature": 0.0,
+            "top_k": -1,
+            "top_p": 1.0,
+            "sampling_mode": "single",
+            "ignore_eos": True,
+            "timeout_s": self.timeout_s,
+            "timeout_kind": "absolute_request_deadline",
+            "concurrency": list(self.concurrency),
+            "max_tokens": list(self.max_tokens),
+            "repeats": self.repeats,
+        }
+
+
+PROFILES = {
+    profile.name: profile
+    for profile in (
+        SloProfile(
+            name="dsv2-lite-short-decode-heavy",
+            description="DeepSeek-V2-Lite retained short decode-heavy HTTP contract.",
+            prompt_words=(64,),
+            max_tokens=(64,),
+            num_requests=32,
+            concurrency=(1, 4, 8),
+            repeats=3,
+            warmup=0,
+            timeout_s=240.0,
+            mixed_prompt_shape=False,
+            required_trace_coverage_ratio=1.0,
+            claim_boundary=(
+                "HTTP pressure/SLO evidence for a fixed short decode-heavy contract; "
+                "not a direct decode attribution result, soak result, or production-readiness claim."
+            ),
+        ),
+        SloProfile(
+            name="dsv2-lite-mixed-prompt-shape",
+            description="DeepSeek-V2-Lite retained mixed short/long prompt HTTP contract.",
+            prompt_words=(64, 512),
+            max_tokens=(64,),
+            num_requests=32,
+            concurrency=(1, 4, 8),
+            repeats=3,
+            warmup=0,
+            timeout_s=240.0,
+            mixed_prompt_shape=True,
+            required_trace_coverage_ratio=1.0,
+            claim_boundary=(
+                "HTTP mixed-shape SLO evidence; trace coverage and tails may identify long-prefill "
+                "risk but this does not close sustained soak or production-readiness gates."
+            ),
+        ),
+        SloProfile(
+            name="dsv2-lite-long-prompt-smoke",
+            description="DeepSeek-V2-Lite retained long-prompt HTTP smoke contract.",
+            prompt_words=(2048,),
+            max_tokens=(64,),
+            num_requests=1,
+            concurrency=(1,),
+            repeats=1,
+            warmup=0,
+            timeout_s=900.0,
+            mixed_prompt_shape=False,
+            required_trace_coverage_ratio=1.0,
+            claim_boundary=(
+                "Long-prompt HTTP smoke evidence only. Use it to retain a boundary row and route "
+                "findings to long-prefill work; do not treat it as broad long-context or soak proof."
+            ),
+        ),
+    )
+}
+
+
+def profile_spec_sha256() -> str:
+    payload = {
+        "schema_version": PROFILE_SCHEMA_VERSION,
+        "profiles": {
+            name: asdict(profile) for name, profile in sorted(PROFILES.items())
+        },
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def validate_commit(commit: str) -> None:
+    if not re.fullmatch(r"[0-9a-f]{12}|[0-9a-f]{40}", commit):
+        raise SystemExit(
+            "--commit must be a 12- or 40-character lowercase Git object id"
+        )
+    try:
+        head = subprocess.check_output(
+            ["git", "rev-parse", "--verify", "HEAD^{commit}"],
+            cwd=REPO_ROOT,
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        ).strip()
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise SystemExit(
+            "retained runs require a Git worktree with a valid HEAD"
+        ) from exc
+    if commit not in {head, head[:12]}:
+        raise SystemExit(f"--commit {commit} does not match current HEAD {head}")
+
+
+def csv(values: tuple[int, ...]) -> str:
+    return ",".join(str(value) for value in values)
+
+
+def detect_backend_runtime_version(server_log: Path, backend: str) -> str:
+    if backend == "host-staged":
+        return "host-staged"
+    try:
+        log_text = server_log.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        raise SystemExit(f"cannot read --server-log for NCCL version: {exc}") from exc
+    loaded_versions = NCCL_VERSION_PATTERNS[0].findall(log_text)
+    if loaded_versions:
+        unique_loaded = set(loaded_versions)
+        if len(unique_loaded) != 1:
+            raise SystemExit(
+                f"--server-log contains multiple loaded NCCL versions: {sorted(unique_loaded)}"
+            )
+        return loaded_versions[-1]
+    fallback_versions = set(NCCL_VERSION_PATTERNS[1].findall(log_text))
+    if not fallback_versions:
+        raise SystemExit("--server-log does not contain the loaded NCCL version")
+    if len(fallback_versions) != 1:
+        raise SystemExit(
+            f"--server-log contains multiple NCCL INFO versions: {sorted(fallback_versions)}"
+        )
+    return next(iter(fallback_versions))
+
+
+def startup_failure_runtime_version(error: str, backend: str) -> str:
+    if backend == "host-staged":
+        return "startup-failed"
+    match = re.search(r"loaded ([0-9]+\.[0-9]+\.[0-9]+)", error)
+    return match.group(1) if match else "unavailable-before-init"
+
+
+def build_sweep_command(args: argparse.Namespace) -> list[str]:
+    profile = PROFILES[args.profile]
+    backend_runtime_version = getattr(args, "backend_runtime_version", None)
+    if backend_runtime_version is None:
+        if args.record_startup_failure:
+            backend_runtime_version = startup_failure_runtime_version(
+                args.record_startup_failure, args.backend
+            )
+        else:
+            backend_runtime_version = detect_backend_runtime_version(
+                args.server_log, args.backend
+            )
+    command = [
+        sys.executable,
+        str(SWEEP),
+        "--base-url",
+        args.base_url,
+        "--model",
+        args.model,
+        "--num-requests",
+        str(profile.num_requests),
+        "--warmup",
+        str(profile.warmup),
+        "--prompt-words",
+        csv(profile.prompt_words),
+        "--max-tokens",
+        csv(profile.max_tokens),
+        "--concurrency",
+        csv(profile.concurrency),
+        "--repeats",
+        str(profile.repeats),
+        "--timeout",
+        str(profile.timeout_s),
+        "--server-log",
+        str(args.server_log),
+        "--contract-name",
+        profile.name,
+        "--contract-description",
+        profile.description,
+        "--claim-boundary",
+        profile.claim_boundary,
+        "--required-trace-coverage",
+        str(profile.required_trace_coverage_ratio),
+        "--backend",
+        args.backend,
+        "--model-path",
+        args.model_path,
+        "--server-command",
+        args.server_command,
+        "--source-revision",
+        args.commit,
+        "--model-revision",
+        args.model_revision,
+        "--server-binary",
+        str(args.server_binary),
+        "--backend-runtime-version",
+        backend_runtime_version,
+        "--out-dir",
+        str(args.out_dir),
+    ]
+    if profile.mixed_prompt_shape:
+        command.append("--mixed-prompt-shape")
+    if args.commit:
+        command.extend(["--commit", args.commit])
+    if args.record_startup_failure:
+        command.extend(["--record-startup-failure", args.record_startup_failure])
+    return command
+
+
+def expected_rows(profile: SloProfile) -> set[tuple[str, int, int, int]]:
+    prompt_shape = csv(profile.prompt_words)
+    return {
+        (prompt_shape, concurrency, max_tokens, profile.repeats)
+        for concurrency in profile.concurrency
+        for max_tokens in profile.max_tokens
+    }
+
+
+def is_finite_number(value: Any) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+    )
+
+
+def validate_numeric_summary(
+    value: Any,
+    path: str,
+    expected_samples: int,
+    raw_values: Any | None = None,
+) -> list[str]:
+    if not isinstance(value, dict):
+        return [path]
+    errors = []
+    if value.get("samples") != expected_samples:
+        errors.append(f"{path}.samples")
+    samples = [value.get(field) for field in ("min", "median", "max")]
+    if not all(is_finite_number(sample) and float(sample) >= 0.0 for sample in samples):
+        errors.append(f"{path}.values")
+    elif not float(samples[0]) <= float(samples[1]) <= float(samples[2]):
+        errors.append(f"{path}.ordering")
+    if raw_values is not None:
+        if (
+            not isinstance(raw_values, list)
+            or len(raw_values) != expected_samples
+            or not all(
+                is_finite_number(sample) and float(sample) >= 0.0
+                for sample in raw_values
+            )
+        ):
+            errors.append(f"{path}.raw_values")
+        else:
+            expected = numeric_summary(raw_values)
+            for field in ("min", "median", "max"):
+                actual_value = value.get(field)
+                expected_value = expected[field]
+                if (
+                    not is_finite_number(actual_value)
+                    or not is_finite_number(expected_value)
+                    or not math.isclose(
+                        float(actual_value),
+                        float(expected_value),
+                        rel_tol=1e-12,
+                        abs_tol=1e-12,
+                    )
+                ):
+                    errors.append(f"{path}.{field}_mismatch")
+    return list(dict.fromkeys(errors))
+
+
+def validate_metric_summary(value: Any, path: str, repeats: int) -> list[str]:
+    if not isinstance(value, dict):
+        return [path]
+    errors = []
+    for percentile in ("p50", "p95", "p99"):
+        samples = value.get(percentile)
+        if (
+            not isinstance(samples, list)
+            or len(samples) != repeats
+            or not all(
+                is_finite_number(sample) and float(sample) >= 0.0 for sample in samples
+            )
+        ):
+            errors.append(f"{path}.{percentile}")
+        errors.extend(
+            validate_numeric_summary(
+                value.get(f"{percentile}_summary"),
+                f"{path}.{percentile}_summary",
+                repeats,
+                samples,
+            )
+        )
+    percentile_samples = [value.get(percentile) for percentile in ("p50", "p95", "p99")]
+    if all(
+        isinstance(samples, list) and len(samples) == repeats
+        for samples in percentile_samples
+    ):
+        for sample_index in range(repeats):
+            values = [samples[sample_index] for samples in percentile_samples]
+            if all(is_finite_number(sample) for sample in values) and not (
+                float(values[0]) <= float(values[1]) <= float(values[2])
+            ):
+                errors.append(f"{path}.percentile_ordering")
+    return errors
+
+
+def validate_output_hash_evidence(
+    row: dict[str, Any], profile: SloProfile
+) -> list[str]:
+    prefix = "rows.success"
+    groups = row.get("request_output_hashes_by_repeat")
+    if (
+        not isinstance(groups, list)
+        or len(groups) != profile.repeats
+        or any(
+            not isinstance(group, list)
+            or len(group) != profile.num_requests
+            or any(not isinstance(value, str) or not value for value in group)
+            for group in groups
+        )
+    ):
+        return [f"{prefix}.request_output_hashes_by_repeat"]
+
+    stable = all(group == groups[0] for group in groups[1:])
+    errors = []
+    if row.get("stable_per_request_hashes") is not stable or not stable:
+        errors.append(f"{prefix}.stable_per_request_hashes")
+    flattened = [value for group in groups for value in group]
+    if row.get("output_hash_distribution") != value_counts(flattened):
+        errors.append(f"{prefix}.output_hash_distribution")
+    expected_combined = [combined_output_hash(group) for group in groups]
+    if row.get("combined_output_hashes") != expected_combined:
+        errors.append(f"{prefix}.combined_output_hashes")
+    if row.get("hash_manifests_consistent") is not True:
+        errors.append(f"{prefix}.hash_manifests_consistent")
+    return errors
+
+
+def validate_success_flags(
+    row: dict[str, Any], backend: str, profile: SloProfile
+) -> list[str]:
+    prefix = "rows.success"
+    errors = []
+    if row.get("backend") != backend:
+        errors.append(f"{prefix}.backend")
+    if row.get("repeats") != profile.repeats:
+        errors.append(f"{prefix}.repeats")
+    if row.get("passed") is not True:
+        errors.append(f"{prefix}.passed")
+    if row.get("tail_sample_sufficient") != (profile.num_requests >= 30):
+        errors.append(f"{prefix}.tail_sample_sufficient")
+    for field in (
+        "output_evidence_present",
+        "trace_coverage_passed",
+        "metric_sample_coverage_passed",
+        "benchmark_commands_passed",
+        "hash_stability_checked",
+        "stable_per_request_hashes",
+        "hash_manifests_consistent",
+    ):
+        if row.get(field) is not True:
+            errors.append(f"{prefix}.{field}")
+
+    expected_marker = repeat_noise_marker(
+        [
+            row.get(metric, {}).get("p95", [])
+            for metric in ("ttft_ms", "tpot_ms", "itl_ms")
+        ]
+        + [row.get("qps", []), row.get("output_tokens_per_s", [])],
+        profile.repeats,
+    )
+    if row.get("noisy_cell") != expected_marker:
+        errors.append(f"{prefix}.noisy_cell")
+
+    for field, expected in (
+        ("completed", profile.num_requests),
+        ("failed", 0),
+        ("timeouts", 0),
+    ):
+        values = row.get(field)
+        if not isinstance(values, list) or values != [expected] * profile.repeats:
+            errors.append(f"{prefix}.{field}")
+
+    return errors
+
+
+def validate_success_metrics(row: dict[str, Any], profile: SloProfile) -> list[str]:
+    prefix = "rows.success"
+    errors = validate_numeric_summary(
+        row.get("qps_summary"),
+        f"{prefix}.qps_summary",
+        profile.repeats,
+        row.get("qps"),
+    )
+    errors.extend(
+        validate_numeric_summary(
+            row.get("output_tokens_per_s_summary"),
+            f"{prefix}.output_tokens_per_s_summary",
+            profile.repeats,
+            row.get("output_tokens_per_s"),
+        )
+    )
+    for metric in ("ttft_ms", "tpot_ms", "itl_ms"):
+        errors.extend(
+            validate_metric_summary(
+                row.get(metric), f"{prefix}.{metric}", profile.repeats
+            )
+        )
+
+    sample_counts = row.get("metric_sample_counts")
+    expected_tpot_samples = profile.num_requests if row.get("max_tokens", 0) > 1 else 0
+    expected_counts = {
+        "ttft": [profile.num_requests] * profile.repeats,
+        "tpot": [expected_tpot_samples] * profile.repeats,
+        "itl": [profile.num_requests * max(0, int(row.get("max_tokens", 0)) - 1)]
+        * profile.repeats,
+    }
+    if not isinstance(sample_counts, dict) or any(
+        sample_counts.get(metric) != expected
+        for metric, expected in expected_counts.items()
+    ):
+        errors.append(f"{prefix}.metric_sample_counts")
+
+    return errors
+
+
+def validate_trace_evidence(row: dict[str, Any], profile: SloProfile) -> list[str]:
+    prefix = "rows.success"
+    traces = row.get("trace_coverage")
+    if not isinstance(traces, list) or len(traces) != profile.repeats:
+        return [f"{prefix}.trace_coverage"]
+    errors = []
+    for trace in traces:
+        errors.extend(validate_trace_record(trace, profile, prefix))
+    return errors
+
+
+def validate_trace_record(trace: Any, profile: SloProfile, prefix: str) -> list[str]:
+    if not isinstance(trace, dict):
+        return [f"{prefix}.trace_coverage"]
+    errors = []
+    expected_values = {
+        "traced_requests": profile.num_requests,
+        "server_error_records": 0,
+        "missing_traces": [],
+        "missing_server_records": [],
+        "token_timing_mismatches": [],
+        "token_timing_unknown": [],
+    }
+    errors.extend(
+        f"{prefix}.trace_coverage.{field}"
+        for field, expected in expected_values.items()
+        if trace.get(field) != expected
+    )
+    coverage_fields = (
+        "coverage_ratio",
+        "active_set_coverage_ratio",
+        "decode_batch_coverage_ratio",
+        "token_timing_coverage_ratio",
+    )
+    errors.extend(
+        f"{prefix}.trace_coverage.{field}"
+        for field in coverage_fields
+        if not is_finite_number(trace.get(field))
+        or float(trace[field]) < profile.required_trace_coverage_ratio
+    )
+    errors.extend(
+        f"{prefix}.trace_coverage.{field}"
+        for field in ("active_set_size_max", "decode_batch_size_max")
+        if not isinstance(trace.get(field), int)
+        or isinstance(trace.get(field), bool)
+        or trace[field] <= 0
+    )
+    return errors
+
+
+def validate_success_row(
+    row: dict[str, Any], backend: str, profile: SloProfile
+) -> list[str]:
+    return list(
+        dict.fromkeys(
+            validate_success_flags(row, backend, profile)
+            + validate_success_metrics(row, profile)
+            + validate_trace_evidence(row, profile)
+            + validate_output_hash_evidence(row, profile)
+        )
+    )
+
+
+def validate_child_identity(
+    summary: dict[str, Any], model: str, backend: str, profile: SloProfile
+) -> list[str]:
+    errors = []
+    contract = summary.get("contract")
+    if not isinstance(contract, dict):
+        errors.append("contract")
+        contract = {}
+    if summary.get("schema_version") != 1:
+        errors.append("schema_version")
+    if summary.get("kind") != "openai_http_completions_sweep":
+        errors.append("kind")
+    if summary.get("model") != model:
+        errors.append("model")
+    if summary.get("backend") != backend or contract.get("backend") != backend:
+        errors.append("backend")
+    if contract.get("name") != profile.name:
+        errors.append("contract.name")
+    if contract.get("description") != profile.description:
+        errors.append("contract.description")
+    if contract.get("claim_boundary") != profile.claim_boundary:
+        errors.append("contract.claim_boundary")
+    if (
+        contract.get("required_trace_coverage_ratio")
+        != profile.required_trace_coverage_ratio
+    ):
+        errors.append("contract.required_trace_coverage_ratio")
+
+    return errors
+
+
+def validate_child_workload(summary: dict[str, Any], profile: SloProfile) -> list[str]:
+    errors = []
+    workload = summary.get("workload")
+    if not isinstance(workload, dict):
+        errors.append("workload")
+        workload = {}
+    for field, expected in profile.workload_contract().items():
+        if workload.get(field) != expected:
+            errors.append(f"workload.{field}")
+    expected_sampling_profiles = {
+        "single": {
+            "label": "single",
+            "temperature": 0.0,
+            "top_k": -1,
+            "top_p": 1.0,
+        }
+    }
+    if workload.get("sampling_profiles") != expected_sampling_profiles:
+        errors.append("workload.sampling_profiles")
+    return errors
+
+
+def validate_child_metric_contract(summary: dict[str, Any]) -> list[str]:
+    errors = []
+    metric_definitions = summary.get("metric_definitions")
+    if (
+        not isinstance(metric_definitions, dict)
+        or metric_definitions.get("percentile_method")
+        != "R7 linear interpolation over sorted samples"
+        or "completion_tokens" not in str(metric_definitions.get("tpot"))
+        or "completion_tokens" not in str(metric_definitions.get("itl"))
+    ):
+        errors.append("metric_definitions")
+    latency_budget = summary.get("latency_budget")
+    if (
+        not isinstance(latency_budget, dict)
+        or latency_budget.get("configured") is not False
+        or latency_budget.get("passed") is not None
+        or not isinstance(latency_budget.get("reason"), str)
+        or not latency_budget["reason"]
+    ):
+        errors.append("latency_budget")
+    return errors
+
+
+def validate_child_leaf_artifacts(
+    summary: dict[str, Any], profile: SloProfile
+) -> list[str]:
+    artifacts = summary.get("leaf_artifacts")
+    expected_count = len(expected_rows(profile)) * profile.repeats
+    if not isinstance(artifacts, list) or len(artifacts) != expected_count:
+        return ["leaf_artifacts"]
+    paths = []
+    errors = []
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            errors.append("leaf_artifacts.items")
+            continue
+        path = artifact.get("artifact")
+        digest = artifact.get("sha256")
+        if not isinstance(path, str) or not path:
+            errors.append("leaf_artifacts.artifact")
+        else:
+            paths.append(path)
+        if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+            errors.append("leaf_artifacts.sha256")
+    if len(paths) != len(set(paths)):
+        errors.append("leaf_artifacts.duplicates")
+    prompt_slug = csv(profile.prompt_words).replace(",", "-")
+    expected_names = {
+        f"pw{prompt_slug}_c{concurrency}_mt{max_tokens}_r{repeat}.json"
+        for concurrency in profile.concurrency
+        for max_tokens in profile.max_tokens
+        for repeat in range(profile.repeats)
+    }
+    if {Path(path).name for path in paths} != expected_names:
+        errors.append("leaf_artifacts.contract_cells")
+    return errors
+
+
+def validate_child_contract(
+    summary: dict[str, Any], model: str, backend: str, profile: SloProfile
+) -> list[str]:
+    return (
+        validate_child_identity(summary, model, backend, profile)
+        + validate_child_workload(summary, profile)
+        + validate_child_metric_contract(summary)
+        + validate_child_leaf_artifacts(summary, profile)
+    )
+
+
+def validate_child_rows(
+    summary: dict[str, Any], backend: str, profile: SloProfile
+) -> list[str]:
+    errors = []
+    rows = summary.get("rows")
+    if not isinstance(rows, list):
+        errors.append("rows")
+    elif any(not isinstance(row, dict) for row in rows):
+        errors.append("rows.items")
+    else:
+        actual_rows = {
+            (
+                csv(tuple(row.get("prompt_words", [])))
+                if isinstance(row.get("prompt_words"), list)
+                else str(row.get("prompt_words")),
+                row.get("concurrency"),
+                row.get("max_tokens"),
+                row.get("repeats"),
+            )
+            for row in rows
+        }
+        if actual_rows != expected_rows(profile):
+            errors.append("rows.contract_cells")
+        if len(rows) != len(actual_rows):
+            errors.append("rows.duplicate_cells")
+        required_row_fields = {
+            "noisy_cell",
+            "output_hash_distribution",
+            "request_output_hashes_by_repeat",
+            "combined_output_hashes",
+            "hash_manifests_consistent",
+            "qps_summary",
+            "output_tokens_per_s_summary",
+            "ttft_ms",
+            "tpot_ms",
+            "itl_ms",
+            "completed",
+            "failed",
+            "timeouts",
+            "trace_coverage",
+            "metric_sample_counts",
+            "passed",
+            "benchmark_commands_passed",
+            "tail_sample_sufficient",
+        }
+        if any(not required_row_fields.issubset(row) for row in rows):
+            errors.append("rows.required_metrics")
+        if summary.get("report_intent") == "http_serving_slo":
+            for row in rows:
+                errors.extend(validate_success_row(row, backend, profile))
+    return errors
+
+
+def validate_source_metadata(metadata: dict[str, Any]) -> list[str]:
+    errors = []
+    if not isinstance(metadata.get("commit"), str) or not re.fullmatch(
+        r"[0-9a-f]{12}|[0-9a-f]{40}", metadata["commit"]
+    ):
+        errors.append("metadata.commit")
+    if not metadata.get("model_path"):
+        errors.append("metadata.model_path")
+    if not metadata.get("server_command"):
+        errors.append("metadata.server_command")
+    if metadata.get("source_revision") != metadata.get("commit"):
+        errors.append("metadata.source_revision")
+    return errors
+
+
+def validate_model_metadata(metadata: dict[str, Any]) -> list[str]:
+    errors = []
+    if not isinstance(metadata.get("model_revision"), str) or not metadata["model_revision"]:
+        errors.append("metadata.model_revision")
+    fingerprint = metadata.get("model_fingerprint")
+    if (
+        not isinstance(fingerprint, dict)
+        or not isinstance(fingerprint.get("config.json"), str)
+        or not re.fullmatch(r"[0-9a-f]{64}", fingerprint["config.json"])
+        or not isinstance(fingerprint.get("model.safetensors.index.json"), str)
+        or not re.fullmatch(
+            r"[0-9a-f]{64}", fingerprint["model.safetensors.index.json"]
+        )
+        or not isinstance(fingerprint.get("tokenizer.json"), str)
+        or not re.fullmatch(r"[0-9a-f]{64}", fingerprint["tokenizer.json"])
+    ):
+        errors.append("metadata.model_fingerprint")
+    if not isinstance(metadata.get("server_binary_sha256"), str) or not re.fullmatch(
+        r"[0-9a-f]{64}", metadata["server_binary_sha256"]
+    ):
+        errors.append("metadata.server_binary_sha256")
+    return errors
+
+
+def validate_backend_metadata(
+    summary: dict[str, Any], metadata: dict[str, Any], backend: str
+) -> list[str]:
+    backend_runtime_version = metadata.get("backend_runtime_version")
+    startup_failure = summary.get("report_intent") == "http_serving_slo_startup_failure"
+    if backend == "host-staged":
+        allowed = {"host-staged"}
+        if startup_failure:
+            allowed.add("startup-failed")
+        if backend_runtime_version not in allowed:
+            return ["metadata.backend_runtime_version"]
+    elif backend_runtime_version != "unavailable-before-init" and (
+        not isinstance(backend_runtime_version, str)
+        or not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", backend_runtime_version)
+    ):
+        return ["metadata.backend_runtime_version"]
+    return []
+
+
+def validate_hardware_metadata(metadata: dict[str, Any]) -> list[str]:
+    hardware = metadata.get("hardware_toolchain")
+    if not isinstance(hardware, dict):
+        return ["metadata.hardware_toolchain"]
+    gpu = hardware.get("gpu")
+    gpu_identity = hardware.get("gpu_identity_sha256")
+    if (
+        not isinstance(gpu, list)
+        or len(gpu) != 2
+        or not all(isinstance(item, str) and item for item in gpu)
+        or not isinstance(gpu_identity, list)
+        or len(gpu_identity) != 2
+        or not all(
+            isinstance(item, str) and re.fullmatch(r"[0-9a-f]{64}", item)
+            for item in gpu_identity
+        )
+        or not isinstance(hardware.get("nvcc_version"), str)
+        or not hardware["nvcc_version"]
+    ):
+        return ["metadata.hardware_toolchain"]
+    return []
+
+
+def validate_child_metadata(summary: dict[str, Any], backend: str) -> list[str]:
+    metadata = summary.get("metadata")
+    if not isinstance(metadata, dict):
+        return ["metadata"]
+    return (
+        validate_source_metadata(metadata)
+        + validate_model_metadata(metadata)
+        + validate_backend_metadata(summary, metadata, backend)
+        + validate_hardware_metadata(metadata)
+    )
+
+
+def child_validation_errors(
+    summary: dict[str, Any], model: str, backend: str, profile: SloProfile
+) -> list[str]:
+    return list(
+        dict.fromkeys(
+            validate_child_contract(summary, model, backend, profile)
+            + validate_child_rows(summary, backend, profile)
+            + validate_child_metadata(summary, backend)
+        )
+    )
+
+
+def build_retained_slo_report(
+    model: str, summaries: list[tuple[Path, dict[str, Any]]]
+) -> dict[str, Any]:
+    required = {(backend, profile) for backend in BACKENDS for profile in PROFILES}
+    found: dict[tuple[str, str], tuple[Path, dict[str, Any]]] = {}
+    duplicates = []
+    invalid_children = []
+
+    for path, summary in summaries:
+        if not isinstance(summary, dict):
+            invalid_children.append(
+                {"artifact": str(path), "errors": ["document must be an object"]}
+            )
+            continue
+        contract = summary.get("contract")
+        if not isinstance(contract, dict):
+            invalid_children.append({"artifact": str(path), "errors": ["contract"]})
+            continue
+        backend = summary.get("backend")
+        profile_name = contract.get("name")
+        if not isinstance(backend, str) or not isinstance(profile_name, str):
+            invalid_children.append({"artifact": str(path), "errors": ["contract key"]})
+            continue
+        key = (backend, profile_name)
+        if key not in required:
+            invalid_children.append({"artifact": str(path), "errors": ["contract key"]})
+            continue
+        errors = child_validation_errors(
+            summary, model, backend, PROFILES[profile_name]
+        )
+        if errors:
+            invalid_children.append({"artifact": str(path), "errors": errors})
+            continue
+        if key in found:
+            duplicates.append(
+                {"backend": backend, "profile": profile_name, "artifact": str(path)}
+            )
+            continue
+        found[key] = (path, summary)
+
+    missing = [
+        {"backend": backend, "profile": profile}
+        for backend, profile in sorted(required - set(found))
+    ]
+    failed_children = [
+        {"backend": backend, "profile": profile, "artifact": str(path)}
+        for (backend, profile), (path, summary) in sorted(found.items())
+        if summary.get("report_intent") != "http_serving_slo"
+        or (summary.get("correctness_gate") or {}).get("passed") is not True
+        or bool(summary.get("run_errors"))
+        or any(row.get("passed") is not True for row in summary.get("rows", []))
+    ]
+    ordered = [found[key] for key in sorted(found)]
+    child_commits = [
+        str((summary.get("metadata") or {}).get("commit"))
+        for _, summary in ordered
+        if (summary.get("metadata") or {}).get("commit")
+    ]
+    commit_counts = value_counts(child_commits)
+    commit_consistent = len(commit_counts) == 1 and len(child_commits) == len(required)
+    child_hardware = [
+        (summary.get("metadata") or {}).get("hardware_toolchain")
+        for _, summary in ordered
+    ]
+    hardware_documents = [
+        json.dumps(hardware, sort_keys=True, separators=(",", ":"))
+        for hardware in child_hardware
+        if hardware
+    ]
+    hardware_consistent = len(set(hardware_documents)) == 1 and len(
+        hardware_documents
+    ) == len(required)
+    provenance_documents = []
+    backend_runtime_versions = []
+    server_commands_by_backend: dict[str, set[str]] = {
+        backend: set() for backend in BACKENDS
+    }
+    for _, summary in ordered:
+        metadata = summary.get("metadata") or {}
+        provenance = {
+            field: metadata.get(field)
+            for field in (
+                "source_revision",
+                "model_revision",
+                "model_fingerprint",
+                "model_path",
+                "server_binary_sha256",
+            )
+        }
+        provenance_documents.append(
+            json.dumps(provenance, sort_keys=True, separators=(",", ":"))
+        )
+        backend = summary["backend"]
+        backend_runtime_versions.append(
+            f"{backend}:{metadata.get('backend_runtime_version')}"
+        )
+        server_commands_by_backend[backend].add(str(metadata.get("server_command")))
+    provenance_consistent = len(set(provenance_documents)) == 1 and len(
+        provenance_documents
+    ) == len(required)
+    backend_runtime_consistent = len(backend_runtime_versions) == len(required) and all(
+        len(
+            {
+                value
+                for value in backend_runtime_versions
+                if value.startswith(f"{backend}:")
+            }
+        )
+        == 1
+        for backend in BACKENDS
+    )
+    server_commands_consistent = all(
+        len(commands) == 1 for commands in server_commands_by_backend.values()
+    )
+    passed = (
+        not missing
+        and not duplicates
+        and not invalid_children
+        and not failed_children
+        and commit_consistent
+        and hardware_consistent
+        and provenance_consistent
+        and backend_runtime_consistent
+        and server_commands_consistent
+    )
+
+    return {
+        "schema_version": 1,
+        "kind": "deepseek_v2_lite_retained_http_slo_report",
+        "report_intent": "http_serving_slo",
+        "model": model,
+        "backends": list(BACKENDS),
+        "profiles": sorted(PROFILES),
+        "profile_schema_version": PROFILE_SCHEMA_VERSION,
+        "profile_spec_sha256": profile_spec_sha256(),
+        "profile_specs": {
+            name: asdict(profile) for name, profile in sorted(PROFILES.items())
+        },
+        "latency_budget": {
+            "configured": False,
+            "passed": None,
+            "reason": "The retained report records latency distributions but does not define a production latency budget.",
+        },
+        "metadata": {
+            "commit": child_commits[0] if commit_consistent else None,
+            "benchmark_command": artifact_command(sys.argv),
+            "hardware_toolchain": child_hardware[0] if hardware_consistent else None,
+            "child_commits": commit_counts,
+            "provenance": json.loads(provenance_documents[0])
+            if provenance_consistent
+            else None,
+            "backend_runtime_versions": value_counts(backend_runtime_versions),
+            "server_commands": {
+                backend: sorted(commands)
+                for backend, commands in server_commands_by_backend.items()
+            },
+        },
+        "coverage_gate": {
+            "passed": passed,
+            "required_children": len(required),
+            "retained_children": len(found),
+            "missing": missing,
+            "duplicates": duplicates,
+            "invalid_children": invalid_children,
+            "failed_children": failed_children,
+            "commit_consistent": commit_consistent,
+            "hardware_consistent": hardware_consistent,
+            "provenance_consistent": provenance_consistent,
+            "backend_runtime_consistent": backend_runtime_consistent,
+            "server_commands_consistent": server_commands_consistent,
+        },
+        "reports": [
+            {
+                "artifact": str(path),
+                "backend": summary["backend"],
+                "profile": summary["contract"]["name"],
+                "correctness_gate": summary["correctness_gate"],
+                "workload": summary["workload"],
+                "rows": summary["rows"],
+                "metadata": summary["metadata"],
+                "metric_definitions": summary["metric_definitions"],
+                "latency_budget": summary["latency_budget"],
+                "leaf_artifacts": summary["leaf_artifacts"],
+                "claim_boundary": summary["contract"]["claim_boundary"],
+            }
+            for path, summary in ordered
+        ],
+        "claim_boundary": REPORT_CLAIM_BOUNDARY,
+    }
+
+
+def verify_leaf_artifacts(
+    summaries: list[tuple[Path, dict[str, Any]]],
+) -> dict[str, Any]:
+    checked = 0
+    failures = []
+    for path, summary in summaries:
+        if not isinstance(summary, dict):
+            failures.append(
+                {"summary": str(path), "failures": ["document must be an object"]}
+            )
+            continue
+        verification = verify_summary_leaf_artifacts(summary)
+        checked += verification["checked"]
+        if not verification["passed"]:
+            failures.append(
+                {"summary": str(path), "failures": verification["failures"]}
+            )
+    return {
+        "passed": not failures and checked > 0,
+        "checked": checked,
+        "failures": failures,
+    }
+
+
+def run_profile(args: argparse.Namespace) -> int:
+    required_paths = (
+        args.server_log,
+        args.server_binary,
+        Path(args.model_path) / "config.json",
+        Path(args.model_path) / "model.safetensors.index.json",
+    )
+    missing = [str(path) for path in required_paths if not path.is_file()]
+    if missing:
+        raise SystemExit(
+            f"required retained-run files are missing: {', '.join(missing)}"
+        )
+    validate_commit(args.commit)
+    return subprocess.run(build_sweep_command(args), check=False).returncode
+
+
+def combine(args: argparse.Namespace) -> int:
+    if any(path.resolve() == args.out.resolve() for path in args.summary):
+        raise SystemExit("--out must not overwrite an input --summary")
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.unlink(missing_ok=True)
+    summaries = [
+        (path, json.loads(path.read_text(encoding="utf-8"))) for path in args.summary
+    ]
+    report = build_retained_slo_report(args.model, summaries)
+    leaf_artifact_verification = verify_leaf_artifacts(summaries)
+    report["leaf_artifact_verification"] = leaf_artifact_verification
+    report["coverage_gate"]["leaf_artifacts_verified"] = leaf_artifact_verification[
+        "passed"
+    ]
+    report["coverage_gate"]["passed"] = (
+        report["coverage_gate"]["passed"]
+        and leaf_artifact_verification["passed"]
+    )
+    print(write_json(args.out, report))
+    return 0 if report["coverage_gate"]["passed"] else 1
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser(
+        "run", help="Run one fixed backend/profile contract."
+    )
+    run_parser.add_argument("--profile", choices=sorted(PROFILES), required=True)
+    run_parser.add_argument("--backend", choices=BACKENDS, required=True)
+    run_parser.add_argument("--base-url", default="http://127.0.0.1:8000")
+    run_parser.add_argument("--model", default="DeepSeek-V2-Lite")
+    run_parser.add_argument("--model-path", required=True)
+    run_parser.add_argument("--server-command", required=True)
+    run_parser.add_argument("--server-log", type=Path, required=True)
+    run_parser.add_argument("--commit", required=True)
+    run_parser.add_argument("--model-revision", required=True)
+    run_parser.add_argument("--server-binary", type=Path, required=True)
+    run_parser.add_argument("--record-startup-failure")
+    run_parser.add_argument("--out-dir", type=Path, required=True)
+
+    combine_parser = subparsers.add_parser(
+        "combine", help="Combine all six retained summaries."
+    )
+    combine_parser.add_argument("--model", default="DeepSeek-V2-Lite")
+    combine_parser.add_argument("--summary", action="append", type=Path, required=True)
+    combine_parser.add_argument("--out", type=Path, required=True)
+
+    args = parser.parse_args()
+    if args.command == "run":
+        raise SystemExit(run_profile(args))
+    raise SystemExit(combine(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_http_common.py
+++ b/scripts/bench_http_common.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Shared metadata and summary helpers for HTTP benchmark artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import platform
+import shlex
+import statistics
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODEL_FINGERPRINT_FILES = (
+    "config.json",
+    "generation_config.json",
+    "model.safetensors.index.json",
+    "special_tokens_map.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+)
+
+
+def write_json(path: Path, document: Any) -> str:
+    """Atomically replace a retained JSON artifact and return its rendered form."""
+    rendered = json.dumps(document, indent=2, sort_keys=True)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            handle.write(rendered + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+            temp_path = Path(handle.name)
+        os.replace(temp_path, path)
+    finally:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
+    return rendered
+
+
+def sha256_file(path: Path) -> str | None:
+    try:
+        digest = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+    except OSError:
+        return None
+
+
+def model_fingerprint(model_path: str | None) -> dict[str, str]:
+    if not model_path:
+        return {}
+    root = Path(model_path)
+    return {
+        name: digest
+        for name in MODEL_FINGERPRINT_FILES
+        if (digest := sha256_file(root / name)) is not None
+    }
+
+
+def current_commit() -> str | None:
+    return run_text(["git", "rev-parse", "--short=12", "HEAD"], cwd=REPO_ROOT)
+
+
+def shell_command(argv: list[str]) -> str:
+    """Render argv so artifact commands can be pasted back into a POSIX shell."""
+    return shlex.join(argv)
+
+
+def artifact_command(argv: list[str]) -> str:
+    """Render argv without leaking absolute paths inside the source checkout."""
+    normalized = []
+    for arg in argv:
+        path = Path(arg)
+        if path.is_absolute():
+            try:
+                arg = path.resolve().relative_to(REPO_ROOT).as_posix()
+            except ValueError:
+                pass
+        normalized.append(arg)
+    return shell_command(normalized)
+
+
+def run_text(command: list[str], *, cwd: Path | None = None) -> str | None:
+    try:
+        return subprocess.check_output(
+            command,
+            cwd=cwd,
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        ).strip()
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def nvcc_version() -> str | None:
+    commands = [["nvcc", "--version"]]
+    roots = [
+        Path(value)
+        for name in ("CUDA_HOME", "CUDA_PATH")
+        if (value := os.environ.get(name))
+    ]
+    roots.extend([Path("/usr/local/cuda"), *sorted(Path("/usr/local").glob("cuda-*"))])
+    for root in roots:
+        command = [str(root / "bin" / "nvcc"), "--version"]
+        if command not in commands:
+            commands.append(command)
+    for command in commands:
+        if value := run_text(command):
+            return value
+    return None
+
+
+def detect_hardware_toolchain() -> dict[str, Any]:
+    nvidia_smi = run_text(
+        [
+            "nvidia-smi",
+            "--query-gpu=name,driver_version,memory.total",
+            "--format=csv,noheader",
+        ]
+    )
+    gpu_uuids = run_text(["nvidia-smi", "--query-gpu=uuid", "--format=csv,noheader"])
+    return {
+        "gpu": nvidia_smi.splitlines() if nvidia_smi else [],
+        "gpu_identity_sha256": [
+            hashlib.sha256(uuid.strip().encode("utf-8")).hexdigest()
+            for uuid in gpu_uuids.splitlines()
+            if uuid.strip()
+        ]
+        if gpu_uuids
+        else [],
+        "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
+        "nvcc_version": nvcc_version(),
+        "rustc_version": run_text(["rustc", "--version"]),
+        "cargo_version": run_text(["cargo", "--version"]),
+        "python_version": platform.python_version(),
+        "platform": platform.platform(),
+    }
+
+
+def numeric_summary(
+    values: list[float | int | None],
+) -> dict[str, float | int | None]:
+    clean = [
+        float(value)
+        for value in values
+        if isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+    ]
+    if not clean:
+        return {"median": None, "min": None, "max": None, "samples": 0}
+    return {
+        "median": statistics.median(clean),
+        "min": min(clean),
+        "max": max(clean),
+        "samples": len(clean),
+    }
+
+
+def repeat_noise_marker(
+    value_groups: list[list[float | int | None]], repeats: int
+) -> str:
+    if repeats < 2:
+        return "insufficient_repeats"
+    for values in value_groups:
+        summary = numeric_summary(values)
+        median = summary["median"]
+        if median is None or summary["samples"] < 2:
+            continue
+        spread = float(summary["max"]) - float(summary["min"])
+        if float(median) == 0.0:
+            if spread > 0.0:
+                return "noisy"
+            continue
+        if spread / float(median) > 0.10:
+            return "noisy"
+    return "stable"
+
+
+def value_counts(values: list[str]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for value in values:
+        counts[value] = counts.get(value, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def combined_output_hash(values: list[str]) -> str:
+    return hashlib.sha256("".join(values).encode("utf-8")).hexdigest()[:16]

--- a/scripts/bench_http_serving.py
+++ b/scripts/bench_http_serving.py
@@ -16,13 +16,26 @@ import json
 import re
 import socket
 import statistics
+import sys
+import threading
 import time
 import urllib.parse
 import uuid
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field as dataclass_field
 from itertools import product
 from pathlib import Path
 from typing import Any
+
+from bench_http_common import (
+    artifact_command,
+    combined_output_hash,
+    current_commit,
+    detect_hardware_toolchain,
+    model_fingerprint,
+    sha256_file,
+    value_counts,
+    write_json,
+)
 
 
 DEFAULT_PROMPT_WORDS = (
@@ -55,6 +68,9 @@ class RequestResult:
     output_chars: int
     output_hash: str
     text_prefix: str
+    stream_chunk_tpot_ms: float | None = None
+    stream_chunk_itl_ms: list[float] = dataclass_field(default_factory=list)
+    token_timing_valid: bool | None = None
     sampling_label: str = "single"
     temperature: float = 0.0
     top_k: int = -1
@@ -68,6 +84,16 @@ class SamplingProfile:
     temperature: float
     top_k: int
     top_p: float
+
+
+@dataclass
+class StreamCapture:
+    chunks: list[str] = dataclass_field(default_factory=list)
+    inter_chunk_ms: list[float] = dataclass_field(default_factory=list)
+    first_chunk_s: float | None = None
+    first_chunk_wall_s: float | None = None
+    last_chunk_s: float | None = None
+    done_received: bool = False
 
 
 def arg_value(args: argparse.Namespace, name: str, default: Any) -> Any:
@@ -100,13 +126,17 @@ def sampled_profile(args: argparse.Namespace) -> SamplingProfile:
     )
 
 
-def sampling_profile_for(args: argparse.Namespace, global_index: int) -> SamplingProfile:
+def sampling_profile_for(
+    args: argparse.Namespace, global_index: int
+) -> SamplingProfile:
     if sampling_mode(args) == "mixed-greedy-sampled":
         return greedy_profile() if global_index % 2 == 0 else sampled_profile(args)
     return single_profile(args)
 
 
-def sampling_profiles_for_report(args: argparse.Namespace) -> dict[str, dict[str, float | int | str]]:
+def sampling_profiles_for_report(
+    args: argparse.Namespace,
+) -> dict[str, dict[str, float | int | str]]:
     if sampling_mode(args) == "mixed-greedy-sampled":
         profiles = [greedy_profile(), sampled_profile(args)]
     else:
@@ -134,14 +164,19 @@ def validate_sampling_args(args: argparse.Namespace) -> None:
     validate_top_p("--top-p", args.top_p)
     validate_top_p("--sample-top-p", args.sample_top_p)
     if args.sampling_mode == "mixed-greedy-sampled" and args.sample_temperature <= 0.0:
-        raise SystemExit("--sample-temperature must be positive in mixed-greedy-sampled mode")
+        raise SystemExit(
+            "--sample-temperature must be positive in mixed-greedy-sampled mode"
+        )
 
 
 def percentile(sorted_values: list[float], pct: float) -> float:
     if not sorted_values:
         return 0.0
-    idx = round((pct / 100.0) * (len(sorted_values) - 1))
-    return sorted_values[idx]
+    rank = (pct / 100.0) * (len(sorted_values) - 1)
+    lower = int(rank)
+    upper = min(lower + 1, len(sorted_values) - 1)
+    weight = rank - lower
+    return sorted_values[lower] * (1.0 - weight) + sorted_values[upper] * weight
 
 
 def summarize(values: list[float]) -> dict[str, float | int | None]:
@@ -181,6 +216,52 @@ def summarize_counts(values: list[int]) -> dict[str, int | None]:
     }
 
 
+def build_retention_gate(report: dict[str, Any]) -> dict[str, Any]:
+    required_trace = report.get("contract", {}).get("required_trace_coverage_ratio")
+    if required_trace is None:
+        return {"required": False, "passed": None}
+    required_trace = float(required_trace)
+    trace = report["server_trace"]
+    outcomes_passed = (
+        report["summary"]["completed"] == report["workload"]["num_requests"]
+        and report["summary"]["failed"] == 0
+        and report["summary"]["timeouts"] == 0
+    )
+    trace_passed = all(
+        float(trace.get(field) or 0.0) >= required_trace
+        for field in (
+            "coverage_ratio",
+            "active_set_coverage_ratio",
+            "decode_batch_coverage_ratio",
+            "token_timing_coverage_ratio",
+        )
+    )
+    return {
+        "required": True,
+        "passed": outcomes_passed and trace_passed,
+        "request_outcomes_passed": outcomes_passed,
+        "trace_coverage_passed": trace_passed,
+        "required_trace_coverage_ratio": required_trace,
+    }
+
+
+def is_full_server_trace(trace: dict[str, Any] | None) -> bool:
+    if trace is None:
+        return False
+    trace_fields = {
+        "queued_at_unix_s",
+        "scheduled_at_unix_s",
+        "first_token_emit_unix_s",
+        "prompt_tokens",
+        "completion_tokens",
+        "active_set_size",
+        "decode_batch_size_max",
+        "decode_step_count",
+        "batch_decode_steps",
+    }
+    return any(field in trace for field in trace_fields)
+
+
 def summarize_trace_ms(measured: list[RequestResult]) -> dict[str, Any]:
     fields = [
         "frontend_to_queue_ms",
@@ -199,10 +280,35 @@ def summarize_trace_ms(measured: list[RequestResult]) -> dict[str, Any]:
         values = [
             float(result.server_trace[field])
             for result in measured
-            if result.server_trace is not None and isinstance(result.server_trace.get(field), (int, float))
+            if is_full_server_trace(result.server_trace)
+            and isinstance(result.server_trace.get(field), (int, float))
         ]
         phase_summary[field] = summarize(values)
-    traced = [result for result in measured if result.server_trace is not None]
+    attached = [result for result in measured if result.server_trace is not None]
+    traced = [
+        result for result in measured if is_full_server_trace(result.server_trace)
+    ]
+    server_error_records = [
+        result
+        for result in measured
+        if result.server_trace is not None
+        and isinstance(result.server_trace.get("server_error"), str)
+    ]
+    token_timing_requests = [
+        result
+        for result in measured
+        if getattr(result, "token_timing_valid", None) is True
+    ]
+    token_timing_mismatches = [
+        result.request_id
+        for result in measured
+        if getattr(result, "token_timing_valid", None) is False
+    ]
+    token_timing_unknown = [
+        result.request_id
+        for result in measured
+        if getattr(result, "token_timing_valid", None) is None
+    ]
     prompt_tokens = [
         int(result.server_trace["prompt_tokens"])
         for result in traced
@@ -261,15 +367,45 @@ def summarize_trace_ms(measured: list[RequestResult]) -> dict[str, Any]:
         batched_total = None
         singleton_total = None
         batched_share = None
+    active_set_counts = value_counts([str(value) for value in active_set_sizes])
+    decode_batch_counts = value_counts([str(value) for value in decode_batch_sizes])
     return {
         "source": "server log lines matching `openinfer_http_trace`; frontend_to_queue includes HTTP ingress, tokenization, and vLLM submit before engine queue",
         "traced_requests": len(traced),
-        "missing_traces": [result.request_id for result in measured if result.server_trace is None],
+        "attached_server_records": len(attached),
+        "server_error_records": len(server_error_records),
+        "missing_traces": [
+            result.request_id
+            for result in measured
+            if not is_full_server_trace(result.server_trace)
+        ],
+        "missing_server_records": [
+            result.request_id for result in measured if result.server_trace is None
+        ],
+        "coverage_ratio": len(traced) / len(measured) if measured else 0.0,
+        "server_record_coverage_ratio": len(attached) / len(measured)
+        if measured
+        else 0.0,
         "prompt_tokens": summarize_counts(prompt_tokens),
         "completion_tokens": summarize_counts(completion_tokens),
         "phases_ms": phase_summary,
+        "active_set_sizes": active_set_counts,
+        "active_set_coverage_ratio": len(active_set_sizes) / len(measured)
+        if measured
+        else 0.0,
         "active_set_size_max": max(active_set_sizes) if active_set_sizes else None,
-        "decode_batch_size_max": max(decode_batch_sizes) if decode_batch_sizes else None,
+        "decode_batch_sizes": decode_batch_counts,
+        "decode_batch_coverage_ratio": len(decode_batch_sizes) / len(measured)
+        if measured
+        else 0.0,
+        "decode_batch_size_max": max(decode_batch_sizes)
+        if decode_batch_sizes
+        else None,
+        "token_timing_coverage_ratio": (
+            len(token_timing_requests) / len(measured) if measured else 0.0
+        ),
+        "token_timing_mismatches": token_timing_mismatches,
+        "token_timing_unknown": token_timing_unknown,
         "decode_steps": {
             "per_request": summarize_counts(decode_step_counts),
             "batched_request_steps_total": batched_total,
@@ -306,7 +442,9 @@ def single_or_list(values: list[int]) -> int | list[int]:
     return values[0] if len(values) == 1 else values
 
 
-def workload_shapes(prompt_words: list[int], max_tokens: list[int]) -> list[tuple[int, int]]:
+def workload_shapes(
+    prompt_words: list[int], max_tokens: list[int]
+) -> list[tuple[int, int]]:
     return list(product(prompt_words, max_tokens))
 
 
@@ -341,6 +479,162 @@ def parse_sse_error(payload: dict[str, Any]) -> str | None:
     return None
 
 
+def set_deadline_timeout(conn: http.client.HTTPConnection, deadline_s: float) -> None:
+    remaining_s = deadline_s - time.perf_counter()
+    if remaining_s <= 0.0:
+        raise TimeoutError("request exceeded its absolute timeout")
+    conn.timeout = remaining_s
+    if conn.sock is not None:
+        conn.sock.settimeout(remaining_s)
+
+
+def iter_response_lines(
+    response: http.client.HTTPResponse,
+    conn: http.client.HTTPConnection,
+    deadline_s: float,
+):
+    buffered = b""
+    while True:
+        set_deadline_timeout(conn, deadline_s)
+        chunk = response.read1(4096)
+        if not chunk:
+            if buffered:
+                yield buffered
+            return
+        buffered += chunk
+        while b"\n" in buffered:
+            line, buffered = buffered.split(b"\n", 1)
+            yield line
+
+
+def parse_sse_line(raw: bytes) -> tuple[bool, str]:
+    line = raw.decode("utf-8", errors="replace").strip()
+    if not line or not line.startswith("data:"):
+        return False, ""
+    data = line.removeprefix("data:").strip()
+    if data == "[DONE]":
+        return True, ""
+    payload = json.loads(data)
+    stream_error = parse_sse_error(payload)
+    if stream_error is not None:
+        raise RuntimeError(f"SSE error: {stream_error}")
+    if parse_sse_finish_reason(payload) == "error":
+        raise RuntimeError("SSE finish_reason=error")
+    return False, parse_sse_text(payload)
+
+
+def consume_sse_stream(
+    response: http.client.HTTPResponse,
+    conn: http.client.HTTPConnection,
+    deadline_s: float,
+) -> StreamCapture:
+    capture = StreamCapture()
+    for raw in iter_response_lines(response, conn, deadline_s):
+        done, text = parse_sse_line(raw)
+        if done:
+            capture.done_received = True
+            break
+        if not text:
+            continue
+        now = time.perf_counter()
+        if capture.first_chunk_s is None:
+            capture.first_chunk_s = now
+            capture.first_chunk_wall_s = time.time()
+        if capture.last_chunk_s is not None:
+            capture.inter_chunk_ms.append((now - capture.last_chunk_s) * 1000.0)
+        capture.last_chunk_s = now
+        capture.chunks.append(text)
+    if not capture.done_received:
+        raise RuntimeError("SSE stream ended before [DONE]")
+    return capture
+
+
+def start_deadline_watchdog(
+    conn: http.client.HTTPConnection,
+    deadline_s: float,
+    expired: threading.Event,
+) -> threading.Timer:
+    def interrupt_at_deadline() -> None:
+        expired.set()
+        if conn.sock is None:
+            return
+        try:
+            conn.sock.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
+
+    timer = threading.Timer(
+        max(0.0, deadline_s - time.perf_counter()), interrupt_at_deadline
+    )
+    timer.daemon = True
+    timer.start()
+    return timer
+
+
+def successful_result(
+    *,
+    index: int,
+    request_id: str,
+    prompt_words: int,
+    max_tokens: int,
+    sampling_label: str,
+    temperature: float,
+    top_k: int,
+    top_p: float,
+    status: int,
+    start_s: float,
+    start_wall_s: float,
+    capture: StreamCapture,
+) -> RequestResult:
+    end_s = time.perf_counter()
+    text = "".join(capture.chunks)
+    chunk_tpot_ms = None
+    if (
+        capture.first_chunk_s is not None
+        and capture.last_chunk_s is not None
+        and len(capture.chunks) > 1
+    ):
+        chunk_tpot_ms = (
+            (capture.last_chunk_s - capture.first_chunk_s)
+            * 1000.0
+            / (len(capture.chunks) - 1)
+        )
+    return RequestResult(
+        index=index,
+        request_id=request_id,
+        prompt_words=prompt_words,
+        max_tokens=max_tokens,
+        ok=True,
+        status=status,
+        error=None,
+        timed_out=False,
+        start_s=start_s,
+        start_wall_s=start_wall_s,
+        first_token_s=capture.first_chunk_s,
+        first_token_wall_s=capture.first_chunk_wall_s,
+        end_s=end_s,
+        end_wall_s=time.time(),
+        latency_ms=(end_s - start_s) * 1000.0,
+        ttft_ms=(
+            None
+            if capture.first_chunk_s is None
+            else (capture.first_chunk_s - start_s) * 1000.0
+        ),
+        tpot_ms=None,
+        itl_ms=[],
+        output_chunks=len(capture.chunks),
+        output_chars=len(text),
+        output_hash=hashlib.sha256(text.encode("utf-8")).hexdigest()[:16],
+        text_prefix=text[:80],
+        stream_chunk_tpot_ms=chunk_tpot_ms,
+        stream_chunk_itl_ms=capture.inter_chunk_ms,
+        sampling_label=sampling_label,
+        temperature=temperature,
+        top_k=top_k,
+        top_p=top_p,
+    )
+
+
 def request_once(
     index: int,
     request_id: str,
@@ -357,18 +651,24 @@ def request_once(
     sampling_label: str = "single",
 ) -> RequestResult:
     start = time.perf_counter()
+    deadline = start + timeout
     start_wall = time.time()
-    first_token: float | None = None
-    first_token_wall: float | None = None
-    last_token: float | None = None
-    inter_token_ms: list[float] = []
-    chunks: list[str] = []
     status: int | None = None
+    conn: http.client.HTTPConnection | None = None
+    deadline_expired = threading.Event()
+    deadline_timer: threading.Timer | None = None
 
     try:
-        conn_cls = http.client.HTTPSConnection if url.scheme == "https" else http.client.HTTPConnection
+        conn_cls = (
+            http.client.HTTPSConnection
+            if url.scheme == "https"
+            else http.client.HTTPConnection
+        )
         port = url.port
         conn = conn_cls(url.hostname, port=port, timeout=timeout)
+
+        deadline_timer = start_deadline_watchdog(conn, deadline, deadline_expired)
+        set_deadline_timeout(conn, deadline)
         path = (url.path.rstrip("/") or "") + "/v1/completions"
         body = {
             "model": model,
@@ -387,100 +687,37 @@ def request_once(
             body=json.dumps(body).encode("utf-8"),
             headers={"Content-Type": "application/json"},
         )
+        set_deadline_timeout(conn, deadline)
         response = conn.getresponse()
         status = response.status
         if status != 200:
             error_body = response.read(4096).decode("utf-8", errors="replace")
             raise RuntimeError(f"HTTP {status}: {error_body}")
 
-        while True:
-            raw = response.readline()
-            if not raw:
-                break
-            line = raw.decode("utf-8", errors="replace").strip()
-            if not line or not line.startswith("data:"):
-                continue
-            data = line.removeprefix("data:").strip()
-            if data == "[DONE]":
-                break
-            payload = json.loads(data)
-            stream_error = parse_sse_error(payload)
-            if stream_error is not None:
-                raise RuntimeError(f"SSE error: {stream_error}")
-            finish_reason = parse_sse_finish_reason(payload)
-            if finish_reason == "error":
-                raise RuntimeError("SSE finish_reason=error")
-            text = parse_sse_text(payload)
-            if not text:
-                continue
-            now = time.perf_counter()
-            if first_token is None:
-                first_token = now
-                first_token_wall = time.time()
-            if last_token is not None:
-                inter_token_ms.append((now - last_token) * 1000.0)
-            last_token = now
-            chunks.append(text)
-        conn.close()
-        if max_tokens > 0 and not chunks:
+        capture = consume_sse_stream(response, conn, deadline)
+        if deadline_expired.is_set() or time.perf_counter() > deadline:
+            raise TimeoutError("request exceeded its absolute timeout")
+        if max_tokens > 0 and not capture.chunks:
             raise RuntimeError("stream completed without streamed text chunks")
-        end = time.perf_counter()
-        end_wall = time.time()
-        text = "".join(chunks)
-        output_hash = hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
-        latency_ms = (end - start) * 1000.0
-        ttft_ms = None if first_token is None else (first_token - start) * 1000.0
-        tpot_ms = None
-        if first_token is not None and last_token is not None and len(chunks) > 1:
-            tpot_ms = (last_token - first_token) * 1000.0 / (len(chunks) - 1)
-        return RequestResult(
+        return successful_result(
             index=index,
             request_id=request_id,
             prompt_words=prompt_words,
             max_tokens=max_tokens,
-            ok=True,
-            status=status,
-            error=None,
-            timed_out=False,
-            start_s=start,
-            start_wall_s=start_wall,
-            first_token_s=first_token,
-            first_token_wall_s=first_token_wall,
-            end_s=end,
-            end_wall_s=end_wall,
-            latency_ms=latency_ms,
-            ttft_ms=ttft_ms,
-            tpot_ms=tpot_ms,
-            itl_ms=inter_token_ms,
-            output_chunks=len(chunks),
-            output_chars=len(text),
-            output_hash=output_hash,
-            text_prefix=text[:80],
             sampling_label=sampling_label,
             temperature=temperature,
             top_k=top_k,
             top_p=top_p,
-        )
-    except (TimeoutError, socket.timeout) as exc:
-        end = time.perf_counter()
-        return failed_result(
-            index,
-            request_id,
-            prompt_words,
-            max_tokens,
-            sampling_label,
-            temperature,
-            top_k,
-            top_p,
-            status,
-            start,
-            start_wall,
-            end,
-            str(exc),
-            timed_out=True,
+            status=status,
+            start_s=start,
+            start_wall_s=start_wall,
+            capture=capture,
         )
     except Exception as exc:  # noqa: BLE001 - benchmark reports the error string.
         end = time.perf_counter()
+        timed_out = deadline_expired.is_set() or isinstance(
+            exc, (TimeoutError, socket.timeout)
+        )
         return failed_result(
             index,
             request_id,
@@ -495,8 +732,13 @@ def request_once(
             start_wall,
             end,
             str(exc),
-            timed_out=False,
+            timed_out=timed_out,
         )
+    finally:
+        if deadline_timer is not None:
+            deadline_timer.cancel()
+        if conn is not None:
+            conn.close()
 
 
 def failed_result(
@@ -574,7 +816,9 @@ def load_server_traces(
         stream_error_match = STREAM_ERROR_RE.search(line)
         if stream_error_match:
             request_id = stream_error_match.group(1)
-            traces.setdefault(request_id, {"request_id": request_id})["server_error"] = line.strip()
+            traces.setdefault(request_id, {"request_id": request_id})[
+                "server_error"
+            ] = line.strip()
             continue
         match = TRACE_RE.search(line)
         if not match:
@@ -592,7 +836,9 @@ def load_server_traces(
     return traces
 
 
-def attach_server_traces(results: list[RequestResult], traces: dict[str, dict[str, Any]]) -> None:
+def attach_server_traces(
+    results: list[RequestResult], traces: dict[str, dict[str, Any]]
+) -> None:
     for result in results:
         trace = find_server_trace(
             result.request_id,
@@ -606,14 +852,39 @@ def attach_server_traces(results: list[RequestResult], traces: dict[str, dict[st
         if result.ok and result.first_token_wall_s is not None:
             emit_at = trace.get("first_token_emit_unix_s")
             if isinstance(emit_at, (int, float)):
-                trace["stream_flush_ms"] = max(0.0, (result.first_token_wall_s - float(emit_at)) * 1000.0)
+                trace["stream_flush_ms"] = max(
+                    0.0, (result.first_token_wall_s - float(emit_at)) * 1000.0
+                )
             queued_at = trace.get("queued_at_unix_s")
             if isinstance(queued_at, (int, float)):
-                trace["frontend_to_queue_ms"] = max(0.0, (float(queued_at) - result.start_wall_s) * 1000.0)
+                trace["frontend_to_queue_ms"] = max(
+                    0.0, (float(queued_at) - result.start_wall_s) * 1000.0
+                )
             scheduled_at = trace.get("scheduled_at_unix_s")
-            if isinstance(queued_at, (int, float)) and isinstance(scheduled_at, (int, float)):
-                trace["admission_queue_ms"] = max(0.0, (float(scheduled_at) - float(queued_at)) * 1000.0)
+            if isinstance(queued_at, (int, float)) and isinstance(
+                scheduled_at, (int, float)
+            ):
+                trace["admission_queue_ms"] = max(
+                    0.0, (float(scheduled_at) - float(queued_at)) * 1000.0
+                )
         apply_server_error_gate(result)
+        finalize_token_timing(result)
+
+
+def finalize_token_timing(result: RequestResult) -> None:
+    trace = result.server_trace
+    if trace is None or not isinstance(trace.get("completion_tokens"), int):
+        return
+    completion_tokens = int(trace["completion_tokens"])
+    result.token_timing_valid = result.output_chunks == completion_tokens
+    if result.token_timing_valid:
+        if result.stream_chunk_tpot_ms is not None:
+            result.tpot_ms = result.stream_chunk_tpot_ms
+        if result.stream_chunk_itl_ms:
+            result.itl_ms = list(result.stream_chunk_itl_ms)
+        return
+    result.tpot_ms = None
+    result.itl_ms = []
 
 
 def apply_server_error_gate(result: RequestResult) -> None:
@@ -645,7 +916,9 @@ def find_server_trace(
     matches = [
         trace
         for trace_id, trace in traces.items()
-        if trace_id == request_id or trace_id == f"cmpl-{request_id}" or trace_id.startswith(prefix)
+        if trace_id == request_id
+        or trace_id == f"cmpl-{request_id}"
+        or trace_id.startswith(prefix)
     ]
     timed_matches = []
     for trace in matches:
@@ -674,7 +947,9 @@ def find_server_trace(
     return None
 
 
-def run_batch(args: argparse.Namespace, measured: bool) -> tuple[list[RequestResult], float]:
+def run_batch(
+    args: argparse.Namespace, measured: bool
+) -> tuple[list[RequestResult], float]:
     url = urllib.parse.urlparse(args.base_url)
     if url.scheme not in {"http", "https"} or not url.hostname:
         raise SystemExit(f"invalid --base-url: {args.base_url}")
@@ -719,36 +994,64 @@ def run_batch(args: argparse.Namespace, measured: bool) -> tuple[list[RequestRes
                 top_p=profile.top_p,
                 sampling_label=profile.label,
             )
-            for idx, (_global_index, prompt_words, max_tokens, prompt, profile) in enumerate(workloads)
+            for idx, (
+                _global_index,
+                prompt_words,
+                max_tokens,
+                prompt,
+                profile,
+            ) in enumerate(workloads)
         ]
-        results = [future.result() for future in concurrent.futures.as_completed(futures)]
+        results = [
+            future.result() for future in concurrent.futures.as_completed(futures)
+        ]
     ended = time.perf_counter()
     results.sort(key=lambda result: result.index)
     return results, ended - started
 
 
-def build_report(args: argparse.Namespace, measured: list[RequestResult], wall_s: float) -> dict[str, Any]:
+def build_report(
+    args: argparse.Namespace, measured: list[RequestResult], wall_s: float
+) -> dict[str, Any]:
+    backend = getattr(args, "backend", None)
+    contract_name = getattr(args, "contract_name", None)
+    contract_description = getattr(args, "contract_description", None)
+    claim_boundary = getattr(args, "claim_boundary", None)
+    required_trace_coverage = getattr(args, "required_trace_coverage", None)
+    for result in measured:
+        finalize_token_timing(result)
     successes = [result for result in measured if result.ok]
     failures = [result for result in measured if not result.ok]
     latencies = [result.latency_ms for result in successes]
     ttfts = [result.ttft_ms for result in successes if result.ttft_ms is not None]
     tpots = [result.tpot_ms for result in successes if result.tpot_ms is not None]
     itls: list[float] = []
+    stream_chunk_tpots = [
+        result.stream_chunk_tpot_ms
+        for result in successes
+        if result.stream_chunk_tpot_ms is not None
+    ]
+    stream_chunk_itls = [
+        value for result in successes for value in result.stream_chunk_itl_ms
+    ]
     output_chunks = [result.output_chunks for result in successes]
     output_chars = [result.output_chars for result in successes]
     hashes = [result.output_hash for result in successes]
     input_tokens = [
         int(result.server_trace["prompt_tokens"])
-        if result.server_trace is not None and isinstance(result.server_trace.get("prompt_tokens"), int)
+        if result.server_trace is not None
+        and isinstance(result.server_trace.get("prompt_tokens"), int)
         else result.prompt_words
         for result in successes
     ]
     output_tokens = [
         int(result.server_trace["completion_tokens"])
-        if result.server_trace is not None and isinstance(result.server_trace.get("completion_tokens"), int)
-        else (result.max_tokens if args.ignore_eos else result.output_chunks)
         for result in successes
+        if result.server_trace is not None
+        and isinstance(result.server_trace.get("completion_tokens"), int)
     ]
+    output_token_counts_complete = len(output_tokens) == len(successes)
+    output_tokens_total = sum(output_tokens) if output_token_counts_complete else None
     shape_counts: dict[str, int] = {}
     for result in measured:
         key = f"prompt_words={result.prompt_words},max_tokens={result.max_tokens}"
@@ -757,11 +1060,39 @@ def build_report(args: argparse.Namespace, measured: list[RequestResult], wall_s
     for result in successes:
         itls.extend(result.itl_ms)
 
-    return {
+    report = {
         "schema_version": 1,
         "kind": "openai_http_completions_stream_benchmark",
+        "report_intent": "http_serving_slo"
+        if contract_name
+        else "http_serving_benchmark",
         "base_url": args.base_url,
         "model": args.model,
+        "backend": backend,
+        "contract": {
+            "name": contract_name,
+            "backend": backend,
+            "description": contract_description,
+            "required_trace_coverage_ratio": required_trace_coverage,
+            "claim_boundary": claim_boundary
+            or "HTTP streaming benchmark evidence only; direct, profiler, soak, and production-readiness claims require separate artifacts.",
+        },
+        "metadata": {
+            "commit": getattr(args, "commit", None) or current_commit(),
+            "backend": backend,
+            "contract_name": contract_name,
+            "model_path": getattr(args, "model_path", None),
+            "server_command": getattr(args, "server_command", None),
+            "source_revision": getattr(args, "source_revision", None),
+            "model_revision": getattr(args, "model_revision", None),
+            "model_fingerprint": model_fingerprint(getattr(args, "model_path", None)),
+            "server_binary_sha256": sha256_file(Path(getattr(args, "server_binary")))
+            if getattr(args, "server_binary", None)
+            else None,
+            "backend_runtime_version": getattr(args, "backend_runtime_version", None),
+            "benchmark_command": artifact_command(sys.argv),
+            "hardware_toolchain": detect_hardware_toolchain(),
+        },
         "workload": {
             "num_requests": args.num_requests,
             "concurrency": args.concurrency,
@@ -777,6 +1108,7 @@ def build_report(args: argparse.Namespace, measured: list[RequestResult], wall_s
             "sampling_counts": count_sampling(measured),
             "ignore_eos": args.ignore_eos,
             "timeout_s": args.timeout,
+            "timeout_kind": "absolute_request_deadline",
         },
         "summary": {
             "wall_s": wall_s,
@@ -788,10 +1120,24 @@ def build_report(args: argparse.Namespace, measured: list[RequestResult], wall_s
             "failed_sampling_counts": count_sampling(failures),
             "qps": len(successes) / wall_s if wall_s > 0 else 0.0,
             "input_tokens_total": sum(input_tokens),
-            "output_tokens_total": sum(output_tokens),
+            "output_tokens_total": output_tokens_total,
             "input_tokens_per_s": sum(input_tokens) / wall_s if wall_s > 0 else 0.0,
-            "output_tokens_per_s": sum(output_tokens) / wall_s if wall_s > 0 else 0.0,
-            "error_rate": len(failures) / args.num_requests if args.num_requests else 0.0,
+            "output_tokens_per_s": (
+                output_tokens_total / wall_s
+                if output_tokens_total is not None and wall_s > 0
+                else None
+            ),
+            "output_token_count_source": (
+                "server_trace.completion_tokens"
+                if output_token_counts_complete
+                else "unavailable"
+            ),
+            "output_token_count_coverage_ratio": (
+                len(output_tokens) / len(successes) if successes else 0.0
+            ),
+            "error_rate": len(failures) / args.num_requests
+            if args.num_requests
+            else 0.0,
             "timeout_rate": (
                 sum(1 for result in failures if result.timed_out) / args.num_requests
                 if args.num_requests
@@ -800,37 +1146,98 @@ def build_report(args: argparse.Namespace, measured: list[RequestResult], wall_s
             "output_chunks_total": sum(output_chunks),
             "output_chars_total": sum(output_chars),
             "unique_output_hashes": len(set(hashes)),
-            "combined_output_hash": hashlib.sha256("".join(hashes).encode("utf-8")).hexdigest()[:16],
+            "output_hash_distribution": value_counts(hashes),
+            "combined_output_hash": combined_output_hash(hashes),
         },
         "metrics": {
             "latency": summarize(latencies),
             "ttft": summarize(ttfts),
             "tpot": summarize(tpots),
             "itl": summarize(itls),
+            "stream_chunk_tpot": summarize(stream_chunk_tpots),
+            "stream_chunk_itl": summarize(stream_chunk_itls),
+        },
+        "metric_definitions": {
+            "percentile_method": "R7 linear interpolation over sorted samples",
+            "ttft": "request start to first non-empty streamed text chunk",
+            "tpot": "mean inter-token time per request, emitted only when streamed text chunk count equals server completion_tokens",
+            "itl": "inter-token latency, emitted only when streamed text chunk count equals server completion_tokens",
+            "stream_chunk_tpot": "mean inter-chunk time per request; diagnostic when a chunk can contain multiple tokens",
+            "stream_chunk_itl": "inter-chunk latency; diagnostic when a chunk can contain multiple tokens",
+            "output_tokens": "server trace completion_tokens only; unavailable when any successful request lacks a trusted token count",
         },
         "server_trace": summarize_trace_ms(measured),
         "requests": [asdict(result) for result in measured],
     }
+    report["retention_gate"] = build_retention_gate(report)
+    report["latency_budget"] = {
+        "configured": False,
+        "passed": None,
+        "reason": "This retained report records latency distributions but does not define a production latency budget.",
+    }
+    return report
 
 
-def main() -> None:
+def write_report(args: argparse.Namespace, report: dict[str, Any]) -> None:
+    if args.out:
+        rendered = write_json(args.out, report)
+    else:
+        rendered = json.dumps(report, indent=2, sort_keys=True)
+    print(rendered)
+
+
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--base-url", default="http://127.0.0.1:8000")
     parser.add_argument("--model", required=True)
     parser.add_argument("--num-requests", type=int, default=8)
     parser.add_argument("--concurrency", type=int, default=2)
-    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--warmup", type=int)
     parser.add_argument(
         "--prompt-words",
         type=parse_int_list,
-        default=[16],
+        default=None,
         help="Prompt word count, or comma-separated counts for a mixed workload.",
     )
     parser.add_argument(
         "--max-tokens",
         type=parse_int_list,
-        default=[16],
+        default=None,
         help="Completion token count, or comma-separated counts for a mixed workload.",
+    )
+    parser.add_argument("--contract-name", help="Stable report contract name.")
+    parser.add_argument(
+        "--contract-description", help="Contract description written into JSON."
+    )
+    parser.add_argument(
+        "--claim-boundary", help="Claim boundary written into the JSON report."
+    )
+    parser.add_argument(
+        "--required-trace-coverage",
+        type=float,
+        help="Require request, active-set, and decode-batch trace coverage at this ratio.",
+    )
+    parser.add_argument(
+        "--backend", help="Backend label, for example host-staged or nccl."
+    )
+    parser.add_argument("--model-path", help="Server model path used for this run.")
+    parser.add_argument(
+        "--server-command", help="Server launch command used for this run."
+    )
+    parser.add_argument(
+        "--commit", help="OpenInfer commit for this run; defaults to git HEAD."
+    )
+    parser.add_argument(
+        "--source-revision", help="Exact source-tree revision identifier."
+    )
+    parser.add_argument(
+        "--model-revision", help="Model snapshot or revision identifier."
+    )
+    parser.add_argument(
+        "--server-binary", type=Path, help="Server binary used for this run."
+    )
+    parser.add_argument(
+        "--backend-runtime-version", help="Loaded backend runtime version."
     )
     parser.add_argument("--temperature", type=float, default=0.0)
     parser.add_argument("--top-k", type=int, default=-1)
@@ -847,8 +1254,10 @@ def main() -> None:
     parser.add_argument("--sample-temperature", type=float, default=0.8)
     parser.add_argument("--sample-top-k", type=int, default=40)
     parser.add_argument("--sample-top-p", type=float, default=0.95)
-    parser.add_argument("--timeout", type=float, default=120.0)
-    parser.add_argument("--ignore-eos", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--timeout", type=float)
+    parser.add_argument(
+        "--ignore-eos", action=argparse.BooleanOptionalAction, default=True
+    )
     parser.add_argument(
         "--server-log",
         type=Path,
@@ -856,29 +1265,62 @@ def main() -> None:
     )
     parser.add_argument("--out", type=Path)
     args = parser.parse_args()
+    if args.prompt_words is None:
+        args.prompt_words = [16]
+    if args.max_tokens is None:
+        args.max_tokens = [16]
+    if args.timeout is None:
+        args.timeout = 120.0
+    if args.warmup is None:
+        args.warmup = 1
+    return args
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    if args.contract_name and not args.backend:
+        raise SystemExit("--backend is required when --contract-name is set")
+    if args.required_trace_coverage is not None:
+        if args.required_trace_coverage <= 0.0 or args.required_trace_coverage > 1.0:
+            raise SystemExit("--required-trace-coverage must be in (0, 1]")
+        if args.server_log is None:
+            raise SystemExit("--server-log is required with --required-trace-coverage")
 
     if args.concurrency <= 0:
         raise SystemExit("--concurrency must be positive")
     if args.num_requests <= 0:
         raise SystemExit("--num-requests must be positive")
+    if args.timeout <= 0.0:
+        raise SystemExit("--timeout must be positive")
     validate_sampling_args(args)
-    if args.warmup > 0:
-        warmup_results, _ = run_batch(args, measured=False)
-        failed = [result for result in warmup_results if not result.ok]
-        if failed:
-            raise SystemExit(f"warmup failed: {failed[0].error}")
+
+
+def run_warmup(args: argparse.Namespace) -> None:
+    if args.warmup <= 0:
+        return
+    warmup_results, _ = run_batch(args, measured=False)
+    attach_server_traces(warmup_results, load_server_traces(args.server_log))
+    if any(not result.ok for result in warmup_results):
+        report = build_report(args, warmup_results, wall_s=0.0)
+        report["report_intent"] = "http_serving_slo_warmup_failure"
+        report["warmup_failed"] = True
+        write_report(args, report)
+        raise SystemExit(1)
+
+
+def main() -> None:
+    args = parse_args()
+    validate_args(args)
+    run_warmup(args)
 
     trace_offset = server_log_offset(args.server_log)
     measured, wall_s = run_batch(args, measured=True)
-    attach_server_traces(measured, load_server_traces(args.server_log, start_offset=trace_offset))
+    attach_server_traces(
+        measured, load_server_traces(args.server_log, start_offset=trace_offset)
+    )
     report = build_report(args, measured, wall_s)
-    rendered = json.dumps(report, indent=2, sort_keys=True)
-    if args.out:
-        args.out.parent.mkdir(parents=True, exist_ok=True)
-        args.out.write_text(rendered + "\n", encoding="utf-8")
-    print(rendered)
+    write_report(args, report)
 
-    if report["summary"]["failed"]:
+    if report["summary"]["failed"] or report["retention_gate"].get("passed") is False:
         raise SystemExit(1)
 
 

--- a/scripts/bench_http_sweep.py
+++ b/scripts/bench_http_sweep.py
@@ -10,9 +10,65 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from bench_http_common import (
+    artifact_command,
+    combined_output_hash,
+    current_commit,
+    detect_hardware_toolchain,
+    model_fingerprint,
+    numeric_summary,
+    repeat_noise_marker,
+    sha256_file,
+    value_counts,
+    write_json,
+)
+
 
 SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
 BENCH = SCRIPT_DIR / "bench_http_serving.py"
+PERCENTILES = ("p50", "p95", "p99")
+TRACE_COVERAGE_FIELDS = (
+    "traced_requests",
+    "attached_server_records",
+    "server_error_records",
+    "missing_traces",
+    "missing_server_records",
+    "coverage_ratio",
+    "server_record_coverage_ratio",
+    "active_set_coverage_ratio",
+    "active_set_size_max",
+    "decode_batch_coverage_ratio",
+    "decode_batch_size_max",
+    "token_timing_coverage_ratio",
+    "token_timing_mismatches",
+    "token_timing_unknown",
+)
+LEAF_METADATA_FIELDS = (
+    "commit",
+    "backend",
+    "contract_name",
+    "model_path",
+    "server_command",
+    "source_revision",
+    "model_revision",
+    "model_fingerprint",
+    "server_binary_sha256",
+    "backend_runtime_version",
+    "hardware_toolchain",
+)
+LEAF_WORKLOAD_FIELDS = (
+    "num_requests",
+    "warmup",
+    "temperature",
+    "top_k",
+    "top_p",
+    "sampling_mode",
+    "sampling_profiles",
+    "ignore_eos",
+    "timeout_s",
+    "timeout_kind",
+)
 
 
 def parse_int_list(value: str) -> list[int]:
@@ -25,13 +81,23 @@ def parse_int_list(value: str) -> list[int]:
     return parsed
 
 
-def request_hashes(report: dict[str, Any], sampling_label: str | None = None) -> list[str]:
+def request_hashes(
+    report: dict[str, Any], sampling_label: str | None = None
+) -> list[str]:
     return [
         request["output_hash"]
         for request in report["requests"]
         if request["ok"]
         and (sampling_label is None or request.get("sampling_label") == sampling_label)
     ]
+
+
+def report_hash_manifest_passes(report: dict[str, Any]) -> bool:
+    hashes = request_hashes(report)
+    summary = report.get("summary") or {}
+    return summary.get("output_hash_distribution") == value_counts(
+        hashes
+    ) and summary.get("combined_output_hash") == combined_output_hash(hashes)
 
 
 def successful_requests_have_output_evidence(report: dict[str, Any]) -> bool:
@@ -45,7 +111,9 @@ def successful_requests_have_output_evidence(report: dict[str, Any]) -> bool:
     return True
 
 
-def sampling_profiles(args: argparse.Namespace) -> dict[str, dict[str, float | int | str]]:
+def sampling_profiles(
+    args: argparse.Namespace,
+) -> dict[str, dict[str, float | int | str]]:
     if args.sampling_mode == "mixed-greedy-sampled":
         return {
             "greedy": {
@@ -88,14 +156,144 @@ def sampling_cli_args(args: argparse.Namespace) -> list[str]:
     ]
 
 
-def run_one(
+def nested_value(document: dict[str, Any], path: tuple[str, ...]) -> Any:
+    current: Any = document
+    for key in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def first_nested_value(reports: list[dict[str, Any]], *paths: tuple[str, ...]) -> Any:
+    for report in reports:
+        for path in paths:
+            value = nested_value(report, path)
+            if value is not None:
+                return value
+    return None
+
+
+def noisy_cell_marker(reports: list[dict[str, Any]]) -> str:
+    if any(
+        (report.get("metadata") or {}).get("benchmark_returncode") != 0
+        for report in reports
+    ):
+        return "benchmark_error"
+    if any(
+        report["summary"]["failed"] or report["summary"]["timeouts"]
+        for report in reports
+    ):
+        return "failed_or_timeout"
+    return repeat_noise_marker(
+        [
+            [report["metrics"][metric]["p95_ms"] for report in reports]
+            for metric in ("ttft", "tpot", "itl")
+        ]
+        + [
+            [report["summary"]["qps"] for report in reports],
+            [report["summary"]["output_tokens_per_s"] for report in reports],
+        ],
+        len(reports),
+    )
+
+
+def report_trace_gate_passes(
+    report: dict[str, Any], required_trace_coverage: float | None
+) -> bool:
+    if required_trace_coverage is None:
+        return True
+    trace = report.get("server_trace") or {}
+    return all(
+        float(trace.get(field) or 0.0) >= required_trace_coverage
+        for field in (
+            "coverage_ratio",
+            "active_set_coverage_ratio",
+            "decode_batch_coverage_ratio",
+            "token_timing_coverage_ratio",
+        )
+    )
+
+
+def metric_repeat_summary(reports: list[dict[str, Any]], metric: str) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for percentile in PERCENTILES:
+        values = [report["metrics"][metric][f"{percentile}_ms"] for report in reports]
+        result[percentile] = values
+        result[f"{percentile}_summary"] = numeric_summary(values)
+    return result
+
+
+def trace_coverage(report: dict[str, Any]) -> dict[str, Any]:
+    trace = report.get("server_trace") or {}
+    return {field: trace.get(field) for field in TRACE_COVERAGE_FIELDS}
+
+
+def empty_metric_repeat_summary() -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for percentile in PERCENTILES:
+        result[percentile] = []
+        result[f"{percentile}_summary"] = numeric_summary([])
+    return result
+
+
+def empty_trace_coverage() -> dict[str, Any]:
+    return {
+        "traced_requests": 0,
+        "attached_server_records": 0,
+        "server_error_records": 0,
+        "missing_traces": [],
+        "missing_server_records": [],
+        "coverage_ratio": 0.0,
+        "server_record_coverage_ratio": 0.0,
+        "active_set_coverage_ratio": 0.0,
+        "active_set_size_max": None,
+        "decode_batch_coverage_ratio": 0.0,
+        "decode_batch_size_max": None,
+        "token_timing_coverage_ratio": 0.0,
+        "token_timing_mismatches": [],
+        "token_timing_unknown": [],
+    }
+
+
+def prepare_summary_path(out_dir: Path) -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = out_dir / "sweep_summary.json"
+    summary_path.unlink(missing_ok=True)
+    for cell_path in out_dir.glob("pw*_c*_mt*_r*.json"):
+        cell_path.unlink()
+    return summary_path
+
+
+def leaf_artifact_manifest(reports: list[dict[str, Any]]) -> list[dict[str, str]]:
+    artifacts = []
+    for report in reports:
+        artifact = (report.get("metadata") or {}).get("benchmark_artifact")
+        if not isinstance(artifact, str):
+            continue
+        digest = sha256_file(Path(artifact))
+        if digest is not None:
+            artifacts.append({"artifact": artifact, "sha256": digest})
+    return sorted(artifacts, key=lambda item: item["artifact"])
+
+
+def build_benchmark_command(
     args: argparse.Namespace,
-    prompt_words: int,
+    prompt_words: int | list[int],
     concurrency: int,
     max_tokens: int,
     repeat: int,
-) -> dict[str, Any]:
-    out = args.out_dir / f"pw{prompt_words}_c{concurrency}_mt{max_tokens}_r{repeat}.json"
+) -> tuple[list[str], Path]:
+    prompt_words_arg = (
+        ",".join(str(value) for value in prompt_words)
+        if isinstance(prompt_words, list)
+        else str(prompt_words)
+    )
+    prompt_words_slug = prompt_words_arg.replace(",", "-")
+    out = (
+        args.out_dir
+        / f"pw{prompt_words_slug}_c{concurrency}_mt{max_tokens}_r{repeat}.json"
+    )
     cmd = [
         sys.executable,
         str(BENCH),
@@ -110,7 +308,7 @@ def run_one(
         "--warmup",
         str(args.warmup),
         "--prompt-words",
-        str(prompt_words),
+        prompt_words_arg,
         "--max-tokens",
         str(max_tokens),
         "--temperature",
@@ -121,108 +319,319 @@ def run_one(
         str(out),
     ]
     cmd.extend(sampling_cli_args(args))
+    optional_values = (
+        ("--server-log", args.server_log),
+        ("--contract-name", args.contract_name),
+        ("--contract-description", args.contract_description),
+        ("--backend", args.backend),
+        ("--model-path", args.model_path),
+        ("--server-command", args.server_command),
+        ("--commit", args.commit),
+        ("--source-revision", args.source_revision),
+        ("--model-revision", args.model_revision),
+        ("--server-binary", args.server_binary),
+        ("--backend-runtime-version", args.backend_runtime_version),
+        ("--claim-boundary", args.claim_boundary),
+        ("--required-trace-coverage", args.required_trace_coverage),
+    )
+    cmd.extend(
+        item
+        for flag, value in optional_values
+        if value is not None
+        for item in (flag, str(value))
+    )
     if args.no_ignore_eos:
         cmd.append("--no-ignore-eos")
-    if args.server_log:
-        cmd.extend(["--server-log", str(args.server_log)])
-    subprocess.run(cmd, check=True)
-    return json.loads(out.read_text(encoding="utf-8"))
+    return cmd, out
 
 
-def build_summary(args: argparse.Namespace, reports: list[dict[str, Any]]) -> dict[str, Any]:
-    cells: dict[tuple[int, int, int], list[dict[str, Any]]] = {}
+def run_one(
+    args: argparse.Namespace,
+    prompt_words: int | list[int],
+    concurrency: int,
+    max_tokens: int,
+    repeat: int,
+) -> dict[str, Any]:
+    cmd, out = build_benchmark_command(
+        args, prompt_words, concurrency, max_tokens, repeat
+    )
+    out.unlink(missing_ok=True)
+    completed = subprocess.run(cmd, check=False)
+    if not out.exists():
+        raise FileNotFoundError(
+            f"benchmark command exited {completed.returncode} without writing {out}"
+        )
+    report = json.loads(out.read_text(encoding="utf-8"))
+    metadata = report.setdefault("metadata", {})
+    metadata["benchmark_returncode"] = completed.returncode
+    metadata["benchmark_artifact"] = str(out)
+    write_json(out, report)
+    return report
+
+
+def metric_sample_counts_pass(report: dict[str, Any]) -> bool:
+    successful = [request for request in report["requests"] if request["ok"]]
+    expected = {
+        "ttft": sum(request.get("ttft_ms") is not None for request in successful),
+        "tpot": sum(request.get("tpot_ms") is not None for request in successful),
+        "itl": sum(len(request.get("itl_ms") or []) for request in successful),
+    }
+    return all(
+        report["metrics"][metric]["samples"] == samples
+        for metric, samples in expected.items()
+    )
+
+
+def cell_evidence(
+    args: argparse.Namespace, reports: list[dict[str, Any]]
+) -> dict[str, Any]:
+    hash_groups = [request_hashes(report) for report in reports]
+    greedy_groups = [
+        request_hashes(report, sampling_label="greedy") for report in reports
+    ]
+    sampled_groups = [
+        request_hashes(report, sampling_label="sampled") for report in reports
+    ]
+    hashes_stable = all(group == hash_groups[0] for group in hash_groups[1:])
+    greedy_hashes_stable = all(group == greedy_groups[0] for group in greedy_groups[1:])
+    evidence = {
+        "zero_failures": all(
+            not report["summary"]["failed"] and not report["summary"]["timeouts"]
+            for report in reports
+        ),
+        "hashes_stable": hashes_stable,
+        "greedy_hashes_stable": greedy_hashes_stable,
+        "greedy_hashes_present": all(bool(group) for group in greedy_groups),
+        "sampled_hashes_present": all(bool(group) for group in sampled_groups),
+        "output_evidence_present": all(
+            successful_requests_have_output_evidence(report) for report in reports
+        ),
+        "trace_coverage_passed": all(
+            report_trace_gate_passes(report, args.required_trace_coverage)
+            for report in reports
+        ),
+        "metric_sample_coverage_passed": all(
+            metric_sample_counts_pass(report) for report in reports
+        ),
+        "benchmark_commands_passed": all(
+            (report.get("metadata") or {}).get("benchmark_returncode") == 0
+            for report in reports
+        ),
+        "hash_manifests_consistent": all(
+            report_hash_manifest_passes(report) for report in reports
+        ),
+        "request_output_hashes_by_repeat": hash_groups,
+        "greedy_output_hashes_by_repeat": greedy_groups,
+        "sampled_output_hashes_by_repeat": sampled_groups,
+    }
+    single_mode = args.sampling_mode == "single"
+    evidence["passed"] = all(
+        evidence[field]
+        for field in (
+            "zero_failures",
+            "output_evidence_present",
+            "trace_coverage_passed",
+            "metric_sample_coverage_passed",
+            "benchmark_commands_passed",
+            "hash_manifests_consistent",
+        )
+    ) and (
+        hashes_stable
+        if single_mode
+        else evidence["greedy_hashes_present"]
+        and greedy_hashes_stable
+        and evidence["sampled_hashes_present"]
+    )
+    return evidence
+
+
+def build_cell_row(
+    args: argparse.Namespace,
+    reports: list[dict[str, Any]],
+    backend: str | None,
+    prompt_words: int | list[int],
+    concurrency: int,
+    max_tokens: int,
+) -> dict[str, Any]:
+    evidence = cell_evidence(args, reports)
+    hash_groups = evidence["request_output_hashes_by_repeat"]
+    return {
+        "backend": backend
+        or first_nested_value(
+            reports, ("backend",), ("contract", "backend"), ("metadata", "backend")
+        ),
+        "concurrency": concurrency,
+        "prompt_words": prompt_words,
+        "max_tokens": max_tokens,
+        "repeats": len(reports),
+        "tail_sample_sufficient": args.num_requests >= 30,
+        "passed": evidence["passed"],
+        "noisy_cell": noisy_cell_marker(reports),
+        "output_evidence_present": evidence["output_evidence_present"],
+        "trace_coverage_passed": evidence["trace_coverage_passed"],
+        "metric_sample_coverage_passed": evidence["metric_sample_coverage_passed"],
+        "benchmark_commands_passed": evidence["benchmark_commands_passed"],
+        "hash_manifests_consistent": evidence["hash_manifests_consistent"],
+        "hash_stability_checked": args.sampling_mode == "single",
+        "stable_per_request_hashes": evidence["hashes_stable"],
+        "greedy_hash_stability_checked": args.sampling_mode == "mixed-greedy-sampled",
+        "stable_greedy_hashes": evidence["greedy_hashes_stable"],
+        "greedy_hashes_present": evidence["greedy_hashes_present"],
+        "sampled_hashes_present": evidence["sampled_hashes_present"],
+        "request_output_hashes_by_repeat": hash_groups,
+        "greedy_output_hashes_by_repeat": evidence["greedy_output_hashes_by_repeat"],
+        "sampled_output_hashes_by_repeat": evidence["sampled_output_hashes_by_repeat"],
+        "output_hash_distribution": value_counts(
+            [output_hash for group in hash_groups for output_hash in group]
+        ),
+        "combined_output_hashes": [
+            combined_output_hash(group) for group in hash_groups
+        ],
+        "qps": [report["summary"]["qps"] for report in reports],
+        "qps_summary": numeric_summary(
+            [report["summary"]["qps"] for report in reports]
+        ),
+        "input_tokens_per_s": [
+            report["summary"]["input_tokens_per_s"] for report in reports
+        ],
+        "output_tokens_per_s": [
+            report["summary"]["output_tokens_per_s"] for report in reports
+        ],
+        "output_tokens_per_s_summary": numeric_summary(
+            [report["summary"]["output_tokens_per_s"] for report in reports]
+        ),
+        "ttft_ms": metric_repeat_summary(reports, "ttft"),
+        "tpot_ms": metric_repeat_summary(reports, "tpot"),
+        "itl_ms": metric_repeat_summary(reports, "itl"),
+        "ttft_avg_ms": [report["metrics"]["ttft"]["avg_ms"] for report in reports],
+        "tpot_avg_ms": [report["metrics"]["tpot"]["avg_ms"] for report in reports],
+        "itl_avg_ms": [report["metrics"]["itl"]["avg_ms"] for report in reports],
+        "completed": [report["summary"]["completed"] for report in reports],
+        "failed": [report["summary"]["failed"] for report in reports],
+        "timeouts": [report["summary"]["timeouts"] for report in reports],
+        "trace_coverage": [trace_coverage(report) for report in reports],
+        "metric_sample_counts": {
+            metric: [report["metrics"][metric]["samples"] for report in reports]
+            for metric in ("ttft", "tpot", "itl")
+        },
+        "trace_phases_avg_ms": [
+            {
+                phase: stats["avg_ms"]
+                for phase, stats in (
+                    (report.get("server_trace") or {}).get("phases_ms", {})
+                ).items()
+            }
+            for report in reports
+        ],
+    }
+
+
+def build_rows(
+    args: argparse.Namespace,
+    reports: list[dict[str, Any]],
+    backend: str | None,
+) -> list[dict[str, Any]]:
+    cells: dict[tuple[tuple[int, ...], int, int], list[dict[str, Any]]] = {}
     for report in reports:
         workload = report["workload"]
-        key = (workload["prompt_words"], workload["concurrency"], workload["max_tokens"])
+        raw_prompt_words = workload["prompt_words"]
+        prompt_word_key = (
+            tuple(raw_prompt_words)
+            if isinstance(raw_prompt_words, list)
+            else (int(raw_prompt_words),)
+        )
+        key = (prompt_word_key, workload["concurrency"], workload["max_tokens"])
         cells.setdefault(key, []).append(report)
 
     rows = []
-    correctness_ok = True
-    hash_stability_required = args.sampling_mode == "single"
-    greedy_hash_stability_required = args.sampling_mode == "mixed-greedy-sampled"
-    sampled_hash_presence_required = args.sampling_mode == "mixed-greedy-sampled"
-    for (prompt_words, concurrency, max_tokens), cell_reports in sorted(cells.items()):
-        baseline = request_hashes(cell_reports[0])
-        baseline_greedy = request_hashes(cell_reports[0], sampling_label="greedy")
-        zero_failures = True
-        hashes_stable = True
-        greedy_hashes_stable = True
-        greedy_hashes_present = bool(baseline_greedy)
-        sampled_hashes_present = bool(request_hashes(cell_reports[0], sampling_label="sampled"))
-        output_evidence_present = True
-        for report in cell_reports:
-            summary = report["summary"]
-            hashes = request_hashes(report)
-            greedy_hashes = request_hashes(report, sampling_label="greedy")
-            sampled_hashes = request_hashes(report, sampling_label="sampled")
-            if summary["failed"] or summary["timeouts"]:
-                zero_failures = False
-            if hashes != baseline:
-                hashes_stable = False
-            if not greedy_hashes:
-                greedy_hashes_present = False
-            if not sampled_hashes:
-                sampled_hashes_present = False
-            if greedy_hashes != baseline_greedy:
-                greedy_hashes_stable = False
-            if not successful_requests_have_output_evidence(report):
-                output_evidence_present = False
-        cell_ok = (
-            zero_failures
-            and output_evidence_present
-            and (hashes_stable if hash_stability_required else True)
-            and (
-                (greedy_hashes_present and greedy_hashes_stable)
-                if greedy_hash_stability_required
-                else True
-            )
-            and (sampled_hashes_present if sampled_hash_presence_required else True)
+    for (prompt_word_key, concurrency, max_tokens), cell_reports in sorted(
+        cells.items()
+    ):
+        prompt_words: int | list[int] = (
+            list(prompt_word_key) if len(prompt_word_key) > 1 else prompt_word_key[0]
         )
-        correctness_ok = correctness_ok and cell_ok
         rows.append(
-            {
-                "concurrency": concurrency,
-                "prompt_words": prompt_words,
-                "max_tokens": max_tokens,
-                "repeats": len(cell_reports),
-                "passed": cell_ok,
-                "output_evidence_present": output_evidence_present,
-                "hash_stability_checked": hash_stability_required,
-                "stable_per_request_hashes": hashes_stable,
-                "greedy_hash_stability_checked": greedy_hash_stability_required,
-                "stable_greedy_hashes": greedy_hashes_stable,
-                "greedy_hashes_present": greedy_hashes_present,
-                "sampled_hashes_present": sampled_hashes_present,
-                "combined_output_hashes": [
-                    report["summary"]["combined_output_hash"] for report in cell_reports
-                ],
-                "qps": [report["summary"]["qps"] for report in cell_reports],
-                "input_tokens_per_s": [
-                    report["summary"]["input_tokens_per_s"] for report in cell_reports
-                ],
-                "output_tokens_per_s": [
-                    report["summary"]["output_tokens_per_s"] for report in cell_reports
-                ],
-                "ttft_avg_ms": [report["metrics"]["ttft"]["avg_ms"] for report in cell_reports],
-                "tpot_avg_ms": [report["metrics"]["tpot"]["avg_ms"] for report in cell_reports],
-                "itl_avg_ms": [report["metrics"]["itl"]["avg_ms"] for report in cell_reports],
-                "failed": [report["summary"]["failed"] for report in cell_reports],
-                "timeouts": [report["summary"]["timeouts"] for report in cell_reports],
-                "trace_phases_avg_ms": [
-                    {
-                        phase: stats["avg_ms"]
-                        for phase, stats in report["server_trace"]["phases_ms"].items()
-                    }
-                    for report in cell_reports
-                ],
-            }
+            build_cell_row(
+                args,
+                cell_reports,
+                backend,
+                prompt_words,
+                concurrency,
+                max_tokens,
+            )
         )
+    return rows
+
+
+def build_summary(
+    args: argparse.Namespace, reports: list[dict[str, Any]]
+) -> dict[str, Any]:
+    summary_backend = args.backend or first_nested_value(
+        reports,
+        ("backend",),
+        ("contract", "backend"),
+        ("metadata", "backend"),
+    )
+    summary_contract_name = args.contract_name or first_nested_value(
+        reports,
+        ("contract", "name"),
+        ("metadata", "contract_name"),
+    )
+    summary_claim_boundary = args.claim_boundary or first_nested_value(
+        reports,
+        ("contract", "claim_boundary"),
+    )
+    metric_definitions = first_nested_value(reports, ("metric_definitions",)) or {}
+    metric_definitions_consistent = bool(reports) and all(
+        report.get("metric_definitions") == metric_definitions for report in reports
+    )
+    latency_budget = first_nested_value(reports, ("latency_budget",)) or {}
+    latency_budget_consistent = bool(reports) and all(
+        report.get("latency_budget") == latency_budget for report in reports
+    )
+    rows = build_rows(args, reports, summary_backend)
+
+    correctness_ok = (
+        metric_definitions_consistent
+        and latency_budget_consistent
+        and all(row["passed"] for row in rows)
+    )
 
     return {
         "schema_version": 1,
         "kind": "openai_http_completions_sweep",
+        "report_intent": "http_serving_slo"
+        if summary_contract_name
+        else "http_serving_benchmark",
         "base_url": args.base_url,
         "model": args.model,
+        "backend": summary_backend,
+        "metadata": {
+            "commit": args.commit or current_commit(),
+            "backend": summary_backend,
+            "contract_name": summary_contract_name,
+            "model_path": args.model_path,
+            "server_command": args.server_command,
+            "source_revision": args.source_revision,
+            "model_revision": args.model_revision,
+            "model_fingerprint": model_fingerprint(args.model_path),
+            "server_binary_sha256": sha256_file(args.server_binary)
+            if args.server_binary
+            else None,
+            "backend_runtime_version": args.backend_runtime_version,
+            "benchmark_command": artifact_command(sys.argv),
+            "hardware_toolchain": detect_hardware_toolchain(),
+        },
+        "contract": {
+            "name": summary_contract_name,
+            "backend": summary_backend,
+            "description": args.contract_description,
+            "required_trace_coverage_ratio": args.required_trace_coverage,
+            "claim_boundary": summary_claim_boundary
+            or "HTTP streaming sweep evidence only; direct, profiler, soak, and production-readiness claims require separate artifacts.",
+        },
+        "metric_definitions": metric_definitions,
+        "latency_budget": latency_budget,
         "workload": {
             "num_requests": args.num_requests,
             "warmup": args.warmup,
@@ -234,31 +643,312 @@ def build_summary(args: argparse.Namespace, reports: list[dict[str, Any]]) -> di
             "sampling_profiles": sampling_profiles(args),
             "ignore_eos": not args.no_ignore_eos,
             "timeout_s": args.timeout,
+            "timeout_kind": "absolute_request_deadline",
             "concurrency": args.concurrency,
             "max_tokens": args.max_tokens,
             "repeats": args.repeats,
+            "tail_sample_sufficient": args.num_requests >= 30,
         },
         "correctness_gate": {
             "passed": correctness_ok,
+            "metric_definitions_consistent": metric_definitions_consistent,
+            "latency_budget_consistent": latency_budget_consistent,
             "rule": (
-                "single mode: failed=0, timeout=0, and per-request output_hash list stable "
-                "across repeats for each prompt_words/concurrency/max_tokens cell; mixed-greedy-sampled "
-                "mode: failed=0, timeout=0, successful requests have output evidence, and "
+                "all modes: failed=0, timeout=0, successful requests have output evidence, and retained "
+                "profiles meet request/active-set/decode-batch trace coverage; single mode also requires "
+                "the per-request output_hash list to stay stable across repeats for each cell; "
+                "mixed-greedy-sampled mode requires "
                 "both greedy and sampled requests are present; greedy output_hash lists stay "
                 "stable across repeats, while sampled output hashes are reported but not required stable"
             ),
         },
+        "leaf_artifacts": leaf_artifact_manifest(reports),
         "rows": rows,
     }
 
 
-def main() -> None:
+def verify_summary_leaf_artifacts(summary: dict[str, Any]) -> dict[str, Any]:
+    manifest = summary.get("leaf_artifacts")
+    if not isinstance(manifest, list):
+        return {"passed": False, "checked": 0, "failures": ["leaf_artifacts"]}
+
+    failures: list[str] = []
+    reports: list[dict[str, Any]] = []
+    seen_paths = set()
+    summary_metadata = summary.get("metadata")
+    summary_workload = summary.get("workload")
+    summary_contract = summary.get("contract")
+    if not isinstance(summary_metadata, dict):
+        failures.append("metadata")
+        summary_metadata = {}
+    if not isinstance(summary_workload, dict):
+        failures.append("workload")
+        summary_workload = {}
+    if not isinstance(summary_contract, dict):
+        failures.append("contract")
+        summary_contract = {}
+
+    for index, item in enumerate(manifest):
+        prefix = f"leaf_artifacts[{index}]"
+        if not isinstance(item, dict):
+            failures.append(prefix)
+            continue
+        raw_path = item.get("artifact")
+        expected_digest = item.get("sha256")
+        if not isinstance(raw_path, str) or not raw_path:
+            failures.append(f"{prefix}.artifact")
+            continue
+        if raw_path in seen_paths:
+            failures.append(f"{prefix}.duplicate")
+            continue
+        seen_paths.add(raw_path)
+        path = Path(raw_path)
+        if not path.is_absolute():
+            path = REPO_ROOT / path
+        actual_digest = sha256_file(path)
+        if actual_digest != expected_digest:
+            failures.append(f"{prefix}.sha256")
+            continue
+        try:
+            report = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            failures.append(f"{prefix}.json")
+            continue
+        if not isinstance(report, dict):
+            failures.append(f"{prefix}.document")
+            continue
+        reports.append(report)
+
+        if report.get("schema_version") != 1:
+            failures.append(f"{prefix}.schema_version")
+        if report.get("kind") != "openai_http_completions_stream_benchmark":
+            failures.append(f"{prefix}.kind")
+        for field in ("report_intent", "base_url", "model", "backend"):
+            if report.get(field) != summary.get(field):
+                failures.append(f"{prefix}.{field}")
+        if report.get("contract") != summary_contract:
+            failures.append(f"{prefix}.contract")
+        if report.get("metric_definitions") != summary.get("metric_definitions"):
+            failures.append(f"{prefix}.metric_definitions")
+        if report.get("latency_budget") != summary.get("latency_budget"):
+            failures.append(f"{prefix}.latency_budget")
+
+        metadata = report.get("metadata")
+        if not isinstance(metadata, dict):
+            failures.append(f"{prefix}.metadata")
+        else:
+            for field in LEAF_METADATA_FIELDS:
+                if metadata.get(field) != summary_metadata.get(field):
+                    failures.append(f"{prefix}.metadata.{field}")
+            if metadata.get("benchmark_artifact") != raw_path:
+                failures.append(f"{prefix}.metadata.benchmark_artifact")
+            if metadata.get("benchmark_returncode") != 0:
+                failures.append(f"{prefix}.metadata.benchmark_returncode")
+
+        workload = report.get("workload")
+        if not isinstance(workload, dict):
+            failures.append(f"{prefix}.workload")
+        else:
+            for field in LEAF_WORKLOAD_FIELDS:
+                if workload.get(field) != summary_workload.get(field):
+                    failures.append(f"{prefix}.workload.{field}")
+            if workload.get("concurrency") not in summary_workload.get(
+                "concurrency", []
+            ):
+                failures.append(f"{prefix}.workload.concurrency")
+            if workload.get("max_tokens") not in summary_workload.get("max_tokens", []):
+                failures.append(f"{prefix}.workload.max_tokens")
+
+    expected_count = sum(
+        row.get("repeats", 0)
+        for row in summary.get("rows", [])
+        if isinstance(row, dict) and isinstance(row.get("repeats"), int)
+    )
+    if len(manifest) != expected_count:
+        failures.append("leaf_artifacts.count")
+
+    if reports:
+        verification_args = argparse.Namespace(
+            sampling_mode=summary_workload.get("sampling_mode"),
+            num_requests=summary_workload.get("num_requests"),
+            required_trace_coverage=summary_contract.get(
+                "required_trace_coverage_ratio"
+            ),
+        )
+        try:
+            rebuilt_rows = build_rows(
+                verification_args, reports, summary.get("backend")
+            )
+        except (KeyError, TypeError, ValueError):
+            failures.append("rows.rebuild")
+        else:
+            if rebuilt_rows != summary.get("rows"):
+                failures.append("rows.recomputed")
+
+    return {
+        "passed": bool(reports) and not failures,
+        "checked": len(reports),
+        "failures": list(dict.fromkeys(failures)),
+    }
+
+
+def build_startup_failure_summary(
+    args: argparse.Namespace, error: str
+) -> dict[str, Any]:
+    if args.mixed_prompt_shape and len(args.prompt_words) > 1:
+        prompt_word_cells: list[int | list[int]] = [args.prompt_words]
+    else:
+        prompt_word_cells = args.prompt_words
+
+    rows = []
+    for prompt_words in prompt_word_cells:
+        for max_tokens in args.max_tokens:
+            for concurrency in args.concurrency:
+                rows.append(
+                    {
+                        "backend": args.backend,
+                        "concurrency": concurrency,
+                        "prompt_words": prompt_words,
+                        "max_tokens": max_tokens,
+                        "repeats": args.repeats,
+                        "tail_sample_sufficient": args.num_requests >= 30,
+                        "passed": False,
+                        "noisy_cell": "startup_failure",
+                        "output_evidence_present": False,
+                        "trace_coverage_passed": False,
+                        "metric_sample_coverage_passed": False,
+                        "benchmark_commands_passed": False,
+                        "hash_manifests_consistent": False,
+                        "hash_stability_checked": args.sampling_mode == "single",
+                        "stable_per_request_hashes": False,
+                        "greedy_hash_stability_checked": args.sampling_mode
+                        == "mixed-greedy-sampled",
+                        "stable_greedy_hashes": False,
+                        "greedy_hashes_present": False,
+                        "sampled_hashes_present": False,
+                        "output_hash_distribution": {},
+                        "request_output_hashes_by_repeat": [],
+                        "greedy_output_hashes_by_repeat": [],
+                        "sampled_output_hashes_by_repeat": [],
+                        "combined_output_hashes": [],
+                        "qps": [],
+                        "qps_summary": numeric_summary([]),
+                        "input_tokens_per_s": [],
+                        "output_tokens_per_s": [],
+                        "output_tokens_per_s_summary": numeric_summary([]),
+                        "ttft_ms": empty_metric_repeat_summary(),
+                        "tpot_ms": empty_metric_repeat_summary(),
+                        "itl_ms": empty_metric_repeat_summary(),
+                        "ttft_avg_ms": [],
+                        "tpot_avg_ms": [],
+                        "itl_avg_ms": [],
+                        "completed": [0 for _ in range(args.repeats)],
+                        "failed": [args.num_requests for _ in range(args.repeats)],
+                        "timeouts": [0 for _ in range(args.repeats)],
+                        "trace_coverage": [
+                            empty_trace_coverage() for _ in range(args.repeats)
+                        ],
+                        "metric_sample_counts": {
+                            "ttft": [0 for _ in range(args.repeats)],
+                            "tpot": [0 for _ in range(args.repeats)],
+                            "itl": [0 for _ in range(args.repeats)],
+                        },
+                        "trace_phases_avg_ms": [{} for _ in range(args.repeats)],
+                    }
+                )
+
+    return {
+        "schema_version": 1,
+        "kind": "openai_http_completions_sweep",
+        "report_intent": "http_serving_slo_startup_failure"
+        if args.contract_name
+        else "http_serving_benchmark_startup_failure",
+        "base_url": args.base_url,
+        "model": args.model,
+        "backend": args.backend,
+        "metadata": {
+            "commit": args.commit or current_commit(),
+            "backend": args.backend,
+            "contract_name": args.contract_name,
+            "model_path": args.model_path,
+            "server_command": args.server_command,
+            "source_revision": args.source_revision,
+            "model_revision": args.model_revision,
+            "model_fingerprint": model_fingerprint(args.model_path),
+            "server_binary_sha256": sha256_file(args.server_binary)
+            if args.server_binary
+            else None,
+            "backend_runtime_version": args.backend_runtime_version,
+            "benchmark_command": artifact_command(sys.argv),
+            "hardware_toolchain": detect_hardware_toolchain(),
+        },
+        "contract": {
+            "name": args.contract_name,
+            "backend": args.backend,
+            "description": args.contract_description,
+            "required_trace_coverage_ratio": args.required_trace_coverage,
+            "claim_boundary": args.claim_boundary
+            or "HTTP streaming sweep evidence only; direct, profiler, soak, and production-readiness claims require separate artifacts.",
+        },
+        "metric_definitions": {
+            "percentile_method": "R7 linear interpolation over sorted samples",
+            "ttft": "request start to first non-empty streamed text chunk",
+            "tpot": "requires streamed text chunk count to equal server completion_tokens",
+            "itl": "requires streamed text chunk count to equal server completion_tokens",
+        },
+        "latency_budget": {
+            "configured": False,
+            "passed": None,
+            "reason": "The server did not start, and this retained contract does not define a production latency budget.",
+        },
+        "workload": {
+            "num_requests": args.num_requests,
+            "warmup": args.warmup,
+            "prompt_words": args.prompt_words,
+            "temperature": args.temperature,
+            "top_k": args.top_k,
+            "top_p": args.top_p,
+            "sampling_mode": args.sampling_mode,
+            "sampling_profiles": sampling_profiles(args),
+            "ignore_eos": not args.no_ignore_eos,
+            "timeout_s": args.timeout,
+            "timeout_kind": "absolute_request_deadline",
+            "concurrency": args.concurrency,
+            "max_tokens": args.max_tokens,
+            "repeats": args.repeats,
+            "tail_sample_sufficient": args.num_requests >= 30,
+        },
+        "startup_failure": {
+            "error": error,
+            "server_log": str(args.server_log) if args.server_log else None,
+        },
+        "correctness_gate": {
+            "passed": False,
+            "rule": "server must start before retained HTTP contract requests can be issued",
+        },
+        "leaf_artifacts": [],
+        "rows": rows,
+        "run_errors": [
+            {
+                "phase": "server_startup",
+                "error": error,
+            }
+        ],
+    }
+
+
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--base-url", default="http://127.0.0.1:8000")
     parser.add_argument("--model", required=True)
     parser.add_argument("--num-requests", type=int, default=8)
     parser.add_argument("--warmup", type=int, default=2)
     parser.add_argument("--prompt-words", type=parse_int_list, default=[16])
+    parser.add_argument(
+        "--mixed-prompt-shape",
+        action="store_true",
+        help="Treat all --prompt-words values as one alternating mixed-shape cell.",
+    )
     parser.add_argument("--temperature", type=float, default=0.0)
     parser.add_argument("--top-k", type=int, default=-1)
     parser.add_argument("--top-p", type=float, default=1.0)
@@ -276,32 +966,96 @@ def main() -> None:
     parser.add_argument("--max-tokens", type=parse_int_list, default=[16])
     parser.add_argument("--repeats", type=int, default=3)
     parser.add_argument("--server-log", type=Path)
+    parser.add_argument("--contract-name")
+    parser.add_argument("--contract-description")
+    parser.add_argument("--claim-boundary")
+    parser.add_argument("--required-trace-coverage", type=float)
+    parser.add_argument("--backend")
+    parser.add_argument("--model-path")
+    parser.add_argument("--server-command")
+    parser.add_argument("--commit")
+    parser.add_argument("--source-revision")
+    parser.add_argument("--model-revision")
+    parser.add_argument("--server-binary", type=Path)
+    parser.add_argument("--backend-runtime-version")
+    parser.add_argument(
+        "--record-startup-failure",
+        help="Write a retained sweep_summary.json for a server startup failure without issuing HTTP requests.",
+    )
     parser.add_argument("--out-dir", type=Path, required=True)
-    args = parser.parse_args()
+    return parser.parse_args()
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    if args.contract_name and args.backend is None:
+        raise SystemExit("--backend is required when --contract-name is set")
+    if args.required_trace_coverage is not None:
+        if args.required_trace_coverage <= 0.0 or args.required_trace_coverage > 1.0:
+            raise SystemExit("--required-trace-coverage must be in (0, 1]")
+        if args.server_log is None:
+            raise SystemExit("--server-log is required with --required-trace-coverage")
 
     if args.repeats <= 0:
         raise SystemExit("--repeats must be positive")
+    if args.timeout <= 0.0:
+        raise SystemExit("--timeout must be positive")
     if args.top_p <= 0.0 or args.top_p > 1.0:
         raise SystemExit("--top-p must be in (0, 1]")
     if args.sample_top_p <= 0.0 or args.sample_top_p > 1.0:
         raise SystemExit("--sample-top-p must be in (0, 1]")
     if args.sampling_mode == "mixed-greedy-sampled" and args.sample_temperature <= 0.0:
-        raise SystemExit("--sample-temperature must be positive in mixed-greedy-sampled mode")
-    args.out_dir.mkdir(parents=True, exist_ok=True)
+        raise SystemExit(
+            "--sample-temperature must be positive in mixed-greedy-sampled mode"
+        )
 
+
+def prompt_word_cells(args: argparse.Namespace) -> list[int | list[int]]:
+    if args.mixed_prompt_shape and len(args.prompt_words) > 1:
+        return [args.prompt_words]
+    return args.prompt_words
+
+
+def run_sweep(
+    args: argparse.Namespace,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     reports = []
-    for prompt_words in args.prompt_words:
+    run_errors = []
+    for prompt_words in prompt_word_cells(args):
         for max_tokens in args.max_tokens:
             for concurrency in args.concurrency:
                 for repeat in range(args.repeats):
-                    reports.append(run_one(args, prompt_words, concurrency, max_tokens, repeat))
+                    try:
+                        reports.append(
+                            run_one(args, prompt_words, concurrency, max_tokens, repeat)
+                        )
+                    except Exception as exc:  # noqa: BLE001 - retain partial sweep.
+                        run_errors.append(
+                            {
+                                "prompt_words": prompt_words,
+                                "concurrency": concurrency,
+                                "max_tokens": max_tokens,
+                                "repeat": repeat,
+                                "error": str(exc),
+                            }
+                        )
+    return reports, run_errors
 
+
+def main() -> None:
+    args = parse_args()
+    validate_args(args)
+    summary_path = prepare_summary_path(args.out_dir)
+    if args.record_startup_failure:
+        summary = build_startup_failure_summary(args, args.record_startup_failure)
+        print(write_json(summary_path, summary))
+        raise SystemExit(1)
+
+    reports, run_errors = run_sweep(args)
     summary = build_summary(args, reports)
-    (args.out_dir / "sweep_summary.json").write_text(
-        json.dumps(summary, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
-    print(json.dumps(summary, indent=2, sort_keys=True))
+    summary["run_errors"] = run_errors
+    if run_errors:
+        summary["correctness_gate"]["passed"] = False
+    print(write_json(summary_path, summary))
     if not summary["correctness_gate"]["passed"]:
         raise SystemExit(1)
 

--- a/tests/test_bench_dsv2lite_http_slo.py
+++ b/tests/test_bench_dsv2lite_http_slo.py
@@ -1,0 +1,557 @@
+#!/usr/bin/env python3
+"""Regression tests for scripts/bench_dsv2lite_http_slo.py."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "bench_dsv2lite_http_slo.py"
+)
+BENCHMARKING_DOC = (
+    Path(__file__).resolve().parents[1]
+    / "docs"
+    / "models"
+    / "deepseek-v2-lite"
+    / "benchmarking.md"
+)
+SCRIPTS_DIR = SCRIPT_PATH.parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+SPEC = importlib.util.spec_from_file_location("bench_dsv2lite_http_slo", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+bench_dsv2lite_http_slo = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = bench_dsv2lite_http_slo
+SPEC.loader.exec_module(bench_dsv2lite_http_slo)
+TEST_COMMIT = (
+    bench_dsv2lite_http_slo.subprocess.check_output(
+        ["git", "rev-parse", "--short=12", "HEAD"],
+        cwd=Path(__file__).resolve().parents[1],
+        text=True,
+    )
+    .strip()
+    .lower()
+)
+
+
+def valid_summary(
+    backend: str,
+    profile: bench_dsv2lite_http_slo.SloProfile,
+    *,
+    commit: str = TEST_COMMIT,
+) -> dict[str, object]:
+    def metric() -> dict[str, object]:
+        return {
+            percentile: [1.0] * profile.repeats for percentile in ("p50", "p95", "p99")
+        } | {
+            f"{percentile}_summary": {
+                "median": 1.0,
+                "min": 1.0,
+                "max": 1.0,
+                "samples": profile.repeats,
+            }
+            for percentile in ("p50", "p95", "p99")
+        }
+
+    trace = {
+        "traced_requests": profile.num_requests,
+        "attached_server_records": profile.num_requests,
+        "server_error_records": 0,
+        "missing_traces": [],
+        "missing_server_records": [],
+        "coverage_ratio": 1.0,
+        "server_record_coverage_ratio": 1.0,
+        "active_set_coverage_ratio": 1.0,
+        "active_set_size_max": 1,
+        "decode_batch_coverage_ratio": 1.0,
+        "decode_batch_size_max": 1,
+        "token_timing_coverage_ratio": 1.0,
+        "token_timing_mismatches": [],
+        "token_timing_unknown": [],
+    }
+    prompt_shape: int | list[int]
+    if profile.mixed_prompt_shape:
+        prompt_shape = list(profile.prompt_words)
+    else:
+        prompt_shape = profile.prompt_words[0]
+    rows = [
+        {
+            "backend": backend,
+            "prompt_words": prompt_shape,
+            "concurrency": concurrency,
+            "max_tokens": max_tokens,
+            "repeats": profile.repeats,
+            "tail_sample_sufficient": profile.num_requests >= 30,
+            "passed": True,
+            "noisy_cell": "insufficient_repeats" if profile.repeats == 1 else "stable",
+            "output_evidence_present": True,
+            "trace_coverage_passed": True,
+            "metric_sample_coverage_passed": True,
+            "benchmark_commands_passed": True,
+            "hash_manifests_consistent": True,
+            "hash_stability_checked": True,
+            "stable_per_request_hashes": True,
+            "output_hash_distribution": {
+                "hash": profile.num_requests * profile.repeats
+            },
+            "request_output_hashes_by_repeat": [
+                ["hash"] * profile.num_requests for _ in range(profile.repeats)
+            ],
+            "greedy_output_hashes_by_repeat": [[] for _ in range(profile.repeats)],
+            "sampled_output_hashes_by_repeat": [[] for _ in range(profile.repeats)],
+            "combined_output_hashes": [
+                bench_dsv2lite_http_slo.combined_output_hash(
+                    ["hash"] * profile.num_requests
+                )
+                for _ in range(profile.repeats)
+            ],
+            "qps": [1.0] * profile.repeats,
+            "qps_summary": {
+                "median": 1.0,
+                "min": 1.0,
+                "max": 1.0,
+                "samples": profile.repeats,
+            },
+            "output_tokens_per_s_summary": {
+                "median": 1.0,
+                "min": 1.0,
+                "max": 1.0,
+                "samples": profile.repeats,
+            },
+            "output_tokens_per_s": [1.0] * profile.repeats,
+            "ttft_ms": metric(),
+            "tpot_ms": metric(),
+            "itl_ms": metric(),
+            "completed": [profile.num_requests] * profile.repeats,
+            "failed": [0] * profile.repeats,
+            "timeouts": [0] * profile.repeats,
+            "trace_coverage": [copy.deepcopy(trace) for _ in range(profile.repeats)],
+            "metric_sample_counts": {
+                "ttft": [profile.num_requests] * profile.repeats,
+                "tpot": [profile.num_requests] * profile.repeats,
+                "itl": [profile.num_requests * (max_tokens - 1)] * profile.repeats,
+            },
+        }
+        for concurrency in profile.concurrency
+        for max_tokens in profile.max_tokens
+    ]
+    return {
+        "schema_version": 1,
+        "kind": "openai_http_completions_sweep",
+        "report_intent": "http_serving_slo",
+        "model": "DeepSeek-V2-Lite",
+        "backend": backend,
+        "contract": {
+            "name": profile.name,
+            "backend": backend,
+            "description": profile.description,
+            "required_trace_coverage_ratio": profile.required_trace_coverage_ratio,
+            "claim_boundary": profile.claim_boundary,
+        },
+        "metadata": {
+            "commit": commit,
+            "model_path": "models/DeepSeek-V2-Lite",
+            "server_command": "openinfer --model-path models/DeepSeek-V2-Lite",
+            "source_revision": commit,
+            "model_revision": "604d5664dddd88a0433dbae533b7fe9472482de0",
+            "model_fingerprint": {
+                "config.json": "a" * 64,
+                "model.safetensors.index.json": "b" * 64,
+                "tokenizer.json": "d" * 64,
+            },
+            "server_binary_sha256": "c" * 64,
+            "backend_runtime_version": "2.26.2" if backend == "nccl" else "host-staged",
+            "hardware_toolchain": {
+                "gpu": ["NVIDIA GeForce RTX 5090", "NVIDIA GeForce RTX 5090"],
+                "gpu_identity_sha256": ["1" * 64, "2" * 64],
+                "nvcc_version": "Cuda compilation tools, release 12.8",
+            },
+        },
+        "workload": profile.workload_contract()
+        | {
+            "sampling_profiles": {
+                "single": {
+                    "label": "single",
+                    "temperature": 0.0,
+                    "top_k": -1,
+                    "top_p": 1.0,
+                }
+            }
+        },
+        "metric_definitions": {
+            "percentile_method": "R7 linear interpolation over sorted samples",
+            "ttft": "request start to first non-empty streamed text chunk",
+            "tpot": "requires streamed text chunk count to equal server completion_tokens",
+            "itl": "requires streamed text chunk count to equal server completion_tokens",
+        },
+        "latency_budget": {
+            "configured": False,
+            "passed": None,
+            "reason": "No production latency budget.",
+        },
+        "correctness_gate": {"passed": True},
+        "leaf_artifacts": [
+            {
+                "artifact": (
+                    f"artifacts/{backend}/{profile.name}/"
+                    f"pw{'-'.join(str(value) for value in profile.prompt_words)}_"
+                    f"c{concurrency}_mt{max_tokens}_r{repeat}.json"
+                ),
+                "sha256": "f" * 64,
+            }
+            for concurrency in profile.concurrency
+            for max_tokens in profile.max_tokens
+            for repeat in range(profile.repeats)
+        ],
+        "run_errors": [],
+        "rows": rows,
+    }
+
+
+def all_summaries() -> list[tuple[Path, dict[str, object]]]:
+    return [
+        (
+            Path(backend) / profile.name / "sweep_summary.json",
+            valid_summary(backend, profile),
+        )
+        for backend in bench_dsv2lite_http_slo.BACKENDS
+        for profile in bench_dsv2lite_http_slo.PROFILES.values()
+    ]
+
+
+class BenchDsv2LiteHttpSloTests(unittest.TestCase):
+    def test_commit_validation_rejects_non_head_commit(self) -> None:
+        with self.assertRaises(SystemExit):
+            bench_dsv2lite_http_slo.validate_commit("000000000000")
+
+    def test_leaf_artifact_verification_aggregates_child_failures(self) -> None:
+        summaries = [(Path("summary.json"), {"leaf_artifacts": []})]
+        with mock.patch.object(
+            bench_dsv2lite_http_slo,
+            "verify_summary_leaf_artifacts",
+            return_value={"passed": True, "checked": 3, "failures": []},
+        ):
+            passed = bench_dsv2lite_http_slo.verify_leaf_artifacts(summaries)
+        with mock.patch.object(
+            bench_dsv2lite_http_slo,
+            "verify_summary_leaf_artifacts",
+            return_value={
+                "passed": False,
+                "checked": 3,
+                "failures": ["rows.recomputed"],
+            },
+        ):
+            failed = bench_dsv2lite_http_slo.verify_leaf_artifacts(summaries)
+
+        self.assertTrue(passed["passed"])
+        self.assertEqual(passed["checked"], 3)
+        self.assertFalse(failed["passed"])
+        self.assertEqual(failed["failures"][0]["failures"], ["rows.recomputed"])
+
+    def test_documented_run_templates_include_required_provenance_flags(self) -> None:
+        text = BENCHMARKING_DOC.read_text(encoding="utf-8")
+        marker = "python3 scripts/bench_dsv2lite_http_slo.py run"
+        blocks = [section.split("\n\n", 1)[0] for section in text.split(marker)[1:]]
+
+        self.assertEqual(len(blocks), 1)
+        for flag in (
+            "--profile",
+            "--backend",
+            "--model-path",
+            "--server-command",
+            "--commit",
+            "--model-revision",
+            "--server-binary",
+        ):
+            self.assertIn(flag, blocks[0])
+        for profile in bench_dsv2lite_http_slo.PROFILES:
+            self.assertIn(profile, text)
+
+    def test_profile_command_locks_complete_workload(self) -> None:
+        args = SimpleNamespace(
+            profile="dsv2-lite-long-prompt-smoke",
+            backend="nccl",
+            base_url="http://127.0.0.1:8000",
+            model="DeepSeek-V2-Lite",
+            model_path="models/DeepSeek-V2-Lite",
+            server_command="openinfer --model-path models/DeepSeek-V2-Lite",
+            model_revision="604d5664dddd88a0433dbae533b7fe9472482de0",
+            server_binary=Path("target/release/openinfer"),
+            backend_runtime_version="2.26.2",
+            server_log=Path("server.log"),
+            commit=TEST_COMMIT,
+            record_startup_failure=None,
+            out_dir=Path("artifacts/long"),
+        )
+
+        command = bench_dsv2lite_http_slo.build_sweep_command(args)
+
+        self.assertEqual(command[command.index("--prompt-words") + 1], "2048")
+        self.assertEqual(command[command.index("--max-tokens") + 1], "64")
+        self.assertEqual(command[command.index("--num-requests") + 1], "1")
+        self.assertEqual(command[command.index("--concurrency") + 1], "1")
+        self.assertEqual(command[command.index("--repeats") + 1], "1")
+        self.assertEqual(command[command.index("--timeout") + 1], "900.0")
+        self.assertEqual(command[command.index("--source-revision") + 1], TEST_COMMIT)
+        self.assertEqual(
+            command[command.index("--model-revision") + 1],
+            "604d5664dddd88a0433dbae533b7fe9472482de0",
+        )
+        self.assertEqual(
+            command[command.index("--backend-runtime-version") + 1], "2.26.2"
+        )
+        self.assertEqual(
+            bench_dsv2lite_http_slo.PROFILES[
+                "dsv2-lite-short-decode-heavy"
+            ].num_requests,
+            32,
+        )
+
+    def test_retained_report_requires_all_fixed_children(self) -> None:
+        summaries = all_summaries()
+
+        report = bench_dsv2lite_http_slo.build_retained_slo_report(
+            "DeepSeek-V2-Lite", summaries
+        )
+        missing = bench_dsv2lite_http_slo.build_retained_slo_report(
+            "DeepSeek-V2-Lite", summaries[:-1]
+        )
+
+        self.assertTrue(report["coverage_gate"]["passed"])
+        self.assertEqual(report["coverage_gate"]["retained_children"], 6)
+        self.assertEqual(report["metadata"]["commit"], TEST_COMMIT)
+        self.assertEqual(len(report["profile_spec_sha256"]), 64)
+        self.assertFalse(report["latency_budget"]["configured"])
+        self.assertIsNone(report["latency_budget"]["passed"])
+        self.assertFalse(missing["coverage_gate"]["passed"])
+        self.assertEqual(len(missing["coverage_gate"]["missing"]), 1)
+
+    def test_retained_report_rejects_workload_drift(self) -> None:
+        summaries = all_summaries()
+        drifted = copy.deepcopy(summaries)
+        drifted[0][1]["workload"]["timeout_s"] = 241.0
+
+        report = bench_dsv2lite_http_slo.build_retained_slo_report(
+            "DeepSeek-V2-Lite", drifted
+        )
+
+        self.assertFalse(report["coverage_gate"]["passed"])
+        self.assertIn(
+            "workload.timeout_s",
+            report["coverage_gate"]["invalid_children"][0]["errors"],
+        )
+
+    def test_retained_report_rejects_empty_metric_payload(self) -> None:
+        summaries = all_summaries()
+        summaries[0][1]["rows"][0]["ttft_ms"] = {}
+
+        report = bench_dsv2lite_http_slo.build_retained_slo_report(
+            "DeepSeek-V2-Lite", summaries
+        )
+
+        self.assertFalse(report["coverage_gate"]["passed"])
+        self.assertIn(
+            "rows.success.ttft_ms.p50",
+            report["coverage_gate"]["invalid_children"][0]["errors"],
+        )
+
+    def test_retained_report_rejects_forged_success_counts(self) -> None:
+        summaries = all_summaries()
+        summaries[0][1]["rows"][0]["failed"] = [1] * 3
+
+        report = bench_dsv2lite_http_slo.build_retained_slo_report(
+            "DeepSeek-V2-Lite", summaries
+        )
+
+        self.assertFalse(report["coverage_gate"]["passed"])
+        self.assertIn(
+            "rows.success.failed",
+            report["coverage_gate"]["invalid_children"][0]["errors"],
+        )
+
+    def test_retained_report_rejects_non_object_child(self) -> None:
+        summaries = all_summaries()
+        summaries[0] = (summaries[0][0], [])
+
+        report = bench_dsv2lite_http_slo.build_retained_slo_report(
+            "DeepSeek-V2-Lite", summaries
+        )
+
+        self.assertFalse(report["coverage_gate"]["passed"])
+        self.assertEqual(
+            report["coverage_gate"]["invalid_children"][0]["errors"],
+            ["document must be an object"],
+        )
+
+    def test_retained_report_rejects_duplicate_cell(self) -> None:
+        summaries = all_summaries()
+        summaries[0][1]["rows"].append(copy.deepcopy(summaries[0][1]["rows"][0]))
+
+        report = bench_dsv2lite_http_slo.build_retained_slo_report(
+            "DeepSeek-V2-Lite", summaries
+        )
+
+        self.assertFalse(report["coverage_gate"]["passed"])
+        self.assertIn(
+            "rows.duplicate_cells",
+            report["coverage_gate"]["invalid_children"][0]["errors"],
+        )
+
+    def test_retained_report_rejects_forged_repeat_summary(self) -> None:
+        summaries = all_summaries()
+        summaries[0][1]["rows"][0]["ttft_ms"]["p50_summary"]["median"] = 2.0
+
+        report = bench_dsv2lite_http_slo.build_retained_slo_report(
+            "DeepSeek-V2-Lite", summaries
+        )
+
+        self.assertFalse(report["coverage_gate"]["passed"])
+        self.assertIn(
+            "rows.success.ttft_ms.p50_summary.median_mismatch",
+            report["coverage_gate"]["invalid_children"][0]["errors"],
+        )
+
+    def test_retained_report_recomputes_noisy_marker(self) -> None:
+        summaries = all_summaries()
+        row = summaries[0][1]["rows"][0]
+        row["qps"] = [1.0, 1.0, 2.0]
+        row["qps_summary"] = {
+            "median": 1.0,
+            "min": 1.0,
+            "max": 2.0,
+            "samples": 3,
+        }
+
+        report = bench_dsv2lite_http_slo.build_retained_slo_report(
+            "DeepSeek-V2-Lite", summaries
+        )
+
+        self.assertFalse(report["coverage_gate"]["passed"])
+        self.assertIn(
+            "rows.success.noisy_cell",
+            report["coverage_gate"]["invalid_children"][0]["errors"],
+        )
+
+    def test_retained_report_recomputes_output_hash_evidence(self) -> None:
+        summaries = all_summaries()
+        row = summaries[0][1]["rows"][0]
+        row["output_hash_distribution"] = {"forged": 96}
+        row["combined_output_hashes"] = ["forged"] * 3
+
+        report = bench_dsv2lite_http_slo.build_retained_slo_report(
+            "DeepSeek-V2-Lite", summaries
+        )
+
+        self.assertFalse(report["coverage_gate"]["passed"])
+        errors = report["coverage_gate"]["invalid_children"][0]["errors"]
+        self.assertIn("rows.success.output_hash_distribution", errors)
+        self.assertIn("rows.success.combined_output_hashes", errors)
+
+    def test_combine_removes_stale_output_before_read_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            invalid = root / "invalid.json"
+            invalid.write_text("not json\n", encoding="utf-8")
+            output = root / "retained.json"
+            output.write_text('{"stale": true}\n', encoding="utf-8")
+            args = SimpleNamespace(
+                model="DeepSeek-V2-Lite", summary=[invalid], out=output
+            )
+
+            with self.assertRaises(Exception):
+                bench_dsv2lite_http_slo.combine(args)
+
+            self.assertFalse(output.exists())
+
+    def test_retained_report_rejects_mixed_commits(self) -> None:
+        summaries = all_summaries()
+        summaries[-1][1]["metadata"]["commit"] = "different"
+
+        report = bench_dsv2lite_http_slo.build_retained_slo_report(
+            "DeepSeek-V2-Lite", summaries
+        )
+
+        self.assertFalse(report["coverage_gate"]["passed"])
+        self.assertFalse(report["coverage_gate"]["commit_consistent"])
+        self.assertIsNone(report["metadata"]["commit"])
+
+    def test_retained_report_rejects_provenance_drift(self) -> None:
+        summaries = all_summaries()
+        summaries[-1][1]["metadata"]["model_revision"] = "different-model-revision"
+
+        report = bench_dsv2lite_http_slo.build_retained_slo_report(
+            "DeepSeek-V2-Lite", summaries
+        )
+
+        self.assertFalse(report["coverage_gate"]["passed"])
+        self.assertFalse(report["coverage_gate"]["provenance_consistent"])
+
+    def test_detects_loaded_nccl_version_from_server_log(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            server_log = Path(tmp) / "server.log"
+            server_log.write_text(
+                "DeepSeek-V2-Lite NCCL backend loaded: version=2.26.2, version_code=22602\n",
+                encoding="utf-8",
+            )
+
+            version = bench_dsv2lite_http_slo.detect_backend_runtime_version(
+                server_log, "nccl"
+            )
+
+        self.assertEqual(version, "2.26.2")
+
+    def test_loaded_nccl_version_takes_precedence_over_generic_log_lines(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            server_log = Path(tmp) / "server.log"
+            server_log.write_text(
+                "DeepSeek-V2-Lite NCCL backend loaded: version=2.26.2, version_code=22602\n"
+                "NCCL version 2.30.7\n",
+                encoding="utf-8",
+            )
+
+            version = bench_dsv2lite_http_slo.detect_backend_runtime_version(
+                server_log, "nccl"
+            )
+
+        self.assertEqual(version, "2.26.2")
+
+    def test_startup_failure_extracts_rejected_nccl_version_without_loaded_log(
+        self,
+    ) -> None:
+        args = SimpleNamespace(
+            profile="dsv2-lite-short-decode-heavy",
+            backend="nccl",
+            base_url="http://127.0.0.1:8000",
+            model="DeepSeek-V2-Lite",
+            model_path="models/DeepSeek-V2-Lite",
+            server_command="openinfer --model-path models/DeepSeek-V2-Lite",
+            model_revision="604d5664dddd88a0433dbae533b7fe9472482de0",
+            server_binary=Path("target/release/openinfer"),
+            backend_runtime_version=None,
+            server_log=Path("missing-server.log"),
+            commit=TEST_COMMIT,
+            record_startup_failure=(
+                "DeepSeek-V2-Lite NCCL EP2 on sm_120 requires NCCL >= 2.26.2, "
+                "loaded 2.25.1"
+            ),
+            out_dir=Path("artifacts/startup-failure"),
+        )
+
+        command = bench_dsv2lite_http_slo.build_sweep_command(args)
+
+        self.assertEqual(
+            command[command.index("--backend-runtime-version") + 1], "2.25.1"
+        )
+        self.assertIn("--record-startup-failure", command)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bench_http_common.py
+++ b/tests/test_bench_http_common.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Regression tests for scripts/bench_http_common.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "bench_http_common.py"
+SPEC = importlib.util.spec_from_file_location("bench_http_common", SCRIPT_PATH)
+assert SPEC is not None
+bench_http_common = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = bench_http_common
+assert SPEC.loader is not None
+SPEC.loader.exec_module(bench_http_common)
+
+
+class BenchHttpCommonTests(unittest.TestCase):
+    def test_shell_command_preserves_argument_boundaries(self) -> None:
+        rendered = bench_http_common.shell_command(
+            ["bench", "--claim-boundary", "HTTP only; no soak", "plain"]
+        )
+
+        self.assertEqual(rendered, "bench --claim-boundary 'HTTP only; no soak' plain")
+
+    def test_artifact_command_makes_repo_paths_relative(self) -> None:
+        script = bench_http_common.REPO_ROOT / "scripts" / "bench_http_serving.py"
+
+        rendered = bench_http_common.artifact_command(
+            [str(script), "--claim-boundary", "HTTP only; no soak"]
+        )
+
+        self.assertEqual(
+            rendered,
+            "scripts/bench_http_serving.py --claim-boundary 'HTTP only; no soak'",
+        )
+
+    def test_model_fingerprint_covers_tokenizer_and_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "config.json").write_text("{}\n", encoding="utf-8")
+            (root / "tokenizer.json").write_text("{}\n", encoding="utf-8")
+
+            fingerprint = bench_http_common.model_fingerprint(str(root))
+
+        self.assertEqual(set(fingerprint), {"config.json", "tokenizer.json"})
+        self.assertTrue(all(len(digest) == 64 for digest in fingerprint.values()))
+
+    def test_hardware_metadata_hashes_gpu_identity(self) -> None:
+        def command_output(command: list[str], **_: object) -> str | None:
+            if "--query-gpu=uuid" in command:
+                return "GPU-first\nGPU-second"
+            return None
+
+        with mock.patch.object(
+            bench_http_common, "run_text", side_effect=command_output
+        ):
+            metadata = bench_http_common.detect_hardware_toolchain()
+
+        self.assertEqual(
+            metadata["gpu_identity_sha256"],
+            [
+                "7aa60c235ac46afbfbddf4d225387b61ccf89385ab0ca84d6d3213d4a523aaea",
+                "ea89ccea8cbe62bc875a1ff5182c5a5c0a84ef6833bd54eacf4debc379a331f7",
+            ],
+        )
+
+    def test_nvcc_version_falls_back_to_cuda_home(self) -> None:
+        with mock.patch.dict("os.environ", {"CUDA_HOME": "/opt/cuda"}, clear=True):
+            with mock.patch.object(
+                bench_http_common,
+                "run_text",
+                side_effect=lambda command: "CUDA 12.8"
+                if command == ["/opt/cuda/bin/nvcc", "--version"]
+                else None,
+            ):
+                version = bench_http_common.nvcc_version()
+
+        self.assertEqual(version, "CUDA 12.8")
+
+    def test_numeric_summary_ignores_bool_and_non_finite_values(self) -> None:
+        summary = bench_http_common.numeric_summary(
+            [False, True, 1.0, 3.0, math.nan, math.inf]
+        )
+
+        self.assertEqual(summary, {"median": 2.0, "min": 1.0, "max": 3.0, "samples": 2})
+
+    def test_zero_median_with_nonzero_spread_is_noisy(self) -> None:
+        marker = bench_http_common.repeat_noise_marker([[0.0, 0.0, 1.0]], 3)
+
+        self.assertEqual(marker, "noisy")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bench_http_serving.py
+++ b/tests/test_bench_http_serving.py
@@ -7,6 +7,7 @@ import importlib.util
 import json
 import sys
 import threading
+import time
 import unittest
 import urllib.parse
 import tempfile
@@ -17,6 +18,9 @@ from unittest import mock
 
 
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "bench_http_serving.py"
+SCRIPTS_DIR = SCRIPT_PATH.parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
 SPEC = importlib.util.spec_from_file_location("bench_http_serving", SCRIPT_PATH)
 assert SPEC and SPEC.loader
 bench_http_serving = importlib.util.module_from_spec(SPEC)
@@ -26,6 +30,8 @@ SPEC.loader.exec_module(bench_http_serving)
 
 class DoneOnlyHandler(BaseHTTPRequestHandler):
     response_body = b"data: [DONE]\n\n"
+    response_chunks: list[bytes] | None = None
+    chunk_delay_s = 0.0
     request_bodies: list[dict[str, object]] = []
 
     def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API.
@@ -36,7 +42,16 @@ class DoneOnlyHandler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header("Content-Type", "text/event-stream")
         self.end_headers()
-        self.wfile.write(self.response_body)
+        if self.response_chunks is None:
+            self.wfile.write(self.response_body)
+            return
+        for chunk in self.response_chunks:
+            time.sleep(self.chunk_delay_s)
+            try:
+                self.wfile.write(chunk)
+                self.wfile.flush()
+            except OSError:
+                return
 
     def log_message(self, format: str, *args: object) -> None:
         return
@@ -45,6 +60,8 @@ class DoneOnlyHandler(BaseHTTPRequestHandler):
 class BenchHttpServingTests(unittest.TestCase):
     def setUp(self) -> None:
         DoneOnlyHandler.response_body = b"data: [DONE]\n\n"
+        DoneOnlyHandler.response_chunks = None
+        DoneOnlyHandler.chunk_delay_s = 0.0
         DoneOnlyHandler.request_bodies = []
         self.server = ThreadingHTTPServer(("127.0.0.1", 0), DoneOnlyHandler)
         self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
@@ -56,6 +73,117 @@ class BenchHttpServingTests(unittest.TestCase):
         self.server.shutdown()
         self.server.server_close()
         self.thread.join(timeout=5)
+
+    def test_percentile_uses_r7_linear_interpolation(self) -> None:
+        self.assertEqual(
+            bench_http_serving.percentile([1.0, 2.0, 100.0, 101.0], 50), 51.0
+        )
+        self.assertAlmostEqual(
+            bench_http_serving.percentile([1.0, 2.0, 100.0, 101.0], 95),
+            100.85,
+        )
+
+    def test_absolute_timeout_rejects_trickle_stream(self) -> None:
+        DoneOnlyHandler.response_chunks = [
+            b'data: {"choices":[{"text":"a","finish_reason":null}]}\n\n',
+            b'data: {"choices":[{"text":"b","finish_reason":null}]}\n\n',
+            b"data: [DONE]\n\n",
+        ]
+        DoneOnlyHandler.chunk_delay_s = 0.08
+
+        result = bench_http_serving.request_once(
+            index=0,
+            request_id="req-trickle-timeout",
+            url=self.url,
+            model="fake-model",
+            prompt_words=1,
+            prompt="hello",
+            max_tokens=2,
+            temperature=0.0,
+            timeout=0.12,
+            ignore_eos=True,
+        )
+
+        self.assertFalse(result.ok)
+        self.assertTrue(result.timed_out)
+        self.assertLess(result.latency_ms, 220.0)
+
+    def test_absolute_timeout_interrupts_byte_trickle_inside_one_line(self) -> None:
+        line = b'data: {"choices":[{"text":"slow","finish_reason":null}]}\n\n'
+        DoneOnlyHandler.response_chunks = [
+            line[index : index + 1] for index in range(len(line))
+        ]
+        DoneOnlyHandler.chunk_delay_s = 0.01
+
+        result = bench_http_serving.request_once(
+            index=0,
+            request_id="req-byte-trickle-timeout",
+            url=self.url,
+            model="fake-model",
+            prompt_words=1,
+            prompt="hello",
+            max_tokens=1,
+            temperature=0.0,
+            timeout=0.12,
+            ignore_eos=True,
+        )
+
+        self.assertFalse(result.ok)
+        self.assertTrue(result.timed_out)
+        self.assertLess(result.latency_ms, 250.0)
+
+    def test_token_timing_requires_chunk_token_parity(self) -> None:
+        result = bench_http_serving.RequestResult(
+            index=0,
+            request_id="req-coalesced",
+            prompt_words=1,
+            max_tokens=3,
+            ok=True,
+            status=200,
+            error=None,
+            timed_out=False,
+            start_s=0.0,
+            start_wall_s=0.0,
+            first_token_s=0.1,
+            first_token_wall_s=0.1,
+            end_s=0.3,
+            end_wall_s=0.3,
+            latency_ms=300.0,
+            ttft_ms=100.0,
+            tpot_ms=None,
+            itl_ms=[],
+            output_chunks=2,
+            output_chars=3,
+            output_hash="hash",
+            text_prefix="abc",
+            stream_chunk_tpot_ms=100.0,
+            stream_chunk_itl_ms=[100.0],
+            server_trace={"completion_tokens": 3},
+        )
+
+        bench_http_serving.finalize_token_timing(result)
+
+        self.assertFalse(result.token_timing_valid)
+        self.assertIsNone(result.tpot_ms)
+        self.assertEqual(result.itl_ms, [])
+
+    def test_retention_gate_rejects_incomplete_token_timing_coverage(self) -> None:
+        report = {
+            "contract": {"required_trace_coverage_ratio": 1.0},
+            "workload": {"num_requests": 1},
+            "summary": {"completed": 1, "failed": 0, "timeouts": 0},
+            "server_trace": {
+                "coverage_ratio": 1.0,
+                "active_set_coverage_ratio": 1.0,
+                "decode_batch_coverage_ratio": 1.0,
+                "token_timing_coverage_ratio": 0.0,
+            },
+        }
+
+        gate = bench_http_serving.build_retention_gate(report)
+
+        self.assertFalse(gate["passed"])
+        self.assertFalse(gate["trace_coverage_passed"])
 
     def test_done_only_stream_fails_when_tokens_requested(self) -> None:
         result = bench_http_serving.request_once(
@@ -74,6 +202,30 @@ class BenchHttpServingTests(unittest.TestCase):
         self.assertFalse(result.ok)
         self.assertEqual(result.status, 200)
         self.assertIn("without streamed text chunks", result.error or "")
+        self.assertEqual(result.output_chunks, 0)
+
+    def test_text_stream_without_done_marker_fails(self) -> None:
+        DoneOnlyHandler.response_body = (
+            b'data: {"choices":[{"text":"complete","finish_reason":"length"}]}\n\n'
+        )
+
+        result = bench_http_serving.request_once(
+            index=0,
+            request_id="req-truncated-stream",
+            url=self.url,
+            model="fake-model",
+            prompt_words=1,
+            prompt="hello",
+            max_tokens=1,
+            temperature=0.0,
+            timeout=5,
+            ignore_eos=True,
+        )
+
+        self.assertFalse(result.ok)
+        self.assertFalse(result.timed_out)
+        self.assertEqual(result.status, 200)
+        self.assertIn("ended before [DONE]", result.error or "")
         self.assertEqual(result.output_chunks, 0)
 
     def test_finish_reason_error_stream_fails_even_after_text_chunk(self) -> None:
@@ -102,8 +254,7 @@ class BenchHttpServingTests(unittest.TestCase):
 
     def test_error_payload_stream_fails(self) -> None:
         DoneOnlyHandler.response_body = (
-            b'data: {"error":{"message":"generation failed"}}\n\n'
-            b"data: [DONE]\n\n"
+            b'data: {"error":{"message":"generation failed"}}\n\ndata: [DONE]\n\n'
         )
 
         result = bench_http_serving.request_once(
@@ -123,10 +274,11 @@ class BenchHttpServingTests(unittest.TestCase):
         self.assertEqual(result.status, 200)
         self.assertIn("SSE error: generation failed", result.error or "")
 
-    def test_mixed_sampling_payload_alternates_greedy_and_sampled_profiles(self) -> None:
+    def test_mixed_sampling_payload_alternates_greedy_and_sampled_profiles(
+        self,
+    ) -> None:
         DoneOnlyHandler.response_body = (
-            b'data: {"choices":[{"text":"x","finish_reason":null}]}\n\n'
-            b"data: [DONE]\n\n"
+            b'data: {"choices":[{"text":"x","finish_reason":null}]}\n\ndata: [DONE]\n\n'
         )
         args = type(
             "Args",
@@ -152,11 +304,16 @@ class BenchHttpServingTests(unittest.TestCase):
         )()
 
         results, _wall_s = bench_http_serving.run_batch(args, measured=True)
-        bodies = sorted(DoneOnlyHandler.request_bodies, key=lambda body: str(body["request_id"]))
+        bodies = sorted(
+            DoneOnlyHandler.request_bodies, key=lambda body: str(body["request_id"])
+        )
 
         self.assertTrue(all(result.ok for result in results))
         self.assertEqual(
-            [(result.sampling_label, result.temperature, result.top_k, result.top_p) for result in results],
+            [
+                (result.sampling_label, result.temperature, result.top_k, result.top_p)
+                for result in results
+            ],
             [
                 ("greedy", 0.0, -1, 1.0),
                 ("sampled", 0.8, 40, 0.95),
@@ -209,9 +366,13 @@ class BenchHttpServingTests(unittest.TestCase):
 
         self.assertIsNotNone(result.server_trace)
         assert result.server_trace is not None
-        self.assertAlmostEqual(result.server_trace["admission_queue_ms"], 20.0, places=3)
+        self.assertAlmostEqual(
+            result.server_trace["admission_queue_ms"], 20.0, places=3
+        )
         self.assertAlmostEqual(result.server_trace["stream_flush_ms"], 50.0, places=3)
-        self.assertAlmostEqual(result.server_trace["frontend_to_queue_ms"], 10.0, places=3)
+        self.assertAlmostEqual(
+            result.server_trace["frontend_to_queue_ms"], 10.0, places=3
+        )
 
     def test_server_trace_loader_ignores_lines_before_measured_offset(self) -> None:
         stale = (
@@ -238,8 +399,7 @@ class BenchHttpServingTests(unittest.TestCase):
 
     def test_run_batch_uses_unique_request_prefix_per_args_instance(self) -> None:
         DoneOnlyHandler.response_body = (
-            b'data: {"choices":[{"text":"x","finish_reason":null}]}\n\n'
-            b"data: [DONE]\n\n"
+            b'data: {"choices":[{"text":"x","finish_reason":null}]}\n\ndata: [DONE]\n\n'
         )
 
         def make_args() -> SimpleNamespace:
@@ -308,8 +468,8 @@ class BenchHttpServingTests(unittest.TestCase):
             text_prefix="text",
         )
         lines = (
-            'ERROR vllm_engine_core_client::client::stream: stream.rs:90 '
-            'request failed with an internal error during generation '
+            "ERROR vllm_engine_core_client::client::stream: stream.rs:90 "
+            "request failed with an internal error during generation "
             'self.request_id="cmpl-bench-0-generated"\n'
             'INFO openinfer_http_trace {"request_id":"cmpl-bench-0-generated",'
             '"queued_at_unix_s":100.01,"terminal_unix_s":100.30,'
@@ -499,15 +659,23 @@ class BenchHttpServingTests(unittest.TestCase):
             },
         )
         self.assertEqual(report["workload"]["sampling_mode"], "mixed-greedy-sampled")
-        self.assertEqual(report["workload"]["sampling_counts"], {"greedy": 1, "sampled": 1})
-        self.assertEqual(report["summary"]["completed_sampling_counts"], {"greedy": 1, "sampled": 1})
+        self.assertEqual(
+            report["workload"]["sampling_counts"], {"greedy": 1, "sampled": 1}
+        )
+        self.assertEqual(
+            report["summary"]["completed_sampling_counts"], {"greedy": 1, "sampled": 1}
+        )
         self.assertEqual(report["summary"]["failed_sampling_counts"], {})
-        self.assertEqual(report["workload"]["sampling_profiles"]["greedy"]["temperature"], 0.0)
-        self.assertEqual(report["workload"]["sampling_profiles"]["sampled"]["top_k"], 40)
+        self.assertEqual(
+            report["workload"]["sampling_profiles"]["greedy"]["temperature"], 0.0
+        )
+        self.assertEqual(
+            report["workload"]["sampling_profiles"]["sampled"]["top_k"], 40
+        )
         self.assertEqual(report["requests"][0]["sampling_label"], "greedy")
         self.assertEqual(report["requests"][1]["temperature"], 0.8)
 
-    def test_ignore_eos_output_token_fallback_uses_requested_max_tokens(self) -> None:
+    def test_output_token_throughput_is_unavailable_without_server_trace(self) -> None:
         result = bench_http_serving.RequestResult(
             index=0,
             request_id="bench-0",
@@ -551,8 +719,10 @@ class BenchHttpServingTests(unittest.TestCase):
         )()
         report = bench_http_serving.build_report(args, [result], wall_s=2.0)
 
-        self.assertEqual(report["summary"]["output_tokens_total"], 16)
-        self.assertAlmostEqual(report["summary"]["output_tokens_per_s"], 8.0)
+        self.assertIsNone(report["summary"]["output_tokens_total"])
+        self.assertIsNone(report["summary"]["output_tokens_per_s"])
+        self.assertEqual(report["summary"]["output_token_count_source"], "unavailable")
+        self.assertEqual(report["summary"]["output_token_count_coverage_ratio"], 0.0)
 
     def test_server_trace_summary_includes_decode_step_breakdown(self) -> None:
         first = SimpleNamespace(
@@ -599,7 +769,9 @@ class BenchHttpServingTests(unittest.TestCase):
         self.assertEqual(summary["decode_steps"]["per_request"]["total"], 5)
         self.assertEqual(summary["decode_steps"]["batched_request_steps_total"], 4)
         self.assertEqual(summary["decode_steps"]["singleton_request_steps_total"], 1)
-        self.assertAlmostEqual(summary["decode_steps"]["request_step_batched_share"], 0.8)
+        self.assertAlmostEqual(
+            summary["decode_steps"]["request_step_batched_share"], 0.8
+        )
 
     def test_server_trace_summary_marks_partial_decode_breakdown_unknown(self) -> None:
         legacy = SimpleNamespace(
@@ -626,7 +798,96 @@ class BenchHttpServingTests(unittest.TestCase):
 
         self.assertEqual(summary["decode_steps"]["batched_request_steps_total"], 3)
         self.assertEqual(summary["decode_steps"]["singleton_request_steps_total"], 2)
-        self.assertAlmostEqual(summary["decode_steps"]["request_step_batched_share"], 0.6)
+        self.assertAlmostEqual(
+            summary["decode_steps"]["request_step_batched_share"], 0.6
+        )
+
+    def test_contract_report_records_hashes_and_full_trace_gate(self) -> None:
+        result = bench_http_serving.RequestResult(
+            index=0,
+            request_id="bench-0",
+            prompt_words=64,
+            max_tokens=64,
+            ok=True,
+            status=200,
+            error=None,
+            timed_out=False,
+            start_s=0.0,
+            start_wall_s=0.0,
+            first_token_s=0.1,
+            first_token_wall_s=0.1,
+            end_s=0.4,
+            end_wall_s=0.4,
+            latency_ms=400.0,
+            ttft_ms=100.0,
+            tpot_ms=5.0,
+            itl_ms=[5.0, 6.0],
+            output_chunks=64,
+            output_chars=128,
+            output_hash="hash-a",
+            text_prefix="text",
+            server_trace={
+                "queued_at_unix_s": 0.0,
+                "prompt_tokens": 64,
+                "completion_tokens": 64,
+                "active_set_size": 1,
+                "decode_batch_size_max": 1,
+                "decode_step_count": 63,
+                "batch_decode_steps": 0,
+            },
+        )
+        args = SimpleNamespace(
+            base_url="http://127.0.0.1:8000",
+            model="DeepSeek-V2-Lite",
+            backend="host-staged",
+            contract_name="dsv2-lite-short-decode-heavy",
+            contract_description="fixed short contract",
+            claim_boundary="HTTP SLO only",
+            required_trace_coverage=1.0,
+            commit="abcdef123456",
+            model_path="models/DeepSeek-V2-Lite",
+            server_command="openinfer --model-path models/DeepSeek-V2-Lite",
+            num_requests=1,
+            concurrency=1,
+            warmup=0,
+            prompt_words=[64],
+            max_tokens=[64],
+            temperature=0.0,
+            top_k=-1,
+            top_p=1.0,
+            sampling_mode="single",
+            sample_temperature=0.8,
+            sample_top_k=40,
+            sample_top_p=0.95,
+            ignore_eos=True,
+            timeout=240.0,
+        )
+
+        report = bench_http_serving.build_report(args, [result], wall_s=2.0)
+
+        self.assertEqual(report["report_intent"], "http_serving_slo")
+        self.assertEqual(report["contract"]["backend"], "host-staged")
+        self.assertEqual(report["contract"]["description"], "fixed short contract")
+        self.assertEqual(report["summary"]["output_hash_distribution"], {"hash-a": 1})
+        self.assertEqual(report["server_trace"]["coverage_ratio"], 1.0)
+        self.assertEqual(report["server_trace"]["active_set_coverage_ratio"], 1.0)
+        self.assertEqual(report["server_trace"]["decode_batch_coverage_ratio"], 1.0)
+        self.assertTrue(report["retention_gate"]["passed"])
+        self.assertFalse(report["latency_budget"]["configured"])
+        self.assertIsNone(report["latency_budget"]["passed"])
+
+    def test_server_error_record_is_not_full_trace_coverage(self) -> None:
+        result = SimpleNamespace(
+            request_id="bench-error",
+            server_trace={"server_error": "request failed"},
+        )
+
+        trace = bench_http_serving.summarize_trace_ms([result])
+
+        self.assertEqual(trace["attached_server_records"], 1)
+        self.assertEqual(trace["server_error_records"], 1)
+        self.assertEqual(trace["traced_requests"], 0)
+        self.assertEqual(trace["coverage_ratio"], 0.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_bench_http_sweep.py
+++ b/tests/test_bench_http_sweep.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import copy
 import importlib.util
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest import mock
 
 
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "bench_http_sweep.py"
@@ -22,6 +25,18 @@ def args_for(sampling_mode: str) -> SimpleNamespace:
     return SimpleNamespace(
         base_url="http://127.0.0.1:8000",
         model="fake-model",
+        backend=None,
+        contract_name=None,
+        contract_description=None,
+        claim_boundary=None,
+        required_trace_coverage=None,
+        commit="abcdef123456",
+        model_path=None,
+        server_command=None,
+        source_revision=None,
+        model_revision=None,
+        server_binary=None,
+        backend_runtime_version=None,
         num_requests=2,
         warmup=0,
         prompt_words=[8],
@@ -56,19 +71,56 @@ def report_with_hashes(
             "max_tokens": 4,
         },
         "summary": {
+            "completed": len(hashes),
             "failed": 0,
             "timeouts": 0,
-            "combined_output_hash": "".join(hashes),
+            "combined_output_hash": bench_http_sweep.combined_output_hash(hashes),
+            "output_hash_distribution": bench_http_sweep.value_counts(hashes),
             "qps": 1.0,
             "input_tokens_per_s": 2.0,
             "output_tokens_per_s": 3.0,
         },
         "metrics": {
-            "ttft": {"avg_ms": 4.0},
-            "tpot": {"avg_ms": 5.0},
-            "itl": {"avg_ms": 6.0},
+            "ttft": {
+                "avg_ms": 4.0,
+                "p50_ms": 4.0,
+                "p95_ms": 4.0,
+                "p99_ms": 4.0,
+                "samples": len(hashes),
+            },
+            "tpot": {
+                "avg_ms": 5.0,
+                "p50_ms": 5.0,
+                "p95_ms": 5.0,
+                "p99_ms": 5.0,
+                "samples": len(hashes),
+            },
+            "itl": {
+                "avg_ms": 6.0,
+                "p50_ms": 6.0,
+                "p95_ms": 6.0,
+                "p99_ms": 6.0,
+                "samples": len(hashes) * 3,
+            },
         },
-        "server_trace": {"phases_ms": {}},
+        "server_trace": {
+            "phases_ms": {},
+            "coverage_ratio": 0.0,
+            "active_set_coverage_ratio": 0.0,
+            "decode_batch_coverage_ratio": 0.0,
+        },
+        "metric_definitions": {
+            "percentile_method": "R7 linear interpolation over sorted samples",
+            "ttft": "request start to first non-empty streamed text chunk",
+            "tpot": "requires streamed text chunk count to equal server completion_tokens",
+            "itl": "requires streamed text chunk count to equal server completion_tokens",
+        },
+        "latency_budget": {
+            "configured": False,
+            "passed": None,
+            "reason": "No production latency budget.",
+        },
+        "metadata": {"benchmark_returncode": 0},
         "requests": [
             {
                 "ok": True,
@@ -76,19 +128,289 @@ def report_with_hashes(
                 "output_chunks": output_chunks,
                 "output_hash": value,
                 "sampling_label": label,
+                "ttft_ms": 4.0,
+                "tpot_ms": 5.0,
+                "itl_ms": [6.0, 6.0, 6.0],
             }
             for value, label in zip(hashes, labels)
         ],
     }
 
 
+def retained_leaf_report(
+    args: SimpleNamespace, hashes: list[str], artifact: Path
+) -> dict[str, object]:
+    report = report_with_hashes(hashes)
+    report.update(
+        {
+            "schema_version": 1,
+            "kind": "openai_http_completions_stream_benchmark",
+            "report_intent": "http_serving_slo",
+            "base_url": args.base_url,
+            "model": args.model,
+            "backend": args.backend,
+            "contract": {
+                "name": args.contract_name,
+                "backend": args.backend,
+                "description": args.contract_description,
+                "required_trace_coverage_ratio": args.required_trace_coverage,
+                "claim_boundary": args.claim_boundary,
+            },
+        }
+    )
+    report["workload"].update(
+        {
+            "num_requests": args.num_requests,
+            "warmup": args.warmup,
+            "temperature": args.temperature,
+            "top_k": args.top_k,
+            "top_p": args.top_p,
+            "sampling_mode": args.sampling_mode,
+            "sampling_profiles": bench_http_sweep.sampling_profiles(args),
+            "ignore_eos": not args.no_ignore_eos,
+            "timeout_s": args.timeout,
+            "timeout_kind": "absolute_request_deadline",
+        }
+    )
+    report["metadata"].update(
+        {
+            "commit": args.commit,
+            "backend": args.backend,
+            "contract_name": args.contract_name,
+            "model_path": args.model_path,
+            "server_command": args.server_command,
+            "source_revision": args.source_revision,
+            "model_revision": args.model_revision,
+            "model_fingerprint": {},
+            "server_binary_sha256": None,
+            "backend_runtime_version": args.backend_runtime_version,
+            "hardware_toolchain": bench_http_sweep.detect_hardware_toolchain(),
+            "benchmark_artifact": str(artifact),
+        }
+    )
+    return report
+
+
 class BenchHttpSweepTests(unittest.TestCase):
+    def test_prepare_summary_path_removes_stale_aggregate(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = Path(tmp)
+            stale = out_dir / "sweep_summary.json"
+            stale_cell = out_dir / "pw8_c2_mt4_r0.json"
+            unrelated = out_dir / "notes.json"
+            stale.write_text('{"passed": true}\n', encoding="utf-8")
+            stale_cell.write_text('{"passed": true}\n', encoding="utf-8")
+            unrelated.write_text("{}\n", encoding="utf-8")
+
+            summary_path = bench_http_sweep.prepare_summary_path(out_dir)
+
+            self.assertEqual(summary_path, stale)
+            self.assertFalse(stale.exists())
+            self.assertFalse(stale_cell.exists())
+            self.assertTrue(unrelated.exists())
+
+    def test_run_one_does_not_reuse_stale_child_artifact(self) -> None:
+        args = args_for("single")
+        args.base_url = "http://127.0.0.1:1"
+        args.server_log = None
+        with tempfile.TemporaryDirectory() as tmp:
+            args.out_dir = Path(tmp)
+            stale = args.out_dir / "pw8_c2_mt4_r0.json"
+            stale.write_text('{"stale": true}\n', encoding="utf-8")
+            with mock.patch.object(
+                bench_http_sweep.subprocess,
+                "run",
+                return_value=SimpleNamespace(returncode=1),
+            ):
+                with self.assertRaises(FileNotFoundError):
+                    bench_http_sweep.run_one(args, 8, 2, 4, 0)
+
+            self.assertFalse(stale.exists())
+
+    def test_summary_hashes_each_leaf_artifact(self) -> None:
+        args = args_for("single")
+        with tempfile.TemporaryDirectory() as tmp:
+            reports = []
+            for repeat in range(2):
+                report = report_with_hashes(["a", "b"])
+                artifact = Path(tmp) / f"repeat-{repeat}.json"
+                report["metadata"]["benchmark_artifact"] = str(artifact)
+                bench_http_sweep.write_json(artifact, report)
+                reports.append(report)
+
+            summary = bench_http_sweep.build_summary(args, reports)
+
+        self.assertEqual(len(summary["leaf_artifacts"]), 2)
+        self.assertTrue(
+            all(len(artifact["sha256"]) == 64 for artifact in summary["leaf_artifacts"])
+        )
+
+    def test_leaf_verifier_recomputes_rows_after_manifest_rehash(self) -> None:
+        args = args_for("single")
+        args.backend = "host-staged"
+        args.contract_name = "retained-test"
+        args.contract_description = "Retained test contract."
+        args.claim_boundary = "HTTP test evidence only."
+        with tempfile.TemporaryDirectory() as tmp:
+            reports = []
+            paths = []
+            for repeat in range(args.repeats):
+                path = Path(tmp) / f"repeat-{repeat}.json"
+                report = retained_leaf_report(args, ["a", "b"], path)
+                bench_http_sweep.write_json(path, report)
+                reports.append(report)
+                paths.append(path)
+            summary = bench_http_sweep.build_summary(args, reports)
+
+            passed = bench_http_sweep.verify_summary_leaf_artifacts(summary)
+            reports[0]["summary"]["qps"] = 99.0
+            bench_http_sweep.write_json(paths[0], reports[0])
+            summary["leaf_artifacts"][0]["sha256"] = bench_http_sweep.sha256_file(
+                paths[0]
+            )
+            failed = bench_http_sweep.verify_summary_leaf_artifacts(summary)
+
+        self.assertTrue(passed["passed"])
+        self.assertFalse(failed["passed"])
+        self.assertIn("rows.recomputed", failed["failures"])
+
+    def test_leaf_verifier_rejects_provenance_drift_after_manifest_rehash(self) -> None:
+        args = args_for("single")
+        args.backend = "host-staged"
+        args.contract_name = "retained-test"
+        args.contract_description = "Retained test contract."
+        args.claim_boundary = "HTTP test evidence only."
+        with tempfile.TemporaryDirectory() as tmp:
+            reports = []
+            paths = []
+            for repeat in range(args.repeats):
+                path = Path(tmp) / f"repeat-{repeat}.json"
+                report = retained_leaf_report(args, ["a", "b"], path)
+                bench_http_sweep.write_json(path, report)
+                reports.append(report)
+                paths.append(path)
+            summary = bench_http_sweep.build_summary(args, reports)
+
+            reports[0]["metadata"]["server_binary_sha256"] = "f" * 64
+            bench_http_sweep.write_json(paths[0], reports[0])
+            summary["leaf_artifacts"][0]["sha256"] = bench_http_sweep.sha256_file(
+                paths[0]
+            )
+            failed = bench_http_sweep.verify_summary_leaf_artifacts(summary)
+
+        self.assertFalse(failed["passed"])
+        self.assertIn(
+            "leaf_artifacts[0].metadata.server_binary_sha256", failed["failures"]
+        )
+
+    def test_metric_samples_allow_valid_early_eos(self) -> None:
+        report = report_with_hashes(["a", "b"])
+        report["metrics"]["tpot"]["samples"] = 0
+        report["metrics"]["itl"]["samples"] = 0
+        for request in report["requests"]:
+            request["tpot_ms"] = None
+            request["itl_ms"] = []
+
+        self.assertTrue(bench_http_sweep.metric_sample_counts_pass(report))
+
+    def test_nonzero_child_returncode_fails_cell(self) -> None:
+        args = args_for("single")
+        report = report_with_hashes(["a", "b"])
+        report["metadata"]["benchmark_returncode"] = 1
+
+        summary = bench_http_sweep.build_summary(args, [report, copy.deepcopy(report)])
+
+        self.assertFalse(summary["correctness_gate"]["passed"])
+        self.assertFalse(summary["rows"][0]["benchmark_commands_passed"])
+        self.assertEqual(summary["rows"][0]["noisy_cell"], "benchmark_error")
+
+    def test_missing_child_returncode_fails_cell(self) -> None:
+        args = args_for("single")
+        report = report_with_hashes(["a", "b"])
+        del report["metadata"]["benchmark_returncode"]
+
+        summary = bench_http_sweep.build_summary(args, [report, copy.deepcopy(report)])
+
+        self.assertFalse(summary["correctness_gate"]["passed"])
+        self.assertFalse(summary["rows"][0]["benchmark_commands_passed"])
+        self.assertEqual(summary["rows"][0]["noisy_cell"], "benchmark_error")
+
+    def test_summary_records_repeat_noise_hashes_and_trace_gate(self) -> None:
+        args = args_for("single")
+        args.backend = "nccl"
+        args.contract_name = "fixed-contract"
+        args.contract_description = "fixed workload"
+        args.claim_boundary = "HTTP only"
+        args.required_trace_coverage = 1.0
+        first = report_with_hashes(["hash-a", "hash-b"])
+        second = copy.deepcopy(first)
+        first["metrics"]["ttft"]["p95_ms"] = 100.0
+        second["metrics"]["ttft"]["p95_ms"] = 130.0
+        first["summary"]["output_tokens_per_s"] = 100.0
+        second["summary"]["output_tokens_per_s"] = 70.0
+        for report in (first, second):
+            report["server_trace"].update(
+                {
+                    "traced_requests": 2,
+                    "coverage_ratio": 1.0,
+                    "active_set_coverage_ratio": 1.0,
+                    "decode_batch_coverage_ratio": 1.0,
+                    "active_set_size_max": 2,
+                    "decode_batch_size_max": 2,
+                    "token_timing_coverage_ratio": 1.0,
+                    "token_timing_mismatches": [],
+                    "token_timing_unknown": [],
+                }
+            )
+
+        summary = bench_http_sweep.build_summary(args, [first, second])
+
+        row = summary["rows"][0]
+        self.assertTrue(summary["correctness_gate"]["passed"])
+        self.assertEqual(row["noisy_cell"], "noisy")
+        self.assertEqual(row["output_hash_distribution"], {"hash-a": 2, "hash-b": 2})
+        self.assertEqual(
+            row["request_output_hashes_by_repeat"],
+            [["hash-a", "hash-b"], ["hash-a", "hash-b"]],
+        )
+        self.assertTrue(row["hash_manifests_consistent"])
+        self.assertTrue(row["trace_coverage_passed"])
+        self.assertEqual(row["ttft_ms"]["p95_summary"]["median"], 115.0)
+        self.assertEqual(
+            bench_http_sweep.noisy_cell_marker([first]),
+            "insufficient_repeats",
+        )
+
+    def test_startup_failure_summary_retains_contract(self) -> None:
+        args = args_for("single")
+        args.backend = "nccl"
+        args.contract_name = "fixed-contract"
+        args.contract_description = "fixed workload"
+        args.claim_boundary = "HTTP only"
+        args.required_trace_coverage = 1.0
+        args.server_log = Path("server.log")
+        args.mixed_prompt_shape = False
+
+        summary = bench_http_sweep.build_startup_failure_summary(
+            args, "server failed before communicator creation"
+        )
+
+        self.assertEqual(summary["report_intent"], "http_serving_slo_startup_failure")
+        self.assertFalse(summary["correctness_gate"]["passed"])
+        self.assertEqual(summary["rows"][0]["noisy_cell"], "startup_failure")
+        self.assertEqual(summary["rows"][0]["failed"], [2, 2])
+        self.assertEqual(summary["run_errors"][0]["phase"], "server_startup")
+
     def test_mixed_sampling_does_not_require_repeat_hash_stability(self) -> None:
         summary = bench_http_sweep.build_summary(
             args_for("mixed-greedy-sampled"),
             [
-                report_with_hashes(["greedy", "sampled-a"], labels=["greedy", "sampled"]),
-                report_with_hashes(["greedy", "sampled-b"], labels=["greedy", "sampled"]),
+                report_with_hashes(
+                    ["greedy", "sampled-a"], labels=["greedy", "sampled"]
+                ),
+                report_with_hashes(
+                    ["greedy", "sampled-b"], labels=["greedy", "sampled"]
+                ),
             ],
         )
 
@@ -99,7 +421,9 @@ class BenchHttpSweepTests(unittest.TestCase):
         self.assertFalse(summary["rows"][0]["stable_per_request_hashes"])
         self.assertTrue(summary["rows"][0]["stable_greedy_hashes"])
         self.assertTrue(summary["rows"][0]["sampled_hashes_present"])
-        self.assertEqual(summary["workload"]["sampling_profiles"]["sampled"]["top_k"], 40)
+        self.assertEqual(
+            summary["workload"]["sampling_profiles"]["sampled"]["top_k"], 40
+        )
 
     def test_mixed_sampling_requires_sampled_requests(self) -> None:
         summary = bench_http_sweep.build_summary(
@@ -119,8 +443,12 @@ class BenchHttpSweepTests(unittest.TestCase):
         summary = bench_http_sweep.build_summary(
             args_for("mixed-greedy-sampled"),
             [
-                report_with_hashes(["greedy-a", "sampled-a"], labels=["greedy", "sampled"]),
-                report_with_hashes(["greedy-b", "sampled-b"], labels=["greedy", "sampled"]),
+                report_with_hashes(
+                    ["greedy-a", "sampled-a"], labels=["greedy", "sampled"]
+                ),
+                report_with_hashes(
+                    ["greedy-b", "sampled-b"], labels=["greedy", "sampled"]
+                ),
             ],
         )
 
@@ -134,7 +462,9 @@ class BenchHttpSweepTests(unittest.TestCase):
             args_for("mixed-greedy-sampled"),
             [
                 report_with_hashes(["greedy", "sampled"], labels=["greedy", "sampled"]),
-                report_with_hashes(["", ""], output_chunks=0, labels=["greedy", "sampled"]),
+                report_with_hashes(
+                    ["", ""], output_chunks=0, labels=["greedy", "sampled"]
+                ),
             ],
         )
 
@@ -151,6 +481,16 @@ class BenchHttpSweepTests(unittest.TestCase):
         self.assertFalse(summary["correctness_gate"]["passed"])
         self.assertTrue(summary["rows"][0]["hash_stability_checked"])
         self.assertFalse(summary["rows"][0]["passed"])
+
+    def test_leaf_hash_summary_must_match_request_hashes(self) -> None:
+        args = args_for("single")
+        report = report_with_hashes(["a", "b"])
+        report["summary"]["output_hash_distribution"] = {"forged": 2}
+
+        summary = bench_http_sweep.build_summary(args, [report, copy.deepcopy(report)])
+
+        self.assertFalse(summary["correctness_gate"]["passed"])
+        self.assertFalse(summary["rows"][0]["hash_manifests_consistent"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #466.

This PR separates DeepSeek-V2-Lite correctness/integration evidence from benchmark and serving SLO evidence, then adds a retained HTTP SLO report path for the fixed host-staged and NCCL contracts.

## Changes

- Mark `e2e_ep2` as a correctness/integration gate, with explicit no-performance claim boundaries.
- Mark `dsv2_lite_ep2_decode_attribution` as a direct diagnostic benchmark and enrich its structured JSON metadata.
- Add shared HTTP benchmark artifact helpers and a DSV2-Lite retained SLO runner.
- Extend the HTTP serving/sweep scripts to retain TTFT, TPOT, ITL, throughput, failures/timeouts, trace coverage, output hashes, repeat summaries, and noisy-cell markers.
- Add DSV2-Lite docs for the verification ladder, retained SLO profiles, NCCL runtime floor on Blackwell, and production-readiness boundaries.

## Validation

- `python3 -m py_compile scripts/bench_http_common.py scripts/bench_http_serving.py scripts/bench_http_sweep.py scripts/bench_dsv2lite_http_slo.py`
- `python3 -m unittest -v tests/test_bench_http_common.py tests/test_bench_http_serving.py tests/test_bench_http_sweep.py tests/test_bench_dsv2lite_http_slo.py`
- `cargo fmt --all --check`
- `cargo metadata --locked --no-deps --format-version 1`

A real 2x RTX 5090 validation run retained all six host-staged/NCCL children with zero failures/timeouts and full required trace coverage. The report is HTTP pressure/SLO evidence for the fixed contracts; it is not a sustained soak, vLLM parity, multi-node recovery, or production-readiness claim.