### PR TITLE
feat(qwen35): add opt-in FlashInfer SM120 GDN prefill

### DIFF
--- a/openinfer-kernels/Cargo.toml
+++ b/openinfer-kernels/Cargo.toml
@@ -21,6 +21,9 @@ tvm-ffi-triton-cubin = ["dep:tvm-ffi", "qwen35-4b"]
 # Qwen3.5 Triton AOT kernels (GDR chunkwise prefill) — the only feature that
 # needs Python + Triton at build time.
 qwen35-4b = []
+# Opt-in SM120 FlashInfer CuTe-DSL GDN prefill artifact. The build also
+# requires OPENINFER_FLASHINFER_GDN_AOT=1 and a CUDA 13+ CuTe toolchain.
+flashinfer-gdn-prefill = ["qwen35-4b"]
 deepseek-v2-lite = []
 # Shared MoE/MLA third-party substrate: DeepEP, DeepGEMM, and FlashMLA.
 moe = []

--- a/openinfer-kernels/build.rs
+++ b/openinfer-kernels/build.rs
@@ -1418,8 +1418,7 @@ fn compile_flashinfer_gdn_aot(
 
     let root = crate_root();
     let python = std::env::var_os("OPENINFER_FLASHINFER_PYTHON")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("python3"));
+        .map_or_else(|| PathBuf::from("python3"), PathBuf::from);
     let generator = root.join("tools/flashinfer/gen_qwen35_gdn_aot.py");
     let artifact_dir = out_dir.join("flashinfer_gdn_sm120");
     // The FlashInfer Python sources are vendored as a submodule.  Keep the

--- a/openinfer-kernels/build.rs
+++ b/openinfer-kernels/build.rs
@@ -1392,7 +1392,88 @@ fn compile_triton_aot_kernels(cuda_include: &Path, out_dir: &Path, sm_targets: &
     println!("cargo:rerun-if-env-changed=OPENINFER_TRITON_PYTHON");
 }
 
+fn compile_flashinfer_gdn_aot(out_dir: &Path, sm_targets: &[String]) {
+    println!("cargo:rerun-if-env-changed=OPENINFER_FLASHINFER_GDN_AOT");
+    println!("cargo:rerun-if-env-changed=OPENINFER_FLASHINFER_PYTHON");
+
+    let requested = std::env::var_os("OPENINFER_FLASHINFER_GDN_AOT").is_some();
+    if !requested {
+        println!(
+            "cargo:warning=FlashInfer SM120 GDN AOT is available but disabled; set OPENINFER_FLASHINFER_GDN_AOT=1 to generate it"
+        );
+        return;
+    }
+    if !sm_targets.iter().any(|sm| sm == "120") {
+        println!(
+            "cargo:warning=FlashInfer SM120 GDN AOT requested without an sm_120 target; retaining Triton fallback"
+        );
+        return;
+    }
+
+    let root = crate_root();
+    let python = std::env::var_os("OPENINFER_FLASHINFER_PYTHON")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("python3"));
+    let generator = root.join("tools/flashinfer/gen_qwen35_gdn_aot.py");
+    let artifact_dir = out_dir.join("flashinfer_gdn_sm120");
+    let status = Command::new(&python)
+        .arg(&generator)
+        .arg("--output-dir")
+        .arg(&artifact_dir)
+        .current_dir(&root)
+        .status()
+        .unwrap_or_else(|err| {
+            panic!(
+                "failed to run FlashInfer GDN AOT generator {} with {}: {err}",
+                generator.display(),
+                python.display()
+            )
+        });
+    assert!(
+        status.success(),
+        "FlashInfer SM120 GDN AOT generation failed; install CUDA 13+ CuTe DSL build dependencies or unset OPENINFER_FLASHINFER_GDN_AOT"
+    );
+
+    let object = artifact_dir.join("openinfer_qwen35_gdn_sm120.o");
+    let wrapper = artifact_dir.join("openinfer_qwen35_gdn_sm120_wrapper.c");
+    assert!(object.is_file(), "missing generated CuTe object {}", object.display());
+    assert!(wrapper.is_file(), "missing generated C shim {}", wrapper.display());
+
+    let mut build = cc::Build::new();
+    build
+        .file(&wrapper)
+        .object(&object)
+        .include(&artifact_dir)
+        .flag_if_supported("-std=c11")
+        .warnings(false);
+    time_phase("cc flashinfer_gdn_sm120", || {
+        build.compile("flashinfer_gdn_sm120");
+    });
+
+    let runtime_libs = artifact_dir.join("runtime_libs.txt");
+    if let Ok(contents) = fs::read_to_string(&runtime_libs) {
+        for lib in contents.lines().map(str::trim).filter(|line| !line.is_empty()) {
+            let path = Path::new(lib);
+            if let Some(parent) = path.parent() {
+                println!("cargo:rustc-link-search=native={}", parent.display());
+            }
+            if let Some(file_name) = path.file_name().and_then(|name| name.to_str()) {
+                let name = file_name
+                    .strip_prefix("lib")
+                    .unwrap_or(file_name)
+                    .split('.')
+                    .next()
+                    .unwrap_or(file_name);
+                println!("cargo:rustc-link-lib=dylib={name}");
+            }
+        }
+    }
+    println!("cargo:rustc-cfg=flashinfer_gdn_aot");
+    println!("cargo:rerun-if-changed={}", generator.display());
+}
+
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg(flashinfer_gdn_aot)");
     ensure_git_submodules_initialized(&workspace_root());
 
     let toolkit = openinfer_build::CudaToolkit::discover();
@@ -1881,6 +1962,9 @@ fn main() {
         println!(
             "cargo:warning=Qwen3.5 Triton AOT kernels disabled; enable the openinfer-kernels `qwen35-4b` feature to build them (needs Python + Triton at build time)"
         );
+    }
+    if cfg!(feature = "flashinfer-gdn-prefill") {
+        compile_flashinfer_gdn_aot(&out_dir, &sm_targets);
     }
 
     println!("cargo:rustc-link-search=native={}", out_dir.display());

--- a/openinfer-kernels/build.rs
+++ b/openinfer-kernels/build.rs
@@ -1392,7 +1392,13 @@ fn compile_triton_aot_kernels(cuda_include: &Path, out_dir: &Path, sm_targets: &
     println!("cargo:rerun-if-env-changed=OPENINFER_TRITON_PYTHON");
 }
 
