### PR TITLE
perf(core): pinned double-buffered staging for weight uploads

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -140,7 +140,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 | --- | --- |
 | `subsystems/frontend/simulated-inference-engine.md` | CPU-only simulated model crate for vLLM/OpenAI frontend and `vllm bench serve` validation without CUDA, real model weights, or real-model performance claims. |
 | `subsystems/frontend/cpu-profiling-baseline.md` | Frontend CPU profiling baseline using `openinfer-sim` with fixed TTFT=5ms/TPOT=12ms: 200 req / concurrency=16 shows ~150ms TTFT overhead (no dominant hotspot), heap allocation ~10%, stream polling ~7.5%, IPC ~1%; reproducible benchmark command and perf evidence documented. |
-| `subsystems/frontend/startup-time.md` | Qwen3-4B warm startup-to-ready 3.25s → ~1.45s: frontend tokenizer load runs concurrently with the engine load (HTTP still binds only after the engine registers), and the source safetensors mmap is kept alive to dodge ~0.4s of munmap stalling the next cudaMalloc. |
+| `subsystems/frontend/startup-time.md` | Qwen3-4B warm startup-to-ready: frontend tokenizer load runs concurrently with the engine load (HTTP still binds only after the engine registers); mmap teardown is paid at the end of load since #377; pinned-staging upload (2026-07) cuts warm ready 5.22s → 4.66s on sm_89, and the remaining floor is the engine's own post-load startup work. |
 | `subsystems/frontend/prometheus-metrics.md` | `/metrics` request histograms work for every model; Qwen3, Qwen3.5, and GLM5.2 schedulers also publish running/waiting/KV engine gauges through `LoadSnapshot` watches. |
 | `subsystems/frontend/dashboards/README.md` | Grafana 10.4-validated dashboard for OpenInfer's live `/metrics` surface: HTTP traffic, request outcomes, scheduler/KV state, token throughput, and request latency. |
 

--- a/docs/subsystems/frontend/startup-time.md
+++ b/docs/subsystems/frontend/startup-time.md
@@ -1,8 +1,8 @@
 # Server startup-to-ready time
 
-**TL;DR**: Qwen3-4B warm (page-cache-hot) startup-to-HTTP-ready cut 3.25s → ~1.45s by (1) loading the engine on a blocking thread so the vLLM frontend's ~1.15s tokenizer/chat-template load runs concurrently, and (2) keeping the source safetensors mmap alive for the model's lifetime instead of paying ~0.4s of munmap page-table teardown on the critical path. Readiness semantics unchanged: HTTP binds only after the engine bridge registers.
+**TL;DR**: Qwen3-4B warm (page-cache-hot) startup-to-HTTP-ready cut 3.25s → ~1.45s by (1) loading the engine on a blocking thread so the vLLM frontend's ~1.15s tokenizer/chat-template load runs concurrently, and (2) moving the ~0.4s munmap page-table teardown of the touched source mmap off the allocation hot path (since #377 it is paid once at the end of the load function). Readiness semantics unchanged: HTTP binds only after the engine bridge registers. 2026-07: the engine path has since outgrown the frontend overlap, and the once-rejected pinned-staging upload is adopted (warm ready 5.22s → 4.66s on sm_89) — see below.
 
-Last touched: 2026-06
+Last touched: 2026-07
 
 ## Warm-start breakdown (RTX 5070 Ti, Qwen3-4B, 8GB bf16)
 
@@ -10,15 +10,15 @@ Baseline 3.25s was three serial phases:
 
 | Phase | Cost | Fix |
 | --- | --- | --- |
-| Engine load (CUDA ctx 0.18s + H2D upload ~1.1s @ ~7GB/s pageable) | 1.3s | kept (pageable `clone_htod`; pinned staging judged not worth the complexity — see below) |
-| munmap of the 8GB touched source mmap | 0.42s | mmap now lives in `Qwen3Model::_weight_source` until model drop |
+| Engine load (CUDA ctx 0.18s + H2D upload ~1.1s @ ~7GB/s pageable) | 1.3s | pageable at the time; pinned staging adopted 2026-07 — see below |
+| munmap of the 8GB touched source mmap | 0.42s | dropped at the end of the load function since #377 |
 | vLLM frontend: tokenizer (11MB tokenizer.json) + text/chat backends | 1.15s | runs concurrently with engine load |
 
 After: engine path ~1.35s and frontend path ~1.25s overlap; ready ≈ max of the two + process start ≈ 1.45s.
 
 ## The munmap trap
 
-munmap of ~8GB of touched pages costs ~0.4s of kernel page-table teardown holding the process mmap lock. Dropping the mmaps "in the background" just moves the stall to whatever allocates next — cudaMalloc (KV cache), cuBLAS init on the worker thread, or first-decode graph capture all take the same lock. We measured the 0.4s gap migrating from `kv_budget` → `KvCacheManager::new` → `RankWorker::spawn` as the drop point moved. Keeping the mapping is free: the pages are clean file-backed page cache the kernel reclaims under pressure, so the only cost is RSS accounting.
+munmap of ~8GB of touched pages costs ~0.4s of kernel page-table teardown holding the process mmap lock. Dropping the mmaps "in the background" just moves the stall to whatever allocates next — cudaMalloc (KV cache), cuBLAS init on the worker thread, or first-decode graph capture all take the same lock. We measured the 0.4s gap migrating from `kv_budget` → `KvCacheManager::new` → `RankWorker::spawn` as the drop point moved. The 2026-06 fix kept the mapping alive for the model's lifetime; #377 later changed this to an explicit drop at the end of the load function (after the `GPU model loaded` timing log), so the teardown is paid once before profiling starts instead of at an arbitrary later allocation point.
 
 ## Concurrent startup invariant (openinfer-vllm-frontend)
 
@@ -30,10 +30,10 @@ Consequences to keep in mind:
 - The graceful ctrl-c handler is installed only **after** the engine load resolves (`cancel_token_on_ctrl_c`). The blocking load can't be cancelled, so during load SIGINT keeps its default kill behavior — same as before the change. (When testing this: background jobs of non-interactive shells inherit SIGINT=SIG_IGN; use a spawner that restores default dispositions.)
 - LoRA mode stays sequential: the LoRA routes need the handle when the router is built.
 
-## Rejected: pinned-staging H2D upload
+## Pinned-staging H2D upload (rejected 2026-06, adopted 2026-07)
 
-Upload runs at ~7GB/s from pageable mmap memory. A pinned double-buffer pipeline would reach CPU-memcpy speed (~14GB/s, ~0.55s) but the frontend path (~1.25s, external vllm crates) is the floor — e2e gain ≲0.1s for an unsafe staging pipeline. Revisit only if the tokenizer load gets faster or engine-only load time (tests/benches) becomes the pain.
+The 2026-06 rejection reasoned from the numbers above: upload ran at ~7GB/s pageable, and with the engine path (~1.35s) barely above the concurrent frontend path (~1.25s), a faster upload stood to gain ≲0.1s of HTTP-ready. By 2026-07 the engine path had grown far past that floor (warm HTTP-ready ~5.2s on sm_89), so the frontend overlap no longer hides the upload: the pinned double-buffer pipeline (`WeightStager` in openinfer-core) cuts the warm Qwen3-4B load phase ~1.26s → ~0.69s and HTTP-ready 5.22s → 4.66s — the phase saving passes through in full. (The timed load phase ends at the `GPU model loaded` log, before the mmap teardown; HTTP-ready includes everything.) Cold ready stays storage-bound (5.39s → 5.33s on local NVMe). On dual-GH200 Qwen3-14B TP2 the picture is platform-dependent: pageable copies over NVLink-C2C are already fast, so the pipeline wins there only once the strided column-shard gather lands with it (warm rank-0 load 1.19s → 0.69s vs main; the intermediate gather-only state regresses to 1.33s), validated by the TP2 golden gate with the page cache warm and cold.
 
 ## Next
 
-None active. The remaining floor is the external vllm tokenizer/backend load (~1.15s); revisit if upstream gets faster or if cold-start (bandwidth-bound, per roadmap out of scope) becomes a target.
+The warm HTTP-ready floor is now the engine's own post-load startup work (profile, warmup, graph capture — ~3.7s of the ~4.7s), no longer the frontend path; that is where the next startup-time win lives. Cold-start stays bandwidth-bound (per roadmap out of scope).

--- a/openinfer-core/src/weight_loader.rs
+++ b/openinfer-core/src/weight_loader.rs
@@ -401,11 +401,11 @@ impl<'a> StagedWeightLoader<'a> {
                 .is_some_and(|end| end <= src_cols),
             "col range out of bounds for '{name}': col_offset={col_offset} take={take} total_cols={src_cols}"
         );
-        let host = gather_cols(full, src_rows, src_cols, col_offset, take);
         // SAFETY: fully overwritten by the staged upload below.
-        let mut data = unsafe { self.ctx.stream.alloc::<bf16>(host.len()) }
+        let mut data = unsafe { self.ctx.stream.alloc::<bf16>(src_rows * take) }
             .map_err(|e| anyhow::anyhow!("Alloc failed for '{name}': {e}"))?;
-        self.stager.upload(&host, &mut data, 0)?;
+        self.stager
+            .upload_cols(full, src_cols, col_offset, take, &mut data)?;
         Ok(DeviceMatrix {
             data,
             rows: src_rows,

--- a/openinfer-core/src/weight_loader.rs
+++ b/openinfer-core/src/weight_loader.rs
@@ -1,5 +1,6 @@
 //! Safetensors weight loading and RoPE precomputation.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs;
 use std::os::unix::fs::FileExt;
@@ -265,29 +266,49 @@ fn find_tensor<'a>(
     }
 }
 
-#[allow(clippy::cast_ptr_alignment)]
-fn tensor_as_bf16<'d>(
+fn tensor_bf16_bytes<'d>(
     tensor: &safetensors::tensor::TensorView<'d>,
     name: &str,
-) -> Result<&'d [bf16]> {
+) -> Result<&'d [u8]> {
     anyhow::ensure!(
         tensor.dtype() == Dtype::BF16,
         "Tensor '{name}': expected dtype BF16, got {:?}",
         tensor.dtype()
     );
     let data = tensor.data();
