### PR TITLE
feat(qwen3): pre-capture single-GPU decode CUDA graphs at startup

### DIFF
--- a/docs/models/qwen3/decode-attention.md
+++ b/docs/models/qwen3/decode-attention.md
@@ -60,7 +60,7 @@ The transition lands exactly where CTA count crosses SM count: bs≤8 (≤64 CTA
 
 The grid must be fixed for graph replay, but SplitKv's chunk count varies with context. Resolved by **fixed-upper-bound grid + out-of-graph metadata**:
 
-- One captured graph per `(batch bucket, attention_path)` — `graph_index = bucket_idx × 2 + path.graph_slot()`. bs=1 has a `NonPartition` slot and a `SplitKv` slot; first use of a combination captures, later steps replay.
+- One captured graph per `(batch bucket, attention_path)` — `graph_index = bucket_idx × 2 + path.graph_slot()`. bs=1 has a `NonPartition` slot and a `SplitKv` slot; every `(bucket, path)` combination is pre-captured at startup, so serving steps are pure replay.
 - SplitKv workspace is pre-allocated to the active policy's grid (`bs × max_split_chunks()`: default `Tuned` `bs × 64` = `SPLIT_KV_TUNED_MAX_CHUNKS`, `Pin`/`PerToken` `bs × 256`), so buffer pointers stay stable across replay — the policy is fixed before construction, so the size never shifts under a live executor. The grid is fixed per `(bucket, policy)` (see *Chunk size and batch-invariance*).
 - Per-step context differences go through `memcpy_htod` in `sync_split_kv_meta` **before** `run_or_capture` (outside the graph): chunk_size, valid-chunk count, `valid_mask`, `o_indptr`. Chunks beyond the real count are masked off (`valid_mask = 0`, those CTAs early-exit).
 

--- a/docs/subsystems/frontend/startup-time.md
+++ b/docs/subsystems/frontend/startup-time.md
@@ -36,4 +36,6 @@ The 2026-06 rejection reasoned from the numbers above: upload ran at ~7GB/s page
 
 ## Next
 
-The warm HTTP-ready floor is now the engine's own post-load startup work (profile, warmup, graph capture — ~3.7s of the ~4.7s), no longer the frontend path; that is where the next startup-time win lives. Cold-start stays bandwidth-bound (per roadmap out of scope).
+The warm HTTP-ready floor is now the engine's own post-load startup work (profile, warmup, graph capture — ~3.7s of the ~4.7s), no longer the frontend path; that is where the next startup-time win lives.
+
+2026-07-28: single-GPU decode graphs are now pre-captured at startup too (same sweep as TP), so the per-bucket first-hit capture stall is gone from serving. Measured on RTX 5070 Ti (Qwen3-4B, default Tuned policy): the 36-bucket sweep costs **0.91s** of engine startup (`Engine loaded: elapsed_ms=5620` end-to-end) and memory plateaus at 14.1/16.3GB — Tuned/Pin graph execs are ~2MB/bucket. `--batch-invariant=per-token` is the exception: its per-row GemmEx loop bakes N nodes per (projection, layer) into a bucket-N graph, so the sweep retains ~1.8GB total — on 16GB cards it needs KV-budget headroom (see `models/qwen3/single-gpu-graph-precapture.md`). Cold-start stays bandwidth-bound (per roadmap out of scope).

--- a/docs/subsystems/scheduler/scheduler.md
+++ b/docs/subsystems/scheduler/scheduler.md
@@ -41,7 +41,7 @@ The bridge to FlashInfer's `paged_kv_t` (which expects separate `k_data`/`v_data
 ## Scheduling policy
 
 - **FCFS prefill-priority.** Pending prefill always preempts continued decode at step boundaries.
-- **Bucket CUDA Graphs.** Batch buckets `[1, 2, 4, 8, 16, 32, 64]`, padded up at runtime. One captured graph per bucket, capture-on-first-use, replay afterward.
+- **Bucket CUDA Graphs.** Batch buckets 1–256 (36 sizes), padded up at runtime. One graph per `(bucket, attention path)`, all pre-captured at startup (single GPU and TP alike), replay afterward.
 - **Padding page.** `KvPool` reserves one page at construction. Padding batch slots point at it with `seq_len=1, last_page_len=1` — KV append writes harmless garbage, attention output is discarded.
 - **Unified forward.** When both pending prefill and active decode exist, one forward pass handles all tokens. Decode rows ride free inside the compute-bound prefill GEMM (<2% FLOPs added). Pure decode (the common case) still uses CUDA Graph.
 - **Admission.** Reject when `KvPool` full. No queue behind memory pressure.

--- a/openinfer-qwen3/src/batch_decode.rs
+++ b/openinfer-qwen3/src/batch_decode.rs
@@ -48,7 +48,9 @@ macro_rules! trace_decode_kv_len {
 /// How a `batch_decode` call interacts with the per-bucket CUDA graphs.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum DecodeGraphUse {
-    /// Replay if captured, lazily capture otherwise (single-GPU serving).
+    /// Replay if captured, capture otherwise (serving). After the startup
+    /// pre-capture sweep this is always a replay; the capture fallback only
+    /// covers construction paths that skipped the sweep.
     Serve,
     /// Eager kernels even with graphs enabled; the TP memory profile uses it to
     /// avoid an uncoordinated capture (see [`PrecapturePhase`]).

--- a/openinfer-qwen3/src/batch_decode_buffers.rs
+++ b/openinfer-qwen3/src/batch_decode_buffers.rs
@@ -14,9 +14,9 @@ use openinfer_kv_cache::KvView;
 use crate::split_kv::SplitKvConfig;
 
 /// Bucket sizes for CUDA Graph capture. Actual batch is padded to the nearest bucket.
-/// Based on vLLM's cudagraph capture list up to 256; graphs are captured lazily per
-/// bucket, and activation buffers are shared (sized once at the largest bucket), so
-/// extra buckets cost capture time on first hit, not memory.
+/// Based on vLLM's cudagraph capture list up to 256; every bucket's graph is
+/// pre-captured at startup, and activation buffers are shared (sized once at the
+/// largest bucket), so extra buckets cost startup capture time, not memory.
 ///
 /// Buckets 8/16 are viable only because decode GEMMs at N <= GEMM_LT_MAX_N run
 /// tuned cublasLt algos: cuBLAS's GemmEx heuristic skips split-K for batch in

--- a/openinfer-qwen3/src/executor.rs
+++ b/openinfer-qwen3/src/executor.rs
@@ -1041,6 +1041,10 @@ pub struct Qwen3Executor {
     /// [`enable_decode_overlap`] to create overlap streams on the correct
     /// device (the model, KV cache, and compute stream all live here).
     device_ordinal: usize,
+    /// Whether CUDA Graph decode was requested at construction. Drives the
+    /// startup pre-capture sweeps: main-stream graphs at construction, the
+    /// green-ctx split cache when decode-overlap is enabled.
+    enable_cuda_graph: bool,
 }
 
 /// Executor-side state for the opt-in KV block-event feed.
@@ -1220,20 +1224,48 @@ impl Qwen3Executor {
                 })
             }
         };
