### PR TITLE
Add CUDA development container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,13 +1,2 @@
-.git
-**/.git
-.venv
-**/.venv
-target
-**/target
-models
-datasets
-traces
-bench_results
-artifacts
-profile
-docs/private
+**
+!rust-toolchain.toml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+**/.git
+.venv
+**/.venv
+target
+**/target
+models
+datasets
+traces
+bench_results
+artifacts
+profile
+docs/private

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@ Every model line is behind a cargo feature; only `qwen3` is a default feature, s
 
 **Always use `--release`** — debug builds are extremely slow for GPU/CUDA and will timeout.
 
+When developing with Docker, use `docker/Dockerfile.dev` and `docker/dev.sh` as described in `docker/README.md`.
+
 ```bash
 # Qwen3 (default feature, no Python anywhere in the build)
 cargo run --release -- --model-path models/Qwen3-4B

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,88 @@
+# syntax=docker/dockerfile:1.7
+
+# Override this build argument to test a newer toolkit without editing the file.
+ARG CUDA_IMAGE=nvidia/cuda:13.2.0-devel-ubuntu24.04
+FROM ${CUDA_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG DEV_USER=openinfer
+ARG DEV_UID=1000
+ARG DEV_GID=1000
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Keep this list in sync with scripts/setup_dev.sh. libnccl-dev/libnccl2 come
+# from the NVIDIA apt repository already configured by the CUDA base image.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        clang \
+        cmake \
+        curl \
+        git \
+        libclang-dev \
+        libibverbs-dev \
+        libnccl-dev \
+        libnccl2 \
+        libssl-dev \
+        ninja-build \
+        pkg-config \
+        protobuf-compiler \
+        python3 \
+        python3-dev \
+        python3-venv \
+        sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# Give OpenInfer one stable NCCL location on every architecture. This prevents
+# the build from finding a new header while the runtime loader finds an older
+# libnccl.so from another Python or system environment.
+RUN multiarch="$(dpkg-architecture -qDEB_HOST_MULTIARCH)" \
+    && mkdir -p /opt/nccl/include /opt/nccl/lib \
+    && ln -s /usr/include/nccl.h /opt/nccl/include/nccl.h \
+    && ln -s "/usr/lib/${multiarch}/libnccl.so" /opt/nccl/lib/libnccl.so \
+    && ln -s "/usr/lib/${multiarch}/libnccl.so.2" /opt/nccl/lib/libnccl.so.2 \
+    && printf '#include <nccl.h>\nint main(void) { return NCCL_VERSION_CODE < 23004; }\n' \
+        >/tmp/check_nccl.c \
+    && cc -I/usr/local/cuda/include /tmp/check_nccl.c -o /tmp/check_nccl \
+    && /tmp/check_nccl \
+    && rm -f /tmp/check_nccl /tmp/check_nccl.c
+
+ENV CUDA_HOME=/usr/local/cuda
+ENV OPENINFER_NCCL_ROOT=/opt/nccl
+ENV LD_LIBRARY_PATH=/opt/nccl/lib:/usr/local/cuda/lib64
+ENV TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas
+ENV UV_LINK_MODE=copy
+
+# Match the host UID/GID so bind-mounted source and caches remain writable.
+RUN if getent passwd "${DEV_UID}" >/dev/null; then userdel -f "$(getent passwd "${DEV_UID}" | cut -d: -f1)"; fi \
+    && if getent group "${DEV_GID}" >/dev/null; then groupdel "$(getent group "${DEV_GID}" | cut -d: -f1)"; fi \
+    && groupadd --gid "${DEV_GID}" "${DEV_USER}" \
+    && useradd --uid "${DEV_UID}" --gid "${DEV_GID}" --create-home --shell /bin/bash "${DEV_USER}" \
+    && echo "${DEV_USER} ALL=(root) NOPASSWD:ALL" >"/etc/sudoers.d/${DEV_USER}" \
+    && chmod 0440 "/etc/sudoers.d/${DEV_USER}"
+
+RUN curl -LsSf https://astral.sh/uv/install.sh \
+        | env UV_INSTALL_DIR=/usr/local/bin sh \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | env RUSTUP_HOME=/opt/rustup CARGO_HOME=/opt/cargo sh -s -- \
+            -y --default-toolchain none --profile minimal \
+    && chmod -R a+rX /opt/rustup /opt/cargo \
+    && chmod a+rx /opt/cargo/bin/*
+
+ENV RUSTUP_HOME=/opt/rustup
+ENV CARGO_HOME=/opt/cargo
+ENV PATH=/opt/cargo/bin:/usr/local/cuda/bin:/usr/local/bin:${PATH}
+
+WORKDIR /workspace/openinfer
+COPY rust-toolchain.toml /tmp/openinfer-rust-toolchain.toml
+RUN cd /tmp \
+    && rustup toolchain install \
+        "$(sed -n 's/^channel = "\(.*\)"/\1/p' /tmp/openinfer-rust-toolchain.toml)" \
+        --component rustfmt \
+        --component clippy \
+    && rm -f /tmp/openinfer-rust-toolchain.toml
+
+USER ${DEV_USER}
+CMD ["/bin/bash"]

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -4,12 +4,16 @@
 ARG CUDA_IMAGE=nvidia/cuda:13.2.0-devel-ubuntu24.04
 FROM ${CUDA_IMAGE}
 
+ARG CUDA_IMAGE
 ARG DEBIAN_FRONTEND=noninteractive
 ARG DEV_USER=openinfer
 ARG DEV_UID=1000
 ARG DEV_GID=1000
+ARG TRITON_VERSION=3.7.1
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+LABEL org.openinfer.cuda-image="${CUDA_IMAGE}"
 
 # Keep this list in sync with scripts/setup_dev.sh. libnccl-dev/libnccl2 come
 # from the NVIDIA apt repository already configured by the CUDA base image.
@@ -66,6 +70,10 @@ RUN if getent passwd "${DEV_UID}" >/dev/null; then userdel -f "$(getent passwd "
 
 RUN curl -LsSf https://astral.sh/uv/install.sh \
         | env UV_INSTALL_DIR=/usr/local/bin sh \
+    && uv venv --python python3 /opt/openinfer-venv \
+    && uv pip install --python /opt/openinfer-venv/bin/python \
+        "triton==${TRITON_VERSION}" \
+    && /opt/openinfer-venv/bin/python -c "import triton; print(triton.__version__)" \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
         | env RUSTUP_HOME=/opt/rustup CARGO_HOME=/opt/cargo sh -s -- \
             -y --default-toolchain none --profile minimal \
@@ -74,6 +82,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh \
 
 ENV RUSTUP_HOME=/opt/rustup
 ENV CARGO_HOME=/opt/cargo
+ENV OPENINFER_TRITON_PYTHON=/opt/openinfer-venv/bin/python
 ENV PATH=/opt/cargo/bin:/usr/local/cuda/bin:/usr/local/bin:${PATH}
 
 WORKDIR /workspace/openinfer

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -68,12 +68,15 @@ RUN if getent passwd "${DEV_UID}" >/dev/null; then userdel -f "$(getent passwd "
     && echo "${DEV_USER} ALL=(root) NOPASSWD:ALL" >"/etc/sudoers.d/${DEV_USER}" \
     && chmod 0440 "/etc/sudoers.d/${DEV_USER}"
 
+ARG TILELANG_VERSION=0.1.12
 RUN curl -LsSf https://astral.sh/uv/install.sh \
         | env UV_INSTALL_DIR=/usr/local/bin sh \
     && uv venv --python python3 /opt/openinfer-venv \
     && uv pip install --python /opt/openinfer-venv/bin/python \
         "triton==${TRITON_VERSION}" \
-    && /opt/openinfer-venv/bin/python -c "import triton; print(triton.__version__)" \
+        "tilelang==${TILELANG_VERSION}" \
+    && /opt/openinfer-venv/bin/python -c \
+        "import tilelang, triton; print(f'tilelang={tilelang.__version__} triton={triton.__version__}')" \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
         | env RUSTUP_HOME=/opt/rustup CARGO_HOME=/opt/cargo sh -s -- \
             -y --default-toolchain none --profile minimal \
@@ -83,6 +86,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh \
 ENV RUSTUP_HOME=/opt/rustup
 ENV CARGO_HOME=/opt/cargo
 ENV OPENINFER_TRITON_PYTHON=/opt/openinfer-venv/bin/python
+ENV OPENINFER_TILELANG_PYTHON=/opt/openinfer-venv/bin/python
 ENV PATH=/opt/cargo/bin:/usr/local/cuda/bin:/usr/local/bin:${PATH}
 
 WORKDIR /workspace/openinfer

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -92,7 +92,8 @@ RUN cd /tmp \
         "$(sed -n 's/^channel = "\(.*\)"/\1/p' /tmp/openinfer-rust-toolchain.toml)" \
         --component rustfmt \
         --component clippy \
-    && rm -f /tmp/openinfer-rust-toolchain.toml
+    && rm -f /tmp/openinfer-rust-toolchain.toml \
+    && chown -R "${DEV_UID}:${DEV_GID}" /opt/cargo
 
 USER ${DEV_USER}
 CMD ["/bin/bash"]

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -56,7 +56,7 @@ RUN multiarch="$(dpkg-architecture -qDEB_HOST_MULTIARCH)" \
 
 ENV CUDA_HOME=/usr/local/cuda
 ENV OPENINFER_NCCL_ROOT=/opt/nccl
-ENV LD_LIBRARY_PATH=/opt/nccl/lib:/usr/local/cuda/lib64
+ENV LD_LIBRARY_PATH=/opt/nccl/lib:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
 ENV TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas
 ENV UV_LINK_MODE=copy
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -25,6 +25,7 @@ RUN apt-get update \
         libibverbs-dev \
         libnccl-dev \
         libnccl2 \
+        libprotobuf-dev \
         libssl-dev \
         ninja-build \
         pkg-config \

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,7 +2,7 @@
 
 The development image contains the native toolchain required to build
 OpenInfer: CUDA, the Rust nightly pinned by `rust-toolchain.toml`, Python 3,
-uv, clang, OpenSSL, protoc, and NCCL 2.30.4 or newer.
+uv, Triton, clang, OpenSSL, protoc, and NCCL 2.30.4 or newer.
 
 Build it once:
 
@@ -18,13 +18,19 @@ docker/dev.sh shell
 ```
 
 Linked Git worktrees are supported: the wrapper detects an external Git
