### PR TITLE
feat(kernels): instantiate FlashInfer attention at head_dim 512

### DIFF
--- a/openinfer-kernels/build.rs
+++ b/openinfer-kernels/build.rs
@@ -228,7 +228,7 @@ fn nvcc_job_count() -> usize {
 fn nvcc_task_priority(cu_file: &Path) -> usize {
     match cu_file.file_stem().and_then(|stem| stem.to_str()) {
         Some("paged_attention") => 0,
-        Some("flashinfer_sampling") => 1,
+        Some("paged_attention_hd512" | "flashinfer_sampling") => 1,
         Some("flashinfer_top1") => 2,
         Some("flashinfer_norm") => 3,
         _ => 10,
@@ -1585,6 +1585,7 @@ fn main() {
 
         // Files that include FlashInfer headers (C++17, header-only)
         if stem == "paged_attention"
+            || stem == "paged_attention_hd512"
             || stem == "flashinfer_norm"
             || stem == "flashinfer_sampling"
             || stem == "flashinfer_top1"

--- a/openinfer-kernels/csrc/shared/paged_attention_hd512.cu
+++ b/openinfer-kernels/csrc/shared/paged_attention_hd512.cu
@@ -1,0 +1,291 @@
+// FlashInfer attention instantiations at HEAD_DIM=512 (Gemma 4 global
+// attention layers). Separate TU so the long FlashInfer template builds
+// compile in parallel with paged_attention.cu.
+
+#include "ffi_guard.cuh"
+
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cstdint>
+
+#include <flashinfer/attention/decode.cuh>
+#include <flashinfer/attention/prefill.cuh>
+#include <flashinfer/attention/default_decode_params.cuh>
+#include <flashinfer/attention/default_prefill_params.cuh>
+#include <flashinfer/attention/variants.cuh>
+#include <flashinfer/page.cuh>
+
+using namespace flashinfer;
+
+using DType  = __nv_bfloat16;
+using IdType = int32_t;
+using ParamsT = BatchDecodeParams<DType, DType, DType, IdType>;
+using Variant = DefaultAttention</*custom_mask=*/false,
+                                 /*sliding_window=*/false,
+                                 /*logits_soft_cap=*/false,
+                                 /*alibi=*/false>;
+
+using BatchPrefillParamsT = BatchPrefillPagedParams<DType, DType, DType, IdType>;
+using PrefillParamsT = SinglePrefillParams<DType, DType, DType>;
+
+// Helper: build paged_kv_t from our page-first layout.
+//
+// Our KvPool stores all layers interleaved in one buffer. For a given layer L:
+//   k_data = base + L * layer_stride
+//   v_data = base + L * layer_stride + kv_block_len
+//   stride_page = page_stride  (spans all layers — jumps to same layer in next page)
+//   NHD within-block: stride_n = num_kv_heads * head_dim, stride_h = head_dim
+static paged_kv_t<DType, IdType> make_paged_kv(
+    void*    kv_data,
+    int64_t  k_offset_elems,
+    int64_t  v_offset_elems,
+    int32_t* page_indices,
+    int32_t* page_indptr,
+    int32_t* last_page_len_d,
+    int32_t  num_kv_heads,
+    int32_t  head_dim,
+    int32_t  page_size,
+    int32_t  batch_size,
+    int64_t  stride_page)
+{
+    DType* k_data = reinterpret_cast<DType*>(kv_data) + k_offset_elems;
+    DType* v_data = reinterpret_cast<DType*>(kv_data) + v_offset_elems;
+
+    // kv_strides[0] = stride_page, [1] = stride for NHD-n, [2] = stride for NHD-h
+    int64_t kv_strides[3] = {
+        stride_page,
+        static_cast<int64_t>(num_kv_heads) * head_dim,
+        static_cast<int64_t>(head_dim),
+    };
+
+    return paged_kv_t<DType, IdType>(
+        num_kv_heads, page_size, head_dim, batch_size,
+        QKVLayout::kNHD,
+        k_data, v_data, kv_strides,
+        page_indices, page_indptr, last_page_len_d,
+        /*rope_pos_offset=*/nullptr);
+}
+
+extern "C" {
+
+int single_prefill_cuda_hd512(
+    void*    q,
+    void*    output,
+    void*    k_cache,
+    void*    v_cache,
+    int32_t  num_qo_heads,
+    int32_t  num_kv_heads,
+    int32_t  seq_len,          // number of Q tokens (qo_len)
+    int32_t  kv_len,           // total KV length (start_pos + seq_len)
+    int32_t  max_seq_len,      // allocated cache rows (for HND stride)
+    float    sm_scale,
+    void*    stream)
+{
+  OPENINFER_FFI_GUARD_BEGIN
+    uint32_t q_stride_n  = num_qo_heads * 512;
+    uint32_t q_stride_h  = 512;
+
+    uint32_t kv_stride_n = 512;
+    uint32_t kv_stride_h = static_cast<uint32_t>(max_seq_len) * 512;
+
+    PrefillParamsT params(
+        reinterpret_cast<DType*>(q),
+        reinterpret_cast<DType*>(k_cache),
+        reinterpret_cast<DType*>(v_cache),
+        /*maybe_custom_mask=*/nullptr,
+        reinterpret_cast<DType*>(output),
+        /*lse=*/nullptr,
+        /*maybe_alibi_slopes=*/nullptr,
+        num_qo_heads,
+        num_kv_heads,
+        static_cast<uint32_t>(seq_len),
+        static_cast<uint32_t>(kv_len),
+        q_stride_n,
+        q_stride_h,
+        kv_stride_n,
+        kv_stride_h,
+        /*head_dim=*/512U,
+        /*window_left=*/-1,
+        /*logits_soft_cap=*/0.0f,
+        sm_scale,
+        /*rope_scale=*/1.0f,
+        /*rope_theta=*/1e6f);
+
+    return static_cast<int>(
+        SinglePrefillWithKVCacheDispatched<
+            /*HEAD_DIM_QK=*/512,
+            /*HEAD_DIM_VO=*/512,
+            PosEncodingMode::kNone,
+            /*USE_FP16_QK_REDUCTION=*/false,
+            MaskMode::kCausal,
+            Variant,
+            PrefillParamsT>(
+            params,
+            /*tmp=*/nullptr,
+            reinterpret_cast<cudaStream_t>(stream)));
+  OPENINFER_FFI_GUARD_END(-1)
+}
+
+// The decode dispatcher compiles GQA groups {1,2,3,4,8} only; group 16
+// (Gemma 4 12B global layers) must go through the paged-prefill path instead.
+int paged_attention_decode_cuda_hd512(
+    void*    q,
+    void*    output,
+    void*    kv_data,
+    int64_t  k_offset_elems,
+    int64_t  v_offset_elems,
+    int32_t* page_indices,
+    int32_t* page_indptr,
+    int32_t* last_page_len_d,
+    int32_t* request_indices,
+    int32_t* kv_tile_indices,
+    int32_t* kv_chunk_size_ptr,
+    int32_t  num_qo_heads,
+    int32_t  num_kv_heads,
+    int32_t  head_dim,
+    int32_t  page_size,
+    int32_t  batch_size,
+    int64_t  stride_page,
+    float    sm_scale,
+    void*    stream)
+{
+  OPENINFER_FFI_GUARD_BEGIN
+    auto paged_kv = make_paged_kv(
+        kv_data, k_offset_elems, v_offset_elems,
+        page_indices, page_indptr, last_page_len_d,
+        num_kv_heads, head_dim, page_size, batch_size, stride_page);
+
+    ParamsT params(
+        reinterpret_cast<DType*>(q),
+        /*q_rope_offset=*/nullptr,
+        paged_kv,
+        reinterpret_cast<DType*>(output),
+        /*lse=*/nullptr,
+        /*maybe_alibi_slopes=*/nullptr,
+        num_qo_heads,
+        /*q_stride_n=*/num_qo_heads * head_dim,
+        /*q_stride_h=*/head_dim,
+        /*window_left=*/-1,
+        /*logits_soft_cap=*/0.0f,
+        sm_scale,
+        /*rope_scale=*/1.0f,
+        /*rope_theta=*/1e6f);
+
+    params.padded_batch_size = batch_size;
+    params.request_indices   = request_indices;
+    params.kv_tile_indices   = kv_tile_indices;
+    params.o_indptr          = nullptr;
+    params.kv_chunk_size_ptr = kv_chunk_size_ptr;
+    params.block_valid_mask  = nullptr;
+    params.partition_kv      = false;
+
+    return static_cast<int>(
+        BatchDecodeWithPagedKVCacheDispatched<
+            /*HEAD_DIM=*/512,
+            PosEncodingMode::kNone,
+            Variant,
+            ParamsT>(
+            params,
+            /*tmp_v=*/nullptr,
+            /*tmp_s=*/nullptr,
+            /*enable_pdl=*/false,
+            reinterpret_cast<cudaStream_t>(stream)));
+  OPENINFER_FFI_GUARD_END(-1)
+}
+
+// Takes no cta_tile_q override parameter because hd512 only ever selects 16|32
+// via FA2DetermineCtaTileQ (the shared override helper accepts 16|64|128 only).
+int batch_prefill_paged_cuda_hd512(
+    void*    q,
+    void*    output,
+    void*    kv_data,
+    int64_t  k_offset_elems,
+    int64_t  v_offset_elems,
+    int32_t* page_indices,
+    int32_t* page_indptr,
+    int32_t* last_page_len_d,
+    int32_t* q_indptr,
+    int32_t* request_indices,
+    int32_t* qo_tile_indices,
+    int32_t* kv_tile_indices,
+    int32_t* kv_chunk_size_ptr,
+    uint32_t* total_num_rows,
+    int32_t  num_qo_heads,
+    int32_t  num_kv_heads,
+    int32_t  head_dim,
+    int32_t  page_size,
+    int32_t  seq_len,
+    int32_t  batch_size,
+    int32_t  padded_batch_size,
+    int64_t  stride_page,
+    float    sm_scale,
+    void*    stream)
+{
+  OPENINFER_FFI_GUARD_BEGIN
+    auto paged_kv = make_paged_kv(
+        kv_data, k_offset_elems, v_offset_elems,
+        page_indices, page_indptr, last_page_len_d,
+        num_kv_heads, head_dim, page_size, batch_size, stride_page);
+
+    uint32_t q_stride_n = num_qo_heads * head_dim;
+    uint32_t q_stride_h = head_dim;
+
+    BatchPrefillParamsT params(
+        reinterpret_cast<DType*>(q),
+        paged_kv,
+        /*maybe_custom_mask=*/nullptr,
+        q_indptr,
+        /*maybe_mask_indptr=*/nullptr,
+        /*maybe_q_rope_offset=*/nullptr,
+        reinterpret_cast<DType*>(output),
+        /*lse=*/nullptr,
+        /*maybe_alibi_slopes=*/nullptr,
+        num_qo_heads,
+        q_stride_n,
+        q_stride_h,
+        /*window_left=*/-1,
+        /*logits_soft_cap=*/0.0f,
+        sm_scale,
+        /*rope_scale=*/1.0f,
+        /*rope_theta=*/1e6f);
+
+    params.request_indices   = request_indices;
+    params.qo_tile_indices   = qo_tile_indices;
+    params.kv_tile_indices   = kv_tile_indices;
+    params.merge_indptr      = nullptr;
+    params.o_indptr          = q_indptr;
+    params.block_valid_mask  = nullptr;
+    params.kv_chunk_size_ptr = kv_chunk_size_ptr;
+    params.max_total_num_rows = seq_len;
+    params.total_num_rows    = total_num_rows;
+    params.padded_batch_size = padded_batch_size;
+    params.partition_kv      = false;
+
+    uint32_t group_size = num_qo_heads / num_kv_heads;
+    int64_t packed_qo_len = static_cast<int64_t>(seq_len) * group_size;
+    uint32_t cta_tile_q = FA2DetermineCtaTileQ(packed_qo_len, head_dim);
+
+    cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);
+    int result = 0;
+    DISPATCH_CTA_TILE_Q(cta_tile_q, CTA_TILE_Q, {
+        result = static_cast<int>(
+            BatchPrefillWithPagedKVCacheDispatched<
+                CTA_TILE_Q,
+                /*HEAD_DIM_QK=*/512,
+                /*HEAD_DIM_VO=*/512,
+                PosEncodingMode::kNone,
+                /*USE_FP16_QK_REDUCTION=*/false,
+                MaskMode::kCausal,
+                Variant,
+                BatchPrefillParamsT>(
+                params,
+                /*tmp_v=*/nullptr,
+                /*tmp_s=*/nullptr,
+                /*enable_pdl=*/false,
+                s));
+    });
+    return result;
+  OPENINFER_FFI_GUARD_END(-1)
+}
+
+} // extern "C"

--- a/openinfer-kernels/src/ffi/shared.rs
+++ b/openinfer-kernels/src/ffi/shared.rs
@@ -789,6 +789,72 @@ unsafe extern "C" {
 
 }
 
+// hd512 (Gemma 4 global layers): csrc/shared/paged_attention_hd512.cu
+unsafe extern "C" {
+    pub fn single_prefill_cuda_hd512(
+        q: *const Half,
+        output: *mut Half,
+        k_cache: *const Half,
+        v_cache: *const Half,
+        num_qo_heads: i32,
+        num_kv_heads: i32,
+        seq_len: i32,
+        kv_len: i32,
+        max_seq_len: i32,
+        sm_scale: f32,
+        stream: CUstream,
+    ) -> i32;
+
+    pub fn paged_attention_decode_cuda_hd512(
+        q: *const Half,
+        output: *mut Half,
+        kv_data: *const Half,
+        k_offset_elems: i64,
+        v_offset_elems: i64,
+        page_indices: *const i32,
+        page_indptr: *const i32,
+        last_page_len_d: *const i32,
+        request_indices: *const i32,
+        kv_tile_indices: *const i32,
+        kv_chunk_size_ptr: *const i32,
+        num_qo_heads: i32,
+        num_kv_heads: i32,
+        head_dim: i32,
+        page_size: i32,
+        batch_size: i32,
+        stride_page: i64,
+        sm_scale: f32,
+        stream: CUstream,
+    ) -> i32;
+
+    pub fn batch_prefill_paged_cuda_hd512(
+        q: *const Half,
+        output: *mut Half,
+        kv_data: *const Half,
+        k_offset_elems: i64,
+        v_offset_elems: i64,
+        page_indices: *const i32,
+        page_indptr: *const i32,
+        last_page_len_d: *const i32,
+        q_indptr: *const i32,
+        request_indices: *const i32,
+        qo_tile_indices: *const i32,
+        kv_tile_indices: *const i32,
+        kv_chunk_size_ptr: *const i32,
+        total_num_rows: *const u32,
+        num_qo_heads: i32,
+        num_kv_heads: i32,
+        head_dim: i32,
+        page_size: i32,
+        seq_len: i32,
+        batch_size: i32,
+        padded_batch_size: i32,
+        stride_page: i64,
+        sm_scale: f32,
+        stream: CUstream,
+    ) -> i32;
+}
+
 unsafe extern "C" {
     pub fn openinfer_kernels_last_error() -> *const std::os::raw::c_char;
 }

--- a/openinfer-kernels/src/ops.rs
+++ b/openinfer-kernels/src/ops.rs
@@ -16,18 +16,23 @@ mod lora;
 mod norm;
 mod sampling;
 
+pub use attention::Hd512DecodeMetadata;
 pub use attention::PrefillPagedPlan;
 pub use attention::SUPPORTED_GQA_GROUP_SIZES;
+pub use attention::batch_prefill_paged_hd512_into;
 pub use attention::dflash_qk_norm_rope_into;
 pub use attention::eagle3_rope_into;
 pub use attention::paged_attention_batch_decode_hd256_into;
+pub use attention::paged_attention_batch_decode_hd512_into;
 pub use attention::paged_attention_batch_decode_into;
 pub use attention::paged_attention_batch_decode_split_kv_into;
 pub use attention::paged_attention_batch_decode_via_prefill_hd256_into;
+pub use attention::paged_attention_batch_decode_via_prefill_hd512_into;
 pub use attention::prefill_attention_paged_into;
 pub use attention::qk_norm_partial_rope_batched_decode_hd256_into;
 pub use attention::qk_norm_rope_batch_decode_into;
 pub use attention::single_decode_nhd_into;
+pub use attention::single_prefill_hd512_into;
 pub use attention::single_prefill_nhd_causal_into;
 pub use attention::single_prefill_nhd_noncausal_into;
 #[cfg(feature = "moe")]

--- a/openinfer-kernels/src/ops/attention.rs
+++ b/openinfer-kernels/src/ops/attention.rs
@@ -38,6 +38,9 @@ pub struct PrefillPagedPlan {
     batch_size: i32,
     total_tokens: usize,
     cta_tile_q: i32,
+    head_dim: usize,
+    num_qo_heads: usize,
+    num_kv_heads: usize,
 }
 
 impl PrefillPagedPlan {
@@ -159,6 +162,9 @@ impl PrefillPagedPlan {
             batch_size: 1,
             total_tokens: seq_len,
             cta_tile_q,
+            head_dim,
+            num_qo_heads: num_q_heads,
+            num_kv_heads,
         })
     }
 
@@ -202,13 +208,16 @@ impl PrefillPagedPlan {
             batch_size: host.batch_size as i32,
             total_tokens: host.total_tokens,
             cta_tile_q: host.cta_tile_q as i32,
+            head_dim,
+            num_qo_heads: num_q_heads,
+            num_kv_heads,
         })
     }
 
     /// Allocate a worst-case-sized plan once, to be refilled in place by
     /// [`Self::update_batch_with_cta_tile_q`]. Buffer pointers stay fixed across
     /// updates so a CUDA Graph captured against them remains valid on replay.
