### PR TITLE
refactor(core): validate the whole weight load before the first upload

### DIFF
--- a/openinfer-core/src/weight_loader.rs
+++ b/openinfer-core/src/weight_loader.rs
@@ -12,6 +12,7 @@ use std::sync::atomic::Ordering;
 
 use anyhow::Result;
 use cudarc::driver::CudaSlice;
+use cudarc::driver::result::memcpy_htod_async;
 use half::bf16;
 use log::info;
 use log::warn;
@@ -24,6 +25,7 @@ use crate::tensor::DeviceMatrix;
 use crate::tensor::DeviceVec;
 
 mod staging;
+use staging::ColShardPlan;
 use staging::WeightStager;
 
 /// Load shard metadata. Returns (shard_file_paths, weight_map: tensor_name -> shard_index)
@@ -320,14 +322,52 @@ pub struct FusedPart<'a> {
     pub rows: usize,
 }
 
+/// Redeemed by [`StagedWeightLoader::take`] after `finish`.
+#[derive(Clone, Copy)]
+pub struct SlotId(usize);
+
+/// Redeemed by [`StagedWeightLoader::take_vec`] after `finish`.
+#[derive(Clone, Copy)]
+pub struct VecSlotId(usize);
+
+enum PendingUpload<'d> {
+    Contiguous { src: &'d [u8], dst_at: u64 },
+    ColShard { src: &'d [u8], plan: ColShardPlan },
+    Vector { src: Cow<'d, [bf16]>, dst_at: u64 },
+}
+
+fn bf16_bytes(src: &[bf16]) -> &[u8] {
+    // bf16 is a plain two-byte value; a byte view of it is always valid.
+    unsafe { std::slice::from_raw_parts(src.as_ptr().cast(), std::mem::size_of_val(src)) }
+}
+
+struct Slot {
+    data: Option<CudaSlice<bf16>>,
+    rows: usize,
+    cols: usize,
+}
+
+struct VecSlot {
+    data: Option<CudaSlice<bf16>>,
+    len: usize,
+}
+
 /// Validating BF16 checkpoint loader backed by pinned staging: every method
 /// checks dtype and config-derived dimensions at the load boundary; payload
-/// alignment is not required.
+/// alignment is not required. Uploads run in [`Self::finish`], after every
+/// tensor has been validated.
 pub struct StagedWeightLoader<'a> {
     ctx: &'a DeviceContext,
     stager: WeightStager,
     shards: &'a [SafeTensors<'a>],
     weight_map: &'a HashMap<String, usize>,
+    slots: Vec<Slot>,
+    vec_slots: Vec<VecSlot>,
+    pending: Vec<PendingUpload<'a>>,
+    retained: Vec<Vec<bf16>>,
+    finished: bool,
+    failed: bool,
+    alloc_ms: f64,
 }
 
 impl<'a> StagedWeightLoader<'a> {
@@ -341,7 +381,104 @@ impl<'a> StagedWeightLoader<'a> {
             stager: WeightStager::new(ctx)?,
             shards,
             weight_map,
+            slots: Vec::new(),
+            vec_slots: Vec::new(),
+            pending: Vec::new(),
+            retained: Vec::new(),
+            finished: false,
+            failed: false,
+            alloc_ms: 0.0,
         })
+    }
+
+    fn ensure_recording(&self) -> Result<()> {
+        anyhow::ensure!(
+            !self.finished && !self.failed,
+            "staged loader already finished"
+        );
+        Ok(())
+    }
+
+    fn push_slot(&mut self, data: CudaSlice<bf16>, rows: usize, cols: usize) -> SlotId {
+        self.slots.push(Slot {
+            data: Some(data),
+            rows,
+            cols,
+        });
+        SlotId(self.slots.len() - 1)
+    }
+
+    /// Executes every recorded upload; must run before [`Self::take`].
+    pub fn finish(&mut self) -> Result<()> {
+        anyhow::ensure!(
+            !self.finished && !self.failed,
+            "staged loader already finished"
+        );
+        // Poisoned until every upload lands; a failed finish cannot retry
+        // vacuously over the drained op list.
+        self.failed = true;
+        let uploads = self.pending.len();
+        let t_upload = std::time::Instant::now();
+        if let Err(err) = self.execute_uploads() {
+            // Soundness closes here, not in Drop (skippable via `mem::forget`):
+            // no submitted copy may outlive this call unresolved.
+            staging::drain_or_abort(&self.ctx.stream, "staged upload failure");
+            self.retained.clear();
+            return Err(err);
+        }
+        self.retained.clear();
+        self.failed = false;
+        self.finished = true;
+        info!(
+            "weight load: {} uploads, alloc_api_wall {:.0}ms, execute_and_drain_wall {:.0}ms",
+            uploads,
+            self.alloc_ms,
+            t_upload.elapsed().as_secs_f64() * 1e3
+        );
+        Ok(())
+    }
+
+    fn execute_uploads(&mut self) -> Result<()> {
+        for op in std::mem::take(&mut self.pending) {
+            match op {
+                // SAFETY: the destination is owned by `self.slots` (`take`
+                // refuses to hand it out before a successful finish) and the
+                // range was validated by prepare/prepare_cols at record time.
+                PendingUpload::Contiguous { src, dst_at } => unsafe {
+                    self.stager.upload_at(src, dst_at)?;
+                },
+                PendingUpload::ColShard { src, plan } => unsafe {
+                    self.stager.upload_cols_at(src, &plan)?;
+                },
+                // SAFETY: destination validated at record time; sources
+                // outlive the drain (borrowed: shards; owned: retained first).
+                PendingUpload::Vector { src, dst_at } => {
+                    let bytes = match src {
+                        Cow::Borrowed(borrowed) => bf16_bytes(borrowed),
+                        Cow::Owned(owned) => {
+                            self.retained.push(owned);
+                            bf16_bytes(self.retained.last().expect("just pushed"))
+                        }
+                    };
+                    unsafe {
+                        memcpy_htod_async(dst_at, bytes, self.ctx.stream.cu_stream())
+                            .map_err(|e| anyhow::anyhow!("vector upload failed: {e}"))?;
+                    }
+                }
+            }
+        }
+        self.ctx.sync()
+    }
+
+    /// Redeems a recorded matrix after a successful [`Self::finish`].
+    pub fn take(&mut self, slot: SlotId) -> DeviceMatrix {
+        assert!(self.finished, "take before successful finish");
+        let slot = &mut self.slots[slot.0];
+        DeviceMatrix {
+            data: slot.data.take().expect("slot already taken"),
+            rows: slot.rows,
+            cols: slot.cols,
+        }
     }
 
     fn tensor_2d(&self, name: &str, rows: usize, cols: usize) -> Result<&'a [u8]> {