-common directory and mounts it read-only so build scripts can inspect
-submodule state.
+common directory and mounts it at the same path so build scripts can inspect
+and initialize submodules.
 
 Or run a one-off build:
 
 ```bash
 docker/dev.sh run cargo build --release
+```
+
+Qwen3.5's build-time AOT compiler uses the image's pinned Triton environment:
+
+```bash
+docker/dev.sh run cargo build --release --features qwen35
 ```
 
 Mount model weights read-only at their existing absolute path:
@@ -40,6 +46,10 @@ changing the Dockerfile after upgrading the host driver:
 ```bash
 CUDA_IMAGE=nvidia/cuda:<version>-devel-ubuntu24.04 docker/dev.sh build
 ```
+
+The persistent native target cache is automatically namespaced by the CUDA
+base recorded in the image. Set `OPENINFER_DEV_CACHE_KEY` only when a custom
+image needs a more specific namespace.
 
 On a tray without a GIN-capable NIC, pass `EP_DISABLE_GIN=1` when starting
 the container. It is intentionally not baked into the image because networked

--- a/docker/README.md
+++ b/docker/README.md
@@ -61,3 +61,6 @@ image needs a more specific namespace.
 On a tray without a GIN-capable NIC, pass `EP_DISABLE_GIN=1` when starting
 the container. It is intentionally not baked into the image because networked
 deployments require GIN.
