### PR TITLE
chore(ci): add stale cleanup and DCO checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,15 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  dco:
+    if: github.event_name == 'pull_request'
+    name: DCO sign-off
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check commit sign-offs
+        uses: KineticCafe/actions-dco@v3.1.0
+
   rust-format:
     name: Rust formatting
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,49 @@
+name: Close stale issues and pull requests
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    name: Mark and close stale items
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Process stale issues and pull requests
+        uses: actions/stale@v10.4.0
+        with:
+          days-before-stale: 14
+          days-before-close: 30
+
+          stale-issue-label: stale
+          stale-pr-label: stale
+          stale-issue-message: >-
+            This issue has been inactive for 14 days. It will be closed after
+            another 30 days unless there is new activity.
+          stale-pr-message: >-
+            This pull request has been inactive for 14 days. It will be closed
+            after another 30 days unless there is new activity.
+          close-issue-message: >-
+            Closing because there was no activity during the 30-day stale
+            period. Please reopen or create a new issue if this is still
+            relevant.
+          close-pr-message: >-
+            Closing because there was no activity during the 30-day stale
+            period. Please reopen when the work is ready to continue.
+
+          exempt-issue-labels: roadmap
+          remove-stale-when-updated: true
+          close-issue-reason: not_planned
+          delete-branch: false
+
+          ascending: true
+          sort-by: updated
+          operations-per-run: 100


### PR DESCRIPTION
## Summary

- mark inactive issues and pull requests stale after 14 days
- close stale items after another 30 days, while exempting roadmap issues
- add a DCO check that validates Signed-off-by trailers on every pull request commit

## Validation

- actionlint v1.7.12
- YAML parsing for both workflows
- git diff --check
- pre-commit hooks