### PR TITLE
perf(core): parallelize weight prefetch for single-rank Qwen loads

### DIFF
--- a/openinfer-core/src/weight_loader.rs
+++ b/openinfer-core/src/weight_loader.rs
@@ -3,11 +3,14 @@
 use anyhow::Result;
 use cudarc::driver::CudaSlice;
 use half::bf16;
-use log::info;
+use log::{info, warn};
 use memmap2::Mmap;
 use safetensors::{Dtype, SafeTensors};
 use std::collections::HashMap;
 use std::fs;
+use std::os::unix::fs::FileExt;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 
 use crate::tensor::{DeviceContext, DeviceMatrix, DeviceVec};
 
@@ -44,6 +47,154 @@ pub fn load_shard_info(model_path: &str) -> Result<(Vec<String>, HashMap<String,
     }
 
     Ok((shard_files, weight_map))
+}
+
+/// Advisory parallel page-cache prefetch for a single-rank whole-model load;
+/// the loader never depends on it. Dropping cancels and joins the workers, and
+/// failures are aggregated into one warning with the first cause retained.
+pub struct WeightPrefetch {
+    cancel: Arc<AtomicBool>,
+    stats: Arc<PrefetchStats>,
+    unreadable_shards: usize,
+    spawn_failures: usize,
+    workers: Vec<std::thread::JoinHandle<()>>,
+}
+
+#[derive(Default)]
+struct PrefetchStats {
+    read_errors: AtomicUsize,
+    first_error: Mutex<Option<String>>,
+}
+
+impl PrefetchStats {
+    fn record_first_error(&self, message: impl FnOnce() -> String) {
+        let mut slot = match self.first_error.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if slot.is_none() {
+            *slot = Some(message());
+        }
+    }
+}
+
+impl WeightPrefetch {
+    pub fn spawn(shard_paths: &[String]) -> Self {
+        const CHUNK: u64 = 16 << 20;
+        const THREADS: usize = 8;
+
+        let stats = Arc::new(PrefetchStats::default());
+        let mut files: Vec<(Arc<fs::File>, u64, String)> = Vec::new();
+        let mut chunks: Vec<(usize, u64)> = Vec::new();
+        let mut unreadable_shards = 0usize;
+        for path in shard_paths {
+            let meta = fs::File::open(path).and_then(|file| {
+                let len = file.metadata()?.len();
+                Ok((file, len))
+            });
+            match meta {
+                Ok((file, len)) => {
+                    let idx = files.len();
+                    files.push((Arc::new(file), len, path.clone()));
+                    chunks.extend((0..len).step_by(CHUNK as usize).map(|off| (idx, off)));
+                }
+                Err(err) => {
+                    unreadable_shards += 1;
+                    stats.record_first_error(|| format!("{path}: {err}"));
+                }
+            }
+        }
+
+        let cancel = Arc::new(AtomicBool::new(false));
+        let mut workers = Vec::new();
+        let mut spawn_failures = 0usize;
+        let threads = THREADS.min(chunks.len());
+        if !chunks.is_empty() {
+            let total_bytes: u64 = files.iter().map(|(_, len, _)| len).sum();
+            let num_files = files.len();
+            let files = Arc::new(files);
+            let chunks = Arc::new(chunks);
+            let next = Arc::new(AtomicUsize::new(0));
+            for _ in 0..threads {
+                let worker = {
+                    let (files, chunks, next) = (files.clone(), chunks.clone(), next.clone());
+                    let (cancel, stats) = (cancel.clone(), stats.clone());
+                    std::thread::Builder::new()
+                        .name("weight-prefetch".into())
+                        .spawn(move || {
+                            let mut buf = vec![0u8; CHUNK as usize];
+                            while !cancel.load(Ordering::Relaxed) {
+                                let i = next.fetch_add(1, Ordering::Relaxed);
+                                let Some(&(file_idx, off)) = chunks.get(i) else {
+                                    break;
+                                };
+                                let (file, len, path) = &files[file_idx];
+                                let want = CHUNK.min(len - off) as usize;
+                                if let Err(err) = file.read_exact_at(&mut buf[..want], off) {
+                                    stats.read_errors.fetch_add(1, Ordering::Relaxed);
+                                    stats.record_first_error(|| format!("{path}@{off}: {err}"));
+                                }
+                            }
+                        })
+                };
+                match worker {
+                    Ok(handle) => workers.push(handle),
+                    Err(err) => {
+                        spawn_failures += 1;
+                        stats.record_first_error(|| format!("worker spawn: {err}"));
+                    }
+                }
+            }
+            if !workers.is_empty() {
+                info!(
+                    "Prefetching {num_files} weight shard(s) ({:.1} GB) on {} threads",
+                    total_bytes as f64 / 1e9,
+                    workers.len()
+                );
+            }
+        }
+        Self {
+            cancel,
+            stats,
+            unreadable_shards,
+            spawn_failures,
+            workers,
+        }
+    }
+}
+
+impl Drop for WeightPrefetch {
+    fn drop(&mut self) {
+        self.cancel.store(true, Ordering::Relaxed);
+        let mut panicked = 0usize;
+        for worker in self.workers.drain(..) {
+            if let Err(payload) = worker.join() {
+                panicked += 1;
+                let message = payload
+                    .downcast_ref::<&str>()
+                    .map(|s| (*s).to_string())
+                    .or_else(|| payload.downcast_ref::<String>().cloned())
+                    .unwrap_or_else(|| "non-string panic payload".to_string());
+                self.stats
+                    .record_first_error(|| format!("worker panic: {message}"));
+            }
+        }
+        let read_errors = self.stats.read_errors.load(Ordering::Relaxed);
+        if self.unreadable_shards + self.spawn_failures + read_errors + panicked > 0 {
+            let first = match self.stats.first_error.lock() {
+                Ok(guard) => guard.clone(),
+                Err(poisoned) => poisoned.into_inner().clone(),
+            };
+            warn!(
+                "weight prefetch incomplete: {} unreadable shard(s), {} worker spawn failure(s), {} chunk read error(s), {} panic(s); first error: {}",
+                self.unreadable_shards,
+                self.spawn_failures,
+                read_errors,
+                panicked,
+                first.as_deref().unwrap_or("unknown")
+            );
+        }
+    }
 }
 
 /// Memory-map shard files and return the mmaps.

