### PR TITLE
feat(glm52): align TP4 prefill KV layout with EP

### DIFF
--- a/docs/models/glm52/tp4-prefill-only.md
+++ b/docs/models/glm52/tp4-prefill-only.md
@@ -4,9 +4,48 @@
 > 4-GPU TP4 host with a cubin-free kernel stack (FlashInfer CUTLASS grouped
 > MoE GEMM, DeepGEMM unpaged MQA indexer, NCCL bf16 all-reduces). 4×GB300
 > 16K TTFT 409 s → 1.36 s vs the 32-row bring-up path; leads a same-day
-> vLLM 0.25 rerun at every length except 4K.
+> vLLM 0.25 rerun at every length except 4K. TP4 now persists the canonical
+> 656-byte `fp8_ds_mla` row used by EP consumers.
 
 **Last touched:** 2026-07
+
+## Preparation: canonical P/D KV layout
+
+- **Read**:
+  - `docs/index.md` — routed the work to the GLM5.2 model line.
+  - `docs/models/glm52/tp4-prefill-only.md` — TP4 prefill currently persists a 576-byte cache row and rejects external P/D.
+  - `docs/models/glm52/pd-m2-execution.md` — the established P/D wire contract is the 656-byte `fp8_ds_mla` row plus the 132-byte index-K sidecar.
+- **Relevant history**:
+  - Existing P/D support validates TP8 vLLM → EP8 OpenInfer, but no TP4 → EP16 path exists.
+- **Plan**:
+  1. Create a non-`main` feature branch and make TP4 prefill persist the canonical 656-byte MLA row while retaining its BF16 sparse-prefill execution.
+  2. Add one startup `info` record that states topology, MLA backend/layout, page size, bytes per token/page, and MLA/index-K arena counts.
+  3. Add focused CPU/unit coverage for TP4-producer versus EP16-consumer cache geometry and run release library tests.
+  4. On the local 4×GB300 host, run the smallest TP4 prefill correctness/prefix-cache smoke available, then assess whether a true EP16 consumer run is possible with the available 4 GPUs.
+- **Risks / open questions**:
+  - This host has four GPUs and cannot perform a real 16-rank EP16 decode run; format/geometry can be gated locally, while end-to-end EP16 needs a 16-GPU environment.
+  - The 656-byte row increases TP4 target-cache capacity by 13.9%; the launch-time VRAM ledger must remain exact.
+
+### Execution result
+
+- TP4 prefill keeps `FlashInferFp8` as its 16-head/rank execution backend,
+  but persists the EP-consumer `fp8_ds_mla` row:
+  `512B fp8 cKV + 16B UE8M0/f32 scales + 128B bf16 RoPE = 656B/token`.
+- Startup logs the complete per-rank geometry: 78 MLA arenas at
+  `41,984B/page`, plus 21 index-K arenas at `8,448B/page`.
+- Release build and focused cache-layout unit test passed.
+- A 4×GB300 smoke using the full 141-shard checkpoint reached HTTP-ready.
+  A 401-token prompt completed successfully; two repeats both reported
+  `cached_tokens=384` (six complete 64-token pages) and returned the same
+  token.
+- The matching EP4 consumer topology also reached HTTP-ready and reported
+  the same 656-byte MLA / 132-byte index-K geometry. A 401-token prompt
+  decoded 16 coherent tokens; its repeat reported `cached_tokens=384` and
+  returned byte-identical output.
+- Container prerequisite: keep the NCCL runtime and development library on
+  one version. Mixing system NCCL 2.28.9 with a pip NCCL 2.30.7 produced
+  `corrupted comm object detected`/`ncclInvalidArgument`; upgrading both
+  system packages to 2.30.7 fixed the prefill all-reduce preflight.
 
 ## Contract
 

--- a/openinfer-glm52/src/model/mod.rs
+++ b/openinfer-glm52/src/model/mod.rs
@@ -26,7 +26,6 @@ use cudarc::driver::PinnedHostSlice;
 use half::bf16;
 use openinfer_core::cuda_graph::CudaGraphDumpSummary;
 use openinfer_core::cuda_graph::CudaGraphState;