+        let enable_cuda_graph = model.enable_cuda_graph;
+        let primary = RankWorker::spawn(
+            0,
+            LocalQwen3Lane::new(
+                model,
+                kv_buffer,
+                total_blocks,
+                padding_block_id,
+                max_prefill_tokens,
+            )?,
+        )?;
+        // Pre-capture every reachable decode graph now — the same sweep the TP
+        // path runs, with a single rank (no collectives, so no watchdog).
+        // Serving must never hit a lazy mid-request capture: that is the #481
+        // capture window on one GPU. Uncompiled GQA groups reroute decode to
+        // the eager unified path and skip it.
+        if enable_cuda_graph && metadata.config.decode_group_is_compiled() {
+            let started = std::time::Instant::now();
+            let run_phase = |phase: PrecapturePhase| -> Result<()> {
+                primary.precapture(phase, None)?.recv().map_err(|_| {
+                    anyhow::anyhow!(
+                        "rank-0 worker dropped during decode graph pre-capture {phase:?}"
+                    )
+                })?
+            };
+            run_phase(PrecapturePhase::Warmup)?;
+            for bucket_idx in 0..BATCH_BUCKETS.len() {
+                run_phase(PrecapturePhase::Capture { bucket_idx })?;
+                run_phase(PrecapturePhase::Launch { bucket_idx })?;
+            }
+            run_phase(PrecapturePhase::Finalize)?;
+            log::info!(
+                "Single-GPU decode graph pre-capture: {} buckets captured in {:.2}s",
+                BATCH_BUCKETS.len(),
+                started.elapsed().as_secs_f64()
+            );
+        }
         Ok(Self {
             metadata,
             kv_mgr,
             request_kvs: HashMap::new(),
-            primary: RankWorker::spawn(
-                0,
-                LocalQwen3Lane::new(
-                    model,
-                    kv_buffer,
-                    total_blocks,
-                    padding_block_id,
-                    max_prefill_tokens,
-                )?,
-            )?,
+            primary,
             workers: Vec::new(),
             loaded_lora_adapters: HashSet::new(),
             prefix_cache_enabled: true,
@@ -1255,6 +1287,7 @@ impl Qwen3Executor {
             dflash_ready_requests: HashSet::new(),
             kv_events,
             device_ordinal,
+            enable_cuda_graph,
         })
     }
 
