### PR TITLE
perf(qwen3): drop the duplicate cublasLt tuning burst from startup

### DIFF
--- a/openinfer-kernels/csrc/shared/linear.cu
+++ b/openinfer-kernels/csrc/shared/linear.cu
@@ -3,9 +3,11 @@
 #include <cublasLt.h>
 
 #include <array>
+#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
 #include <map>
+#include <mutex>
 
 static constexpr int CUBLAS_STATUS_ERROR_OFFSET = 100000;
 
@@ -42,6 +44,16 @@ thread_local cublasLtHandle_t g_lt_handle = nullptr;
 thread_local void *g_lt_workspace = nullptr;
 thread_local std::map<std::array<int, 3>, LtGemmPlan> g_lt_plans;
 static const size_t LT_WORKSPACE_SIZE = 32 * 1024 * 1024; // 32MB
+
+// Tuned winners are device-scoped, not thread-scoped: one thread benchmarks a
+// shape and the rest adopt the published winner.
+struct LtTunedEntry {
+  bool ready = false;
+  cublasLtMatmulAlgo_t algo{};
+};
+static std::mutex g_lt_tuned_mu;
+static std::condition_variable g_lt_tuned_cv;
+static std::map<std::array<int, 4>, LtTunedEntry> g_lt_tuned_algos;
 
 // Pin-path workspace, separate from the 32MB default. Arch-dependent, with 128MB kept as margin
 // for the tested decode buckets. Allocated lazily on first Pin use.
@@ -435,6 +447,48 @@ int gemm_lt_tune_cuda(const __nv_bfloat16 *const *Ws, int num_ws, int M, int N, 
     return static_cast<int>(cudaSuccess);
   }
 
+  int device = -1;
+  cudaError_t dev_status = cudaGetDevice(&device);
+  if (dev_status != cudaSuccess) {
+    return static_cast<int>(dev_status);
+  }
+  const std::array<int, 4> shared_key{device, M, N, K};
+  {
+    std::unique_lock<std::mutex> lock(g_lt_tuned_mu);
+    for (;;) {
+      auto it = g_lt_tuned_algos.find(shared_key);
+      if (it == g_lt_tuned_algos.end()) {
+        g_lt_tuned_algos.emplace(shared_key, LtTunedEntry{});
+        break;
+      }
+      if (it->second.ready) {
+        LtGemmPlan plan;
+        cublasStatus_t status = lt_plan_create(plan, M, N, K);
+        if (status != CUBLAS_STATUS_SUCCESS) {
+          lt_plan_destroy(plan);
+          return cublas_status_to_error(status);
+        }
+        plan.algo = it->second.algo;
+        g_lt_plans.emplace(key, plan);
+        return static_cast<int>(cudaSuccess);
+      }
+      g_lt_tuned_cv.wait(lock);
+    }
+  }
+  struct TunedClaim {
+    std::array<int, 4> key;
+    bool published = false;
+    ~TunedClaim() {
+      if (!published) {
+        {
+          std::lock_guard<std::mutex> lock(g_lt_tuned_mu);
+          g_lt_tuned_algos.erase(key);
+        }
+        g_lt_tuned_cv.notify_all();
+      }
+    }
+  } claim{shared_key};
+
   LtGemmPlan plan;
   cublasStatus_t status = lt_plan_create(plan, M, N, K);
   cublasLtMatmulHeuristicResult_t results[16];
@@ -526,6 +580,12 @@ int gemm_lt_tune_cuda(const __nv_bfloat16 *const *Ws, int num_ws, int M, int N, 
     return cublas_status_to_error(CUBLAS_STATUS_NOT_SUPPORTED);
   }
   plan.algo = results[best].algo;
+  {
+    std::lock_guard<std::mutex> lock(g_lt_tuned_mu);
+    g_lt_tuned_algos[shared_key] = LtTunedEntry{true, plan.algo};
+  }
+  g_lt_tuned_cv.notify_all();
+  claim.published = true;
   g_lt_plans.emplace(key, plan);
   return static_cast<int>(cudaSuccess);
 }

--- a/openinfer-qwen3/src/weights.rs
+++ b/openinfer-qwen3/src/weights.rs
@@ -615,7 +615,12 @@ impl Qwen3Model {
             t_gpu.elapsed().as_secs_f64() * 1e3
         );
         drop(shards);
-        drop(mmaps);
+        // Page-table teardown of the multi-GB mapping is not worth blocking
+        // startup on; nothing references the mmaps once every weight is uploaded.
+        std::thread::Builder::new()
+            .name("qwen3-weights-unmap".into())
+            .spawn(move || drop(mmaps))
+            .map_err(|e| anyhow::anyhow!("weight unmap thread spawn failed: {e}"))?;
 
         let num_hidden_layers = config.num_hidden_layers;
         let model = Self {


### PR DESCRIPTION
## Description

Fixes #748 

Startup runs the cublasLt decode-GEMM tuning sweep twice: once on the memory-profile thread and again when the serving worker binds, because the tuned-plan cache is thread_local. The sweep benches up to 16 algos for 23 iterations per (M, N, K), which costs about 1.5 s per thread on the measured host. The winner only depends on the device, not the thread, so this adds a process-level single-flight (device, M, N, K) -> algo map: the first thread to claim a shape benchmarks and publishes it, and any concurrent thread waits on the claim and adopts the published winner instead of re-benchmarking (a failed owner erases its claim so a waiter retries). The Pin policy path is untouched (it returns before the sweep), and Tuned-policy algo selection becomes consistent across threads in one process instead of two independently benchmarked, potentially divergent picks. The second commit moves the multi-gigabyte safetensors munmap off the startup critical path — nothing references the mapping once every weight is uploaded — and fails the load outright if the unmap thread cannot be spawned.

## Test Env

Measured on one sm_89 GPU, Qwen3-4B, warm page cache, three repetitions with medians: the serving worker's tune drops 1491 ms -> 0 ms, engine load 5160 -> 3663 ms, HTTP-ready 5743 -> 4099 ms (-29%).

Validation on the same GPU: `hf_golden_gate` (the serving thread now runs reused algos; logits still match the HF golden), `sampling_behavior`, `scheduler_robustness`, `prefix_cache`, `cached_tokens_usage`, both context-window tests, and the crate unit tests all pass; fmt and clippy clean.

## Type of Change

- [x] Optimisation (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project (see `docs/conventions/coding-style.md`).
- [x] I have performed a self-review of my own code.
- [x] I have formatted my commits according to Commitizen conventions.
- [x] I have run the local test suite and all tests pass (see `CLAUDE.md`).
