### PR TITLE
fix(qwen3): use configured device ordinal for decode overlap resources

### DIFF
--- a/openinfer-qwen3/src/executor.rs
+++ b/openinfer-qwen3/src/executor.rs
@@ -959,6 +959,10 @@ pub struct Qwen3Executor {
     /// engine was built with events on — single-GPU, no LoRA). `None` on the
     /// plain path, where the whole feed costs nothing.
     kv_events: Option<ExecutorKvEvents>,
+    /// CUDA device ordinal this executor was built on. Used by
+    /// [`enable_decode_overlap`] to create overlap streams on the correct
+    /// device (the model, KV cache, and compute stream all live here).
+    device_ordinal: usize,
 }
 
 /// Executor-side state for the opt-in KV block-event feed.
@@ -1104,6 +1108,7 @@ impl Qwen3Executor {
             )?;
             (kv_mgr, None)
         };
+        let device_ordinal = model.device_ctx().device_ordinal;
         let metadata = Qwen3ExecutorMetadata {
             block_size: budget.block_size,
             stop_token_ids: model.config().stop_token_ids.clone(),
@@ -1186,6 +1191,7 @@ impl Qwen3Executor {
             speculative: None,
             dflash_ready_requests: HashSet::new(),
             kv_events,
+            device_ordinal,
         })
     }
 
@@ -1505,6 +1511,7 @@ impl Qwen3Executor {
             dflash_ready_requests: HashSet::new(),
             // KV events are single-GPU only (asserted above); never wired here.
             kv_events: None,
+            device_ordinal: device_ordinals[0],
         })
     }
 
@@ -1579,7 +1586,7 @@ impl Qwen3Executor {
             self.workers.is_empty() || matches!(overlap, crate::DecodeOverlap::Off),
             "decode-overlap is unsupported under tensor parallelism"
         );
-        let device_ordinal = 0; // single-GPU path
+        let device_ordinal = self.device_ordinal;
         self.overlap = crate::green_ctx::OverlapStreams::create(device_ordinal, overlap)?;
         Ok(())
     }


### PR DESCRIPTION
The device ordinal passed to OverlapStreams::create was hardcoded to 0. This created green-context streams and SM-partition resources on device 0 even when the model, KV cache, and compute stream lived on a different device (--device-ordinal N).

Persist device_ordinal on Qwen3Executor from the model's device context at construction time, and use it in enable_decode_overlap instead of the hardcoded 0. Both the single-GPU and TP construction paths are covered.

Fixes #700.

## Description

`enable_decode_overlap` hard-coded `device_ordinal = 0` because `Qwen3Executor` did not persist the configured device ordinal after construction.

This change adds a `device_ordinal` field to `Qwen3Executor`, populated from the model's device context at construction time (both the single-GPU and TP paths), and uses it in `enable_decode_overlap` instead of the hardcoded `0`.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

- [ ] Documentation update



## Checklist

- [x] My code follows the style guidelines of this project (see `docs/conventions/coding-style.md`).

- [x] I have performed a self-review of my own code.

- [x] I have formatted my commits according to Commitizen conventions.

- [ ] I have run the local test suite and all tests pass (see `CLAUDE.md`).