-    /// Scalar fields start at 0; an unfilled plan must not be used for a forward.
+    /// Geometry starts unset; update before forward.
     pub fn new_preallocated(
         ctx: &DeviceContext,
         max_total_tokens: usize,
@@ -232,6 +241,9 @@ impl PrefillPagedPlan {
             batch_size: 0,
             total_tokens: 0,
             cta_tile_q: 0,
+            head_dim: 0,
+            num_qo_heads: 0,
+            num_kv_heads: 0,
         })
     }
 
@@ -342,6 +354,9 @@ impl PrefillPagedPlan {
         self.batch_size = host.batch_size as i32;
         self.total_tokens = host.total_tokens;
         self.cta_tile_q = host.cta_tile_q as i32;
+        self.head_dim = head_dim;
+        self.num_qo_heads = num_q_heads;
+        self.num_kv_heads = num_kv_heads;
         Ok(())
     }
 }
@@ -1637,5 +1652,624 @@ pub fn paged_attention_batch_decode_via_prefill_hd256_into(
         );
     }
 
+    Ok(())
+}
+
+// ============================================================================
+// hd512 (Gemma 4 global layers)
+// ============================================================================
+
+/// Decode-metadata aggregate for the hd512 direct-decode path, validated at
+/// use: the wrapper calls [`Self::validate`] with the batch size it derives.
+///
+/// `page_indptr` needs at least `batch_size + 1` elements, the other per-request
+/// slices at least `batch_size`; `page_indices` must be non-empty (its
+/// per-request reach is device-side data and cannot be verified here).
+///
+/// The pages referenced by `page_indices` must lie within `kv_buffer`; the
+/// wrapper cannot verify device-side contents — caller contract.
+pub struct Hd512DecodeMetadata<'a> {
+    page_indices: &'a CudaSlice<i32>,
+    page_indptr: &'a CudaSlice<i32>,
+    last_page_len: &'a CudaSlice<i32>,
+    positions: &'a CudaSlice<i32>,
+    request_indices: &'a CudaSlice<i32>,
+    kv_tile_indices: &'a CudaSlice<i32>,
+    kv_chunk_size: &'a CudaSlice<i32>,
+}
+
+impl<'a> Hd512DecodeMetadata<'a> {
+    pub fn new(
+        page_indices: &'a CudaSlice<i32>,
+        page_indptr: &'a CudaSlice<i32>,
+        last_page_len: &'a CudaSlice<i32>,
+        positions: &'a CudaSlice<i32>,
+        request_indices: &'a CudaSlice<i32>,
+        kv_tile_indices: &'a CudaSlice<i32>,
+        kv_chunk_size: &'a CudaSlice<i32>,
+    ) -> Self {
+        Self {
+            page_indices,
+            page_indptr,
+            last_page_len,
+            positions,
+            request_indices,
+            kv_tile_indices,
+            kv_chunk_size,
+        }
+    }
+
+    pub fn validate(&self, batch_size: usize) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            !self.page_indices.is_empty(),
+            "Hd512DecodeMetadata: page_indices must be non-empty"
+        );
+        anyhow::ensure!(
+            self.page_indptr.len() > batch_size,
+            "Hd512DecodeMetadata: page_indptr length {} must be >= batch_size + 1 = {}",
+            self.page_indptr.len(),
+            batch_size + 1
+        );
+        for (name, len) in [
+            ("last_page_len", self.last_page_len.len()),
+            ("positions", self.positions.len()),
+            ("request_indices", self.request_indices.len()),
+            ("kv_tile_indices", self.kv_tile_indices.len()),
+            ("kv_chunk_size", self.kv_chunk_size.len()),
+        ] {
+            anyhow::ensure!(
+                len >= batch_size,
+                "Hd512DecodeMetadata: {name} length {len} must be >= batch_size {batch_size}",
+            );
+        }
+        Ok(())
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn paged_attention_batch_decode_hd512_into(
+    ctx: &DeviceContext,
+    q: &HiddenStates,
+    k: &HiddenStates,
+    v: &HiddenStates,
+    kv_buffer: &CudaSlice<bf16>,
+    layout: &PagedKvLayout,
+    layer: usize,
+    meta: &Hd512DecodeMetadata,
+    output: &mut HiddenStates,
+    num_qo_heads: usize,
+) -> Result<()> {
+    let num_kv_heads = layout.num_kv_heads;
+    let head_dim = layout.head_dim;
+    anyhow::ensure!(
+        head_dim == 512,
+        "hd512 decode expects head_dim 512, got {}",
+        head_dim
+    );
+    let batch_size = q.seq_len;
+    meta.validate(batch_size)?;
+    anyhow::ensure!(
+        output.seq_len == batch_size,
+        "hd512 decode output.seq_len {} != q.seq_len {batch_size}",
+        output.seq_len
+    );
+    anyhow::ensure!(
+        k.seq_len == batch_size,
+        "hd512 decode k.seq_len {} != q.seq_len {batch_size}",
+        k.seq_len
+    );
+    anyhow::ensure!(
+        v.seq_len == batch_size,
+        "hd512 decode v.seq_len {} != q.seq_len {batch_size}",
+        v.seq_len
+    );
+    anyhow::ensure!(
+        q.hidden_dim == num_qo_heads * 512,
+        "hd512 decode q.hidden_dim {} != num_qo_heads {} * 512",
+        q.hidden_dim,
+        num_qo_heads
+    );
+    anyhow::ensure!(
+        output.hidden_dim == num_qo_heads * 512,
+        "hd512 decode output.hidden_dim {} != num_qo_heads {} * 512",
+        output.hidden_dim,
+        num_qo_heads
+    );
+    anyhow::ensure!(
+        k.hidden_dim == num_kv_heads * 512,
+        "hd512 decode k.hidden_dim {} != num_kv_heads {} * 512",
+        k.hidden_dim,
+        num_kv_heads
+    );
+    anyhow::ensure!(
+        v.hidden_dim == num_kv_heads * 512,
+        "hd512 decode v.hidden_dim {} != num_kv_heads {} * 512",
+        v.hidden_dim,
+        num_kv_heads
+    );
+    anyhow::ensure!(
+        layer < layout.num_layers,
+        "hd512 decode layer {layer} >= layout.num_layers {}",
+        layout.num_layers
+    );
+    ensure_hidden_capacity(q, "batch_decode_hd512 q")?;
+    ensure_hidden_capacity(output, "batch_decode_hd512 output")?;
+    ensure_hidden_capacity(k, "batch_decode_hd512 k")?;
+    ensure_hidden_capacity(v, "batch_decode_hd512 v")?;
+    let page_size = layout.page_size;
+
+    let k_offset = (layer * layout.layer_stride) as i64;
+    let v_offset = (layer * layout.layer_stride + layout.kv_block_len) as i64;
+    let stride_page = layout.page_stride as i64;
+
+    let (buf_ptr, _gbuf) = kv_buffer.device_ptr(&ctx.stream);
+    let (q_ptr, _gq) = q.data.device_ptr(&ctx.stream);
+    let (out_ptr, _go) = output.data.device_ptr_mut(&ctx.stream);
+    let (pi_ptr, _gpi) = meta.page_indices.device_ptr(&ctx.stream);
+    let (pip_ptr, _gpip) = meta.page_indptr.device_ptr(&ctx.stream);
+    let (lpl_ptr, _glpl) = meta.last_page_len.device_ptr(&ctx.stream);
+    let (ri_ptr, _gri) = meta.request_indices.device_ptr(&ctx.stream);
+    let (kti_ptr, _gkti) = meta.kv_tile_indices.device_ptr(&ctx.stream);
+    let (kcs_ptr, _gkcs) = meta.kv_chunk_size.device_ptr(&ctx.stream);
+
+    let stream = crate::tensor::active_cu_stream(ctx);
+
+    scatter_decode_kv_into_paged(
+        ctx,
+        k,
+        v,
+        kv_buffer,
+        layout,
+        layer,
+        meta.page_indices,
+        meta.page_indptr,
+        meta.last_page_len,
+        meta.positions,
+        meta.request_indices,
+        batch_size,
+        "batch hd512 decode",
+    )?;
+
+    let sm_scale = 1.0f32 / (head_dim as f32).sqrt();
+    let result = unsafe {
+        ffi::paged_attention_decode_cuda_hd512(
+            q_ptr as *const ffi::Half,
+            out_ptr as *mut ffi::Half,
+            buf_ptr as *const ffi::Half,
+            k_offset,
+            v_offset,
+            pi_ptr as *const i32,
+            pip_ptr as *const i32,
+            lpl_ptr as *const i32,
+            ri_ptr as *const i32,
+            kti_ptr as *const i32,
+            kcs_ptr as *const i32,
+            num_qo_heads as i32,
+            num_kv_heads as i32,
+            head_dim as i32,
+            page_size as i32,
+            batch_size as i32,
+            stride_page,
+            sm_scale,
+            stream,
+        )
+    };
+    if result != 0 {
+        anyhow::bail!(
+            "paged_attention_decode_cuda_hd512 (batch) failed with error {result}{}",
+            crate::ops::ffi_exception_message(result)
+        );
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn paged_attention_batch_decode_via_prefill_hd512_into(
+    ctx: &DeviceContext,
+    q: &HiddenStates,
+    k: &HiddenStates,
+    v: &HiddenStates,
+    kv_buffer: &CudaSlice<bf16>,
+    layout: &PagedKvLayout,
+    layer: usize,
+    plan: &PrefillPagedPlan,
+    positions_d: &CudaSlice<i32>,
+    output: &mut HiddenStates,
+    num_qo_heads: usize,
+) -> Result<()> {
+    let num_kv_heads = layout.num_kv_heads;
+    let head_dim = layout.head_dim;
+    anyhow::ensure!(
+        head_dim == 512,
+        "hd512 decode expects head_dim 512, got {}",
+        head_dim
+    );
+    anyhow::ensure!(
+        q.hidden_dim == num_qo_heads * 512,
+        "hd512 decode-via-prefill q.hidden_dim {} != num_qo_heads {} * 512",
+        q.hidden_dim,
+        num_qo_heads
+    );
+    anyhow::ensure!(
+        output.hidden_dim == num_qo_heads * 512,
+        "hd512 decode-via-prefill output.hidden_dim {} != num_qo_heads {} * 512",
+        output.hidden_dim,
+        num_qo_heads
+    );
+    anyhow::ensure!(
+        q.seq_len >= plan.total_tokens,
+        "hd512 decode-via-prefill q.seq_len {} < plan.total_tokens {}",
+        q.seq_len,
+        plan.total_tokens
+    );
+    anyhow::ensure!(
+        output.seq_len >= plan.total_tokens,
+        "hd512 decode-via-prefill output.seq_len {} < plan.total_tokens {}",
+        output.seq_len,
+        plan.total_tokens
+    );
+    anyhow::ensure!(
+        layer < layout.num_layers,
+        "hd512 decode-via-prefill layer {layer} >= layout.num_layers {}",
+        layout.num_layers
+    );
+    ensure_hidden_capacity(q, "decode_via_prefill_hd512 q")?;
+    ensure_hidden_capacity(output, "decode_via_prefill_hd512 output")?;
+    anyhow::ensure!(
+        positions_d.len() >= plan.batch_size() as usize,
+        "hd512 decode-via-prefill positions_d length {} must be >= plan.batch_size {}",
+        positions_d.len(),
+        plan.batch_size(),
+    );
+    let batch_size = plan.batch_size() as usize;
+    anyhow::ensure!(
+        k.hidden_dim == num_kv_heads * 512,
+        "hd512 decode-via-prefill k.hidden_dim {} != num_kv_heads {} * 512",
+        k.hidden_dim,
+        num_kv_heads
+    );
+    anyhow::ensure!(
+        v.hidden_dim == num_kv_heads * 512,
+        "hd512 decode-via-prefill v.hidden_dim {} != num_kv_heads {} * 512",
+        v.hidden_dim,
+        num_kv_heads
+    );
+    anyhow::ensure!(
+        k.seq_len >= batch_size,
+        "hd512 decode-via-prefill k.seq_len {} < batch_size {}",
+        k.seq_len,
+        batch_size
+    );
+    anyhow::ensure!(
+        v.seq_len >= batch_size,
+        "hd512 decode-via-prefill v.seq_len {} < batch_size {}",
+        v.seq_len,
+        batch_size
+    );
+    ensure_hidden_capacity(k, "decode_via_prefill_hd512 k")?;
+    ensure_hidden_capacity(v, "decode_via_prefill_hd512 v")?;
+    anyhow::ensure!(
+        plan.head_dim == 512,
+        "plan built for head_dim {}, expected 512",
+        plan.head_dim
+    );
+    anyhow::ensure!(
+        plan.num_kv_heads == num_kv_heads,
+        "plan built for num_kv_heads {}, expected {}",
+        plan.num_kv_heads,
+        num_kv_heads
+    );
+    anyhow::ensure!(
+        plan.num_qo_heads == num_qo_heads,
+        "plan built for num_qo_heads {}, expected {}",
+        plan.num_qo_heads,
+        num_qo_heads
+    );
+    anyhow::ensure!(
+        plan.total_tokens == plan.batch_size() as usize,
+        "decode-via-prefill plan shape mismatch: total_tokens={}, plan_batch={}",
+        plan.total_tokens,
+        plan.batch_size()
+    );
+
+    // Plan tiles laid out for a cta_tile_q override would be misread by the
+    // kernel's own 16|32 derivation.
+    let kernel_cta_tile_q = unsafe {
+        ffi::batch_prefill_cta_tile_q_with_override(
+            plan.total_tokens as i32,
+            plan.num_qo_heads as i32,
+            plan.num_kv_heads as i32,
+            plan.head_dim as i32,
+            0, // auto-detect, matching the hd512 kernel
+        )
+    };
+    anyhow::ensure!(
+        kernel_cta_tile_q == plan.cta_tile_q(),
+        "hd512 decode-via-prefill cta_tile_q: plan recorded {}, kernel derives {}; \
+         overridden plans are not supported at hd512",
+        plan.cta_tile_q(),
+        kernel_cta_tile_q
+    );
+
+    scatter_decode_kv_into_paged(
+        ctx,
+        k,
+        v,
+        kv_buffer,
+        layout,
+        layer,
+        &plan.page_indices_d,
+        &plan.page_indptr_d,
+        &plan.last_page_len_d,
+        positions_d,
+        &plan.batch_indices_d,
+        plan.batch_size() as usize,
+        "batch hd512 decode via prefill",
+    )?;
+
+    let k_offset = (layer * layout.layer_stride) as i64;
+    let v_offset = (layer * layout.layer_stride + layout.kv_block_len) as i64;
+    let stride_page = layout.page_stride as i64;
+    let sm_scale = 1.0f32 / (head_dim as f32).sqrt();
+
+    let (buf_ptr, _gbuf) = kv_buffer.device_ptr(&ctx.stream);
+    let (q_ptr, _gq) = q.data.device_ptr(&ctx.stream);
+    let (out_ptr, _go) = output.data.device_ptr_mut(&ctx.stream);
+    let (pi_ptr, _gpi) = plan.page_indices_d.device_ptr(&ctx.stream);
+    let (pip_ptr, _gpip) = plan.page_indptr_d.device_ptr(&ctx.stream);
+    let (lpl_ptr, _glpl) = plan.last_page_len_d.device_ptr(&ctx.stream);
+    let (qi_ptr, _gqi) = plan.q_indptr_d.device_ptr(&ctx.stream);
+    let (ri_ptr, _gri) = plan.request_indices_d.device_ptr(&ctx.stream);
+    let (qti_ptr, _gqti) = plan.qo_tile_indices_d.device_ptr(&ctx.stream);
+    let (kti_ptr, _gkti) = plan.kv_tile_indices_d.device_ptr(&ctx.stream);
+    let (kcs_ptr, _gkcs) = plan.kv_chunk_size_d.device_ptr(&ctx.stream);
+    let (tnr_ptr, _gtnr) = plan.total_num_rows_d.device_ptr(&ctx.stream);
+
+    let result = unsafe {
+        ffi::batch_prefill_paged_cuda_hd512(
+            q_ptr as *const ffi::Half,
+            out_ptr as *mut ffi::Half,
+            buf_ptr as *const ffi::Half,
+            k_offset,
+            v_offset,
+            pi_ptr as *const i32,
+            pip_ptr as *const i32,
+            lpl_ptr as *const i32,
+            qi_ptr as *const i32,
+            ri_ptr as *const i32,
+            qti_ptr as *const i32,
+            kti_ptr as *const i32,
+            kcs_ptr as *const i32,
+            tnr_ptr as *const u32,
+            num_qo_heads as i32,
+            num_kv_heads as i32,
+            head_dim as i32,
+            layout.page_size as i32,
+            plan.total_tokens as i32,
+            plan.batch_size,
+            plan.num_tiles,
+            stride_page,
+            sm_scale,
+            crate::tensor::active_cu_stream(ctx),
+        )
+    };
+    if result != 0 {
+        anyhow::bail!(
+            "batch_prefill_paged_cuda_hd512 (decode via prefill) failed for layer {layer}, \
+             bs={}, tiles={}, qo_heads={num_qo_heads}, kv_heads={num_kv_heads}: {result}{}",
+            plan.batch_size,
+            plan.num_tiles,
+            crate::ops::ffi_exception_message(result)
+        );
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+/// The pages referenced by `plan.page_indices_d()` must lie within
+/// `kv_buffer`; the wrapper cannot verify device-side contents — caller
+/// contract.
+pub fn batch_prefill_paged_hd512_into(
+    ctx: &DeviceContext,
+    q: &HiddenStates,
+    kv_buffer: &CudaSlice<bf16>,
+    layout: &PagedKvLayout,
+    layer: usize,
+    plan: &PrefillPagedPlan,
+    output: &mut HiddenStates,
+    num_qo_heads: usize,
+) -> Result<()> {
+    let num_kv_heads = layout.num_kv_heads;
+    let head_dim = layout.head_dim;
+    anyhow::ensure!(
+        head_dim == 512,
+        "hd512 prefill expects head_dim 512, got {}",
+        head_dim
+    );
+    anyhow::ensure!(
+        q.hidden_dim == num_qo_heads * 512,
+        "hd512 prefill q.hidden_dim {} != num_qo_heads {} * 512",
+        q.hidden_dim,
+        num_qo_heads
+    );
+    anyhow::ensure!(
+        output.hidden_dim == num_qo_heads * 512,
+        "hd512 prefill output.hidden_dim {} != num_qo_heads {} * 512",
+        output.hidden_dim,
+        num_qo_heads
+    );
+    anyhow::ensure!(
+        q.seq_len >= plan.total_tokens,
+        "hd512 prefill q.seq_len {} < plan.total_tokens {}",
+        q.seq_len,
+        plan.total_tokens
+    );
+    anyhow::ensure!(
+        output.seq_len >= plan.total_tokens,
+        "hd512 prefill output.seq_len {} < plan.total_tokens {}",
+        output.seq_len,
+        plan.total_tokens
+    );
+    anyhow::ensure!(
+        layer < layout.num_layers,
+        "hd512 prefill layer {layer} >= layout.num_layers {}",
+        layout.num_layers
+    );
+    ensure_hidden_capacity(q, "batch_prefill_paged_hd512 q")?;
+    ensure_hidden_capacity(output, "batch_prefill_paged_hd512 output")?;
+    anyhow::ensure!(
+        plan.head_dim == 512,
+        "plan built for head_dim {}, expected 512",
+        plan.head_dim
+    );
+    anyhow::ensure!(
+        plan.num_kv_heads == num_kv_heads,
+        "plan built for num_kv_heads {}, expected {}",
+        plan.num_kv_heads,
+        num_kv_heads
+    );
+    anyhow::ensure!(
+        plan.num_qo_heads == num_qo_heads,
+        "plan built for num_qo_heads {}, expected {}",
+        plan.num_qo_heads,
+        num_qo_heads
+    );
+
+    // Plan tiles laid out for a cta_tile_q override would be misread by the
+    // kernel's own 16|32 derivation.
+    let kernel_cta_tile_q = unsafe {
+        ffi::batch_prefill_cta_tile_q_with_override(
+            plan.total_tokens as i32,
+            plan.num_qo_heads as i32,
+            plan.num_kv_heads as i32,
+            plan.head_dim as i32,
+            0, // auto-detect, matching the hd512 kernel
+        )
+    };
+    anyhow::ensure!(
+        kernel_cta_tile_q == plan.cta_tile_q(),
+        "hd512 prefill cta_tile_q: plan recorded {}, kernel derives {}; \
+         overridden plans are not supported at hd512",
+        plan.cta_tile_q(),
+        kernel_cta_tile_q
+    );
+
+    let k_offset = (layer * layout.layer_stride) as i64;
+    let v_offset = (layer * layout.layer_stride + layout.kv_block_len) as i64;
+    let stride_page = layout.page_stride as i64;
+    let sm_scale = 1.0f32 / (head_dim as f32).sqrt();
+
+    let (buf_ptr, _gbuf) = kv_buffer.device_ptr(&ctx.stream);
+    let (q_ptr, _gq) = q.data.device_ptr(&ctx.stream);
+    let (out_ptr, _go) = output.data.device_ptr_mut(&ctx.stream);
+    let (pi_ptr, _gpi) = plan.page_indices_d.device_ptr(&ctx.stream);
+    let (pip_ptr, _gpip) = plan.page_indptr_d.device_ptr(&ctx.stream);
+    let (lpl_ptr, _glpl) = plan.last_page_len_d.device_ptr(&ctx.stream);
+    let (qi_ptr, _gqi) = plan.q_indptr_d.device_ptr(&ctx.stream);
+    let (ri_ptr, _gri) = plan.request_indices_d.device_ptr(&ctx.stream);
+    let (qti_ptr, _gqti) = plan.qo_tile_indices_d.device_ptr(&ctx.stream);
+    let (kti_ptr, _gkti) = plan.kv_tile_indices_d.device_ptr(&ctx.stream);
+    let (kcs_ptr, _gkcs) = plan.kv_chunk_size_d.device_ptr(&ctx.stream);
+    let (tnr_ptr, _gtnr) = plan.total_num_rows_d.device_ptr(&ctx.stream);
+
+    let result = unsafe {
+        ffi::batch_prefill_paged_cuda_hd512(
+            q_ptr as *const ffi::Half,
+            out_ptr as *mut ffi::Half,
+            buf_ptr as *const ffi::Half,
+            k_offset,
+            v_offset,
+            pi_ptr as *const i32,
+            pip_ptr as *const i32,
+            lpl_ptr as *const i32,
+            qi_ptr as *const i32,
+            ri_ptr as *const i32,
+            qti_ptr as *const i32,
+            kti_ptr as *const i32,
+            kcs_ptr as *const i32,
+            tnr_ptr as *const u32,
+            num_qo_heads as i32,
+            num_kv_heads as i32,
+            head_dim as i32,
+            layout.page_size as i32,
+            plan.total_tokens as i32,
+            plan.batch_size(),
+            plan.num_tiles,
+            stride_page,
+            sm_scale,
+            crate::tensor::active_cu_stream(ctx),
+        )
+    };
+    if result != 0 {
+        anyhow::bail!(
+            "batch_prefill_paged_cuda_hd512 (prefill) failed for layer {layer}, \
+             bs={}, tiles={}, qo_heads={num_qo_heads}, kv_heads={num_kv_heads}: {result}{}",
+            plan.batch_size(),
+            plan.num_tiles,
+            crate::ops::ffi_exception_message(result)
+        );
+    }
+
+    Ok(())
+}
+
+/// `q` rows are NHD `[seq, heads, 512]`; `k_cache`/`v_cache` are HND
+/// `[heads, max_seq_len, 512]` — the head axis is strided by `max_seq_len`.
+pub fn single_prefill_hd512_into(
+    ctx: &DeviceContext,
+    q: &HiddenStates,
+    row_offset: usize,
+    q_seq_len: usize,
+    k_cache: &HiddenStates,
+    v_cache: &HiddenStates,
+    output: &mut HiddenStates,
+    num_q_heads: usize,
+    num_kv_heads: usize,
+    kv_len: usize,
+) -> Result<()> {
+    assert_eq!(q.hidden_dim, num_q_heads * 512);
+    assert_eq!(output.hidden_dim, q.hidden_dim);
+    assert_eq!(output.seq_len, q.seq_len);
+    assert_eq!(k_cache.hidden_dim, num_kv_heads * 512);
+    assert_eq!(v_cache.hidden_dim, k_cache.hidden_dim);
+    assert_eq!(v_cache.seq_len, k_cache.seq_len);
+    assert!(kv_len <= k_cache.seq_len);
+    assert!(
+        q_seq_len <= kv_len,
+        "causal prefill q_seq_len {q_seq_len} exceeds kv_len {kv_len}"
+    );
+    let byte_offset = checked_row_offset(q, row_offset, q_seq_len, "single_prefill_hd512 q")?;
+    ensure_hidden_capacity(output, "single_prefill_hd512 output")?;
+    ensure_hidden_capacity(k_cache, "single_prefill_hd512 k_cache")?;
+    ensure_hidden_capacity(v_cache, "single_prefill_hd512 v_cache")?;
+    let (q_ptr, _gq) = q.data.device_ptr(&ctx.stream);
+    let q_ptr = q_ptr + byte_offset;
+    let (k_ptr, _gk) = k_cache.data.device_ptr(&ctx.stream);
+    let (v_ptr, _gv) = v_cache.data.device_ptr(&ctx.stream);
+    let (out_ptr, _go) = output.data.device_ptr_mut(&ctx.stream);
+    let out_ptr = out_ptr + byte_offset;
+    let result = unsafe {
+        ffi::single_prefill_cuda_hd512(
+            q_ptr as *const ffi::Half,
+            out_ptr as *mut ffi::Half,
+            k_ptr as *const ffi::Half,
+            v_ptr as *const ffi::Half,
+            num_q_heads as i32,
+            num_kv_heads as i32,
+            q_seq_len as i32,
+            kv_len as i32,
+            k_cache.seq_len as i32,
+            1.0f32 / (512.0f32).sqrt(),
+            crate::tensor::active_cu_stream(ctx),
+        )
+    };
+    if result != 0 {
+        anyhow::bail!(
+            "single_prefill_cuda_hd512 failed with error {result}{}",
+            crate::ops::ffi_exception_message(result)
+        );
+    }
     Ok(())
 }


### PR DESCRIPTION
## Description

Fixes #783 

Gemma 4 global attention layers run head_dim 512, a shape no supported model line has needed: the vendored FlashInfer v0.6.14 carries hd512 support end to end (the 99KB-smem K/V time-sharing layout, the VO-split paged path, the `FA2DetermineCtaTileQ` hd512 branch), but this repo instantiated nothing at 512. This adds the three instantiations and the plumbing to reach them.

- New TU `csrc/shared/paged_attention_hd512.cu` with `single_prefill_cuda_hd512`, `batch_prefill_paged_cuda_hd512`, `paged_attention_decode_cuda_hd512`, mirroring the hd256 trio. A separate TU so the long FlashInfer template build parallelizes with `paged_attention.cu`; build.rs adds it to the FlashInfer-include set and the nvcc scheduling priorities.
- FFI declarations and safe wrappers (`batch_prefill_paged_hd512_into`, `paged_attention_batch_decode_hd512_into`, `paged_attention_batch_decode_via_prefill_hd512_into`, `single_prefill_hd512_into`). The wrappers take batch size and total tokens from the plan rather than redundant parameters. `PrefillPagedPlan` now records the geometry it was built with (head dim, query/KV head counts) and the hd512 wrappers validate it, so a plan built for another head configuration is rejected instead of misdispatching (a preallocated plan starts with geometry unset and records it on first update, so no constructor signatures outside openinfer-kernels change). Direct-decode metadata device arrays travel in an `Hd512DecodeMetadata` aggregate (private fields, plain constructor); the wrapper derives the batch size from `q.seq_len` — the single shape owner — and unconditionally validates every slice length against it before touching pointers; what cannot be checked host-side — that page indices stay within the KV buffer — is documented as caller contract.
- The paged-prefill wrapper takes no cta_tile_q override: hd512 only ever selects 16 or 32 via `FA2DetermineCtaTileQ`, and the shared override helper accepts 16|64|128.
- The decode dispatcher compiles GQA groups {1,2,3,4,8} only, so group 16 (Gemma 4 12B global layers: 16 query heads over 1 KV head) decodes through the paged-prefill path; both decode routes are wrapped and tested. Upstream flashinfer#3563 tracks widening the decode dispatch.
- ~`tests/hd512_attention_smoke/` (main/reference/fixture modules): host-reference tests comparing each kernel entry point against naive f64 attention at the global-attention shapes the three published sizes actually use (16/1, 16/2, 32/4), plus tail-aligned short-query prefill and both decode routes. The paged tests compute the reference over the post-run device pages, so fill/scatter conventions cannot desynchronize reference and kernel; the single-prefill test compares against the same bf16-quantized host K/V it uploads~.

## Test Env

Verification on Single GPU (sm_89, x86_64): `cargo build --release -p openinfer-kernels`, `cargo fmt --check`, `cargo clippy --release -p openinfer-kernels --all-targets -- -D warnings`, ~and the smoke suite 7/7 passing with mean-normalized deltas 1.2e-3 to 1.8e-3~. The suite requires the worktree's own flashinfer submodule checkout (v0.6.14); it skips cleanly on machines without a CUDA device.

Throughput numbers are deliberately out of scope. These results establish correctness on sm_89 and settle the 99KB shared-memory capacity question; they do not certify other architectures — sm_90/sm_120 need their own correctness and performance runs.


## Type of Change

- [x] New feature (non-breaking change which adds functionality)