### PR TITLE
fix(qwen3): reclaim completed KV blocks when prefix cache is off (#681)

### DIFF
--- a/docs/models/qwen3/prefix-cache.md
+++ b/docs/models/qwen3/prefix-cache.md
@@ -50,7 +50,7 @@ Negative result: registering 40 extra unique ~1900-token prompts did not move wa
 
 - **RoPE scalar-path corruption (fixed on this branch).** `prefill_attention_paged_into` had a `batch_size == 1` fast path that used a scalar `start_pos` (always 0 from the qwen3 call site) instead of the plan's per-token positions array. Cold runs were unaffected (start really is 0); warm bs=1 prefills rotated the suffix K/Q from position 0 and scattered the mis-rotated K into KV pages — decode drift up to 3.3 nat in `hf_golden_gate` cached replay. The scalar branch and its dead kernel wrapper (`prefill_qk_norm_rope_only_cuda`) are deleted; all callers go through the positions array, which is bit-identical for cold runs (both C entry points launched the same kernel). Lesson: a "fast path" that duplicates position logic is a fork that only breaks when positions stop being trivial.
 - **TTFT measurement: drain the stream.** The server has no abort-on-disconnect — a client that hangs up after the first token leaves the request decoding its remaining tokens, and the *next* request's prefill contends with that zombie decode. Early-disconnect measurement inflated warm TTFT 16.3 → 25.5ms p50. Always read SSE to `[DONE]` between samples.
-- **Cache-off runs still register blocks.** Disabling matching only skips lookup; completed blocks are still registered on apply. Tests use this: phase 1 (off) builds cold baselines *and* populates the cache for phase 2 (on).
+- **Cache-off runs do not seed later warm replays.** Blocks are still registered while a request executes, but request teardown marks their canonical primaries reset-on-release. Re-enabling the cache therefore starts cold and tests must seed retained blocks explicitly before asserting a warm hit.
 
 ## Tests
 

--- a/kvbm/kvbm-logical/src/blocks/immutable.rs
+++ b/kvbm/kvbm-logical/src/blocks/immutable.rs
@@ -209,6 +209,29 @@ impl<T: BlockMetadata + Sync> ImmutableBlock<T> {
             .store_reset_on_release(self.inner.block_id, value);
     }
 
+    /// Set reset-on-release on the canonical primary for this block's hash.
+    ///
+    /// Unlike [`Self::set_evict_on_reset`], which addresses this physical
+    /// slot, this method follows a duplicate's primary keepalive. It is the
+    /// appropriate operation for a request-level retention policy: duplicate
+    /// slots already reset unconditionally, while their otherwise-hidden
+    /// primary would fall back to the inactive cache on its final drop.
+    ///
+    /// For a primary block this is equivalent to
+    /// `set_evict_on_reset(value)`. For a duplicate it updates the primary
+    /// pinned by that duplicate. Multiple callers use the same last-writer-wins
+    /// semantics as the physical-slot setter.
+    pub fn set_primary_evict_on_reset(&self, value: bool) {
+        let primary = self
+            .inner
+            ._primary_keepalive
+            .as_ref()
+            .unwrap_or(&self.inner);
+        primary
+            .store
+            .store_reset_on_release(primary.block_id, value);
+    }
+
     /// Type-erased lifecycle pin for cross-policy use.
     ///
     /// Returns an [`LifecyclePinRef`] that:

--- a/kvbm/kvbm-logical/src/blocks/immutable.rs
+++ b/kvbm/kvbm-logical/src/blocks/immutable.rs
@@ -209,19 +209,12 @@ impl<T: BlockMetadata + Sync> ImmutableBlock<T> {
             .store_reset_on_release(self.inner.block_id, value);
     }
 
-    /// Set reset-on-release on the canonical primary for this block's hash.
+    /// Set reset-on-release on this block's canonical primary.
     ///
-    /// Unlike [`Self::set_evict_on_reset`], which addresses this physical
-    /// slot, this method follows a duplicate's primary keepalive. It is the
-    /// appropriate operation for a request-level retention policy: duplicate
-    /// slots already reset unconditionally, while their otherwise-hidden
-    /// primary would fall back to the inactive cache on its final drop.
-    ///
-    /// For a primary block this is equivalent to
-    /// `set_evict_on_reset(value)`. For a duplicate it updates the primary
-    /// pinned by that duplicate. Multiple callers use the same last-writer-wins
-    /// semantics as the physical-slot setter.
-    pub fn set_primary_evict_on_reset(&self, value: bool) {
+    /// A duplicate resets itself but keeps its primary alive; marking the
+    /// primary prevents that hidden block from entering the inactive cache on
+    /// final drop.
+    pub fn set_primary_reset_on_release(&self, value: bool) {
         let primary = self
             .inner
             ._primary_keepalive

--- a/kvbm/kvbm-logical/src/manager/tests.rs
+++ b/kvbm/kvbm-logical/src/manager/tests.rs
@@ -3892,6 +3892,63 @@ mod reset_on_release_tests {
         );
     }
 
+    /// A non-retaining caller can own a duplicate rather than the canonical
+    /// primary. Marking the physical duplicate is insufficient because the
+    /// duplicate already resets unconditionally; the hidden primary held by
+    /// `_primary_keepalive` must receive the reset-on-release policy instead.
+    #[test]
+    fn duplicate_can_mark_canonical_primary_for_reset() {
+        let registry = crate::registry::BlockRegistry::builder()
+            .frequency_tracker(
+                crate::manager::FrequencyTrackingCapacity::default().create_tracker(),
+            )
+            .build();
+        let manager = BlockManager::<TestBlockData>::builder()
+            .block_count(4)
+            .block_size(4)
+            .registry(registry)
+            .with_lru_backend()
+            .duplication_policy(BlockDuplicationPolicy::Allow)
+            .build()
+            .expect("build manager");
+
+        let token = create_test_token_block_from_iota(50_041);
+        let hash = token.kvbm_sequence_hash();
+
+        let primary_mutable = manager
+            .allocate_blocks(1)
+            .expect("allocate primary")
+            .into_iter()
+            .next()
+            .unwrap();
+        let primary = manager.register_block(primary_mutable.complete(&token).unwrap());
+
+        let duplicate_mutable = manager
+            .allocate_blocks(1)
+            .expect("allocate duplicate")
+            .into_iter()
+            .next()
+            .unwrap();
+        let duplicate = manager.register_block(duplicate_mutable.complete(&token).unwrap());
+        assert_ne!(primary.block_id(), duplicate.block_id());
+
+        duplicate.set_primary_evict_on_reset(true);
+
+        let store = manager.store_for_test();
+        drop(primary);
+        assert_eq!(
+            store.reset_len(),
+            2,
+            "the duplicate must keep the primary active until its own drop"
+        );
+
+        drop(duplicate);
+
+        assert_eq!(store.inactive_len(), 0);
+        assert_eq!(store.reset_len(), 4);
+        assert!(!manager.block_registry().is_registered(hash));
+    }
+
     /// Pool gauges (`inflight_immutable`, `inactive_pool_size`,
     /// `reset_pool_size`) must stay coherent across the full lifecycle
     /// when the reset-on-release flag fires. Regression-protects the

--- a/kvbm/kvbm-logical/src/manager/tests.rs
+++ b/kvbm/kvbm-logical/src/manager/tests.rs
@@ -3892,26 +3892,10 @@ mod reset_on_release_tests {
         );
     }
 
-    /// A non-retaining caller can own a duplicate rather than the canonical
-    /// primary. Marking the physical duplicate is insufficient because the
-    /// duplicate already resets unconditionally; the hidden primary held by
-    /// `_primary_keepalive` must receive the reset-on-release policy instead.
+    /// A duplicate must mark its hidden primary, not only its own slot.
     #[test]
     fn duplicate_can_mark_canonical_primary_for_reset() {
-        let registry = crate::registry::BlockRegistry::builder()
-            .frequency_tracker(
-                crate::manager::FrequencyTrackingCapacity::default().create_tracker(),
-            )
-            .build();
-        let manager = BlockManager::<TestBlockData>::builder()
-            .block_count(4)
-            .block_size(4)
-            .registry(registry)
-            .with_lru_backend()
-            .duplication_policy(BlockDuplicationPolicy::Allow)
-            .build()
-            .expect("build manager");
-
+        let manager = create_test_manager(4);
         let token = create_test_token_block_from_iota(50_041);
         let hash = token.kvbm_sequence_hash();
 
@@ -3932,7 +3916,7 @@ mod reset_on_release_tests {
         let duplicate = manager.register_block(duplicate_mutable.complete(&token).unwrap());
         assert_ne!(primary.block_id(), duplicate.block_id());
 
-        duplicate.set_primary_evict_on_reset(true);
+        duplicate.set_primary_reset_on_release(true);
 
         let store = manager.store_for_test();
         drop(primary);

--- a/openinfer-kv-cache/src/pool.rs
+++ b/openinfer-kv-cache/src/pool.rs
@@ -453,6 +453,21 @@ impl RequestKv {
             .map_err(|e| anyhow::anyhow!("release: {e}"))
     }
 
+    /// Make every registered block owned by this request bypass inactive
+    /// retention when its final guard drops.
+    ///
+    /// The canonical-primary operation is intentional: an assignment can be
+    /// a duplicate whose physical slot already resets on drop while its hidden
+    /// primary remains pinned. Marking that primary ensures a no-prefix-cache
+    /// request returns all of its physical footprint to the reset pool.
+    /// Unassigned reservations need no marking because they already reset via
+    /// their mutable-block RAII guards.
+    pub fn mark_blocks_reset_on_release(&self) {
+        for (_, block) in self.seq.inner().assignments().assigned_iter() {
+            block.set_primary_evict_on_reset(true);
+        }
+    }
+
     // ── Queries ────────────────────────────────────────────────────────
 
     /// Tokens with KV already computed.
@@ -645,6 +660,110 @@ mod tests {
             ha[0],
             "salt (lora) must scope the prefix cache"
         );
+    }
+
+    fn complete_non_retained_speculative_request(
+        pool: &BlockPool,
+        prompt: &[u32],
+        max_output_tokens: usize,
+    ) {
+        const MAX_PREFILL_CHUNK: usize = 1024;
+        const MAX_VERIFY_SPAN: usize = 17;
+
+        let mut request = pool.new_request(prompt.to_vec(), max_output_tokens, None);
+        let mut prefilled = 0;
+        while prompt.len() - prefilled > MAX_PREFILL_CHUNK {
+            request
+                .schedule_prefill(MAX_PREFILL_CHUNK, pool)
+                .expect("schedule prefill chunk");
+            request
+                .apply_prefill_chunk(pool)
+                .expect("apply prefill chunk");
+            prefilled += MAX_PREFILL_CHUNK;
+        }
+        request
+            .schedule_prefill(prompt.len() - prefilled, pool)
+            .expect("schedule final prefill chunk");
+        request
+            .apply_prefill(70_000, pool)
+            .expect("apply final prefill chunk");
+
+        while !request.is_complete() {
+            let span = (max_output_tokens - request.generated_tokens()).min(MAX_VERIFY_SPAN);
+            request
+                .schedule_speculative(span, pool)
+                .expect("schedule speculative verify");
+            let accepted = (0..span)
+                .map(|offset| 80_000 + offset as u32)
+                .collect::<Vec<_>>();
+            request
+                .apply_speculative(&accepted, pool)
+                .expect("apply speculative verify");
+        }
+
+        request.mark_blocks_reset_on_release();
+    }
+
+    /// DFlash recomputes identical prompts because prefix matching is off.
+    /// Completed requests must therefore reset their registered primaries;
+    /// otherwise the next recomputation creates duplicates whose canonical
+    /// keepalives consume capacity outside the request's scheduler footprint.
+    #[test]
+    fn non_retained_speculative_requests_reuse_all_completed_blocks() {
+        let pool = BlockPool::new(16, 10).unwrap();
+        let baseline = pool.available_blocks();
+        let prompt = (0..64).map(|i| 10_000 + i).collect::<Vec<_>>();
+
+        for round in 0..8 {
+            complete_non_retained_speculative_request(&pool, &prompt, 32);
+            assert_eq!(
+                pool.available_blocks(),
+                baseline,
+                "round {round} leaked request KV capacity"
+            );
+        }
+    }
+
+    /// CPU-only shape of issue #681: 160 request pages, a 1643-token prompt
+    /// split into 1024 + 619 prefill chunks, 512 output tokens, and 17-token
+    /// speculative verify spans. A completed request must leave enough clean
+    /// pages for the identical request to finish again.
+    #[test]
+    fn issue_681_profiled_capacity_reuses_blocks_across_requests() {
+        // BlockPool reserves one additional CUDA-graph padding page.
+        let pool = BlockPool::new(16, 161).unwrap();
+        assert_eq!(pool.max_request_blocks(), 160);
+        let baseline = pool.available_blocks();
+        let prompt = (0..1643).map(|i| 30_000 + i).collect::<Vec<_>>();
+
+        for round in 0..2 {
+            complete_non_retained_speculative_request(&pool, &prompt, 512);
+            assert_eq!(
+                pool.available_blocks(),
+                baseline,
+                "issue #681 request {round} did not release its KV pages"
+            );
+        }
+    }
+
+    /// The non-retention path is opt-in. Ordinary prefix-cache requests still
+    /// leave registered primaries in the inactive pool for a later match.
+    #[test]
+    fn retained_request_blocks_still_match_as_prefix() {
+        let pool = BlockPool::new(16, 10).unwrap();
+        let prompt = (0..33).map(|i| 20_000 + i).collect::<Vec<_>>();
+
+        let mut first = pool.new_request(prompt.clone(), 1, None);
+        first
+            .schedule_prefill(prompt.len(), &pool)
+            .expect("schedule seed prefill");
+        first
+            .apply_prefill(90_000, &pool)
+            .expect("apply seed prefill");
+        drop(first);
+
+        let mut replay = pool.new_request(prompt, 1, None);
+        assert_eq!(replay.match_and_add_prefix(&pool).unwrap(), 32);
     }
 
     /// kvbm's `schedule_decode` allocates the next generation block when the

--- a/openinfer-kv-cache/src/pool.rs
+++ b/openinfer-kv-cache/src/pool.rs
@@ -453,18 +453,14 @@ impl RequestKv {
             .map_err(|e| anyhow::anyhow!("release: {e}"))
     }
 
-    /// Make every registered block owned by this request bypass inactive
-    /// retention when its final guard drops.
+    /// Mark every assigned block's canonical primary to reset on release.
     ///
-    /// The canonical-primary operation is intentional: an assignment can be
-    /// a duplicate whose physical slot already resets on drop while its hidden
-    /// primary remains pinned. Marking that primary ensures a no-prefix-cache
-    /// request returns all of its physical footprint to the reset pool.
-    /// Unassigned reservations need no marking because they already reset via
-    /// their mutable-block RAII guards.
+    /// A duplicate resets itself but keeps its primary alive; marking the
+    /// primary prevents that hidden block from entering the inactive cache on
+    /// final drop.
     pub fn mark_blocks_reset_on_release(&self) {
         for (_, block) in self.seq.inner().assignments().assigned_iter() {
-            block.set_primary_evict_on_reset(true);
+            block.set_primary_reset_on_release(true);
         }
     }
 
@@ -704,26 +700,6 @@ mod tests {
         request.mark_blocks_reset_on_release();
     }
 
-    /// DFlash recomputes identical prompts because prefix matching is off.
-    /// Completed requests must therefore reset their registered primaries;
-    /// otherwise the next recomputation creates duplicates whose canonical
-    /// keepalives consume capacity outside the request's scheduler footprint.
-    #[test]
-    fn non_retained_speculative_requests_reuse_all_completed_blocks() {
-        let pool = BlockPool::new(16, 10).unwrap();
-        let baseline = pool.available_blocks();
-        let prompt = (0..64).map(|i| 10_000 + i).collect::<Vec<_>>();
-
-        for round in 0..8 {
-            complete_non_retained_speculative_request(&pool, &prompt, 32);
-            assert_eq!(
-                pool.available_blocks(),
-                baseline,
-                "round {round} leaked request KV capacity"
-            );
-        }
-    }
-
     /// CPU-only shape of issue #681: 160 request pages, a 1643-token prompt
     /// split into 1024 + 619 prefill chunks, 512 output tokens, and 17-token
     /// speculative verify spans. A completed request must leave enough clean
@@ -744,26 +720,6 @@ mod tests {
                 "issue #681 request {round} did not release its KV pages"
             );
         }
-    }
-
-    /// The non-retention path is opt-in. Ordinary prefix-cache requests still
-    /// leave registered primaries in the inactive pool for a later match.
-    #[test]
-    fn retained_request_blocks_still_match_as_prefix() {
-        let pool = BlockPool::new(16, 10).unwrap();
-        let prompt = (0..33).map(|i| 20_000 + i).collect::<Vec<_>>();
-
-        let mut first = pool.new_request(prompt.clone(), 1, None);
-        first
-            .schedule_prefill(prompt.len(), &pool)
-            .expect("schedule seed prefill");
-        first
-            .apply_prefill(90_000, &pool)
-            .expect("apply seed prefill");
-        drop(first);
-
-        let mut replay = pool.new_request(prompt, 1, None);
-        assert_eq!(replay.match_and_add_prefix(&pool).unwrap(), 32);
     }
 
     /// kvbm's `schedule_decode` allocates the next generation block when the

