### PR TITLE
chore(ci): notify on unverified cross-author commit attribution

### DIFF
--- a/.github/scripts/attribution-notice-test.sh
+++ b/.github/scripts/attribution-notice-test.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")" || exit 1
+
+WRITES=$(mktemp)
+trap 'rm -f "$WRITES"' EXIT
+FAILED=0
+
+# shellcheck disable=SC2317,SC2329
+gh() {
+  local a prev="" jq_prog="" url=""
+  for a in "$@"; do
+    if [ "$a" = "--method" ] || [ "$a" = "-f" ]; then
+      printf '%s\n' "gh $*" >>"$WRITES"
+      return 0
+    fi
+    if [ "$prev" = "--jq" ]; then
+      jq_prog="$a"
+    fi
+    case "$a" in repos/*) url="$a" ;; esac
+    prev="$a"
+  done
+  local data='[]'
+  case "$url" in
+    */pulls/*/commits) data="$COMMITS_FIXTURE" ;;
+    */issues/*/comments) data="$COMMENTS_FIXTURE" ;;
+    */pulls/*) data="$PR_FIXTURE" ;;
+  esac
+  jq -cr "$jq_prog" <<<"$data"
+}
+
+expect() {
+  if grep -qF -- "$2" "$WRITES"; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    FAILED=1
+  fi
+}
+
+expect_absent() {
+  if grep -qF -- "$2" "$WRITES"; then
+    echo "  FAIL: $1"
+    FAILED=1
+  else
+    echo "  ok: $1"
+  fi
+}
+
+expect_no_writes() {
+  if [ -s "$WRITES" ]; then
+    echo "  FAIL: expected no writes, got: $(cat "$WRITES")"
+    FAILED=1
+  else
+    echo "  ok: no writes"
+  fi
+}
+
+run_script() {
+  : >"$WRITES"
+  local rc=0
+  set +e
+  # shellcheck disable=SC1091
+  (. ./attribution-notice.sh)
+  rc=$?
+  set -e
+  if [ "$rc" -ne 0 ]; then
+    echo "  FAIL: script exited nonzero"
+    FAILED=1
+  fi
+}
+
+export REPO=test/repo PR_NUMBER=1 PR_AUTHOR=alice
+export PR_FIXTURE='{"commits":5}'
+
+COMMITS_MIXED='[
+  {"sha":"aaaa111100000000","author":{"login":"alice"},"committer":{"login":"alice"},"commit":{"verification":{"verified":false}}},
+  {"sha":"bbbb111100000000","author":{"login":"bob"},"committer":{"login":"bob"},"commit":{"verification":{"verified":false}}},
+  {"sha":"bbbb222200000000","author":{"login":"bob"},"committer":{"login":"bob"},"commit":{"verification":{"verified":false}}},
+  {"sha":"cccc111100000000","author":null,"committer":null,"commit":{"verification":{"verified":false}}},
+  {"sha":"dddd111100000000","author":{"login":"bob"},"committer":{"login":"bob"},"commit":{"verification":{"verified":true}}},
+  {"sha":"eeee111100000000","author":{"login":"bob"},"committer":{"login":"eve"},"commit":{"verification":{"verified":true}}},
+  {"sha":"ffff111100000000","author":{"login":"carol"},"committer":{"login":"web-flow"},"commit":{"verification":{"verified":true}}}
+]'
+COMMITS_CLEAN='[
+  {"sha":"aaaa111100000000","author":{"login":"alice"},"committer":{"login":"alice"},"commit":{"verification":{"verified":false}}},
+  {"sha":"dddd111100000000","author":{"login":"bob"},"committer":{"login":"bob"},"commit":{"verification":{"verified":true}}}
+]'
+COMMENTS_NONE='[]'
+COMMENTS_MARKED='[{"id":42,"user":{"login":"github-actions[bot]"},"body":"<!-- commit-attribution-notice -->\nold"}]'
+COMMENTS_SQUATTED='[{"id":7,"user":{"login":"mallory"},"body":"<!-- commit-attribution-notice -->\nfake"}]'
+
+echo "scenario: cross-author commits without the author's own signature are flagged"
+COMMITS_FIXTURE=$COMMITS_MIXED COMMENTS_FIXTURE=$COMMENTS_NONE run_script
+expect "creates a new comment" "repos/test/repo/issues/1/comments -f"
+expect "flags bob's first unsigned commit" "bbbb1111"
+expect "flags bob's second unsigned commit" "bbbb2222"
+expect "flags verified commit signed by a different committer" "eeee1111"
+expect_absent "PR author's own unsigned commit exempt" "aaaa1111"
+expect_absent "unlinked-email commit exempt" "cccc1111"
+expect_absent "self-signed verified commit exempt" "dddd1111"
+expect_absent "web-flow commit exempt" "ffff1111"
+expect_absent "does not patch when no comment exists" "--method PATCH"
+
+echo "scenario: clean PR produces no writes"
+COMMITS_FIXTURE=$COMMITS_CLEAN COMMENTS_FIXTURE=$COMMENTS_NONE run_script
+expect_no_writes
+
+echo "scenario: clean PR with stale notice patches it to resolved"
+COMMITS_FIXTURE=$COMMITS_CLEAN COMMENTS_FIXTURE=$COMMENTS_MARKED run_script
+expect "patches the existing comment" "--method PATCH repos/test/repo/issues/comments/42"
+expect "patched body is the resolved notice" "are resolved"
+expect_absent "does not create a second comment" "issues/1/comments -f"
+
+echo "scenario: flagged PR with existing notice updates it in place"
+COMMITS_FIXTURE=$COMMITS_MIXED COMMENTS_FIXTURE=$COMMENTS_MARKED run_script
+expect "patches the existing comment" "--method PATCH repos/test/repo/issues/comments/42"
+expect "patched body carries the flagged sha" "bbbb1111"
+expect_absent "does not create a second comment" "issues/1/comments -f"
+
+echo "scenario: marker comment from a non-bot author is ignored"
+COMMITS_FIXTURE=$COMMITS_MIXED COMMENTS_FIXTURE=$COMMENTS_SQUATTED run_script
+expect "creates its own comment" "issues/1/comments -f"
+expect_absent "does not touch the squatted comment" "comments/7"
+
+echo "scenario: PR beyond the 250-commit window is reported, never resolved"
+COMMITS_FIXTURE=$COMMITS_CLEAN COMMENTS_FIXTURE=$COMMENTS_MARKED PR_FIXTURE='{"commits":300}' run_script
+expect "patches the existing comment" "--method PATCH repos/test/repo/issues/comments/42"
+expect "reports the unscannable commit count" "300 commits"
+expect_absent "does not claim attributions resolved" "are resolved"
+
+if [ "$FAILED" -eq 0 ]; then
+  echo "all scenarios passed"
+fi
+exit "$FAILED"

--- a/.github/scripts/attribution-notice.sh
+++ b/.github/scripts/attribution-notice.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# A verified signature vouches for the author only when committer and author
+# match (GitHub binds signatures to the committer) or the commit came from
+# GitHub's web flow.
+set -euo pipefail
+
+: "${REPO:?}" "${PR_NUMBER:?}" "${PR_AUTHOR:?}"
+
+export MARKER='<!-- commit-attribution-notice -->'
+
+comment_id=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+  --jq '.[] | select((.body | startswith(env.MARKER))
+                     and (.user.login // "") == "github-actions[bot]")
+            | .id' | sed -n '1p')
+
+upsert() {
+  if [ -n "$comment_id" ]; then
+    gh api --method PATCH "repos/$REPO/issues/comments/$comment_id" -f body="$1"
+  else
+    gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body="$1"
+  fi
+}
+
+total=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .commits)
+if [ "$total" -gt 250 ]; then
+  upsert "$MARKER"$'\n'"### Commit attribution notice"$'\n\n'"This pull request has $total commits, more than the 250 the API exposes for scanning; commit attributions were not verified. This check never fails the build."
+  exit 0
+fi
+
+suspicious=$(gh api "repos/$REPO/pulls/$PR_NUMBER/commits" --paginate --jq '
+  .[]
+  | select(.author != null and .author.login != env.PR_AUTHOR)
+  | select(
+      (.commit.verification.verified
+       and ((.committer.login // "") == .author.login
+            or (.committer.login // "") == "web-flow"))
+      | not)
+  | {sha: .sha[0:8], login: .author.login}')
+
+if [ -z "$suspicious" ]; then
+  if [ -n "$comment_id" ]; then
+    upsert "$MARKER"$'\n'"All commit attributions previously flagged on this pull request are resolved."
+  fi
+  exit 0
+fi
+
+body=$(jq -rs --arg marker "$MARKER" --arg pr_author "$PR_AUTHOR" '
+  map("- `" + .sha + "` attributed to @" + .login)
+  | $marker + "\n### Commit attribution notice\n\n"
+    + "This pull request contains commits attributed to an account other than "
+    + "the PR author @" + $pr_author + " without a verified signature from that account:\n\n"
+    + join("\n")
+    + "\n\nIf you are mentioned above and did not take part in this pull request, "
+    + "please say so here. Attributing a commit to someone else normally requires "
+    + "that person to be involved; maintainers should treat unacknowledged "
+    + "attribution as a review blocker.\n\nThis check never fails the build."' \
+  <<<"$suspicious")
+
+upsert "$body"

--- a/.github/workflows/attribution.yml
+++ b/.github/workflows/attribution.yml
@@ -1,0 +1,39 @@
+# SECURITY: pull_request_target grants a write-capable token on fork PRs.
+# The checkout below must never take a ref override — it stays on the
+# trusted base commit, and nothing here may execute PR code.
+
+name: Commit attribution
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  attribution-notice:
+    name: Commit attribution notice
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Scan commits and maintain the notice comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: bash .github/scripts/attribution-notice.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,22 @@ jobs:
       - name: Check commit sign-offs
         uses: KineticCafe/actions-dco@v3.1.0
 
+  attribution-script:
+    name: Attribution script checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Lint attribution scripts
+        run: shellcheck .github/scripts/attribution-notice.sh .github/scripts/attribution-notice-test.sh
+
+      - name: Run attribution behavior tests
+        run: bash .github/scripts/attribution-notice-test.sh
+
   rust-format:
     name: Rust formatting
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description


GitHub attributes a commit to whatever account matches the author email, without verifying anything and without notifying the person being attributed. A PR can therefore carry commits attributed to a contributor who never took part in it, and nothing in the current pipeline surfaces that: the DCO check only verifies that the author's own sign-off line is present, and sign-off trailers are plain text.

This adds a non-blocking workflow that scans PR commits for commits attributed to a GitHub account other than the PR author without a verified signature from that account, and maintains a single sticky comment mentioning those accounts. A verified signature exempts a commit only when committer and author match (GitHub binds signature verification to the committer, so a valid signature from someone else does not vouch for the author) or when the commit was created through GitHub's web flow; the sticky comment is only ever looked up among github-actions[bot] comments, so a pre-planted marker comment from another user cannot capture or suppress the notice. The mentioned person gets a normal GitHub notification and can disown the attribution; for genuine collaboration (maintainer pushes, co-developed branches, rebased/cherry-picked patches, which unavoidably lose their original signatures) the mention is harmless and nothing is blocked. Enforcement stays with reviewers. Commits whose author email is not linked to any GitHub account (common for corporate emails) are deliberately out of scope: they credit no account, so there is no one to impersonate or notify, and flagging them would spam every contributor who commits with an unlinked work email.

Layout: the workflow is a thin pull_request_target caller that checks out only the trusted base (no ref override — the security invariant, documented in the workflow header) and runs .github/scripts/attribution-notice.sh, which owns all logic and talks to GitHub exclusively through gh api. attribution-notice-test.sh stubs that seam with fixtures and asserts the flagging decisions; it runs as a blocking "Attribution script checks" job in ci.yml together with shellcheck, so the watchdog itself has a regression gate.

Verified by the offline behavior test (six scenarios: flag cross-author commits lacking the author's own signature — including a verified commit signed by a different committer — while exempting self-authored, unlinked-email, self-signed, and web-flow commits; no writes on clean PRs; resolve and update paths for the sticky comment; marker comments from non-bot authors ignored), by a negative control confirming the test fails when the script exits nonzero, and by dry-running the script (writes stubbed) against real PRs with both outcomes.