-    // safetensors does not guarantee data-section alignment, and a misaligned
-    // bf16 view is UB.
     anyhow::ensure!(
-        (data.as_ptr() as usize).is_multiple_of(std::mem::align_of::<bf16>()),
-        "Tensor '{name}': data is not aligned for bf16"
+        data.len().is_multiple_of(std::mem::size_of::<bf16>()),
+        "Tensor '{name}': {} bytes is not a whole number of bf16 elements",
+        data.len()
     );
-    Ok(unsafe {
-        std::slice::from_raw_parts(
-            data.as_ptr().cast::<bf16>(),
-            data.len() / std::mem::size_of::<bf16>(),
-        )
-    })
+    Ok(data)
+}
+
+/// Aligned payloads borrow zero-copy; misaligned ones (legal in safetensors)
+/// decode into an owned buffer, since a misaligned bf16 view is UB.
+#[allow(clippy::cast_ptr_alignment)]
+fn tensor_bf16_cow<'d>(
+    tensor: &safetensors::tensor::TensorView<'d>,
+    name: &str,
+) -> Result<Cow<'d, [bf16]>> {
+    let data = tensor_bf16_bytes(tensor, name)?;
+    if (data.as_ptr() as usize).is_multiple_of(std::mem::align_of::<bf16>()) {
+        // SAFETY: alignment checked; any bit pattern is a valid bf16.
+        Ok(Cow::Borrowed(unsafe {
+            std::slice::from_raw_parts(
+                data.as_ptr().cast::<bf16>(),
+                data.len() / std::mem::size_of::<bf16>(),
+            )
+        }))
+    } else {
+        Ok(Cow::Owned(
+            data.as_chunks::<2>()
+                .0
+                .iter()
+                .map(|&b| bf16::from_bits(u16::from_le_bytes(b)))
+                .collect(),
+        ))
+    }
 }
 
 /// One row-consecutive part of a fused matrix: `rows` rows starting at
@@ -299,9 +320,9 @@ pub struct FusedPart<'a> {
     pub rows: usize,
 }
 
-/// Staged weight loading over one deserialized checkpoint: every method
-/// validates dtype, alignment, and the caller's config-derived dimensions at
-/// the load boundary, then uploads through the pinned staging pipeline.
+/// Validating BF16 checkpoint loader backed by pinned staging: every method
+/// checks dtype and config-derived dimensions at the load boundary; payload
+/// alignment is not required.
 pub struct StagedWeightLoader<'a> {
     ctx: &'a DeviceContext,
     stager: WeightStager,
@@ -323,7 +344,7 @@ impl<'a> StagedWeightLoader<'a> {
         })
     }
 
-    fn tensor_2d(&self, name: &str, rows: usize, cols: usize) -> Result<&'a [bf16]> {
+    fn tensor_2d(&self, name: &str, rows: usize, cols: usize) -> Result<&'a [u8]> {
         let tensor = find_tensor(self.shards, self.weight_map, name)?;
         let shape = tensor.shape();
         anyhow::ensure!(
@@ -334,13 +355,13 @@ impl<'a> StagedWeightLoader<'a> {
             shape[0] == rows && shape[1] == cols,
             "Tensor '{name}' has shape {shape:?}, config expects [{rows}, {cols}]"
         );
-        tensor_as_bf16(&tensor, name)
+        tensor_bf16_bytes(&tensor, name)
     }
 
     pub fn matrix(&mut self, name: &str, rows: usize, cols: usize) -> Result<DeviceMatrix> {
         let src = self.tensor_2d(name, rows, cols)?;
         // SAFETY: fully overwritten by the staged upload below.
-        let mut data = unsafe { self.ctx.stream.alloc::<bf16>(src.len()) }
+        let mut data = unsafe { self.ctx.stream.alloc::<bf16>(rows * cols) }
             .map_err(|e| anyhow::anyhow!("Alloc failed for '{name}': {e}"))?;
         self.stager.upload(src, &mut data, 0)?;
         Ok(DeviceMatrix { data, rows, cols })
@@ -364,7 +385,10 @@ impl<'a> StagedWeightLoader<'a> {
                 part.rows,
                 part.src_rows
             );
-            srcs.push(&full[part.row_offset * cols..(part.row_offset + part.rows) * cols]);
+            let elem = std::mem::size_of::<bf16>();
+            srcs.push(
+                &full[part.row_offset * cols * elem..(part.row_offset + part.rows) * cols * elem],
+            );
             total_rows += part.rows;
         }
         // SAFETY: every element is overwritten by the staged uploads below.
@@ -375,7 +399,7 @@ impl<'a> StagedWeightLoader<'a> {
         let mut dst_offset = 0;
         for src in srcs {
             self.stager.upload(src, &mut data, dst_offset)?;
-            dst_offset += src.len();
+            dst_offset += src.len() / std::mem::size_of::<bf16>();
         }
         Ok(DeviceMatrix {
             data,
@@ -421,8 +445,8 @@ impl<'a> StagedWeightLoader<'a> {
             shape.len() == 1 && shape[0] == len,
             "Tensor '{name}' has shape {shape:?}, config expects [{len}]"
         );
-        let src = tensor_as_bf16(&tensor, name)?;
-        DeviceVec::from_host(self.ctx, src)
+        let src = tensor_bf16_cow(&tensor, name)?;
+        DeviceVec::from_host(self.ctx, &src)
     }
 }
 
@@ -475,7 +499,7 @@ pub fn load_tensor_2d_row_shard(
             total_rows
         ));
     }
-    let elems = tensor_as_bf16(&tensor, name)?;
+    let elems = tensor_bf16_cow(&tensor, name)?;
     let start = row_offset * cols;
     let end = (row_offset + rows) * cols;
     DeviceMatrix::from_host(ctx, &elems[start..end], rows, cols)
@@ -525,8 +549,8 @@ pub fn load_tensor_2d_col_shard(
             total_cols
         ));
     }
-    let elems = tensor_as_bf16(&tensor, name)?;
-    let host = gather_cols(elems, rows, total_cols, col_offset, cols);
+    let elems = tensor_bf16_cow(&tensor, name)?;
+    let host = gather_cols(&elems, rows, total_cols, col_offset, cols);
     DeviceMatrix::from_host(ctx, &host, rows, cols)
 }
 
@@ -698,4 +722,43 @@ pub fn load_shard_info_fixed(model_path: &str) -> Result<(Vec<String>, HashMap<S
     }
 
     Ok((shard_files, weight_map))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use safetensors::Dtype;
+    use safetensors::tensor::TensorView;
+
+    use super::tensor_bf16_cow;
+
+    #[test]
+    fn tensor_bf16_cow_borrows_aligned_and_decodes_unaligned() {
+        let vals: [u16; 4] = [0x3f80, 0x0001, 0xbf12, 0x7fff];
+        let mut bytes = vec![0u8; vals.len() * 2 + 3];
+        // A Vec<u8> base has no alignment guarantee; derive both offsets from
+        // the actual address so each branch is forced deterministically.
+        let base = bytes.as_ptr() as usize;
+        let aligned_off = base.next_multiple_of(2) - base;
+        for (off, expect_borrowed) in [(aligned_off, true), (aligned_off + 1, false)] {
+            for (i, v) in vals.iter().enumerate() {
+                bytes[off + i * 2..off + i * 2 + 2].copy_from_slice(&v.to_le_bytes());
+            }
+            let view = TensorView::new(
+                Dtype::BF16,
+                vec![vals.len()],
+                &bytes[off..off + vals.len() * 2],
+            )
+            .unwrap();
+            let cow = tensor_bf16_cow(&view, "w").unwrap();
+            assert_eq!(
+                matches!(cow, Cow::Borrowed(_)),
+                expect_borrowed,
+                "off={off}"
+            );
+            let got: Vec<u16> = cow.iter().map(|b| b.to_bits()).collect();
+            assert_eq!(got, vals, "off={off}");
+        }
+    }
 }

--- a/openinfer-core/src/weight_loader.rs
+++ b/openinfer-core/src/weight_loader.rs
@@ -22,6 +22,9 @@ use crate::tensor::DeviceContext;
 use crate::tensor::DeviceMatrix;
 use crate::tensor::DeviceVec;
 
+mod staging;
+use staging::WeightStager;
+
 /// Load shard metadata. Returns (shard_file_paths, weight_map: tensor_name -> shard_index)
 pub fn load_shard_info(model_path: &str) -> Result<(Vec<String>, HashMap<String, usize>)> {
     let single_path = format!("{}/model.safetensors", model_path);
@@ -262,6 +265,167 @@ fn find_tensor<'a>(
     }
 }
 