-fn compile_flashinfer_gdn_aot(out_dir: &Path, sm_targets: &[String]) {
+fn compile_flashinfer_gdn_aot(
+    cuda_include: &Path,
+    extra_cuda_includes: &[PathBuf],
+    flashinfer: &FlashInferIncludes,
+    out_dir: &Path,
+    sm_targets: &[String],
+) {
     println!("cargo:rerun-if-env-changed=OPENINFER_FLASHINFER_GDN_AOT");
     println!("cargo:rerun-if-env-changed=OPENINFER_FLASHINFER_PYTHON");
 
@@ -1416,19 +1422,30 @@ fn compile_flashinfer_gdn_aot(out_dir: &Path, sm_targets: &[String]) {
         .unwrap_or_else(|| PathBuf::from("python3"));
     let generator = root.join("tools/flashinfer/gen_qwen35_gdn_aot.py");
     let artifact_dir = out_dir.join("flashinfer_gdn_sm120");
-    let status = Command::new(&python)
+    // The FlashInfer Python sources are vendored as a submodule.  Keep the
+    // AOT build reproducible without requiring an editable pip install of the
+    // whole package; the CuTe/CUDA dependencies still come from the selected
+    // build Python environment.
+    let mut python_path = vec![root.join("third_party/flashinfer")];
+    if let Some(existing) = std::env::var_os("PYTHONPATH") {
+        python_path.extend(std::env::split_paths(&existing));
+    }
+    let mut command = Command::new(&python);
+    command
         .arg(&generator)
         .arg("--output-dir")
         .arg(&artifact_dir)
-        .current_dir(&root)
-        .status()
-        .unwrap_or_else(|err| {
-            panic!(
-                "failed to run FlashInfer GDN AOT generator {} with {}: {err}",
-                generator.display(),
-                python.display()
-            )
-        });
+        .current_dir(&root);
+    if let Ok(joined) = std::env::join_paths(python_path) {
+        command.env("PYTHONPATH", joined);
+    }
+    let status = command.status().unwrap_or_else(|err| {
+        panic!(
+            "failed to run FlashInfer GDN AOT generator {} with {}: {err}",
+            generator.display(),
+            python.display()
+        )
+    });
     assert!(
         status.success(),
         "FlashInfer SM120 GDN AOT generation failed; install CUDA 13+ CuTe DSL build dependencies or unset OPENINFER_FLASHINFER_GDN_AOT"
@@ -1436,23 +1453,42 @@ fn compile_flashinfer_gdn_aot(out_dir: &Path, sm_targets: &[String]) {
 
     let object = artifact_dir.join("openinfer_qwen35_gdn_sm120.o");
     let wrapper = artifact_dir.join("openinfer_qwen35_gdn_sm120_wrapper.c");
-    assert!(object.is_file(), "missing generated CuTe object {}", object.display());
-    assert!(wrapper.is_file(), "missing generated C shim {}", wrapper.display());
+    assert!(
+        object.is_file(),
+        "missing generated CuTe object {}",
+        object.display()
+    );
+    assert!(
+        wrapper.is_file(),
+        "missing generated C shim {}",
+        wrapper.display()
+    );
 
     let mut build = cc::Build::new();
     build
         .file(&wrapper)
         .object(&object)
         .include(&artifact_dir)
+        .include(cuda_include)
         .flag_if_supported("-std=c11")
         .warnings(false);
+    for include in extra_cuda_includes {
+        build.include(include);
+    }
+    for include in &flashinfer.cccl {
+        build.include(include);
+    }
     time_phase("cc flashinfer_gdn_sm120", || {
         build.compile("flashinfer_gdn_sm120");
     });
 
     let runtime_libs = artifact_dir.join("runtime_libs.txt");
     if let Ok(contents) = fs::read_to_string(&runtime_libs) {
-        for lib in contents.lines().map(str::trim).filter(|line| !line.is_empty()) {
+        for lib in contents
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+        {
             let path = Path::new(lib);
             if let Some(parent) = path.parent() {
                 println!("cargo:rustc-link-search=native={}", parent.display());
@@ -1469,6 +1505,9 @@ fn compile_flashinfer_gdn_aot(out_dir: &Path, sm_targets: &[String]) {
         }
     }
     println!("cargo:rustc-cfg=flashinfer_gdn_aot");
+    if !cfg!(target_os = "windows") {
+        println!("cargo:rustc-link-lib=pthread");
+    }
     println!("cargo:rerun-if-changed={}", generator.display());
 }
 
@@ -1481,6 +1520,17 @@ fn main() {
     let cuda_include = toolkit
         .header_dir("cuda.h")
         .unwrap_or_else(|| toolkit.root.join("include"));
+    // NVIDIA's pip CUDA packages split cuBLAS headers out of the nvcc
+    // package. Add sibling math-library include roots when using that layout.
+    let mut extra_cuda_includes = Vec::new();
+    if let Some(nvidia_root) = toolkit.root.parent() {
+        for (package, header) in [("cublas", "cublas_v2.h"), ("curand", "curand.h")] {
+            let include = nvidia_root.join(package).join("include");
+            if include.join(header).is_file() {
+                extra_cuda_includes.push(include);
+            }
+        }
+    }
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
     let sm_targets = detect_sm_targets();
     let nvcc_sm_targets = normalize_nvcc_sms(&sm_targets, &nvcc);
@@ -1609,6 +1659,9 @@ fn main() {
             "-I".to_string(),
             csrc_dir.to_string_lossy().to_string(),
         ];
+        for include in &extra_cuda_includes {
+            nvcc_args.extend(["-I".to_string(), include.to_string_lossy().to_string()]);
+        }
         if stem == "glm52_flashmla_sparse" {
             nvcc_args.extend(glm52_flashmla_sparse_arch_args(&nvcc_sm_targets, &nvcc));
         } else if stem == "glm52_deepgemm_mqa" {
@@ -1638,6 +1691,13 @@ fn main() {
         }
         nvcc_args.extend(["--compiler-options".to_string(), "-fPIC".to_string()]);
 
+        // CUDA 13's cuda_fp16.h includes libcudacxx's nv/target even for
+        // translation units that do not otherwise include FlashInfer. Keep
+        // the vendored CCCL ahead of the toolkit headers for every TU.
+        for dir in &flashinfer.cccl {
+            nvcc_args.extend(["-I".to_string(), dir.to_string_lossy().to_string()]);
+        }
+
         // Files that include FlashInfer headers (C++17, header-only)
         if stem == "paged_attention"
             || stem == "flashinfer_norm"
@@ -1645,9 +1705,6 @@ fn main() {
             || stem == "flashinfer_top1"
             || stem == "glm52_topk"
         {
-            for dir in &flashinfer.cccl {
-                nvcc_args.extend(["-I".to_string(), dir.to_string_lossy().to_string()]);
-            }
             nvcc_args.extend([
                 "--std=c++17".to_string(),
                 "-I".to_string(),
@@ -1964,7 +2021,13 @@ fn main() {
         );
     }
     if cfg!(feature = "flashinfer-gdn-prefill") {
-        compile_flashinfer_gdn_aot(&out_dir, &sm_targets);
+        compile_flashinfer_gdn_aot(
+            &cuda_include,
+            &extra_cuda_includes,
+            &flashinfer,
+            &out_dir,
+            &sm_targets,
+        );
     }
 
     println!("cargo:rustc-link-search=native={}", out_dir.display());

--- a/openinfer-kernels/csrc/qwen35/flashinfer_gdn.cu
+++ b/openinfer-kernels/csrc/qwen35/flashinfer_gdn.cu
@@ -1,6 +1,34 @@
 #include "common.cuh"
 
+#include <cuda.h>
 #include <stdint.h>
+
+__global__ void gated_delta_rule_gate_exp_kernel(
+    const float* __restrict__ input,
+    float* __restrict__ output,
+    int32_t length) {
+  const int32_t index = static_cast<int32_t>(blockIdx.x * blockDim.x + threadIdx.x);
+  if (index < length) {
+    output[index] = expf(input[index]);
+  }
+}
+
+extern "C" CUresult gated_delta_rule_prefill_gate_exp_cuda(
+    const float* input,
+    float* output,
+    int32_t length,
+    CUstream stream) {
+  if (input == nullptr || output == nullptr || length < 0) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  if (length == 0) {
+    return CUDA_SUCCESS;
+  }
+  constexpr int threads = 256;
+  const int blocks = (length + threads - 1) / threads;
+  gated_delta_rule_gate_exp_kernel<<<blocks, threads, 0, stream>>>(input, output, length);
+  return static_cast<CUresult>(cudaGetLastError());
+}
 
 // FlashInfer stores recurrent state as [H, V, K], while OpenInfer's decode
 // kernels use [H, K, V] with V contiguous.  Keep the conversion explicit at

--- a/openinfer-kernels/csrc/qwen35/flashinfer_gdn.cu
+++ b/openinfer-kernels/csrc/qwen35/flashinfer_gdn.cu
@@ -1,0 +1,52 @@
+#include "common.cuh"
+
+#include <stdint.h>
+
+// FlashInfer stores recurrent state as [H, V, K], while OpenInfer's decode
+// kernels use [H, K, V] with V contiguous.  Keep the conversion explicit at
+// the backend boundary so a layout change cannot silently alter the model.
+__global__ void transpose_gdn_state_kernel(
+    const float* __restrict__ src,
+    float* __restrict__ dst,
+    int32_t num_heads,
+    int32_t key_dim,
+    int32_t value_dim,
+    bool to_flashinfer) {
+  const int64_t total = static_cast<int64_t>(num_heads) * key_dim * value_dim;
+  const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= total) return;
+
+  const int64_t head_stride = static_cast<int64_t>(key_dim) * value_dim;
+  const int64_t head = idx / head_stride;
+  const int64_t rem = idx - head * head_stride;
+  const int64_t row = rem / value_dim;
+  const int64_t col = rem - row * value_dim;
+
+  const int64_t src_idx = head * head_stride + row * value_dim + col;
+  const int64_t dst_idx = head * head_stride + col * key_dim + row;
+  if (to_flashinfer) {
+    dst[dst_idx] = src[src_idx];
+  } else {
+    dst[src_idx] = src[dst_idx];
+  }
+}
+
+extern "C" CUresult gated_delta_rule_state_transpose_cuda(
+    const float* src,
+    float* dst,
+    int32_t num_heads,
+    int32_t key_dim,
+    int32_t value_dim,
+    bool to_flashinfer,
+    CUstream stream) {
+  if (src == nullptr || dst == nullptr || num_heads <= 0 || key_dim <= 0 || value_dim <= 0) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  const int64_t total = static_cast<int64_t>(num_heads) * key_dim * value_dim;
+  constexpr int threads = 256;
+  const int blocks = static_cast<int>((total + threads - 1) / threads);
+  transpose_gdn_state_kernel<<<blocks, threads, 0, stream>>>(
+      src, dst, num_heads, key_dim, value_dim, to_flashinfer);
+  return static_cast<CUresult>(cudaGetLastError());
+}

--- a/openinfer-kernels/src/ffi/qwen35.rs
+++ b/openinfer-kernels/src/ffi/qwen35.rs
@@ -111,6 +111,39 @@ unsafe extern "C" {
         kernel_size: i32,
         stream: CUstream,
     );
+
+    /// Convert between OpenInfer's [H,K,V] state and FlashInfer's [H,V,K]
+    /// state. The operation is out-of-place and stream ordered.
+    #[cfg(feature = "qwen35-4b")]
+    pub fn gated_delta_rule_state_transpose_cuda(
+        src: *const f32,
+        dst: *mut f32,
+        num_heads: i32,
+        key_dim: i32,
+        value_dim: i32,
+        to_flashinfer: bool,
+        stream: CUstream,
+    ) -> CUresult;
+}
+
+// The CuTe AOT generator emits this symbol only when the opt-in build
+// produced an SM120 artifact. Keeping the declaration behind the generated
+// cfg lets normal CI and unsupported architectures retain the Triton path.
+#[cfg(flashinfer_gdn_aot)]
+unsafe extern "C" {
+    pub fn openinfer_qwen35_gdn_sm120_cuda(
+        q: *const Half,
+        k: *const Half,
+        v: *const Half,
+        output: *mut Half,
+        alpha: *const f32,
+        beta: *const f32,
+        state: *mut f32,
+        tensormaps: *mut u8,
+        cu_seqlens: *const i64,
+        seq_len: i32,
+        stream: CUstream,
+    ) -> CUresult;
 }
 
 // Chunk-wise GDR prefill kernels, Triton AOT-generated at build time. The

--- a/openinfer-kernels/src/ffi/qwen35.rs
+++ b/openinfer-kernels/src/ffi/qwen35.rs
@@ -124,6 +124,13 @@ unsafe extern "C" {
         to_flashinfer: bool,
         stream: CUstream,
     ) -> CUresult;
+
+    pub fn gated_delta_rule_prefill_gate_exp_cuda(
+        input: *const f32,
+        output: *mut f32,
+        length: i32,
+        stream: CUstream,
+    ) -> CUresult;
 }
 
 // The CuTe AOT generator emits this symbol only when the opt-in build
@@ -139,6 +146,7 @@ unsafe extern "C" {
         alpha: *const f32,
         beta: *const f32,
         state: *mut f32,
+        init_state: *const f32,
         tensormaps: *mut u8,
         cu_seqlens: *const i64,
         seq_len: i32,

--- a/openinfer-kernels/src/ffi/qwen35.rs
+++ b/openinfer-kernels/src/ffi/qwen35.rs
@@ -125,6 +125,7 @@ unsafe extern "C" {
         stream: CUstream,
     ) -> CUresult;
 
+    #[cfg(feature = "qwen35-4b")]
     pub fn gated_delta_rule_prefill_gate_exp_cuda(
         input: *const f32,
         output: *mut f32,

--- a/openinfer-kernels/src/flashinfer_gdn.rs
+++ b/openinfer-kernels/src/flashinfer_gdn.rs
@@ -9,6 +9,11 @@ use cudarc::driver::sys::{CUresult, CUstream};
 
 use crate::ffi;
 
+/// Returns whether build.rs emitted the optional SM120 CuTe artifact.
+pub const fn aot_available() -> bool {
+    cfg!(flashinfer_gdn_aot)
+}
+
 fn check_cuda(result: CUresult, operation: &str) -> Result<()> {
     if result as u32 == 0 {
         Ok(())
@@ -31,6 +36,7 @@ pub fn launch_prefill(
     alpha: *const f32,
     beta: *const f32,
     state: *mut f32,
+    init_state: *const f32,
     tensormaps: *mut u8,
     cu_seqlens: *const i64,
     seq_len: i32,
@@ -43,16 +49,7 @@ pub fn launch_prefill(
         // stream-ordered launch completes.
         let result = unsafe {
             ffi::openinfer_qwen35_gdn_sm120_cuda(
-                q,
-                k,
-                v,
-                output,
-                alpha,
-                beta,
-                state,
-                tensormaps,
-                cu_seqlens,
-                seq_len,
+                q, k, v, output, alpha, beta, state, init_state, tensormaps, cu_seqlens, seq_len,
                 stream,
             )
         };
@@ -62,7 +59,10 @@ pub fn launch_prefill(
 
     #[cfg(not(flashinfer_gdn_aot))]
     {
-        let _ = (q, k, v, output, alpha, beta, state, tensormaps, cu_seqlens, seq_len, stream);
+        let _ = (
+            q, k, v, output, alpha, beta, state, init_state, tensormaps, cu_seqlens, seq_len,
+            stream,
+        );
         Ok(false)
     }
 }
@@ -96,3 +96,9 @@ pub fn transpose_state(
     check_cuda(result, "GDN state transpose")
 }
 
+/// Convert cumulative log-gates to FlashInfer's positive alpha factors.
+pub fn exp_gate(input: *const f32, output: *mut f32, length: i32, stream: CUstream) -> Result<()> {
+    let result =
+        unsafe { ffi::gated_delta_rule_prefill_gate_exp_cuda(input, output, length, stream) };
+    check_cuda(result, "GDN gate exponentiation")
+}

--- a/openinfer-kernels/src/flashinfer_gdn.rs
+++ b/openinfer-kernels/src/flashinfer_gdn.rs
@@ -96,7 +96,7 @@ pub fn transpose_state(
     check_cuda(result, "GDN state transpose")
 }
 
-/// Convert cumulative log-gates to FlashInfer's positive alpha factors.
+/// Convert per-token log-gates to FlashInfer's positive alpha factors.
 pub fn exp_gate(input: *const f32, output: *mut f32, length: i32, stream: CUstream) -> Result<()> {
     let result =
         unsafe { ffi::gated_delta_rule_prefill_gate_exp_cuda(input, output, length, stream) };

--- a/openinfer-kernels/src/flashinfer_gdn.rs
+++ b/openinfer-kernels/src/flashinfer_gdn.rs
@@ -1,0 +1,98 @@
+//! Optional FlashInfer SM120 GDN prefill launcher.
+//!
+//! The generated CuTe artifact is deliberately hidden behind this small
+//! pointer-level API.  Qwen3.5 owns tensor validation and state conversion;
+//! this module owns whether an artifact was produced by `build.rs`.
+
+use anyhow::{Result, anyhow};
+use cudarc::driver::sys::{CUresult, CUstream};
+
+use crate::ffi;
+
+fn check_cuda(result: CUresult, operation: &str) -> Result<()> {
+    if result as u32 == 0 {
+        Ok(())
+    } else {
+        Err(anyhow!("{operation} returned CUDA result {result:?}"))
+    }
+}
+
+/// Launch the generated SM120 FlashInfer GDN artifact when available.
+///
+/// Returns `Ok(true)` when the artifact launched and `Ok(false)` when this
+/// build did not generate it.  The latter is the normal path for CI,
+/// unsupported architectures, and builds that intentionally retain Triton.
+#[allow(clippy::too_many_arguments)]
+pub fn launch_prefill(
+    q: *const ffi::Half,
+    k: *const ffi::Half,
+    v: *const ffi::Half,
+    output: *mut ffi::Half,
+    alpha: *const f32,
+    beta: *const f32,
+    state: *mut f32,
+    tensormaps: *mut u8,
+    cu_seqlens: *const i64,
+    seq_len: i32,
+    stream: CUstream,
+) -> Result<bool> {
+    #[cfg(flashinfer_gdn_aot)]
+    {
+        // SAFETY: callers obtain every pointer from live cudarc allocations
+        // on the same CUDA stream and keep those allocations alive until the
+        // stream-ordered launch completes.
+        let result = unsafe {
+            ffi::openinfer_qwen35_gdn_sm120_cuda(
+                q,
+                k,
+                v,
+                output,
+                alpha,
+                beta,
+                state,
+                tensormaps,
+                cu_seqlens,
+                seq_len,
+                stream,
+            )
+        };
+        check_cuda(result, "FlashInfer SM120 GDN prefill")?;
+        return Ok(true);
+    }
+
+    #[cfg(not(flashinfer_gdn_aot))]
+    {
+        let _ = (q, k, v, output, alpha, beta, state, tensormaps, cu_seqlens, seq_len, stream);
+        Ok(false)
+    }
+}
+
+/// Transpose one recurrent state matrix between the OpenInfer and FlashInfer
+/// layouts.  This kernel is available whenever the Qwen3.5 CUDA kernels are
+/// built, independent of whether the optional CuTe artifact exists.
+pub fn transpose_state(
+    src: *const f32,
+    dst: *mut f32,
+    num_heads: i32,
+    key_dim: i32,
+    value_dim: i32,
+    to_flashinfer: bool,
+    stream: CUstream,
+) -> Result<()> {
+    // SAFETY: callers pass valid device pointers and a stream from the owning
+    // DeviceContext; the CUDA kernel performs a bounds-checked out-of-place
+    // transpose.
+    let result = unsafe {
+        ffi::gated_delta_rule_state_transpose_cuda(
+            src,
+            dst,
+            num_heads,
+            key_dim,
+            value_dim,
+            to_flashinfer,
+            stream,
+        )
+    };
+    check_cuda(result, "GDN state transpose")
+}
+

--- a/openinfer-kernels/src/lib.rs
+++ b/openinfer-kernels/src/lib.rs
@@ -2,6 +2,8 @@
 #![feature(generic_const_exprs)]
 
 pub mod ffi;
+#[cfg(feature = "flashinfer-gdn-prefill")]
+pub mod flashinfer_gdn;
 pub mod forward_pass;
 pub mod gpu_buffers;
 pub mod ops;

--- a/openinfer-kernels/tools/flashinfer/gen_qwen35_gdn_aot.py
+++ b/openinfer-kernels/tools/flashinfer/gen_qwen35_gdn_aot.py
@@ -26,13 +26,14 @@ TENSOR_MAP_BYTES = 256 * 128
 PREFIX = "openinfer_qwen35_gdn_sm120"
 
 
-def _patch_grid_argument_annotation(kernel_cls, cutlass) -> None:
-    """Make the upstream ``grid_x`` launch scalar exportable.
+def _patch_export_annotations(kernel_cls, cutlass, cuda_driver) -> None:
+    """Make upstream launch-only arguments exportable.
 
     FlashInfer v0.6.14 annotates ``grid_x`` as a Python ``int``.  CuTe's C
     header exporter only accepts DSL numeric types, even though the value is a
-    runtime launch scalar.  Treating it as Int32 preserves the ABI and lets
-    the generated wrapper vary the grid for future batched callers.
+    runtime launch scalar.  It also leaves ``stream`` unannotated, while the
+    exporter requires the CUDA binding type.  These annotations preserve the
+    runtime ABI without changing the vendored FlashInfer source.
     """
 
     call = kernel_cls.__call__
@@ -43,6 +44,7 @@ def _patch_grid_argument_annotation(kernel_cls, cutlass) -> None:
     if annotations is None:
         raise RuntimeError("cannot find CuTe GDN kernel annotations")
     annotations["grid_x"] = cutlass.Int32
+    annotations["stream"] = cuda_driver.CUstream
 
 
 def _fake_tensor(cute, cutlass, dtype, shape, stride):
@@ -65,6 +67,7 @@ def _write_c_shim(output_dir: Path, header_name: str) -> None:
     header_prefix = PREFIX
     wrapper_name = f"cute_dsl_{PREFIX}_wrapper"
     text = f'''#include "{header_name}"
+#include <cuda.h>
 #include <cuda_runtime.h>
 #include <stdint.h>
 #include <pthread.h>
@@ -78,7 +81,7 @@ static void load_{header_prefix}(void) {{
 
 // q/k/v/o are token-major [T, H, D] buffers.  CuTe consumes the equivalent
 // TMA views [T, D, H] with the static strides below.  alpha/beta are [T, H].
-// state is [1, H, V, K], matching FlashInfer's final-state contract.
+// state and init_state are [1, H, V, K], matching FlashInfer's state contract.
 CUresult {header_prefix}_cuda(
     const uint16_t* q,
     const uint16_t* k,
@@ -87,6 +90,7 @@ CUresult {header_prefix}_cuda(
     const float* alpha,
     const float* beta,
     float* state,
+    const float* init_state,
     uint8_t* tensormaps,
     const int64_t* cu_seqlens,
     int32_t seq_len,
@@ -101,10 +105,11 @@ CUresult {header_prefix}_cuda(
     {header_prefix}_Tensor_g_alpha_t alpha_desc = {{(void*)alpha, {{seq_len}}}};
     {header_prefix}_Tensor_g_beta_t beta_desc = {{(void*)beta, {{seq_len}}}};
     {header_prefix}_Tensor_g_state_t state_desc = {{(void*)state}};
+    {header_prefix}_Tensor_g_init_state_t init_state_desc = {{(void*)init_state}};
     {header_prefix}_Tensor_g_tensormaps_t tensormaps_desc = {{(void*)tensormaps}};
     {header_prefix}_Tensor_cu_seqlens_t cu_desc = {{(void*)cu_seqlens}};
 
-    {wrapper_name}(
+    int32_t launch_status = {wrapper_name}(
         &g_module,
         &q_desc,
         &k_desc,
@@ -113,6 +118,7 @@ CUresult {header_prefix}_cuda(
         &alpha_desc,
         &beta_desc,
         &state_desc,
+        &init_state_desc,
         &tensormaps_desc,
         &cu_desc,
         1.0f / 11.313708498984761f,
@@ -125,7 +131,8 @@ CUresult {header_prefix}_cuda(
         0,
         {HEADS},
         stream);
-    return (CUresult)cudaGetLastError();
+    if (launch_status != 0) return CUDA_ERROR_LAUNCH_FAILED;
+    return cudaGetLastError() == cudaSuccess ? CUDA_SUCCESS : CUDA_ERROR_LAUNCH_FAILED;
 }}
 '''
     (output_dir / f"{PREFIX}_wrapper.c").write_text(text, encoding="utf-8")
@@ -149,7 +156,7 @@ def generate(output_dir: Path) -> None:
     )
 
     output_dir.mkdir(parents=True, exist_ok=True)
-    _patch_grid_argument_annotation(_FullyFusedDeltaRuleSm120, cutlass)
+    _patch_export_annotations(_FullyFusedDeltaRuleSm120, cutlass, cuda_driver)
 
     token_count = cute.sym_int32(divisibility=64, symbol="total_tokens")
     q_stride = (HEADS * HEAD_DIM, 1, HEAD_DIM)
@@ -167,6 +174,9 @@ def generate(output_dir: Path) -> None:
     state = _fake_tensor(
         cute, cutlass, cutlass.Float32, (1, HEADS, HEAD_DIM, HEAD_DIM), state_stride
     )
+    init_state = _fake_tensor(
+        cute, cutlass, cutlass.Float32, (1, HEADS, HEAD_DIM, HEAD_DIM), state_stride
+    )
     tensormaps = _fake_tensor(
         cute, cutlass, cutlass.Uint8, (TENSOR_MAP_BYTES,), (1,)
     )
@@ -176,7 +186,7 @@ def generate(output_dir: Path) -> None:
     kernel = _FullyFusedDeltaRuleSm120(
         needs_alpha=True,
         needs_beta=True,
-        needs_init_state=False,
+        needs_init_state=True,
         needs_checkpointing=False,
         dtype=cutlass.BFloat16,
     )
@@ -188,7 +198,7 @@ def generate(output_dir: Path) -> None:
         alpha,
         beta,
         state,
-        None,
+        init_state,
         None,
         None,
         tensormaps,
@@ -205,7 +215,7 @@ def generate(output_dir: Path) -> None:
         stream,
     )
 
-    options = (cutlass.GPUArch("sm_120a"),)
+    options = (cute.GPUArch("sm_120a"),)
     compiled = cute.compile[options](kernel, *args)
     compiled.export_to_c(str(output_dir), PREFIX, function_prefix=PREFIX)
     _write_c_shim(output_dir, f"{PREFIX}.h")

--- a/openinfer-kernels/tools/flashinfer/gen_qwen35_gdn_aot.py
+++ b/openinfer-kernels/tools/flashinfer/gen_qwen35_gdn_aot.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Generate the SM120 Qwen3.5 GDN prefill artifact.
+
+The checked-in FlashInfer implementation is a CuTe DSL source, not a C ABI
+library.  This script is intentionally a build-time tool: it compiles one
+shape-general (dynamic token count) Qwen3.5 configuration and exports the
+CuTe launcher plus a small C ABI shim.  Python is therefore not required by
+the OpenInfer serving process.
+
+The first integration target is the Qwen3.5-4B linear-attention shape after
+OpenInfer's prepare stage: 32 value heads, head dimension 128, bf16 I/O and a
+single variable-length sequence.  The existing Triton pipeline remains the
+fallback for other shapes and architectures.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+from pathlib import Path
+
+
+HEADS = 32
+HEAD_DIM = 128
+TENSOR_MAP_BYTES = 256 * 128
+PREFIX = "openinfer_qwen35_gdn_sm120"
+
+
+def _patch_grid_argument_annotation(kernel_cls, cutlass) -> None:
+    """Make the upstream ``grid_x`` launch scalar exportable.
+
+    FlashInfer v0.6.14 annotates ``grid_x`` as a Python ``int``.  CuTe's C
+    header exporter only accepts DSL numeric types, even though the value is a
+    runtime launch scalar.  Treating it as Int32 preserves the ABI and lets
+    the generated wrapper vary the grid for future batched callers.
+    """
+
+    call = kernel_cls.__call__
+    annotations = getattr(call, "__annotations__", None)
+    if annotations is None:
+        wrapped = getattr(call, "__wrapped__", None)
+        annotations = getattr(wrapped, "__annotations__", None)
+    if annotations is None:
+        raise RuntimeError("cannot find CuTe GDN kernel annotations")
+    annotations["grid_x"] = cutlass.Int32
+
+
+def _fake_tensor(cute, cutlass, dtype, shape, stride):
+    return cute.runtime.make_fake_tensor(
+        dtype,
+        shape,
+        stride=stride,
+        assumed_align=16,
+    )
+
+
+def _write_c_shim(output_dir: Path, header_name: str) -> None:
+    """Write the raw-pointer launcher consumed by Rust.
+
+    The generated CuTe header owns the opaque CUDA module and descriptor
+    structs.  This shim only fills those descriptors from OpenInfer's
+    contiguous token-major buffers and handles one-time module loading.
+    """
+
+    header_prefix = PREFIX
+    wrapper_name = f"cute_dsl_{PREFIX}_wrapper"
+    text = f'''#include "{header_name}"
+#include <cuda_runtime.h>
+#include <stdint.h>
+#include <pthread.h>
+
+static {header_prefix}_Kernel_Module_t g_module;
+static pthread_once_t g_module_once = PTHREAD_ONCE_INIT;
+
+static void load_{header_prefix}(void) {{
+    {header_prefix}_Kernel_Module_Load(&g_module);
+}}
+
+// q/k/v/o are token-major [T, H, D] buffers.  CuTe consumes the equivalent
+// TMA views [T, D, H] with the static strides below.  alpha/beta are [T, H].
+// state is [1, H, V, K], matching FlashInfer's final-state contract.
+CUresult {header_prefix}_cuda(
+    const uint16_t* q,
+    const uint16_t* k,
+    const uint16_t* v,
+    uint16_t* output,
+    const float* alpha,
+    const float* beta,
+    float* state,
+    uint8_t* tensormaps,
+    const int64_t* cu_seqlens,
+    int32_t seq_len,
+    cudaStream_t stream) {{
+    int once_err = pthread_once(&g_module_once, load_{header_prefix});
+    if (once_err != 0) return CUDA_ERROR_UNKNOWN;
+
+    {header_prefix}_Tensor_g_q_t q_desc = {{(void*)q, {{seq_len}}}};
+    {header_prefix}_Tensor_g_k_t k_desc = {{(void*)k, {{seq_len}}}};
+    {header_prefix}_Tensor_g_v_t v_desc = {{(void*)v, {{seq_len}}}};
+    {header_prefix}_Tensor_g_o_t o_desc = {{(void*)output, {{seq_len}}}};
+    {header_prefix}_Tensor_g_alpha_t alpha_desc = {{(void*)alpha, {{seq_len}}}};
+    {header_prefix}_Tensor_g_beta_t beta_desc = {{(void*)beta, {{seq_len}}}};
+    {header_prefix}_Tensor_g_state_t state_desc = {{(void*)state}};
+    {header_prefix}_Tensor_g_tensormaps_t tensormaps_desc = {{(void*)tensormaps}};
+    {header_prefix}_Tensor_cu_seqlens_t cu_desc = {{(void*)cu_seqlens}};
+
+    {wrapper_name}(
+        &g_module,
+        &q_desc,
+        &k_desc,
+        &v_desc,
+        &o_desc,
+        &alpha_desc,
+        &beta_desc,
+        &state_desc,
+        &tensormaps_desc,
+        &cu_desc,
+        1.0f / 11.313708498984761f,
+        {HEADS},
+        {HEADS},
+        {HEADS},
+        {HEADS},
+        1,
+        1,
+        0,
+        {HEADS},
+        stream);
+    return (CUresult)cudaGetLastError();
+}}
+'''
+    (output_dir / f"{PREFIX}_wrapper.c").write_text(text, encoding="utf-8")
+
+
+def generate(output_dir: Path) -> None:
+    try:
+        import cutlass as _cutlass_module
+        import cutlass.cute as cute
+        import cutlass.cute.runtime
+        import cuda.bindings.driver as cuda_driver
+    except ImportError as exc:
+        raise RuntimeError(
+            "FlashInfer SM120 AOT generation requires nvidia-cutlass-dsl and "
+            "cuda-python; install flashinfer-python[cu13] build dependencies"
+        ) from exc
+
+    cutlass = _cutlass_module
+    from flashinfer.gdn_kernels.delta_rule_dsl.delta_rule_sm120 import (
+        _FullyFusedDeltaRuleSm120,
+    )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _patch_grid_argument_annotation(_FullyFusedDeltaRuleSm120, cutlass)
+
+    token_count = cute.sym_int32(divisibility=64, symbol="total_tokens")
+    q_stride = (HEADS * HEAD_DIM, 1, HEAD_DIM)
+    alpha_stride = (HEADS, 1)
+    state_stride = (HEADS * HEAD_DIM * HEAD_DIM, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1)
+
+    q = _fake_tensor(cute, cutlass, cutlass.BFloat16, (token_count, HEAD_DIM, HEADS), q_stride)
+    k = _fake_tensor(cute, cutlass, cutlass.BFloat16, (token_count, HEAD_DIM, HEADS), q_stride)
+    v = _fake_tensor(cute, cutlass, cutlass.BFloat16, (token_count, HEAD_DIM, HEADS), q_stride)
+    output = _fake_tensor(
+        cute, cutlass, cutlass.BFloat16, (token_count, HEAD_DIM, HEADS), q_stride
+    )
+    alpha = _fake_tensor(cute, cutlass, cutlass.Float32, (token_count, HEADS), alpha_stride)
+    beta = _fake_tensor(cute, cutlass, cutlass.Float32, (token_count, HEADS), alpha_stride)
+    state = _fake_tensor(
+        cute, cutlass, cutlass.Float32, (1, HEADS, HEAD_DIM, HEAD_DIM), state_stride
+    )
+    tensormaps = _fake_tensor(
+        cute, cutlass, cutlass.Uint8, (TENSOR_MAP_BYTES,), (1,)
+    )
+    cu_seqlens = _fake_tensor(cute, cutlass, cutlass.Int64, (2,), (1,))
+    stream = cuda_driver.CUstream(0)
+
+    kernel = _FullyFusedDeltaRuleSm120(
+        needs_alpha=True,
+        needs_beta=True,
+        needs_init_state=False,
+        needs_checkpointing=False,
+        dtype=cutlass.BFloat16,
+    )
+    args = (
+        q,
+        k,
+        v,
+        output,
+        alpha,
+        beta,
+        state,
+        None,
+        None,
+        None,
+        tensormaps,
+        cu_seqlens,
+        cutlass.Float32(1.0 / math.sqrt(HEAD_DIM)),
+        cutlass.Int32(HEADS),
+        cutlass.Int32(HEADS),
+        cutlass.Int32(HEADS),
+        cutlass.Int32(HEADS),
+        cutlass.Int32(1),
+        cutlass.Int32(1),
+        cutlass.Int32(0),
+        cutlass.Int32(HEADS),
+        stream,
+    )
+
+    options = (cutlass.GPUArch("sm_120a"),)
+    compiled = cute.compile[options](kernel, *args)
+    compiled.export_to_c(str(output_dir), PREFIX, function_prefix=PREFIX)
+    _write_c_shim(output_dir, f"{PREFIX}.h")
+
+    runtime_libs = cute.runtime.find_runtime_libraries(enable_tvm_ffi=False)
+    (output_dir / "runtime_libs.txt").write_text(
+        "\n".join(str(path) for path in runtime_libs) + "\n", encoding="utf-8"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/openinfer-qwen35-4b/Cargo.toml
+++ b/openinfer-qwen35-4b/Cargo.toml
@@ -33,6 +33,7 @@ vllm-text = { workspace = true }
 [features]
 default = []
 qwen35-4b = ["openinfer-kernels/qwen35-4b"]
+flashinfer-gdn-prefill = ["qwen35-4b", "openinfer-kernels/flashinfer-gdn-prefill"]
 
 [lints]
 workspace = true

--- a/openinfer-qwen35-4b/src/prefill_buffers.rs
+++ b/openinfer-qwen35-4b/src/prefill_buffers.rs
@@ -44,6 +44,19 @@ pub struct GdrChunkwiseScratch35 {
 
     /// Per-chunk recurrent state snapshots, fp32: [num_chunks, num_value_heads, key_dim, value_dim]
     pub chunk_state: CudaSlice<f32>,
+
+    /// FlashInfer state workspace, fp32: [1, num_value_heads, value_dim, key_dim].
+    /// This is kept separate from the decode state because the two backends
+    /// intentionally use transposed matrix layouts.
+    #[cfg(feature = "flashinfer-gdn-prefill")]
+    pub flashinfer_state: CudaSlice<f32>,
+    /// FlashInfer varlen metadata: device-side [0, seq_len] int64.
+    #[cfg(feature = "flashinfer-gdn-prefill")]
+    pub flashinfer_cu_seqlens: CudaSlice<i64>,
+    /// FlashInfer TMA descriptor workspace. The launcher uses at most the
+    /// device SM count; 256 entries covers current Blackwell parts.
+    #[cfg(feature = "flashinfer-gdn-prefill")]
+    pub flashinfer_tensormaps: CudaSlice<u8>,
 }
 
 impl GdrChunkwiseScratch35 {
@@ -91,6 +104,22 @@ impl GdrChunkwiseScratch35 {
             .alloc_zeros(num_chunks * num_value_heads * value_dim * key_dim)
             .map_err(|e| anyhow::anyhow!("Alloc chunk_state failed: {}", e))?;
 
+        #[cfg(feature = "flashinfer-gdn-prefill")]
+        let flashinfer_state: CudaSlice<f32> = ctx
+            .stream
+            .alloc_zeros(num_value_heads * value_dim * key_dim)
+            .map_err(|e| anyhow::anyhow!("Alloc FlashInfer state failed: {}", e))?;
+        #[cfg(feature = "flashinfer-gdn-prefill")]
+        let flashinfer_cu_seqlens: CudaSlice<i64> = ctx
+            .stream
+            .alloc_zeros(2)
+            .map_err(|e| anyhow::anyhow!("Alloc FlashInfer cu_seqlens failed: {}", e))?;
+        #[cfg(feature = "flashinfer-gdn-prefill")]
+        let flashinfer_tensormaps: CudaSlice<u8> = ctx
+            .stream
+            .alloc_zeros(256 * 128)
+            .map_err(|e| anyhow::anyhow!("Alloc FlashInfer tensormaps failed: {}", e))?;
+
         Ok(Self {
             g_cumsum,
             beta,
@@ -103,6 +132,12 @@ impl GdrChunkwiseScratch35 {
             u: HiddenStates::zeros(ctx, vv_hidden_dim, seq_len)?,
             v_new: HiddenStates::zeros(ctx, vv_hidden_dim, seq_len)?,
             chunk_state,
+            #[cfg(feature = "flashinfer-gdn-prefill")]
+            flashinfer_state,
+            #[cfg(feature = "flashinfer-gdn-prefill")]
+            flashinfer_cu_seqlens,
+            #[cfg(feature = "flashinfer-gdn-prefill")]
+            flashinfer_tensormaps,
         })
     }
 
@@ -166,6 +201,14 @@ impl GdrChunkwiseScratch35 {
         let peak_layer = shared_layer + full_attn_temps.max(mlp_temps);
         let per_layer_bytes = peak_layer * 2; // bf16
 
-        gdr_bytes + per_layer_bytes
+        #[cfg(feature = "flashinfer-gdn-prefill")]
+        let flashinfer_bytes =
+            num_vh * val_dim * key_dim * std::mem::size_of::<f32>()
+                + 2 * std::mem::size_of::<i64>()
+                + 256 * 128;
+        #[cfg(not(feature = "flashinfer-gdn-prefill"))]
+        let flashinfer_bytes = 0;
+
+        gdr_bytes + flashinfer_bytes + per_layer_bytes
     }
 }

--- a/openinfer-qwen35-4b/src/prefill_buffers.rs
+++ b/openinfer-qwen35-4b/src/prefill_buffers.rs
@@ -50,6 +50,14 @@ pub struct GdrChunkwiseScratch35 {
     /// intentionally use transposed matrix layouts.
     #[cfg(feature = "flashinfer-gdn-prefill")]
     pub flashinfer_state: CudaSlice<f32>,
+    /// FlashInfer initial-state input, fp32: [1, num_value_heads, value_dim, key_dim].
+    /// Kept separate from `flashinfer_state` because the generated kernel reads
+    /// the initial state while writing the final state.
+    #[cfg(feature = "flashinfer-gdn-prefill")]
+    pub flashinfer_init_state: CudaSlice<f32>,
+    /// FlashInfer alpha input, fp32: exp(prefix-summed gate), [seq_len, num_value_heads].
+    #[cfg(feature = "flashinfer-gdn-prefill")]
+    pub flashinfer_alpha: CudaSlice<f32>,
     /// FlashInfer varlen metadata: device-side [0, seq_len] int64.
     #[cfg(feature = "flashinfer-gdn-prefill")]
     pub flashinfer_cu_seqlens: CudaSlice<i64>,
@@ -110,6 +118,16 @@ impl GdrChunkwiseScratch35 {
             .alloc_zeros(num_value_heads * value_dim * key_dim)
             .map_err(|e| anyhow::anyhow!("Alloc FlashInfer state failed: {}", e))?;
         #[cfg(feature = "flashinfer-gdn-prefill")]
+        let flashinfer_init_state: CudaSlice<f32> = ctx
+            .stream
+            .alloc_zeros(num_value_heads * value_dim * key_dim)
+            .map_err(|e| anyhow::anyhow!("Alloc FlashInfer init state failed: {}", e))?;
+        #[cfg(feature = "flashinfer-gdn-prefill")]
+        let flashinfer_alpha: CudaSlice<f32> = ctx
+            .stream
+            .alloc_zeros(seq_len * num_value_heads)
+            .map_err(|e| anyhow::anyhow!("Alloc FlashInfer alpha failed: {}", e))?;
+        #[cfg(feature = "flashinfer-gdn-prefill")]
         let flashinfer_cu_seqlens: CudaSlice<i64> = ctx
             .stream
             .alloc_zeros(2)
@@ -134,6 +152,10 @@ impl GdrChunkwiseScratch35 {
             chunk_state,
             #[cfg(feature = "flashinfer-gdn-prefill")]
             flashinfer_state,
+            #[cfg(feature = "flashinfer-gdn-prefill")]
+            flashinfer_init_state,
+            #[cfg(feature = "flashinfer-gdn-prefill")]
+            flashinfer_alpha,
             #[cfg(feature = "flashinfer-gdn-prefill")]
             flashinfer_cu_seqlens,
             #[cfg(feature = "flashinfer-gdn-prefill")]
@@ -202,10 +224,10 @@ impl GdrChunkwiseScratch35 {
         let per_layer_bytes = peak_layer * 2; // bf16
 
         #[cfg(feature = "flashinfer-gdn-prefill")]
-        let flashinfer_bytes =
-            num_vh * val_dim * key_dim * std::mem::size_of::<f32>()
-                + 2 * std::mem::size_of::<i64>()
-                + 256 * 128;
+        let flashinfer_bytes = seq * num_vh * std::mem::size_of::<f32>()
+            + 2 * num_vh * val_dim * key_dim * std::mem::size_of::<f32>()
+            + 2 * std::mem::size_of::<i64>()
+            + 256 * 128;
         #[cfg(not(feature = "flashinfer-gdn-prefill"))]
         let flashinfer_bytes = 0;
 

--- a/openinfer-qwen35-4b/src/prefill_buffers.rs
+++ b/openinfer-qwen35-4b/src/prefill_buffers.rs
@@ -55,7 +55,7 @@ pub struct GdrChunkwiseScratch35 {
     /// the initial state while writing the final state.
     #[cfg(feature = "flashinfer-gdn-prefill")]
     pub flashinfer_init_state: CudaSlice<f32>,
-    /// FlashInfer alpha input, fp32: exp(prefix-summed gate), [seq_len, num_value_heads].
+    /// FlashInfer alpha input, fp32: exp(per-token gate), [seq_len, num_value_heads].
     #[cfg(feature = "flashinfer-gdn-prefill")]
     pub flashinfer_alpha: CudaSlice<f32>,
     /// FlashInfer varlen metadata: device-side [0, seq_len] int64.

--- a/openinfer-qwen35-4b/src/recurrent.rs
+++ b/openinfer-qwen35-4b/src/recurrent.rs
@@ -419,6 +419,90 @@ fn gated_delta_rule_prefill_chunk_o_stage_into(
     Ok(())
 }
 
+#[cfg(feature = "flashinfer-gdn-prefill")]
+#[allow(clippy::too_many_arguments)]
+fn gated_delta_rule_prefill_flashinfer_into(
+    ctx: &DeviceContext,
+    scratch: &mut GdrChunkwiseScratch35,
+    state: &mut CudaSlice<f32>,
+    output: &mut HiddenStates,
+    num_value_heads: usize,
+    key_dim: usize,
+    value_dim: usize,
+) -> Result<bool> {
+    // The first generated artifact is intentionally exact to Qwen3.5-4B's
+    // expanded post-prepare shape. Unsupported variants retain Triton.
+    if num_value_heads != 32 || key_dim != 128 || value_dim != 128 {
+        return Ok(false);
+    }
+
+    ctx.stream.memcpy_htod(
+        &[0_i64, scratch.q_expanded.seq_len as i64],
+        &mut scratch.flashinfer_cu_seqlens,
+    )?;
+
+    {
+        let (state_ptr, _state_guard) = state.device_ptr(&ctx.stream);
+        let (fi_state_ptr, _fi_state_guard) =
+            scratch.flashinfer_state.device_ptr_mut(&ctx.stream);
+        openinfer_kernels::flashinfer_gdn::transpose_state(
+            state_ptr as *const f32,
+            fi_state_ptr as *mut f32,
+            num_value_heads as i32,
+            key_dim as i32,
+            value_dim as i32,
+            true,
+            ctx.stream.cu_stream(),
+        )?;
+    }
+
+    let used = {
+        let (q_ptr, _q_guard) = scratch.q_expanded.data.device_ptr(&ctx.stream);
+        let (k_ptr, _k_guard) = scratch.k_expanded.data.device_ptr(&ctx.stream);
+        let (v_ptr, _v_guard) = scratch.v_raw.data.device_ptr(&ctx.stream);
+        let (o_ptr, _o_guard) = output.data.device_ptr_mut(&ctx.stream);
+        let (g_ptr, _g_guard) = scratch.g_cumsum.device_ptr(&ctx.stream);
+        let (beta_ptr, _beta_guard) = scratch.beta.device_ptr(&ctx.stream);
+        let (fi_state_ptr, _fi_state_guard) =
+            scratch.flashinfer_state.device_ptr_mut(&ctx.stream);
+        let (tensormaps_ptr, _tensormaps_guard) =
+            scratch.flashinfer_tensormaps.device_ptr_mut(&ctx.stream);
+        let (cu_ptr, _cu_guard) = scratch.flashinfer_cu_seqlens.device_ptr(&ctx.stream);
+
+        openinfer_kernels::flashinfer_gdn::launch_prefill(
+            q_ptr as *const ffi::Half,
+            k_ptr as *const ffi::Half,
+            v_ptr as *const ffi::Half,
+            o_ptr as *mut ffi::Half,
+            g_ptr as *const f32,
+            beta_ptr as *const f32,
+            fi_state_ptr as *mut f32,
+            tensormaps_ptr as *mut u8,
+            cu_ptr as *const i64,
+            scratch.q_expanded.seq_len as i32,
+            ctx.stream.cu_stream(),
+        )?
+    };
+    if !used {
+        return Ok(false);
+    }
+
+    {
+        let (fi_state_ptr, _fi_state_guard) = scratch.flashinfer_state.device_ptr(&ctx.stream);
+        let (state_ptr, _state_guard) = state.device_ptr_mut(&ctx.stream);
+        openinfer_kernels::flashinfer_gdn::transpose_state(
+            fi_state_ptr as *const f32,
+            state_ptr as *mut f32,
+            num_value_heads as i32,
+            key_dim as i32,
+            value_dim as i32,
+            false,
+            ctx.stream.cu_stream(),
+        )?;
+    }
+    Ok(true)
+}
+
 /// Chunk-wise GDR prefill operator contract for Qwen3.5.
 ///
 /// The chunk-wise path is an explicit multi-stage operator with pre-allocated
@@ -479,6 +563,20 @@ pub fn gated_delta_rule_prefill_chunkwise_into(
         num_value_heads,
     )
     .map_err(|e| anyhow::anyhow!("GDR prefill prepare failed: {e}"))?;
+
+    #[cfg(feature = "flashinfer-gdn-prefill")]
+    if gated_delta_rule_prefill_flashinfer_into(
+        ctx,
+        scratch,
+        state,
+        output,
+        num_value_heads,
+        key_dim,
+        val_dim,
+    )? {
+        return Ok(());
+    }
+
     gated_delta_rule_prefill_chunk_cumsum_inplace(
         ctx,
         &mut scratch.g_cumsum,

--- a/openinfer-qwen35-4b/src/recurrent.rs
+++ b/openinfer-qwen35-4b/src/recurrent.rs
@@ -242,6 +242,28 @@ fn gated_delta_rule_prefill_chunk_cumsum_inplace(
     Ok(())
 }
 
+fn gated_delta_rule_prefill_chunk_cumsum_into(
+    ctx: &DeviceContext,
+    g_in: &CudaSlice<f32>,
+    g_out: &mut CudaSlice<f32>,
+    seq_len: usize,
+    num_value_heads: usize,
+) -> Result<()> {
+    let (g_in_ptr, _g_in_guard) = g_in.device_ptr(&ctx.stream);
+    let (g_out_ptr, _g_out_guard) = g_out.device_ptr_mut(&ctx.stream);
+    let result = unsafe {
+        ffi::gated_delta_rule_prefill_chunk_cumsum_cuda(
+            g_in_ptr as *const f32,
+            g_out_ptr as *mut f32,
+            seq_len as i32,
+            num_value_heads as i32,
+            ctx.stream.cu_stream(),
+        )
+    };
+    result.result()?;
+    Ok(())
+}
+
 fn gated_delta_rule_prefill_chunk_a_into(
     ctx: &DeviceContext,
     k: &HiddenStates,
@@ -435,6 +457,30 @@ fn gated_delta_rule_prefill_flashinfer_into(
     if num_value_heads != 32 || key_dim != 128 || value_dim != 128 {
         return Ok(false);
     }
+    if !openinfer_kernels::flashinfer_gdn::aot_available() {
+        return Ok(false);
+    }
+
+    // FlashInfer receives positive cumulative decay factors, while the
+    // fallback pipeline keeps cumulative log-gates for its exp-difference
+    // formulas. Build the former in a separate buffer so fallback semantics
+    // remain unchanged when the optional artifact is unavailable.
+    gated_delta_rule_prefill_chunk_cumsum_into(
+        ctx,
+        &scratch.g_cumsum,
+        &mut scratch.flashinfer_alpha,
+        scratch.q_expanded.seq_len,
+        num_value_heads,
+    )?;
+    {
+        let (alpha_ptr, _alpha_guard) = scratch.flashinfer_alpha.device_ptr_mut(&ctx.stream);
+        openinfer_kernels::flashinfer_gdn::exp_gate(
+            alpha_ptr as *const f32,
+            alpha_ptr as *mut f32,
+            (scratch.q_expanded.seq_len * num_value_heads) as i32,
+            ctx.stream.cu_stream(),
+        )?;
+    }
 
     ctx.stream.memcpy_htod(
         &[0_i64, scratch.q_expanded.seq_len as i64],
@@ -443,11 +489,11 @@ fn gated_delta_rule_prefill_flashinfer_into(
 
     {
         let (state_ptr, _state_guard) = state.device_ptr(&ctx.stream);
-        let (fi_state_ptr, _fi_state_guard) =
-            scratch.flashinfer_state.device_ptr_mut(&ctx.stream);
+        let (fi_init_state_ptr, _fi_init_state_guard) =
+            scratch.flashinfer_init_state.device_ptr_mut(&ctx.stream);
         openinfer_kernels::flashinfer_gdn::transpose_state(
             state_ptr as *const f32,
-            fi_state_ptr as *mut f32,
+            fi_init_state_ptr as *mut f32,
             num_value_heads as i32,
             key_dim as i32,
             value_dim as i32,
@@ -461,10 +507,11 @@ fn gated_delta_rule_prefill_flashinfer_into(
         let (k_ptr, _k_guard) = scratch.k_expanded.data.device_ptr(&ctx.stream);
         let (v_ptr, _v_guard) = scratch.v_raw.data.device_ptr(&ctx.stream);
         let (o_ptr, _o_guard) = output.data.device_ptr_mut(&ctx.stream);
-        let (g_ptr, _g_guard) = scratch.g_cumsum.device_ptr(&ctx.stream);
+        let (alpha_ptr, _alpha_guard) = scratch.flashinfer_alpha.device_ptr(&ctx.stream);
         let (beta_ptr, _beta_guard) = scratch.beta.device_ptr(&ctx.stream);
-        let (fi_state_ptr, _fi_state_guard) =
-            scratch.flashinfer_state.device_ptr_mut(&ctx.stream);
+        let (fi_state_ptr, _fi_state_guard) = scratch.flashinfer_state.device_ptr_mut(&ctx.stream);
+        let (fi_init_state_ptr, _fi_init_state_guard) =
+            scratch.flashinfer_init_state.device_ptr(&ctx.stream);
         let (tensormaps_ptr, _tensormaps_guard) =
             scratch.flashinfer_tensormaps.device_ptr_mut(&ctx.stream);
         let (cu_ptr, _cu_guard) = scratch.flashinfer_cu_seqlens.device_ptr(&ctx.stream);
@@ -474,9 +521,10 @@ fn gated_delta_rule_prefill_flashinfer_into(
             k_ptr as *const ffi::Half,
             v_ptr as *const ffi::Half,
             o_ptr as *mut ffi::Half,
-            g_ptr as *const f32,
+            alpha_ptr as *const f32,
             beta_ptr as *const f32,
             fi_state_ptr as *mut f32,
+            fi_init_state_ptr as *const f32,
             tensormaps_ptr as *mut u8,
             cu_ptr as *const i64,
             scratch.q_expanded.seq_len as i32,

--- a/openinfer-qwen35-4b/src/recurrent.rs
+++ b/openinfer-qwen35-4b/src/recurrent.rs
@@ -242,28 +242,6 @@ fn gated_delta_rule_prefill_chunk_cumsum_inplace(
     Ok(())
 }
 
-fn gated_delta_rule_prefill_chunk_cumsum_into(
-    ctx: &DeviceContext,
-    g_in: &CudaSlice<f32>,
-    g_out: &mut CudaSlice<f32>,
-    seq_len: usize,
-    num_value_heads: usize,
-) -> Result<()> {
-    let (g_in_ptr, _g_in_guard) = g_in.device_ptr(&ctx.stream);
-    let (g_out_ptr, _g_out_guard) = g_out.device_ptr_mut(&ctx.stream);
-    let result = unsafe {
-        ffi::gated_delta_rule_prefill_chunk_cumsum_cuda(
-            g_in_ptr as *const f32,
-            g_out_ptr as *mut f32,
-            seq_len as i32,
-            num_value_heads as i32,
-            ctx.stream.cu_stream(),
-        )
-    };
-    result.result()?;
-    Ok(())
-}
-
 fn gated_delta_rule_prefill_chunk_a_into(
     ctx: &DeviceContext,
     k: &HiddenStates,
@@ -461,21 +439,15 @@ fn gated_delta_rule_prefill_flashinfer_into(
         return Ok(false);
     }
 
-    // FlashInfer receives positive cumulative decay factors, while the
-    // fallback pipeline keeps cumulative log-gates for its exp-difference
-    // formulas. Build the former in a separate buffer so fallback semantics
-    // remain unchanged when the optional artifact is unavailable.
-    gated_delta_rule_prefill_chunk_cumsum_into(
-        ctx,
-        &scratch.g_cumsum,
-        &mut scratch.flashinfer_alpha,
-        scratch.q_expanded.seq_len,
-        num_value_heads,
-    )?;
+    // FlashInfer receives per-token positive decay factors and performs the
+    // prefix/cumprod processing internally. The fallback pipeline keeps the
+    // prepared per-token log-gates for its own cumsum and exp-difference
+    // formulas, so write the exponentiated values to a separate buffer.
     {
+        let (g_ptr, _g_guard) = scratch.g_cumsum.device_ptr(&ctx.stream);
         let (alpha_ptr, _alpha_guard) = scratch.flashinfer_alpha.device_ptr_mut(&ctx.stream);
         openinfer_kernels::flashinfer_gdn::exp_gate(
-            alpha_ptr as *const f32,
+            g_ptr as *const f32,
             alpha_ptr as *mut f32,
             (scratch.q_expanded.seq_len * num_value_heads) as i32,
             ctx.stream.cu_stream(),


### PR DESCRIPTION
## Summary

- add an opt-in FlashInfer CuTe DSL SM120 AOT path for Qwen3.5-4B GDN prefill
- keep the existing Triton chunkwise pipeline as the default and fallback
- convert OpenInfer [H,K,V] recurrent state to FlashInfer [H,V,K] and back
- pass independent initial/final state buffers and convert prepared per-token log-gates to FlashInfer per-token alpha factors
- make build.rs handle vendored FlashInfer, CUDA 13 pip headers, CCCL/libcudacxx, runtime libraries, and pthread linkage

## Validation

On RTX 5090 D (SM120, driver 595.71.05):

```text
Finished release profile [optimized] target(s)

flashinfer_gdn_sm120 recurrence smoke test:
max_output_error=0.00645859
max_state_error=0.0088997
```

The smoke test uses non-zero q/k/v, per-token alpha/beta, and initial state, then compares the generated C ABI launch against a CPU token-by-token GDN recurrence. Direct nightly rustfmt and git diff --check also pass.

The C ABI smoke test supplies alpha directly. After Codex review identified a double-prefix issue in the Rust adapter, commit 9ec952f changed the adapter from exp(cumsum(g)) to per-token exp(g), matching FlashInfer's internal prefix/cumprod contract. A full Rust-path GPU rerun is still pending.

## Scope

The generated artifact is intentionally specialized to Qwen3.5-4B (32 value heads, key/value head dimension 128). Other shapes and builds without the opt-in AOT artifact retain the Triton path.