-use openinfer_kernels::ops::GLM52_FLASHINFER_SPARSE_BYTES_PER_TOKEN;
 use openinfer_kernels::ops::GLM52_FLASHMLA_SPARSE_BYTES_PER_TOKEN;
 use openinfer_kernels::ops::GLM52_FLASHMLA_SPARSE_PAGE_SIZE;
 use openinfer_kernels::ops::GLM52_FLASHMLA_SPARSE_TOPK;
@@ -128,11 +127,10 @@ pub(crate) fn glm52_arena_bytes(
     prefill_only: bool,
 ) -> Result<usize> {
     let num_blocks = glm52_pool_blocks(max_model_len, pool_slots);
-    let cache_bytes_per_token = if prefill_only {
-        GLM52_FLASHINFER_SPARSE_BYTES_PER_TOKEN
-    } else {
-        GLM52_FLASHMLA_SPARSE_BYTES_PER_TOKEN
-    };
+    // Prefill-only is a P/D producer: persist the same fp8_ds_mla row the EP
+    // decode consumer reads, even though TP4's local attention execution uses
+    // a different backend.
+    let cache_bytes_per_token = GLM52_FLASHMLA_SPARSE_BYTES_PER_TOKEN;
     let mla = GLM52_LAYERS * num_blocks * GLM52_FLASHMLA_SPARSE_PAGE_SIZE * cache_bytes_per_token;
     let (table_width, index_layout) = glm52_index_cache_layout(max_model_len, pool_slots);
     let index_k = (0..GLM52_LAYERS)
@@ -175,6 +173,19 @@ fn glm52_index_cache_layout(
         cache_block_stride_bytes: INDEX_CACHE_BLOCK * (GLM52_INDEX_HEAD_DIM + 4),
     };
     (glm52_table_width(max_model_len), layout)
+}
+
+fn glm52_persistent_mla_bytes_per_token(
+    prefill_only: bool,
+    backend: crate::mla_decode::Glm52MlaBackend,
+) -> usize {
+    if prefill_only {
+        // P/D producer wire/storage format, independent of TP4's local
+        // attention execution backend.
+        GLM52_FLASHMLA_SPARSE_BYTES_PER_TOKEN
+    } else {
+        backend.cache_bytes_per_token()
+    }
 }
 
 /// The decode batch buckets, ascending. Each bucket has its own captured
@@ -549,9 +560,30 @@ impl Glm52RankModel {
             crate::config::GLM52_HEADS
         };
         let mla_backend = glm52_select_mla_backend(mla_heads)?;
-        let mla_cache_bytes_per_token = mla_backend.cache_bytes_per_token();
+        let mla_cache_bytes_per_token =
+            glm52_persistent_mla_bytes_per_token(prefill_chunk_size.is_some(), mla_backend);
+        let indexer_arenas = (0..GLM52_LAYERS)
+            .filter(|&layer| glm52_layer_has_full_indexer(layer))
+            .count();
         log::info!(
-            "GLM5.2 MLA backend: {:?} ({} heads/rank, {} bytes/cache token)",
+            "GLM5.2 KV cache: topology={moe_topo:?} backend={mla_backend:?} \
+             page_tokens={} mla_layout={} mla_bytes/token={} mla_bytes/page={} \
+             mla_arenas={} index_k_layout=fp8[64,128]+f32[64] \
+             index_k_bytes/token={} index_k_bytes/page={} index_k_arenas={indexer_arenas}",
+            GLM52_FLASHMLA_SPARSE_PAGE_SIZE,
+            if mla_cache_bytes_per_token == GLM52_FLASHMLA_SPARSE_BYTES_PER_TOKEN {
+                "fp8_ds_mla"
+            } else {
+                "flashinfer_fp8"
+            },
+            mla_cache_bytes_per_token,
+            GLM52_FLASHMLA_SPARSE_PAGE_SIZE * mla_cache_bytes_per_token,
+            GLM52_LAYERS,
+            GLM52_INDEX_HEAD_DIM + 4,
+            INDEX_CACHE_BLOCK * (GLM52_INDEX_HEAD_DIM + 4),
+        );
+        log::info!(
+            "GLM5.2 MLA execution: backend={:?} ({} heads/rank, persistent {} bytes/cache token)",
             mla_backend,
             mla_heads,
             mla_cache_bytes_per_token
@@ -719,7 +751,9 @@ impl Glm52RankModel {
                 argmax_indices_host: unsafe { ctx.ctx.alloc_pinned::<i32>(rows)? },
             });
         }