+#[allow(clippy::cast_ptr_alignment)]
+fn tensor_as_bf16<'d>(
+    tensor: &safetensors::tensor::TensorView<'d>,
+    name: &str,
+) -> Result<&'d [bf16]> {
+    anyhow::ensure!(
+        tensor.dtype() == Dtype::BF16,
+        "Tensor '{name}': expected dtype BF16, got {:?}",
+        tensor.dtype()
+    );
+    let data = tensor.data();
+    // safetensors does not guarantee data-section alignment, and a misaligned
+    // bf16 view is UB.
+    anyhow::ensure!(
+        (data.as_ptr() as usize).is_multiple_of(std::mem::align_of::<bf16>()),
+        "Tensor '{name}': data is not aligned for bf16"
+    );
+    Ok(unsafe {
+        std::slice::from_raw_parts(
+            data.as_ptr().cast::<bf16>(),
+            data.len() / std::mem::size_of::<bf16>(),
+        )
+    })
+}
+
+/// One row-consecutive part of a fused matrix: `rows` rows starting at
+/// `row_offset` of a source tensor that must have exactly `src_rows` rows.
+pub struct FusedPart<'a> {
+    pub name: &'a str,
+    pub src_rows: usize,
+    pub row_offset: usize,
+    pub rows: usize,
+}
+
+/// Staged weight loading over one deserialized checkpoint: every method
+/// validates dtype, alignment, and the caller's config-derived dimensions at
+/// the load boundary, then uploads through the pinned staging pipeline.
+pub struct StagedWeightLoader<'a> {
+    ctx: &'a DeviceContext,
+    stager: WeightStager,
+    shards: &'a [SafeTensors<'a>],
+    weight_map: &'a HashMap<String, usize>,
+}
+
+impl<'a> StagedWeightLoader<'a> {
+    pub fn new(
+        ctx: &'a DeviceContext,
+        shards: &'a [SafeTensors<'a>],
+        weight_map: &'a HashMap<String, usize>,
+    ) -> Result<Self> {
+        Ok(Self {
+            ctx,
+            stager: WeightStager::new(ctx)?,
+            shards,
+            weight_map,
+        })
+    }
+
+    fn tensor_2d(&self, name: &str, rows: usize, cols: usize) -> Result<&'a [bf16]> {
+        let tensor = find_tensor(self.shards, self.weight_map, name)?;
+        let shape = tensor.shape();
+        anyhow::ensure!(
+            shape.len() == 2,
+            "Tensor '{name}' expected 2D, got shape {shape:?}"
+        );
+        anyhow::ensure!(
+            shape[0] == rows && shape[1] == cols,
+            "Tensor '{name}' has shape {shape:?}, config expects [{rows}, {cols}]"
+        );
+        tensor_as_bf16(&tensor, name)
+    }
+
+    pub fn matrix(&mut self, name: &str, rows: usize, cols: usize) -> Result<DeviceMatrix> {
+        let src = self.tensor_2d(name, rows, cols)?;
+        // SAFETY: fully overwritten by the staged upload below.
+        let mut data = unsafe { self.ctx.stream.alloc::<bf16>(src.len()) }
+            .map_err(|e| anyhow::anyhow!("Alloc failed for '{name}': {e}"))?;
+        self.stager.upload(src, &mut data, 0)?;
+        Ok(DeviceMatrix { data, rows, cols })
+    }
+
+    /// Row-concatenation of `parts`, each a validated row range of its
+    /// source tensor; all sources must have exactly `cols` columns.
+    pub fn fused_rows(&mut self, cols: usize, parts: &[FusedPart]) -> Result<DeviceMatrix> {
+        anyhow::ensure!(!parts.is_empty(), "fused load needs at least one part");
+        let mut total_rows = 0usize;
+        let mut srcs = Vec::with_capacity(parts.len());
+        for part in parts {
+            let name = part.name;
+            let full = self.tensor_2d(name, part.src_rows, cols)?;
+            anyhow::ensure!(
+                part.row_offset
+                    .checked_add(part.rows)
+                    .is_some_and(|end| end <= part.src_rows),
+                "row range out of bounds for '{name}': row_offset={} rows={} total_rows={}",
+                part.row_offset,
+                part.rows,
+                part.src_rows
+            );
+            srcs.push(&full[part.row_offset * cols..(part.row_offset + part.rows) * cols]);
+            total_rows += part.rows;
+        }
+        // SAFETY: every element is overwritten by the staged uploads below.
+        let mut data =
+            unsafe { self.ctx.stream.alloc::<bf16>(total_rows * cols) }.map_err(|e| {
+                anyhow::anyhow!("Alloc failed for fused '{}' group: {e}", parts[0].name)
+            })?;
+        let mut dst_offset = 0;
+        for src in srcs {
+            self.stager.upload(src, &mut data, dst_offset)?;
+            dst_offset += src.len();
+        }
+        Ok(DeviceMatrix {
+            data,
+            rows: total_rows,
+            cols,
+        })
+    }
+
+    /// `take` columns starting at `col_offset` of a source tensor validated
+    /// to exactly `src_rows` x `src_cols` before anything is allocated.
+    pub fn col_shard(
+        &mut self,
+        name: &str,
+        src_rows: usize,
+        src_cols: usize,
+        col_offset: usize,
+        take: usize,
+    ) -> Result<DeviceMatrix> {
+        let full = self.tensor_2d(name, src_rows, src_cols)?;
+        anyhow::ensure!(
+            col_offset
+                .checked_add(take)
+                .is_some_and(|end| end <= src_cols),
+            "col range out of bounds for '{name}': col_offset={col_offset} take={take} total_cols={src_cols}"
+        );
+        let host = gather_cols(full, src_rows, src_cols, col_offset, take);
+        // SAFETY: fully overwritten by the staged upload below.
+        let mut data = unsafe { self.ctx.stream.alloc::<bf16>(host.len()) }
+            .map_err(|e| anyhow::anyhow!("Alloc failed for '{name}': {e}"))?;
+        self.stager.upload(&host, &mut data, 0)?;
+        Ok(DeviceMatrix {
+            data,
+            rows: src_rows,
+            cols: take,
+        })
+    }
+
+    /// Small tensors; plain pageable copy, no staging.
+    pub fn vector(&mut self, name: &str, len: usize) -> Result<DeviceVec> {
+        let tensor = find_tensor(self.shards, self.weight_map, name)?;
+        let shape = tensor.shape();
+        anyhow::ensure!(
+            shape.len() == 1 && shape[0] == len,
+            "Tensor '{name}' has shape {shape:?}, config expects [{len}]"
+        );
+        let src = tensor_as_bf16(&tensor, name)?;
+        DeviceVec::from_host(self.ctx, src)
+    }
+}
+
 pub fn load_tensor_1d(
     ctx: &DeviceContext,
     shards: &[SafeTensors],
@@ -283,7 +447,6 @@ pub fn load_tensor_2d(
     DeviceMatrix::from_safetensors(ctx, tensor.data(), shape[0], shape[1])
 }
 
-#[allow(clippy::cast_ptr_alignment)]
 pub fn load_tensor_2d_row_shard(
     ctx: &DeviceContext,
     shards: &[SafeTensors],
@@ -312,15 +475,28 @@ pub fn load_tensor_2d_row_shard(
             total_rows
         ));
     }
-    let data = tensor.data();
-    let elems =
-        unsafe { std::slice::from_raw_parts(data.as_ptr().cast::<bf16>(), total_rows * cols) };
+    let elems = tensor_as_bf16(&tensor, name)?;
     let start = row_offset * cols;
     let end = (row_offset + rows) * cols;
     DeviceMatrix::from_host(ctx, &elems[start..end], rows, cols)
 }
 
-#[allow(clippy::cast_ptr_alignment)]
+fn gather_cols(
+    elems: &[bf16],
+    rows: usize,
+    total_cols: usize,
+    col_offset: usize,
+    take: usize,
+) -> Vec<bf16> {
+    let mut host = vec![bf16::ZERO; rows * take];
+    for row in 0..rows {
+        let src = row * total_cols + col_offset;
+        let dst = row * take;
+        host[dst..dst + take].copy_from_slice(&elems[src..src + take]);
+    }
+    host
+}
+
 pub fn load_tensor_2d_col_shard(
     ctx: &DeviceContext,
     shards: &[SafeTensors],
@@ -349,15 +525,8 @@ pub fn load_tensor_2d_col_shard(
             total_cols
         ));
     }
-    let data = tensor.data();
-    let elems =
-        unsafe { std::slice::from_raw_parts(data.as_ptr().cast::<bf16>(), rows * total_cols) };
-    let mut host = vec![bf16::ZERO; rows * cols];
-    for row in 0..rows {
-        let src = row * total_cols + col_offset;
-        let dst = row * cols;
-        host[dst..dst + cols].copy_from_slice(&elems[src..src + cols]);
-    }
+    let elems = tensor_as_bf16(&tensor, name)?;
+    let host = gather_cols(elems, rows, total_cols, col_offset, cols);
     DeviceMatrix::from_host(ctx, &host, rows, cols)
 }
 

--- a/openinfer-core/src/weight_loader/staging.rs
+++ b/openinfer-core/src/weight_loader/staging.rs
@@ -13,9 +13,10 @@ use log::error;
 
 use crate::tensor::DeviceContext;
 
-/// bf16 elements per pinned staging buffer: 64 MiB amortizes the per-chunk
-/// event sync while capping pinned memory at 128 MiB across both buffers.
-const STAGE_ELEMS: usize = (64 << 20) / std::mem::size_of::<bf16>();
+const BF16_SIZE: usize = std::mem::size_of::<bf16>();
+/// Bytes per pinned staging buffer: 64 MiB amortizes the per-chunk event sync
+/// while capping pinned memory at 128 MiB across both buffers.
+const STAGE_BYTES: usize = 64 << 20;
 /// A single memcpy thread cannot keep up with the pinned H2D copy rate.
 const FILL_THREADS: usize = 4;
 
@@ -24,8 +25,8 @@ struct StagingBuf {
     dma_done: CudaEvent,
 }
 