--- a/openinfer-qwen3/src/weights.rs
+++ b/openinfer-qwen3/src/weights.rs
@@ -15,8 +15,8 @@ use crate::lora::{
 use half::bf16;
 use openinfer_core::tensor::{DeviceContext, DeviceMatrix, DeviceVec, HiddenStates};
 use openinfer_core::weight_loader::{
-    deserialize_shards, load_shard_info, load_tensor_1d, load_tensor_2d, load_tensor_2d_col_shard,
-    load_tensor_2d_row_shard, mmap_shards, precompute_rope,
+    WeightPrefetch, deserialize_shards, load_shard_info, load_tensor_1d, load_tensor_2d,
+    load_tensor_2d_col_shard, load_tensor_2d_row_shard, mmap_shards, precompute_rope,
 };
 use openinfer_kv_cache::KvBuffer;
 
@@ -383,6 +383,8 @@ impl Qwen3Model {
 
         let (shard_paths, weight_map) = load_shard_info(model_path)?;
         debug!("Loading {} safetensor shard(s)", shard_paths.len());
+        let prefetch =
+            (tensor_parallel.world_size == 1).then(|| WeightPrefetch::spawn(&shard_paths));
         let mmaps = mmap_shards(&shard_paths)?;
         let shards = deserialize_shards(&mmaps)?;
 
@@ -593,6 +595,7 @@ impl Qwen3Model {
         )?;
 
         ctx.sync()?;
+        drop(prefetch);
         info!(
             "GPU model loaded in {:.0}ms",
             t_gpu.elapsed().as_secs_f64() * 1e3

--- a/openinfer-qwen35-4b/src/weights.rs
+++ b/openinfer-qwen35-4b/src/weights.rs
@@ -9,8 +9,9 @@ use std::time::Instant;
 use super::config::{Config35, LayerType, TensorParallelConfig};
 use openinfer_core::tensor::{DeviceContext, DeviceMatrix, DeviceVec, HiddenStates};
 use openinfer_core::weight_loader::{
-    deserialize_shards, load_shard_info_fixed, load_tensor_1d, load_tensor_1d_f32, load_tensor_2d,
-    load_tensor_2d_col_shard, load_tensor_2d_row_shard, mmap_shards, precompute_rope,
+    WeightPrefetch, deserialize_shards, load_shard_info_fixed, load_tensor_1d, load_tensor_1d_f32,
+    load_tensor_2d, load_tensor_2d_col_shard, load_tensor_2d_row_shard, mmap_shards,
+    precompute_rope,
 };
 
 /// Full attention layer weights (8 layers in Qwen3.5-4B).
@@ -221,6 +222,8 @@ impl Qwen35Model {
 
         let (shard_paths, weight_map) = load_shard_info_fixed(model_path)?;
         debug!("Loading {} safetensor shard(s)", shard_paths.len());
+        let prefetch =
+            (tensor_parallel.world_size == 1).then(|| WeightPrefetch::spawn(&shard_paths));
         let mmaps = mmap_shards(&shard_paths)?;
         let shards = deserialize_shards(&mmaps)?;
 
@@ -456,6 +459,7 @@ impl Qwen35Model {
         )?;
 
         ctx.sync()?;
+        drop(prefetch);
         info!(
             "GPU model loaded in {:.0}ms",
             t_gpu.elapsed().as_secs_f64() * 1e3


### PR DESCRIPTION
## Description

On client-cold loads from the measured Lustre filesystem, sequential tensor copies fault safetensors mmap pages through one demand-driven stream. WeightPrefetch runs up to eight background readers over 16 MiB chunks to populate the page cache ahead of that copy loop. The mmap copy path remains authoritative. Dropping the guard cancels and joins every worker, while setup and worker failures are reported once with the first cause retained.

Prefetch is enabled only at the single-rank Qwen3 and Qwen3.5 whole-model call sites. TP and drafter loaders remain unchanged to avoid duplicate full-checkpoint reads.

Measured on a GH200 node (aarch64, sm_90) with model weights on a Lustre parallel filesystem, 3 cold + 2 warm repetitions per arm; cold = client page cache evicted via `posix_fadvise(DONTNEED)` before every repetition. The paired campaign ran an earlier build with the same read loop; the final RAII/call-site form received separate sanity validation below.

| model | arm | cold: weights / engine ready | warm: weights / engine ready |
|---|---|---|---|
| Qwen3.5-27B (55.6 GB) | off | 5.3 s / 10.4 s | 1.26 s / 6.29 s |
| | on | 4.0 s / 9.0 s | 1.36 s / 6.31 s |
| Qwen3.5-9B (19.3 GB) | off | 1.63 s / 5.93 s | 0.49 s / 4.74 s |
| | on | 1.41 s / 5.67 s | 0.50 s / 4.78 s |

Scope of these numbers: `fadvise` evicts the client cache but not the storage servers', and this filesystem was serving ~9 GB/s from server cache during the run, so they cover the client-cold/server-warm regime only. Genuinely cold storage is not measured and no claim is made about that regime.

## Validation

- `hf_golden_gate` passes for qwen3 and qwen35 on the campaign build, covering both model paths after the loader change.
- Final-form sanity, Qwen3.5-27B cold/warm: prefetch engages (11 shards, 55.6 GB), and every run reaches server ready with zero prefetch threads alive and zero failure warnings.
- Final-form parity, Qwen3-4B warm startup against a main-loader binary: engine ready 4.49–4.50 s (main loader) vs 4.50–4.52 s (prefetch), weight phase 0.38 s vs 0.39 s; the prefetch log line appears only in the patched arm.
- Workspace build and `cargo clippy` clean on the final form.