+
+On GB300 NVL72 hosts, the wrapper automatically forwards the IMEX channel
+device required by cross-tray LSA when that device exists.

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,16 +10,27 @@ Build it once:
 docker/dev.sh build
 ```
 
-Open a shell with the repository and persistent compiler caches mounted:
+Open a shell with the repository at its original absolute path and persistent
+compiler caches mounted:
 
 ```bash
 docker/dev.sh shell
 ```
 
+Linked Git worktrees are supported: the wrapper detects an external Git
+common directory and mounts it read-only so build scripts can inspect
+submodule state.
+
 Or run a one-off build:
 
 ```bash
 docker/dev.sh run cargo build --release
+```
+
+Mount model weights read-only at their existing absolute path:
+
+```bash
+OPENINFER_MODEL_DIR=/models/Qwen3-4B docker/dev.sh shell
 ```
 
 The default base is the pinned CUDA 13.2 development image, which is the

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,35 @@
+# OpenInfer development container
+
+The development image contains the native toolchain required to build
+OpenInfer: CUDA, the Rust nightly pinned by `rust-toolchain.toml`, Python 3,
+uv, clang, OpenSSL, protoc, and NCCL 2.30.4 or newer.
+
+Build it once:
+
+```bash
+docker/dev.sh build
+```
+
+Open a shell with the repository and persistent compiler caches mounted:
+
+```bash
+docker/dev.sh shell
+```
+
+Or run a one-off build:
+
+```bash
+docker/dev.sh run cargo build --release
+```
+
+The default base is the pinned CUDA 13.2 development image, which is the
+newest version supported by the current GB300 tray driver. Override it without
+changing the Dockerfile after upgrading the host driver:
+
+```bash
+CUDA_IMAGE=nvidia/cuda:<version>-devel-ubuntu24.04 docker/dev.sh build
+```
+
+On a tray without a GIN-capable NIC, pass `EP_DISABLE_GIN=1` when starting
+the container. It is intentionally not baked into the image because networked
+deployments require GIN.

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,7 +2,7 @@
 
 The development image contains the native toolchain required to build
 OpenInfer: CUDA, the Rust nightly pinned by `rust-toolchain.toml`, Python 3,
-uv, Triton, clang, OpenSSL, protoc, and NCCL 2.30.4 or newer.
+uv, Triton, TileLang, clang, OpenSSL, protoc, and NCCL 2.30.4 or newer.
 
 Build it once:
 
@@ -31,6 +31,13 @@ Qwen3.5's build-time AOT compiler uses the image's pinned Triton environment:
 
 ```bash
 docker/dev.sh run cargo build --release --features qwen35
