### PR TITLE
fix(server): fail closed on unrecognized model configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3385,6 +3385,7 @@ dependencies = [
  "rand 0.10.1",
  "serde",
  "serde_json",
+ "tempfile",
  "tikv-jemallocator",
  "tokio",
  "tokio-util",

--- a/openinfer-qwen3/src/config.rs
+++ b/openinfer-qwen3/src/config.rs
@@ -2,7 +2,10 @@ use std::fs;
 
 use anyhow::Context;
 use anyhow::Result;
+use anyhow::bail;
+use anyhow::ensure;
 use serde::Deserialize;
+use serde_json::Value;
 
 pub(crate) const PREFILL_ATTENTION_CTA_TILE_Q: i32 = 64;
 
@@ -503,4 +506,22 @@ impl TensorParallelConfig {
     pub(crate) fn is_sharded(self) -> bool {
         self.world_size > 1
     }
+}
+
+/// Identity check that `json` is a Qwen3 config; size and shape validation belong to the config loader.
+pub fn probe_config_json(json: &Value) -> Result<()> {
+    let model_type = json.get("model_type").and_then(Value::as_str).unwrap_or("");
+    if model_type != "qwen3" {
+        bail!("not a Qwen3 config: model_type={model_type}");
+    }
+    let architectures: Vec<&str> = json
+        .get("architectures")
+        .and_then(Value::as_array)
+        .map(|arr| arr.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+    ensure!(
+        architectures.contains(&"Qwen3ForCausalLM"),
+        "Qwen3 architectures must contain Qwen3ForCausalLM"
+    );
+    Ok(())
 }

--- a/openinfer-qwen3/src/lib.rs
+++ b/openinfer-qwen3/src/lib.rs
@@ -24,6 +24,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use anyhow::Result;
+pub use config::probe_config_json;
 use log::info;
 use log::warn;
 use openinfer_core::engine::EngineHandle;

--- a/openinfer-qwen35/src/config.rs
+++ b/openinfer-qwen35/src/config.rs
@@ -2,8 +2,11 @@ use std::collections::HashSet;
 use std::fs;
 
 use anyhow::Result;
+use anyhow::bail;
+use anyhow::ensure;
 use log::warn;
 use serde::Deserialize;
+use serde_json::Value;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct TensorParallelConfig {
@@ -542,6 +545,33 @@ pub(crate) fn tokenizer_effective_vocab(model_path: &str) -> Result<usize> {
          a row-range selection bound cannot mask holes"
     );
     Ok(width)
+}
+
+/// Identity check that `json` is a Qwen3.5 config; size and shape validation belong to the config loader.
+pub fn probe_config_json(json: &Value) -> Result<()> {
+    let model_type = json.get("model_type").and_then(Value::as_str).unwrap_or("");
+    if model_type != "qwen3_5" {
+        bail!("not a Qwen3.5 config: model_type={model_type}");
+    }
+    let architectures: Vec<&str> = json
+        .get("architectures")
+        .and_then(Value::as_array)
+        .map(|arr| arr.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+    ensure!(
+        architectures.contains(&"Qwen3_5ForConditionalGeneration"),
+        "Qwen3.5 architectures must contain Qwen3_5ForConditionalGeneration"
+    );
+    let text_model_type = json
+        .get("text_config")
+        .and_then(|tc| tc.get("model_type"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    ensure!(
+        text_model_type == "qwen3_5_text",
+        "Qwen3.5 text_config.model_type must be qwen3_5_text, got {text_model_type}"
+    );
+    Ok(())
 }
 
 #[cfg(test)]

--- a/openinfer-qwen35/src/lib.rs
+++ b/openinfer-qwen35/src/lib.rs
@@ -25,6 +25,7 @@ use std::path::Path;
 
 use anyhow::Result;
 use anyhow::anyhow;
+pub use config::probe_config_json;
 use openinfer_core::engine::EngineHandle;
 use openinfer_core::engine::EngineLoadOptions;
 use openinfer_core::engine::EpBackend;

--- a/openinfer-server/Cargo.toml
+++ b/openinfer-server/Cargo.toml
@@ -62,3 +62,6 @@ qwen35 = ["dep:openinfer-qwen35", "openinfer-qwen35/qwen35"]
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/openinfer-server/src/server_engine.rs
+++ b/openinfer-server/src/server_engine.rs
@@ -41,6 +41,41 @@ impl fmt::Display for ModelType {
     }
 }
 
+fn config_model_type(json: &serde_json::Value) -> Option<&str> {
+    json.get("model_type").and_then(serde_json::Value::as_str)
+}
+
+fn text_config_model_type(json: &serde_json::Value) -> Option<&str> {
+    json.get("text_config")
+        .and_then(|text| text.get("model_type"))
+        .and_then(serde_json::Value::as_str)
+}
+
+fn seen_config_field(json: &serde_json::Value, key: &str) -> String {
+    json.get(key)
+        .map_or_else(|| "missing".to_string(), serde_json::Value::to_string)
+}
+
+fn unrecognized_config_error(json: &serde_json::Value) -> anyhow::Error {
+    let families = [
+        ("DeepSeek-V2-Lite", cfg!(feature = "deepseek-v2-lite")),
+        ("GLM5.2", cfg!(feature = "glm52")),
+        ("Kimi-K2.6", cfg!(feature = "kimi-k2")),
+        ("Qwen3", cfg!(feature = "qwen3")),
+        ("Qwen3.5", cfg!(feature = "qwen35")),
+    ]
+    .iter()
+    .filter_map(|&(name, compiled)| compiled.then_some(name))
+    .collect::<Vec<_>>()
+    .join(", ");
+    anyhow::anyhow!(
+        "unrecognized model config: model_type={}, architectures={}; \
+         model families compiled into this build: {families}",
+        seen_config_field(json, "model_type"),
+        seen_config_field(json, "architectures"),
+    )
+}
+
 /// Detect model type from config.json.
 pub fn detect_model_type(model_path: impl AsRef<Path>) -> Result<ModelType> {
     let config_path = model_path.as_ref().join("config.json");
@@ -49,11 +84,7 @@ pub fn detect_model_type(model_path: impl AsRef<Path>) -> Result<ModelType> {
     let json: serde_json::Value = serde_json::from_str(&content)
         .with_context(|| format!("failed to parse {}", config_path.display()))?;
 
-    if json
-        .get("model_type")
-        .and_then(serde_json::Value::as_str)
-        .is_some_and(|model_type| model_type == "deepseek_v2")
-    {
+    if config_model_type(&json) == Some("deepseek_v2") {
         #[cfg(feature = "deepseek-v2-lite")]
         {
             openinfer_deepseek_v2_lite::probe_config_json(&json)?;
@@ -67,11 +98,7 @@ pub fn detect_model_type(model_path: impl AsRef<Path>) -> Result<ModelType> {
         }
     }
 
-    if json
-        .get("model_type")
-        .and_then(serde_json::Value::as_str)
-        .is_some_and(|model_type| model_type == "glm_moe_dsa")
-    {
+    if config_model_type(&json) == Some("glm_moe_dsa") {
         #[cfg(feature = "glm52")]
         {
             openinfer_glm52::probe_config_json(&json)?;
@@ -83,15 +110,8 @@ pub fn detect_model_type(model_path: impl AsRef<Path>) -> Result<ModelType> {
         );
     }
 
-    if json
-        .get("model_type")
-        .and_then(serde_json::Value::as_str)
-        .is_some_and(|model_type| model_type == "kimi_k25" || model_type == "kimi_k2")
-        || json
-            .get("text_config")
-            .and_then(|text| text.get("model_type"))
-            .and_then(serde_json::Value::as_str)
-            .is_some_and(|model_type| model_type == "kimi_k2")
+    if matches!(config_model_type(&json), Some("kimi_k25" | "kimi_k2"))
+        || text_config_model_type(&json) == Some("kimi_k2")
     {
         #[cfg(feature = "kimi-k2")]
         {
@@ -104,19 +124,99 @@ pub fn detect_model_type(model_path: impl AsRef<Path>) -> Result<ModelType> {
         );
     }
 
-    if json.get("text_config").is_some() {
+    if config_model_type(&json) == Some("qwen3_5")
+        || text_config_model_type(&json) == Some("qwen3_5_text")
+    {
         #[cfg(feature = "qwen35")]
-        return Ok(ModelType::Qwen35);
+        {
+            openinfer_qwen35::probe_config_json(&json)?;
+            return Ok(ModelType::Qwen35);
+        }
         #[cfg(not(feature = "qwen35"))]
         anyhow::bail!(
             "Qwen3.5 support is feature-gated; rebuild openinfer-server with --features qwen35"
         );
     }
 
+    if config_model_type(&json) == Some("qwen3") {
+        #[cfg(feature = "qwen3")]
+        {
+            openinfer_qwen3::probe_config_json(&json)?;
+            return Ok(ModelType::Qwen3);
+        }
+        #[cfg(not(feature = "qwen3"))]
+        anyhow::bail!(
+            "Qwen3 support is feature-gated; rebuild openinfer-server with --features qwen3"
+        );
+    }
+
+    Err(unrecognized_config_error(&json))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn detect(json: &str) -> Result<ModelType> {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("config.json"), json).unwrap();
+        detect_model_type(dir.path())
+    }
+
+    #[test]
     #[cfg(feature = "qwen3")]
-    return Ok(ModelType::Qwen3);
-    #[cfg(not(feature = "qwen3"))]
-    anyhow::bail!(
-        "Qwen3 support is feature-gated; rebuild openinfer-server with --features qwen3-4b"
-    );
+    fn qwen3_identity_routes_to_qwen3() {
+        let json = r#"{"model_type":"qwen3","architectures":["Qwen3ForCausalLM"]}"#;
+        assert_eq!(detect(json).unwrap(), ModelType::Qwen3);
+    }
+
+    #[test]
+    #[cfg(feature = "qwen35")]
+    fn qwen35_identity_routes_to_qwen35() {
+        let json = r#"{"model_type":"qwen3_5","architectures":["Qwen3_5ForConditionalGeneration"],"text_config":{"model_type":"qwen3_5_text"}}"#;
+        assert_eq!(detect(json).unwrap(), ModelType::Qwen35);
+    }
+
+    #[test]
+    fn gemma4_12b_rejected() {
+        let json = r#"{"model_type":"gemma4_unified","architectures":["Gemma4UnifiedForConditionalGeneration"],"text_config":{"model_type":"gemma4_unified_text"}}"#;
+        let err = detect(json).unwrap_err().to_string();
+        assert!(err.contains("gemma4_unified"));
+    }
+
+    #[test]
+    fn gemma4_26b_rejected() {
+        let json = r#"{"model_type":"gemma4","architectures":["Gemma4ForConditionalGeneration"],"text_config":{"model_type":"gemma4_text"}}"#;
+        let err = detect(json).unwrap_err().to_string();
+        assert!(err.contains("gemma4"));
+    }
+
+    #[test]
+    fn unknown_family_without_text_config_rejected() {
+        let json = r#"{"model_type":"frobnicate_lm","architectures":["FrobnicateForCausalLM"]}"#;
+        let err = detect(json).unwrap_err().to_string();
+        assert!(err.contains("frobnicate_lm"));
+    }
+
+    #[test]
+    fn empty_config_rejected() {
+        let err = detect("{}").unwrap_err().to_string();
+        assert!(err.contains("unrecognized"));
+    }
+
+    #[test]
+    #[cfg(feature = "qwen3")]
+    fn qwen3_bad_architectures_rejected() {
+        let json = r#"{"model_type":"qwen3","architectures":["SomethingElse"]}"#;
+        detect(json).unwrap_err();
+    }
+
+    #[test]
+    fn invalid_typed_identity_fields_are_shown_verbatim() {
+        let err = detect(r#"{"model_type":123,"architectures":"Foo"}"#)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("model_type=123"));
+        assert!(err.contains("architectures=\"Foo\""));
+    }
 }


### PR DESCRIPTION
## Description

Fixes #774


`detect_model_type` ended in two unconditional tails: any config carrying a `text_config` object was routed to the Qwen3.5 engine and everything else to Qwen3, with no validation. An unsupported model directory started the wrong engine and failed later during model-specific config or weight loading with an unrelated field, shape, or tensor error instead of an "unsupported model" one. Every Gemma 4 checkpoint ships a `text_config`, so the #758 bring-up would have silently started the Qwen3.5 engine.

- `openinfer-qwen3` and `openinfer-qwen35` gain `probe_config_json`, mirroring the existing glm52/kimi/deepseek probes. Identity assertions only, no size pinning — both crates serve multiple sizes. The identity strings were checked against every published dense size these crates serve (the MoE variants such as Qwen3-30B-A3B declare their own `model_type` and are not supported by these engines): Qwen3 0.6B/1.7B/4B/8B/14B/32B all carry `model_type "qwen3"` + `Qwen3ForCausalLM` and no `text_config`; Qwen3.5 0.8B/2B/4B/9B/27B all carry outer `model_type "qwen3_5"` + `Qwen3_5ForConditionalGeneration` + `text_config.model_type "qwen3_5_text"`.
- The server routes Qwen3.5 by outer `model_type` or `text_config.model_type`, Qwen3 by `model_type`, both through their probes; the deepseek/glm52/kimi branches are untouched.
- The fallthrough is now an error naming the seen `model_type` and `architectures` verbatim — the raw JSON value when the key is present (wrong-typed values included), `missing` only when it is absent; a config without `model_type` used to silently route to Qwen3 — plus the model families compiled into this build.
- The Qwen3 feature-gate message suggested `--features qwen3-4b`, a feature name that no longer exists; it now says `--features qwen3`.

Behavior change: a config that previously fell through to an engine by default now errors. Any dense Qwen3 / Qwen3.5 checkpoint supported by these engines keeps routing exactly as before; only configs that no engine actually supports stop being accepted.

## Test Env

Eight unit tests in `server_engine.rs` — routing for both Qwen identities, Gemma 4 12B and 26B identity configs rejected (these flip into routing tests when a gemma4 family lands), an unknown family rejected, a config with no `model_type` rejected, wrong-typed identity fields rendered verbatim rather than as missing, and a probe failure on wrong `architectures`.

Verification on Single GPU (sm_89, x86_64), on a base that includes #771: `cargo fmt --check`; `cargo clippy --all-targets -- -D warnings` for openinfer-server (default features and `--features qwen35`), openinfer-qwen3, and openinfer-qwen35; `cargo test --release -p openinfer-server --lib` under default features (7 tests) and `--features qwen35` (8 tests, so the qwen35 routing test really ran); `cargo check -p openinfer-server --no-default-features` for the no-model-features build.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)