### PR TITLE
perf(sampling): batch logprob extraction into one device reduction

### DIFF
--- a/openinfer-kernels/csrc/shared/logprob_topk.cu
+++ b/openinfer-kernels/csrc/shared/logprob_topk.cu
@@ -1,0 +1,123 @@
+#include "common.cuh"
+
+#define LOGPROB_BLOCK 256
+
+// Fixed block size and reduction order keep outputs bitwise reproducible and
+// independent of batch composition.
+
+__device__ __forceinline__ bool rank_better(float lhs_val, int lhs_idx,
+                                            float rhs_val, int rhs_idx) {
+  return lhs_val > rhs_val || (lhs_val == rhs_val && lhs_idx < rhs_idx);
+}
+
+__global__ void logprob_topk_batch_kernel(
+    const __nv_bfloat16* __restrict__ x,
+    const int* __restrict__ row_indices,
+    const int* __restrict__ picked,
+    const int* __restrict__ top_k,
+    float* __restrict__ out_picked_lp,
+    float* __restrict__ out_topk_vals,
+    int* __restrict__ out_topk_ids,
+    int rows,
+    int n,
+    int k_max) {
+  extern __shared__ char shared_mem[];
+  float* shared_vals = reinterpret_cast<float*>(shared_mem);
+  int* shared_idxs =
+      reinterpret_cast<int*>(shared_mem + blockDim.x * sizeof(float));
+  // Aliases the arrays above: sizeof(double) == sizeof(float) + sizeof(int).
+  double* shared_sums = reinterpret_cast<double*>(shared_mem);
+
+  int slot = blockIdx.x;
+  if (slot >= rows) return;
+  const __nv_bfloat16* row_x = x + static_cast<size_t>(row_indices[slot]) * n;
+  int tid = threadIdx.x;
+
+  float local_max = -INFINITY;
+  for (int i = tid; i < n; i += blockDim.x) {
+    local_max = fmaxf(local_max, __bfloat162float(row_x[i]));
+  }
+  shared_vals[tid] = local_max;
+  __syncthreads();
+  for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+    if (tid < s) {
+      shared_vals[tid] = fmaxf(shared_vals[tid], shared_vals[tid + s]);
+    }
+    __syncthreads();
+  }
+  float row_max = shared_vals[0];
+  __syncthreads();
+
+  double local_sum = 0.0;
+  for (int i = tid; i < n; i += blockDim.x) {
+    local_sum +=
+        static_cast<double>(expf(__bfloat162float(row_x[i]) - row_max));
+  }
+  shared_sums[tid] = local_sum;
+  __syncthreads();
+  for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+    if (tid < s) {
+      shared_sums[tid] += shared_sums[tid + s];
+    }
+    __syncthreads();
+  }
+  float lse = row_max + static_cast<float>(log(shared_sums[0]));
+  __syncthreads();
+
+  if (tid == 0) {
+    out_picked_lp[slot] = __bfloat162float(row_x[picked[slot]]) - lse;
+  }
+
+  // Selection runs in strictly decreasing (value, -id) lexicographic order,
+  // so "after the previous winner" replaces a selected-set membership test.
+  int k = top_k[slot];
+  float prev_val = INFINITY;
+  int prev_id = -1;
+  for (int j = 0; j < k; ++j) {
+    float local_best = -INFINITY;
+    int local_id = n;
+    for (int i = tid; i < n; i += blockDim.x) {
+      float v = __bfloat162float(row_x[i]);
+      bool eligible = v < prev_val || (v == prev_val && i > prev_id);
+      if (eligible && rank_better(v, i, local_best, local_id)) {
+        local_best = v;
+        local_id = i;
+      }
+    }
+    shared_vals[tid] = local_best;
+    shared_idxs[tid] = local_id;
+    __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+      if (tid < s) {
+        float rhs_val = shared_vals[tid + s];
+        int rhs_idx = shared_idxs[tid + s];
+        if (rank_better(rhs_val, rhs_idx, shared_vals[tid], shared_idxs[tid])) {
+          shared_vals[tid] = rhs_val;
+          shared_idxs[tid] = rhs_idx;
+        }
+      }
+      __syncthreads();
+    }
+    prev_val = shared_vals[0];
+    prev_id = shared_idxs[0];
+    if (tid == 0) {
+      out_topk_vals[static_cast<size_t>(slot) * k_max + j] = prev_val - lse;
+      out_topk_ids[static_cast<size_t>(slot) * k_max + j] = prev_id;
+    }
+    __syncthreads();
+  }
+}
+
+extern "C" {
+void logprob_topk_batch_bf16_cuda(const __nv_bfloat16* x,
+                                  const int* row_indices, const int* picked,
+                                  const int* top_k, float* out_picked_lp,
+                                  float* out_topk_vals, int* out_topk_ids,
+                                  int rows, int n, int k_max,
+                                  cudaStream_t stream) {
+  size_t smem = LOGPROB_BLOCK * (sizeof(float) + sizeof(int));
+  logprob_topk_batch_kernel<<<rows, LOGPROB_BLOCK, smem, stream>>>(
+      x, row_indices, picked, top_k, out_picked_lp, out_topk_vals, out_topk_ids,
+      rows, n, k_max);
+}
+}

