### PR TITLE
docs: fix escaped markdown in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,28 +1,17 @@
-\## Description
+## Description
 
 Fixes # (issue number)
 
+## Type of Change
 
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
 
-\## Type of Change
+## Checklist
 
-\- \[ ] Bug fix (non-breaking change which fixes an issue)
-
-\- \[ ] New feature (non-breaking change which adds functionality)
-
-\- \[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-
-\- \[ ] Documentation update
-
-
-
-\## Checklist
-
-\- \[ ] My code follows the style guidelines of this project (see `docs/conventions/coding-style.md`).
-
-\- \[ ] I have performed a self-review of my own code.
-
-\- \[ ] I have formatted my commits according to Commitizen conventions.
-
-\- \[ ] I have run the local test suite and all tests pass (see `CLAUDE.md`).
-
+- [ ] My code follows the style guidelines of this project (see `docs/conventions/coding-style.md`).
+- [ ] I have performed a self-review of my own code.
+- [ ] I have formatted my commits according to Commitizen conventions.
+- [ ] I have run the local test suite and all tests pass (see `CLAUDE.md`).


### PR DESCRIPTION
## Description

The PR template shipped in #130 with every markdown control character backslash-escaped (\##, \- \[ ]), so each new PR pre-fills a body whose headings and checkboxes render as literal text until the backslashes are removed by hand. #682 fixed the same damage in CONTRIBUTING.md but missed the template. Rewrite the template as plain markdown; content unchanged.



## Type of Change

- [x] Documentation update



## Checklist

- [x] My code follows the style guidelines of this project (see `docs/conventions/coding-style.md`).
- [x] I have performed a self-review of my own code.
- [x] I have formatted my commits according to Commitizen conventions.
- [ ] I have run the local test suite and all tests pass (see `CLAUDE.md`).

