### PR TITLE
fix(qwen35): size the TP sampling scratch from the decodable vocab

### DIFF
--- a/openinfer-qwen35/src/tp_executor.rs
+++ b/openinfer-qwen35/src/tp_executor.rs
@@ -822,7 +822,7 @@ impl TpWorkerPrepared {
         let decode_buffers = model.create_batch_decode_buffers_with_capacity(max_batch)?;
         let sample_scratch = openinfer_sample::SampleScratch::new(
             model.device_ctx(),
-            model.config().vocab_size,
+            model.config().selection_vocab,
             max_batch,
         )?;
         Ok((


### PR DESCRIPTION
## Description

Fixes #760 

#676 bounded token selection to the tokenizer's decodable vocabulary and sized every logits arena from `selection_vocab`, but it did not touch `tp_executor.rs`, where the tensor-parallel worker still built its `SampleScratch` from the checkpoint's padded `vocab_size` — a line that predates it, from #627. `select_batch` requires the scratch width to equal the logits width, because a mismatch would otherwise be a silent kernel out-of-bounds rather than a clean error, so on any checkpoint whose tokenizer stops short of the padded width every tensor-parallel prefill and decode failed with `select_batch: logits vocab 248077 != scratch vocab 248320`. Qwen3.5-4B is such a checkpoint, so TP serving was broken for it.

The four tests that cover this path — the two `hf_golden_gate` TP2 logits gates, `e2e_scheduler` TP2, and `serving_tp2` — are all `#[ignore]` because they need two CUDA devices, NCCL, and weights, which is why CI stayed green.

After the change the only remaining uses of `vocab_size` in this crate are the narrowing comparison itself and the checkpoint tensor-shape validation, both of which want the padded width. Qwen3 and Kimi have no equivalent narrowing and are unaffected.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)