@@ -1516,7 +1549,7 @@ impl Qwen3Executor {
             let run_phase = |phase: PrecapturePhase| -> Result<()> {
                 let pending = std::iter::once(&primary)
                     .chain(workers.iter())
-                    .map(|worker| worker.precapture(phase))
+                    .map(|worker| worker.precapture(phase, None))
                     .collect::<Result<Vec<_>>>()?;
                 let ranks = pending.len();
                 for (rank, recv) in pending.into_iter().enumerate() {
@@ -1580,6 +1613,7 @@ impl Qwen3Executor {
             // KV events are single-GPU only (asserted above); never wired here.
             kv_events: None,
             device_ordinal: device_ordinals[0],
+            enable_cuda_graph,
         })
     }
 
@@ -1659,6 +1693,35 @@ impl Qwen3Executor {
         );
         let device_ordinal = self.device_ordinal;
         self.overlap = crate::green_ctx::OverlapStreams::create(device_ordinal, overlap)?;
+        // SplitConcurrent decode replays the split cache (`graphs_split`), whose
+        // graphs are pinned to the decode-partition stream — pre-capture them on
+        // that stream now so the first mixed step never captures mid-serving.
+        if let Some(ref overlap_streams) = self.overlap {
+            if self.enable_cuda_graph && self.metadata.config.decode_group_is_compiled() {
+                let started = std::time::Instant::now();
+                let decode_stream = overlap_streams.decode_stream;
+                let run_phase = |phase: PrecapturePhase| -> Result<()> {
+                    self.primary
+                        .precapture(phase, Some(decode_stream))?
+                        .recv()
+                        .map_err(|_| {
+                            anyhow::anyhow!(
+                                "rank-0 worker dropped during split-stream graph pre-capture {phase:?}"
+                            )
+                        })?
+                };
+                for bucket_idx in 0..BATCH_BUCKETS.len() {
+                    run_phase(PrecapturePhase::Capture { bucket_idx })?;
+                    run_phase(PrecapturePhase::Launch { bucket_idx })?;
+                }
+                run_phase(PrecapturePhase::Finalize)?;
+                log::info!(
+                    "Split-stream decode graph pre-capture (--decode-overlap): {} buckets captured in {:.2}s",
+                    BATCH_BUCKETS.len(),
+                    started.elapsed().as_secs_f64()
+                );
+            }
+        }
         Ok(())
     }
 
