### PR TITLE
fix(qwen35): compile and lint clean under the qwen35 feature

### DIFF
--- a/openinfer-qwen35/src/lib.rs
+++ b/openinfer-qwen35/src/lib.rs
@@ -108,6 +108,7 @@ impl Qwen35LaunchOptions {
     }
 }
 
+#[allow(clippy::needless_pass_by_value)]
 pub fn launch_with_options_and_policy(
     model_path: &Path,
     options: Qwen35LaunchOptions,

--- a/openinfer-qwen35/src/scheduler/tests.rs
+++ b/openinfer-qwen35/src/scheduler/tests.rs
@@ -9,6 +9,7 @@ use super::*;
 fn send_rejection_reports_kv_lifetime_request_tokens() {
     let (token_tx, mut token_rx) = TokenSink::standalone();
     let req = SchedulerRequest {
+        trace_parent: None,
         request_id: Some("too-large".to_string()),
         queued_at_unix_s: None,
         data_parallel_rank: None,
@@ -90,6 +91,7 @@ fn tp2_scheduler_chunked_prefill_then_decode_smoke() {
 
     handle
         .submit(SchedulerRequest {
+            trace_parent: None,
             request_id: Some("tp2-scheduler-smoke".to_string()),
             queued_at_unix_s: None,
             data_parallel_rank: None,
@@ -142,6 +144,7 @@ fn tp2_scheduler_chunked_prefill_then_decode_smoke() {
 fn send_rejection_reports_context_window_limit() {
     let (token_tx, mut token_rx) = TokenSink::standalone();
     let req = SchedulerRequest {
+        trace_parent: None,
         request_id: Some("too-long".to_string()),
         queued_at_unix_s: None,
         data_parallel_rank: None,

--- a/openinfer-qwen35/src/tp_executor.rs
+++ b/openinfer-qwen35/src/tp_executor.rs
@@ -579,6 +579,7 @@ fn spawn_nccl_startup_watchdog() -> Result<(mpsc::SyncSender<()>, JoinHandle<()>
     Ok((done_tx, watchdog))
 }
 
+#[allow(clippy::needless_pass_by_value)]
 fn disarm_nccl_startup_watchdog(
     done_tx: mpsc::SyncSender<()>,
     watchdog: JoinHandle<()>,
@@ -641,6 +642,7 @@ impl TpStartupGate {
 }
 
 impl TpWorker {
+    #[allow(clippy::type_complexity)]
     fn spawn(
         rank: usize,
         world_size: usize,
@@ -903,6 +905,7 @@ fn effective_recurrent_capacity(
 }
 
 impl TpWorkerState {
+    #[allow(clippy::needless_pass_by_value)]
     fn run(&mut self, rx: mpsc::Receiver<TpWorkerCommand>) {
         while let Ok(command) = rx.recv() {
             let fatal = match command {
@@ -947,6 +950,7 @@ impl TpWorkerState {
         }
     }
 
+    #[allow(clippy::needless_pass_by_value)]
     fn respond(
         &self,
         resp: mpsc::Sender<TpWorkerResponse>,
@@ -1236,6 +1240,7 @@ impl From<DecodeStepItem> for TpDecodeStepItem {
     }
 }
 
+#[allow(clippy::needless_pass_by_value)]
 fn wait_for_acks(
     responses: mpsc::Receiver<TpWorkerResponse>,
     expected: usize,
@@ -1257,6 +1262,7 @@ fn wait_for_acks(
     Ok(())
 }
 
+#[allow(clippy::needless_pass_by_value)]
 fn wait_for_prefill(
     responses: mpsc::Receiver<TpWorkerResponse>,
     expected: usize,
@@ -1287,6 +1293,7 @@ fn wait_for_prefill(
     result.ok_or_else(|| anyhow::anyhow!("Qwen3.5 TP prefill returned no primary result"))
 }
 
+#[allow(clippy::needless_pass_by_value)]
 fn wait_for_decode(
     responses: mpsc::Receiver<TpWorkerResponse>,
     expected: usize,

--- a/openinfer-qwen35/tests/common/mod.rs
+++ b/openinfer-qwen35/tests/common/mod.rs
@@ -9,9 +9,8 @@ pub(crate) fn load_tokenizer(model_path: &str) -> DynTokenizer {
 #[allow(dead_code)]
 pub(crate) fn tp2_device_ordinals() -> Vec<usize> {
     const ENV: &str = "OPENINFER_TEST_TP_DEVICES";
-    let value = match std::env::var(ENV) {
-        Ok(value) => value,
-        Err(_) => return vec![0, 1],
+    let Ok(value) = std::env::var(ENV) else {
+        return vec![0, 1];
     };
 
     let devices: Vec<usize> = value

--- a/openinfer-qwen35/tests/e2e_scheduler.rs
+++ b/openinfer-qwen35/tests/e2e_scheduler.rs
@@ -550,8 +550,7 @@ fn run_full_scheduler_e2e(
 fn context_limit_for(handle: &EngineHandle, model_path: &str) -> usize {
     handle
         .servable_len()
-        .map(|len| len as usize)
-        .unwrap_or_else(|| max_position_embeddings(model_path))
+        .map_or_else(|| max_position_embeddings(model_path), |len| len as usize)
 }
 
 #[test]

--- a/openinfer-qwen35/tests/serving_tp2.rs
+++ b/openinfer-qwen35/tests/serving_tp2.rs
@@ -183,7 +183,7 @@ async fn assert_concurrent_completions(client: &Client, base_url: &str) -> Resul
 }
 
 fn assert_invalid_cuda_graph_tp_startup_fails(model_path: &str) -> Result<()> {
-    let error = match openinfer_qwen35::start_engine_with_capacity(
+    let Err(error) = openinfer_qwen35::start_engine_with_capacity(
         Path::new(model_path),
         EngineLoadOptions {
             enable_cuda_graph: true,
@@ -193,9 +193,8 @@ fn assert_invalid_cuda_graph_tp_startup_fails(model_path: &str) -> Result<()> {
         },
         8,
         1,
-    ) {
-        Ok(_) => bail!("TP2 + CUDA Graph must fail before serving requests"),
-        Err(error) => error,
+    ) else {
+        bail!("TP2 + CUDA Graph must fail before serving requests");
     };
     let message = error.to_string();
     if !message.contains("eager execution only") {
@@ -231,7 +230,7 @@ async fn post_completion_stream(client: &Client, base_url: &str, body: Value) ->
 fn completion_body(stream: bool, max_tokens: usize, logprobs: usize) -> Value {
     let mut body = json!({
         "model": MODEL_NAME,
-        "prompt": [151644, 872, 198, 9707, 151645, 198, 151644, 77091, 198],
+        "prompt": [151_644, 872, 198, 9707, 151_645, 198, 151_644, 77091, 198],
         "max_tokens": max_tokens,
         "temperature": 0.0,
         "ignore_eos": true,
@@ -246,7 +245,7 @@ fn completion_body(stream: bool, max_tokens: usize, logprobs: usize) -> Value {
 fn alternate_completion_body(stream: bool, max_tokens: usize, logprobs: usize) -> Value {
     let mut body = json!({
         "model": MODEL_NAME,
-        "prompt": [151644, 872, 198, 3838, 374, 220, 17, 489, 220, 17, 30, 151645, 198, 151644, 77091, 198],
+        "prompt": [151_644, 872, 198, 3838, 374, 220, 17, 489, 220, 17, 30, 151_645, 198, 151_644, 77091, 198],
         "max_tokens": max_tokens,
         "temperature": 0.0,
         "ignore_eos": true,


### PR DESCRIPTION
## Description

CI never builds the `qwen35` feature, so two kinds of drift accumulated where no gate could see them. `cargo test -p openinfer-qwen35 --features qwen35 --lib` stopped compiling when `GenerateRequest` gained the `trace_parent` field — the three initializers in the feature-gated `scheduler/tests.rs` were never updated. And clippy under the feature is red with seventeen findings: eight in the library (`tp_executor.rs` and the launch path) plus nine in the crate's integration tests; since cargo lints every workspace member in the build graph, even `cargo clippy -p openinfer-server --features qwen35` inherits the library-side red.


Verification on Single GPU (sm_89, x86_64): `cargo fmt --check`; `cargo test --release -p openinfer-qwen35 --features qwen35 --lib` now compiles and passes (76 tests: 70 passed, 6 ignored — the ignored ones need two devices or model weights); `cargo clippy --release --all-targets -- -D warnings` with `--features qwen35` for both openinfer-qwen35 and openinfer-server, red on the unpatched base and green here.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)