@@ -358,18 +495,29 @@ impl<'a> StagedWeightLoader<'a> {
         tensor_bf16_bytes(&tensor, name)
     }
 
-    pub fn matrix(&mut self, name: &str, rows: usize, cols: usize) -> Result<DeviceMatrix> {
-        let src = self.tensor_2d(name, rows, cols)?;
-        // SAFETY: fully overwritten by the staged upload below.
-        let mut data = unsafe { self.ctx.stream.alloc::<bf16>(rows * cols) }
+    fn alloc_timed(&mut self, elems: usize, name: &str) -> Result<CudaSlice<bf16>> {
+        let t = std::time::Instant::now();
+        // SAFETY: overwritten by its recorded upload before `take` can
+        // expose it.
+        let data = unsafe { self.ctx.stream.alloc::<bf16>(elems) }
             .map_err(|e| anyhow::anyhow!("Alloc failed for '{name}': {e}"))?;
-        self.stager.upload(src, &mut data, 0)?;
-        Ok(DeviceMatrix { data, rows, cols })
+        self.alloc_ms += t.elapsed().as_secs_f64() * 1e3;
+        Ok(data)
+    }
+
+    pub fn matrix(&mut self, name: &str, rows: usize, cols: usize) -> Result<SlotId> {
+        self.ensure_recording()?;
+        let src = self.tensor_2d(name, rows, cols)?;
+        let mut data = self.alloc_timed(rows * cols, name)?;
+        let dst_at = staging::prepare(&self.ctx.stream, src, &mut data, 0)?;
+        self.pending.push(PendingUpload::Contiguous { src, dst_at });
+        Ok(self.push_slot(data, rows, cols))
     }
 
     /// Row-concatenation of `parts`, each a validated row range of its
     /// source tensor; all sources must have exactly `cols` columns.
-    pub fn fused_rows(&mut self, cols: usize, parts: &[FusedPart]) -> Result<DeviceMatrix> {
+    pub fn fused_rows(&mut self, cols: usize, parts: &[FusedPart]) -> Result<SlotId> {
+        self.ensure_recording()?;
         anyhow::ensure!(!parts.is_empty(), "fused load needs at least one part");
         let mut total_rows = 0usize;
         let mut srcs = Vec::with_capacity(parts.len());
@@ -391,21 +539,14 @@ impl<'a> StagedWeightLoader<'a> {
             );
             total_rows += part.rows;
         }
-        // SAFETY: every element is overwritten by the staged uploads below.
-        let mut data =
-            unsafe { self.ctx.stream.alloc::<bf16>(total_rows * cols) }.map_err(|e| {
-                anyhow::anyhow!("Alloc failed for fused '{}' group: {e}", parts[0].name)
-            })?;
+        let mut data = self.alloc_timed(total_rows * cols, parts[0].name)?;
         let mut dst_offset = 0;
         for src in srcs {
-            self.stager.upload(src, &mut data, dst_offset)?;
+            let dst_at = staging::prepare(&self.ctx.stream, src, &mut data, dst_offset)?;
+            self.pending.push(PendingUpload::Contiguous { src, dst_at });
             dst_offset += src.len() / std::mem::size_of::<bf16>();
         }
-        Ok(DeviceMatrix {
-            data,
-            rows: total_rows,
-            cols,
-        })
+        Ok(self.push_slot(data, total_rows, cols))
     }
 
     /// `take` columns starting at `col_offset` of a source tensor validated
@@ -417,7 +558,8 @@ impl<'a> StagedWeightLoader<'a> {
         src_cols: usize,
         col_offset: usize,
         take: usize,
-    ) -> Result<DeviceMatrix> {
+    ) -> Result<SlotId> {
+        self.ensure_recording()?;
         let full = self.tensor_2d(name, src_rows, src_cols)?;
         anyhow::ensure!(
             col_offset
@@ -425,20 +567,23 @@ impl<'a> StagedWeightLoader<'a> {
                 .is_some_and(|end| end <= src_cols),
             "col range out of bounds for '{name}': col_offset={col_offset} take={take} total_cols={src_cols}"
         );
-        // SAFETY: fully overwritten by the staged upload below.
-        let mut data = unsafe { self.ctx.stream.alloc::<bf16>(src_rows * take) }
-            .map_err(|e| anyhow::anyhow!("Alloc failed for '{name}': {e}"))?;
-        self.stager
-            .upload_cols(full, src_cols, col_offset, take, &mut data)?;
-        Ok(DeviceMatrix {
-            data,
-            rows: src_rows,
-            cols: take,
-        })
+        let mut data = self.alloc_timed(src_rows * take, name)?;
+        let plan = staging::prepare_cols(
+            &self.ctx.stream,
+            full,
+            src_cols,
+            col_offset,
+            take,
+            &mut data,
+        )?;
+        self.pending
+            .push(PendingUpload::ColShard { src: full, plan });
+        Ok(self.push_slot(data, src_rows, take))
     }
 
-    /// Small tensors; plain pageable copy, no staging.
-    pub fn vector(&mut self, name: &str, len: usize) -> Result<DeviceVec> {
+    /// Small tensors; uploaded as plain pageable copies.
+    pub fn vector(&mut self, name: &str, len: usize) -> Result<VecSlotId> {
+        self.ensure_recording()?;
         let tensor = find_tensor(self.shards, self.weight_map, name)?;
         let shape = tensor.shape();
         anyhow::ensure!(
@@ -446,7 +591,33 @@ impl<'a> StagedWeightLoader<'a> {
             "Tensor '{name}' has shape {shape:?}, config expects [{len}]"
         );
         let src = tensor_bf16_cow(&tensor, name)?;
-        DeviceVec::from_host(self.ctx, &src)
+        let mut data = self.alloc_timed(len, name)?;
+        let dst_at = staging::prepare(&self.ctx.stream, bf16_bytes(&src), &mut data, 0)?;
+        self.pending.push(PendingUpload::Vector { src, dst_at });
+        self.vec_slots.push(VecSlot {
+            data: Some(data),
+            len,
+        });
+        Ok(VecSlotId(self.vec_slots.len() - 1))
+    }
+
+    /// Redeems a recorded vector after a successful [`Self::finish`].
+    pub fn take_vec(&mut self, slot: VecSlotId) -> DeviceVec {
+        assert!(self.finished, "take before successful finish");
+        let slot = &mut self.vec_slots[slot.0];
+        DeviceVec {
+            data: slot.data.take().expect("slot already taken"),
+            len: slot.len,
+        }
+    }
+}
+
+impl Drop for StagedWeightLoader<'_> {
+    // Second layer only: the soundness boundary closes inside `finish`.
+    fn drop(&mut self) {
+        if self.failed {
+            staging::drain_or_abort(&self.ctx.stream, "staged loader drop");
+        }
     }
 }
 

--- a/openinfer-core/src/weight_loader/staging.rs
+++ b/openinfer-core/src/weight_loader/staging.rs
@@ -25,6 +25,15 @@ struct StagingBuf {
     dma_done: CudaEvent,
 }
 
+/// Validated execution plan for one strided column-shard upload.
+pub(crate) struct ColShardPlan {
+    stride_b: usize,
+    off_b: usize,
+    take_b: usize,
+    rows: usize,
+    dst_at: u64,
+}
+
 /// Pinned double-buffering overlaps the source read with the H2D copy that
 /// pageable `clone_htod` would serialize; sources are raw bytes.
 pub(crate) struct WeightStager {
@@ -53,127 +62,53 @@ impl WeightStager {
         })
     }
 
-    /// Stage `src` into `dst` at element `dst_offset`. The copy is async on
-    /// the stager's stream; `src` is copied out synchronously and not read
-    /// after return.
-    pub(crate) fn upload(
-        &mut self,
-        src: &[u8],
-        dst: &mut CudaSlice<bf16>,
-        dst_offset: usize,
-    ) -> Result<()> {
-        self.ensure_uploadable(dst)?;
-        anyhow::ensure!(
-            src.len().is_multiple_of(BF16_SIZE),
-            "staged upload source of {} bytes is not a whole number of bf16 elements",
-            src.len()
-        );
-        anyhow::ensure!(
-            dst_offset
-                .checked_mul(BF16_SIZE)
-                .and_then(|off| off.checked_add(src.len()))
-                .is_some_and(|end| end <= dst.len() * BF16_SIZE),
-            "staged upload out of bounds: dst_offset {dst_offset} + src bytes {} > dst len {}",
-            src.len(),
-            dst.len()
-        );
-        let stream = self.stream.clone();
-        let (dst_ptr, _dst_order) = dst.device_ptr_mut(&stream);
+    /// # Safety
+    /// `dst_at` must address `src.len()` writable bytes still allocated on the
+    /// stager's stream, as validated by [`prepare`].
+    pub(crate) unsafe fn upload_at(&mut self, src: &[u8], dst_at: u64) -> Result<()> {
         for (i, chunk) in src.chunks(STAGE_BYTES).enumerate() {
-            let dst_at = dst_ptr + (dst_offset * BF16_SIZE + i * STAGE_BYTES) as u64;
+            let chunk_at = dst_at + (i * STAGE_BYTES) as u64;
             let fill = |stage: *mut u8| {
                 // SAFETY: `chunk.len() <= STAGE_BYTES`, and the privately
                 // owned buffer cannot overlap `chunk`.
                 unsafe { fill_pinned(chunk, stage) };
             };
-            // SAFETY: the chunks partition `src`, so `dst_at` stays inside
-            // `dst` per the entry ensure, with `chunk.len() <= STAGE_BYTES`.
-            unsafe { self.stage_chunk(chunk.len(), dst_at, fill) }?;
+            // SAFETY: the chunks partition `src`, so `chunk_at` stays inside
+            // the validated destination range, with `chunk.len() <= STAGE_BYTES`.
+            unsafe { self.stage_chunk(chunk.len(), chunk_at, fill) }?;
         }
         Ok(())
     }
 
-    /// Strided variant of [`Self::upload`]: gathers `take`-column row
-    /// segments straight into the pinned buffers (column counts in
-    /// elements).
-    pub(crate) fn upload_cols(
-        &mut self,
-        src: &[u8],
-        total_cols: usize,
-        col_offset: usize,
-        take: usize,
-        dst: &mut CudaSlice<bf16>,
-    ) -> Result<()> {
-        self.ensure_uploadable(dst)?;
-        let stride_b = total_cols
-            .checked_mul(BF16_SIZE)
-            .filter(|&s| s > 0 && src.len().is_multiple_of(s));
-        anyhow::ensure!(
-            stride_b.is_some(),
-            "strided upload source of {} bytes is not a multiple of {total_cols} bf16 columns",
-            src.len()
-        );
-        let stride_b = stride_b.unwrap();
-        anyhow::ensure!(
-            col_offset
-                .checked_add(take)
-                .is_some_and(|end| end <= total_cols),
-            "col range out of bounds: col_offset={col_offset} take={take} total_cols={total_cols}"
-        );
-        let take_b = take * BF16_SIZE;
-        anyhow::ensure!(
-            (1..=STAGE_BYTES).contains(&take_b),
-            "column shard width {take} outside 1..={}",
-            STAGE_BYTES / BF16_SIZE
-        );
-        let rows = src.len() / stride_b;
-        anyhow::ensure!(
-            rows.checked_mul(take).is_some_and(|n| n == dst.len()),
-            "staged upload shape mismatch: {rows} rows x {take} cols vs dst len {}",
-            dst.len()
-        );
-        let rows_per_chunk = STAGE_BYTES / take_b;
-        let off_b = col_offset * BF16_SIZE;
-        let stream = self.stream.clone();
-        let (dst_ptr, _dst_order) = dst.device_ptr_mut(&stream);
+    /// # Safety
+    /// `plan` must come from [`prepare_cols`] for this `src`, with its
+    /// destination still allocated on the stager's stream.
+    pub(crate) unsafe fn upload_cols_at(&mut self, src: &[u8], plan: &ColShardPlan) -> Result<()> {
+        let rows_per_chunk = STAGE_BYTES / plan.take_b;
         let mut row = 0;
-        while row < rows {
-            let chunk_rows = rows_per_chunk.min(rows - row);
-            let dst_at = dst_ptr + (row * take_b) as u64;
+        while row < plan.rows {
+            let chunk_rows = rows_per_chunk.min(plan.rows - row);
+            let dst_at = plan.dst_at + (row * plan.take_b) as u64;
             let fill = |stage: *mut u8| {
                 // SAFETY: the privately owned buffer cannot overlap `src`,
                 // and the subslice covers `chunk_rows` full rows since
                 // `off_b + take_b <= stride_b`.
                 unsafe {
                     fill_pinned_strided(
-                        &src[row * stride_b..],
-                        stride_b,
-                        off_b,
-                        take_b,
+                        &src[row * plan.stride_b..],
+                        plan.stride_b,
+                        plan.off_b,
+                        plan.take_b,
                         chunk_rows,
                         stage,
                     );
                 }
             };
-            // SAFETY: the destination rows lie inside `dst` per the
-            // rows x take bound, with `chunk_rows * take_b <= STAGE_BYTES`.
-            unsafe { self.stage_chunk(chunk_rows * take_b, dst_at, fill) }?;
+            // SAFETY: the destination rows lie inside the validated range per
+            // the rows x take bound, with `chunk_rows * take_b <= STAGE_BYTES`.
+            unsafe { self.stage_chunk(chunk_rows * plan.take_b, dst_at, fill) }?;
             row += chunk_rows;
         }
-        Ok(())
-    }
-
-    // Both the events and `dst`'s stream-ordered allocation are only ordered
-    // against work on the stager's own stream.
-    fn ensure_uploadable(&self, dst: &CudaSlice<bf16>) -> Result<()> {
-        anyhow::ensure!(
-            Arc::ptr_eq(dst.stream(), &self.stream),
-            "staged upload into a buffer allocated on a different stream than the stager's"
-        );
-        anyhow::ensure!(
-            !crate::tensor::has_stream_override(),
-            "staged upload under a thread-local stream override is unsupported"
-        );
         Ok(())
     }
 
@@ -227,6 +162,97 @@ impl WeightStager {
     }
 }
 
+// Both the stager's events and `dst`'s stream-ordered allocation are only
+// ordered against work on `stream`, which must be the stager's own stream.
+fn ensure_uploadable(stream: &Arc<CudaStream>, dst: &CudaSlice<bf16>) -> Result<()> {
+    anyhow::ensure!(
+        Arc::ptr_eq(dst.stream(), stream),
+        "staged upload into a buffer allocated on a different stream than the stager's"
+    );
+    anyhow::ensure!(
+        !crate::tensor::has_stream_override(),
+        "staged upload under a thread-local stream override is unsupported"
+    );
+    Ok(())
+}
+
+/// Validates a contiguous staged upload and returns the destination device
+/// address for a deferred [`WeightStager::upload_at`].
+pub(crate) fn prepare(
+    stream: &Arc<CudaStream>,
+    src: &[u8],
+    dst: &mut CudaSlice<bf16>,
+    dst_offset: usize,
+) -> Result<u64> {
+    ensure_uploadable(stream, dst)?;
+    anyhow::ensure!(
+        src.len().is_multiple_of(BF16_SIZE),
+        "staged upload source of {} bytes is not a whole number of bf16 elements",
+        src.len()
+    );
+    anyhow::ensure!(
+        dst_offset
+            .checked_mul(BF16_SIZE)
+            .and_then(|off| off.checked_add(src.len()))
+            .is_some_and(|end| end <= dst.len() * BF16_SIZE),
+        "staged upload out of bounds: dst_offset {dst_offset} + src bytes {} > dst len {}",
+        src.len(),
+        dst.len()
+    );
+    // Dropping the guard immediately is fine only because the runtime context
+    // disables cudarc event tracking; revisit if that ever changes.
+    let (dst_ptr, _dst_order) = dst.device_ptr_mut(stream);
+    Ok(dst_ptr + (dst_offset * BF16_SIZE) as u64)
+}
+
+/// Validates a strided staged upload and returns its execution plan for a
+/// deferred [`WeightStager::upload_cols_at`] (column counts in elements).
+pub(crate) fn prepare_cols(
+    stream: &Arc<CudaStream>,
+    src: &[u8],
+    total_cols: usize,
+    col_offset: usize,
+    take: usize,
+    dst: &mut CudaSlice<bf16>,
+) -> Result<ColShardPlan> {
+    ensure_uploadable(stream, dst)?;
+    let stride_b = total_cols
+        .checked_mul(BF16_SIZE)
+        .filter(|&s| s > 0 && src.len().is_multiple_of(s));
+    anyhow::ensure!(
+        stride_b.is_some(),
+        "strided upload source of {} bytes is not a multiple of {total_cols} bf16 columns",
+        src.len()
+    );
+    let stride_b = stride_b.unwrap();
+    anyhow::ensure!(
+        col_offset
+            .checked_add(take)
+            .is_some_and(|end| end <= total_cols),
+        "col range out of bounds: col_offset={col_offset} take={take} total_cols={total_cols}"
+    );
+    let take_b = take * BF16_SIZE;
+    anyhow::ensure!(
+        (1..=STAGE_BYTES).contains(&take_b),
+        "column shard width {take} outside 1..={}",
+        STAGE_BYTES / BF16_SIZE
+    );
+    let rows = src.len() / stride_b;
+    anyhow::ensure!(
+        rows.checked_mul(take).is_some_and(|n| n == dst.len()),
+        "staged upload shape mismatch: {rows} rows x {take} cols vs dst len {}",
+        dst.len()
+    );
+    let (dst_ptr, _dst_order) = dst.device_ptr_mut(stream);
+    Ok(ColShardPlan {
+        stride_b,
+        off_b: col_offset * BF16_SIZE,
+        take_b,
+        rows,
+        dst_at: dst_ptr,
+    })
+}
+
 impl Drop for WeightStager {
     fn drop(&mut self) {
         // PinnedHostSlice's drop only waits on its embedded, never-recorded
@@ -243,7 +269,7 @@ impl Drop for WeightStager {
     }
 }
 
-fn drain_or_abort(stream: &CudaStream, context: &str) {
+pub(super) fn drain_or_abort(stream: &CudaStream, context: &str) {
     if let Err(sync_err) = stream.synchronize() {
         error!(
             "{context}; stream drain failed ({sync_err}); aborting instead of freeing pinned memory under an in-flight DMA"

--- a/openinfer-core/tests/weight_loader_gpu.rs
+++ b/openinfer-core/tests/weight_loader_gpu.rs
@@ -1,0 +1,77 @@
+//! GPU, model-free: StagedWeightLoader state-machine contract.
+
+use std::collections::HashMap;
+
+use half::bf16;
+use openinfer_core::tensor::DeviceContext;
+use openinfer_core::weight_loader::StagedWeightLoader;
+use safetensors::Dtype;
+use safetensors::SafeTensors;
+use safetensors::tensor::TensorView;
+
+#[test]
+fn record_after_finish_is_rejected() {
+    let ctx = DeviceContext::new().unwrap();
+    let data: Vec<u8> = (0..4u16)
+        .flat_map(|i| bf16::from_f32(f32::from(i)).to_bits().to_le_bytes())
+        .collect();
+    let view = TensorView::new(Dtype::BF16, vec![2, 2], &data).unwrap();
+    let bytes = safetensors::serialize([("w".to_string(), view)], None).unwrap();
+    let shards = vec![SafeTensors::deserialize(&bytes).unwrap()];
+    let weight_map = HashMap::new();
+
+    let mut loader = StagedWeightLoader::new(&ctx, &shards, &weight_map).unwrap();
+    let slot = loader.matrix("w", 2, 2).unwrap();
+    loader.finish().unwrap();
+
+    assert!(
+        loader.matrix("w", 2, 2).is_err(),
+        "matrix record after finish must be rejected"
+    );
+    assert!(
+        loader.vector("w", 4).is_err(),
+        "vector record after finish must be rejected"
+    );
+    let taken = loader.take(slot);
+    assert_eq!((taken.rows, taken.cols), (2, 2));
+}
+
+#[test]
+fn unaligned_vector_payload_roundtrips() {
+    let ctx = DeviceContext::new().unwrap();
+    let values: Vec<bf16> = (0..4u16)
+        .map(|i| bf16::from_f32(f32::from(i) + 0.5))
+        .collect();
+    let payload: Vec<u8> = values
+        .iter()
+        .flat_map(|v| v.to_bits().to_le_bytes())
+        .collect();
+    let view = TensorView::new(Dtype::BF16, vec![4], &payload).unwrap();
+    let bytes = safetensors::serialize([("v".to_string(), view)], None).unwrap();
+
+    // Stage the archive at both parities and keep the one whose payload
+    // pointer is odd, forcing the owned-decode path.
+    let mut backing = vec![0u8; bytes.len() + 1];
+    let mut chosen = None;
+    for start in [0usize, 1] {
+        backing[start..start + bytes.len()].copy_from_slice(&bytes);
+        let shard = SafeTensors::deserialize(&backing[start..start + bytes.len()]).unwrap();
+        if shard.tensor("v").unwrap().data().as_ptr() as usize % 2 == 1 {
+            chosen = Some(start);
+            break;
+        }
+    }
+    let start = chosen.expect("adjacent offsets have opposite payload parity");
+    let shards = vec![SafeTensors::deserialize(&backing[start..start + bytes.len()]).unwrap()];
+    let weight_map = HashMap::new();
+
+    let mut loader = StagedWeightLoader::new(&ctx, &shards, &weight_map).unwrap();
+    let slot = loader.vector("v", 4).unwrap();
+    loader.finish().unwrap();
+
+    let out = loader.take_vec(slot);
+    let host: Vec<bf16> = ctx.stream.clone_dtoh(&out.data).unwrap();
+    let got: Vec<u16> = host.iter().map(|v| v.to_bits()).collect();
+    let want: Vec<u16> = values.iter().map(|v| v.to_bits()).collect();
+    assert_eq!(got, want);
+}

--- a/openinfer-qwen3/src/weights.rs
+++ b/openinfer-qwen3/src/weights.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 #[cfg(test)]
 use std::path::Path;
-use std::time::Instant;
 
 use anyhow::Context;
 use anyhow::Result;
@@ -9,18 +8,10 @@ use cudarc::nccl::safe::Comm;
 use cudarc::nccl::safe::ReduceOp;
 use half::bf16;
 use log::debug;
-use log::info;
 use openinfer_core::tensor::DeviceContext;
 use openinfer_core::tensor::DeviceMatrix;
 use openinfer_core::tensor::DeviceVec;
 use openinfer_core::tensor::HiddenStates;
-use openinfer_core::weight_loader::FusedPart;
-use openinfer_core::weight_loader::StagedWeightLoader;
-use openinfer_core::weight_loader::WeightPrefetch;
-use openinfer_core::weight_loader::deserialize_shards;
-use openinfer_core::weight_loader::load_shard_info;
-use openinfer_core::weight_loader::mmap_shards;
-use openinfer_core::weight_loader::precompute_rope;
 use openinfer_kv_cache::KvBuffer;
 
 use super::config::Config;
@@ -33,6 +24,9 @@ use crate::lora::DeviceLoraTokenGroup;
 use crate::lora::LoraProjectionKind;
 use crate::lora::apply_lora_projection_delta_indexed;
 use crate::lora::apply_lora_projection_delta_range;
+
+mod load;
+pub(crate) use load::ModelRuntimeConfig;
 
 pub const DEFAULT_GPU_MEMORY_UTILIZATION: f64 = 0.90;
 pub const DEFAULT_KV_CACHE_MEMORY_MARGIN_BYTES: usize = 150 * 1024 * 1024;
@@ -101,27 +95,6 @@ pub(crate) struct KvBudget {
     pub(crate) head_dim: usize,
     pub(crate) block_size: usize,
     pub(crate) num_blocks: usize,
-}
-
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct ModelRuntimeConfig {
-    pub(crate) enable_cuda_graph: bool,
-    pub(crate) tensor_parallel: Option<TensorParallelConfig>,
-    pub(crate) device_ordinal: usize,
-    pub(crate) max_loras: usize,
-    pub(crate) max_lora_rank: usize,
-}
-
-impl Default for ModelRuntimeConfig {
-    fn default() -> Self {
-        Self {
-            enable_cuda_graph: true,
-            tensor_parallel: None,
-            device_ordinal: 0,
-            max_loras: crate::Qwen3LoraOptions::DEFAULT_MAX_LORAS,
-            max_lora_rank: crate::Qwen3LoraOptions::DEFAULT_MAX_LORA_RANK,
-        }
-    }
 }
 
 /// Attention layer weights.
@@ -381,213 +354,6 @@ unsafe impl Send for Qwen3Model {}
 unsafe impl Sync for Qwen3Model {}
 
 impl Qwen3Model {
-    pub(crate) fn from_safetensors_with_runtime(
-        model_path: &str,
-        runtime: ModelRuntimeConfig,
-    ) -> Result<Self> {
-        info!("Loading model from: {}", model_path);
-        debug!("Initializing GPU device {}", runtime.device_ordinal);
-        let ctx = DeviceContext::new_with_device(runtime.device_ordinal)?;
-
-        let config = Config::from_file(model_path)?;
-        let tensor_parallel = runtime.tensor_parallel.unwrap_or_default();
-        tensor_parallel.validate_for(&config)?;
-
-        let (shard_paths, weight_map) = load_shard_info(model_path)?;
-        debug!("Loading {} safetensor shard(s)", shard_paths.len());
-        let prefetch =
-            (tensor_parallel.world_size == 1).then(|| WeightPrefetch::spawn(&shard_paths));
-        let mmaps = mmap_shards(&shard_paths)?;
-        let shards = deserialize_shards(&mmaps)?;
-
-        let t_gpu = Instant::now();
-        let mut loader = StagedWeightLoader::new(&ctx, &shards, &weight_map)?;
-        let hidden = config.hidden_size;
-        debug!("Loading embeddings to GPU");
-        let embed_tokens = loader.matrix("model.embed_tokens.weight", config.vocab_size, hidden)?;
-        let lm_head = if config.tie_word_embeddings {
-            debug!("Using tied input/output embeddings");
-            None
-        } else {
-            debug!("Loading untied LM head to GPU");
-            Some(loader.matrix(config.lm_head_tensor_name(), config.vocab_size, hidden)?)
-        };
-
-        debug!(
-            "Loading layers to GPU: num_layers={}, tp_rank={}, tp_world_size={}",
-            config.num_hidden_layers, tensor_parallel.rank, tensor_parallel.world_size,
-        );
-        let mut layers = Vec::with_capacity(config.num_hidden_layers);
-        let q_total = config.num_attention_heads * config.head_dim;
-        let kv_total = config.num_key_value_heads * config.head_dim;
-        let inter_total = config.intermediate_size;
-        let (q_row_offset, q_rows) = tensor_parallel.shard_range(q_total);
-        let (kv_row_offset, kv_rows) = tensor_parallel.shard_range(kv_total);
-        let (inter_row_offset, inter_rows) = tensor_parallel.shard_range(inter_total);
-        for i in 0..config.num_hidden_layers {
-            let prefix = format!("model.layers.{}", i);
-
-            // shard_range covers world_size == 1 too (offset 0, full rows), so
-            // one fused load serves both the sharded and unsharded paths.
-            let q_name = format!("{prefix}.self_attn.q_proj.weight");
-            let k_name = format!("{prefix}.self_attn.k_proj.weight");
-            let v_name = format!("{prefix}.self_attn.v_proj.weight");
-            let qkv_proj = loader.fused_rows(
-                hidden,
-                &[
-                    FusedPart {
-                        name: &q_name,
-                        src_rows: q_total,
-                        row_offset: q_row_offset,
-                        rows: q_rows,
-                    },
-                    FusedPart {
-                        name: &k_name,
-                        src_rows: kv_total,
-                        row_offset: kv_row_offset,
-                        rows: kv_rows,
-                    },
-                    FusedPart {
-                        name: &v_name,
-                        src_rows: kv_total,
-                        row_offset: kv_row_offset,
-                        rows: kv_rows,
-                    },
-                ],
-            )?;
-
-            let gate_name = format!("{prefix}.mlp.gate_proj.weight");
-            let up_name = format!("{prefix}.mlp.up_proj.weight");
-            let gate_up_proj = loader.fused_rows(
-                hidden,
-                &[
-                    FusedPart {
-                        name: &gate_name,
-                        src_rows: inter_total,
-                        row_offset: inter_row_offset,
-                        rows: inter_rows,
-                    },
-                    FusedPart {
-                        name: &up_name,
-                        src_rows: inter_total,
-                        row_offset: inter_row_offset,
-                        rows: inter_rows,
-                    },
-                ],
-            )?;
-
-            let block = TransformerBlock {
-                input_layernorm: loader
-                    .vector(&format!("{}.input_layernorm.weight", prefix), hidden)?,
-                attention: Attention {
-                    qkv_proj,
-                    o_proj: if tensor_parallel.is_sharded() {
-                        loader.col_shard(
-                            &format!("{}.self_attn.o_proj.weight", prefix),
-                            hidden,
-                            q_total,
-                            q_row_offset,
-                            q_rows,
-                        )?
-                    } else {
-                        loader.matrix(
-                            &format!("{}.self_attn.o_proj.weight", prefix),
-                            hidden,
-                            q_total,
-                        )?
-                    },
-                    q_norm: loader.vector(
-                        &format!("{}.self_attn.q_norm.weight", prefix),
-                        config.head_dim,
-                    )?,
-                    k_norm: loader.vector(
-                        &format!("{}.self_attn.k_norm.weight", prefix),
-                        config.head_dim,
-                    )?,
-                    q_dim: q_rows,
-                    kv_dim: kv_rows,
-                },
-                post_attention_layernorm: loader.vector(
-                    &format!("{}.post_attention_layernorm.weight", prefix),
-                    hidden,
-                )?,
-                mlp: MLP {
-                    gate_up_proj,
-                    down_proj: if tensor_parallel.is_sharded() {
-                        loader.col_shard(
-                            &format!("{}.mlp.down_proj.weight", prefix),
-                            hidden,
-                            inter_total,
-                            inter_row_offset,
-                            inter_rows,
-                        )?
-                    } else {
-                        loader.matrix(
-                            &format!("{}.mlp.down_proj.weight", prefix),
-                            hidden,
-                            inter_total,
-                        )?
-                    },
-                },
-            };
-            layers.push(block);
-        }
-
-        let norm = loader.vector("model.norm.weight", hidden)?;
-
-        debug!("Precomputing RoPE cache on GPU");
-        let (cos_cache, sin_cache) = precompute_rope(
-            &ctx,
-            config.head_dim,
-            config.max_position_embeddings,
-            config.rope_theta,
-        )?;
-
-        ctx.sync()?;
-        drop(loader);
-        drop(prefetch);
-        info!(
-            "GPU model loaded in {:.0}ms",
-            t_gpu.elapsed().as_secs_f64() * 1e3
-        );
-        drop(shards);
-        // Page-table teardown of the multi-GB mapping is not worth blocking
-        // startup on; nothing references the mmaps once every weight is uploaded.
-        std::thread::Builder::new()
-            .name("qwen3-weights-unmap".into())
-            .spawn(move || drop(mmaps))
-            .map_err(|e| anyhow::anyhow!("weight unmap thread spawn failed: {e}"))?;
-
-        let num_hidden_layers = config.num_hidden_layers;
-        let model = Self {
-            ctx,
-            config,
-            embed_tokens,
-            lm_head,
-            layers,
-            norm,
-            cos_cache,
-            sin_cache,
-            enable_cuda_graph: runtime.enable_cuda_graph,
-            tensor_parallel,
-            tp_comm: None,
-            lora_adapters: HashMap::new(),
-            packed_lora: PackedLoraRegistry::empty(runtime.max_loras, num_hidden_layers),
-            max_loras: runtime.max_loras,
-            max_lora_rank: runtime.max_lora_rank,
-        };
-
-        if model.enable_cuda_graph {
-            debug!(
-                "Decode path CUDA Graph is enabled (single GPU captures on first decode step; TP pre-captures every bucket at startup)"
-            );
-        } else {
-            debug!("Decode path CUDA Graph is disabled");
-        }
-
-        Ok(model)
-    }
-
     pub(super) fn output_projection(&self) -> &DeviceMatrix {
         self.lm_head.as_ref().unwrap_or(&self.embed_tokens)
     }

--- a/openinfer-qwen3/src/weights/load.rs
+++ b/openinfer-qwen3/src/weights/load.rs
@@ -1,0 +1,282 @@
+//! Checkpoint loading for [`Qwen3Model`]: record the whole plan, then upload.
+
+use std::collections::HashMap;
+use std::time::Instant;
+
+use anyhow::Result;
+use log::debug;
+use log::info;
+use openinfer_core::tensor::DeviceContext;
+use openinfer_core::weight_loader::FusedPart;
+use openinfer_core::weight_loader::SlotId;
+use openinfer_core::weight_loader::StagedWeightLoader;
+use openinfer_core::weight_loader::VecSlotId;
+use openinfer_core::weight_loader::WeightPrefetch;
+use openinfer_core::weight_loader::deserialize_shards;
+use openinfer_core::weight_loader::load_shard_info;
+use openinfer_core::weight_loader::mmap_shards;
+use openinfer_core::weight_loader::precompute_rope;
+
+use super::Attention;
+use super::MLP;
+use super::PackedLoraRegistry;
+use super::Qwen3Model;
+use super::TransformerBlock;
+use crate::config::Config;
+use crate::config::TensorParallelConfig;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ModelRuntimeConfig {
+    pub(crate) enable_cuda_graph: bool,
+    pub(crate) tensor_parallel: Option<TensorParallelConfig>,
+    pub(crate) device_ordinal: usize,
+    pub(crate) max_loras: usize,
+    pub(crate) max_lora_rank: usize,
+}
+
+impl Default for ModelRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            enable_cuda_graph: true,
+            tensor_parallel: None,
+            device_ordinal: 0,
+            max_loras: crate::Qwen3LoraOptions::DEFAULT_MAX_LORAS,
+            max_lora_rank: crate::Qwen3LoraOptions::DEFAULT_MAX_LORA_RANK,
+        }
+    }
+}
+
+struct LayerSlots {
+    input_layernorm: VecSlotId,
+    qkv: SlotId,
+    o: SlotId,
+    q_norm: VecSlotId,
+    k_norm: VecSlotId,
+    post_attention_layernorm: VecSlotId,
+    gate_up: SlotId,
+    down: SlotId,
+}
+
+impl Qwen3Model {
+    pub(crate) fn from_safetensors_with_runtime(
+        model_path: &str,
+        runtime: ModelRuntimeConfig,
+    ) -> Result<Self> {
+        info!("Loading model from: {}", model_path);
+        debug!("Initializing GPU device {}", runtime.device_ordinal);
+        let ctx = DeviceContext::new_with_device(runtime.device_ordinal)?;
+
+        let config = Config::from_file(model_path)?;
+        let tensor_parallel = runtime.tensor_parallel.unwrap_or_default();
+        tensor_parallel.validate_for(&config)?;
+
+        let (shard_paths, weight_map) = load_shard_info(model_path)?;
+        debug!("Loading {} safetensor shard(s)", shard_paths.len());
+        let prefetch =
+            (tensor_parallel.world_size == 1).then(|| WeightPrefetch::spawn(&shard_paths));
+        let mmaps = mmap_shards(&shard_paths)?;
+        let shards = deserialize_shards(&mmaps)?;
+
+        let t_gpu = Instant::now();
+        let mut loader = StagedWeightLoader::new(&ctx, &shards, &weight_map)?;
+        let hidden = config.hidden_size;
+        debug!("Loading embeddings to GPU");
+        let embed_slot = loader.matrix("model.embed_tokens.weight", config.vocab_size, hidden)?;
+        let lm_head_slot = if config.tie_word_embeddings {
+            debug!("Using tied input/output embeddings");
+            None
+        } else {
+            debug!("Loading untied LM head to GPU");
+            Some(loader.matrix(config.lm_head_tensor_name(), config.vocab_size, hidden)?)
+        };
+
+        debug!(
+            "Loading layers to GPU: num_layers={}, tp_rank={}, tp_world_size={}",
+            config.num_hidden_layers, tensor_parallel.rank, tensor_parallel.world_size,
+        );
+        let mut layer_slots = Vec::with_capacity(config.num_hidden_layers);
+        let q_total = config.num_attention_heads * config.head_dim;
+        let kv_total = config.num_key_value_heads * config.head_dim;
+        let inter_total = config.intermediate_size;
+        let (q_row_offset, q_rows) = tensor_parallel.shard_range(q_total);
+        let (kv_row_offset, kv_rows) = tensor_parallel.shard_range(kv_total);
+        let (inter_row_offset, inter_rows) = tensor_parallel.shard_range(inter_total);
+        for i in 0..config.num_hidden_layers {
+            let prefix = format!("model.layers.{}", i);
+
+            // shard_range covers world_size == 1 too (offset 0, full rows), so
+            // one fused load serves both the sharded and unsharded paths.
+            let q_name = format!("{prefix}.self_attn.q_proj.weight");
+            let k_name = format!("{prefix}.self_attn.k_proj.weight");
+            let v_name = format!("{prefix}.self_attn.v_proj.weight");
+            let qkv_proj = loader.fused_rows(
+                hidden,
+                &[
+                    FusedPart {
+                        name: &q_name,
+                        src_rows: q_total,
+                        row_offset: q_row_offset,
+                        rows: q_rows,
+                    },
+                    FusedPart {
+                        name: &k_name,
+                        src_rows: kv_total,
+                        row_offset: kv_row_offset,
+                        rows: kv_rows,
+                    },
+                    FusedPart {
+                        name: &v_name,
+                        src_rows: kv_total,
+                        row_offset: kv_row_offset,
+                        rows: kv_rows,
+                    },
+                ],
+            )?;
+
+            let gate_name = format!("{prefix}.mlp.gate_proj.weight");
+            let up_name = format!("{prefix}.mlp.up_proj.weight");
+            let gate_up_proj = loader.fused_rows(
+                hidden,
+                &[
+                    FusedPart {
+                        name: &gate_name,
+                        src_rows: inter_total,
+                        row_offset: inter_row_offset,
+                        rows: inter_rows,
+                    },
+                    FusedPart {
+                        name: &up_name,
+                        src_rows: inter_total,
+                        row_offset: inter_row_offset,
+                        rows: inter_rows,
+                    },
+                ],
+            )?;
+
+            layer_slots.push(LayerSlots {
+                input_layernorm: loader
+                    .vector(&format!("{}.input_layernorm.weight", prefix), hidden)?,
+                qkv: qkv_proj,
+                o: if tensor_parallel.is_sharded() {
+                    loader.col_shard(
+                        &format!("{}.self_attn.o_proj.weight", prefix),
+                        hidden,
+                        q_total,
+                        q_row_offset,
+                        q_rows,
+                    )?
+                } else {
+                    loader.matrix(
+                        &format!("{}.self_attn.o_proj.weight", prefix),
+                        hidden,
+                        q_total,
+                    )?
+                },
+                q_norm: loader.vector(
+                    &format!("{}.self_attn.q_norm.weight", prefix),
+                    config.head_dim,
+                )?,
+                k_norm: loader.vector(
+                    &format!("{}.self_attn.k_norm.weight", prefix),
+                    config.head_dim,
+                )?,
+                post_attention_layernorm: loader.vector(
+                    &format!("{}.post_attention_layernorm.weight", prefix),
+                    hidden,
+                )?,
+                gate_up: gate_up_proj,
+                down: if tensor_parallel.is_sharded() {
+                    loader.col_shard(
+                        &format!("{}.mlp.down_proj.weight", prefix),
+                        hidden,
+                        inter_total,
+                        inter_row_offset,
+                        inter_rows,
+                    )?
+                } else {
+                    loader.matrix(
+                        &format!("{}.mlp.down_proj.weight", prefix),
+                        hidden,
+                        inter_total,
+                    )?
+                },
+            });
+        }
+
+        let norm_slot = loader.vector("model.norm.weight", hidden)?;
+
+        debug!("Precomputing RoPE cache on GPU");
+        let (cos_cache, sin_cache) = precompute_rope(
+            &ctx,
+            config.head_dim,
+            config.max_position_embeddings,
+            config.rope_theta,
+        )?;
+
+        loader.finish()?;
+        let embed_tokens = loader.take(embed_slot);
+        let lm_head = lm_head_slot.map(|slot| loader.take(slot));
+        let norm = loader.take_vec(norm_slot);
+        let layers: Vec<TransformerBlock> = layer_slots
+            .into_iter()
+            .map(|slots| TransformerBlock {
+                input_layernorm: loader.take_vec(slots.input_layernorm),
+                attention: Attention {
+                    qkv_proj: loader.take(slots.qkv),
+                    o_proj: loader.take(slots.o),
+                    q_norm: loader.take_vec(slots.q_norm),
+                    k_norm: loader.take_vec(slots.k_norm),
+                    q_dim: q_rows,
+                    kv_dim: kv_rows,
+                },
+                post_attention_layernorm: loader.take_vec(slots.post_attention_layernorm),
+                mlp: MLP {
+                    gate_up_proj: loader.take(slots.gate_up),
+                    down_proj: loader.take(slots.down),
+                },
+            })
+            .collect();
+        drop(loader);
+        drop(prefetch);
+        info!(
+            "GPU model loaded in {:.0}ms",
+            t_gpu.elapsed().as_secs_f64() * 1e3
+        );
+        drop(shards);
+        // Page-table teardown of the multi-GB mapping is not worth blocking
+        // startup on; nothing references the mmaps once every weight is uploaded.
+        std::thread::Builder::new()
+            .name("qwen3-weights-unmap".into())
+            .spawn(move || drop(mmaps))
+            .map_err(|e| anyhow::anyhow!("weight unmap thread spawn failed: {e}"))?;
+
+        let num_hidden_layers = config.num_hidden_layers;
+        let model = Self {
+            ctx,
+            config,
+            embed_tokens,
+            lm_head,
+            layers,
+            norm,
+            cos_cache,
+            sin_cache,
+            enable_cuda_graph: runtime.enable_cuda_graph,
+            tensor_parallel,
+            tp_comm: None,
+            lora_adapters: HashMap::new(),
+            packed_lora: PackedLoraRegistry::empty(runtime.max_loras, num_hidden_layers),
+            max_loras: runtime.max_loras,
+            max_lora_rank: runtime.max_lora_rank,
+        };
+
+        if model.enable_cuda_graph {
+            debug!(
+                "Decode path CUDA Graph is enabled (single GPU captures on first decode step; TP pre-captures every bucket at startup)"
+            );
+        } else {
+            debug!("Decode path CUDA Graph is disabled");
+        }
+
+        Ok(model)
+    }
+}


### PR DESCRIPTION
## Description
> Stacked on #742; only the last commit belongs to this PR — the first four are #742's and will drop out once it merges."

The staged weight loader ran validate -> allocate -> upload serially per tensor, so a shape mismatch deep in the checkpoint surfaced only after earlier tensors were already written to the GPU. This splits the load into a recorded plan and its execution: entry methods (matrices, fused rows, column shards, and the norm vectors alike) validate against the config-derived shapes, allocate, and record the upload; `finish()` executes every recorded upload afterwards, so all load-boundary validation completes before the first H2D write. `finish` stays poisoned until every upload lands — a failed call cannot be retried into a vacuous success — and ownership is restructured so the loader holds every destination until `finish()` succeeds and `take()` redeems it: matrices can no longer be observed half-written on an error path, and the internal unsafe stays local to `finish` (sources are checker-borrowed from the shards, destinations are slot-owned). One log line reports the phase walls, e.g. `weight load: 398 uploads, alloc 279ms, upload 594ms`.

This is a fail-fast and observability refactor, not an optimization. 

## Test Env

Measured on one sm_89 GPU, Qwen3-4B, warm page cache, five repetitions per arm with means, arms paired in the same session (the surrounding startup phases drift with GPU clock state across sessions, so only same-session pairs are comparable):

| variant | warm load phase | HTTP-ready |
|---|---|---|
| base (per-tensor validate/alloc/upload) | 964 ms | 5126 ms |
| this change (validate everything, then upload) | 986 ms | 5128 ms |

The +22 ms is the price of deferring every upload behind full validation; HTTP-ready is unchanged within noise. Three performance variants were measured on the same rig and rejected:

- Running the uploads on a worker thread overlapped with construction reaches 905 ms, but the 36 ms over base buys a thread, raw cross-thread pointers, and a weaker validation-before-write ordering — not worth it for a correctness-sensitive path.
- Pre-growing the stream-ordered allocator's pool changes nothing: pool growth costs ~36 ms/GB regardless of call count (one 8 GB warm-up allocation costs the same ~290 ms as the 146 per-tensor ones), so the allocation wall is a per-byte floor, not per-call overhead.
- Routing the ~150 small vectors through the pinned stager costs +14% load phase (per-chunk event and thread overhead dwarfs a few-KB copy); they defer with the matrices but upload as plain pageable copies, which return only after the source is staged.

Validation on the same GPU, on the rebased tree: `hf_golden_gate` (logits through the new loader still match the HF golden), `sampling_behavior`, and the core unit tests pass; fmt and clippy clean.
