### PR TITLE
perf(glm52): enlarge sparse prefill attention tiles

### DIFF
--- a/openinfer-glm52/src/prefill_tp.rs
+++ b/openinfer-glm52/src/prefill_tp.rs
@@ -71,7 +71,12 @@ use crate::rows::Rows;
 use crate::runner::Glm52PrefillBatch;
 
 /// FlashMLA sparse attention sub-tile (query rows per launch).
-const PREFILL_ATTN_TILE_ROWS: usize = 512;
+///
+/// The SM100 sparse-prefill kernel accepts arbitrary positive query rows.
+/// Keeping 4K rows in the temporary 64-head buffers cuts a 16K coordinator
+/// chunk from 32 launches to 4 while staying inside the fixed
+/// prefill scratch reservation.
+const PREFILL_ATTN_TILE_ROWS: usize = 4096;
 /// Dense-MLP sub-tile: bounds the 12288-wide gate|up scratch.
 const PREFILL_DENSE_TILE_ROWS: usize = 2048;
 


### PR DESCRIPTION
## Summary

Increase the GLM5.2 TP4 sparse-prefill attention tile from 512 to 4,096 query rows. This reduces a 16K chunk from 32 attention launches per layer to 4 without changing the kernel or cache layout.

## Measured impact

On TP4 with an exact 16,384-token cold prompt and one output token:

- median TTFT: 1,294.0 ms → 1,215.2 ms (-6.1%)
- sparse-attention section: ~394.8 ms/rank → ~323.9 ms/rank (-18.0%)
- post-build free VRAM: 86.2 GiB/rank → 84.8 GiB/rank

A 16,384-row tile was also tested, but only improved TTFT by another 0.6% while consuming another 4.9 GiB/rank, so 4,096 is retained.

## Validation

- `cargo build --release --features glm52 --bin openinfer`
- `cargo test --release -p openinfer-glm52 --lib prefill -- --nocapture` (9 passed, 2 ignored)
- `cargo fmt --all -- --check`
- exact-16K TP4 HTTP serving A/B on 4× GB300
