### PR TITLE
fix(qwen35): batch linear decode kernels

### DIFF
--- a/openinfer-kernels/csrc/qwen35/conv1d.cu
+++ b/openinfer-kernels/csrc/qwen35/conv1d.cu
@@ -1,4 +1,5 @@
 #include "common.cuh"
+#include <stdint.h>
 
 // ============================================================================
 // Causal Depthwise Conv1d for Gated Delta Net linear attention
@@ -78,6 +79,54 @@ __global__ void conv1d_prefill_kernel(
     }
 }
 
+__global__ void conv1d_decode_batch_kernel(
+    const __nv_bfloat16* __restrict__ x_batch,
+    const __nv_bfloat16* __restrict__ conv_weight,
+    const uint64_t* __restrict__ conv_state_ptrs,
+    __nv_bfloat16* __restrict__ out_batch,
+    int num_channels,
+    int batch_size,
+    int kernel_size
+) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = num_channels * batch_size;
+    if (idx >= total) return;
+
+    int c = idx % num_channels;
+    int slot = idx / num_channels;
+    int state_width = kernel_size - 1;
+    const __nv_bfloat16* x = x_batch + (size_t)slot * num_channels;
+    __nv_bfloat16* conv_state =
+        reinterpret_cast<__nv_bfloat16*>(static_cast<uintptr_t>(conv_state_ptrs[slot]));
+
+    float old_state[4];
+    #pragma unroll
+    for (int i = 0; i < state_width; i++) {
+        old_state[i] = __bfloat162float(conv_state[c * state_width + i]);
+    }
+
+    float sum = 0.0f;
+    #pragma unroll
+    for (int k = 0; k < 4; k++) {
+        if (k >= kernel_size) break;
+        float val = (k == kernel_size - 1)
+            ? __bfloat162float(x[c])
+            : old_state[k];
+        sum += val * __bfloat162float(conv_weight[c * kernel_size + k]);
+    }
+
+    float sum_bf16 = __bfloat162float(__float2bfloat16(sum));
+    float silu_out = sum_bf16 / (1.0f + expf(-sum_bf16));
+    out_batch[(size_t)slot * num_channels + c] = __float2bfloat16(silu_out);
+
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+        if (i >= state_width) break;
+        conv_state[c * state_width + i] =
+            (i + 1 < state_width) ? __float2bfloat16(old_state[i + 1]) : x[c];
+    }
+}
+
 extern "C" {
 
 void conv1d_prefill_cuda(
@@ -94,6 +143,24 @@ void conv1d_prefill_cuda(
     int blocks = (total + CONV1D_BLOCK - 1) / CONV1D_BLOCK;
     conv1d_prefill_kernel<<<blocks, CONV1D_BLOCK, 0, stream>>>(
         x_seq, conv_weight, conv_state, out_seq, num_channels, seq_len, kernel_size
+    );
+}
+
+void conv1d_decode_batch_cuda(
+    const __nv_bfloat16* x_batch,
+    const __nv_bfloat16* conv_weight,
+    const uint64_t* conv_state_ptrs,
+    __nv_bfloat16* out_batch,
+    int num_channels,
+    int batch_size,
+    int kernel_size,
+    cudaStream_t stream
+) {
+    int total = num_channels * batch_size;
+    int blocks = (total + CONV1D_BLOCK - 1) / CONV1D_BLOCK;
+    conv1d_decode_batch_kernel<<<blocks, CONV1D_BLOCK, 0, stream>>>(
+        x_batch, conv_weight, conv_state_ptrs, out_batch,
+        num_channels, batch_size, kernel_size
     );
 }
 

--- a/openinfer-kernels/csrc/qwen35/gated_delta_rule.cu
+++ b/openinfer-kernels/csrc/qwen35/gated_delta_rule.cu
@@ -1,5 +1,6 @@
 #include "common.cuh"
 #include <cmath>
+#include <stdint.h>
 
 // ============================================================================
 // Gated Delta Rule — Recurrent decode step for linear attention
@@ -170,6 +171,135 @@ __global__ void gated_delta_rule_decode_kernel(
     }
 }
 
+__global__ void gated_delta_rule_decode_batch_kernel(
+    const __nv_bfloat16* __restrict__ qkv_batch,   // [batch, qkv_dim]
+    const __nv_bfloat16* __restrict__ b_proj_batch, // [batch, num_value_heads]
+    const __nv_bfloat16* __restrict__ a_proj_batch, // [batch, num_value_heads]
+    const __nv_bfloat16* __restrict__ dt_bias,      // [num_value_heads]
+    const float* __restrict__ A_log,                // [num_value_heads]
+    const uint64_t* __restrict__ state_ptrs,        // [batch] device pointers
+    __nv_bfloat16* __restrict__ output_batch,       // [batch, num_value_heads * val_dim]
+    int num_key_heads,
+    int num_value_heads,
+    int key_dim,
+    int val_dim
+) {
+    int slot = blockIdx.y;
+    int v_head = blockIdx.x;
+    int val_idx = threadIdx.x & 0x7F;
+    int j_slice = threadIdx.x >> 7;
+    int warp_id = threadIdx.x >> 5;
+    int lane_id = threadIdx.x & 0x1F;
+
+    int k_head = v_head * num_key_heads / num_value_heads;
+    int q_dim_total = key_dim * num_key_heads;
+    int k_dim_total = q_dim_total;
+    int qkv_dim = q_dim_total + k_dim_total + num_value_heads * val_dim;
+
+    const __nv_bfloat16* qkv = qkv_batch + (size_t)slot * qkv_dim;
+    const __nv_bfloat16* b_proj = b_proj_batch + (size_t)slot * num_value_heads;
+    const __nv_bfloat16* a_proj = a_proj_batch + (size_t)slot * num_value_heads;
+
+    __shared__ float smem_q[GDR_KEY_DIM];
+    __shared__ float smem_k[GDR_KEY_DIM];
+    __shared__ float smem_norm[2];
+    __shared__ float warp_norms[GDR_BLOCK_DIM / WARP_SIZE];
+    __shared__ float s_exp_g;
+    __shared__ float s_beta;
+    __shared__ float smem_kv_partial[GDR_J_SLICES][GDR_VAL_DIM];
+    __shared__ float smem_out_partial[GDR_J_SLICES][GDR_VAL_DIM];
+
+    float q_val = __bfloat162float(qkv[k_head * key_dim + val_idx]);
+    float k_val = __bfloat162float(qkv[q_dim_total + k_head * key_dim + val_idx]);
+    float v_val = __bfloat162float(qkv[q_dim_total + k_dim_total + v_head * val_dim + val_idx]);
+
+    float q_sq = (j_slice == 0) ? q_val * q_val : 0.0f;
+    q_sq = warp_reduce_sum(q_sq);
+    if (lane_id == 0) warp_norms[warp_id] = q_sq;
+    __syncthreads();
+
+    if (threadIdx.x == 0) {
+        float total = warp_norms[0] + warp_norms[1] + warp_norms[2] + warp_norms[3];
+        smem_norm[0] = rsqrtf(total + 1e-12f);
+    }
+    __syncthreads();
+
+    float k_sq = (j_slice == 0) ? k_val * k_val : 0.0f;
+    k_sq = warp_reduce_sum(k_sq);
+    if (lane_id == 0) warp_norms[warp_id] = k_sq;
+    __syncthreads();
+
+    if (threadIdx.x == 0) {
+        float total = warp_norms[0] + warp_norms[1] + warp_norms[2] + warp_norms[3];
+        smem_norm[1] = rsqrtf(total + 1e-12f);
+    }
+    __syncthreads();
+
+    q_val *= smem_norm[0];
+    k_val *= smem_norm[1];
+    q_val *= rsqrtf((float)key_dim);
+
+    if (j_slice == 0) {
+        smem_q[val_idx] = q_val;
+        smem_k[val_idx] = k_val;
+    }
+
+    if (threadIdx.x == 0) {
+        float a_val = __bfloat162float(a_proj[v_head]);
+        float b_val = __bfloat162float(b_proj[v_head]);
+        float bias = __bfloat162float(dt_bias[v_head]);
+        float a_log = A_log[v_head];
+
+        float x = a_val + bias;
+        float softplus_x = (x > 20.0f) ? x : logf(1.0f + expf(x));
+        float g = -expf(a_log) * softplus_x;
+        s_exp_g = expf(g);
+        s_beta = 1.0f / (1.0f + expf(-b_val));
+    }
+    __syncthreads();
+
+    float exp_g = s_exp_g;
+    float beta = s_beta;
+    float* state = reinterpret_cast<float*>(static_cast<uintptr_t>(state_ptrs[slot]));
+    float* my_state = state + v_head * key_dim * val_dim;
+
+    int j_start = j_slice * GDR_J_PER_SLICE;
+    int j_end = j_start + GDR_J_PER_SLICE;
+
+    float partial_kv = 0.0f;
+    for (int j = j_start; j < j_end; j++) {
+        float s = my_state[j * val_dim + val_idx];
+        s *= exp_g;
+        my_state[j * val_dim + val_idx] = s;
+        partial_kv += s * smem_k[j];
+    }
+
+    smem_kv_partial[j_slice][val_idx] = partial_kv;
+    __syncthreads();
+
+    float kv_mem = smem_kv_partial[0][val_idx] + smem_kv_partial[1][val_idx]
+                 + smem_kv_partial[2][val_idx] + smem_kv_partial[3][val_idx];
+    float my_delta = (v_val - kv_mem) * beta;
+
+    float partial_out = 0.0f;
+    for (int j = j_start; j < j_end; j++) {
+        float s = my_state[j * val_dim + val_idx];
+        s += my_delta * smem_k[j];
+        my_state[j * val_dim + val_idx] = s;
+        partial_out += s * smem_q[j];
+    }
+
+    smem_out_partial[j_slice][val_idx] = partial_out;
+    __syncthreads();
+
+    if (j_slice == 0) {
+        float out = smem_out_partial[0][val_idx] + smem_out_partial[1][val_idx]
+                   + smem_out_partial[2][val_idx] + smem_out_partial[3][val_idx];
+        output_batch[(size_t)slot * num_value_heads * val_dim + v_head * val_dim + val_idx] =
+            __float2bfloat16(out);
+    }
+}
+
 extern "C" {
 
 void gated_delta_rule_decode_cuda(
@@ -191,6 +321,28 @@ void gated_delta_rule_decode_cuda(
         qkv, b_proj, a_proj, dt_bias, A_log,
         state, output,
         num_key_heads, num_value_heads, key_dim, val_dim
+    );
+}
+
+void gated_delta_rule_decode_batch_cuda(
+    const __nv_bfloat16* qkv_batch,
+    const __nv_bfloat16* b_proj_batch,
+    const __nv_bfloat16* a_proj_batch,
+    const __nv_bfloat16* dt_bias,
+    const float* A_log,
+    const uint64_t* state_ptrs,
+    __nv_bfloat16* output_batch,
+    int batch_size,
+    int num_key_heads,
+    int num_value_heads,
+    int key_dim,
+    int val_dim,
+    cudaStream_t stream
+) {
+    dim3 grid(num_value_heads, batch_size);
+    gated_delta_rule_decode_batch_kernel<<<grid, GDR_BLOCK_DIM, 0, stream>>>(
+        qkv_batch, b_proj_batch, a_proj_batch, dt_bias, A_log, state_ptrs,
+        output_batch, num_key_heads, num_value_heads, key_dim, val_dim
     );
 }
 

--- a/openinfer-kernels/src/ffi/qwen35.rs
+++ b/openinfer-kernels/src/ffi/qwen35.rs
@@ -73,6 +73,22 @@ unsafe extern "C" {
         stream: CUstream,
     );
 
+    pub fn gated_delta_rule_decode_batch_cuda(
+        qkv_batch: *const Half,
+        b_proj_batch: *const Half,
+        a_proj_batch: *const Half,
+        dt_bias: *const Half,
+        A_log: *const f32,
+        state_ptrs: *const u64,
+        output_batch: *mut Half,
+        batch_size: i32,
+        num_key_heads: i32,
+        num_value_heads: i32,
+        key_dim: i32,
+        val_dim: i32,
+        stream: CUstream,
+    );
+
     // Causal depthwise conv1d prefill (parallel over sequence)
     pub fn conv1d_prefill_cuda(
         x_seq: *const Half,
@@ -81,6 +97,17 @@ unsafe extern "C" {
         out_seq: *mut Half,
         num_channels: i32,
         seq_len: i32,
+        kernel_size: i32,
+        stream: CUstream,
+    );
+
+    pub fn conv1d_decode_batch_cuda(
+        x_batch: *const Half,
+        conv_weight: *const Half,
+        conv_state_ptrs: *const u64,
+        out_batch: *mut Half,
+        num_channels: i32,
+        batch_size: i32,
         kernel_size: i32,
         stream: CUstream,
     );

--- a/openinfer-qwen35-4b/src/batch_decode.rs
+++ b/openinfer-qwen35-4b/src/batch_decode.rs
@@ -2,11 +2,10 @@
 //! and per-request recurrent-state updates for linear attention.
 
 use anyhow::{Context, Result};
-use cudarc::driver::{DevicePtr, DevicePtrMut};
+use cudarc::driver::{CudaSlice, DevicePtr, DevicePtrMut};
 
 use super::batch_decode_graph::{BATCH_BUCKETS, BatchDecodeGraphState, bucket_for};
 use super::decode_buffers::BatchDecodeBuffers35;
-use super::recurrent_state::RecurrentState;
 use super::weights::{
     FullAttentionLayer, LayerKind, LinearAttentionLayer, Qwen35Model, TransformerBlock35,
 };
@@ -279,7 +278,56 @@ impl Qwen35Model {
 
         let kv_buffer = kv_states[0].buffer();
         let layout = *kv_states[0].layout();
-        self.batch_decode_kernels_graph(kv_buffer, &layout, bs, recurrent_states, bufs)
+        let (linear_state_ptrs, linear_conv_state_ptrs) =
+            self.linear_state_pointer_tables(recurrent_states, bs)?;
+        self.batch_decode_kernels_graph(
+            kv_buffer,
+            &layout,
+            bs,
+            &linear_state_ptrs,
+            &linear_conv_state_ptrs,
+            bufs,
+        )
+    }
+
+    fn linear_state_pointer_tables(
+        &self,
+        recurrent_states: &mut [&mut RecurrentState],
+        batch_size: usize,
+    ) -> Result<(Vec<CudaSlice<u64>>, Vec<CudaSlice<u64>>)> {
+        let num_linear_layers =
+            self.config.num_hidden_layers - self.config.num_full_attention_layers();
+        let mut linear_state_ptrs = Vec::with_capacity(num_linear_layers);
+        let mut linear_conv_state_ptrs = Vec::with_capacity(num_linear_layers);
+        for layer_idx in 0..num_linear_layers {
+            let mut state_ptrs = Vec::with_capacity(batch_size);
+            let mut conv_state_ptrs = Vec::with_capacity(batch_size);
+            for slot in recurrent_states.iter_mut().take(batch_size) {
+                let state_ptr = {
+                    let (ptr, _guard) = slot.layers[layer_idx]
+                        .state
+                        .device_ptr_mut(&self.ctx.stream);
+                    ptr as u64
+                };
+                let conv_ptr = {
+                    let (ptr, _guard) = slot.layers[layer_idx]
+                        .conv_state
+                        .data
+                        .device_ptr_mut(&self.ctx.stream);
+                    ptr as u64
+                };
+                state_ptrs.push(state_ptr);
+                conv_state_ptrs.push(conv_ptr);
+            }
+            linear_state_ptrs.push(self.ctx.stream.clone_htod(&state_ptrs).map_err(|e| {
+                anyhow::anyhow!("copy Qwen3.5 eager linear state pointer table {layer_idx}: {e}")
+            })?);
+            linear_conv_state_ptrs.push(self.ctx.stream.clone_htod(&conv_state_ptrs).map_err(
+                |e| anyhow::anyhow!("copy Qwen3.5 eager conv state pointer table {layer_idx}: {e}"),
+            )?);
+        }
+
+        Ok((linear_state_ptrs, linear_conv_state_ptrs))
     }
 
     // =========================================================================
@@ -364,14 +412,15 @@ impl Qwen35Model {
 
         // Take graphs out of graph_state to avoid split-borrow in the closure.
         let mut graphs = std::mem::take(&mut graph_state.graphs);
+        let linear_state_ptrs = &graph_state.linear_state_ptrs;
+        let linear_conv_state_ptrs = &graph_state.linear_conv_state_ptrs;
         let result = graphs[bucket_idx].run_or_capture(&self.ctx, || {
-            let mut slot_refs: Vec<&mut RecurrentState> =
-                graph_state.slot_states.iter_mut().collect();
             self.batch_decode_kernels_graph(
                 kv_buffer,
                 &layout,
                 padded_bs,
-                &mut slot_refs,
+                linear_state_ptrs,
+                linear_conv_state_ptrs,
                 &mut graph_state.buffers,
             )
         });
@@ -458,14 +507,13 @@ impl Qwen35Model {
             self.config.num_key_value_heads,
             self.config.head_dim
         );
-        let mut slot_states: Vec<&mut RecurrentState> =
-            graph_state.slot_states.iter_mut().collect();
         self.batch_decode_batched_hybrid_kernels(
             kv_buffer,
             &layout,
             &plan,
             bs,
-            &mut slot_states,
+            &graph_state.linear_state_ptrs,
+            &graph_state.linear_conv_state_ptrs,
             bufs,
         )
     }
@@ -475,7 +523,8 @@ impl Qwen35Model {
         kv_buffer: &cudarc::driver::CudaSlice<half::bf16>,
         layout: &KvLayout,
         padded_bs: usize,
-        slot_states: &mut [&mut RecurrentState],
+        linear_state_ptrs: &[CudaSlice<u64>],
+        linear_conv_state_ptrs: &[CudaSlice<u64>],
         bufs: &mut BatchDecodeBuffers35,
     ) -> Result<()> {
         let eps = self.config.rms_norm_eps;
@@ -508,8 +557,8 @@ impl Qwen35Model {
                 LayerKind::LinearAttention(attn) => {
                     self.batch_decode_linear_attention_slots(
                         attn,
-                        slot_states,
-                        linear_idx,
+                        &linear_state_ptrs[linear_idx],
+                        &linear_conv_state_ptrs[linear_idx],
                         padded_bs,
                         bufs,
                     )?;
@@ -576,7 +625,8 @@ impl Qwen35Model {
         layout: &KvLayout,
         plan: &ops::PrefillPagedPlan,
         bs: usize,
-        slot_states: &mut [&mut RecurrentState],
+        linear_state_ptrs: &[CudaSlice<u64>],
+        linear_conv_state_ptrs: &[CudaSlice<u64>],
         bufs: &mut BatchDecodeBuffers35,
     ) -> Result<()> {
         let eps = self.config.rms_norm_eps;
@@ -611,7 +661,11 @@ impl Qwen35Model {
                 }
                 LayerKind::LinearAttention(attn) => {
                     self.batch_decode_linear_attention_slots(
-                        attn, slot_states, linear_idx, bs, bufs,
+                        attn,
+                        &linear_state_ptrs[linear_idx],
+                        &linear_conv_state_ptrs[linear_idx],
+                        bs,
+                        bufs,
                     )
                         .with_context(|| {
                             format!("hybrid decode linear-attn layer_idx={layer_idx}, linear_idx={linear_idx}, bs={bs}")
@@ -691,8 +745,8 @@ impl Qwen35Model {
     fn batch_decode_linear_attention_slots(
         &self,
         attn: &LinearAttentionLayer,
-        slot_states: &mut [&mut RecurrentState],
-        layer_idx: usize,
+        state_ptrs: &CudaSlice<u64>,
+        conv_state_ptrs: &CudaSlice<u64>,
         padded_bs: usize,
         bufs: &mut BatchDecodeBuffers35,
     ) -> Result<()> {
@@ -701,38 +755,29 @@ impl Qwen35Model {
         ops::gemm_into(&self.ctx, &attn.in_proj_b, &bufs.normed, &mut bufs.b_proj);
         ops::gemm_into(&self.ctx, &attn.in_proj_a, &bufs.normed, &mut bufs.a_proj);
 
-        for (slot_idx, slot_state) in slot_states.iter_mut().enumerate().take(padded_bs) {
-            let slot_state = &mut **slot_state;
-            let layer_state = &mut slot_state.layers[layer_idx];
-
-            ops::extract_vec_into(&self.ctx, &bufs.qkv, slot_idx, &mut bufs.qkv_tmp)?;
-            ops::conv1d_decode_into(
-                &self.ctx,
-                &bufs.qkv_tmp,
-                &attn.conv1d_weight,
-                &mut layer_state.conv_state,
-                &mut bufs.qkv_conv_tmp,
-                self.config.linear_conv_kernel_dim,
-            );
-            ops::extract_vec_into(&self.ctx, &bufs.b_proj, slot_idx, &mut bufs.b_tmp)?;
-            ops::extract_vec_into(&self.ctx, &bufs.a_proj, slot_idx, &mut bufs.a_tmp)?;
-
-            ops::gated_delta_rule_decode_vec_into(
-                &self.ctx,
-                &bufs.qkv_conv_tmp,
-                &bufs.b_tmp,
-                &bufs.a_tmp,
-                &attn.dt_bias,
-                &attn.a_log,
-                &mut layer_state.state,
-                &mut bufs.gdr_tmp,
-                self.config.linear_num_key_heads,
-                self.config.linear_num_value_heads,
-                self.config.linear_key_head_dim,
-                self.config.linear_value_head_dim,
-            );
-            ops::write_vec_into(&self.ctx, &bufs.gdr_tmp, &mut bufs.gdr_out, slot_idx)?;
-        }
+        ops::conv1d_decode_batch_into(
+            &self.ctx,
+            &bufs.qkv,
+            &attn.conv1d_weight,
+            conv_state_ptrs,
+            &mut bufs.qkv_conv,
+            self.config.linear_conv_kernel_dim,
+        );
+        ops::gated_delta_rule_decode_batch_into(
+            &self.ctx,
+            &bufs.qkv_conv,
+            &bufs.b_proj,
+            &bufs.a_proj,
+            &attn.dt_bias,
+            &attn.a_log,
+            state_ptrs,
+            &mut bufs.gdr_out,
+            padded_bs,
+            self.config.linear_num_key_heads,
+            self.config.linear_num_value_heads,
+            self.config.linear_key_head_dim,
+            self.config.linear_value_head_dim,
+        );
 
         ops::rms_norm_gated_batch_into(
             &self.ctx,

--- a/openinfer-qwen35-4b/src/batch_decode.rs
+++ b/openinfer-qwen35-4b/src/batch_decode.rs
@@ -6,6 +6,7 @@ use cudarc::driver::{CudaSlice, DevicePtr, DevicePtrMut};
 
 use super::batch_decode_graph::{BATCH_BUCKETS, BatchDecodeGraphState, bucket_for};
 use super::decode_buffers::BatchDecodeBuffers35;
+use super::recurrent_state::{LinearStatePointerTables, RecurrentState};
 use super::weights::{
     FullAttentionLayer, LayerKind, LinearAttentionLayer, Qwen35Model, TransformerBlock35,
 };
@@ -237,6 +238,7 @@ impl Qwen35Model {
         token_ids: &[u32],
         kv_states: &mut [&mut KvState],
         recurrent_states: &mut [&mut RecurrentState],
+        linear_pointer_tables: &LinearStatePointerTables,
         bufs: &mut BatchDecodeBuffers35,
     ) -> Result<()> {
         let bs = token_ids.len();
@@ -254,6 +256,7 @@ impl Qwen35Model {
             "batch size {bs} exceeds eager decode buffer capacity {}",
             bufs.max_batch_size
         );
+        linear_pointer_tables.validate_for(&self.config, bs, "Qwen3.5 eager decode")?;
 
         let mut positions = Vec::with_capacity(bs);
         for (i, kv) in kv_states.iter_mut().enumerate() {
@@ -278,56 +281,14 @@ impl Qwen35Model {
 
         let kv_buffer = kv_states[0].buffer();
         let layout = *kv_states[0].layout();
-        let (linear_state_ptrs, linear_conv_state_ptrs) =
-            self.linear_state_pointer_tables(recurrent_states, bs)?;
         self.batch_decode_kernels_graph(
             kv_buffer,
             &layout,
             bs,
-            &linear_state_ptrs,
-            &linear_conv_state_ptrs,
+            &linear_pointer_tables.state_ptrs,
+            &linear_pointer_tables.conv_state_ptrs,
             bufs,
         )
-    }
-
-    fn linear_state_pointer_tables(
-        &self,
-        recurrent_states: &mut [&mut RecurrentState],
-        batch_size: usize,
-    ) -> Result<(Vec<CudaSlice<u64>>, Vec<CudaSlice<u64>>)> {
-        let num_linear_layers =
-            self.config.num_hidden_layers - self.config.num_full_attention_layers();
-        let mut linear_state_ptrs = Vec::with_capacity(num_linear_layers);
-        let mut linear_conv_state_ptrs = Vec::with_capacity(num_linear_layers);
-        for layer_idx in 0..num_linear_layers {
-            let mut state_ptrs = Vec::with_capacity(batch_size);
-            let mut conv_state_ptrs = Vec::with_capacity(batch_size);
-            for slot in recurrent_states.iter_mut().take(batch_size) {
-                let state_ptr = {
-                    let (ptr, _guard) = slot.layers[layer_idx]
-                        .state
-                        .device_ptr_mut(&self.ctx.stream);
-                    ptr as u64
-                };
-                let conv_ptr = {
-                    let (ptr, _guard) = slot.layers[layer_idx]
-                        .conv_state
-                        .data
-                        .device_ptr_mut(&self.ctx.stream);
-                    ptr as u64
-                };
-                state_ptrs.push(state_ptr);
-                conv_state_ptrs.push(conv_ptr);
-            }
-            linear_state_ptrs.push(self.ctx.stream.clone_htod(&state_ptrs).map_err(|e| {
-                anyhow::anyhow!("copy Qwen3.5 eager linear state pointer table {layer_idx}: {e}")
-            })?);
-            linear_conv_state_ptrs.push(self.ctx.stream.clone_htod(&conv_state_ptrs).map_err(
-                |e| anyhow::anyhow!("copy Qwen3.5 eager conv state pointer table {layer_idx}: {e}"),
-            )?);
-        }
-
-        Ok((linear_state_ptrs, linear_conv_state_ptrs))
     }
 
     // =========================================================================
@@ -374,6 +335,11 @@ impl Qwen35Model {
         }
 
         let padded_bs = bucket_for(bs);
+        graph_state.linear_pointer_tables.validate_for(
+            &self.config,
+            padded_bs,
+            "Qwen3.5 graph decode",
+        )?;
 
         // Advance KV states and collect positions. Slot seq_len is incremented
         // on the CPU outside the graph so it never appears inside the capture.
@@ -412,8 +378,8 @@ impl Qwen35Model {
 
         // Take graphs out of graph_state to avoid split-borrow in the closure.
         let mut graphs = std::mem::take(&mut graph_state.graphs);
-        let linear_state_ptrs = &graph_state.linear_state_ptrs;
-        let linear_conv_state_ptrs = &graph_state.linear_conv_state_ptrs;
+        let linear_state_ptrs = &graph_state.linear_pointer_tables.state_ptrs;
+        let linear_conv_state_ptrs = &graph_state.linear_pointer_tables.conv_state_ptrs;
         let result = graphs[bucket_idx].run_or_capture(&self.ctx, || {
             self.batch_decode_kernels_graph(
                 kv_buffer,
@@ -435,6 +401,11 @@ impl Qwen35Model {
         graph_state: &mut BatchDecodeGraphState,
     ) -> Result<()> {
         let bs = token_ids.len();
+        graph_state.linear_pointer_tables.validate_for(
+            &self.config,
+            bs,
+            "Qwen3.5 hybrid decode",
+        )?;
         let mut positions_i32 = Vec::with_capacity(bs);
         let mut start_positions = Vec::with_capacity(bs);
         for (i, kv) in kv_states.iter_mut().enumerate() {
@@ -512,8 +483,8 @@ impl Qwen35Model {
             &layout,
             &plan,
             bs,
-            &graph_state.linear_state_ptrs,
-            &graph_state.linear_conv_state_ptrs,
+            &graph_state.linear_pointer_tables.state_ptrs,
+            &graph_state.linear_pointer_tables.conv_state_ptrs,
             bufs,
         )
     }

--- a/openinfer-qwen35-4b/src/batch_decode_graph.rs
+++ b/openinfer-qwen35-4b/src/batch_decode_graph.rs
@@ -1,7 +1,6 @@
 //! CUDA Graph state for Qwen3.5 batched decode with bucket padding.
 
 use anyhow::Result;
-use cudarc::driver::{CudaSlice, DevicePtrMut};
 
 use openinfer_core::cuda_graph::CudaGraphState;
 use openinfer_core::kv_pool::KvPool;
@@ -10,7 +9,7 @@ use openinfer_core::tensor::DeviceContext;
 use super::config::Config35;
 use super::config::TensorParallelConfig;
 use super::decode_buffers::BatchDecodeBuffers35;
-use super::recurrent_state::RecurrentState;
+use super::recurrent_state::{LinearStatePointerTables, RecurrentState};
 
 /// Bucket sizes for CUDA Graph capture. Actual batch is padded to nearest bucket.
 pub(crate) const BATCH_BUCKETS: &[usize] = &[1, 2, 4, 8, 16, 32, 64];
@@ -52,8 +51,7 @@ pub(crate) fn bucket_for(bs: usize) -> usize {
 pub(crate) struct BatchDecodeGraphState {
     pub(crate) buffers: BatchDecodeBuffers35,
     pub(crate) slot_states: Vec<RecurrentState>,
-    pub(crate) linear_state_ptrs: Vec<CudaSlice<u64>>,
-    pub(crate) linear_conv_state_ptrs: Vec<CudaSlice<u64>>,
+    pub(crate) linear_pointer_tables: LinearStatePointerTables,
     /// One `CudaGraphState` per BATCH_BUCKETS entry (indexed by position).
     pub(crate) graphs: Vec<CudaGraphState>,
 }
@@ -83,34 +81,16 @@ impl BatchDecodeGraphState {
         for _ in 0..max_batch {
             slot_states.push(RecurrentState::new(ctx, config)?);
         }
-        let num_linear_layers = config.num_hidden_layers - config.num_full_attention_layers();
-        let mut linear_state_ptrs = Vec::with_capacity(num_linear_layers);
-        let mut linear_conv_state_ptrs = Vec::with_capacity(num_linear_layers);
-        for layer_idx in 0..num_linear_layers {
-            let mut state_ptrs = Vec::with_capacity(max_batch);
-            let mut conv_state_ptrs = Vec::with_capacity(max_batch);
-            for slot in &mut slot_states {
-                let state_ptr = {
-                    let (ptr, _guard) = slot.layers[layer_idx].state.device_ptr_mut(&ctx.stream);
-                    ptr as u64
-                };
-                let conv_ptr = {
-                    let (ptr, _guard) = slot.layers[layer_idx]
-                        .conv_state
-                        .data
-                        .device_ptr_mut(&ctx.stream);
-                    ptr as u64
-                };
-                state_ptrs.push(state_ptr);
-                conv_state_ptrs.push(conv_ptr);
-            }
-            linear_state_ptrs.push(ctx.stream.clone_htod(&state_ptrs).map_err(|e| {
-                anyhow::anyhow!("copy Qwen3.5 linear state pointer table {layer_idx}: {e}")
-            })?);
-            linear_conv_state_ptrs.push(ctx.stream.clone_htod(&conv_state_ptrs).map_err(|e| {
-                anyhow::anyhow!("copy Qwen3.5 conv state pointer table {layer_idx}: {e}")
-            })?);
-        }
+        let linear_pointer_tables = {
+            let mut slot_refs: Vec<&mut RecurrentState> = slot_states.iter_mut().collect();
+            LinearStatePointerTables::from_recurrent_refs(
+                ctx,
+                config,
+                &mut slot_refs,
+                max_batch,
+                "Qwen3.5 graph",
+            )?
+        };
 
         let graphs = BATCH_BUCKETS
             .iter()
@@ -120,8 +100,7 @@ impl BatchDecodeGraphState {
         Ok(Self {
             buffers,
             slot_states,
-            linear_state_ptrs,
-            linear_conv_state_ptrs,
+            linear_pointer_tables,
             graphs,
         })
     }

--- a/openinfer-qwen35-4b/src/batch_decode_graph.rs
+++ b/openinfer-qwen35-4b/src/batch_decode_graph.rs
@@ -1,6 +1,7 @@
 //! CUDA Graph state for Qwen3.5 batched decode with bucket padding.
 
 use anyhow::Result;
+use cudarc::driver::{CudaSlice, DevicePtrMut};
 
 use openinfer_core::cuda_graph::CudaGraphState;
 use openinfer_core::kv_pool::KvPool;
@@ -51,6 +52,8 @@ pub(crate) fn bucket_for(bs: usize) -> usize {
 pub(crate) struct BatchDecodeGraphState {
     pub(crate) buffers: BatchDecodeBuffers35,
     pub(crate) slot_states: Vec<RecurrentState>,
+    pub(crate) linear_state_ptrs: Vec<CudaSlice<u64>>,
+    pub(crate) linear_conv_state_ptrs: Vec<CudaSlice<u64>>,
     /// One `CudaGraphState` per BATCH_BUCKETS entry (indexed by position).
     pub(crate) graphs: Vec<CudaGraphState>,
 }
@@ -80,6 +83,34 @@ impl BatchDecodeGraphState {
         for _ in 0..max_batch {
             slot_states.push(RecurrentState::new(ctx, config)?);
         }
+        let num_linear_layers = config.num_hidden_layers - config.num_full_attention_layers();
+        let mut linear_state_ptrs = Vec::with_capacity(num_linear_layers);
+        let mut linear_conv_state_ptrs = Vec::with_capacity(num_linear_layers);
+        for layer_idx in 0..num_linear_layers {
+            let mut state_ptrs = Vec::with_capacity(max_batch);
+            let mut conv_state_ptrs = Vec::with_capacity(max_batch);
+            for slot in &mut slot_states {
+                let state_ptr = {
+                    let (ptr, _guard) = slot.layers[layer_idx].state.device_ptr_mut(&ctx.stream);
+                    ptr as u64
+                };
+                let conv_ptr = {
+                    let (ptr, _guard) = slot.layers[layer_idx]
+                        .conv_state
+                        .data
+                        .device_ptr_mut(&ctx.stream);
+                    ptr as u64
+                };
+                state_ptrs.push(state_ptr);
+                conv_state_ptrs.push(conv_ptr);
+            }
+            linear_state_ptrs.push(ctx.stream.clone_htod(&state_ptrs).map_err(|e| {
+                anyhow::anyhow!("copy Qwen3.5 linear state pointer table {layer_idx}: {e}")
+            })?);
+            linear_conv_state_ptrs.push(ctx.stream.clone_htod(&conv_state_ptrs).map_err(|e| {
+                anyhow::anyhow!("copy Qwen3.5 conv state pointer table {layer_idx}: {e}")
+            })?);
+        }
 
         let graphs = BATCH_BUCKETS
             .iter()
@@ -89,6 +120,8 @@ impl BatchDecodeGraphState {
         Ok(Self {
             buffers,
             slot_states,
+            linear_state_ptrs,
+            linear_conv_state_ptrs,
             graphs,
         })
     }

--- a/openinfer-qwen35-4b/src/config.rs
+++ b/openinfer-qwen35-4b/src/config.rs
@@ -99,8 +99,9 @@ pub(crate) struct Config35 {
 }
 
 /// Head dims baked into the kernels; head counts are runtime parameters.
-const GDN_AOT_KEY_HEAD_DIM: usize = 128;
-const GDN_AOT_VALUE_HEAD_DIM: usize = 128;
+pub(crate) const GDN_AOT_KEY_HEAD_DIM: usize = 128;
+pub(crate) const GDN_AOT_VALUE_HEAD_DIM: usize = 128;
+pub(crate) const LINEAR_CONV_MAX_KERNEL_DIM: usize = 4;
 const FULL_ATTN_HEAD_DIM: usize = 256;
 
 impl Config35 {
@@ -160,6 +161,12 @@ impl Config35 {
             "Qwen3.5 full-attention kernels are baked for head_dim {}; config has {}.",
             FULL_ATTN_HEAD_DIM,
             t.head_dim,
+        );
+        anyhow::ensure!(
+            (1..=LINEAR_CONV_MAX_KERNEL_DIM).contains(&t.linear_conv_kernel_dim),
+            "Qwen3.5 linear conv decode kernels support kernel_dim in 1..={}; config has {}.",
+            LINEAR_CONV_MAX_KERNEL_DIM,
+            t.linear_conv_kernel_dim,
         );
         anyhow::ensure!(
             t.linear_num_key_heads > 0
@@ -565,6 +572,41 @@ mod tests {
 }"#;
         std::fs::write(dir.path().join("config.json"), json).unwrap();
         Config35::from_file(dir.path().to_str().unwrap()).expect("48 value heads must load");
+    }
+
+    #[test]
+    fn guard_rejects_wide_linear_conv_decode_kernel() {
+        let dir = tempfile::tempdir().unwrap();
+        let json = r#"{
+  "max_position_embeddings": 4096,
+  "tie_word_embeddings": true,
+  "text_config": {
+    "hidden_size": 512,
+    "intermediate_size": 1024,
+    "num_hidden_layers": 2,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 2,
+    "head_dim": 256,
+    "vocab_size": 1000,
+    "rms_norm_eps": 1e-6,
+    "layer_types": ["linear_attention", "full_attention"],
+    "linear_conv_kernel_dim": 5,
+    "linear_key_head_dim": 128,
+    "linear_num_key_heads": 16,
+    "linear_num_value_heads": 48,
+    "linear_value_head_dim": 128,
+    "rope_parameters": { "rope_theta": 10000.0, "partial_rotary_factor": 0.25 },
+    "eos_token_id": 0
+  }
+}"#;
+        std::fs::write(dir.path().join("config.json"), json).unwrap();
+
+        let err = Config35::from_file(dir.path().to_str().unwrap())
+            .expect_err("wide conv decode kernels must be rejected");
+        assert!(
+            err.to_string().contains("linear conv decode kernels"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/openinfer-qwen35-4b/src/decode_buffers.rs
+++ b/openinfer-qwen35-4b/src/decode_buffers.rs
@@ -6,7 +6,7 @@ use cudarc::driver::CudaSlice;
 
 use super::config::{Config35, TensorParallelConfig};
 use openinfer_core::kv_pool::KvState;
-use openinfer_core::tensor::{DeviceContext, DeviceVec, HiddenStates};
+use openinfer_core::tensor::{DeviceContext, HiddenStates};
 
 /// Pre-allocated GPU buffers for Qwen3.5 batch decode (N requests, 1 token each).
 pub(crate) struct BatchDecodeBuffers35 {
@@ -34,15 +34,9 @@ pub(crate) struct BatchDecodeBuffers35 {
     pub(crate) z: HiddenStates,
     pub(crate) b_proj: HiddenStates,
     pub(crate) a_proj: HiddenStates,
+    pub(crate) qkv_conv: HiddenStates,
     pub(crate) gdr_out: HiddenStates,
     pub(crate) normed_gated: HiddenStates,
-
-    // Per-request reusable scratch for linear-attention serial decode
-    pub(crate) qkv_tmp: DeviceVec,
-    pub(crate) qkv_conv_tmp: DeviceVec,
-    pub(crate) b_tmp: DeviceVec,
-    pub(crate) a_tmp: DeviceVec,
-    pub(crate) gdr_tmp: DeviceVec,
 
     // Metadata
     pub(crate) token_ids_d: CudaSlice<u32>,
@@ -107,14 +101,9 @@ impl BatchDecodeBuffers35 {
             z: HiddenStates::zeros(ctx, z_dim, bs)?,
             b_proj: HiddenStates::zeros(ctx, b_dim, bs)?,
             a_proj: HiddenStates::zeros(ctx, a_dim, bs)?,
+            qkv_conv: HiddenStates::zeros(ctx, qkv_dim, bs)?,
             gdr_out: HiddenStates::zeros(ctx, z_dim, bs)?,
             normed_gated: HiddenStates::zeros(ctx, z_dim, bs)?,
-
-            qkv_tmp: DeviceVec::zeros(ctx, qkv_dim)?,
-            qkv_conv_tmp: DeviceVec::zeros(ctx, qkv_dim)?,
-            b_tmp: DeviceVec::zeros(ctx, b_dim)?,
-            a_tmp: DeviceVec::zeros(ctx, a_dim)?,
-            gdr_tmp: DeviceVec::zeros(ctx, z_dim)?,
 
             token_ids_d: ctx.stream.alloc_zeros(bs)?,
             positions_d: ctx.stream.alloc_zeros(bs)?,
@@ -154,6 +143,7 @@ impl BatchDecodeBuffers35 {
         self.z.seq_len = bs;
         self.b_proj.seq_len = bs;
         self.a_proj.seq_len = bs;
+        self.qkv_conv.seq_len = bs;
         self.gdr_out.seq_len = bs;
         self.normed_gated.seq_len = bs;
     }

--- a/openinfer-qwen35-4b/src/kernel_plan.rs
+++ b/openinfer-qwen35-4b/src/kernel_plan.rs
@@ -230,15 +230,15 @@ pub static KERNEL_PLAN: KernelPlan = KernelPlan {
                 },
                 KernelOp {
                     id: "conv1d_decode",
-                    rust: "batch_decode::batch_decode_linear_attention_slots -> ops::conv1d_decode_into",
+                    rust: "batch_decode::batch_decode_linear_attention_slots -> ops::conv1d_decode_batch_into",
                     backend: "CUDA",
-                    notes: "depthwise conv1d on per-slot recurrent conv state",
+                    notes: "batched depthwise conv1d over slot-indexed recurrent conv states",
                 },
                 KernelOp {
                     id: "gated_delta_rule_decode",
-                    rust: "batch_decode::batch_decode_linear_attention_slots -> ops::gated_delta_rule_decode_vec_into",
+                    rust: "batch_decode::batch_decode_linear_attention_slots -> ops::gated_delta_rule_decode_batch_into",
                     backend: "CUDA",
-                    notes: "GDR per-slot decode — fixed-budget recurrent state update",
+                    notes: "batched GDR decode over slot-indexed recurrent states",
                 },
                 KernelOp {
                     id: "rms_norm_gated_decode",

--- a/openinfer-qwen35-4b/src/ops.rs
+++ b/openinfer-qwen35-4b/src/ops.rs
@@ -2,8 +2,8 @@
 
 pub(crate) use openinfer_core::ops::PrefillPagedPlan;
 pub(crate) use openinfer_core::ops::{
-    GEMM_LT_MAX_N, add_batch, add_batch_into, embedding_batch, extract_vec, extract_vec_into, gemm,
-    gemm_into, gemm_lt_tune, gemm_rows_into_checked, paged_attention_batch_decode_hd256_into,
+    GEMM_LT_MAX_N, add_batch, add_batch_into, embedding_batch, extract_vec, gemm, gemm_into,
+    gemm_lt_tune, gemm_rows_into_checked, paged_attention_batch_decode_hd256_into,
     paged_attention_batch_decode_via_prefill_hd256_into,
     qk_norm_partial_rope_batched_decode_hd256_into, rms_norm_gated_batch_into,
     silu_mul_fused_batch_into, write_vec_into,
@@ -11,7 +11,7 @@ pub(crate) use openinfer_core::ops::{
 pub use openinfer_core::ops::{rms_norm_batch_offset_into, rms_norm_offset_into};
 pub use recurrent::gated_delta_rule_prefill_chunkwise_into;
 pub(crate) use recurrent::{
-    conv1d_decode_into, conv1d_prefill_batch_into, gated_delta_rule_decode_vec_into,
+    conv1d_decode_batch_into, conv1d_prefill_batch_into, gated_delta_rule_decode_batch_into,
 };
 
 use crate::recurrent;

--- a/openinfer-qwen35-4b/src/recurrent.rs
+++ b/openinfer-qwen35-4b/src/recurrent.rs
@@ -544,11 +544,12 @@ pub fn gated_delta_rule_prefill_chunkwise_into(
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
+    use cudarc::driver::DevicePtrMut;
     use half::bf16;
 
     use super::{
-        conv1d_prefill_batch_into, gated_delta_rule_decode_vec_into,
-        gated_delta_rule_prefill_chunkwise_into,
+        conv1d_prefill_batch_into, gated_delta_rule_decode_batch_into,
+        gated_delta_rule_decode_vec_into, gated_delta_rule_prefill_chunkwise_into,
     };
     use crate::prefill_buffers::GdrChunkwiseScratch35;
     use openinfer_core::tensor::{DeviceContext, DeviceVec, HiddenStates};
@@ -691,6 +692,150 @@ mod tests {
 
         assert!(max_out_diff < 0.02, "output diff {max_out_diff}");
         assert!(max_state_diff < 0.02, "state diff {max_state_diff}");
+        Ok(())
+    }
+
+    #[test]
+    fn gdr_decode_batch_matches_single_slot_reference() -> Result<()> {
+        let ctx = DeviceContext::new()?;
+        let batch_size = 3usize;
+        let num_key_heads = 16usize;
+        let num_value_heads = 48usize;
+        let key_dim = 128usize;
+        let val_dim = 128usize;
+
+        let qkv_dim = 2 * num_key_heads * key_dim + num_value_heads * val_dim;
+        let out_dim = num_value_heads * val_dim;
+        let state_len = num_value_heads * key_dim * val_dim;
+
+        let qkv_host = bf16_vec(
+            &(0..batch_size * qkv_dim)
+                .map(|i| ((i % 89) as f32 - 44.0) * 0.0078125)
+                .collect::<Vec<_>>(),
+        );
+        let b_host = bf16_vec(
+            &(0..batch_size * num_value_heads)
+                .map(|i| ((i % 11) as f32 - 5.0) * 0.03125)
+                .collect::<Vec<_>>(),
+        );
+        let a_host = bf16_vec(
+            &(0..batch_size * num_value_heads)
+                .map(|i| ((i % 13) as f32 - 6.0) * 0.03125)
+                .collect::<Vec<_>>(),
+        );
+        let dt_host = bf16_vec(
+            &(0..num_value_heads)
+                .map(|i| ((i % 7) as f32 - 3.0) * 0.0625)
+                .collect::<Vec<_>>(),
+        );
+        let alog_host: Vec<f32> = (0..num_value_heads)
+            .map(|i| ((i % 5) as f32 - 2.0) * 0.125)
+            .collect();
+
+        let qkv_batch = HiddenStates {
+            data: ctx.stream.clone_htod(&qkv_host)?,
+            hidden_dim: qkv_dim,
+            seq_len: batch_size,
+        };
+        let b_batch = HiddenStates {
+            data: ctx.stream.clone_htod(&b_host)?,
+            hidden_dim: num_value_heads,
+            seq_len: batch_size,
+        };
+        let a_batch = HiddenStates {
+            data: ctx.stream.clone_htod(&a_host)?,
+            hidden_dim: num_value_heads,
+            seq_len: batch_size,
+        };
+        let dt_bias = DeviceVec::from_host(&ctx, &dt_host)?;
+        let a_log = ctx.stream.clone_htod(&alog_host)?;
+
+        let mut batch_states: Vec<cudarc::driver::CudaSlice<f32>> = (0..batch_size)
+            .map(|_| ctx.stream.alloc_zeros(state_len))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        let mut state_ptrs = Vec::with_capacity(batch_size);
+        for state in &mut batch_states {
+            let (ptr, _guard) = state.device_ptr_mut(&ctx.stream);
+            state_ptrs.push(ptr as u64);
+        }
+        let state_ptrs_d = ctx.stream.clone_htod(&state_ptrs)?;
+
+        let mut out_batch = HiddenStates::zeros(&ctx, out_dim, batch_size)?;
+        gated_delta_rule_decode_batch_into(
+            &ctx,
+            &qkv_batch,
+            &b_batch,
+            &a_batch,
+            &dt_bias,
+            &a_log,
+            &state_ptrs_d,
+            &mut out_batch,
+            batch_size,
+            num_key_heads,
+            num_value_heads,
+            key_dim,
+            val_dim,
+        );
+
+        let mut out_ref_rows: Vec<f32> = Vec::with_capacity(batch_size * out_dim);
+        let mut ref_states = Vec::with_capacity(batch_size);
+        for row in 0..batch_size {
+            let qkv_row =
+                DeviceVec::from_host(&ctx, &qkv_host[row * qkv_dim..(row + 1) * qkv_dim])?;
+            let b_row = DeviceVec::from_host(
+                &ctx,
+                &b_host[row * num_value_heads..(row + 1) * num_value_heads],
+            )?;
+            let a_row = DeviceVec::from_host(
+                &ctx,
+                &a_host[row * num_value_heads..(row + 1) * num_value_heads],
+            )?;
+            let mut state_ref: cudarc::driver::CudaSlice<f32> =
+                ctx.stream.alloc_zeros(state_len)?;
+            let mut out_row = DeviceVec::zeros(&ctx, out_dim)?;
+            gated_delta_rule_decode_vec_into(
+                &ctx,
+                &qkv_row,
+                &b_row,
+                &a_row,
+                &dt_bias,
+                &a_log,
+                &mut state_ref,
+                &mut out_row,
+                num_key_heads,
+                num_value_heads,
+                key_dim,
+                val_dim,
+            );
+            out_ref_rows.extend_from_slice(&out_row.to_host(&ctx)?);
+            ref_states.push(state_ref);
+        }
+
+        let out_batch_host = ctx.stream.clone_dtoh(&out_batch.data)?;
+        ctx.sync()?;
+        let out_batch_host: Vec<f32> = out_batch_host.iter().map(|x| x.to_f32()).collect();
+        let max_out_diff = out_batch_host
+            .iter()
+            .zip(out_ref_rows.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0_f32, f32::max);
+
+        let mut max_state_diff = 0.0_f32;
+        for (batch_state, ref_state) in batch_states.iter().zip(ref_states.iter()) {
+            let batch_state_host = ctx.stream.clone_dtoh(batch_state)?;
+            let ref_state_host = ctx.stream.clone_dtoh(ref_state)?;
+            ctx.sync()?;
+            max_state_diff = max_state_diff.max(
+                batch_state_host
+                    .iter()
+                    .zip(ref_state_host.iter())
+                    .map(|(a, b)| (a - b).abs())
+                    .fold(0.0_f32, f32::max),
+            );
+        }
+
+        assert!(max_out_diff < 0.05, "output diff {max_out_diff}");
+        assert!(max_state_diff < 0.05, "state diff {max_state_diff}");
         Ok(())
     }
 

--- a/openinfer-qwen35-4b/src/recurrent.rs
+++ b/openinfer-qwen35-4b/src/recurrent.rs
@@ -1,10 +1,12 @@
 use anyhow::Result;
 use cudarc::driver::{CudaSlice, DevicePtr, DevicePtrMut};
 
+use crate::config::{GDN_AOT_KEY_HEAD_DIM, GDN_AOT_VALUE_HEAD_DIM, LINEAR_CONV_MAX_KERNEL_DIM};
 use crate::ffi;
 use crate::prefill_buffers::GdrChunkwiseScratch35;
 use openinfer_core::tensor::{DeviceContext, DeviceVec, HiddenStates};
 
+#[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn gated_delta_rule_decode_vec_into(
     ctx: &DeviceContext,
@@ -46,32 +48,89 @@ pub(crate) fn gated_delta_rule_decode_vec_into(
     }
 }
 
-pub(crate) fn conv1d_decode_into(
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn gated_delta_rule_decode_batch_into(
     ctx: &DeviceContext,
-    x: &DeviceVec,
+    qkv: &HiddenStates,
+    b_proj: &HiddenStates,
+    a_proj: &HiddenStates,
+    dt_bias: &DeviceVec,
+    a_log: &CudaSlice<f32>,
+    state_ptrs: &CudaSlice<u64>,
+    output: &mut HiddenStates,
+    batch_size: usize,
+    num_key_heads: usize,
+    num_value_heads: usize,
+    key_dim: usize,
+    val_dim: usize,
+) {
+    assert_eq!(qkv.seq_len, batch_size);
+    assert_eq!(b_proj.seq_len, batch_size);
+    assert_eq!(a_proj.seq_len, batch_size);
+    assert_eq!(output.seq_len, batch_size);
+    assert_eq!(b_proj.hidden_dim, num_value_heads);
+    assert_eq!(a_proj.hidden_dim, num_value_heads);
+    assert_eq!(output.hidden_dim, num_value_heads * val_dim);
+    assert_eq!(key_dim, GDN_AOT_KEY_HEAD_DIM);
+    assert_eq!(val_dim, GDN_AOT_VALUE_HEAD_DIM);
+    assert!(state_ptrs.len() >= batch_size);
+
+    let (qkv_ptr, _gq) = qkv.data.device_ptr(&ctx.stream);
+    let (b_ptr, _gb) = b_proj.data.device_ptr(&ctx.stream);
+    let (a_ptr, _ga) = a_proj.data.device_ptr(&ctx.stream);
+    let (dt_ptr, _gdt) = dt_bias.data.device_ptr(&ctx.stream);
+    let (alog_ptr, _gal) = a_log.device_ptr(&ctx.stream);
+    let (state_ptrs, _gsp) = state_ptrs.device_ptr(&ctx.stream);
+    let (o_ptr, _go) = output.data.device_ptr_mut(&ctx.stream);
+
+    unsafe {
+        ffi::gated_delta_rule_decode_batch_cuda(
+            qkv_ptr as *const ffi::Half,
+            b_ptr as *const ffi::Half,
+            a_ptr as *const ffi::Half,
+            dt_ptr as *const ffi::Half,
+            alog_ptr as *const f32,
+            state_ptrs as *const u64,
+            o_ptr as *mut ffi::Half,
+            batch_size as i32,
+            num_key_heads as i32,
+            num_value_heads as i32,
+            key_dim as i32,
+            val_dim as i32,
+            ctx.stream.cu_stream(),
+        );
+    }
+}
+
+pub(crate) fn conv1d_decode_batch_into(
+    ctx: &DeviceContext,
+    x: &HiddenStates,
     conv_weight: &DeviceVec,
-    conv_state: &mut DeviceVec,
-    out: &mut DeviceVec,
+    conv_state_ptrs: &CudaSlice<u64>,
+    out: &mut HiddenStates,
     kernel_size: usize,
 ) {
-    let num_channels = x.len;
-    assert_eq!(out.len, num_channels);
+    let batch_size = x.seq_len;
+    let num_channels = x.hidden_dim;
+    assert_eq!(out.hidden_dim, num_channels);
+    assert_eq!(out.seq_len, batch_size);
     assert_eq!(conv_weight.len, num_channels * kernel_size);
-    assert_eq!(conv_state.len, num_channels * (kernel_size - 1));
+    assert!(kernel_size <= LINEAR_CONV_MAX_KERNEL_DIM);
+    assert!(conv_state_ptrs.len() >= batch_size);
 
     let (x_ptr, _gx) = x.data.device_ptr(&ctx.stream);
     let (w_ptr, _gw) = conv_weight.data.device_ptr(&ctx.stream);
-    let (s_ptr, _gs) = conv_state.data.device_ptr_mut(&ctx.stream);
+    let (s_ptrs, _gs) = conv_state_ptrs.device_ptr(&ctx.stream);
     let (o_ptr, _go) = out.data.device_ptr_mut(&ctx.stream);
 
     unsafe {
-        ffi::conv1d_prefill_cuda(
+        ffi::conv1d_decode_batch_cuda(
             x_ptr as *const ffi::Half,
             w_ptr as *const ffi::Half,
-            s_ptr as *mut ffi::Half,
+            s_ptrs as *const u64,
             o_ptr as *mut ffi::Half,
             num_channels as i32,
-            1i32,
+            batch_size as i32,
             kernel_size as i32,
             ctx.stream.cu_stream(),
         );

--- a/openinfer-qwen35-4b/src/recurrent_state.rs
+++ b/openinfer-qwen35-4b/src/recurrent_state.rs
@@ -5,7 +5,7 @@
 //! - Conv state: [qkv_dim × (conv_kernel_dim - 1)] bf16
 
 use anyhow::Result;
-use cudarc::driver::CudaSlice;
+use cudarc::driver::{CudaSlice, DevicePtrMut};
 
 use super::config::Config35;
 use openinfer_core::tensor::{DeviceContext, DeviceVec};
@@ -25,6 +25,18 @@ pub(crate) struct RecurrentState {
     pub(crate) layers: Vec<LayerRecurrentState>,
     /// Number of tokens processed so far (for prefill/decode tracking).
     pub(crate) seq_len: usize,
+}
+
+/// Device-side tables of per-slot recurrent-state pointers.
+///
+/// Batched linear decode kernels take a device array of pointers per linear
+/// layer. The underlying `CudaSlice` allocations inside `RecurrentState` stay
+/// at fixed device addresses for the request lifetime, so these tables should
+/// be built once per slot/request and then reused across decode tokens.
+pub(crate) struct LinearStatePointerTables {
+    pub(crate) state_ptrs: Vec<CudaSlice<u64>>,
+    pub(crate) conv_state_ptrs: Vec<CudaSlice<u64>>,
+    batch_size: usize,
 }
 
 /// Per-layer element counts shared by allocation and reservation:
@@ -55,6 +67,78 @@ impl RecurrentState {
         }
 
         Ok(Self { layers, seq_len: 0 })
+    }
+}
+
+impl LinearStatePointerTables {
+    pub(crate) fn from_recurrent_refs(
+        ctx: &DeviceContext,
+        config: &Config35,
+        recurrent_states: &mut [&mut RecurrentState],
+        batch_size: usize,
+        label: &str,
+    ) -> Result<Self> {
+        anyhow::ensure!(
+            batch_size <= recurrent_states.len(),
+            "{label} pointer table batch {batch_size} exceeds recurrent refs {}",
+            recurrent_states.len()
+        );
+        let num_linear_layers = config.num_hidden_layers - config.num_full_attention_layers();
+        let mut linear_state_ptrs = Vec::with_capacity(num_linear_layers);
+        let mut linear_conv_state_ptrs = Vec::with_capacity(num_linear_layers);
+        for layer_idx in 0..num_linear_layers {
+            let mut state_ptrs = Vec::with_capacity(batch_size);
+            let mut conv_state_ptrs = Vec::with_capacity(batch_size);
+            for slot in recurrent_states.iter_mut().take(batch_size) {
+                let state_ptr = {
+                    let (ptr, _guard) = slot.layers[layer_idx].state.device_ptr_mut(&ctx.stream);
+                    ptr as u64
+                };
+                let conv_ptr = {
+                    let (ptr, _guard) = slot.layers[layer_idx]
+                        .conv_state
+                        .data
+                        .device_ptr_mut(&ctx.stream);
+                    ptr as u64
+                };
+                state_ptrs.push(state_ptr);
+                conv_state_ptrs.push(conv_ptr);
+            }
+            linear_state_ptrs.push(ctx.stream.clone_htod(&state_ptrs).map_err(|e| {
+                anyhow::anyhow!("copy {label} linear state pointer table {layer_idx}: {e}")
+            })?);
+            linear_conv_state_ptrs.push(ctx.stream.clone_htod(&conv_state_ptrs).map_err(|e| {
+                anyhow::anyhow!("copy {label} conv state pointer table {layer_idx}: {e}")
+            })?);
+        }
+
+        Ok(Self {
+            state_ptrs: linear_state_ptrs,
+            conv_state_ptrs: linear_conv_state_ptrs,
+            batch_size,
+        })
+    }
+
+    pub(crate) fn validate_for(
+        &self,
+        config: &Config35,
+        batch_size: usize,
+        label: &str,
+    ) -> Result<()> {
+        let num_linear_layers = config.num_hidden_layers - config.num_full_attention_layers();
+        anyhow::ensure!(
+            self.batch_size >= batch_size,
+            "{label} pointer table capacity {} is smaller than batch {batch_size}",
+            self.batch_size
+        );
+        anyhow::ensure!(
+            self.state_ptrs.len() == num_linear_layers
+                && self.conv_state_ptrs.len() == num_linear_layers,
+            "{label} pointer table layer count mismatch: state={}, conv={}, expected={num_linear_layers}",
+            self.state_ptrs.len(),
+            self.conv_state_ptrs.len()
+        );
+        Ok(())
     }
 }
 

--- a/openinfer-qwen35-4b/src/tp_executor.rs
+++ b/openinfer-qwen35-4b/src/tp_executor.rs
@@ -21,7 +21,7 @@ use crate::executor::{
 use crate::logprobs::snapshot_requested_logprobs;
 use crate::prefill::PREFILL_CHUNK_LEN;
 use crate::prefill_buffers::GdrChunkwiseScratch35;
-use crate::recurrent_state::RecurrentState;
+use crate::recurrent_state::{LinearStatePointerTables, RecurrentState};
 use crate::weights::{ModelRuntimeConfig, Qwen35Model};
 use openinfer_core::kv_pool::KvState;
 use openinfer_core::sampler::SamplingParams;
@@ -753,6 +753,7 @@ struct TpRequestState {
     phase: TpRequestPhase,
     kv: KvState,
     recurrent: RecurrentState,
+    linear_pointer_tables: LinearStatePointerTables,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1084,12 +1085,13 @@ impl TpWorkerState {
 
             {
                 let state = &mut self.requests[state_idx];
-                let mut kv_refs = vec![&mut state.kv];
-                let mut recurrent_refs = vec![&mut state.recurrent];
+                let mut kv_refs = [&mut state.kv];
+                let mut recurrent_refs = [&mut state.recurrent];
                 self.model.batch_decode_eager_logits(
                     &[request.token_id],
                     &mut kv_refs,
                     &mut recurrent_refs,
+                    &state.linear_pointer_tables,
                     &mut self.decode_buffers,
                 )?;
             }
@@ -1134,11 +1136,23 @@ impl TpWorkerState {
         if let Some(idx) = self.request_index(request_id) {
             return Ok(idx);
         }
+        let mut recurrent = RecurrentState::new(self.model.device_ctx(), self.model.config())?;
+        let linear_pointer_tables = {
+            let mut recurrent_refs = [&mut recurrent];
+            LinearStatePointerTables::from_recurrent_refs(
+                self.model.device_ctx(),
+                self.model.config(),
+                &mut recurrent_refs,
+                1,
+                "Qwen3.5 TP eager",
+            )?
+        };
         let state = TpRequestState {
             request_id,
             phase: TpRequestPhase::Prefilling,
             kv: self.model.alloc_kv(),
-            recurrent: RecurrentState::new(self.model.device_ctx(), self.model.config())?,
+            recurrent,
+            linear_pointer_tables,
         };
         self.requests.push(state);
         Ok(self.requests.len() - 1)


### PR DESCRIPTION
## Summary

- batch Qwen3.5 linear-attention decode conv1d/GDR across active decode slots instead of launching per-slot kernels inside the decode graph
- keep CUDA Graph replay address-stable by precomputing per-linear-layer device pointer tables for recurrent and conv state slots
- remove obsolete per-slot decode scratch buffers from the batch decode hot path

Fixes #689.

## Evidence

Artifact bundle is retained on the RTX 5090 validation host. Public summary paths are intentionally omitted from the PR body; the bundle contains raw benchmark JSON/stdout, server logs, trace JSONL, nsys report/sqlite, parsed CSV/JSON, and README.

Validation:

```bash
# RTX 5090 validation host. Replace paths with the local equivalents.
export OPENINFER_CUDA_SM=120
export OPENINFER_TRITON_PYTHON=<python-with-triton>
export CUDA_HOME=<cuda-toolkit-root>
export OPENINFER_TEST_MODEL_PATH=<path-to-Qwen3.5-4B-weights>

cargo fmt --check

cargo build --release -p openinfer-server --features qwen35-4b

cargo build --release --bin bench_serving --features qwen35-4b

cargo test --release -p openinfer-qwen35-4b --features qwen35-4b --test e2e_scheduler -- --nocapture

cargo test --release -p openinfer-qwen35-4b --features qwen35-4b --test hf_golden_gate -- --nocapture
```

Additional post-review guard validation:

```bash
cargo test --release -p openinfer-qwen35-4b --features qwen35-4b config::tests -- --nocapture
```

HTTP serving benchmark, prefix cache not enabled, same `vllm bench serve` client:

| Cell | Runs | completed | failed | avg out | mean TPOT | output tok/s | graph GPU |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1024/256 c1 | 3 | 4/run | 0 | 256.0 | 6.90ms | 141.2 | 6.85ms |
| 1024/256 c16 | 3 | 16/run | 0 | 256.0 | 11.30ms | 1173.5 | 9.58ms |
| 1024/256 QPS 8 | 1 | 16 | 0 | 256.0 | 10.78ms | 906.5 | 8.91ms |
| 1024/256 QPS 12 | 1 | 24 | 0 | 256.0 | 11.85ms | 1371.4 | 9.05ms |
| 1024/256 QPS 16 | 1 | 32 | 0 | 256.0 | 12.81ms | 1759.4 | 9.37ms |

Delta vs retained baseline artifact:

- HTTP `1024/256 c16` mean TPOT: `17.35ms -> 11.30ms` (`-34.8%`)
- HTTP `1024/256 c16` decode graph GPU elapsed: `15.15ms -> 9.58ms` (`-36.8%`)
- HTTP `1024/256 c16` output throughput: `804.0 -> 1173.5 tok/s` (`+46.0%`)

An additional `nsys --cuda-graph-trace=node` composition check on HTTP c16/output64 confirms the expanded graph now contains:

- `gated_delta_rule_decode_batch_kernel`
- `conv1d_decode_batch_kernel`

The nsys run is not used for TPOT claims because profiler overhead inflates latency.

## Claim boundary

This PR does not claim vLLM parity, SOTA, or production readiness. It only claims the measured OpenInfer HTTP c16 regression bucket is reduced on the retained single RTX 5090 setup, with raw artifacts preserved.

