### PR TITLE
perf(qwen3): prefetch checkpoint once across sequential TP rank loads

### DIFF
--- a/openinfer-core/src/weight_loader.rs
+++ b/openinfer-core/src/weight_loader.rs
@@ -49,7 +49,7 @@ pub fn load_shard_info(model_path: &str) -> Result<(Vec<String>, HashMap<String,
     Ok((shard_files, weight_map))
 }
 
-/// Advisory parallel page-cache prefetch for a single-rank whole-model load;
+/// Advisory parallel page-cache prefetch for a whole-checkpoint load;
 /// the loader never depends on it. Dropping cancels and joins the workers, and
 /// failures are aggregated into one warning with the first cause retained.
 pub struct WeightPrefetch {

--- a/openinfer-qwen3/src/executor.rs
+++ b/openinfer-qwen3/src/executor.rs
@@ -19,6 +19,7 @@ use openinfer_core::kv_pool::KvLayout;
 use openinfer_core::ops;
 use openinfer_core::sampler::SamplingParams;
 use openinfer_core::tensor::{DeviceContext, HiddenStates};
+use openinfer_core::weight_loader::{WeightPrefetch, load_shard_info};
 use openinfer_kv_cache::{
     KvBlockGuard, KvBuffer, KvCacheEvent, KvCacheManager, KvView, LoadReservation, PrefixProbe,
     RegisteredBlock,
@@ -1355,6 +1356,10 @@ impl Qwen3Executor {
 
         let world_size = device_ordinals.len();
         let mut models = Vec::with_capacity(world_size);
+        // TP ranks load sequentially and suppress per-rank prefetch, so keep one
+        // whole-checkpoint prefetch alive across the loop.
+        let (shard_paths, _) = load_shard_info(model_path)?;
+        let prefetch = WeightPrefetch::spawn(&shard_paths);
         for (rank, &device_ordinal) in device_ordinals.iter().enumerate() {
             models.push(Qwen3Model::from_safetensors_with_runtime(
                 model_path,
@@ -1367,6 +1372,7 @@ impl Qwen3Executor {
                 },
             )?);
         }
+        drop(prefetch);
         // Profile each rank independently and use the minimum shared block
         // count. The logical scheduler uses one block budget for all ranks, but
         // free memory and worker-thread runtime allocations are per device.


### PR DESCRIPTION

## Description

Follow-up to #731: enabling its whole-checkpoint prefetch inside each TP rank would multiply prefetch reads by world_size. Qwen3 loads TP ranks sequentially, so the executor now keeps one shared WeightPrefetch alive across the rank loop while per-rank prefetch remains disabled.

Measured on a GH200 node (aarch64, sm_90), Qwen3-14B (29.5 GB, 8 shards) at `--tp-size 2`, weights on a Lustre parallel filesystem, two cold and two warm repetitions per arm, cold arms interleaved to reduce temporal drift, client page cache evicted via `posix_fadvise(DONTNEED)` before each cold repetition (client-cold/server-warm regime, as in #731):

| arm | cold: rank-0 weights / engine ready | warm: rank-0 weights / engine ready |
|---|---|---|
| base (#731 binary) | 3.5 s / 10.8–11.5 s | 1.49 s / 8.9 s |
| prefetch across ranks | 1.6–1.7 s / 9.1–9.2 s | 1.48–1.49 s / 8.5 s |

Cold engine ready improves by 15–20%. Rank 1 is already fast in the base arm (1.3–1.6 s cold) because rank 0's page faults leave much of the file cached; the prefetch mainly brings rank 0 to that speed. There is no measurable warm rank-0 weight-phase cost; the warm arms ran sequentially rather than interleaved, so the small warm ready-time difference is not attributable to the change.

Validation: the greedy completion at `--tp-size 2` is byte-identical between the two binaries in every run; zero prefetch threads alive at server ready and zero failure warnings in all runs; the prefetch log line appears only in the patched arm; `cargo clippy` clean.