--- a/openinfer-qwen3/src/executor.rs
+++ b/openinfer-qwen3/src/executor.rs
@@ -1546,9 +1546,28 @@ impl Qwen3Executor {
 
     /// Prefix caching is on by default; tests that assert bit-identical
     /// replay disable it (a cache hit changes prefill GEMM shapes, which
-    /// drifts logits by bf16 ULPs).
+    /// drifts logits by bf16 ULPs). Disabling it also disables retention of
+    /// completed request blocks: retaining blocks that can never be matched
+    /// creates duplicate primaries outside request-level capacity accounting.
     pub fn set_prefix_cache_enabled(&mut self, enabled: bool) {
+        let retained_before = self.retains_completed_kv_blocks();
         self.prefix_cache_enabled = enabled;
+        self.finish_retention_transition(retained_before);
+    }
+
+    /// Whether a completed request should leave its registered GPU blocks in
+    /// the inactive L1 cache for a later prefix match.
+    fn retains_completed_kv_blocks(&self) -> bool {
+        self.prefix_cache_enabled && !self.l1_retention_disabled
+    }
+
+    /// Drain blocks retained under the old policy once when L1 retention is
+    /// disabled. Active blocks are untouched; `drop_request` marks them for
+    /// reset when their final owners finish.
+    fn finish_retention_transition(&mut self, retained_before: bool) {
+        if retained_before && !self.retains_completed_kv_blocks() {
+            self.kv_mgr.pool().evict_inactive();
+        }
     }
 
     /// Configure two-stream prefill/decode overlap (see [`crate::DecodeOverlap`]).
@@ -1604,9 +1623,11 @@ impl Qwen3Executor {
     /// way to force the bytes from L2 is to not keep the HBM copy around.
     pub fn set_no_prefix_cache(&mut self, on: bool) {
         if self.offload.is_some() {
+            let retained_before = self.retains_completed_kv_blocks();
             self.l1_retention_disabled = on;
+            self.finish_retention_transition(retained_before);
         } else {
-            self.prefix_cache_enabled = !on;
+            self.set_prefix_cache_enabled(!on);
         }
     }
 
@@ -1632,7 +1653,7 @@ impl Qwen3Executor {
             "Qwen3 DFlash speculative decoding enabled: draft block size {}",
             meta.block_size
         );
-        self.prefix_cache_enabled = false;
+        self.set_prefix_cache_enabled(false);
         self.speculative = Some(meta);
         Ok(())
     }
@@ -2217,16 +2238,23 @@ impl ModelExecutor for Qwen3Executor {
         // Remove and drop — RAII on SchedulableSequence's block guards
         // returns all allocated blocks regardless of lifecycle state. The same
         // RAII frees any parked prefetch's reserved/held blocks.
-        let removed = self.request_kvs.remove(&request_id);
+        let retain_completed_kv = self.retains_completed_kv_blocks();
+        let mut removed = self.request_kvs.remove(&request_id);
         // With the event feed on, capture this request's still-unflushed store
         // run before its cursor is gone: a request can register its last full
         // block in the very step it finishes (see `ExecutorKvEvents`).
-        if let (Some(mut rkv), Some(events)) = (removed, self.kv_events.as_mut()) {
-            let run = rkv.take_newly_registered_blocks();
-            if !run.is_empty() {
-                events.pending_dropped.push(run);
+        if let Some(rkv) = removed.as_mut() {
+            if let Some(events) = self.kv_events.as_mut() {
+                let run = rkv.take_newly_registered_blocks();
+                if !run.is_empty() {
+                    events.pending_dropped.push(run);
+                }
+            }
+            if !retain_completed_kv {
+                rkv.mark_blocks_reset_on_release();
             }
         }
+        drop(removed);
         // A parked prefetch may still have a load in flight: pegaflow's worker
         // is writing the reserved GPU blocks (H2D). Dropping the reservation now
         // frees those physical pages for immediate reuse while the DMA keeps

--- a/openinfer-qwen3/tests/hf_golden_gate.rs
+++ b/openinfer-qwen3/tests/hf_golden_gate.rs
@@ -576,12 +576,13 @@ fn run_eager_suite(golden: &Golden, model_path: &str, devices: &[usize], label: 
     let (batched, _) = run(golden, &mut ex, &all[..n], true);
     report_and_assert(&format!("{label}batched eager ({n}, no pad)"), &batched);
 
-    // Prefix-cached replay. Every block is already registered (the runs
-    // above register blocks even with matching disabled), so these rerun
-    // with warm caches: prefill skips the cached prefix and attention spans
-    // cached KV + recomputed suffix (kv_len > q_len). Same HF tolerances —
-    // a wrong RoPE offset, mask, or stale page would blow far past them.
+    // Prefix-cached replay. Matching-disabled requests intentionally reset
+    // their completed blocks, so first seed under enabled retention and then
+    // rerun warm: prefill skips the cached prefix and attention spans cached
+    // KV + recomputed suffix (kv_len > q_len). Same HF tolerances — a wrong
+    // RoPE offset, mask, or stale page would blow far past them.
     ex.set_prefix_cache_enabled(true);
+    let _ = run(golden, &mut ex, &all, false);
     let (cached, _) = run(golden, &mut ex, &all, false);
     assert!(
         cached.cached_tokens > 0,
@@ -644,6 +645,7 @@ fn pega_logprobs_match_hf_golden_within_bf16_tolerance() {
         // tables that now point at blocks written by earlier requests.
         ex.set_prefix_cache_enabled(true);
         let n = BUCKET_STRADDLES[1];
+        let _ = run(&golden, &mut ex, &all[..n], true);
         let (cached, _) = run(&golden, &mut ex, &all[..n], true);
         assert!(
             cached.cached_tokens > 0,

--- a/openinfer-qwen3/tests/prefix_cache.rs
+++ b/openinfer-qwen3/tests/prefix_cache.rs
@@ -173,8 +173,9 @@ fn prefix_cache_behavior() {
     let c = prompt(3, 64); // exactly 4 blocks — the cap edge
     let d = prompt(4, 40); // never seen before the mixed batch
 
-    // ── Phase 1: matching disabled — true cold baselines. apply_prefill /
-    // apply_decode still register completed blocks, so phase 2 finds them.
+    // ── Phase 1: matching and completed-block retention disabled — true cold
+    // baselines. Dropping each request resets its registered KV, so enabling
+    // the cache later must start cold rather than resurrecting these blocks.
     ex.set_prefix_cache_enabled(false);
     let (cached, a_cold) = run_one(&mut ex, 1, &a);
     assert_eq!(
@@ -184,8 +185,16 @@ fn prefix_cache_behavior() {
     let (_, b_cold) = run_one(&mut ex, 2, &b);
     let (_, c_cold) = run_one(&mut ex, 3, &c);
 
-    // ── Phase 2: warm replays.
+    // ── Phase 2: enable retention and seed the cache explicitly. The first A
+    // run must be cold: phase 1's disabled-mode request may not survive.
     ex.set_prefix_cache_enabled(true);
+    let (cached, _) = run_one(&mut ex, 4, &a);
+    assert_eq!(
+        cached, 0,
+        "cache-disabled requests must not seed a later enabled cache"
+    );
+    let _ = run_one(&mut ex, 5, &b);
+    let _ = run_one(&mut ex, 6, &c);
 
     let (cached, a_warm) = run_one(&mut ex, 11, &a);
     assert_eq!(
@@ -240,6 +249,14 @@ fn prefix_cache_behavior() {
     ex.drop_request(RequestId::new(31)).expect("drop");
     assert_close("D cold in mixed batch", &d_solo, &d_mixed);
     ex.set_prefix_cache_enabled(true);
+
+    // Disabling the cache above drained the earlier A/B/C primaries. Seed B
+    // again so the unified-path assertions below exercise warm page reuse.
+    let (cached, _) = run_one(&mut ex, 32, &b);
+    assert_eq!(
+        cached, 0,
+        "re-enabled cache starts cold after transition drain"
+    );
 
     // ── Unified path: warm prefill of A while another request decodes.
     let pr = ex


### PR DESCRIPTION
Qwen3 DFlash disables prefix matching so the target prefill produces fresh hidden states for the draft model, but disabling matching did not disable retention of completed request blocks. Registered blocks entered kvbm's inactive cache even though no later DFlash request can match them; when a later request recomputed the same hash, BlockDuplicationPolicy::Allow registered a duplicate that pinned the old primary via _primary_keepalive, leaving it physically resident but invisible to scheduler accounting. Near capacity, speculative verification then failed to allocate its next page.

Add ImmutableBlock::set_primary_evict_on_reset to mark the canonical primary (followed through a duplicate's keepalive) for reset-on-release, and RequestKv::mark_blocks_reset_on_release to apply it across a request's registered assignments. Qwen3 centralizes the retention decision in retains_completed_kv_blocks / finish_retention_transition: enabling->disabling drains the inactive pool once, and drop_request marks a completed request's blocks for reset when retention is off. Prefix-cache-enabled serving keeps its existing inactive-cache reuse behaviour.

## Description

Fixes #681 (issue number)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project (see `docs/conventions/coding-style.md`).
- [x] I have performed a self-review of my own code.
- [x] I have formatted my commits according to Commitizen conventions.
- [x] I have run the local test suite and all tests pass (see `CLAUDE.md`).
