### PR TITLE
docs(contributing): fix escaped markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,45 +10,38 @@ If you have questions, need help, or want to discuss a feature, please reach out
 
 * **GitHub Issues & Discussions:** Please use this repository's official Issues and Discussions tabs to ask questions or report problems.
 
-
-\## 🛠️ Setup \& Development
+## 🛠️ Setup & Development
 
 We keep our detailed technical documentation close to the code. Please refer to these guides:
 
-\* \*\*First-time Setup:\*\* See \[Developer Onboarding](docs/playbooks/developer-onboarding.md) to set up your toolchain.
+* **First-time Setup:** See [Developer Onboarding](docs/playbooks/developer-onboarding.md) to set up your toolchain.
 
-\* \*\*Building \& Running Tests:\*\* Check \[CLAUDE.md](./CLAUDE.md) for quick commands on building and running the test suite.
+* **Building & Running Tests:** Check [CLAUDE.md](./CLAUDE.md) for quick commands on building and running the test suite.
 
-\* \*\*Coding Style \& Principles:\*\* Read our \[Coding Style Guide](docs/conventions/coding-style.md).
+* **Coding Style & Principles:** Read our [Coding Style Guide](docs/conventions/coding-style.md).
 
-
-
-\## 🌿 Branch Naming
+## 🌿 Branch Naming
 
 When creating a branch, use the following prefixes depending on your work:
 
-\* `feat/` for new features (e.g., `feat/add-login-button`)
+* `feat/` for new features (e.g., `feat/add-login-button`)
 
-\* `fix/` for bug fixes (e.g., `fix/memory-leak`)
+* `fix/` for bug fixes (e.g., `fix/memory-leak`)
 
-\* `chore/` for maintenance, CI/CD, or dependency updates (e.g., `chore/update-deps`)
+* `chore/` for maintenance, CI/CD, or dependency updates (e.g., `chore/update-deps`)
 
+## 📝 Commit Messages
 
-
-\## 📝 Commit Messages
-
-We use \*\*Commitizen\*\* conventions for clear history. Your commit messages should look like this:
+We use **Commitizen** conventions for clear history. Your commit messages should look like this:
 
 `type(scope): description` (e.g., `feat(auth): add OAuth2 support`)
 
+## 🚀 How to Submit a PR
 
-\## 🚀 How to Submit a PR
+1. Fork the repository and create your branch from `main`.
 
-1\. Fork the repository and create your branch from `main`.
+2. Ensure your code passes all tests (e.g., cargo test --release).
 
-2\. Ensure your code passes all tests (e.g., cargo test --release).
+3. Open a Pull Request against the `main` branch.
 
-3\. Open a Pull Request against the `main` branch.
-
-4\. Fill out the PR template—our maintainers will review it shortly!
-
+4. Fill out the PR template—our maintainers will review it shortly!


### PR DESCRIPTION
## Description

Fixes the Markdown formatting in `CONTRIBUTING.md` by removing accidental escape characters from headings, lists, emphasis, links, and numbered steps.

The escaped punctuation caused GitHub to render most of the contribution guide as plain text instead of structured Markdown.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Validation

- `git diff --check`
- `cargo fmt --all --check`
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo test --release --locked -p openinfer-build -p openinfer-engine --lib`
- Verified all three referenced documentation paths exist
- Confirmed no escaped heading, list, or numbered-list markers remain

## Checklist

- [x] My change follows the style guidelines of this project.
- [x] I have performed a self-review of my change.
- [x] I have formatted my commit according to Commitizen conventions.
- [x] The change is documentation-only and does not alter production behavior.