--- a/openinfer-kernels/src/ffi/shared.rs
+++ b/openinfer-kernels/src/ffi/shared.rs
@@ -115,6 +115,20 @@ unsafe extern "C" {
 
     pub fn argmax_cuda(x: *const Half, out: *mut i32, n: i32, stream: CUstream);
 
+    pub fn logprob_topk_batch_bf16_cuda(
+        x: *const Half,
+        row_indices: *const i32,
+        picked: *const i32,
+        top_k: *const i32,
+        out_picked_lp: *mut f32,
+        out_topk_vals: *mut f32,
+        out_topk_ids: *mut i32,
+        rows: i32,
+        n: i32,
+        k_max: i32,
+        stream: CUstream,
+    );
+
     pub fn flashinfer_top1_cuda(
         logits: *const Half,
         top1_value_scratch: *mut Half,

--- a/openinfer-kernels/src/ops.rs
+++ b/openinfer-kernels/src/ops.rs
@@ -75,7 +75,8 @@ pub use sampling::{
     BatchSamplingRow, BatchSamplingScratch, argmax, argmax_batch_bf16_into,
     argmax_batch_bf16_split_indexed_into, argmax_batch_bf16_split_partials_len, argmax_bf16_into,
     argmax_bf16_split_into, flashinfer_top1_batch_into, flashinfer_top1_row_states_bytes,
-    gpu_sample_batch_into, markov_step_argmax_into, markov_step_argmax_partials_len,
+    gpu_sample_batch_into, logprob_topk_batch_bf16_into, markov_step_argmax_into,
+    markov_step_argmax_partials_len,
 };
 
 /// Calling thread's last FFI exception message, ready to append to an error;

--- a/openinfer-kernels/src/ops/sampling.rs
+++ b/openinfer-kernels/src/ops/sampling.rs
@@ -542,6 +542,96 @@ pub fn argmax_batch_bf16_split_indexed_into(
     Ok(())
 }
 
+/// Launch the per-row logprob reduction into pre-allocated buffers laid out
+/// `[rows]` / `[rows * k_max]` row-major; each row writes `top_k[i] <= k_max`
+/// entries and leaves the tail untouched.
+///
+/// # Safety
+///
+/// The device-resident contents of `row_indices`, `picked`, and `top_k`
+/// cannot be validated here: for every `i < rows`, `row_indices[i]` must lie
+/// in `[0, logits.seq_len)`, `picked[i]` in `[0, logits.hidden_dim)`, and
+/// `top_k[i]` in `[0, min(k_max, logits.hidden_dim)]`. The launch goes to
+/// `active_cu_stream(ctx)`: input buffers must be populated before the
+/// launch and outputs read back after it, in that stream's order.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn logprob_topk_batch_bf16_into(
+    ctx: &DeviceContext,
+    logits: HiddenStatesRef<'_>,
+    row_indices: &CudaSlice<i32>,
+    picked: &CudaSlice<i32>,
+    top_k: &CudaSlice<i32>,
+    rows: usize,
+    k_max: usize,
+    out_picked_lp: &mut CudaSlice<f32>,
+    out_topk_vals: &mut CudaSlice<f32>,
+    out_topk_ids: &mut CudaSlice<i32>,
+) -> Result<()> {
+    ensure!(
+        rows > 0 && logits.hidden_dim > 0,
+        "logprob_topk requires rows > 0 and a non-empty vocab"
+    );
+    let backing = logits
+        .hidden_dim
+        .checked_mul(logits.seq_len)
+        .ok_or_else(|| anyhow!("logprob_topk arena extent overflows"))?;
+    ensure!(
+        logits.data.len() >= backing,
+        "logprob_topk arena backing too small: have {}, need {backing}",
+        logits.data.len()
+    );
+    ensure!(
+        row_indices.len() >= rows && picked.len() >= rows && top_k.len() >= rows,
+        "logprob_topk inputs must hold {rows} elements: have {}/{}/{}",
+        row_indices.len(),
+        picked.len(),
+        top_k.len()
+    );
+    ensure!(
+        out_picked_lp.len() >= rows,
+        "logprob_topk picked output too small: have {}, need {rows}",
+        out_picked_lp.len()
+    );
+    let topk_needed = rows
+        .checked_mul(k_max)
+        .ok_or_else(|| anyhow!("logprob_topk rows * k_max overflows"))?;
+    ensure!(
+        out_topk_vals.len() >= topk_needed && out_topk_ids.len() >= topk_needed,
+        "logprob_topk top-k outputs too small: have {}/{}, need {topk_needed}",
+        out_topk_vals.len(),
+        out_topk_ids.len()
+    );
+    let rows_i32 = i32::try_from(rows)?;
+    let vocab_i32 = i32::try_from(logits.hidden_dim)?;
+    let k_max_i32 = i32::try_from(k_max)?;
+
+    let (x_ptr, _gx) = logits.data.device_ptr(&ctx.stream);
+    let (rows_ptr, _gr) = row_indices.device_ptr(&ctx.stream);
+    let (picked_ptr, _gp) = picked.device_ptr(&ctx.stream);
+    let (k_ptr, _gk) = top_k.device_ptr(&ctx.stream);
+    let (lp_ptr, _gl) = out_picked_lp.device_ptr_mut(&ctx.stream);
+    let (vals_ptr, _gv) = out_topk_vals.device_ptr_mut(&ctx.stream);
+    let (ids_ptr, _gi) = out_topk_ids.device_ptr_mut(&ctx.stream);
+
+    unsafe {
+        ffi::logprob_topk_batch_bf16_cuda(
+            x_ptr as *const ffi::Half,
+            rows_ptr as *const i32,
+            picked_ptr as *const i32,
+            k_ptr as *const i32,
+            lp_ptr as *mut f32,
+            vals_ptr as *mut f32,
+            ids_ptr as *mut i32,
+            rows_i32,
+            vocab_i32,
+            k_max_i32,
+            crate::tensor::active_cu_stream(ctx),
+        );
+    }
+
+    Ok(())
+}
+
 /// DSpark Markov-head step argmax. For each request `row`, argmax over
 /// `base[row*block_size + step] + bias[row]` and write the chosen token id as
 /// u32 (so it feeds straight back as the next step's prev-token lookup).

--- a/openinfer-qwen3/src/executor.rs
+++ b/openinfer-qwen3/src/executor.rs
@@ -18,7 +18,7 @@ use openinfer_core::engine::{
 use openinfer_core::kv_pool::KvLayout;
 use openinfer_core::ops;
 use openinfer_core::sampler::SamplingParams;
-use openinfer_core::tensor::{DeviceContext, DeviceVec, HiddenStates};
+use openinfer_core::tensor::{DeviceContext, HiddenStates};
 use openinfer_kv_cache::{
     KvBlockGuard, KvBuffer, KvCacheEvent, KvCacheManager, KvView, LoadReservation, PrefixProbe,
     RegisteredBlock,
@@ -162,44 +162,110 @@ impl DecodeStepItem {
     }
 }
 
+fn gather_decode_logprobs(
+    lane: &LocalQwen3Lane,
+    requests: &[DecodeStepItem],
+    logits: &HiddenStates,
+    row_offset: usize,
+    tokens: &[u32],
+) -> Result<Vec<Option<TokenLogprob>>> {
+    let wanted: Vec<usize> = requests
+        .iter()
+        .enumerate()
+        .filter(|(_, req)| req.logprobs > 0)
+        .map(|(i, _)| i)
+        .collect();
+    let lp_requests: Vec<openinfer_sample::LogprobRequest> = wanted
+        .iter()
+        .map(|&i| openinfer_sample::LogprobRequest {
+            row: row_offset + i,
+            picked: tokens[row_offset + i],
+            top_k: requests[i].logprobs,
+        })
+        .collect();
+    let results =
+        openinfer_sample::token_logprobs_batch(lane.model.device_ctx(), logits, &lp_requests)?;
+    let mut logprobs: Vec<Option<TokenLogprob>> = vec![None; requests.len()];
+    for (i, lp) in wanted.into_iter().zip(results) {
+        logprobs[i] = Some(lp);
+    }
+    Ok(logprobs)
+}
+
 fn build_prefill_request_results(
-    lane: &mut LocalQwen3Lane,
+    lane: &LocalQwen3Lane,
     requests: &[PrefillStepItem],
     logits: &HiddenStates,
     tokens: &[u32],
     all_position_logits: Option<&HiddenStates>,
     compute_prompt_logprobs: bool,
 ) -> Result<Vec<PrefillRequestResult>> {
-    let mut token_offset = 0usize;
+    let ctx = lane.model.device_ctx();
+
+    let first_token_wanted: Vec<usize> = requests
+        .iter()
+        .enumerate()
+        .filter(|(_, req)| req.is_final_chunk() && req.logprobs > 0)
+        .map(|(i, _)| i)
+        .collect();
+    let first_token_requests: Vec<openinfer_sample::LogprobRequest> = first_token_wanted
+        .iter()
+        .map(|&i| openinfer_sample::LogprobRequest {
+            row: i,
+            picked: tokens[i],
+            top_k: requests[i].logprobs,
+        })
+        .collect();
+    let mut first_token_logprobs: Vec<Option<TokenLogprob>> = vec![None; requests.len()];
+    for (i, lp) in first_token_wanted
+        .into_iter()
+        .zip(openinfer_sample::token_logprobs_batch(
+            ctx,
+            logits,
+            &first_token_requests,
+        )?)
+    {
+        first_token_logprobs[i] = Some(lp);
+    }
+
+    let mut prompt_requests: Vec<openinfer_sample::LogprobRequest> = Vec::new();
+    if compute_prompt_logprobs && all_position_logits.is_some() {
+        let mut token_offset = 0usize;
+        for req in requests {
+            if req.echo {
+                for j in 1..req.prompt_tokens.len() {
+                    prompt_requests.push(openinfer_sample::LogprobRequest {
+                        row: token_offset + j - 1,
+                        picked: req.prompt_tokens[j],
+                        top_k: req.logprobs,
+                    });
+                }
+            }
+            token_offset += req.chunk_tokens;
+        }
+    }
+    let mut prompt_results = match all_position_logits {
+        Some(all_logits) if !prompt_requests.is_empty() => Some(
+            openinfer_sample::token_logprobs_batch(ctx, all_logits, &prompt_requests)?.into_iter(),
+        ),
+        _ => None,
+    };
+
     let mut outputs = Vec::with_capacity(requests.len());
     for (i, req) in requests.iter().enumerate() {
         let completed = req.is_final_chunk();
-        let first_token = tokens[i];
-        let first_token_logprob = if completed && req.logprobs > 0 {
-            let logits_i = ops::extract_vec(lane.model.device_ctx(), logits, i)?;
-            Some(lane.extract_logprobs(&logits_i, first_token, req.logprobs)?)
-        } else {
-            None
-        };
         let prompt_logprobs = if req.echo {
             if compute_prompt_logprobs {
-                let mut echo_logprobs = Vec::with_capacity(req.prompt_tokens.len());
+                let mut echo_logprobs: Vec<Option<TokenLogprob>> =
+                    Vec::with_capacity(req.prompt_tokens.len());
                 echo_logprobs.push(None);
-                if let Some(all_logits) = all_position_logits {
-                    for j in 1..req.prompt_tokens.len() {
-                        let prev_pos = token_offset + j - 1;
-                        let target_token = req.prompt_tokens[j];
-                        echo_logprobs.push(lane.extract_prompt_logprobs(
-                            all_logits,
-                            prev_pos,
-                            target_token,
-                            req.logprobs,
-                        ));
+                match &mut prompt_results {
+                    Some(results) => {
+                        for _ in 1..req.prompt_tokens.len() {
+                            echo_logprobs.push(results.next());
+                        }
                     }
-                } else {
-                    for _ in 1..req.prompt_tokens.len() {
-                        echo_logprobs.push(None);
-                    }
+                    None => echo_logprobs.resize(req.prompt_tokens.len(), None),
                 }
                 Some(echo_logprobs)
             } else {
@@ -208,11 +274,10 @@ fn build_prefill_request_results(
         } else {
             None
         };
-        token_offset += req.chunk_tokens;
         outputs.push(PrefillRequestResult {
             request_id: req.request_id,
-            first_token,
-            first_token_logprob,
+            first_token: tokens[i],
+            first_token_logprob: first_token_logprobs[i].take(),
             prompt_logprobs,
             cached_tokens: req.cached_tokens,
             completed,
@@ -223,28 +288,22 @@ fn build_prefill_request_results(
 }
 
 fn build_decode_request_results(
-    lane: &mut LocalQwen3Lane,
+    lane: &LocalQwen3Lane,
     requests: &[DecodeStepItem],
     logits: &HiddenStates,
     row_offset: usize,
     tokens: &[u32],
 ) -> Result<Vec<DecodeRequestResult>> {
-    let mut outputs = Vec::with_capacity(requests.len());
-    for (i, req) in requests.iter().enumerate() {
-        let token = tokens[row_offset + i];
-        let logprob = if req.logprobs > 0 {
-            let logits_i = ops::extract_vec(lane.model.device_ctx(), logits, row_offset + i)?;
-            Some(lane.extract_logprobs(&logits_i, token, req.logprobs)?)
-        } else {
-            None
-        };
-        outputs.push(DecodeRequestResult {
+    let mut logprobs = gather_decode_logprobs(lane, requests, logits, row_offset, tokens)?;
+    Ok(requests
+        .iter()
+        .enumerate()
+        .map(|(i, req)| DecodeRequestResult {
             request_id: req.request_id,
-            token,
-            logprob,
-        });
-    }
-    Ok(outputs)
+            token: tokens[row_offset + i],
+            logprob: logprobs[i].take(),
+        })
+        .collect())
 }
 
 fn build_batch_decode_request_results(
@@ -264,22 +323,16 @@ fn build_batch_decode_request_results(
         &mut lane.sample_scratch,
     )?;
 
-    let mut outputs = Vec::with_capacity(requests.len());
-    for (i, req) in requests.iter().enumerate() {
-        let token = tokens[i];
-        let logprob = if req.logprobs > 0 {
-            let logits_i = ops::extract_vec(lane.model.device_ctx(), &lane.bufs.logits, i)?;
-            Some(lane.extract_logprobs(&logits_i, token, req.logprobs)?)
-        } else {
-            None
-        };
-        outputs.push(DecodeRequestResult {
+    let mut logprobs = gather_decode_logprobs(lane, requests, &lane.bufs.logits, 0, &tokens)?;
+    Ok(requests
+        .iter()
+        .enumerate()
+        .map(|(i, req)| DecodeRequestResult {
             request_id: req.request_id,
-            token,
-            logprob,
-        });
-    }
-    Ok(outputs)
+            token: tokens[i],
+            logprob: logprobs[i].take(),
+        })
+        .collect())
 }
 
 fn execute_step_on_lane(
@@ -3300,32 +3353,6 @@ impl LocalQwen3Lane {
             sample_seed,
             &mut self.sample_scratch,
         )
-    }
-
-    fn extract_logprobs(
-        &self,
-        logits: &DeviceVec,
-        sampled_token: u32,
-        top_k: usize,
-    ) -> Result<TokenLogprob> {
-        let logits_f32 = logits.to_host(self.model.device_ctx())?;
-        openinfer_sample::token_logprob_from_row(&logits_f32, sampled_token, top_k)
-            .ok_or_else(|| anyhow::anyhow!("logprobs computation failed"))
-    }
-
-    fn extract_prompt_logprobs(
-        &self,
-        all_logits: &HiddenStates,
-        prev_pos: usize,
-        target_token: u32,
-        top_k: usize,
-    ) -> Option<TokenLogprob> {
-        openinfer_core::ops::extract_vec(self.model.device_ctx(), all_logits, prev_pos)
-            .ok()
-            .and_then(|logits_vec| {
-                let logits_f32 = logits_vec.to_host(self.model.device_ctx()).ok()?;
-                openinfer_sample::token_logprob_from_row(&logits_f32, target_token, top_k)
-            })
     }
 
     fn execute_prefill(

--- a/openinfer-sample/src/lib.rs
+++ b/openinfer-sample/src/lib.rs
@@ -9,9 +9,8 @@
 //!   off the fused fast path, seeded rows as single-row replayable calls).
 //!   There is no per-row escape hatch, so a caller cannot regress to
 //!   `for i { sample(i) }`.
-//! * [`token_logprob_from_row`] — host-side log-softmax + top-k over one logits
-//!   row into a [`TokenLogprob`]. Generic over the row element so a caller can
-//!   feed `f32` (Qwen) or `bf16` (Kimi) without a widening copy.
+//! * [`token_logprobs_batch`] — batched device logprob extraction;
+//!   [`token_logprob_from_row`] is its host single-row reference.
 //!
 //! Layering: the `.cu`/FFI and the low-level batch primitives live in
 //! `openinfer-kernels` (the CUDA build owner); this crate owns the policy
@@ -31,8 +30,9 @@ use cudarc::driver::CudaSlice;
 use openinfer_engine::engine::TokenLogprob;
 use openinfer_kernels::ops::{
     argmax_batch_bf16_split_indexed_into, argmax_batch_bf16_split_partials_len,
+    logprob_topk_batch_bf16_into,
 };
-use openinfer_kernels::tensor::{DeviceContext, HiddenStates};
+use openinfer_kernels::tensor::{DeviceContext, HiddenStates, has_stream_override};
 
 pub use openinfer_engine::sampler::SamplingParams;
 /// Low-level batched sampling, re-exported so a model that must drive its own
@@ -304,20 +304,21 @@ where
     }
     let log_sum_exp = max + sum.ln() as f32;
 
-    // Top-K by insertion into a K-sized buffer (K <= 32, V ~ 160k). Ties keep
-    // ascending token-id order.
+    // Rank before subtracting LSE so f32 rounding cannot change raw-logit order.
     let k = top_k.min(row.len());
     let mut top: Vec<(u32, f32)> = Vec::with_capacity(k + 1);
     if k > 0 {
         for (id, &v) in row.iter().enumerate() {
             let val: f32 = v.into();
-            let lp = val - log_sum_exp;
-            if top.len() == k && lp <= top[k - 1].1 {
+            if top.len() == k && val <= top[k - 1].1 {
                 continue;
             }
-            let pos = top.partition_point(|&(_, kept)| kept >= lp);
-            top.insert(pos, (id as u32, lp));
+            let pos = top.partition_point(|&(_, kept)| kept >= val);
+            top.insert(pos, (id as u32, val));
             top.truncate(k);
+        }
+        for entry in &mut top {
+            entry.1 -= log_sum_exp;
         }
     }
 
@@ -326,6 +327,125 @@ where
         logprob: picked_val - log_sum_exp,
         top_logprobs: top,
     })
+}
+
+/// One row of a [`token_logprobs_batch`] call: the logprob of `picked` plus
+/// the arena row's `top_k` entries.
+#[derive(Clone, Copy, Debug)]
+pub struct LogprobRequest {
+    pub row: usize,
+    pub picked: u32,
+    pub top_k: usize,
+}
+
+/// Batched device twin of [`token_logprob_from_row`]: one launch and a
+/// compact O(rows x (top_k + 1)) readback per call.
+pub fn token_logprobs_batch(
+    ctx: &DeviceContext,
+    logits: &HiddenStates,
+    requests: &[LogprobRequest],
+) -> Result<Vec<TokenLogprob>> {
+    if requests.is_empty() {
+        return Ok(Vec::new());
+    }
+    ensure!(
+        !has_stream_override(),
+        "token_logprobs_batch: cannot run under a stream override — buffer \
+         traffic is ordered on the primary stream"
+    );
+    let vocab = logits.hidden_dim;
+    ensure!(vocab > 0, "token_logprobs_batch: empty vocab");
+    let mut rows = Vec::with_capacity(requests.len());
+    let mut picked = Vec::with_capacity(requests.len());
+    let mut ks = Vec::with_capacity(requests.len());
+    let mut k_max = 0usize;
+    for r in requests {
+        ensure!(
+            r.row < logits.seq_len,
+            "token_logprobs_batch: row {} out of bounds for arena of {} rows",
+            r.row,
+            logits.seq_len
+        );
+        ensure!(
+            (r.picked as usize) < vocab,
+            "token_logprobs_batch: picked token {} out of bounds for vocab {vocab}",
+            r.picked
+        );
+        let k = r.top_k.min(vocab);
+        k_max = k_max.max(k);
+        rows.push(i32::try_from(r.row)?);
+        picked.push(i32::try_from(r.picked)?);
+        ks.push(i32::try_from(k)?);
+    }
+
+    let htod = |data: &[i32]| -> Result<CudaSlice<i32>> {
+        ctx.stream
+            .clone_htod(data)
+            .map_err(|e| anyhow!("token_logprobs_batch H2D failed: {e}"))
+    };
+    let rows_gpu = htod(&rows)?;
+    let picked_gpu = htod(&picked)?;
+    let ks_gpu = htod(&ks)?;
+    let mut picked_lp_gpu: CudaSlice<f32> = ctx
+        .stream
+        .alloc_zeros(requests.len())
+        .map_err(|e| anyhow!("token_logprobs_batch alloc failed: {e}"))?;
+    let topk_len = requests
+        .len()
+        .checked_mul(k_max)
+        .ok_or_else(|| anyhow!("token_logprobs_batch: rows * k_max overflows"))?
+        .max(1);
+    let mut vals_gpu: CudaSlice<f32> = ctx
+        .stream
+        .alloc_zeros(topk_len)
+        .map_err(|e| anyhow!("token_logprobs_batch alloc failed: {e}"))?;
+    let mut ids_gpu: CudaSlice<i32> = ctx
+        .stream
+        .alloc_zeros(topk_len)
+        .map_err(|e| anyhow!("token_logprobs_batch alloc failed: {e}"))?;
+
+    // Indices validated and stream override rejected above.
+    unsafe {
+        logprob_topk_batch_bf16_into(
+            ctx,
+            logits.as_ref(),
+            &rows_gpu,
+            &picked_gpu,
+            &ks_gpu,
+            requests.len(),
+            k_max,
+            &mut picked_lp_gpu,
+            &mut vals_gpu,
+            &mut ids_gpu,
+        )?;
+    }
+
+    let picked_lp = ctx
+        .stream
+        .clone_dtoh(&picked_lp_gpu)
+        .map_err(|e| anyhow!("token_logprobs_batch D2H failed: {e}"))?;
+    let vals = ctx
+        .stream
+        .clone_dtoh(&vals_gpu)
+        .map_err(|e| anyhow!("token_logprobs_batch D2H failed: {e}"))?;
+    let ids = ctx
+        .stream
+        .clone_dtoh(&ids_gpu)
+        .map_err(|e| anyhow!("token_logprobs_batch D2H failed: {e}"))?;
+    ctx.sync()?;
+
+    Ok((0..requests.len())
+        .map(|i| {
+            let k = ks[i] as usize;
+            let base = i * k_max;
+            TokenLogprob {
+                logprob: picked_lp[i],
+                top_logprobs: (0..k)
+                    .map(|j| (ids[base + j] as u32, vals[base + j]))
+                    .collect(),
+            }
+        })
+        .collect())
 }
 
 #[cfg(test)]

--- a/openinfer-sample/tests/gpu_logprobs.rs
+++ b/openinfer-sample/tests/gpu_logprobs.rs
@@ -1,0 +1,327 @@
+//! GPU-vs-host A/B: `token_logprobs_batch` must match `token_logprob_from_row`
+//! on the same bf16 rows — top-k ids exactly, values within `TOL`. Needs a GPU.
+
+use half::bf16;
+use openinfer_engine::engine::TokenLogprob;
+use openinfer_kernels::tensor::{DeviceContext, HiddenStates, StreamOverrideGuard};
+use openinfer_sample::{LogprobRequest, token_logprob_from_row, token_logprobs_batch};
+
+const TOL: f32 = 5e-5;
+
+fn make_arena(ctx: &DeviceContext, rows: &[Vec<bf16>]) -> HiddenStates {
+    let vocab = rows[0].len();
+    assert!(rows.iter().all(|r| r.len() == vocab), "ragged rows");
+    let mut hs = HiddenStates::zeros(ctx, vocab, rows.len()).unwrap();
+    let flat: Vec<bf16> = rows.iter().flatten().copied().collect();
+    ctx.stream.memcpy_htod(&flat, &mut hs.data).unwrap();
+    ctx.sync().unwrap();
+    hs
+}
+
+/// Deterministic bf16 row quantized to 1/128 steps, so ties recur throughout.
+fn noise_row(vocab: usize, salt: u64) -> Vec<bf16> {
+    (0..vocab as u64)
+        .map(|v| {
+            let mut z = v.wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ salt;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            z ^= z >> 31;
+            bf16::from_f32(((z % 4096) as f32) / 128.0 - 16.0)
+        })
+        .collect()
+}
+
+fn assert_matches_host(row: &[bf16], got: &TokenLogprob, picked: u32, top_k: usize) {
+    let want = token_logprob_from_row(row, picked, top_k).unwrap();
+    assert!(
+        (got.logprob - want.logprob).abs() <= TOL,
+        "picked logprob diverged: got {}, want {} (picked={picked}, k={top_k})",
+        got.logprob,
+        want.logprob
+    );
+    let got_ids: Vec<u32> = got.top_logprobs.iter().map(|&(id, _)| id).collect();
+    let want_ids: Vec<u32> = want.top_logprobs.iter().map(|&(id, _)| id).collect();
+    assert_eq!(got_ids, want_ids, "top-k id sequence diverged (k={top_k})");
+    for (&(id, got_lp), &(_, want_lp)) in got.top_logprobs.iter().zip(&want.top_logprobs) {
+        assert!(
+            (got_lp - want_lp).abs() <= TOL,
+            "top-k logprob diverged at id {id}: got {got_lp}, want {want_lp}"
+        );
+    }
+}
+
+#[test]
+fn matches_host_reference_across_k_at_model_vocab() {
+    let ctx = DeviceContext::new().unwrap();
+    let vocab = 151_936;
+    let rows: Vec<Vec<bf16>> = (0..3).map(|r| noise_row(vocab, 0x00C0_FFEE + r)).collect();
+    let arena = make_arena(&ctx, &rows);
+
+    let requests = [
+        LogprobRequest {
+            row: 0,
+            picked: 7,
+            top_k: 0,
+        },
+        LogprobRequest {
+            row: 1,
+            picked: 151_935,
+            top_k: 1,
+        },
+        LogprobRequest {
+            row: 2,
+            picked: 42_000,
+            top_k: 5,
+        },
+        LogprobRequest {
+            row: 0,
+            picked: 0,
+            top_k: 20,
+        },
+    ];
+    let got = token_logprobs_batch(&ctx, &arena, &requests).unwrap();
+
+    assert_eq!(got.len(), requests.len());
+    for (req, out) in requests.iter().zip(&got) {
+        assert_matches_host(&rows[req.row], out, req.picked, req.top_k);
+    }
+}
+
+#[test]
+fn tie_ordering_matches_host() {
+    let ctx = DeviceContext::new().unwrap();
+    let vocab = 4096;
+    // Two exactly-tied tiers straddling the tested k boundaries.
+    let mut row = vec![bf16::from_f32(0.0); vocab];
+    for &peak in &[901usize, 77, 2048] {
+        row[peak] = bf16::from_f32(8.0);
+    }
+    for &second in &[3000usize, 15, 1999, 512] {
+        row[second] = bf16::from_f32(6.5);
+    }
+    let rows = vec![row];
+    let arena = make_arena(&ctx, &rows);
+
+    for top_k in [2, 3, 5, 7] {
+        let got = token_logprobs_batch(
+            &ctx,
+            &arena,
+            &[LogprobRequest {
+                row: 0,
+                picked: 901,
+                top_k,
+            }],
+        )
+        .unwrap();
+        assert_matches_host(&rows[0], &got[0], 901, top_k);
+    }
+    let got = token_logprobs_batch(
+        &ctx,
+        &arena,
+        &[LogprobRequest {
+            row: 0,
+            picked: 901,
+            top_k: 5,
+        }],
+    )
+    .unwrap();
+    let ids: Vec<u32> = got[0].top_logprobs.iter().map(|&(id, _)| id).collect();
+    assert_eq!(ids, vec![77, 901, 2048, 15, 512]);
+
+    // Adjacent bf16 logits whose f32 `- lse` shifts collapse to one value.
+    let collapse = vec![
+        bf16::from_bits(0x3480),
+        bf16::from_bits(0x3481),
+        bf16::from_bits(0xBC24),
+    ];
+    let collapse_arena = make_arena(&ctx, std::slice::from_ref(&collapse));
+    let got = token_logprobs_batch(
+        &ctx,
+        &collapse_arena,
+        &[LogprobRequest {
+            row: 0,
+            picked: 0,
+            top_k: 3,
+        }],
+    )
+    .unwrap();
+    let ids: Vec<u32> = got[0].top_logprobs.iter().map(|&(id, _)| id).collect();
+    assert_eq!(ids, vec![1, 0, 2]);
+    assert_matches_host(&collapse, &got[0], 0, 3);
+}
+
+#[test]
+fn indexes_arena_rows_out_of_order() {
+    let ctx = DeviceContext::new().unwrap();
+    let vocab = 8192;
+    let rows: Vec<Vec<bf16>> = (0..4).map(|r| noise_row(vocab, 0xBEEF + r)).collect();
+    let arena = make_arena(&ctx, &rows);
+
+    let requests = [
+        LogprobRequest {
+            row: 3,
+            picked: 11,
+            top_k: 4,
+        },
+        LogprobRequest {
+            row: 1,
+            picked: 8000,
+            top_k: 2,
+        },
+        LogprobRequest {
+            row: 3,
+            picked: 500,
+            top_k: 1,
+        },
+    ];
+    let got = token_logprobs_batch(&ctx, &arena, &requests).unwrap();
+    for (req, out) in requests.iter().zip(&got) {
+        assert_matches_host(&rows[req.row], out, req.picked, req.top_k);
+    }
+}
+
+#[test]
+fn k_larger_than_vocab_is_clamped() {
+    let ctx = DeviceContext::new().unwrap();
+    let rows = vec![noise_row(8, 7)];
+    let arena = make_arena(&ctx, &rows);
+
+    let got = token_logprobs_batch(
+        &ctx,
+        &arena,
+        &[LogprobRequest {
+            row: 0,
+            picked: 3,
+            top_k: 32,
+        }],
+    )
+    .unwrap();
+    assert_matches_host(&rows[0], &got[0], 3, 32);
+}
+
+#[test]
+fn rejects_out_of_range_requests() {
+    let ctx = DeviceContext::new().unwrap();
+    let arena = make_arena(&ctx, &[noise_row(64, 1), noise_row(64, 2)]);
+
+    assert!(
+        token_logprobs_batch(
+            &ctx,
+            &arena,
+            &[LogprobRequest {
+                row: 0,
+                picked: 64,
+                top_k: 1
+            }]
+        )
+        .is_err(),
+        "picked token beyond the vocab must be rejected"
+    );
+    assert!(
+        token_logprobs_batch(
+            &ctx,
+            &arena,
+            &[LogprobRequest {
+                row: 2,
+                picked: 0,
+                top_k: 1
+            }]
+        )
+        .is_err(),
+        "row beyond the arena must be rejected"
+    );
+    assert!(
+        token_logprobs_batch(&ctx, &arena, &[]).unwrap().is_empty(),
+        "an empty request list is a no-op"
+    );
+
+    let mut inflated = make_arena(&ctx, &[noise_row(64, 4)]);
+    inflated.seq_len = 4;
+    assert!(
+        token_logprobs_batch(
+            &ctx,
+            &inflated,
+            &[LogprobRequest {
+                row: 3,
+                picked: 0,
+                top_k: 1
+            }]
+        )
+        .is_err(),
+        "seq_len beyond the arena backing must be rejected"
+    );
+}
+
+#[test]
+fn rejects_active_stream_override() {
+    let ctx = DeviceContext::new().unwrap();
+    let arena = make_arena(&ctx, &[noise_row(64, 3)]);
+    let request = [LogprobRequest {
+        row: 0,
+        picked: 1,
+        top_k: 1,
+    }];
+
+    let guard = unsafe { StreamOverrideGuard::activate(ctx.stream.cu_stream()) };
+    let denied = token_logprobs_batch(&ctx, &arena, &request);
+    drop(guard);
+
+    assert!(
+        denied.is_err(),
+        "an active stream override must be rejected"
+    );
+}
+
+#[test]
+fn outputs_are_independent_of_batch_composition() {
+    let ctx = DeviceContext::new().unwrap();
+    let vocab = 151_936;
+    let target = noise_row(vocab, 0xA11CE);
+    let alone_arena = make_arena(&ctx, std::slice::from_ref(&target));
+    let packed_arena = make_arena(&ctx, &[noise_row(vocab, 1), noise_row(vocab, 2), target]);
+
+    let alone = token_logprobs_batch(
+        &ctx,
+        &alone_arena,
+        &[LogprobRequest {
+            row: 0,
+            picked: 1234,
+            top_k: 5,
+        }],
+    )
+    .unwrap();
+    let packed = token_logprobs_batch(
+        &ctx,
+        &packed_arena,
+        &[
+            LogprobRequest {
+                row: 0,
+                picked: 9,
+                top_k: 3,
+            },
+            LogprobRequest {
+                row: 2,
+                picked: 1234,
+                top_k: 5,
+            },
+            LogprobRequest {
+                row: 1,
+                picked: 77,
+                top_k: 1,
+            },
+        ],
+    )
+    .unwrap();
+
+    assert_eq!(alone[0].logprob.to_bits(), packed[1].logprob.to_bits());
+    let alone_bits: Vec<(u32, u32)> = alone[0]
+        .top_logprobs
+        .iter()
+        .map(|&(id, lp)| (id, lp.to_bits()))
+        .collect();
+    let packed_bits: Vec<(u32, u32)> = packed[1]
+        .top_logprobs
+        .iter()
+        .map(|&(id, lp)| (id, lp.to_bits()))
+        .collect();
+    assert_eq!(alone_bits, packed_bits);
+}


### PR DESCRIPTION
## Description

Closes #719.

Every decode row and prompt position that requested logprobs used to extract a full bf16 logits row (a ~297 KiB device copy plus a synchronous D2H) and scan the whole vocabulary on the engine thread, once per row per step. The scan runs inside the shared step loop, so the cost multiplied with the number of logprobs rows in a batch and stalled unrelated requests.

This change computes the log-softmax on the GPU instead. A new shared kernel (`logprob_topk_batch_bf16_cuda`) handles a batch of requested arena rows in one launch: per row, a fixed-tree max reduction, an exp sum accumulated in f64 for the logsumexp, the picked token's logprob, and the requested top-k selected in strictly decreasing (raw logit value, ascending token id) lexicographic order, with the logsumexp subtracted only in the returned values. `openinfer_sample::token_logprobs_batch` wraps it as the policy-level entry: one launch and a compact O(rows x (k+1)) readback per batch call — three small metadata uploads and three small readbacks replace one full-vocab copy and scan per row. Decode makes one call per step; prefill makes up to two, because first-token logits and all-position prompt logits live in different arenas. The Qwen3 decode, first-token, and prompt-logprob paths all route through the batched call; the per-row `extract_vec` + host-scan helpers are removed. The host reference `token_logprob_from_row` stays as the single-row fallback and as the conformance oracle, and now also selects its top-k by raw logits, so the ordering contract is uniform across the models that use it.

Safety and errors: the kernel-facing wrapper trusts device-resident indices, so it is `unsafe` with an explicit contract covering the index bounds and the stream-ordering of buffer traffic relative to the launch; before launching it checks buffer capacities, the arena backing size, and `i32` ranges. The safe policy entry validates every row index, picked token, and k on the host before upload, uses checked arithmetic, and rejects an active stream override, since its uploads, allocations, and readbacks are ordered on the primary stream while the kernel launch honors the override. A failed extraction now propagates as an error on the prompt-logprobs path too, instead of silently returning null entries for the whole batch.

Numerics and ordering: both paths select top-k by raw logits, breaking exact-logit ties by ascending token id, and subtract logsumexp only from returned values, so id ordering is independent of accumulator differences. On the sm_89 GPU A/B suite, ids matched exactly and values were within 5e-5 of the host reference. Per-row outputs were bitwise invariant to batch composition on the tested build.

Measured on Qwen3-4B, one sm_89 GPU, `--no-prefix-cache`, greedy 128-input/256-output requests, three repetitions with medians, same harness as the issue:

| concurrency | arm | before TPOT / tok/s | after TPOT / tok/s | after cost vs logprobs-off |
|---|---|---|---|---|
| 1 | logprobs=1 | 10.69 ms / 94 | 10.12 ms / 99 | +3% |
| 8 | logprobs=1 | 17.40 ms / 456 | 11.06 ms / 707 | +3% |
| 8 | logprobs=5 | 17.44 ms / 455 | 11.45 ms / 683 | +6% |
| 32 | logprobs=1 | 41.34 ms / 788 | 13.56 ms / 2243 | +2% |
| 32 | logprobs=5 | 39.87 ms / 788 | 13.83 ms / 2188 | +4% |

The logprobs-off arms are unchanged within run noise. In the mixed concurrency-8 batch, one logprobs request now raises non-logprobs rows by +2.6% instead of +6.8%, and an all-logprobs batch costs -3.2% throughput instead of -37%. Prompt logprobs on a 1024-token prompt drop from ~10x request latency (841-911 ms vs 84 ms) to ~1.14x (107 ms), about 0.013 ms per scored position. The prompt-logprobs arms were measured through the same temporary bridge instrumentation as the issue campaign (forcing engine-side echo when `prompt_logprobs` is present).

Nsight Systems over the same capture windows: the decode logprobs window goes from 6,949 D2H transfers / 1.87 GB and 6,951 stream synchronizations to 3,127 transfers / 0.90 MB and 1,581 synchronizations (three sub-KB readbacks per step instead of one 0.304 MB row per token), and the per-token device-to-device row copies disappear. The prompt-logprobs window goes from 12,296 D2H transfers / 3.73 GB to 68 transfers / 0.11 MB.

Validation: a GPU A/B suite (`openinfer-sample/tests/gpu_logprobs.rs`) checks the device path against the host reference — exact top-k id sequences on heavily tied rows across k values, a collapse counterexample where the logsumexp-shifted values tie but the raw logits differ, value tolerance, per-row k mixing, out-of-order arena indexing, k clamping at the vocab, rejection of out-of-range rows and picked tokens, of a declared row count beyond the arena backing, and of an active stream override, and bitwise equality of a row's outputs regardless of batch composition. `hf_golden_gate` (which compares served logprobs against HF goldens), `sampling_behavior`, and the sample-crate unit tests pass on the same GPU.

Residual cost: per decode batch call the path still performs three metadata uploads, six small device allocations, three compact readbacks, and one synchronization. At the measured residual (at most +3% TPOT for `logprobs=1` at every concurrency) this is left as is; a persistent scratch or a packed single readback is available follow-up if a later profile justifies it.

Scope: Qwen3.5 and Kimi keep the host path for now; the shared entry is model-agnostic and their adoption (including measuring Kimi's whole-arena readback) is follow-up work.