### PR TITLE
perf(kvbm): plain HashMap inner level for the registry position map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2455,6 +2455,7 @@ dependencies = [
  "bincode",
  "bytes",
  "criterion 0.5.1",
+ "dashmap",
  "derive_builder",
  "dynamo-tokens",
  "futures",

--- a/kvbm/kvbm-logical/Cargo.toml
+++ b/kvbm/kvbm-logical/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+dashmap = { workspace = true }
 dynamo-tokens = { workspace = true }
 
 anyhow = { workspace = true }

--- a/kvbm/kvbm-logical/src/registry/handle.rs
+++ b/kvbm/kvbm-logical/src/registry/handle.rs
@@ -87,7 +87,7 @@ impl Drop for BlockRegistrationHandleInner {
         // during `drop_in_place` the inner allocation is still live (the
         // implicit weak from the strong refcount is released after `Drop`
         // returns). Only remove if the entry still points to us.
-        let map = registry.prefix(&self.seq_hash);
+        let mut map = registry.prefix(&self.seq_hash);
         let should_remove = match map.get(&self.seq_hash) {
             Some(weak_ref) => std::ptr::eq(weak_ref.as_ptr(), self as *const Self),
             None => {

--- a/kvbm/kvbm-logical/src/registry/mod.rs
+++ b/kvbm/kvbm-logical/src/registry/mod.rs
@@ -5,7 +5,8 @@
 //!
 //! The [`BlockRegistry`] is the central coordination point for block deduplication in the
 //! KVBM system. It maps sequence hashes to registration handles using a
-//! [`dynamo_tokens::PositionalRadixTree`], enabling efficient prefix-based lookups.
+//! position-keyed two-level map ([`prt::PositionalRadixTree`]), enabling
+//! efficient prefix-based lookups.
 //!
 //! # Architecture
 //!
@@ -30,6 +31,7 @@
 
 mod attachments;
 mod handle;
+mod prt;
 mod registration;
 
 #[cfg(test)]
@@ -47,7 +49,7 @@ use std::sync::{Arc, Weak};
 
 use handle::BlockRegistrationHandleInner;
 
-pub(crate) type PositionalRadixTree<V> = dynamo_tokens::PositionalRadixTree<V, SequenceHash>;
+pub(crate) type PositionalRadixTree<V> = prt::PositionalRadixTree<V, SequenceHash>;
 
 /// Builder for [`BlockRegistry`].
 ///
@@ -229,8 +231,8 @@ impl BlockRegistry {
     // pattern should replace the direct EventsManager call here.
     #[inline]
     pub fn register_sequence_hash(&self, seq_hash: SequenceHash) -> BlockRegistrationHandle {
-        let map = self.prt.prefix(&seq_hash);
-        let mut weak = map.entry(seq_hash).or_default();
+        let mut map = self.prt.prefix(&seq_hash);
+        let weak = map.entry(seq_hash).or_default();
 
         if let Some(inner) = weak.upgrade() {
             return BlockRegistrationHandle::from_inner(inner);
@@ -254,8 +256,8 @@ impl BlockRegistry {
     /// Used when copying blocks between pools where we don't want to count the transfer as a new access.
     #[allow(dead_code)]
     pub(crate) fn transfer_registration(&self, seq_hash: SequenceHash) -> BlockRegistrationHandle {
-        let map = self.prt.prefix(&seq_hash);
-        let mut weak = map.entry(seq_hash).or_default();
+        let mut map = self.prt.prefix(&seq_hash);
+        let weak = map.entry(seq_hash).or_default();
 
         match weak.upgrade() {
             Some(inner) => BlockRegistrationHandle::from_inner(inner),

--- a/kvbm/kvbm-logical/src/registry/prt.rs
+++ b/kvbm/kvbm-logical/src/registry/prt.rs
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Position-keyed two-level map backing the registry: an outer concurrent
+//! map keyed by block position, an inner plain `HashMap` keyed by sequence
+//! hash.
+//!
+//! This replaces `dynamo_tokens::PositionalRadixTree` for the registry's
+//! use. That implementation's inner level is itself a `DashMap`, so every
+//! first registration at a new block position allocates a full sharded map
+//! — shard count scales with core count (4×cores rounded up to a power of
+//! two; 1024 shards on a 192-core node) — which measured 21µs of a 25µs
+//! per-block registration on a 48-core box, ~35× the cost of the actual
+//! slot transition. The sharding buys nothing here: every inner-map access
+//! goes through the outer entry's `RefMut`, which already holds the outer
+//! shard's write lock exclusively. A plain `HashMap` (allocation-free
+//! `Default`) drops registration to ~2µs/block.
+//!
+//! The outer entry guard doubles as the per-position critical section the
+//! handle-drop race protection relies on — see the comment in
+//! `handle.rs::Drop`.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+
+use dashmap::DashMap;
+use dashmap::mapref::one::RefMut;
+use dynamo_tokens::PositionalHash;
+
+pub(crate) struct PositionalRadixTree<V, K: PositionalHash + Hash + Eq> {
+    map: DashMap<u64, HashMap<K, V>>,
+}
+
+impl<V, K: PositionalHash + Hash + Eq> PositionalRadixTree<V, K> {
+    pub(crate) fn new() -> Self {
+        Self {
+            map: DashMap::new(),
+        }
+    }
+
+    /// Entry for the key's position level, created empty on first touch.
+    /// The returned guard holds the outer shard's write lock, serializing
+    /// all access to this position's inner map.
+    pub(crate) fn prefix(&self, key: &K) -> RefMut<'_, u64, HashMap<K, V>> {
+        self.map.entry(key.position()).or_default()
+    }
+
+    /// Total number of registered entries across all positions.
+    pub(crate) fn len(&self) -> usize {
+        self.map.iter().map(|level| level.len()).sum()
+    }
+}

--- a/kvbm/kvbm-logical/src/registry/tests.rs
+++ b/kvbm/kvbm-logical/src/registry/tests.rs
@@ -581,8 +581,8 @@ fn drop_does_not_remove_entry_when_replaced_by_newer_registration() {
         Arc::downgrade(&registry.prt),
     ));
     {
-        let map = registry.prt.prefix(&seq_hash);
-        let mut weak = map.get_mut(&seq_hash).expect("entry present");
+        let mut map = registry.prt.prefix(&seq_hash);
+        let weak = map.get_mut(&seq_hash).expect("entry present");
         *weak = Arc::downgrade(&inner_b);
     }
 


### PR DESCRIPTION
## What

Follow-up root-cause fix under #704: block registration cost was dominated not by the registry work itself but by a hidden allocation in `dynamo_tokens::PositionalRadixTree` — every first registration at a new block position allocates a full sharded `DashMap` as the inner level. Shard count scales with core count (4×cores rounded to a power of two): 256 shards on a 48-core box, **1024 on a 192-core H200 node**.

Instrumented breakdown of a 25µs/block registration (48-core box, per-stage timers inside `register_block`):

| stage | avg |
|---|---|
| `prt.prefix()` + inner `entry().or_default()` | **20.9µs** |
| handle `Arc` creation | 0.23µs |
| store slot transition (mutex + state) | 0.51µs |
| TinyLFU touch | 0.03µs |

The inner sharding buys nothing: every access goes through the outer entry's `RefMut`, which already holds the outer shard's write lock exclusively — and that guard doubles as the per-position critical section the handle-drop race protection relies on (locking semantics are bit-identical to the old version; the old `position()` bypass path had zero callers in this crate). Replaced the alias with a local two-level map whose inner level is a plain `HashMap` (allocation-free `Default`).

## Measured

1024-block restore commit (`commit_loaded_blocks`), 48-core box: **36.4ms → 1.67ms (22×)**, 1.63µs/block. On 192-core nodes the before-side is ~3× worse (1024-shard allocs measured ~70µs/block in situ during the #704 investigation), so the win is larger there.

This shrinks the constant that made #704 catastrophic; the chunked `Committing` pacing from #705 stays as the bounded-work-per-tick invariant for arbitrarily large restores.

- `kvbm-logical` full suite: 493 passed; clippy clean.
- Toxic-review pass: locking-semantics equivalence, handle-drop race, re-entrancy under the guard, and `len()` self-deadlock surface all verified; one dead trait bound removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)