### PR TITLE
fix: restore --all-features build for qwen35-4b and bench_serving

### DIFF
--- a/openinfer-qwen35-4b/src/lib.rs
+++ b/openinfer-qwen35-4b/src/lib.rs
@@ -287,7 +287,8 @@ mod tests {
             1,
             Qwen35SchedulerPolicy::Auto,
         )
-        .unwrap_err()
+        .err()
+        .expect("scheduler policy validation should reject TP launch")
         .to_string();
 
         assert!(err.contains("scheduler policy"));

--- a/openinfer-qwen35-4b/src/scheduler.rs
+++ b/openinfer-qwen35-4b/src/scheduler.rs
@@ -47,6 +47,7 @@ use self::plan::max_kv_tokens;
 use self::plan::plan_prefill_chunks;
 use self::plan::prefilling_future_pages;
 use self::plan::slot_for_new_request;
+use crate::Qwen35SchedulerPolicy;
 use crate::batch_decode_graph::BatchDecodeGraphState;
 use crate::executor::DecodeRequestResult;
 use crate::executor::DecodeResult;

--- a/openinfer-server/src/bin/bench_serving/main.rs
+++ b/openinfer-server/src/bin/bench_serving/main.rs
@@ -275,6 +275,10 @@ mod tests {
     use openinfer::sampler::SamplingParams;
 
     use super::*;
+    use crate::exec::assert_dsv2_lite_sampling_contract;
+    use crate::exec::timings_from_dsv2_lite_attribution;
+    use crate::exec::timings_from_dsv2_lite_batched_generation;
+    use crate::runners::build_request_metrics;
 
     #[test]
     fn dsv2_lite_sampling_contract_accepts_bench_params() {


### PR DESCRIPTION
## Summary

Three compile errors in feature-gated code paths that default-feature CI never compiles, all surfaced while running an `--all-features` workspace analysis (with [hawk](https://github.com/astral-sh/hawk), a workspace visibility lint):

- **`openinfer-qwen35-4b/src/scheduler.rs`** referenced `Qwen35SchedulerPolicy` (added in #730) without importing it → E0425/E0433 ×4 under `--features qwen35-4b`. The whole crate sits behind `#![cfg(feature = "qwen35-4b")]`, so the default build never sees it.
- **`openinfer-qwen35-4b/src/lib.rs`** (policy test) called `.unwrap_err()` on `Result<EngineHandle, _>`, which requires `EngineHandle: Debug` → E0277 in the lib test target. Replaced with `.err().expect(...)`, same assertion, no `Debug` bound.
- **`openinfer-server/src/bin/bench_serving/main.rs`** — the `#[cfg(all(test, feature = "deepseek-v2-lite"))]` module calls `exec::`/`runners::` helpers without importing them → 12 × E0425 when the dsv2 feature is enabled.

All changes are import/assertion-style only; no behavior change.

## Verification (pinned nightly-2026-07-10)

```sh
cargo check -p openinfer-qwen35-4b --features qwen35-4b --all-targets
cargo check -p openinfer-server --all-features --all-targets   # needs OPENINFER_NCCL_ROOT
cargo check -p openinfer-kimi-k2 -p openinfer-glm52 -p openinfer-deepseek-v2-lite --all-features --all-targets
```

All pass. Before this PR, the first and second failed with the errors above.

## Note

These failure classes (feature-gated lib + test targets) are currently invisible to CI, which builds default features only. Worth considering an `--all-features --all-targets` check job; happy to follow up with one.