@@ -3264,18 +3327,29 @@ impl LocalQwen3Lane {
         })
     }
 
-    /// One phase of the TP startup sweep ([`PrecapturePhase`]). Synthetic rows
+    /// One phase of the startup sweep ([`PrecapturePhase`]). Synthetic rows
     /// are token 0 at position 0 over the shared padding page; outputs unused.
-    fn precapture_phase(&mut self, phase: PrecapturePhase) -> Result<()> {
+    /// `split_stream` targets the green-ctx decode-partition cache
+    /// (`graphs_split`) instead of the full-SM `graphs` cache.
+    fn precapture_phase(
+        &mut self,
+        phase: PrecapturePhase,
+        split_stream: Option<crate::green_ctx::SendStream>,
+    ) -> Result<()> {
         match phase {
             PrecapturePhase::Warmup => self.model.warmup_tp_collective(),
             PrecapturePhase::Capture { bucket_idx } => {
-                self.precapture_decode(bucket_idx, DecodeGraphUse::CaptureOnly)
+                self.precapture_decode(bucket_idx, DecodeGraphUse::CaptureOnly, split_stream)
             }
             PrecapturePhase::Launch { bucket_idx } => {
-                self.precapture_decode(bucket_idx, DecodeGraphUse::Replay)
+                self.precapture_decode(bucket_idx, DecodeGraphUse::Replay, split_stream)
             }
             PrecapturePhase::Finalize => {
+                let graphs = if split_stream.is_some() {
+                    &self.bufs.graphs_split
+                } else {
+                    &self.bufs.graphs
+                };
                 for (bucket_idx, &bucket) in BATCH_BUCKETS.iter().enumerate() {
                     let path = BatchDecodeBuffers::attention_path(
                         bucket,
@@ -3283,8 +3357,8 @@ impl LocalQwen3Lane {
                     );
                     let graph_idx = BatchDecodeBuffers::graph_index(bucket_idx, path);
                     anyhow::ensure!(
-                        self.bufs.graphs[graph_idx].is_captured(),
-                        "TP decode graph pre-capture left bucket {bucket} ({path:?}) uncaptured"
+                        graphs[graph_idx].is_captured(),
+                        "decode graph pre-capture left bucket {bucket} ({path:?}) uncaptured"
                     );
                 }
                 self.precapture_complete = true;
@@ -3293,13 +3367,24 @@ impl LocalQwen3Lane {
         }
     }
 
-    fn precapture_decode(&mut self, bucket_idx: usize, graph_use: DecodeGraphUse) -> Result<()> {
+    fn precapture_decode(
+        &mut self,
+        bucket_idx: usize,
+        graph_use: DecodeGraphUse,
+        split_stream: Option<crate::green_ctx::SendStream>,
+    ) -> Result<()> {
         let bucket = BATCH_BUCKETS[bucket_idx];
         let token_ids = vec![0u32; bucket];
         let kv_views: Vec<KvView> = (0..bucket)
             .map(|_| KvView::new(vec![self.padding_block_id], 1, self.layout.page_size))
             .collect();
         let lora_adapters: Vec<Option<&str>> = vec![None; bucket];
+        // Split sweep (--decode-overlap): run under the decode-partition stream
+        // override so `batch_decode` routes into `graphs_split` and the captured
+        // nodes pin to the partition — the same setup SplitConcurrent serves with.
+        let _override_guard = split_stream.map(|stream| unsafe {
+            openinfer_kernels::tensor::StreamOverrideGuard::activate(stream.0)
+        });
         self.model.batch_decode(
             &token_ids,
             &kv_views,
@@ -3310,8 +3395,18 @@ impl LocalQwen3Lane {
             graph_use,
         )?;
         // Capture acks only after the async cuGraphUpload lands; Launch acks
-        // only after the collectives drained.
-        self.model.device_ctx().stream.synchronize()?;
+        // only after the collectives drained. Under the override the work sits
+        // on the split stream, which `ctx.stream` says nothing about.
+        match split_stream {
+            Some(stream) => {
+                let r = unsafe { cudarc::driver::sys::cuStreamSynchronize(stream.0) };
+                anyhow::ensure!(
+                    r == cudarc::driver::sys::CUresult::CUDA_SUCCESS,
+                    "cuStreamSynchronize(split decode) failed during graph pre-capture: {r:?}"
+                );
+            }
+            None => self.model.device_ctx().stream.synchronize()?,
+        }
         Ok(())
     }
 
@@ -3326,7 +3421,7 @@ impl LocalQwen3Lane {
                 !self.model.tp_graph_enabled(),
                 "Qwen3 TP batch-1 graph was not captured by the startup sweep"
             );
-            self.precapture_decode(bucket_idx, DecodeGraphUse::CaptureOnly)?;
+            self.precapture_decode(bucket_idx, DecodeGraphUse::CaptureOnly, None)?;
         }
         let title = format!("Qwen3 decode CUDA Graph · bs={bucket} · {attention_path:?}");
         self.bufs.graphs[graph_idx]
@@ -3676,10 +3771,12 @@ enum WorkerCommand {
         request_id: RequestId,
         resp: channel::Sender<Result<()>>,
     },
-    /// Startup-only (TP + CUDA Graph): one phase of the decode-graph
-    /// pre-capture sweep. See [`LocalQwen3Lane::precapture_phase`].
+    /// Startup-only (CUDA Graph): one phase of the decode-graph pre-capture
+    /// sweep. See [`LocalQwen3Lane::precapture_phase`]. `split_stream` targets
+    /// the green-ctx decode-partition cache instead of the full-SM one.
     Precapture {
         phase: PrecapturePhase,
+        split_stream: Option<crate::green_ctx::SendStream>,
         resp: channel::Sender<Result<()>>,
     },
     DumpDecodeGraph {
@@ -3689,13 +3786,14 @@ enum WorkerCommand {
     Shutdown,
 }
 
-/// One controller-barriered phase of the TP decode-graph pre-capture sweep.
+/// One controller-barriered phase of the decode-graph pre-capture sweep.
 ///
 /// Capture and launch are separate phases because a captured collective's first
 /// launch blocks on its peers: overlapping that with a peer still in capture/
 /// instantiate/upload (which contend driver locks and allocate device memory)
 /// deadlocks the driver. So every rank finishes capturing a bucket before any
-/// rank launches it.
+/// rank launches it. Single GPU runs the same sequence with one rank — the
+/// separation is harmless and keeps one sweep implementation.
 #[derive(Clone, Copy, Debug)]
 enum PrecapturePhase {
     /// One eager all-reduce per bucket message size, so the size-selected NCCL
@@ -3798,8 +3896,12 @@ impl RankWorker {
                                     lane.drop_dflash_request(request_id);
                                     let _ = resp.send(Ok(()));
                                 }
-                                WorkerCommand::Precapture { phase, resp } => {
-                                    let result = lane.precapture_phase(phase);
+                                WorkerCommand::Precapture {
+                                    phase,
+                                    split_stream,
+                                    resp,
+                                } => {
+                                    let result = lane.precapture_phase(phase, split_stream);
                                     let _ = resp.send(result);
                                 }
                                 WorkerCommand::DumpDecodeGraph { png_path, resp } => {
@@ -3848,11 +3950,17 @@ impl RankWorker {
 
     /// Start one sweep phase; returns the ack receiver. The controller fans a
     /// phase out to all ranks before collecting acks so their collectives pair.
-    fn precapture(&self, phase: PrecapturePhase) -> Result<channel::Receiver<Result<()>>> {
+    /// `split_stream` selects the green-ctx decode-partition graph cache.
+    fn precapture(
+        &self,
+        phase: PrecapturePhase,
+        split_stream: Option<crate::green_ctx::SendStream>,
+    ) -> Result<channel::Receiver<Result<()>>> {
         let (resp_tx, resp_rx) = channel::bounded(1);
         self.tx
             .send(WorkerCommand::Precapture {
                 phase,
+                split_stream,
                 resp: resp_tx,
             })
             .map_err(|_| anyhow::anyhow!("worker channel closed on precapture {phase:?}"))?;

--- a/openinfer-qwen3/src/lib.rs
+++ b/openinfer-qwen3/src/lib.rs
@@ -227,7 +227,7 @@ pub struct Qwen3LaunchOptions {
     /// Tensor-parallel world size; `> 1` uses devices `0..tp_size`.
     pub tp_size: usize,
     /// Whether the user requested CUDA Graph. LoRA serving forces it off;
-    /// under tensor parallelism every decode graph is pre-captured at startup.
+    /// every decode graph is pre-captured at startup (single GPU and TP alike).
     pub cuda_graph: bool,
     /// Export the live rank-0, batch-1 SplitKv decode graph during startup.
     /// The requested PNG gets a detailed sibling `.dot` for LLM inspection.

--- a/openinfer-qwen3/src/weights/load.rs
+++ b/openinfer-qwen3/src/weights/load.rs
@@ -271,7 +271,7 @@ impl Qwen3Model {
 
         if model.enable_cuda_graph {
             debug!(
-                "Decode path CUDA Graph is enabled (single GPU captures on first decode step; TP pre-captures every bucket at startup)"
+                "Decode path CUDA Graph is enabled (every bucket's decode graph is pre-captured at startup)"
             );
         } else {
             debug!("Decode path CUDA Graph is disabled");

--- a/openinfer-qwen3/tests/batch_invariance_decode_gemm_graph.rs
+++ b/openinfer-qwen3/tests/batch_invariance_decode_gemm_graph.rs
@@ -13,6 +13,12 @@ use openinfer_kernels::ops::NumericPolicy;
 use openinfer_kernels::ops::pin_served;
 use openinfer_kernels::ops::reset_numeric_policy_counters;
 use openinfer_kernels::ops::set_numeric_policy;
+use openinfer_qwen3::DEFAULT_KV_CACHE_MEMORY_MARGIN_BYTES;
+use openinfer_qwen3::DEFAULT_KV_PAGE_SIZE;
+use openinfer_qwen3::DEFAULT_MAX_PREFILL_TOKENS;
+use openinfer_qwen3::Qwen3LoraOptions;
+use openinfer_qwen3::Qwen3MemoryOptions;
+use openinfer_qwen3::Qwen3OffloadOptions;
 use openinfer_qwen3::runtime::DecodePlan;
 use openinfer_qwen3::runtime::DecodeStepItem;
 use openinfer_qwen3::runtime::PrefillPlan;
@@ -104,24 +110,42 @@ fn a_first_and_decode(ex: &mut Qwen3Executor, n_requests: usize) -> (u32, Vec<(u
     (a_first, topk)
 }
 
-/// One fresh executor with `policy` active before first decode (graph captured under it).
-fn run_policy(policy: NumericPolicy, model_path: &str) -> Vec<(bool, bool, u64)> {
+/// One fresh executor with `policy` active before construction — decode graphs are
+/// pre-captured at startup under it. Returns the pin-GEMM count from that sweep plus
+/// per-pair `(first_token_eq, topk_eq)` results. Replay skips the kernel closure, so no
+/// later decode step can add to the pin count (Tuned/PerToken are structurally 0 = N/A).
+fn run_policy(policy: NumericPolicy, model_path: &str) -> (u64, Vec<(bool, bool)>) {
     set_numeric_policy(policy);
-    let mut ex = Qwen3Executor::from_runtime(model_path, true, &[0]).expect("build executor");
+    reset_numeric_policy_counters();
+    // PerToken graphs bake one N=1 GemmEx node per (row, projection, layer), so graph
+    // exec memory grows with the bucket (~1.8GB across all 36 startup-captured buckets;
+    // Tuned/Pin stay flat ~2MB/bucket). Shrink the KV pool so the three policy executors
+    // fit on consumer GPUs — the assertions are numerics-only, pool size is irrelevant.
+    let mut ex = Qwen3Executor::from_runtime_with_lora_options(
+        model_path,
+        true,
+        &[0],
+        Qwen3LoraOptions::default(),
+        Qwen3OffloadOptions::disabled(),
+        DEFAULT_MAX_PREFILL_TOKENS,
+        None,
+        Qwen3MemoryOptions::new(
+            0.75,
+            DEFAULT_KV_CACHE_MEMORY_MARGIN_BYTES,
+            DEFAULT_KV_PAGE_SIZE,
+        ),
+        false,
+    )
+    .expect("build executor");
+    let capture_served = pin_served();
     ex.set_prefix_cache_enabled(false);
     let mut out = Vec::new();
     for (_, small, large) in PAIRS {
-        reset_numeric_policy_counters();
         let (ft_s, tk_s) = a_first_and_decode(&mut ex, small);
         let (ft_l, tk_l) = a_first_and_decode(&mut ex, large);
-        let served = pin_served();
-        let ft_eq = ft_s == ft_l;
-        let tk_eq = tk_s == tk_l;
-        // served counts the CAPTURE step only (replay skips the closure). Under baseline/per_token,
-        // launch_gemm_pin is never called → served is structurally 0 (N/A).
-        out.push((ft_eq, tk_eq, served));
+        out.push((ft_s == ft_l, tk_s == tk_l));
     }
-    out
+    (capture_served, out)
 }
 
 #[test]
@@ -129,9 +153,9 @@ fn batch_invariance_decode_gemm_graph() {
     let Some(model_path) = model_path_or_skip() else {
         return;
     };
-    let baseline = run_policy(NumericPolicy::Tuned, &model_path);
-    let pin = run_policy(NumericPolicy::Pin, &model_path);
-    let pertoken = run_policy(NumericPolicy::PerToken, &model_path);
+    let (_, baseline) = run_policy(NumericPolicy::Tuned, &model_path);
+    let (pin_served_at_capture, pin) = run_policy(NumericPolicy::Pin, &model_path);
+    let (_, pertoken) = run_policy(NumericPolicy::PerToken, &model_path);
 
     // Prefill must be identical for A in every batch/policy, else the decode comparison is
     // prefill-contaminated.
@@ -140,7 +164,7 @@ fn batch_invariance_decode_gemm_graph() {
         ("pin", &pin),
         ("per_token", &pertoken),
     ] {
-        for (i, (ft_eq, _, _)) in rows.iter().enumerate() {
+        for (i, (ft_eq, _)) in rows.iter().enumerate() {
             assert!(
                 *ft_eq,
                 "{name}: A's prefill first_token differs across batch on pair {} — decode \
@@ -151,28 +175,27 @@ fn batch_invariance_decode_gemm_graph() {
     }
 
     // Control: baseline must drift on at least one pair (else not reproduced here).
-    let baseline_drifted = baseline.iter().any(|(_, tk_eq, _)| !tk_eq);
+    let baseline_drifted = baseline.iter().any(|(_, tk_eq)| !tk_eq);
     assert!(
         baseline_drifted,
         "baseline did NOT drift on any pair — decode-GEMM coupling not reproduced; \
          the pin proof would be vacuous"
     );
 
-    // Pin: every pair invariant, served>0 (pin ran at capture).
-    for (i, (_, tk_eq, served)) in pin.iter().enumerate() {
+    // Pin: every pair invariant, and pin actually ran during the startup capture sweep.
+    assert!(
+        pin_served_at_capture > 0,
+        "PIN: pin did not run during the startup pre-capture sweep (served=0) — vacuous"
+    );
+    for (i, (_, tk_eq)) in pin.iter().enumerate() {
         assert!(
             *tk_eq,
             "PIN: A's graph decode top-K changed on pair {} — pin did NOT make graph decode \
-             batch-invariant (graph captured under Pin)",
-            PAIRS[i].0.trim()
-        );
-        assert!(
-            *served > 0,
-            "PIN: pin did not run on pair {} (served=0) — vacuous",
+             batch-invariant (graphs captured under Pin)",
             PAIRS[i].0.trim()
         );
     }
-    for (i, (_, tk_eq, _)) in pertoken.iter().enumerate() {
+    for (i, (_, tk_eq)) in pertoken.iter().enumerate() {
         assert!(
             *tk_eq,
             "PER_TOKEN: A's graph decode top-K changed on pair {} — harness bug",


### PR DESCRIPTION
## Description

Single-GPU Qwen3 startup now pre-captures all 36 decode CUDA-graph buckets instead of lazily capturing each bucket on its first decode hit — reusing the TP `PrecapturePhase` sweep with a single rank. Same motivation as the TP sweep (#481): lazy capture on first hit is a per-bucket latency spike and a capture-while-serving hazard.

- `Qwen3Executor::single()`: after `RankWorker::spawn`, gated on `enable_cuda_graph && decode_group_is_compiled()`, runs `Warmup → per-bucket Capture+Launch → Finalize` on the primary worker.
- `enable_decode_overlap`: the green-ctx split-stream cache (`graphs_split`) gets its own sweep at the end, with capture routed through `StreamOverrideGuard`; TP call sites pass `None`.
- `Finalize` asserts the matching cache (`graphs` vs `graphs_split`).
- `batch_invariance_decode_gemm_graph`: pin-GEMM `served>0` assertion moves from per-pair (capture step) to construction time.

Serving decode steps are now pure replay on single GPU.

## Behavior

No serving-path behavior change; only *when* graphs are captured moves (startup vs first hit). `--cuda-graph=false` and LoRA (which forces graphs off) skip the sweep as before.

## Test Env

RTX 5070 Ti 16GB, `/data/models/Qwen3-4B`:

- Main sweep: `Single-GPU decode graph pre-capture: 36 buckets captured in 0.91s`; Engine loaded 5.6s.
- `--decode-overlap stream`: main sweep 0.92s + split sweep 0.88s; single + 3-way concurrent `/v1/completions` OK.
- `hf_golden_gate`: PASS (68s). Workspace `--lib`: PASS. `batch_invariance_decode_gemm_graph`: PASS (142s).

## Note: PerToken graph memory

The startup sweep surfaced a pre-existing property deterministically: the `PerToken` numeric policy's GEMM oracle (`gemm_per_token_cuda`) issues one `cublasGemmEx` per row, so a bucket-N graph bakes ~36 layers × 6 projections × N GEMM nodes — ~1.8GB of graph-exec memory across all 36 buckets, which the KV budget (util 0.90) never reserved. Lazy capture held the same memory, just later and mid-serving. Tuned (production default) and Pin are flat at ~2MB/bucket and unaffected. The batch-invariance test now builds its executors at util 0.75 (its numerics assertions are pool-size independent). Budgeting PerToken graph memory during profiling is a follow-up.

Docs: `docs/models/qwen3/single-gpu-graph-precapture.md` (full record), stale lazy-capture wording fixed in `decode-attention.md`, `scheduler.md`, `startup-time.md`, and code comments.