-        if mla_backend == crate::mla_decode::Glm52MlaBackend::FlashInferFp8 {
+        if prefill_chunk_size.is_none()
+            && mla_backend == crate::mla_decode::Glm52MlaBackend::FlashInferFp8
+        {
             for bucket in &mut buckets {
                 glm52_mla_backend_preflight(
                     ctx,
@@ -1296,5 +1330,23 @@ impl Glm52RankModel {
         });
         bucket.graph = graph;
         result
+    }
+}
+
+#[cfg(test)]
+mod cache_layout_tests {
+    use super::*;
+    use crate::mla_decode::Glm52MlaBackend;
+
+    #[test]
+    fn tp4_prefill_matches_ep_decode_persistent_mla_layout() {
+        let tp4_prefill =
+            glm52_persistent_mla_bytes_per_token(true, Glm52MlaBackend::FlashInferFp8);
+        let ep_decode = glm52_persistent_mla_bytes_per_token(false, Glm52MlaBackend::FlashMlaFp8Ds);
+
+        assert_eq!(tp4_prefill, 656);
+        assert_eq!(tp4_prefill, ep_decode);
+        assert_eq!(GLM52_FLASHMLA_SPARSE_PAGE_SIZE * tp4_prefill, 41_984);
+        assert_eq!(INDEX_CACHE_BLOCK * (GLM52_INDEX_HEAD_DIM + 4), 8_448);
     }
 }

--- a/openinfer-glm52/src/prefill_tp.rs
+++ b/openinfer-glm52/src/prefill_tp.rs
@@ -17,6 +17,7 @@ use cudarc::driver::CudaEvent;
 use cudarc::driver::CudaSlice;
 use half::bf16;
 use openinfer_kernels::ops::Glm52IndexerCacheLayout;
+use openinfer_kernels::ops::Glm52MoeQuantShape;
 use openinfer_kernels::ops::add_into;
 use openinfer_kernels::ops::argmax_batch_bf16_split_partials_len;
 use openinfer_kernels::ops::argmax_bf16_split_into;
@@ -24,7 +25,8 @@ use openinfer_kernels::ops::embedding_rows_into;
 use openinfer_kernels::ops::fused_add_rms_norm_round_into;
 use openinfer_kernels::ops::gemm_strided_batched_bf16;
 use openinfer_kernels::ops::glm52_flashmla_sparse_prefill_launch;
-use openinfer_kernels::ops::glm52_mla_front_pack_fp8_launch;
+use openinfer_kernels::ops::glm52_fp8_per_token_group_quant_bf16_ue8m0_launch;
+use openinfer_kernels::ops::glm52_mla_cache_pack_launch;
 use openinfer_kernels::ops::glm52_mla_query_assemble_launch;
 use openinfer_kernels::ops::glm52_prefill_moe_gather_rows_launch;
 use openinfer_kernels::ops::glm52_prefill_unpack_pages_launch;
@@ -183,7 +185,8 @@ pub(crate) struct Glm52TpPrefillExecutor {
     sin: CudaSlice<bf16>,
     mla_front: Glm52MlaFront,
     ql_nope: CudaSlice<bf16>,
-    query_fp8: CudaSlice<u8>,
+    ckv_fp8: CudaSlice<u8>,
+    ckv_scales: CudaSlice<f32>,
     slot_mapping: CudaSlice<i64>,
     block_ids: CudaSlice<i32>,
     unpacked_kv: CudaSlice<bf16>,
@@ -260,7 +263,8 @@ impl Glm52TpPrefillExecutor {
             ql_nope: ctx
                 .stream
                 .alloc_zeros::<bf16>(chunk * 16 * GLM52_KV_LORA_RANK)?,
-            query_fp8: ctx.stream.alloc_zeros::<u8>(chunk * 16 * GLM52_KV_A_OUT)?,
+            ckv_fp8: ctx.stream.alloc_zeros::<u8>(chunk * GLM52_KV_LORA_RANK)?,
+            ckv_scales: ctx.stream.alloc_zeros::<f32>(chunk * 4)?,
             slot_mapping: ctx.stream.alloc_zeros::<i64>(chunk)?,
             block_ids: ctx
                 .stream
@@ -563,9 +567,9 @@ impl Glm52TpPrefillExecutor {
     }
 
     /// Per-layer chunk-scale MLA pack: the w_uk absorb bmm plus the fused
-    /// front-pack kernel that writes both the fp8 query and this layer's
-    /// packed KV pages at `slot_mapping`. The bf16 attention query is
-    /// assembled later, per attention sub-tile.
+    /// canonical fp8_ds_mla pack that writes this layer's 656-byte KV rows at
+    /// `slot_mapping`. The bf16 attention query is assembled later, per
+    /// attention sub-tile.
     fn pack_mla_cache(
         &mut self,
         ctx: &DeviceContext,
@@ -591,20 +595,25 @@ impl Glm52TpPrefillExecutor {
             GLM52_KV_LORA_RANK,
             16,
         )?;
-        glm52_mla_front_pack_fp8_launch(
+        glm52_fp8_per_token_group_quant_bf16_ue8m0_launch(
+            ctx,
+            Glm52MoeQuantShape {
+                rows,
+                width: GLM52_KV_LORA_RANK,
+                group_size: 128,
+            },
+            &self.mla_front.kv_c,
+            &mut self.ckv_fp8,
+            &mut self.ckv_scales,
+        )?;
+        glm52_mla_cache_pack_launch(
             ctx,
             rows,
-            16,
-            &self.ql_nope,
-            &self.mla_front.q_full,
-            GLM52_QK_NOPE_HEAD_DIM,
-            GLM52_QK_HEAD_DIM,
-            &self.mla_front.ckv,
-            &weights.kv_a_ln.data,
-            GLM52_RMS_EPS,
+            &self.ckv_fp8,
+            &self.ckv_scales,
+            &self.mla_front.k_pe,
             &self.cos,
             &self.sin,
-            &mut self.query_fp8,
             packed_cache,
             &self.slot_mapping,
         )


### PR DESCRIPTION
## Summary

- persist TP4 prefill MLA cache rows in the canonical 656-byte `fp8_ds_mla` layout consumed by EP decode
- keep TP4 prefill attention on its existing FlashInfer/BF16 execution path while separating execution backend from persistent cache format
- log the complete MLA and index-K cache geometry at startup
- add focused unit coverage for TP4 producer and EP consumer layout parity

## Why

TP4 prefill previously persisted a 576-byte FlashInfer-specific row, while EP4/EP16 decode consumes the canonical 656-byte row containing 512 bytes of FP8 cKV, four FP32/UE8M0 scales, and 64 BF16 RoPE values. That mismatch prevented the producer and consumer cache layouts from being directly compatible.

## Validation

- `cargo build --release --features glm52`
- `cargo check --release --features glm52`
- `cargo test --release -p openinfer-glm52 --lib cache_layout_tests -- --nocapture`
- TP4 prefill-only startup on 4x GB300 with the full GLM-5.2-FP8 checkpoint
- TP4 401-token prompt smoke; repeated requests reported `cached_tokens=384` and returned identical output
- EP4 startup on the same host reported the same 656-byte MLA and 132-byte index-K geometry
- EP4 401-token prompt plus 16-token decode; repeated request reported `cached_tokens=384` and returned byte-identical output

This PR validates both endpoints and their cache geometry independently. It does not claim an end-to-end TP4-to-PegaFlow-to-EP4 transfer test.