### PR TITLE
fix(qwen3): request-local prefill chunk boundaries under --batch-invariant

### DIFF
--- a/docs/models/qwen3/model-crate.md
+++ b/docs/models/qwen3/model-crate.md
@@ -8,6 +8,8 @@
 
 `--batch-invariant` is scoped to one process, one toolchain, and one GPU. The cuBLASLt algo is re-tuned on every boot and cached per executor thread (`thread_local`), so it does not promise stability across cuBLAS or driver versions; startup logging records the pinned `splitk` and `reduction_scheme` per `(M,K)`. The builder rejects decode-overlap, DFlash speculative decoding, LoRA, and tensor parallelism.
 
+It also **requires `--no-prefix-cache` and rejects `--kv-offload`**. A prefix hit advances a prompt's `chunk_start` off the request-local chunk grid, re-cutting its prefill chunks according to prior traffic. `--no-prefix-cache` closes that — except under offload, where it only disables HBM retention and deliberately leaves prefix *matching* on (host-tier reuse is the point of that mode), so that pair is rejected outright.
+
 ## Preparation
 
 - **Read**:

--- a/openinfer-qwen3/src/lib.rs
+++ b/openinfer-qwen3/src/lib.rs
@@ -446,12 +446,15 @@ fn start_engine_with_offload_inner(
     let model_path = model_path
         .to_str()
         .ok_or_else(|| anyhow::anyhow!("model path must be valid UTF-8"))?;
-    ensure_batch_invariant_supported(
-        decode_overlap,
-        batch_invariant,
-        dflash_draft_model_path.is_some(),
-        device_ordinals.len(),
-    )?;
+    if batch_invariant {
+        ensure_batch_invariant_supported(
+            decode_overlap,
+            no_prefix_cache,
+            offload_options.enabled,
+            dflash_draft_model_path.is_some(),
+            device_ordinals.len(),
+        )?;
+    }
     apply_batch_invariant_policy(batch_invariant);
     let dflash_draft_model_path = dflash_draft_model_path
         .map(|path| {
@@ -495,12 +498,6 @@ pub fn start_engine_with_lora_control(
     let model_path = model_path
         .to_str()
         .ok_or_else(|| anyhow::anyhow!("model path must be valid UTF-8"))?;
-    ensure_batch_invariant_supported(
-        decode_overlap,
-        batch_invariant,
-        false,
-        device_ordinals.len(),
-    )?;
     if batch_invariant {
         anyhow::bail!(
             "--batch-invariant is not supported with LoRA: the decode-GEMM pin warms and self-checks \
@@ -536,25 +533,39 @@ fn apply_batch_invariant_policy(batch_invariant: bool) {
 
 fn ensure_batch_invariant_supported(
     decode_overlap: DecodeOverlap,
-    batch_invariant: bool,
+    no_prefix_cache: bool,
+    offload: bool,
     dflash: bool,
     world_size: usize,
 ) -> Result<()> {
-    if batch_invariant && !matches!(decode_overlap, DecodeOverlap::Off) {
+    if !matches!(decode_overlap, DecodeOverlap::Off) {
         anyhow::bail!(
             "--batch-invariant is not compatible with --decode-overlap; the stream override would force the pinned GEMM to bail at runtime"
         );
     }
-    if batch_invariant && world_size > 1 {
+    if offload {
+        anyhow::bail!(
+            "--batch-invariant is not supported with KV offload: offload keeps prefix matching on \
+             (--no-prefix-cache only disables HBM retention there), and a host-tier prefix hit \
+             shifts a prompt's chunk boundaries off the request-local grid"
+        );
+    }
+    if world_size > 1 {
         anyhow::bail!(
             "--batch-invariant is not supported with tensor parallelism: world_size={world_size} has unverified cross-rank reduction order"
         );
     }
-    if batch_invariant && dflash {
+    if dflash {
         anyhow::bail!(
             "--batch-invariant is not supported with DFlash speculative decoding: the decode-GEMM \
              pin warms and self-checks only the base projections, so the drafter's fc/MLP GEMMs \
              are not pinned and would bail at the GEMM boundary under Pin"
+        );
+    }
+    if !no_prefix_cache {
+        anyhow::bail!(
+            "--batch-invariant requires --no-prefix-cache; prefix-cache hits move a prompt's chunk \
+             boundaries off the request-local grid, so batch-invariant prefill cannot be provided"
         );
     }
     Ok(())

--- a/openinfer-qwen3/src/scheduler.rs
+++ b/openinfer-qwen3/src/scheduler.rs
@@ -28,6 +28,7 @@ use openinfer_core::engine::{
     TokenEvent, TokenSink,
 };
 use openinfer_core::sampler::SamplingParams;
+use openinfer_kernels::ops::{NumericPolicy, numeric_policy};
 
 use self::effects::apply_effects;
 use self::kv_events::KvEventProducer;
@@ -107,10 +108,14 @@ impl PendingRequest {
 /// step's total forwarded tokens at `max_prefill_tokens`. Each taken request
 /// gets its per-step chunk recorded in `step_chunk`. Echo requests need
 /// logits for every prompt position in one forward, so they only run when
-/// their whole remainder fits the profiled prefill bound.
+/// their whole remainder fits the profiled prefill bound. Under request-local
+/// chunking, a request takes `min(remaining, max_prefill_tokens)` whole or skips
+/// the step, so its chunk boundaries depend only on its own length and are
+/// batch-invariant.
 fn take_prefill_chunks(
     prefilling: &mut Vec<PendingRequest>,
     max_prefill_tokens: usize,
+    request_local: bool,
 ) -> Vec<PendingRequest> {
     let mut budget = max_prefill_tokens;
     let mut taken: Vec<PendingRequest> = Vec::new();
@@ -123,6 +128,13 @@ fn take_prefill_chunks(
                 continue;
             }
             remaining
+        } else if request_local {
+            let desired = remaining.min(max_prefill_tokens);
+            if desired > budget {
+                i += 1;
+                continue;
+            }
+            desired
         } else {
             remaining.min(budget)
         };
@@ -131,8 +143,7 @@ fn take_prefill_chunks(
         budget = budget.saturating_sub(chunk);
         taken.push(req);
     }
-    // Echo skips can take items out of arrival order; results come back
-    // sorted by request id, so the step set must be too.
+    // Whole-or-skip may select later requests; sort to match request-id-ordered results.
     taken.sort_by_key(|req| req.request_id);
     taken
 }
@@ -622,7 +633,14 @@ fn scheduler_loop<E>(
         let pending = if inflight_prefill_pending.is_some() {
             Vec::new()
         } else {
-            take_prefill_chunks(&mut prefilling, max_prefill_tokens)
+            take_prefill_chunks(
+                &mut prefilling,
+                max_prefill_tokens,
+                matches!(
+                    numeric_policy(),
+                    NumericPolicy::Pin | NumericPolicy::PerToken
+                ),
+            )
         };
 
         let Some(plan) = runtime_plan(&executor, &active, pending) else {
@@ -804,7 +822,8 @@ fn scheduler_loop_with_lora_control<E>(
         }
         prefilling.extend(admission.pending);
         deferred = admission.deferred;
-        let pending = take_prefill_chunks(&mut prefilling, max_prefill_tokens);
+        // LoRA rejects --batch-invariant upstream, so Pin never runs on this path.
+        let pending = take_prefill_chunks(&mut prefilling, max_prefill_tokens, false);
 
         if active.is_empty() && pending.is_empty() {
             // A parked load must still be polled to completion before we block.

--- a/openinfer-qwen3/src/scheduler/tests.rs
+++ b/openinfer-qwen3/src/scheduler/tests.rs
@@ -444,7 +444,7 @@ fn prefill_chunking_caps_step_tokens_and_keeps_fifo_progress() {
     // A prompt larger than the budget is split: the head request gets a
     // budget-sized chunk and everyone behind it waits.
     let mut prefilling = vec![mk(1, 64, 1), mk(2, 16, 1)];
-    let taken = take_prefill_chunks(&mut prefilling, 32);
+    let taken = take_prefill_chunks(&mut prefilling, 32, false);
     assert_eq!(taken.len(), 1);
     assert_eq!(taken[0].request_id, RequestId(1));
     assert_eq!(taken[0].step_chunk, 32, "chunk is capped at the budget");
@@ -457,7 +457,7 @@ fn prefill_chunking_caps_step_tokens_and_keeps_fifo_progress() {
     // Requests pack until the budget is filled exactly; the overflow stays
     // queued in arrival order.
     let mut prefilling = vec![mk(3, 16, 1), mk(4, 16, 1), mk(5, 16, 1)];
-    let taken = take_prefill_chunks(&mut prefilling, 32);
+    let taken = take_prefill_chunks(&mut prefilling, 32, false);
     assert_eq!(
         taken.iter().map(|r| r.step_chunk).collect::<Vec<_>>(),
         vec![16, 16],
@@ -469,13 +469,53 @@ fn prefill_chunking_caps_step_tokens_and_keeps_fifo_progress() {
     let mut head = mk(6, 64, 1);
     head.prefill_pos = 48;
     let mut prefilling = vec![head, mk(7, 16, 1)];
-    let taken = take_prefill_chunks(&mut prefilling, 32);
+    let taken = take_prefill_chunks(&mut prefilling, 32, false);
     assert_eq!(
         taken.iter().map(|r| r.step_chunk).collect::<Vec<_>>(),
         vec![16, 16],
         "remainder of the chunked head + the next request share the step"
     );
     assert!(prefilling.is_empty());
+}
+
+// TokenEvent does not expose per-step chunk assignments, so gate them here.
+#[test]
+fn request_local_chunks_are_independent_of_earlier_requests() {
+    let mk = |id: u64, prompt_len| {
+        PendingRequest::from_scheduler_request(RequestId(id), request(prompt_len, 1).0)
+    };
+    let simulate = |mut prefilling: Vec<PendingRequest>, request_local: bool| {
+        let mut target_chunks = Vec::new();
+        while prefilling.iter().any(|req| req.request_id == RequestId(3)) {
+            let taken = take_prefill_chunks(&mut prefilling, 32, request_local);
+            let mut continued = Vec::new();
+            for mut req in taken {
+                if req.request_id == RequestId(3) {
+                    target_chunks.push(req.step_chunk);
+                }
+                req.prefill_pos += req.step_chunk;
+                if req.remaining_prompt_tokens() > 0 {
+                    continued.push(req);
+                }
+            }
+            prefilling.splice(0..0, continued);
+        }
+        target_chunks
+    };
+    let alone = || vec![mk(3, 80)];
+    let behind_others = || vec![mk(1, 24), mk(2, 16), mk(3, 80)];
+
+    assert_eq!(simulate(alone(), true), vec![32, 32, 16]);
+    assert_eq!(simulate(behind_others(), true), vec![32, 32, 16]);
+
+    // Without request-local chunking the same request is cut differently once it queues behind
+    // others — the drift this pins. Its absence would make the two asserts above vacuous.
+    assert_eq!(simulate(alone(), false), vec![32, 32, 16]);
+    assert_ne!(
+        simulate(behind_others(), false),
+        vec![32, 32, 16],
+        "shared-budget chunking must still be batch-dependent, or the request-local asserts prove nothing"
+    );
 }
 
 #[test]
@@ -494,7 +534,7 @@ fn echo_requests_run_only_when_their_prompt_fits_the_prefill_bound() {
     // admission, the chunk picker must still keep it out of the profiled
     // prefill shape instead of running it whole.
     let mut prefilling = vec![mk_echo(1, 64), mk(2, 16)];
-    let taken = take_prefill_chunks(&mut prefilling, 32);
+    let taken = take_prefill_chunks(&mut prefilling, 32, false);
     assert_eq!(taken.len(), 1);
     assert_eq!(taken[0].request_id, RequestId(2));
     assert_eq!(taken[0].step_chunk, 16);
@@ -508,7 +548,7 @@ fn echo_requests_run_only_when_their_prompt_fits_the_prefill_bound() {
     // later requests may still fill the leftover budget, and the step set
     // stays sorted by request id.
     let mut prefilling = vec![mk(3, 24), mk_echo(4, 16), mk(5, 8)];
-    let taken = take_prefill_chunks(&mut prefilling, 32);
+    let taken = take_prefill_chunks(&mut prefilling, 32, false);
     assert_eq!(
         taken
             .iter()

--- a/openinfer-qwen3/tests/batch_invariance_output.rs
+++ b/openinfer-qwen3/tests/batch_invariance_output.rs
@@ -468,17 +468,6 @@ fn output_sequence_batch_invariant_under_pin() {
     harness.barrier();
     phase_two(&mut harness, &baseline);
     harness.barrier();
-}
-
-#[test]
-#[ignore = "chunked-prefill composition drifts per-token logprobs under Pin"]
-fn chunked_prefill_drifts_output_logprobs() {
-    let Some(model_path) = model_path_or_skip() else {
-        return;
-    };
-    let _guard = POLICY_LOCK.lock().unwrap();
-    let handle = start_pin_engine(&model_path);
-    let mut harness = Harness::new(handle);
     phase_three(&mut harness);
     harness.barrier();
 }

--- a/openinfer-qwen3/tests/batch_invariance_reject.rs
+++ b/openinfer-qwen3/tests/batch_invariance_reject.rs
@@ -1,5 +1,5 @@
-//! `--batch-invariant` is rejected at the Qwen3 builder boundary for unsupported combos:
-//! stream overlap, the DFlash drafter, and LoRA each run GEMMs the base-projection pin does not cover; the builder rejects all three.
+//! Builder-boundary tests for unsupported `--batch-invariant` combinations. They call the public
+//! `start_engine_*` entry points, so they also cover guard wiring.
 
 use std::path::Path;
 use std::sync::Mutex;
@@ -22,7 +22,7 @@ fn batch_invariant_rejects_decode_overlap() {
         Path::new("/nonexistent-model"),
         EngineLoadOptions::default(),
         Qwen3OffloadOptions::disabled(),
-        false,
+        true,
         DEFAULT_MAX_PREFILL_TOKENS,
         Qwen3MemoryOptions::default(),
         DecodeOverlap::SharedSm,
@@ -51,7 +51,7 @@ fn batch_invariant_rejects_dflash() {
         Path::new("/nonexistent-model"),
         EngineLoadOptions::default(),
         Qwen3OffloadOptions::disabled(),
-        false,
+        true,
         DEFAULT_MAX_PREFILL_TOKENS,
         Qwen3MemoryOptions::default(),
         DecodeOverlap::Off,
@@ -73,6 +73,64 @@ fn batch_invariant_rejects_dflash() {
 }
 
 #[test]
+fn batch_invariant_rejects_prefix_cache() {
+    let _g = POLICY_LOCK.lock().unwrap();
+    set_numeric_policy(NumericPolicy::Tuned);
+    let err = start_engine_with_offload(
+        Path::new("/nonexistent-model"),
+        EngineLoadOptions::default(),
+        Qwen3OffloadOptions::disabled(),
+        false,
+        DEFAULT_MAX_PREFILL_TOKENS,
+        Qwen3MemoryOptions::default(),
+        DecodeOverlap::Off,
+        true,
+        None,
+        false,
+    )
+    .err()
+    .expect("--batch-invariant with the prefix cache on must be rejected");
+    assert!(
+        format!("{err}").contains("--no-prefix-cache"),
+        "unexpected error: {err}"
+    );
+    assert_eq!(
+        numeric_policy(),
+        NumericPolicy::Tuned,
+        "guard must reject before apply_batch_invariant_policy — global policy was polluted to Pin"
+    );
+}
+
+#[test]
+fn batch_invariant_rejects_kv_offload() {
+    let _g = POLICY_LOCK.lock().unwrap();
+    set_numeric_policy(NumericPolicy::Tuned);
+    let err = start_engine_with_offload(
+        Path::new("/nonexistent-model"),
+        EngineLoadOptions::default(),
+        Qwen3OffloadOptions::enabled(1 << 30),
+        true,
+        DEFAULT_MAX_PREFILL_TOKENS,
+        Qwen3MemoryOptions::default(),
+        DecodeOverlap::Off,
+        true,
+        None,
+        false,
+    )
+    .err()
+    .expect("--batch-invariant + KV offload must be rejected");
+    assert!(
+        format!("{err}").contains("KV offload"),
+        "unexpected error: {err}"
+    );
+    assert_eq!(
+        numeric_policy(),
+        NumericPolicy::Tuned,
+        "guard must reject before apply_batch_invariant_policy — global policy was polluted to Pin"
+    );
+}
+
+#[test]
 fn batch_invariant_rejects_lora() {
     let _g = POLICY_LOCK.lock().unwrap();
     set_numeric_policy(NumericPolicy::Tuned);
@@ -81,7 +139,7 @@ fn batch_invariant_rejects_lora() {
         EngineLoadOptions::default(),
         Qwen3LoraOptions::default(),
         Qwen3OffloadOptions::disabled(),
-        false,
+        true,
         DEFAULT_MAX_PREFILL_TOKENS,
         Qwen3MemoryOptions::default(),
         DecodeOverlap::Off,

--- a/openinfer-server/src/config.rs
+++ b/openinfer-server/src/config.rs
@@ -249,9 +249,9 @@ pub(crate) struct Args {
     #[arg(long, default_value_t = 20, value_parser = clap::value_parser!(u32).range(1..=99))]
     pub decode_sm_pct: u32,
 
-    /// Pin Qwen3's projection GEMMs and split-KV chunk count, and route a unified step's decode
-    /// rows through the decode attention a pure decode step runs. Off by default. Qwen3-only,
-    /// single-GPU.
+    /// Enable single-GPU Qwen3 batch-invariant serving by pinning the numeric paths and cutting
+    /// each prompt's prefill chunks on its own grid. Off by default. Requires `--no-prefix-cache`;
+    /// incompatible with `--kv-offload`, which keeps prefix matching on regardless.
     #[arg(long, default_value_t = false)]
     pub batch_invariant: bool,
 }
@@ -440,6 +440,13 @@ impl Args {
                 "--batch-invariant is not compatible with --decode-overlap; the stream override would force the pinned GEMM to bail at runtime"
             );
         }
+        if self.batch_invariant && self.kv_offload {
+            bail!(
+                "--batch-invariant is not supported with --kv-offload: offload keeps prefix matching \
+                 on (--no-prefix-cache only disables HBM retention there), and a host-tier prefix hit \
+                 shifts a prompt's chunk boundaries off the request-local grid"
+            );
+        }
         if self.batch_invariant && self.dflash_draft_model_path.is_some() {
             bail!(
                 "--batch-invariant is not supported with DFlash speculative decoding; enable one at a time"
@@ -447,6 +454,12 @@ impl Args {
         }
         if self.batch_invariant && self.tp_size > 1 {
             bail!("--batch-invariant is not supported with --tp-size > 1; enable one at a time");
+        }
+        if self.batch_invariant && !self.no_prefix_cache {
+            bail!(
+                "--batch-invariant requires --no-prefix-cache; prefix-cache hits move a prompt's chunk \
+                 boundaries off the request-local grid, so batch-invariant prefill cannot be provided"
+            );
         }
         if provided.contains("decode_sm_pct")
             && !matches!(self.decode_overlap, CliDecodeOverlap::GreenCtx)


### PR DESCRIPTION
## Description

Sub-item of #435, stacked on the output-level batch-invariance gate (the previous PR in this series). Closes the chunked-prefill axis that gate's `#[ignore]`d half documented, and flips it green.

A prompt's prefill chunk boundaries are budget-derived, not request-local: `take_prefill_chunks` packs the per-step token budget across the queue, so the same prompt splits `1024+476` alone and (e.g.) `~248+1024+228` when it shares the step. Chunk boundaries change the prefill attention's call shapes — which tokens attend in-chunk state vs already-scattered paged KV, at what qo_len — and those are different reduction orders. No existing pin reaches this: the projection-GEMM pin makes each GEMM N-invariant, but the attention composition itself differs per boundary. Measured by the output gate: token ids hold by argmax margin only, while per-token logprob bits drift from a timing-dependent index onward (the divergence point moves with how the scheduler happened to interleave the step; the run recorded for this PR first diverges at index 7, logprob `-1.9073486e-5` vs `-1.5258789e-5`, and the drift then propagates through the KV to the rest of the sequence) — one near-tie away from a token flip.

The prefix cache is a second boundary-mover: a hit advances `chunk_start` by matched blocks (block-aligned, not quantum-aligned), so with the cache on, boundaries depend on prior traffic. `--batch-invariant` previously accepted the default cache-on configuration, silently serving composition-dependent prefill. KV offload is a third, and it hides behind the second: under offload, `--no-prefix-cache` only stops HBM retention and leaves prefix matching on, so a host-tier hit moves `chunk_start` exactly the same way.

## Fix

1. Under `Pin`/`PerToken`, `take_prefill_chunks` takes `min(remaining, max_prefill_tokens)` whole or skips the request this step — reusing the take-whole-or-skip shape echo requests already have. A prompt's chunk sequence becomes `[quantum, …, remainder]`, exactly what it gets alone, so the attention composition per token is identical alone or co-batched by construction (the same fixed-size shape as the split-KV chunk pin). Tuned keeps budget-remainder packing, byte-identical.
2. `--batch-invariant` now requires `--no-prefix-cache`, rejected fail-loud at engine start and in the server CLI next to the existing decode-overlap/DFlash/LoRA rejects: cache hits move boundaries off the request-local grid, so the flag could not deliver what it promises with the cache on.
3. `--batch-invariant` also rejects `--kv-offload`. `--no-prefix-cache` is not sufficient there: with offload active it only disables HBM retention (`set_no_prefix_cache` sets `l1_retention_disabled`), deliberately leaving prefix *matching* on so reuse comes from the host tier — that is the whole point of the pure-L2 mode. A host-tier hit still advances `chunk_start` off the grid, so the pair is incompatible by construction and is rejected rather than quietly served. Both rejects live in `batch_invariance_reject`, which drives the real builder — so they also catch a guard that exists but was never wired into a `start_engine_*` entry point. The `--batch-invariant` CLI help now states both requirements.

## Verification — Single GPU (sm_89, x86_64)

The gate for the chunk-assignment property is `scheduler::tests::request_local_chunks_are_independent_of_earlier_requests`: it reads the per-step chunk a request is actually handed, so it sees batch-composition dependence directly, and it carries its own drift arm — with request-local chunking off, the same request must still be cut differently once it queues behind others, or the invariance asserts would be vacuous.

At engine level, the chunked-prefill phase red on the base tree (logprob bits drifted at timing-dependent indices) — now runs green as phase three of the single `output_sequence_batch_invariant_under_pin` test (its `#[ignore]`d twin is folded in, saving one engine startup): token ids and per-token logprob bits identical. Its per-phase guards are liveness checks, not proof of a particular batch shape: a `TokenEvent` stream carries no step composition (`Scheduled` fires only after a request's first prefill chunk has been forwarded), so it can show that B's prefill overlapped A's, never that they shared one step's budget. That is what the scheduler test above is for.

Prefill packing cost (Pin-only; 8 prompts of length L submitted together, wall from first submit to last request's first token, mean of 2 process reps, ms):

| L | base | fix | Δ | remainder |
| --- | --- | --- | --- | --- |
| 1024 | 1291 | 1276 | −1.2% | none — chunks identical to base (control) |
| 1025 | 1314 | 1352 | +2.9% | 1 token |
| 1500 | 1904 | 1896 | −0.4% | 476 |
| 1600 | 1890 | 1946 | +2.9% | 576 |
| 1792 | 2155 | 2202 | +2.2% | 768 |
| Tuned control, 1500 | 1094 | 1081 | −1.1% | flag-false path untouched; noise floor |

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