+```
+
+GLM5.2 builds targeting Hopper use the same environment's pinned TileLang:
+
+```bash
+OPENINFER_CUDA_SM=90 docker/dev.sh run \
+  cargo build --release --features glm52
 ```
 
 Mount model weights read-only at their existing absolute path:

--- a/docker/dev.sh
+++ b/docker/dev.sh
@@ -20,6 +20,7 @@ Environment:
   OPENINFER_DEV_CACHE     Persistent build-cache directory.
   OPENINFER_DEV_CACHE_KEY Override the native build-cache namespace.
   OPENINFER_MODEL_DIR     Read-only model directory mounted at the same path.
+  OPENINFER_CUDA_SM       Forwarded CUDA SM target override.
   EP_DISABLE_GIN          Forwarded when set; useful on trays without a GIN NIC.
 EOF
 }
@@ -69,6 +70,10 @@ esac
 
 if [[ -n "${EP_DISABLE_GIN:-}" ]]; then
   docker_args+=(--env "EP_DISABLE_GIN=$EP_DISABLE_GIN")
+fi
+
+if [[ -n "${OPENINFER_CUDA_SM:-}" ]]; then
+  docker_args+=(--env "OPENINFER_CUDA_SM=$OPENINFER_CUDA_SM")
 fi
 
 if [[ -n "${OPENINFER_MODEL_DIR:-}" ]]; then

--- a/docker/dev.sh
+++ b/docker/dev.sh
@@ -58,6 +58,13 @@ docker_args=(
   --workdir "$repo_root"
 )
 
+# GB300 NVL72 cross-tray LSA requires the IMEX channel in addition to the
+# devices exposed by --gpus. Single-node and non-IMEX hosts have no such path.
+imex_channel=/dev/nvidia-caps-imex-channels/channel0
+if [[ -e "$imex_channel" ]]; then
+  docker_args+=(--device "$imex_channel:$imex_channel")
+fi
+
 # A linked worktree stores a .git file that points at the main checkout's
 # common git directory. Mount that directory at the same absolute path so
 # build.rs can inspect and initialize submodules without making the whole

--- a/docker/dev.sh
+++ b/docker/dev.sh
@@ -18,6 +18,7 @@ Environment:
   OPENINFER_DEV_IMAGE     Image tag (default: openinfer-dev:cu132).
   OPENINFER_DEV_CONTAINER Interactive container name (default: openinfer-dev).
   OPENINFER_DEV_CACHE     Persistent build-cache directory.
+  OPENINFER_MODEL_DIR     Read-only model directory mounted at the same path.
   EP_DISABLE_GIN          Forwarded when set; useful on trays without a GIN NIC.
 EOF
 }
@@ -39,15 +40,37 @@ docker_args=(
   --network host
   --ulimit memlock=-1
   --ulimit stack=67108864
-  --volume "$repo_root:/workspace/openinfer"
+  --volume "$repo_root:$repo_root"
   --volume "$cache_root/cargo-registry:/opt/cargo/registry"
   --volume "$cache_root/cargo-git:/opt/cargo/git"
-  --volume "$cache_root/target:/workspace/openinfer/target"
-  --workdir /workspace/openinfer
+  --volume "$cache_root/target:$repo_root/target"
+  --workdir "$repo_root"
 )
+
+# A linked worktree stores a .git file that points at the main checkout's
+# common git directory. Mount that directory at the same absolute path so
+# build.rs can inspect submodule state without making the whole parent tree
+# visible or writable.
+git_common_dir="$(git -C "$repo_root" rev-parse --path-format=absolute --git-common-dir)"
+case "$git_common_dir/" in
+  "$repo_root/"*) ;;
+  *) docker_args+=(--volume "$git_common_dir:$git_common_dir:ro") ;;
+esac
 
 if [[ -n "${EP_DISABLE_GIN:-}" ]]; then
   docker_args+=(--env "EP_DISABLE_GIN=$EP_DISABLE_GIN")
+fi
+
+if [[ -n "${OPENINFER_MODEL_DIR:-}" ]]; then
+  [[ "$OPENINFER_MODEL_DIR" = /* ]] || {
+    echo "OPENINFER_MODEL_DIR must be an absolute path" >&2
+    exit 2
+  }
+  [[ -d "$OPENINFER_MODEL_DIR" ]] || {
+    echo "OPENINFER_MODEL_DIR does not exist: $OPENINFER_MODEL_DIR" >&2
+    exit 2
+  }
+  docker_args+=(--volume "$OPENINFER_MODEL_DIR:$OPENINFER_MODEL_DIR:ro")
 fi
 
 case "${1:-}" in

--- a/docker/dev.sh
+++ b/docker/dev.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+image="${OPENINFER_DEV_IMAGE:-openinfer-dev:cu132}"
+container="${OPENINFER_DEV_CONTAINER:-openinfer-dev}"
+cache_root="${OPENINFER_DEV_CACHE:-$HOME/.cache/openinfer-dev}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  docker/dev.sh build             Build the development image.
+  docker/dev.sh shell [COMMAND]   Start an interactive development container.
+  docker/dev.sh run COMMAND...    Run a command in a disposable container.
+
+Environment:
+  CUDA_IMAGE              CUDA devel base (default: CUDA 13.2 / Ubuntu 24.04).
+  OPENINFER_DEV_IMAGE     Image tag (default: openinfer-dev:cu132).
+  OPENINFER_DEV_CONTAINER Interactive container name (default: openinfer-dev).
+  OPENINFER_DEV_CACHE     Persistent build-cache directory.
+  EP_DISABLE_GIN          Forwarded when set; useful on trays without a GIN NIC.
+EOF
+}
+
+build_image() {
+  docker build \
+    --file "$repo_root/docker/Dockerfile.dev" \
+    --build-arg "CUDA_IMAGE=${CUDA_IMAGE:-nvidia/cuda:13.2.0-devel-ubuntu24.04}" \
+    --build-arg "DEV_USER=$(id -un)" \
+    --build-arg "DEV_UID=$(id -u)" \
+    --build-arg "DEV_GID=$(id -g)" \
+    --tag "$image" \
+    "$repo_root"
+}
+
+docker_args=(
+  --gpus all
+  --ipc host
+  --network host
+  --ulimit memlock=-1
+  --ulimit stack=67108864
+  --volume "$repo_root:/workspace/openinfer"
+  --volume "$cache_root/cargo-registry:/opt/cargo/registry"
+  --volume "$cache_root/cargo-git:/opt/cargo/git"
+  --volume "$cache_root/target:/workspace/openinfer/target"
+  --workdir /workspace/openinfer
+)
+
+if [[ -n "${EP_DISABLE_GIN:-}" ]]; then
+  docker_args+=(--env "EP_DISABLE_GIN=$EP_DISABLE_GIN")
+fi
+
+case "${1:-}" in
+  build)
+    build_image
+    ;;
+  shell)
+    shift
+    mkdir -p "$cache_root"/{cargo-registry,cargo-git,target}
+    if (( $# == 0 )); then
+      set -- /bin/bash
+    fi
+    docker run --rm -it --name "$container" "${docker_args[@]}" "$image" "$@"
+    ;;
+  run)
+    shift
+    (( $# > 0 )) || { usage >&2; exit 2; }
+    mkdir -p "$cache_root"/{cargo-registry,cargo-git,target}
+    docker run --rm "${docker_args[@]}" "$image" "$@"
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac

--- a/docker/dev.sh
+++ b/docker/dev.sh
@@ -18,6 +18,7 @@ Environment:
   OPENINFER_DEV_IMAGE     Image tag (default: openinfer-dev:cu132).
   OPENINFER_DEV_CONTAINER Interactive container name (default: openinfer-dev).
   OPENINFER_DEV_CACHE     Persistent build-cache directory.
+  OPENINFER_DEV_CACHE_KEY Override the native build-cache namespace.
   OPENINFER_MODEL_DIR     Read-only model directory mounted at the same path.
   EP_DISABLE_GIN          Forwarded when set; useful on trays without a GIN NIC.
 EOF
@@ -34,6 +35,15 @@ build_image() {
     "$repo_root"
 }
 
+toolkit_id="$(
+  docker image inspect \
+    --format '{{ index .Config.Labels "org.openinfer.cuda-image" }}' \
+    "$image" 2>/dev/null || true
+)"
+toolkit_id="${toolkit_id:-$image}"
+cache_key="${OPENINFER_DEV_CACHE_KEY:-$(printf '%s' "$toolkit_id" | sed 's/[^A-Za-z0-9_.-]/_/g')}"
+target_cache="$cache_root/target/$cache_key"
+
 docker_args=(
   --gpus all
   --ipc host
@@ -43,18 +53,18 @@ docker_args=(
   --volume "$repo_root:$repo_root"
   --volume "$cache_root/cargo-registry:/opt/cargo/registry"
   --volume "$cache_root/cargo-git:/opt/cargo/git"
-  --volume "$cache_root/target:$repo_root/target"
+  --volume "$target_cache:$repo_root/target"
   --workdir "$repo_root"
 )
 
 # A linked worktree stores a .git file that points at the main checkout's
 # common git directory. Mount that directory at the same absolute path so
-# build.rs can inspect submodule state without making the whole parent tree
-# visible or writable.
+# build.rs can inspect and initialize submodules without making the whole
+# parent tree visible.
 git_common_dir="$(git -C "$repo_root" rev-parse --path-format=absolute --git-common-dir)"
 case "$git_common_dir/" in
   "$repo_root/"*) ;;
-  *) docker_args+=(--volume "$git_common_dir:$git_common_dir:ro") ;;
+  *) docker_args+=(--volume "$git_common_dir:$git_common_dir") ;;
 esac
 
 if [[ -n "${EP_DISABLE_GIN:-}" ]]; then
@@ -79,7 +89,7 @@ case "${1:-}" in
     ;;
   shell)
     shift
-    mkdir -p "$cache_root"/{cargo-registry,cargo-git,target}
+    mkdir -p "$cache_root"/{cargo-registry,cargo-git} "$target_cache"
     if (( $# == 0 )); then
       set -- /bin/bash
     fi
@@ -88,7 +98,7 @@ case "${1:-}" in
   run)
     shift
     (( $# > 0 )) || { usage >&2; exit 2; }
-    mkdir -p "$cache_root"/{cargo-registry,cargo-git,target}
+    mkdir -p "$cache_root"/{cargo-registry,cargo-git} "$target_cache"
     docker run --rm "${docker_args[@]}" "$image" "$@"
     ;;
   *)


### PR DESCRIPTION
## What changed

- add a reproducible CUDA 13.2 / Ubuntu 24.04 development image
- install the pinned Rust nightly, Python 3.12, uv, clang, OpenSSL, protoc plus protobuf headers, InfiniBand headers, and NCCL
- validate NCCL >= 2.30.4 while building and expose one consistent `/opt/nccl` compile/runtime path
- add a wrapper for image builds, GPU shells, one-off commands, persistent Cargo caches, read-only model mounts, and linked Git worktrees
- point coding agents at the Docker workflow from the repository guidance
- document usage and the tray-specific `EP_DISABLE_GIN` override

## Why

Fresh development containers currently require manual package installation and environment repair. In particular, compilation and runtime could resolve different NCCL installations, root containers could leave bind-mounted source owned by root, and linked worktree/submodule Git pointers could break after the checkout was relocated inside a container. The new wrapper matches the host UID/GID and preserves checkout paths while pinning the native toolchain.

CUDA 13.3 was also built on tray07, but its current 595.71 driver rejects CUDA 13.3 containers at NVIDIA runtime initialization. CUDA 13.2 is therefore the newest validated default; the base remains overrideable through `CUDA_IMAGE` after a driver upgrade.

## Validation

Validated on `pod4-gb300-3-tray07-f3` (aarch64, 4x NVIDIA GB300):

- built `openinfer-dev:cu132` from scratch
- cloned a fresh `main` checkout and required submodules from inside the container
- built `openinfer-server --features glm52` in release mode for `sm_103`; cold compile completed in 1m11s
- loaded the full GLM-5.2-FP8 checkpoint as EP4 with checkpoint-native MTP
- all four ranks loaded 31,077 tensors / 190.6 GiB and captured four whole-step graph buckets
- a real 64-token `/v1/completions` request returned HTTP success at 106.58 output tok/s warm
- native MTP reported 18 verify rounds, mean accepted drafts 2.444, and mean accepted including bonus 3.444
- CUDA 13.2, NCCL 2.30.7, Rust nightly-2026-07-10, Python 3.12, uv, protoc, clang, and OpenSSL detected
- `/opt/nccl/lib/libnccl.so.2` resolves to the validated NCCL 2.30.7 runtime
- `bash -n docker/dev.sh`
- `git diff --check`