-/// Pageable `clone_htod` serializes the page-cache read with the DMA inside
-/// the driver; double-buffered pinned staging overlaps them.
+/// Pinned double-buffering overlaps the source read with the H2D copy that
+/// pageable `clone_htod` would serialize; sources are raw bytes.
 pub(crate) struct WeightStager {
     stream: Arc<CudaStream>,
     bufs: [StagingBuf; 2],
@@ -37,7 +38,7 @@ impl WeightStager {
         let make = || -> Result<StagingBuf> {
             // SAFETY: every byte a DMA reads is initialized by `stage_chunk`'s
             // fill callback first; buffer reuse is gated on `dma_done`.
-            let pinned = unsafe { ctx.ctx.alloc_pinned::<bf16>(STAGE_ELEMS) }
+            let pinned = unsafe { ctx.ctx.alloc_pinned::<bf16>(STAGE_BYTES / BF16_SIZE) }
                 .map_err(|e| anyhow::anyhow!("pinned staging alloc failed: {e}"))?;
             let dma_done = ctx
                 .ctx
@@ -52,105 +53,111 @@ impl WeightStager {
         })
     }
 
-    /// Copy `src` to `dst[dst_offset..dst_offset + src.len()]` through the
-    /// staging pipeline. The copy is asynchronous on the stager's stream, but
-    /// the in-flight DMA reads only the pinned buffers: `src` is copied out
-    /// synchronously and its lifetime is not extended past the call.
+    /// Stage `src` into `dst` at element `dst_offset`. The copy is async on
+    /// the stager's stream; `src` is copied out synchronously and not read
+    /// after return.
     pub(crate) fn upload(
         &mut self,
-        src: &[bf16],
+        src: &[u8],
         dst: &mut CudaSlice<bf16>,
         dst_offset: usize,
     ) -> Result<()> {
         self.ensure_uploadable(dst)?;
         anyhow::ensure!(
+            src.len().is_multiple_of(BF16_SIZE),
+            "staged upload source of {} bytes is not a whole number of bf16 elements",
+            src.len()
+        );
+        anyhow::ensure!(
             dst_offset
-                .checked_add(src.len())
-                .is_some_and(|end| end <= dst.len()),
-            "staged upload out of bounds: dst_offset {dst_offset} + src len {} > dst len {}",
+                .checked_mul(BF16_SIZE)
+                .and_then(|off| off.checked_add(src.len()))
+                .is_some_and(|end| end <= dst.len() * BF16_SIZE),
+            "staged upload out of bounds: dst_offset {dst_offset} + src bytes {} > dst len {}",
             src.len(),
             dst.len()
         );
         let stream = self.stream.clone();
         let (dst_ptr, _dst_order) = dst.device_ptr_mut(&stream);
-        for (i, chunk) in src.chunks(STAGE_ELEMS).enumerate() {
-            let dst_at =
-                dst_ptr + ((dst_offset + i * STAGE_ELEMS) * std::mem::size_of::<bf16>()) as u64;
-            let fill = |stage: *mut bf16| {
-                // SAFETY: the pinned buffer holds STAGE_ELEMS elements and is
-                // privately owned by `self.bufs`, so `chunk` cannot overlap
-                // it.
+        for (i, chunk) in src.chunks(STAGE_BYTES).enumerate() {
+            let dst_at = dst_ptr + (dst_offset * BF16_SIZE + i * STAGE_BYTES) as u64;
+            let fill = |stage: *mut u8| {
+                // SAFETY: `chunk.len() <= STAGE_BYTES`, and the privately
+                // owned buffer cannot overlap `chunk`.
                 unsafe { fill_pinned(chunk, stage) };
             };
-            // SAFETY: the chunks partition `src`, so `dst_at` addresses
-            // `chunk.len()` elements inside `dst` per the entry ensure, and
-            // `chunk.len() <= STAGE_ELEMS` by construction.
+            // SAFETY: the chunks partition `src`, so `dst_at` stays inside
+            // `dst` per the entry ensure, with `chunk.len() <= STAGE_BYTES`.
             unsafe { self.stage_chunk(chunk.len(), dst_at, fill) }?;
         }
         Ok(())
     }
 
     /// Strided variant of [`Self::upload`]: gathers `take`-column row
-    /// segments of a row-major `total_cols`-wide source straight into the
-    /// pinned buffers, with no intermediate host copy.
+    /// segments straight into the pinned buffers (column counts in
+    /// elements).
     pub(crate) fn upload_cols(
         &mut self,
-        src: &[bf16],
+        src: &[u8],
         total_cols: usize,
         col_offset: usize,
         take: usize,
         dst: &mut CudaSlice<bf16>,
     ) -> Result<()> {
         self.ensure_uploadable(dst)?;
+        let stride_b = total_cols
+            .checked_mul(BF16_SIZE)
+            .filter(|&s| s > 0 && src.len().is_multiple_of(s));
         anyhow::ensure!(
-            total_cols > 0 && src.len().is_multiple_of(total_cols),
-            "strided upload source of {} elements is not a multiple of {total_cols} columns",
+            stride_b.is_some(),
+            "strided upload source of {} bytes is not a multiple of {total_cols} bf16 columns",
             src.len()
         );
+        let stride_b = stride_b.unwrap();
         anyhow::ensure!(
             col_offset
                 .checked_add(take)
                 .is_some_and(|end| end <= total_cols),
             "col range out of bounds: col_offset={col_offset} take={take} total_cols={total_cols}"
         );
+        let take_b = take * BF16_SIZE;
         anyhow::ensure!(
-            (1..=STAGE_ELEMS).contains(&take),
-            "column shard width {take} outside 1..={STAGE_ELEMS}"
+            (1..=STAGE_BYTES).contains(&take_b),
+            "column shard width {take} outside 1..={}",
+            STAGE_BYTES / BF16_SIZE
         );
-        let rows = src.len() / total_cols;
+        let rows = src.len() / stride_b;
         anyhow::ensure!(
             rows.checked_mul(take).is_some_and(|n| n == dst.len()),
             "staged upload shape mismatch: {rows} rows x {take} cols vs dst len {}",
             dst.len()
         );
-        let rows_per_chunk = STAGE_ELEMS / take;
+        let rows_per_chunk = STAGE_BYTES / take_b;
+        let off_b = col_offset * BF16_SIZE;
         let stream = self.stream.clone();
         let (dst_ptr, _dst_order) = dst.device_ptr_mut(&stream);
         let mut row = 0;
         while row < rows {
             let chunk_rows = rows_per_chunk.min(rows - row);
-            let dst_at = dst_ptr + (row * take * std::mem::size_of::<bf16>()) as u64;
-            let fill = |stage: *mut bf16| {
-                // SAFETY: the pinned buffer is privately owned by
-                // `self.bufs`, so `src` cannot overlap it; the subslice
-                // holds `(rows - row) * total_cols` elements, covering
-                // `(chunk_rows - 1) * total_cols + col_offset + take` since
-                // `col_offset + take <= total_cols`.
+            let dst_at = dst_ptr + (row * take_b) as u64;
+            let fill = |stage: *mut u8| {
+                // SAFETY: the privately owned buffer cannot overlap `src`,
+                // and the subslice covers `chunk_rows` full rows since
+                // `off_b + take_b <= stride_b`.
                 unsafe {
                     fill_pinned_strided(
-                        &src[row * total_cols..],
-                        total_cols,
-                        col_offset,
-                        take,
+                        &src[row * stride_b..],
+                        stride_b,
+                        off_b,
+                        take_b,
                         chunk_rows,
                         stage,
                     );
                 }
             };
-            // SAFETY: `[row * take, (row + chunk_rows) * take)` lies inside
-            // `dst` by the rows x take bound above, and `chunk_rows * take <=
-            // STAGE_ELEMS` by construction of `rows_per_chunk`.
-            unsafe { self.stage_chunk(chunk_rows * take, dst_at, fill) }?;
+            // SAFETY: the destination rows lie inside `dst` per the
+            // rows x take bound, with `chunk_rows * take_b <= STAGE_BYTES`.
+            unsafe { self.stage_chunk(chunk_rows * take_b, dst_at, fill) }?;
             row += chunk_rows;
         }
         Ok(())
@@ -170,18 +177,14 @@ impl WeightStager {
         Ok(())
     }
 
-    /// One staging step: wait out the next buffer's previous DMA, fill it,
-    /// issue its copy.
-    ///
     /// # Safety
-    /// `dst_at` must address at least `elems` elements of device memory
-    /// writable on the stager's stream, `elems <= STAGE_ELEMS`, and `fill`
-    /// must initialize the `elems` elements at the pointer it is given.
+    /// `dst_at` must address `bytes <= STAGE_BYTES` writable bytes on the
+    /// stager's stream, and `fill` must initialize the `bytes` it is given.
     unsafe fn stage_chunk(
         &mut self,
-        elems: usize,
+        bytes: usize,
         dst_at: u64,
-        fill: impl FnOnce(*mut bf16),
+        fill: impl FnOnce(*mut u8),
     ) -> Result<()> {
         let idx = self.next;
         self.next = (self.next + 1) % self.bufs.len();
@@ -192,15 +195,15 @@ impl WeightStager {
         let stage = buf
             .pinned
             .as_mut_ptr()
-            .map_err(|e| anyhow::anyhow!("staging pointer failed: {e}"))?;
+            .map_err(|e| anyhow::anyhow!("staging pointer failed: {e}"))?
+            .cast::<u8>();
         fill(stage);
-        // SAFETY: `fill` initialized `elems` elements and `dst_at` is valid
-        // per this function's contract. The buffer outlives the copy on every
-        // path — retired via `dma_done` on success, or by the drain-or-abort
-        // branches below. The event synchronize above bound the context to
-        // this thread.
+        // SAFETY: `fill` initialized `bytes` at `stage` and `dst_at` is valid
+        // per the contract; the buffer outlives the copy (`dma_done` or the
+        // drain-or-abort branches), and the event synchronize above bound the
+        // context to this thread.
         let copied = unsafe {
-            let staged = std::slice::from_raw_parts(stage.cast_const(), elems);
+            let staged = std::slice::from_raw_parts(stage.cast_const(), bytes);
             memcpy_htod_async(dst_at, staged, self.stream.cu_stream())
         };
         if let Err(copy_err) = copied {
@@ -226,9 +229,9 @@ impl WeightStager {
 
 impl Drop for WeightStager {
     fn drop(&mut self) {
-        // PinnedHostSlice's own drop only waits on its embedded event, which
-        // this pipeline never records; drain our events instead, and fail
-        // closed when the DMA state is unknown.
+        // PinnedHostSlice's drop only waits on its embedded, never-recorded
+        // event; drain ours instead and fail closed when the DMA state is
+        // unknown.
         for buf in &self.bufs {
             if let Err(err) = buf.dma_done.synchronize() {
                 error!(
@@ -249,19 +252,40 @@ fn drain_or_abort(stream: &CudaStream, context: &str) {
     }
 }
 
-/// Write-combined destination: forward streaming writes only, never read.
-///
 /// # Safety
-/// `dst` must be valid for writes of at least `rows * take` elements and must
-/// not overlap `src`; when `rows > 0`, `src` must hold at least
-/// `(rows - 1) * total_cols + col_offset + take` elements.
+/// `dst` must hold `src.len()` writable bytes without overlapping `src`.
+unsafe fn fill_pinned(src: &[u8], dst: *mut u8) {
+    if src.is_empty() {
+        return;
+    }
+    let per = src.len().div_ceil(FILL_THREADS);
+    let dst_addr = dst as usize;
+    std::thread::scope(|scope| {
+        for (i, part) in src.chunks(per).enumerate() {
+            scope.spawn(move || {
+                // SAFETY: disjoint per-thread ranges within `dst`.
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        part.as_ptr(),
+                        (dst_addr as *mut u8).add(i * per),
+                        part.len(),
+                    );
+                }
+            });
+        }
+    });
+}
+
+/// # Safety
+/// `dst` must hold `rows * take_b` writable bytes without overlapping `src`;
+/// every requested source row slice must exist.
 unsafe fn fill_pinned_strided(
-    src: &[bf16],
-    total_cols: usize,
-    col_offset: usize,
-    take: usize,
+    src: &[u8],
+    stride_b: usize,
+    off_b: usize,
+    take_b: usize,
     rows: usize,
-    dst: *mut bf16,
+    dst: *mut u8,
 ) {
     if rows == 0 {
         return;
@@ -277,45 +301,15 @@ unsafe fn fill_pinned_strided(
             }
             scope.spawn(move || {
                 for row in start..end {
-                    // SAFETY: each thread writes the disjoint row range
-                    // `[start * take, end * take)` of a destination sized for
-                    // `rows * take`; source indices are bounded per the
-                    // function contract.
+                    // SAFETY: disjoint per-thread row ranges; source rows
+                    // exist per the contract.
                     unsafe {
                         std::ptr::copy_nonoverlapping(
-                            src.as_ptr().add(row * total_cols + col_offset),
-                            (dst_addr as *mut bf16).add(row * take),
-                            take,
+                            src.as_ptr().add(row * stride_b + off_b),
+                            (dst_addr as *mut u8).add(row * take_b),
+                            take_b,
                         );
                     }
-                }
-            });
-        }
-    });
-}
-
-/// Write-combined destination: forward streaming writes only, never read.
-///
-/// # Safety
-/// `dst` must be valid for writes of at least `src.len()` elements and must
-/// not overlap `src`.
-unsafe fn fill_pinned(src: &[bf16], dst: *mut bf16) {
-    if src.is_empty() {
-        return;
-    }
-    let per = src.len().div_ceil(FILL_THREADS);
-    let dst_addr = dst as usize;
-    std::thread::scope(|scope| {
-        for (i, part) in src.chunks(per).enumerate() {
-            scope.spawn(move || {
-                // SAFETY: each thread writes a disjoint range of the staging
-                // buffer, which is at least `src.len()` elements long.
-                unsafe {
-                    std::ptr::copy_nonoverlapping(
-                        part.as_ptr(),
-                        (dst_addr as *mut bf16).add(i * per),
-                        part.len(),
-                    );
                 }
             });
         }
@@ -335,21 +329,28 @@ mod tests {
             (9, 6, 3, 3),
             (17, 4, 0, 1),
         ] {
-            let src: Vec<bf16> = (0..rows * total_cols)
-                .map(|i| bf16::from_f32(i as f32))
-                .collect();
-            let mut dst = vec![bf16::ZERO; rows * take];
-            // SAFETY: `dst` holds `rows * take` elements and does not overlap
-            // `src`; `src` holds `rows * total_cols` elements, covering
-            // `(rows - 1) * total_cols + col_offset + take` since
-            // `col_offset + take <= total_cols`.
-            unsafe {
-                fill_pinned_strided(&src, total_cols, col_offset, take, rows, dst.as_mut_ptr());
+            let (stride_b, off_b, take_b) = (
+                total_cols * BF16_SIZE,
+                col_offset * BF16_SIZE,
+                take * BF16_SIZE,
+            );
+            let mut buf = vec![0u8; rows * stride_b];
+            for (i, b) in buf.iter_mut().enumerate() {
+                *b = (i % 251) as u8;
             }
-            let mut expect = Vec::with_capacity(rows * take);
+            let src = &buf[..];
+            let mut dst = vec![0u8; rows * take_b];
+            // SAFETY: `dst` holds `rows * take_b` bytes and does not overlap
+            // `src`; `src` holds `rows * stride_b` bytes, covering
+            // `(rows - 1) * stride_b + off_b + take_b` since
+            // `off_b + take_b <= stride_b`.
+            unsafe {
+                fill_pinned_strided(src, stride_b, off_b, take_b, rows, dst.as_mut_ptr());
+            }
+            let mut expect = Vec::with_capacity(rows * take_b);
             for r in 0..rows {
-                for c in 0..take {
-                    expect.push(src[r * total_cols + col_offset + c]);
+                for c in 0..take_b {
+                    expect.push(src[r * stride_b + off_b + c]);
                 }
             }
             assert_eq!(

--- a/openinfer-core/src/weight_loader/staging.rs
+++ b/openinfer-core/src/weight_loader/staging.rs
@@ -35,8 +35,8 @@ pub(crate) struct WeightStager {
 impl WeightStager {
     pub(crate) fn new(ctx: &DeviceContext) -> Result<Self> {
         let make = || -> Result<StagingBuf> {
-            // SAFETY: every byte a DMA reads is written by `fill_pinned` first;
-            // buffer reuse is gated on `dma_done`.
+            // SAFETY: every byte a DMA reads is initialized by `stage_chunk`'s
+            // fill callback first; buffer reuse is gated on `dma_done`.
             let pinned = unsafe { ctx.ctx.alloc_pinned::<bf16>(STAGE_ELEMS) }
                 .map_err(|e| anyhow::anyhow!("pinned staging alloc failed: {e}"))?;
             let dma_done = ctx
@@ -62,16 +62,7 @@ impl WeightStager {
         dst: &mut CudaSlice<bf16>,
         dst_offset: usize,
     ) -> Result<()> {
-        // Both the events and `dst`'s stream-ordered allocation are only
-        // ordered against work on the stager's own stream.
-        anyhow::ensure!(
-            Arc::ptr_eq(dst.stream(), &self.stream),
-            "staged upload into a buffer allocated on a different stream than the stager's"
-        );
-        anyhow::ensure!(
-            !crate::tensor::has_stream_override(),
-            "staged upload under a thread-local stream override is unsupported"
-        );
+        self.ensure_uploadable(dst)?;
         anyhow::ensure!(
             dst_offset
                 .checked_add(src.len())
@@ -80,54 +71,154 @@ impl WeightStager {
             src.len(),
             dst.len()
         );
-        let (dst_ptr, _dst_order) = dst.device_ptr_mut(&self.stream);
+        let stream = self.stream.clone();
+        let (dst_ptr, _dst_order) = dst.device_ptr_mut(&stream);
         for (i, chunk) in src.chunks(STAGE_ELEMS).enumerate() {
-            let idx = self.next;
-            self.next = (self.next + 1) % self.bufs.len();
-            let buf = &mut self.bufs[idx];
-            buf.dma_done
-                .synchronize()
-                .map_err(|e| anyhow::anyhow!("staging drain failed: {e}"))?;
-            let stage = buf
-                .pinned
-                .as_mut_ptr()
-                .map_err(|e| anyhow::anyhow!("staging pointer failed: {e}"))?;
-            // SAFETY: the staging buffer holds STAGE_ELEMS elements and
-            // `chunk.len() <= STAGE_ELEMS` by construction of the chunk loop;
-            // it is privately owned by `self.bufs` and never lent out, so the
-            // caller-borrowed `chunk` cannot overlap it.
-            unsafe { fill_pinned(chunk, stage) };
             let dst_at =
                 dst_ptr + ((dst_offset + i * STAGE_ELEMS) * std::mem::size_of::<bf16>()) as u64;
-            // SAFETY: `stage` holds `chunk.len()` freshly written elements.
-            // The destination range starts at element `dst_offset + i *
-            // STAGE_ELEMS` and stays inside `dst`: the entry ensure bounds
-            // `dst_offset + src.len() <= dst.len()` and the chunks partition
-            // `src`. The buffer outlives the copy on every path — retired via
-            // `dma_done` (recorded below) on success, or by the
-            // drain-or-abort branches when the copy or record call fails.
-            // The event synchronize above bound the context to this thread.
-            let copied = unsafe {
-                let staged = std::slice::from_raw_parts(stage.cast_const(), chunk.len());
-                memcpy_htod_async(dst_at, staged, self.stream.cu_stream())
+            let fill = |stage: *mut bf16| {
+                // SAFETY: the pinned buffer holds STAGE_ELEMS elements and is
+                // privately owned by `self.bufs`, so `chunk` cannot overlap
+                // it.
+                unsafe { fill_pinned(chunk, stage) };
             };
-            if let Err(copy_err) = copied {
-                // An async-API error can stem from earlier work on the stream
-                // and does not prove this copy never started.
-                drain_or_abort(
-                    &self.stream,
-                    &format!("staged H2D copy failed ({copy_err})"),
-                );
-                return Err(anyhow::anyhow!("staged H2D copy failed: {copy_err}"));
-            }
-            if let Err(record_err) = buf.dma_done.record(&self.stream) {
-                // The copy is in flight with no event covering it.
-                drain_or_abort(
-                    &self.stream,
-                    &format!("staging record failed ({record_err})"),
-                );
-                return Err(anyhow::anyhow!("staging record failed: {record_err}"));
-            }
+            // SAFETY: the chunks partition `src`, so `dst_at` addresses
+            // `chunk.len()` elements inside `dst` per the entry ensure, and
+            // `chunk.len() <= STAGE_ELEMS` by construction.
+            unsafe { self.stage_chunk(chunk.len(), dst_at, fill) }?;
+        }
+        Ok(())
+    }
+
+    /// Strided variant of [`Self::upload`]: gathers `take`-column row
+    /// segments of a row-major `total_cols`-wide source straight into the
+    /// pinned buffers, with no intermediate host copy.
+    pub(crate) fn upload_cols(
+        &mut self,
+        src: &[bf16],
+        total_cols: usize,
+        col_offset: usize,
+        take: usize,
+        dst: &mut CudaSlice<bf16>,
+    ) -> Result<()> {
+        self.ensure_uploadable(dst)?;
+        anyhow::ensure!(
+            total_cols > 0 && src.len().is_multiple_of(total_cols),
+            "strided upload source of {} elements is not a multiple of {total_cols} columns",
+            src.len()
+        );
+        anyhow::ensure!(
+            col_offset
+                .checked_add(take)
+                .is_some_and(|end| end <= total_cols),
+            "col range out of bounds: col_offset={col_offset} take={take} total_cols={total_cols}"
+        );
+        anyhow::ensure!(
+            (1..=STAGE_ELEMS).contains(&take),
+            "column shard width {take} outside 1..={STAGE_ELEMS}"
+        );
+        let rows = src.len() / total_cols;
+        anyhow::ensure!(
+            rows.checked_mul(take).is_some_and(|n| n == dst.len()),
+            "staged upload shape mismatch: {rows} rows x {take} cols vs dst len {}",
+            dst.len()
+        );
+        let rows_per_chunk = STAGE_ELEMS / take;
+        let stream = self.stream.clone();
+        let (dst_ptr, _dst_order) = dst.device_ptr_mut(&stream);
+        let mut row = 0;
+        while row < rows {
+            let chunk_rows = rows_per_chunk.min(rows - row);
+            let dst_at = dst_ptr + (row * take * std::mem::size_of::<bf16>()) as u64;
+            let fill = |stage: *mut bf16| {
+                // SAFETY: the pinned buffer is privately owned by
+                // `self.bufs`, so `src` cannot overlap it; the subslice
+                // holds `(rows - row) * total_cols` elements, covering
+                // `(chunk_rows - 1) * total_cols + col_offset + take` since
+                // `col_offset + take <= total_cols`.
+                unsafe {
+                    fill_pinned_strided(
+                        &src[row * total_cols..],
+                        total_cols,
+                        col_offset,
+                        take,
+                        chunk_rows,
+                        stage,
+                    );
+                }
+            };
+            // SAFETY: `[row * take, (row + chunk_rows) * take)` lies inside
+            // `dst` by the rows x take bound above, and `chunk_rows * take <=
+            // STAGE_ELEMS` by construction of `rows_per_chunk`.
+            unsafe { self.stage_chunk(chunk_rows * take, dst_at, fill) }?;
+            row += chunk_rows;
+        }
+        Ok(())
+    }
+
+    // Both the events and `dst`'s stream-ordered allocation are only ordered
+    // against work on the stager's own stream.
+    fn ensure_uploadable(&self, dst: &CudaSlice<bf16>) -> Result<()> {
+        anyhow::ensure!(
+            Arc::ptr_eq(dst.stream(), &self.stream),
+            "staged upload into a buffer allocated on a different stream than the stager's"
+        );
+        anyhow::ensure!(
+            !crate::tensor::has_stream_override(),
+            "staged upload under a thread-local stream override is unsupported"
+        );
+        Ok(())
+    }
+
+    /// One staging step: wait out the next buffer's previous DMA, fill it,
+    /// issue its copy.
+    ///
+    /// # Safety
+    /// `dst_at` must address at least `elems` elements of device memory
+    /// writable on the stager's stream, `elems <= STAGE_ELEMS`, and `fill`
+    /// must initialize the `elems` elements at the pointer it is given.
+    unsafe fn stage_chunk(
+        &mut self,
+        elems: usize,
+        dst_at: u64,
+        fill: impl FnOnce(*mut bf16),
+    ) -> Result<()> {
+        let idx = self.next;
+        self.next = (self.next + 1) % self.bufs.len();
+        let buf = &mut self.bufs[idx];
+        buf.dma_done
+            .synchronize()
+            .map_err(|e| anyhow::anyhow!("staging drain failed: {e}"))?;
+        let stage = buf
+            .pinned
+            .as_mut_ptr()
+            .map_err(|e| anyhow::anyhow!("staging pointer failed: {e}"))?;
+        fill(stage);
+        // SAFETY: `fill` initialized `elems` elements and `dst_at` is valid
+        // per this function's contract. The buffer outlives the copy on every
+        // path — retired via `dma_done` on success, or by the drain-or-abort
+        // branches below. The event synchronize above bound the context to
+        // this thread.
+        let copied = unsafe {
+            let staged = std::slice::from_raw_parts(stage.cast_const(), elems);
+            memcpy_htod_async(dst_at, staged, self.stream.cu_stream())
+        };
+        if let Err(copy_err) = copied {
+            // An async-API error can stem from earlier work on the stream and
+            // does not prove this copy never started.
+            drain_or_abort(
+                &self.stream,
+                &format!("staged H2D copy failed ({copy_err})"),
+            );
+            return Err(anyhow::anyhow!("staged H2D copy failed: {copy_err}"));
+        }
+        if let Err(record_err) = buf.dma_done.record(&self.stream) {
+            // The copy is in flight with no event covering it.
+            drain_or_abort(
+                &self.stream,
+                &format!("staging record failed ({record_err})"),
+            );
+            return Err(anyhow::anyhow!("staging record failed: {record_err}"));
         }
         Ok(())
     }
@@ -161,6 +252,51 @@ fn drain_or_abort(stream: &CudaStream, context: &str) {
 /// Write-combined destination: forward streaming writes only, never read.
 ///
 /// # Safety
+/// `dst` must be valid for writes of at least `rows * take` elements and must
+/// not overlap `src`; when `rows > 0`, `src` must hold at least
+/// `(rows - 1) * total_cols + col_offset + take` elements.
+unsafe fn fill_pinned_strided(
+    src: &[bf16],
+    total_cols: usize,
+    col_offset: usize,
+    take: usize,
+    rows: usize,
+    dst: *mut bf16,
+) {
+    if rows == 0 {
+        return;
+    }
+    let rows_per = rows.div_ceil(FILL_THREADS);
+    let dst_addr = dst as usize;
+    std::thread::scope(|scope| {
+        for t in 0..FILL_THREADS.min(rows) {
+            let start = t * rows_per;
+            let end = rows.min(start + rows_per);
+            if start >= end {
+                break;
+            }
+            scope.spawn(move || {
+                for row in start..end {
+                    // SAFETY: each thread writes the disjoint row range
+                    // `[start * take, end * take)` of a destination sized for
+                    // `rows * take`; source indices are bounded per the
+                    // function contract.
+                    unsafe {
+                        std::ptr::copy_nonoverlapping(
+                            src.as_ptr().add(row * total_cols + col_offset),
+                            (dst_addr as *mut bf16).add(row * take),
+                            take,
+                        );
+                    }
+                }
+            });
+        }
+    });
+}
+
+/// Write-combined destination: forward streaming writes only, never read.
+///
+/// # Safety
 /// `dst` must be valid for writes of at least `src.len()` elements and must
 /// not overlap `src`.
 unsafe fn fill_pinned(src: &[bf16], dst: *mut bf16) {
@@ -184,4 +320,42 @@ unsafe fn fill_pinned(src: &[bf16], dst: *mut bf16) {
             });
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fill_pinned_strided_matches_scalar_gather() {
+        for &(rows, total_cols, col_offset, take) in &[
+            (1usize, 7usize, 0usize, 7usize),
+            (3, 8, 2, 5),
+            (4, 5, 1, 4),
+            (9, 6, 3, 3),
+            (17, 4, 0, 1),
+        ] {
+            let src: Vec<bf16> = (0..rows * total_cols)
+                .map(|i| bf16::from_f32(i as f32))
+                .collect();
+            let mut dst = vec![bf16::ZERO; rows * take];
+            // SAFETY: `dst` holds `rows * take` elements and does not overlap
+            // `src`; `src` holds `rows * total_cols` elements, covering
+            // `(rows - 1) * total_cols + col_offset + take` since
+            // `col_offset + take <= total_cols`.
+            unsafe {
+                fill_pinned_strided(&src, total_cols, col_offset, take, rows, dst.as_mut_ptr());
+            }
+            let mut expect = Vec::with_capacity(rows * take);
+            for r in 0..rows {
+                for c in 0..take {
+                    expect.push(src[r * total_cols + col_offset + c]);
+                }
+            }
+            assert_eq!(
+                dst, expect,
+                "rows={rows} total_cols={total_cols} col_offset={col_offset} take={take}"
+            );
+        }
+    }
 }

--- a/openinfer-core/src/weight_loader/staging.rs
+++ b/openinfer-core/src/weight_loader/staging.rs
@@ -1,0 +1,187 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use cudarc::driver::CudaEvent;
+use cudarc::driver::CudaSlice;
+use cudarc::driver::CudaStream;
+use cudarc::driver::DevicePtrMut;
+use cudarc::driver::PinnedHostSlice;
+use cudarc::driver::result::memcpy_htod_async;
+use cudarc::driver::sys::CUevent_flags;
+use half::bf16;
+use log::error;
+
+use crate::tensor::DeviceContext;
+
+/// bf16 elements per pinned staging buffer: 64 MiB amortizes the per-chunk
+/// event sync while capping pinned memory at 128 MiB across both buffers.
+const STAGE_ELEMS: usize = (64 << 20) / std::mem::size_of::<bf16>();
+/// A single memcpy thread cannot keep up with the pinned H2D copy rate.
+const FILL_THREADS: usize = 4;
+
+struct StagingBuf {
+    pinned: PinnedHostSlice<bf16>,
+    dma_done: CudaEvent,
+}
+
+/// Pageable `clone_htod` serializes the page-cache read with the DMA inside
+/// the driver; double-buffered pinned staging overlaps them.
+pub(crate) struct WeightStager {
+    stream: Arc<CudaStream>,
+    bufs: [StagingBuf; 2],
+    next: usize,
+}
+
+impl WeightStager {
+    pub(crate) fn new(ctx: &DeviceContext) -> Result<Self> {
+        let make = || -> Result<StagingBuf> {
+            // SAFETY: every byte a DMA reads is written by `fill_pinned` first;
+            // buffer reuse is gated on `dma_done`.
+            let pinned = unsafe { ctx.ctx.alloc_pinned::<bf16>(STAGE_ELEMS) }
+                .map_err(|e| anyhow::anyhow!("pinned staging alloc failed: {e}"))?;
+            let dma_done = ctx
+                .ctx
+                .new_event(Some(CUevent_flags::CU_EVENT_BLOCKING_SYNC))
+                .map_err(|e| anyhow::anyhow!("staging event create failed: {e}"))?;
+            Ok(StagingBuf { pinned, dma_done })
+        };
+        Ok(Self {
+            stream: ctx.stream.clone(),
+            bufs: [make()?, make()?],
+            next: 0,
+        })
+    }
+
+    /// Copy `src` to `dst[dst_offset..dst_offset + src.len()]` through the
+    /// staging pipeline. The copy is asynchronous on the stager's stream, but
+    /// the in-flight DMA reads only the pinned buffers: `src` is copied out
+    /// synchronously and its lifetime is not extended past the call.
+    pub(crate) fn upload(
+        &mut self,
+        src: &[bf16],
+        dst: &mut CudaSlice<bf16>,
+        dst_offset: usize,
+    ) -> Result<()> {
+        // Both the events and `dst`'s stream-ordered allocation are only
+        // ordered against work on the stager's own stream.
+        anyhow::ensure!(
+            Arc::ptr_eq(dst.stream(), &self.stream),
+            "staged upload into a buffer allocated on a different stream than the stager's"
+        );
+        anyhow::ensure!(
+            !crate::tensor::has_stream_override(),
+            "staged upload under a thread-local stream override is unsupported"
+        );
+        anyhow::ensure!(
+            dst_offset
+                .checked_add(src.len())
+                .is_some_and(|end| end <= dst.len()),
+            "staged upload out of bounds: dst_offset {dst_offset} + src len {} > dst len {}",
+            src.len(),
+            dst.len()
+        );
+        let (dst_ptr, _dst_order) = dst.device_ptr_mut(&self.stream);
+        for (i, chunk) in src.chunks(STAGE_ELEMS).enumerate() {
+            let idx = self.next;
+            self.next = (self.next + 1) % self.bufs.len();
+            let buf = &mut self.bufs[idx];
+            buf.dma_done
+                .synchronize()
+                .map_err(|e| anyhow::anyhow!("staging drain failed: {e}"))?;
+            let stage = buf
+                .pinned
+                .as_mut_ptr()
+                .map_err(|e| anyhow::anyhow!("staging pointer failed: {e}"))?;
+            // SAFETY: the staging buffer holds STAGE_ELEMS elements and
+            // `chunk.len() <= STAGE_ELEMS` by construction of the chunk loop;
+            // it is privately owned by `self.bufs` and never lent out, so the
+            // caller-borrowed `chunk` cannot overlap it.
+            unsafe { fill_pinned(chunk, stage) };
+            let dst_at =
+                dst_ptr + ((dst_offset + i * STAGE_ELEMS) * std::mem::size_of::<bf16>()) as u64;
+            // SAFETY: `stage` holds `chunk.len()` freshly written elements.
+            // The destination range starts at element `dst_offset + i *
+            // STAGE_ELEMS` and stays inside `dst`: the entry ensure bounds
+            // `dst_offset + src.len() <= dst.len()` and the chunks partition
+            // `src`. The buffer outlives the copy on every path — retired via
+            // `dma_done` (recorded below) on success, or by the
+            // drain-or-abort branches when the copy or record call fails.
+            // The event synchronize above bound the context to this thread.
+            let copied = unsafe {
+                let staged = std::slice::from_raw_parts(stage.cast_const(), chunk.len());
+                memcpy_htod_async(dst_at, staged, self.stream.cu_stream())
+            };
+            if let Err(copy_err) = copied {
+                // An async-API error can stem from earlier work on the stream
+                // and does not prove this copy never started.
+                drain_or_abort(
+                    &self.stream,
+                    &format!("staged H2D copy failed ({copy_err})"),
+                );
+                return Err(anyhow::anyhow!("staged H2D copy failed: {copy_err}"));
+            }
+            if let Err(record_err) = buf.dma_done.record(&self.stream) {
+                // The copy is in flight with no event covering it.
+                drain_or_abort(
+                    &self.stream,
+                    &format!("staging record failed ({record_err})"),
+                );
+                return Err(anyhow::anyhow!("staging record failed: {record_err}"));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Drop for WeightStager {
+    fn drop(&mut self) {
+        // PinnedHostSlice's own drop only waits on its embedded event, which
+        // this pipeline never records; drain our events instead, and fail
+        // closed when the DMA state is unknown.
+        for buf in &self.bufs {
+            if let Err(err) = buf.dma_done.synchronize() {
+                error!(
+                    "staging DMA drain failed on drop ({err}); aborting instead of freeing pinned memory under an in-flight DMA"
+                );
+                std::process::abort();
+            }
+        }
+    }
+}
+
+fn drain_or_abort(stream: &CudaStream, context: &str) {
+    if let Err(sync_err) = stream.synchronize() {
+        error!(
+            "{context}; stream drain failed ({sync_err}); aborting instead of freeing pinned memory under an in-flight DMA"
+        );
+        std::process::abort();
+    }
+}
+
+/// Write-combined destination: forward streaming writes only, never read.
+///
+/// # Safety
+/// `dst` must be valid for writes of at least `src.len()` elements and must
+/// not overlap `src`.
+unsafe fn fill_pinned(src: &[bf16], dst: *mut bf16) {
+    if src.is_empty() {
+        return;
+    }
+    let per = src.len().div_ceil(FILL_THREADS);
+    let dst_addr = dst as usize;
+    std::thread::scope(|scope| {
+        for (i, part) in src.chunks(per).enumerate() {
+            scope.spawn(move || {
+                // SAFETY: each thread writes a disjoint range of the staging
+                // buffer, which is at least `src.len()` elements long.
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        part.as_ptr(),
+                        (dst_addr as *mut bf16).add(i * per),
+                        part.len(),
+                    );
+                }
+            });
+        }
+    });
+}

--- a/openinfer-qwen3/src/weights.rs
+++ b/openinfer-qwen3/src/weights.rs
@@ -14,13 +14,11 @@ use openinfer_core::tensor::DeviceContext;
 use openinfer_core::tensor::DeviceMatrix;
 use openinfer_core::tensor::DeviceVec;
 use openinfer_core::tensor::HiddenStates;
+use openinfer_core::weight_loader::FusedPart;
+use openinfer_core::weight_loader::StagedWeightLoader;
 use openinfer_core::weight_loader::WeightPrefetch;
 use openinfer_core::weight_loader::deserialize_shards;
 use openinfer_core::weight_loader::load_shard_info;
-use openinfer_core::weight_loader::load_tensor_1d;
-use openinfer_core::weight_loader::load_tensor_2d;
-use openinfer_core::weight_loader::load_tensor_2d_col_shard;
-use openinfer_core::weight_loader::load_tensor_2d_row_shard;
 use openinfer_core::weight_loader::mmap_shards;
 use openinfer_core::weight_loader::precompute_rope;
 use openinfer_kv_cache::KvBuffer;
@@ -403,19 +401,16 @@ impl Qwen3Model {
         let shards = deserialize_shards(&mmaps)?;
 
         let t_gpu = Instant::now();
+        let mut loader = StagedWeightLoader::new(&ctx, &shards, &weight_map)?;
+        let hidden = config.hidden_size;
         debug!("Loading embeddings to GPU");
-        let embed_tokens = load_tensor_2d(&ctx, &shards, &weight_map, "model.embed_tokens.weight")?;
+        let embed_tokens = loader.matrix("model.embed_tokens.weight", config.vocab_size, hidden)?;
         let lm_head = if config.tie_word_embeddings {
             debug!("Using tied input/output embeddings");
             None
         } else {
             debug!("Loading untied LM head to GPU");
-            Some(load_tensor_2d(
-                &ctx,
-                &shards,
-                &weight_map,
-                config.lm_head_tensor_name(),
-            )?)
+            Some(loader.matrix(config.lm_head_tensor_name(), config.vocab_size, hidden)?)
         };
 
         debug!(
@@ -423,174 +418,114 @@ impl Qwen3Model {
             config.num_hidden_layers, tensor_parallel.rank, tensor_parallel.world_size,
         );
         let mut layers = Vec::with_capacity(config.num_hidden_layers);
-        let (q_row_offset, q_rows) =
-            tensor_parallel.shard_range(config.num_attention_heads * config.head_dim);
-        let (kv_row_offset, kv_rows) =
-            tensor_parallel.shard_range(config.num_key_value_heads * config.head_dim);
-        let (inter_row_offset, inter_rows) = tensor_parallel.shard_range(config.intermediate_size);
+        let q_total = config.num_attention_heads * config.head_dim;
+        let kv_total = config.num_key_value_heads * config.head_dim;
+        let inter_total = config.intermediate_size;
+        let (q_row_offset, q_rows) = tensor_parallel.shard_range(q_total);
+        let (kv_row_offset, kv_rows) = tensor_parallel.shard_range(kv_total);
+        let (inter_row_offset, inter_rows) = tensor_parallel.shard_range(inter_total);
         for i in 0..config.num_hidden_layers {
             let prefix = format!("model.layers.{}", i);
 
-            let q_proj = if tensor_parallel.is_sharded() {
-                load_tensor_2d_row_shard(
-                    &ctx,
-                    &shards,
-                    &weight_map,
-                    &format!("{}.self_attn.q_proj.weight", prefix),
-                    q_row_offset,
-                    q_rows,
-                )?
-            } else {
-                load_tensor_2d(
-                    &ctx,
-                    &shards,
-                    &weight_map,
-                    &format!("{}.self_attn.q_proj.weight", prefix),
-                )?
-            };
-            let k_proj = if tensor_parallel.is_sharded() {
-                load_tensor_2d_row_shard(
-                    &ctx,
-                    &shards,
-                    &weight_map,
-                    &format!("{}.self_attn.k_proj.weight", prefix),
-                    kv_row_offset,
-                    kv_rows,
-                )?
-            } else {
-                load_tensor_2d(
-                    &ctx,
-                    &shards,
-                    &weight_map,
-                    &format!("{}.self_attn.k_proj.weight", prefix),
-                )?
-            };
-            let v_proj = if tensor_parallel.is_sharded() {
-                load_tensor_2d_row_shard(
-                    &ctx,
-                    &shards,
-                    &weight_map,
-                    &format!("{}.self_attn.v_proj.weight", prefix),
-                    kv_row_offset,
-                    kv_rows,
-                )?
-            } else {
-                load_tensor_2d(
-                    &ctx,
-                    &shards,
-                    &weight_map,
-                    &format!("{}.self_attn.v_proj.weight", prefix),
-                )?
-            };
-            let q_dim = q_proj.rows;
-            let kv_dim = k_proj.rows;
-            let qkv_proj = DeviceMatrix::vstack(&ctx, &[&q_proj, &k_proj, &v_proj])?;
-            drop(q_proj);
-            drop(k_proj);
-            drop(v_proj);
+            // shard_range covers world_size == 1 too (offset 0, full rows), so
+            // one fused load serves both the sharded and unsharded paths.
+            let q_name = format!("{prefix}.self_attn.q_proj.weight");
+            let k_name = format!("{prefix}.self_attn.k_proj.weight");
+            let v_name = format!("{prefix}.self_attn.v_proj.weight");
+            let qkv_proj = loader.fused_rows(
+                hidden,
+                &[
+                    FusedPart {
+                        name: &q_name,
+                        src_rows: q_total,
+                        row_offset: q_row_offset,
+                        rows: q_rows,
+                    },
+                    FusedPart {
+                        name: &k_name,
+                        src_rows: kv_total,
+                        row_offset: kv_row_offset,
+                        rows: kv_rows,
+                    },
+                    FusedPart {
+                        name: &v_name,
+                        src_rows: kv_total,
+                        row_offset: kv_row_offset,
+                        rows: kv_rows,
+                    },
+                ],
+            )?;
 
-            let gate_proj = if tensor_parallel.is_sharded() {
-                load_tensor_2d_row_shard(
-                    &ctx,
-                    &shards,
-                    &weight_map,
-                    &format!("{}.mlp.gate_proj.weight", prefix),
-                    inter_row_offset,
-                    inter_rows,
-                )?
-            } else {
-                load_tensor_2d(
-                    &ctx,
-                    &shards,
-                    &weight_map,
-                    &format!("{}.mlp.gate_proj.weight", prefix),
-                )?
-            };
-            let up_proj = if tensor_parallel.is_sharded() {
-                load_tensor_2d_row_shard(
-                    &ctx,
-                    &shards,
-                    &weight_map,
-                    &format!("{}.mlp.up_proj.weight", prefix),
-                    inter_row_offset,
-                    inter_rows,
-                )?
-            } else {
-                load_tensor_2d(
-                    &ctx,
-                    &shards,
-                    &weight_map,
-                    &format!("{}.mlp.up_proj.weight", prefix),
-                )?
-            };
-            let gate_up_proj = DeviceMatrix::vstack(&ctx, &[&gate_proj, &up_proj])?;
-            drop(gate_proj);
-            drop(up_proj);
+            let gate_name = format!("{prefix}.mlp.gate_proj.weight");
+            let up_name = format!("{prefix}.mlp.up_proj.weight");
+            let gate_up_proj = loader.fused_rows(
+                hidden,
+                &[
+                    FusedPart {
+                        name: &gate_name,
+                        src_rows: inter_total,
+                        row_offset: inter_row_offset,
+                        rows: inter_rows,
+                    },
+                    FusedPart {
+                        name: &up_name,
+                        src_rows: inter_total,
+                        row_offset: inter_row_offset,
+                        rows: inter_rows,
+                    },
+                ],
+            )?;
 
             let block = TransformerBlock {
-                input_layernorm: load_tensor_1d(
-                    &ctx,
-                    &shards,
-                    &weight_map,
-                    &format!("{}.input_layernorm.weight", prefix),
-                )?,
+                input_layernorm: loader
+                    .vector(&format!("{}.input_layernorm.weight", prefix), hidden)?,
                 attention: Attention {
                     qkv_proj,
                     o_proj: if tensor_parallel.is_sharded() {
-                        load_tensor_2d_col_shard(
-                            &ctx,
-                            &shards,
-                            &weight_map,
+                        loader.col_shard(
                             &format!("{}.self_attn.o_proj.weight", prefix),
+                            hidden,
+                            q_total,
                             q_row_offset,
                             q_rows,
                         )?
                     } else {
-                        load_tensor_2d(
-                            &ctx,
-                            &shards,
-                            &weight_map,
+                        loader.matrix(
                             &format!("{}.self_attn.o_proj.weight", prefix),
+                            hidden,
+                            q_total,
                         )?
                     },
-                    q_norm: load_tensor_1d(
-                        &ctx,
-                        &shards,
-                        &weight_map,
+                    q_norm: loader.vector(
                         &format!("{}.self_attn.q_norm.weight", prefix),
+                        config.head_dim,
                     )?,
-                    k_norm: load_tensor_1d(
-                        &ctx,
-                        &shards,
-                        &weight_map,
+                    k_norm: loader.vector(
                         &format!("{}.self_attn.k_norm.weight", prefix),
+                        config.head_dim,
                     )?,
-                    q_dim,
-                    kv_dim,
+                    q_dim: q_rows,
+                    kv_dim: kv_rows,
                 },
-                post_attention_layernorm: load_tensor_1d(
-                    &ctx,
-                    &shards,
-                    &weight_map,
+                post_attention_layernorm: loader.vector(
                     &format!("{}.post_attention_layernorm.weight", prefix),
+                    hidden,
                 )?,
                 mlp: MLP {
                     gate_up_proj,
                     down_proj: if tensor_parallel.is_sharded() {
-                        load_tensor_2d_col_shard(
-                            &ctx,
-                            &shards,
-                            &weight_map,
+                        loader.col_shard(
                             &format!("{}.mlp.down_proj.weight", prefix),
+                            hidden,
+                            inter_total,
                             inter_row_offset,
                             inter_rows,
                         )?
                     } else {
-                        load_tensor_2d(
-                            &ctx,
-                            &shards,
-                            &weight_map,
+                        loader.matrix(
                             &format!("{}.mlp.down_proj.weight", prefix),
+                            hidden,
+                            inter_total,
                         )?
                     },
                 },
@@ -598,7 +533,7 @@ impl Qwen3Model {
             layers.push(block);
         }
 
-        let norm = load_tensor_1d(&ctx, &shards, &weight_map, "model.norm.weight")?;
+        let norm = loader.vector("model.norm.weight", hidden)?;
 
         debug!("Precomputing RoPE cache on GPU");
         let (cos_cache, sin_cache) = precompute_rope(
@@ -609,6 +544,7 @@ impl Qwen3Model {
         )?;
 
         ctx.sync()?;
+        drop(loader);
         drop(prefetch);
         info!(
             "GPU model loaded in {:.0}ms",
@@ -1263,21 +1199,6 @@ mod tests {
             .slot_for_install("adapter-c", false)
             .expect("released slot should be reused");
         assert_eq!(slot_c, 0);
-    }
-
-    #[test]
-    fn memory_options_default_page_size_is_16() {
-        // #545: default behavior is unchanged when the flag is omitted.
-        assert_eq!(Qwen3MemoryOptions::default().page_size, 16);
-    }
-
-    #[test]
-    fn memory_options_accepts_valid_page_sizes() {
-        for &valid in VALID_KV_PAGE_SIZES {
-            Qwen3MemoryOptions::new(0.9, 0, valid)
-                .validate()
-                .unwrap_or_else(|_| panic!("page_size {valid} should be valid"));
-        }
     }
 
     #[test]


### PR DESCRIPTION
## Description

**Commit 1 — pipeline weight uploads through pinned double-buffered staging.** Weight tensors were uploaded with pageable `cuMemcpyHtoDAsync` one tensor at a time: the driver stages each copy internally, so the page-cache read and the DMA pay serially. A `WeightStager` (openinfer-core `weight_loader/staging.rs`) fills one 64 MiB pinned buffer on four threads while the other buffer's H2D copy is in flight on the load stream. Buffer reuse is event-gated, uploads are rejected under a thread-local stream override or into a buffer allocated on a different stream, and every path where an in-flight DMA could outlive its event fails closed: a failed copy or event record drains the stream before surfacing the error, and a failed drain aborts rather than freeing pinned memory a DMA may still read. The qwen3 load goes through a `StagedWeightLoader` with four entry points (`matrix`, `fused_rows`, `col_shard`, `vector`), each validating dtype, alignment, and exact config-derived dimensions at the load boundary — closing a latent out-of-bounds premise where the embedding kernel takes its copy width from the loaded matrix while the output buffer is sized from the config. q/k/v and gate/up upload straight into their row slices of the fused device matrices, dropping the per-layer vstack pass; an F16 checkpoint or any config/weights shape mismatch now fails loudly at load instead of serving garbage.

**Commit 2 — gather column shards straight into pinned staging.** Column-sharded weights (the TP `o_proj`/`down_proj` path) were gathered into a temporary host Vec and then uploaded, paying an extra full pass of host memcpy plus allocation churn — roughly 28% of a rank's bytes on Qwen3-14B TP2. `WeightStager::upload_cols` copies the strided row segments directly into the pinned buffers during the fill step; chunking is by whole rows, the destination must match `rows x take` exactly, and the chunk state machine is shared with `upload` through one `stage_chunk` driver. A CPU test checks the strided gather element-for-element against a scalar gather. On coherent-memory platforms (GH200) where pageable copies are already fast, commit 1's gather detour alone is a net loss.

## Test Env

Single GPU (sm_89, x86_64), Qwen3-4B on local NVMe, interleaved reps, commit-1 arm vs main; the timed load phase includes the staging-buffer allocation; cold = `posix_fadvise(DONTNEED)`:

| | load phase (4 reps) | HTTP-ready (3 reps) |
|---|---|---|
| main warm | 1256–1269 ms | 5.21–5.22 s |
| staged warm | 685–696 ms | **4.64–4.66 s** |
| main cold | 1647–1733 ms | 5.35–5.39 s |
| staged cold | 1562–1579 ms | 5.31–5.34 s |

Warm load improves 1.8x and passes through to HTTP-ready in full (~0.56 s): the engine path now far exceeds the concurrent frontend load.

Dual-GH200 (aarch64, sm_90), Qwen3-14B at `--tp-size 2` on Lustre (client-cold regime), three arms interleaved, 2 reps each:

| | main | commit 1 only | commits 1+2 |
|---|---|---|---|
| warm rank-0 load | 1189–1190 ms | 1328–1332 ms | **684–704 ms** |
| warm HTTP-ready | 7.24–7.34 s | 7.70–8.10 s | **6.41–6.78 s** |
| cold rank-0 load | 1754–1757 ms | 1946–2601 ms | 1690–1838 ms |
| cold HTTP-ready | 8.13–8.24 s | 8.57–9.93 s | 7.72–8.49 s |

Commit 1 alone regresses GH200 warm loads (pageable copies over NVLink-C2C are already fast; the col-shard host gather is pure overhead there) — commit 2 removes that gather and lands 1.7x ahead of main. 

**Validation.** Greedy completions are byte-identical across all three arms warm; the TP2 golden gate (logprobs vs HF goldens through the sharded load path, tight bf16 tolerance) passes on the combined tree with the page cache both warm and cold; `hf_golden_gate` passes at world_size 1 on sm_89; `cargo test -p openinfer-core --lib` 28/28 including a CPU oracle for the strided gather; fmt and clippy clean. A cold greedy flip first observed between arms was isolated with per-token logprob probes: every arm — including unmodified main — lands on one of two numeric profiles ~1e-3 nat apart, i.e. process-level cuBLASLt algorithm selection (the known cross-process variance the batch-invariance work tracks), not a load-path effect.


## Type of Change

- [x] Optimisation (non-breaking change which fixes an issue)