### PR TITLE
feat(qwen35): overlap Unified prefill with active decode

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 | `models/qwen35/tp-implementation.md` | Qwen3.5 TP Phase 1 implementation record: eager dense TP2 worker/scheduler path, short/long HF logits gates, scheduler e2e, and real OpenAI-compatible HTTP smoke pass; remaining TP work is kept as follow-up, not a Phase 1 claim. |
 | `models/qwen35/mixed-load-itl-470.md` | Issue #470: full cold `--max-batch 8/bg=4` matrix on RTX 4090 (24/24 valid) + starvation negative control. Qwen3.5 is not immune; chunking bounds max/per-step stall but raises p99 at low QPS (~14→~80–92ms) and pulls p99/max back from the prefill wall to the chunk wall at high load; `qps·prefill_s≳1` is a throughput wall (chunking can't fix it, and ON's +15% TTFT can trip it earlier). The old "p99 immunity" was a slot-starvation artifact. |
 | `models/qwen35/adaptive-scheduler-policy.md` | Issue #727 adaptive scheduler policy record: default `off`, opt-in `auto`, hard `--max-prefill-tokens` cap, TP `auto` rejection, and pre-review whole-prefill benchmark tradeoff retained as non-default evidence. |
+| `models/qwen35/unified-prefill-overlap.md` | Issue #715 implementation record: opt-in single-GPU shared-SM overlap keeps one prefill chunk in flight while active decode continues; default serial policy and unsupported-combination guards remain explicit. |
 
 ## models / gemma4
 

--- a/docs/models/qwen35/mixed-load-itl-470.md
+++ b/docs/models/qwen35/mixed-load-itl-470.md
@@ -86,7 +86,7 @@ compared against a decode-only **baseline**.
 
 | Gate | Rule |
 |---|---|
-| **valid** | ≥1 `ITL_STEP` with `prefill_tok>0` **and** `decode_n == bg_concurrency` (the injection actually overlapped a full background batch) |
+| **valid** | ≥1 `ITL_STEP` with `prefill_tok>0` **and** `decode_n == bg_concurrency` (the injection intersected a full background batch; `plan=overlap_*` is concurrent work, not a serial freeze) |
 | **negative control** | `max_batch = bg = 4` must be **invalid** — proves the old artifact reproduces |
 | **cross ON/OFF comparison** | compare only `mixed_itl.all` p99/max + `ITL_STEP` per-step stall; never compare the window-attributed stall buckets across configs |
 | **saturation** | `qps·prefill_s ≳ 1` and/or a clearly lifted mixed **p50** ⇒ throughput wall, not a tail |

--- a/docs/models/qwen35/unified-prefill-overlap.md
+++ b/docs/models/qwen35/unified-prefill-overlap.md
@@ -90,6 +90,11 @@ Unsupported combinations fail before model loading:
   Prefill-associated actions now publish their own active-width distribution;
   a synthetic overlap launch/decode/complete/wait log reports `decode_n=4`
   while counting the 8192-token chunk once.
+- RLCR found that treating every `StreamOverrideGuard` as prefill also disabled
+  graph-safe N=1 GEMMs for existing Qwen3 decode/Green Context overrides. A
+  nested, RAII-restored prefill marker now narrows that routing rule to Qwen3.5
+  async prefill. Its unit test and affected Qwen3/Qwen3.5 builds passed, and the
+  Shared-SM lifecycle gate still observed two `overlap_wait` actions.
 
 ## Verification Contract
 
@@ -98,7 +103,7 @@ Unsupported combinations fail before model loading:
 | GPU | 1x NVIDIA GeForce RTX 5090, 32 GB |
 | Driver / CUDA toolkit | `595.71.05` / `12.8.93`, target `sm_120` |
 | Rust / Triton build env | nightly 2026-07-10 / Triton 3.7.1 |
-| Source | upstream/main `e3f91120` plus this patch; validation source matched the local tree by checksum |
+| Source | benchmark binaries: `c405b556` on upstream/main `e3f91120`; the RLCR follow-up only narrows generic-vs-prefill override classification and was separately GPU-lifecycle verified |
 | Model | `Qwen/Qwen3.5-4B`, revision `851bf6e806efd8d0a36b00ddf55e13ccb7b8cd0a` |
 | HTTP client | vLLM 0.25.1 `bench serve` only; no vLLM server was used |
 | Server binary sha256 | `5f19998277f4be7577846cf3e78bc3fef43151a5add0b0a56dd443a06d39b091` |

--- a/docs/models/qwen35/unified-prefill-overlap.md
+++ b/docs/models/qwen35/unified-prefill-overlap.md
@@ -2,11 +2,11 @@
 
 > **TL;DR:** Issue #715 adds opt-in, single-GPU `--decode-overlap stream` for
 > Qwen3.5. One prefill chunk may run on a second CUDA stream while active decode
-> continues. On one RTX 5090, three-run HTTP c16 mean TPOT improved 3.04% and
-> QPS 8/12/16 mean TPOT improved 6.68%/7.74%/8.05%; c1 regressed 1.20%, so the
-> default remains serial `off`. Stream mode is currently limited to
-> `--max-batch <= 32` until the bucket-64 decode GEMMs have an independent
-> non-prefill cuBLAS route.
+> continues. The default remains serial `off`. Stream mode is currently limited
+> to `--max-batch <= 32` until the bucket-64 decode GEMMs have an independent
+> per-stream cuBLAS route. The original HTTP table below predates that cap and
+> used the server's implicit Qwen3.5 max-batch default, so treat it as pre-cap
+> evidence until the HTTP cells are re-run with an explicit safe max batch.
 >
 > **Last touched:** 2026-08
 
@@ -98,6 +98,17 @@ Unsupported combinations fail before model loading:
   nested, RAII-restored prefill marker now narrows that routing rule to Qwen3.5
   async prefill. Its unit test and affected Qwen3/Qwen3.5 builds passed, and the
   Shared-SM lifecycle gate still observed two `overlap_wait` actions.
+- Follow-up review after the PegaInfer rename fixed the `bench_serving` Qwen3.5
+  crate path, made the `MAX_SHARED_SM_DECODE_BATCH <= GEMM_LT_MAX_N` relationship
+  a compile-time assertion, and added a back-reference at the decode GEMM tuning
+  filter. It also removed the dead prefill cuBLAS workspace allocation: cuBLAS
+  resets a handle's workspace when `cublasSetStream()` is called, so the safe
+  bucket cap is about avoiding undocumented concurrent use of one cuBLAS handle
+  across decode replay and async prefill until bucket-64 has a per-stream route.
+- The HTTP A/B table is now explicitly marked pre-cap evidence. The archived
+  server launch command was not retained, and the old source defaulted omitted
+  Qwen3.5 `--max-batch` to 64. Current `stream` mode rejects that default, so
+  cite the HTTP numbers only after a re-run with explicit `--max-batch <= 32`.
 
 ## Verification Contract
 
@@ -111,6 +122,7 @@ Unsupported combinations fail before model loading:
 | HTTP client | vLLM 0.25.1 `bench serve` only; no vLLM server was used |
 | Server binary sha256 | `5f19998277f4be7577846cf3e78bc3fef43151a5add0b0a56dd443a06d39b091` |
 | `bench_serving` sha256 | `cf5040aa4bbad60011a3fa3799f23d8aa2bae8ef399f35bd5a7872a7d98c1936` |
+| Current HTTP rerun requirement | Use `--decode-overlap stream --max-batch <= 32`; the server default is 64 for Qwen3.5 and is intentionally rejected in stream mode |
 
 Qwen3.5 does not expose product prefix reuse or accept
 `--no-prefix-cache`; the CLI rejects it as an unused option. The primary result
@@ -129,7 +141,7 @@ flag.
 - Release server and `bench_serving` builds passed. Startup rejection probes
   passed for TP, `Auto + SharedSm`, and Green Context.
 
-### HTTP A/B
+### HTTP A/B (pre-cap evidence; needs explicit max-batch rerun)
 
 The same release binary served both modes. Each round ran `off` then `stream`
 with a 15-second cooldown. Fixed-concurrency cells used request rate `inf`;
@@ -147,8 +159,27 @@ vllm bench serve \
   --save-result --save-detailed
 ```
 
-Median of three runs. `ok/fail` is the total across all three. TPOT is the
-median run's mean TPOT; the latency columns retain p50/p99 from the median run.
+The exact historical server launch command was not retained in the archived
+notes. Inspecting the benchmark source commit shows Qwen3.5 server startup
+filled an omitted `--max-batch` from Qwen3.5 `MAX_DECODE_BATCH`, so omitting
+`--max-batch` meant the HTTP table used the implicit 64-slot default.
+Current stream mode rejects that shape; use commands like these for a current
+HTTP rerun:
+
+```bash
+cargo build --release -p pegainfer-server --features qwen35
+
+target/release/pegainfer \
+  --model-path <model> --served-model-name qwen35-715 --port <port> \
+  --cuda-graph=true --qwen35-scheduler-policy off \
+  --max-batch 32 --max-prefill-tokens 1024 \
+  --decode-overlap <off|stream>
+```
+
+Median of three historical runs. `ok/fail` is the total across all three. TPOT is
+the median run's mean TPOT; the latency columns retain p50/p99 from the median
+run. These rows are retained to show the original direction and output sanity,
+not as the current post-cap HTTP result.
 
 | Cell | mode | ok/fail | observed avg in/out | TTFT p50/p99 ms | TPOT mean/p99 ms | ITL p50/p99 ms | output tok/s |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
@@ -180,11 +211,11 @@ An independent 128-token HTTP sanity request completed in every server block.
 Its two deterministic text variants had hashes `3a225a2290dd7ad1` and
 `480c2617c7ed462e` in both modes.
 
-The c16 improvement exceeded run-to-run noise: Stream improved mean TPOT in all
-three paired rounds. The three-run median was `11.48 -> 11.13 ms` (`-3.04%`).
-QPS 8/12/16 improved `6.68%/7.74%/8.05%`. c1 moved
-`6.99 -> 7.07 ms` (`+1.20%`), and QPS TTFT p50 increased by about 2-16 ms.
-These tradeoffs keep Stream opt-in.
+In this pre-cap table, Stream improved c16 mean TPOT in all three paired rounds:
+the three-run median was `11.48 -> 11.13 ms` (`-3.04%`). QPS 8/12/16 improved
+`6.68%/7.74%/8.05%`. c1 moved `6.99 -> 7.07 ms` (`+1.20%`), and QPS TTFT p50
+increased by about 2-16 ms. Re-run these cells with explicit `--max-batch <= 32`
+before citing them as current HTTP performance evidence.
 
 ### Serving plan trace and direct diagnostic
 

--- a/docs/models/qwen35/unified-prefill-overlap.md
+++ b/docs/models/qwen35/unified-prefill-overlap.md
@@ -1,0 +1,261 @@
+# Qwen3.5 Unified Prefill Overlap
+
+> **TL;DR:** Issue #715 adds opt-in, single-GPU `--decode-overlap stream` for
+> Qwen3.5. One prefill chunk may run on a second CUDA stream while active decode
+> continues. On one RTX 5090, three-run HTTP c16 mean TPOT improved 3.04% and
+> QPS 8/12/16 mean TPOT improved 6.68%/7.74%/8.05%; c1 regressed 1.20%, so the
+> default remains serial `off`.
+>
+> **Last touched:** 2026-07
+
+## Preparation
+
+- **Read**:
+  - `docs/index.md` - routes Qwen3.5 scheduler, accuracy, mixed-load, and profiling evidence.
+  - `docs/models/qwen35/adaptive-scheduler-policy.md` - `off` stays the default; `auto` is a separate opt-in policy and cannot be combined with overlap yet.
+  - `docs/models/qwen35/mixed-load-itl-470.md` - valid mixed load needs spare admission capacity and an observed prefill/decode intersection.
+  - `docs/models/qwen35/accuracy.md` - `hf_golden_gate` is the numerical oracle; generated-text hashes are sanity evidence.
+  - `docs/playbooks/bench-vs-vllm.md` and `docs/playbooks/profiling-guide.md` - bind A/B numbers and profiler claims to a fixed environment and raw artifacts.
+- **Relevant history**:
+  - Qwen3 PR #695 shows that a kernel-only stream override leaves allocations, copies, frees, and temporary lifetimes unordered across streams.
+  - Qwen3 issue #699 shows that an in-flight prefill must participate in the scheduler idle wait or the scheduler can park forever after the last decoder retires.
+  - Historical prototype `8ed45964` is design evidence only. It predates current crate names and duplicates merged scheduler/trace work with about 3,000 added lines.
+- **Plan**:
+  1. Add default-off `Qwen35DecodeOverlap::{Off, SharedSm}` startup plumbing and reject TP, Green Context, and `Auto + SharedSm` before model loading.
+  2. Keep at most one `InflightPrefill`; run its allocations, kernels, and stream-ordered drops on one owned prefill stream, then run active decode on the existing compute stream.
+  3. Poll the completion event while decode is active; block on the event when it is the only remaining work; sample and promote exactly once after completion.
+  4. Validate scheduler transitions, GPU correctness and lifecycle, HTTP A/B, mixed load, and Nsight on one RTX 5090.
+
+## Execution Log
+
+### Implementation
+
+- Existing public Qwen3.5 launch APIs delegate to `Qwen35DecodeOverlap::Off`.
+  The server and `bench_serving` expose `--decode-overlap off|stream`.
+- Shared-SM mode owns one prefill stream and at most one `InflightPrefill`. The
+  model context stream and `StreamOverrideGuard` move together for the complete
+  prefill enqueue, including allocations, copies, kernels, and stream-ordered
+  frees.
+- Prefill and decode use separate cuBLAS handles. A stream override routes N=1
+  projections away from the graph-safe decode handle.
+- The scheduler polls the prefill event between decode ticks. If the last
+  decoder retires first, it waits for the event rather than parking on the
+  submit channel. Error, unwind, and shutdown paths drain the prefill stream
+  before KV, recurrent, or convolution state can be released.
+- `ITL_STEP` distinguishes `overlap_launch`, `overlap_decode`,
+  `overlap_complete`, and `overlap_wait`. The aggregator counts each forwarded
+  chunk once and keeps concurrent actions out of serial prefill-freeze
+  statistics.
+
+Unsupported combinations fail before model loading:
+
+- Qwen3.5 TP plus overlap;
+- `--qwen35-scheduler-policy auto --decode-overlap stream`;
+- Qwen3.5 `--decode-overlap green-ctx`.
+
+### Review Fixes
+
+- Lifetime review found that the first `InflightPrefill` layout released request
+  state before its stream-draining owner during unwind. `AsyncPrefillOutput` is
+  now the first field, so it drains before `ScheduledChunk` returns KV pages or
+  releases recurrent/convolution buffers.
+- Oracle review found that in-flight decode ticks were missing from
+  `OPENINFER_ITL_DEBUG`, while the launch tick was mislabeled as a serial
+  Unified stall. Mode-aware plan kinds now retain every overlap tick without
+  classifying it as a freeze.
+- Completion sampling and state promotion initially ran before the timed step.
+  They now emit `overlap_complete` with the active decode width, so the trace
+  includes host work that can delay the next decode action.
+- The aggregator initially counted the same chunk again on every in-flight
+  action. Exact plan classification now counts only `prefill`, `unified`, or
+  `overlap_launch` as a forwarded chunk.
+- The first RNG refactor changed default-Off sampled-output progression. The
+  final path preserves the historical sequence: a successful single-GPU pure
+  decode consumes the same two scheduler values as current main; TP consumes
+  the first value.
+- The lifecycle oracle needed three corrections:
+  - It first assumed the direct scheduler always emits `Scheduled` before a
+    token. A token may arrive first, so the receiver now accepts both orders.
+  - A four-chunk prefill let serial Unified produce one decode token after each
+    chunk, so token progress alone did not prove overlap. The final oracle uses
+    one 8192-token chunk and requires two new decode tokens before the prefill's
+    first token; serial Unified can produce only one decode token at that bound.
+  - It also proves that cancelling the last decoder drains and promotes the
+    in-flight prefill, a post-overlap request succeeds, and final-handle drop
+    returns while another prefill is in flight. Every critical receive has a
+    30-second deadline; the final debug gate observed two `overlap_wait`
+    actions.
+- Shared-SM aggregation initially omitted `decode_n` unless a serial Unified
+  stall existed, which made the mixed-load validity grep report `<none>`.
+  Prefill-associated actions now publish their own active-width distribution;
+  a synthetic overlap launch/decode/complete/wait log reports `decode_n=4`
+  while counting the 8192-token chunk once.
+
+## Verification Contract
+
+| Field | Value |
+| --- | --- |
+| GPU | 1x NVIDIA GeForce RTX 5090, 32 GB |
+| Driver / CUDA toolkit | `595.71.05` / `12.8.93`, target `sm_120` |
+| Rust / Triton build env | nightly 2026-07-10 / Triton 3.7.1 |
+| Source | upstream/main `e3f91120` plus this patch; validation source matched the local tree by checksum |
+| Model | `Qwen/Qwen3.5-4B`, revision `851bf6e806efd8d0a36b00ddf55e13ccb7b8cd0a` |
+| HTTP client | vLLM 0.25.1 `bench serve` only; no vLLM server was used |
+| Server binary sha256 | `5f19998277f4be7577846cf3e78bc3fef43151a5add0b0a56dd443a06d39b091` |
+| `bench_serving` sha256 | `cf5040aa4bbad60011a3fa3799f23d8aa2bae8ef399f35bd5a7872a7d98c1936` |
+
+Qwen3.5 does not expose product prefix reuse or accept
+`--no-prefix-cache`; the CLI rejects it as an unused option. The primary result
+therefore contains no prefix-cache path, and the verified commands omit the
+flag.
+
+### Correctness and lifecycle
+
+- Release Qwen3.5 library tests: 73 passed, 6 expected TP2 tests ignored.
+- Shared-SM lifecycle e2e: 1 passed; the required ITL gate observed two
+  `overlap_wait` actions.
+- Default-Off scheduler e2e: 1 passed, 1 TP2 test ignored.
+- `hf_golden_gate`: 2 passed, 2 TP2 tests ignored. Long-golden logprob delta
+  mean/p99/max was `0.0225/0.0718/0.0968`; short graph mean was
+  `0.0253-0.0281`, max `0.1394-0.2403`.
+- Release server and `bench_serving` builds passed. Startup rejection probes
+  passed for TP, `Auto + SharedSm`, and Green Context.
+
+### HTTP A/B
+
+The same release binary served both modes. Each round ran `off` then `stream`
+with a 15-second cooldown. Fixed-concurrency cells used request rate `inf`;
+QPS cells used max concurrency 64. Shared client flags were:
+
+```bash
+vllm bench serve \
+  --backend openai --endpoint /v1/completions \
+  --model qwen35-715 --served-model-name qwen35-715 \
+  --tokenizer <model> --dataset-name random \
+  --random-input-len 1024 --random-output-len <256|128> \
+  --num-prompts <count> --request-rate <inf|8|12|16> \
+  --max-concurrency <1|16|64> --ignore-eos --temperature 0 --seed 42 \
+  --percentile-metrics ttft,tpot,itl,e2el --metric-percentiles 50,99 \
+  --save-result --save-detailed
+```
+
+Median of three runs. `ok/fail` is the total across all three. TPOT is the
+median run's mean TPOT; the latency columns retain p50/p99 from the median run.
+
+| Cell | mode | ok/fail | observed avg in/out | TTFT p50/p99 ms | TPOT mean/p99 ms | ITL p50/p99 ms | output tok/s |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1024/256 c1 | off | 12/0 | 980.2/256 | 53.06/55.58 | 6.99/7.03 | 6.97/8.01 | 139.1 |
+| 1024/256 c1 | stream | 12/0 | 980.2/256 | 54.58/59.24 | 7.07/7.11 | 7.05/7.78 | 137.6 |
+| 1024/256 c16 | off | 48/0 | 973.7/256 | 569.74/1061.79 | 11.48/13.17 | 9.81/72.01 | 1147.9 |
+| 1024/256 c16 | stream | 48/0 | 973.7/256 | 558.49/1084.71 | 11.13/12.55 | 9.79/56.70 | 1149.4 |
+| 1024/128 QPS 8 | off | 48/0 | 973.7/128 | 73.68/197.11 | 12.12/14.73 | 9.69/68.44 | 622.5 |
+| 1024/128 QPS 8 | stream | 48/0 | 973.7/128 | 75.62/200.71 | 11.31/13.28 | 9.63/59.88 | 624.9 |
+| 1024/128 QPS 12 | off | 72/0 | 983.9/128 | 142.59/388.82 | 14.85/18.93 | 9.79/73.60 | 848.8 |
+| 1024/128 QPS 12 | stream | 72/0 | 983.9/128 | 153.35/405.02 | 13.70/16.92 | 9.85/63.12 | 846.4 |
+| 1024/128 QPS 16 | off | 96/0 | 983.2/128 | 251.95/633.34 | 16.88/22.87 | 9.88/73.94 | 1057.8 |
+| 1024/128 QPS 16 | stream | 96/0 | 983.2/128 | 267.50/667.90 | 15.52/20.34 | 10.02/62.65 | 1054.3 |
+
+Every run completed with zero failures, timeouts, error strings, or zero-token
+outputs. Every request produced exactly 256 or 128 tokens. The saved detailed
+JSON contains all generated text; short sha256 values over each run's combined
+text are retained below.
+
+| Cell | off hashes, rounds 1/2/3 | stream hashes, rounds 1/2/3 |
+| --- | --- | --- |
+| c1 | `04bcd42f10baa890`, `3421ef078cf3d773`, `04bcd42f10baa890` | `412d5660f743ebe0`, `412d5660f743ebe0`, `04bcd42f10baa890` |
+| c16 | `c75c098ef30a0ff6`, `2d4500ae44c7d0a2`, `7f2e24296c2ea7ed` | `ea3ebc8e9588a2b2`, `00ca54985f6f659a`, `af8f43ce6c7751fe` |
+| QPS 8 | `195843022462af6c`, `87177a5fc918381e`, `1e77b081acf3afd2` | `123e3c0d8bfb50b6`, `cc45e46d1de7d057`, `195843022462af6c` |
+| QPS 12 | `4b9032e8a6d680e3`, `fd6608b46bb8cbf3`, `92af3f26065940e1` | `edf4960eb3c9def5`, `cc14d9a7748adf81`, `98c99203f184f11d` |
+| QPS 16 | `440c62bb49fd70f9`, `1d413287575f15f3`, `05ea0f131d26655e` | `72d18e2f184f7111`, `220b321e6b6d3c9f`, `24134af1bf0f9e5f` |
+
+An independent 128-token HTTP sanity request completed in every server block.
+Its two deterministic text variants had hashes `3a225a2290dd7ad1` and
+`480c2617c7ed462e` in both modes.
+
+The c16 improvement exceeded run-to-run noise: Stream improved mean TPOT in all
+three paired rounds. The three-run median was `11.48 -> 11.13 ms` (`-3.04%`).
+QPS 8/12/16 improved `6.68%/7.74%/8.05%`. c1 moved
+`6.99 -> 7.07 ms` (`+1.20%`), and QPS TTFT p50 increased by about 2-16 ms.
+These tradeoffs keep Stream opt-in.
+
+### Serving plan trace and direct diagnostic
+
+Across the six HTTP server blocks, the Off trace contained 6,249 Decode, 252
+Unified, and 27 Prefill ticks. Stream replaced the 252 Unified ticks with 252
+`overlap_launch`, 369 `overlap_decode`, and 252 `overlap_complete` ticks; it had
+zero serial Unified stalls. Every launch had exactly one completion. Real
+active widths reached 32. Rounded CUDA Graph bucket counts were:
+
+| mode | bs1 | bs2 | bs4 | bs8 | bs16 | bs32 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| off | 3800 | 117 | 138 | 297 | 1554 | 595 |
+| stream | 3840 | 151 | 219 | 415 | 1651 | 556 |
+
+A separate in-process 1024/256 c16 diagnostic, three measured iterations and
+48 completed requests per mode, measured steady TPOT avg/p50/p99 at
+`11.06/9.82/58.27 ms` Off and `10.77/9.86/29.12 ms` Stream. HTTP minus direct
+mean TPOT was `0.42 ms` Off and `0.36 ms` Stream. This is an attribution check, not an
+HTTP performance result; it shows that the overlap improvement did not create
+a new frontend/output-path gap.
+
+### Mixed-load regression gate
+
+The valid gate used `max_batch=8`, four 512/4096 background decoders, ten cold
+4096/1 injections at QPS 0.5, warmup 5, and three repetitions. Every injection
+intersected `decode_n=4`, completed with one output token, and retained its hash.
+
+| mode | baseline p50/p99 ms | mixed p50/p99/max ms | injection prefill median ms | serial stalls |
+| --- | ---: | ---: | ---: | ---: |
+| off | 7.83/8.59 | 7.80/58.23/60.89 | 237.41 | 52-53 per run |
+| stream | 7.83/8.61 | 7.82/26.15/41.30 | 240.66 | 0 |
+
+Stream reduced mixed p99 by 55.1% and median-run max by 32.2%, while injection
+prefill rose 1.4%. The intentional `max_batch=4,bg=4` starvation control was
+invalid as expected: `decode_n` reached only 1-3, never 4; one injection waited
+33.9 seconds for a slot, and the tool emitted slot-starvation, pacing, and
+background-exhaustion warnings. It is retained only as a measurement guard.
+
+### Nsight Systems
+
+Nsight Systems 2025.1.1 captured matched Off and Stream mixed-load runs with:
+
+```bash
+nsys profile --force-overwrite=true --trace=cuda,nvtx \
+  --cuda-graph-trace=node --export=sqlite -o <trace> \
+  target/release/bench_serving --model-path <model> \
+  --max-batch 8 --decode-overlap <off|stream> \
+  --format json --out <result> mixed --bg-prompt-len 512 \
+  --bg-concurrency 4 --bg-output-len 2048 --inj-prompt-len 4096 \
+  --inj-output-len 1 --qps 0.5 --num-injections 3 \
+  --inj-warm-frac 0 --warmup 3 --skip-baseline
+```
+
+Off placed prefill and decode on CUDA stream 13. Stream placed active prefill on
+stream 14 and decode on stream 13. Within the prefill-active window, the SQLite
+timeline contained 28,082 cross-stream kernel-overlap pairs totaling 321.4 ms;
+examples include prefill GEMMs overlapping `conv1d_decode_batch_kernel` and
+`gated_delta_rule_decode_batch_kernel`. This proves real simultaneous kernel
+execution, beyond host launch interleave. Profiler timings are not used in the
+HTTP tables because CUDA Graph node tracing inflates absolute time.
+
+`cuda_gpu_kern_sum`, `cuda_api_sum`, and `tools/nsys_tail_stats.py` were all run
+on the Stream SQLite. The top GPU totals remained projection GEMMs; the host
+table was dominated by expected event synchronization and whole-process model
+load traffic. No new kernel-first optimization is justified by this trace.
+
+## Debrief
+
+- **Outcome:** #715 has a compact opt-in Shared-SM path, explicit unsupported
+  combinations, lifecycle-safe cleanup, mode-aware ITL diagnostics, real GPU
+  correctness/lifecycle coverage, repeated HTTP improvement, a valid mixed-load
+  gate, and profiler proof of two-stream kernel overlap.
+- **Subtraction:** the implementation reuses the existing Unified scheduler,
+  request state, paged KV ownership, recurrent/conv state, CUDA Graph decode,
+  and `StreamOverrideGuard`. It does not add a second scheduler, duplicate model
+  state, a new chunk policy, or a speculative abstraction.
+- **Decision:** keep `off` as the default. Stream helps concurrent admission and
+  QPS TPOT but slightly regresses c1 and increases loaded TTFT. `auto`, TP, and
+  Green Context remain separate policies with explicit startup errors.
+- **Claim boundary:** evidence covers this source, model revision, and one RTX
+  5090. It does not claim vLLM parity, SOTA, production readiness, TP overlap,
+  prefix caching, or broad hardware results.

--- a/docs/models/qwen35/unified-prefill-overlap.md
+++ b/docs/models/qwen35/unified-prefill-overlap.md
@@ -4,9 +4,11 @@
 > Qwen3.5. One prefill chunk may run on a second CUDA stream while active decode
 > continues. On one RTX 5090, three-run HTTP c16 mean TPOT improved 3.04% and
 > QPS 8/12/16 mean TPOT improved 6.68%/7.74%/8.05%; c1 regressed 1.20%, so the
-> default remains serial `off`.
+> default remains serial `off`. Stream mode is currently limited to
+> `--max-batch <= 32` until the bucket-64 decode GEMMs have an independent
+> non-prefill cuBLAS route.
 >
-> **Last touched:** 2026-07
+> **Last touched:** 2026-08
 
 ## Preparation
 
@@ -51,7 +53,8 @@ Unsupported combinations fail before model loading:
 
 - Qwen3.5 TP plus overlap;
 - `--qwen35-scheduler-policy auto --decode-overlap stream`;
-- Qwen3.5 `--decode-overlap green-ctx`.
+- Qwen3.5 `--decode-overlap green-ctx`;
+- Qwen3.5 `--decode-overlap stream` with `--max-batch > 32`.
 
 ### Review Fixes
 

--- a/pegainfer-frontend/src/model_line.rs
+++ b/pegainfer-frontend/src/model_line.rs
@@ -230,9 +230,7 @@ impl SharedArgs {
                 "--device-ordinal is ignored under tensor parallelism; tp_size>1 uses devices 0..tp_size",
             ));
         }
-        if provided.contains("decode_sm_pct")
-            && self.decode_overlap != CliDecodeOverlap::GreenCtx
-        {
+        if provided.contains("decode_sm_pct") && self.decode_overlap != CliDecodeOverlap::GreenCtx {
             return Err(CliError::rule(
                 "--decode-sm-pct only applies with --decode-overlap=green-ctx",
             ));

--- a/pegainfer-frontend/src/model_line.rs
+++ b/pegainfer-frontend/src/model_line.rs
@@ -71,6 +71,19 @@ pub type ArgRequirement = (&'static str, &'static [&'static str]);
 
 const DEFAULT_MODEL_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../models/Qwen3-4B");
 
+/// Shared CLI selector for model lines that can overlap prefill and decode.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, clap::ValueEnum)]
+pub enum CliDecodeOverlap {
+    /// One stream; prefill and decode serialize.
+    #[default]
+    Off,
+    /// Two CUDA streams sharing all SMs.
+    Stream,
+    /// Green Context SM partition (SM-pinned streams).
+    #[value(name = "green-ctx")]
+    GreenCtx,
+}
+
 // CLI flags shared by more than one model line. Each line declares the
 // subset it reads via `ModelLine::consumed_shared_args`; providing a flag
 // outside that subset fails validation with a per-line error.
@@ -180,6 +193,16 @@ pub struct SharedArgs {
     /// their own crate defaults.
     #[arg(long)]
     pub max_prefill_tokens: Option<usize>,
+
+    /// How prefill and decode share the GPU. Qwen3 supports `off`, `stream`,
+    /// and `green-ctx`; Qwen3.5 supports `off` and `stream`.
+    #[arg(long, value_enum, default_value_t = CliDecodeOverlap::Off)]
+    pub decode_overlap: CliDecodeOverlap,
+
+    /// Percent of SMs pinned to decode in `--decode-overlap green-ctx` (the rest
+    /// go to prefill); rejected if set in any other mode.
+    #[arg(long, default_value_t = 20, value_parser = clap::value_parser!(u32).range(1..=99))]
+    pub decode_sm_pct: u32,
 }
 
 const SHARED_ARG_REQUIREMENTS: &[ArgRequirement] = &[
@@ -205,6 +228,13 @@ impl SharedArgs {
         if provided.contains("device_ordinal") && self.tp_size > 1 {
             return Err(CliError::rule(
                 "--device-ordinal is ignored under tensor parallelism; tp_size>1 uses devices 0..tp_size",
+            ));
+        }
+        if provided.contains("decode_sm_pct")
+            && self.decode_overlap != CliDecodeOverlap::GreenCtx
+        {
+            return Err(CliError::rule(
+                "--decode-sm-pct only applies with --decode-overlap=green-ctx",
             ));
         }
         Ok(())

--- a/pegainfer-kernels/csrc/shared/linear.cu
+++ b/pegainfer-kernels/csrc/shared/linear.cu
@@ -23,11 +23,8 @@ static int cublas_status_to_error(cublasStatus_t status) {
 // CUDA context/device without racing on a process-global singleton.
 thread_local cublasHandle_t g_cublas_handle = nullptr;
 thread_local cublasHandle_t g_cublas_prefill_handle = nullptr;
-thread_local void *g_cublas_workspace = nullptr;
 thread_local std::map<int, cublasHandle_t> g_cublas_handles_by_device;
 thread_local std::map<int, cublasHandle_t> g_cublas_prefill_handles_by_device;
-thread_local std::map<int, void *> g_cublas_workspaces_by_device;
-static const size_t CUBLAS_WORKSPACE_SIZE = 32 * 1024 * 1024; // 32MB
 
 // cublasLt path for small-N decode GEMMs. cuBLAS's default heuristic leaves
 // 4-6% bandwidth on the table for these shapes; gemm_lt_tune_cuda times every
@@ -227,16 +224,11 @@ void cublas_init() {
   auto prefill_it = g_cublas_prefill_handles_by_device.find(device);
   if (prefill_it == g_cublas_prefill_handles_by_device.end()) {
     cublasHandle_t handle = nullptr;
-    void *workspace = nullptr;
     cublasCreate(&handle);
     cublasSetMathMode(handle, CUBLAS_TENSOR_OP_MATH);
-    cudaMalloc(&workspace, CUBLAS_WORKSPACE_SIZE);
-    cublasSetWorkspace(handle, workspace, CUBLAS_WORKSPACE_SIZE);
     prefill_it = g_cublas_prefill_handles_by_device.emplace(device, handle).first;
-    g_cublas_workspaces_by_device.emplace(device, workspace);
   }
   g_cublas_prefill_handle = prefill_it->second;
-  g_cublas_workspace = g_cublas_workspaces_by_device[device];
 }
 
 int cublas_activate_device_handles() {
@@ -248,16 +240,13 @@ int cublas_activate_device_handles() {
 
   auto handle_it = g_cublas_handles_by_device.find(device);
   auto prefill_it = g_cublas_prefill_handles_by_device.find(device);
-  auto workspace_it = g_cublas_workspaces_by_device.find(device);
   if (handle_it == g_cublas_handles_by_device.end() ||
-      prefill_it == g_cublas_prefill_handles_by_device.end() ||
-      workspace_it == g_cublas_workspaces_by_device.end()) {
+      prefill_it == g_cublas_prefill_handles_by_device.end()) {
     return static_cast<int>(cudaErrorInvalidResourceHandle);
   }
 
   g_cublas_handle = handle_it->second;
   g_cublas_prefill_handle = prefill_it->second;
-  g_cublas_workspace = workspace_it->second;
   return static_cast<int>(cudaSuccess);
 }
 
@@ -274,15 +263,8 @@ void cublas_destroy() {
     }
   }
   g_cublas_prefill_handles_by_device.clear();
-  for (auto &entry : g_cublas_workspaces_by_device) {
-    if (entry.second != nullptr) {
-      cudaFree(entry.second);
-    }
-  }
-  g_cublas_workspaces_by_device.clear();
   g_cublas_handle = nullptr;
   g_cublas_prefill_handle = nullptr;
-  g_cublas_workspace = nullptr;
   for (auto &entry : g_lt_plans) {
     lt_plan_destroy(entry.second);
   }
@@ -308,7 +290,7 @@ void cublas_destroy() {
 
 // General GEMM: Y = W @ X where W is [M, K] row-major, X is [K, N] col-major, Y is [M, N] col-major
 // N=1 is equivalent to GEMV. N>1 enables batched prefill.
-// Uses prefill handle (with workspace) — only called from prefill path, never under CUDA Graphs.
+// Uses the prefill handle — only called from prefill path, never under CUDA Graphs.
 int gemm_cuda(const __nv_bfloat16 *W, const __nv_bfloat16 *X, __nv_bfloat16 *Y,
               int M, int N, int K, cudaStream_t stream) {
   if (g_cublas_prefill_handle == nullptr) {

--- a/pegainfer-kernels/src/ops/linear.rs
+++ b/pegainfer-kernels/src/ops/linear.rs
@@ -803,10 +803,9 @@ fn launch_gemm(
         NumericPolicy::PerToken => return launch_gemm_pertoken(w_ptr, x_ptr, y_ptr, m, n, k, ctx),
         NumericPolicy::Tuned => {}
     }
-    // A stream override denotes split-concurrent prefill. Keep even N=1
-    // projections on the dedicated prefill handle so they cannot rebind the
-    // graph-safe decode handle while a decode graph is running.
-    let graphsafe = graphsafe && !crate::tensor::has_stream_override();
+    // Split-concurrent prefill must keep even N=1 projections on its dedicated
+    // handle so it cannot rebind the graph-safe decode handle.
+    let graphsafe = graphsafe && !crate::tensor::has_prefill_stream_override();
     unsafe {
         // Small-N projections run the cublasLt algo selected by gemm_lt_tune.
         // Shapes this thread never tuned report GEMM_LT_UNTUNED and keep their

--- a/pegainfer-kernels/src/ops/linear.rs
+++ b/pegainfer-kernels/src/ops/linear.rs
@@ -803,6 +803,10 @@ fn launch_gemm(
         NumericPolicy::PerToken => return launch_gemm_pertoken(w_ptr, x_ptr, y_ptr, m, n, k, ctx),
         NumericPolicy::Tuned => {}
     }
+    // A stream override denotes split-concurrent prefill. Keep even N=1
+    // projections on the dedicated prefill handle so they cannot rebind the
+    // graph-safe decode handle while a decode graph is running.
+    let graphsafe = graphsafe && !crate::tensor::has_stream_override();
     unsafe {
         // Small-N projections run the cublasLt algo selected by gemm_lt_tune.
         // Shapes this thread never tuned report GEMM_LT_UNTUNED and keep their

--- a/pegainfer-kernels/src/tensor.rs
+++ b/pegainfer-kernels/src/tensor.rs
@@ -19,11 +19,13 @@ use crate::ffi;
 
 thread_local! {
     static STREAM_OVERRIDE: Cell<Option<CUstream>> = const { Cell::new(None) };
+    static PREFILL_STREAM_OVERRIDE: Cell<bool> = const { Cell::new(false) };
 }
 
 /// Scoped stream override for [`active_cu_stream`]; drop restores the previous value.
 pub struct StreamOverrideGuard {
     previous: Option<CUstream>,
+    previous_prefill: bool,
 }
 
 impl StreamOverrideGuard {
@@ -31,20 +33,41 @@ impl StreamOverrideGuard {
     /// The stream must be valid for the guard's lifetime and belong to the
     /// same CUDA device as the `DeviceContext`.
     pub unsafe fn activate(stream: CUstream) -> Self {
+        Self::activate_inner(stream, false)
+    }
+
+    /// # Safety
+    /// The stream must be valid for the guard's lifetime and belong to the
+    /// same CUDA device as the `DeviceContext`.
+    pub unsafe fn activate_prefill(stream: CUstream) -> Self {
+        Self::activate_inner(stream, true)
+    }
+
+    fn activate_inner(stream: CUstream, prefill: bool) -> Self {
         let previous = STREAM_OVERRIDE.with(|c| c.replace(Some(stream)));
-        Self { previous }
+        let previous_prefill = PREFILL_STREAM_OVERRIDE.with(|c| c.replace(prefill));
+        Self {
+            previous,
+            previous_prefill,
+        }
     }
 }
 
 impl Drop for StreamOverrideGuard {
     fn drop(&mut self) {
         STREAM_OVERRIDE.with(|c| c.set(self.previous));
+        PREFILL_STREAM_OVERRIDE.with(|c| c.set(self.previous_prefill));
     }
 }
 
 /// Returns true if a stream override is currently active on this thread.
 pub fn has_stream_override() -> bool {
     STREAM_OVERRIDE.with(|c| c.get().is_some())
+}
+
+/// Returns true while split-concurrent prefill owns the stream override.
+pub fn has_prefill_stream_override() -> bool {
+    PREFILL_STREAM_OVERRIDE.with(Cell::get)
 }
 
 /// Returns the effective CUDA stream: the thread-local override if set,
@@ -664,14 +687,19 @@ mod tests {
     fn stream_override_guard_restores_on_drop() {
         let outer = 0x10usize as CUstream;
         assert!(!has_stream_override());
+        assert!(!has_prefill_stream_override());
         {
-            let _outer_guard = unsafe { StreamOverrideGuard::activate(outer) };
+            let _outer_guard = unsafe { StreamOverrideGuard::activate_prefill(outer) };
+            assert!(has_prefill_stream_override());
             {
                 let _inner_guard = unsafe { StreamOverrideGuard::activate(0x20usize as CUstream) };
+                assert!(!has_prefill_stream_override());
             }
             assert_eq!(STREAM_OVERRIDE.with(Cell::get), Some(outer));
+            assert!(has_prefill_stream_override());
         }
         assert!(!has_stream_override());
+        assert!(!has_prefill_stream_override());
     }
 
     fn copy_matrix_to_host(ctx: &DeviceContext, matrix: &DeviceMatrix) -> Vec<bf16> {

--- a/pegainfer-qwen3/src/model_line.rs
+++ b/pegainfer-qwen3/src/model_line.rs
@@ -8,6 +8,7 @@ use clap::Args as ClapArgs;
 use clap::FromArgMatches;
 use pegainfer_frontend::engine::LaunchedEngine;
 use pegainfer_frontend::model_line::ArgRequirement;
+use pegainfer_frontend::model_line::CliDecodeOverlap;
 use pegainfer_frontend::model_line::CliError;
 use pegainfer_frontend::model_line::LaunchContext;
 use pegainfer_frontend::model_line::ModelLine;
@@ -99,18 +100,6 @@ struct Qwen3Cli {
     #[arg(long, default_value_t = crate::DEFAULT_KV_PAGE_SIZE)]
     kv_page_size: usize,
 
-    /// How prefill and decode share the GPU (single-GPU Qwen3 only).
-    /// `off` serializes them on one stream (lowest TTFT); `stream` overlaps on
-    /// two streams sharing all SMs; `green-ctx` pins each to a disjoint Green
-    /// Context SM partition (lower decode ITL p99, higher TTFT).
-    #[arg(long, value_enum, default_value_t = CliDecodeOverlap::Off)]
-    decode_overlap: CliDecodeOverlap,
-
-    /// Percent of SMs pinned to decode in `--decode-overlap green-ctx` (the rest
-    /// go to prefill); rejected if set in any other mode.
-    #[arg(long, default_value_t = 20, value_parser = clap::value_parser!(u32).range(1..=99))]
-    decode_sm_pct: u32,
-
     /// Enable single-GPU Qwen3 batch-invariant serving by pinning the numeric paths and cutting
     /// each prompt's prefill chunks on its own grid. Off by default. Requires `--no-prefix-cache`;
     /// incompatible with `--kv-offload`, which keeps prefix matching on regardless.
@@ -118,28 +107,13 @@ struct Qwen3Cli {
     batch_invariant: bool,
 }
 
-/// CLI selector for prefill/decode overlap. Mapped to [`DecodeOverlap`]
-/// together with `--decode-sm-pct`.
-#[derive(Clone, Copy, Debug, clap::ValueEnum)]
-enum CliDecodeOverlap {
-    /// One stream; prefill and decode serialize.
-    Off,
-    /// Two CUDA streams sharing all SMs.
-    Stream,
-    /// Green Context SM partition (SM-pinned streams).
-    #[value(name = "green-ctx")]
-    GreenCtx,
-}
-
-impl CliDecodeOverlap {
-    fn resolve(self, decode_sm_pct: u32) -> DecodeOverlap {
-        match self {
-            Self::Off => DecodeOverlap::Off,
-            Self::Stream => DecodeOverlap::SharedSm,
-            Self::GreenCtx => DecodeOverlap::GreenCtx {
-                decode_pct: decode_sm_pct,
-            },
-        }
+fn resolve_decode_overlap(overlap: CliDecodeOverlap, decode_sm_pct: u32) -> DecodeOverlap {
+    match overlap {
+        CliDecodeOverlap::Off => DecodeOverlap::Off,
+        CliDecodeOverlap::Stream => DecodeOverlap::SharedSm,
+        CliDecodeOverlap::GreenCtx => DecodeOverlap::GreenCtx {
+            decode_pct: decode_sm_pct,
+        },
     }
 }
 
@@ -179,6 +153,8 @@ impl ModelLine for Qwen3Line {
             "no_prefix_cache",
             "max_prefill_tokens",
             "dflash_draft_model_path",
+            "decode_overlap",
+            "decode_sm_pct",
         ]
     }
 
@@ -216,14 +192,7 @@ impl ModelLine for Qwen3Line {
                 "--dump-graph-png is not supported with --enable-lora (LoRA disables CUDA Graph)",
             ));
         }
-        if provided.contains("decode_sm_pct")
-            && !matches!(cli.decode_overlap, CliDecodeOverlap::GreenCtx)
-        {
-            return Err(CliError::rule(
-                "--decode-sm-pct only applies with --decode-overlap=green-ctx",
-            ));
-        }
-        if !matches!(cli.decode_overlap, CliDecodeOverlap::Off) && shared.tp_size > 1 {
+        if shared.decode_overlap != CliDecodeOverlap::Off && shared.tp_size > 1 {
             return Err(CliError::rule(
                 "--decode-overlap is single-GPU only; tp_size>1 has no prefill/decode overlap",
             ));
@@ -234,7 +203,7 @@ impl ModelLine for Qwen3Line {
                     "--batch-invariant is not supported with --enable-lora; enable one at a time",
                 ));
             }
-            if !matches!(cli.decode_overlap, CliDecodeOverlap::Off) {
+            if shared.decode_overlap != CliDecodeOverlap::Off {
                 return Err(CliError::rule(
                     "--batch-invariant is not compatible with --decode-overlap; the stream override would force the pinned GEMM to bail at runtime",
                 ));
@@ -355,7 +324,7 @@ impl ModelLine for Qwen3Line {
                 )
                 .validate()?,
                 lora,
-                decode_overlap: cli.decode_overlap.resolve(cli.decode_sm_pct),
+                decode_overlap: resolve_decode_overlap(shared.decode_overlap, shared.decode_sm_pct),
                 batch_invariant: cli.batch_invariant,
                 dflash_draft_model_path: shared.dflash_draft_model_path.clone(),
             },

--- a/pegainfer-qwen35/src/lib.rs
+++ b/pegainfer-qwen35/src/lib.rs
@@ -37,11 +37,13 @@ const MAX_DECODE_BATCH: usize = batch_decode_graph::MAX_BATCH;
 
 /// Current safe Qwen3.5 Shared-SM overlap admission cap.
 ///
-/// Decode buckets above this value fall back to the workspace-backed prefill
-/// cuBLAS handle today; running them while async prefill is in flight would make
-/// two streams share that handle/workspace. Keep overlap opt-in below that
-/// boundary until the larger decode buckets have an independent GEMM route.
+/// Decode buckets above this value fall back to the prefill cuBLAS handle today.
+/// Replaying decode while async prefill concurrently calls that same handle from
+/// another stream relies on undocumented single-handle multi-stream behavior.
+/// Keep overlap opt-in below this boundary until the larger decode buckets have
+/// an independent per-stream handle/workspace route.
 pub const MAX_SHARED_SM_DECODE_BATCH: usize = ops::GEMM_LT_MAX_N;
+const _: () = assert!(MAX_SHARED_SM_DECODE_BATCH <= ops::GEMM_LT_MAX_N);
 
 /// Low-level Qwen3.5 execution interface.
 ///
@@ -224,7 +226,7 @@ pub fn start_engine_with_capacity_policy_and_overlap(
     if decode_overlap == Qwen35DecodeOverlap::SharedSm {
         anyhow::ensure!(
             max_batch <= MAX_SHARED_SM_DECODE_BATCH,
-            "Qwen3.5 --decode-overlap=stream currently requires --max-batch <= {MAX_SHARED_SM_DECODE_BATCH}; decode bucket 64 still falls back to the workspace-backed prefill GEMM handle"
+            "Qwen3.5 --decode-overlap=stream currently requires --max-batch <= {MAX_SHARED_SM_DECODE_BATCH}; larger decode buckets still fall back to the prefill GEMM handle"
         );
     }
     if device_ordinals.len() > 1 {

--- a/pegainfer-qwen35/src/lib.rs
+++ b/pegainfer-qwen35/src/lib.rs
@@ -72,6 +72,16 @@ pub enum Qwen35SchedulerPolicy {
     Auto,
 }
 
+/// How Qwen3.5 handles a prefill chunk that arrives while decode is active.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum Qwen35DecodeOverlap {
+    /// Preserve the serial Unified prefill-then-decode path.
+    #[default]
+    Off,
+    /// Run prefill on a second CUDA stream while decode uses the model stream.
+    SharedSm,
+}
+
 pub fn start_engine(
     model_path: &Path,
     options: EngineLoadOptions,
@@ -116,8 +126,23 @@ fn launch_with_options_and_policy(
     options: Qwen35LaunchOptions,
     scheduler_policy: Qwen35SchedulerPolicy,
 ) -> Result<EngineHandle> {
+    launch_with_options_policy_and_overlap(
+        model_path,
+        options,
+        scheduler_policy,
+        Qwen35DecodeOverlap::Off,
+    )
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub fn launch_with_options_policy_and_overlap(
+    model_path: &Path,
+    options: Qwen35LaunchOptions,
+    scheduler_policy: Qwen35SchedulerPolicy,
+    decode_overlap: Qwen35DecodeOverlap,
+) -> Result<EngineHandle> {
     let device_ordinals = options.device_ordinals()?;
-    start_engine_with_capacity_and_policy(
+    start_engine_with_capacity_policy_and_overlap(
         model_path,
         EngineLoadOptions {
             enable_cuda_graph: options.cuda_graph,
@@ -129,6 +154,7 @@ fn launch_with_options_and_policy(
         options.max_batch,
         options.max_prefill_tokens,
         scheduler_policy,
+        decode_overlap,
     )
 }
 
@@ -154,6 +180,24 @@ pub(crate) fn start_engine_with_capacity_and_policy(
     max_prefill_tokens: usize,
     scheduler_policy: Qwen35SchedulerPolicy,
 ) -> Result<EngineHandle> {
+    start_engine_with_capacity_policy_and_overlap(
+        model_path,
+        options,
+        max_batch,
+        max_prefill_tokens,
+        scheduler_policy,
+        Qwen35DecodeOverlap::Off,
+    )
+}
+
+pub fn start_engine_with_capacity_policy_and_overlap(
+    model_path: &Path,
+    options: EngineLoadOptions,
+    max_batch: usize,
+    max_prefill_tokens: usize,
+    scheduler_policy: Qwen35SchedulerPolicy,
+    decode_overlap: Qwen35DecodeOverlap,
+) -> Result<EngineHandle> {
     anyhow::ensure!(
         (1..=MAX_DECODE_BATCH).contains(&max_batch),
         "Qwen3.5 max_batch must be in 1..={MAX_DECODE_BATCH}, got {max_batch}"
@@ -164,7 +208,16 @@ pub(crate) fn start_engine_with_capacity_and_policy(
         seed,
         ..
     } = options;
+    anyhow::ensure!(
+        scheduler_policy == Qwen35SchedulerPolicy::Off
+            || decode_overlap == Qwen35DecodeOverlap::Off,
+        "Qwen3.5 --decode-overlap=stream requires --qwen35-scheduler-policy=off"
+    );
     if device_ordinals.len() > 1 {
+        anyhow::ensure!(
+            decode_overlap == Qwen35DecodeOverlap::Off,
+            "Qwen3.5 decode overlap is supported on a single GPU only"
+        );
         if scheduler_policy == Qwen35SchedulerPolicy::Auto {
             return Err(anyhow!(
                 "Qwen3.5 TP uses the fixed off scheduler policy; --qwen35-scheduler-policy=auto is single-GPU only"
@@ -211,6 +264,7 @@ pub(crate) fn start_engine_with_capacity_and_policy(
         max_batch,
         max_prefill_tokens,
         scheduler_policy,
+        decode_overlap,
     )
 }
 
@@ -221,9 +275,11 @@ mod tests {
     use pegainfer_frontend::engine::EngineLoadOptions;
     use pegainfer_frontend::engine::EpBackend;
 
+    use super::Qwen35DecodeOverlap;
     use super::Qwen35LaunchOptions;
     use super::Qwen35SchedulerPolicy;
     use super::start_engine_with_capacity_and_policy;
+    use super::start_engine_with_capacity_policy_and_overlap;
 
     #[test]
     fn launch_options_reject_zero_tp_size() {
@@ -265,5 +321,51 @@ mod tests {
 
         assert!(err.contains("scheduler policy"));
         assert!(err.contains("single-GPU only"));
+    }
+
+    #[test]
+    fn tp_rejects_decode_overlap_before_loading_model() {
+        let err = start_engine_with_capacity_policy_and_overlap(
+            Path::new("unused-model-path"),
+            EngineLoadOptions {
+                enable_cuda_graph: false,
+                device_ordinals: vec![0, 1],
+                parallel_config: None,
+                ep_backend: EpBackend::Nccl,
+                seed: 42,
+            },
+            1,
+            1,
+            Qwen35SchedulerPolicy::Off,
+            Qwen35DecodeOverlap::SharedSm,
+        )
+        .err()
+        .expect("decode-overlap validation should reject TP launch")
+        .to_string();
+
+        assert!(err.contains("single GPU"));
+    }
+
+    #[test]
+    fn auto_policy_rejects_decode_overlap_before_loading_model() {
+        let err = start_engine_with_capacity_policy_and_overlap(
+            Path::new("unused-model-path"),
+            EngineLoadOptions {
+                enable_cuda_graph: true,
+                device_ordinals: vec![0],
+                parallel_config: None,
+                ep_backend: EpBackend::Nccl,
+                seed: 42,
+            },
+            1,
+            1,
+            Qwen35SchedulerPolicy::Auto,
+            Qwen35DecodeOverlap::SharedSm,
+        )
+        .err()
+        .expect("decode-overlap validation should reject auto policy")
+        .to_string();
+
+        assert!(err.contains("scheduler-policy=off"));
     }
 }

--- a/pegainfer-qwen35/src/lib.rs
+++ b/pegainfer-qwen35/src/lib.rs
@@ -35,6 +35,14 @@ pub use scheduler::DEFAULT_MAX_PREFILL_TOKENS;
 /// Maximum supported Qwen3.5 decode scheduler slots.
 const MAX_DECODE_BATCH: usize = batch_decode_graph::MAX_BATCH;
 
+/// Current safe Qwen3.5 Shared-SM overlap admission cap.
+///
+/// Decode buckets above this value fall back to the workspace-backed prefill
+/// cuBLAS handle today; running them while async prefill is in flight would make
+/// two streams share that handle/workspace. Keep overlap opt-in below that
+/// boundary until the larger decode buckets have an independent GEMM route.
+pub const MAX_SHARED_SM_DECODE_BATCH: usize = ops::GEMM_LT_MAX_N;
+
 /// Low-level Qwen3.5 execution interface.
 ///
 /// This is for model-local tests, debugging, and benchmarks. The root server
@@ -213,6 +221,12 @@ pub fn start_engine_with_capacity_policy_and_overlap(
             || decode_overlap == Qwen35DecodeOverlap::Off,
         "Qwen3.5 --decode-overlap=stream requires --qwen35-scheduler-policy=off"
     );
+    if decode_overlap == Qwen35DecodeOverlap::SharedSm {
+        anyhow::ensure!(
+            max_batch <= MAX_SHARED_SM_DECODE_BATCH,
+            "Qwen3.5 --decode-overlap=stream currently requires --max-batch <= {MAX_SHARED_SM_DECODE_BATCH}; decode bucket 64 still falls back to the workspace-backed prefill GEMM handle"
+        );
+    }
     if device_ordinals.len() > 1 {
         anyhow::ensure!(
             decode_overlap == Qwen35DecodeOverlap::Off,
@@ -275,6 +289,7 @@ mod tests {
     use pegainfer_frontend::engine::EngineLoadOptions;
     use pegainfer_frontend::engine::EpBackend;
 
+    use super::MAX_SHARED_SM_DECODE_BATCH;
     use super::Qwen35DecodeOverlap;
     use super::Qwen35LaunchOptions;
     use super::Qwen35SchedulerPolicy;
@@ -367,5 +382,29 @@ mod tests {
         .to_string();
 
         assert!(err.contains("scheduler-policy=off"));
+    }
+
+    #[test]
+    fn shared_sm_rejects_unsafe_decode_bucket_before_loading_model() {
+        let err = start_engine_with_capacity_policy_and_overlap(
+            Path::new("unused-model-path"),
+            EngineLoadOptions {
+                enable_cuda_graph: true,
+                device_ordinals: vec![0],
+                parallel_config: None,
+                ep_backend: EpBackend::Nccl,
+                seed: 42,
+            },
+            MAX_SHARED_SM_DECODE_BATCH + 1,
+            1,
+            Qwen35SchedulerPolicy::Off,
+            Qwen35DecodeOverlap::SharedSm,
+        )
+        .err()
+        .expect("decode-overlap validation should reject unsafe decode bucket")
+        .to_string();
+
+        assert!(err.contains("max-batch"));
+        assert!(err.contains(&MAX_SHARED_SM_DECODE_BATCH.to_string()));
     }
 }

--- a/pegainfer-qwen35/src/model_line.rs
+++ b/pegainfer-qwen35/src/model_line.rs
@@ -113,6 +113,15 @@ impl ModelLine for Qwen35Line {
                 )));
             }
         }
+        if decode_overlap != Qwen35DecodeOverlap::Off {
+            let max_batch = cli.max_batch.unwrap_or(crate::MAX_DECODE_BATCH);
+            if max_batch > crate::MAX_SHARED_SM_DECODE_BATCH {
+                return Err(CliError::rule(format!(
+                    "Qwen3.5 --decode-overlap=stream requires --max-batch <= {}; got {max_batch}",
+                    crate::MAX_SHARED_SM_DECODE_BATCH
+                )));
+            }
+        }
         if decode_overlap != Qwen35DecodeOverlap::Off
             && matches!(cli.qwen35_scheduler_policy, CliQwen35SchedulerPolicy::Auto)
         {
@@ -202,8 +211,27 @@ mod tests {
 
     #[test]
     fn accepts_shared_stream_overlap() {
-        validate_argv(&["pegainfer", "--decode-overlap", "stream"])
-            .expect("Qwen3.5 should accept shared-stream overlap");
+        let max_batch = crate::MAX_SHARED_SM_DECODE_BATCH.to_string();
+        validate_argv(&[
+            "pegainfer",
+            "--decode-overlap",
+            "stream",
+            "--max-batch",
+            &max_batch,
+        ])
+        .expect("Qwen3.5 should accept shared-stream overlap");
+    }
+
+    #[test]
+    fn rejects_stream_overlap_default_max_batch() {
+        let error = validate_argv(&["pegainfer", "--decode-overlap", "stream"])
+            .expect_err("Qwen3.5 should reject stream overlap at the default max_batch");
+        assert!(error.to_string().contains("max-batch"));
+        assert!(
+            error
+                .to_string()
+                .contains(&crate::MAX_SHARED_SM_DECODE_BATCH.to_string())
+        );
     }
 
     #[test]

--- a/pegainfer-qwen35/src/model_line.rs
+++ b/pegainfer-qwen35/src/model_line.rs
@@ -5,10 +5,12 @@ use std::collections::BTreeSet;
 use clap::Args as ClapArgs;
 use clap::FromArgMatches;
 use pegainfer_frontend::engine::LaunchedEngine;
+use pegainfer_frontend::model_line::CliDecodeOverlap;
 use pegainfer_frontend::model_line::CliError;
 use pegainfer_frontend::model_line::LaunchContext;
 use pegainfer_frontend::model_line::ModelLine;
 
+use crate::Qwen35DecodeOverlap;
 use crate::Qwen35LaunchOptions;
 use crate::Qwen35SchedulerPolicy;
 
@@ -54,6 +56,16 @@ fn cli(ctx: &LaunchContext<'_>) -> Qwen35Cli {
     Qwen35Cli::from_arg_matches(ctx.matches).expect("Qwen35Cli parses from the merged command")
 }
 
+fn resolve_decode_overlap(overlap: CliDecodeOverlap) -> Result<Qwen35DecodeOverlap, CliError> {
+    match overlap {
+        CliDecodeOverlap::Off => Ok(Qwen35DecodeOverlap::Off),
+        CliDecodeOverlap::Stream => Ok(Qwen35DecodeOverlap::SharedSm),
+        CliDecodeOverlap::GreenCtx => Err(CliError::rule(
+            "Qwen3.5 supports --decode-overlap=off|stream only",
+        )),
+    }
+}
+
 impl ModelLine for Qwen35Line {
     fn name(&self) -> &'static str {
         "Qwen3.5"
@@ -81,6 +93,8 @@ impl ModelLine for Qwen35Line {
             "tp_size",
             "cuda_graph",
             "max_prefill_tokens",
+            "decode_overlap",
+            "decode_sm_pct",
         ]
     }
 
@@ -90,6 +104,7 @@ impl ModelLine for Qwen35Line {
         _provided: &BTreeSet<String>,
     ) -> Result<(), CliError> {
         let cli = cli(ctx);
+        let decode_overlap = resolve_decode_overlap(ctx.shared.decode_overlap)?;
         if let Some(max_batch) = cli.max_batch {
             if !(1..=crate::MAX_DECODE_BATCH).contains(&max_batch) {
                 return Err(CliError::rule(format!(
@@ -97,6 +112,18 @@ impl ModelLine for Qwen35Line {
                     crate::MAX_DECODE_BATCH
                 )));
             }
+        }
+        if decode_overlap != Qwen35DecodeOverlap::Off
+            && matches!(cli.qwen35_scheduler_policy, CliQwen35SchedulerPolicy::Auto)
+        {
+            return Err(CliError::rule(
+                "Qwen3.5 --decode-overlap=stream requires --qwen35-scheduler-policy=off",
+            ));
+        }
+        if ctx.shared.tp_size > 1 && decode_overlap != Qwen35DecodeOverlap::Off {
+            return Err(CliError::rule(
+                "--decode-overlap is single-GPU only; tp_size>1 has no prefill/decode overlap",
+            ));
         }
         if ctx.shared.tp_size > 1
             && matches!(cli.qwen35_scheduler_policy, CliQwen35SchedulerPolicy::Auto)
@@ -110,7 +137,7 @@ impl ModelLine for Qwen35Line {
 
     fn launch(&self, ctx: &LaunchContext<'_>) -> anyhow::Result<LaunchedEngine> {
         let cli = cli(ctx);
-        crate::launch_with_options_and_policy(
+        crate::launch_with_options_policy_and_overlap(
             ctx.model_path,
             Qwen35LaunchOptions {
                 device_ordinal: ctx.shared.device_ordinal,
@@ -123,6 +150,8 @@ impl ModelLine for Qwen35Line {
                     .unwrap_or(crate::DEFAULT_MAX_PREFILL_TOKENS),
             },
             cli.qwen35_scheduler_policy.resolve(),
+            resolve_decode_overlap(ctx.shared.decode_overlap)
+                .map_err(|error| anyhow::anyhow!(error.to_string()))?,
         )
         .map(LaunchedEngine::Handle)
     }
@@ -169,6 +198,32 @@ mod tests {
     fn accepts_scheduler_policy_off() {
         validate_argv(&["pegainfer", "--qwen35-scheduler-policy", "off"])
             .expect("Qwen3.5 should accept explicit scheduler-policy off");
+    }
+
+    #[test]
+    fn accepts_shared_stream_overlap() {
+        validate_argv(&["pegainfer", "--decode-overlap", "stream"])
+            .expect("Qwen3.5 should accept shared-stream overlap");
+    }
+
+    #[test]
+    fn rejects_green_context_overlap() {
+        let error = validate_argv(&["pegainfer", "--decode-overlap", "green-ctx"])
+            .expect_err("Qwen3.5 should reject green-context overlap");
+        assert!(error.to_string().contains("off|stream"));
+    }
+
+    #[test]
+    fn rejects_auto_policy_with_overlap() {
+        let error = validate_argv(&[
+            "pegainfer",
+            "--decode-overlap",
+            "stream",
+            "--qwen35-scheduler-policy",
+            "auto",
+        ])
+        .expect_err("Qwen3.5 should reject auto policy with overlap");
+        assert!(error.to_string().contains("scheduler-policy=off"));
     }
 
     #[test]

--- a/pegainfer-qwen35/src/model_line.rs
+++ b/pegainfer-qwen35/src/model_line.rs
@@ -247,6 +247,8 @@ mod tests {
             "pegainfer",
             "--decode-overlap",
             "stream",
+            "--max-batch",
+            "32",
             "--qwen35-scheduler-policy",
             "auto",
         ])

--- a/pegainfer-qwen35/src/scheduler.rs
+++ b/pegainfer-qwen35/src/scheduler.rs
@@ -1006,20 +1006,6 @@ fn publish_load(
     });
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum OverlapAction {
-    Decode,
-    Wait,
-}
-
-fn overlap_action(inflight_prefill: bool, have_active: bool) -> Option<OverlapAction> {
-    inflight_prefill.then_some(if have_active {
-        OverlapAction::Decode
-    } else {
-        OverlapAction::Wait
-    })
-}
-
 fn should_block_on_submit(
     active_empty: bool,
     prefilling_empty: bool,
@@ -1120,7 +1106,7 @@ fn scheduler_loop(
         // One async prefill owns its scheduled request state. Do not admit or
         // launch a second chunk until it resolves. Active decode keeps moving;
         // if it retires first, wait on the event instead of blocking on submit.
-        if let Some(action) = overlap_action(inflight_prefill.is_some(), !active.is_empty()) {
+        if inflight_prefill.is_some() {
             deferred = pending;
             let itl_step_start = itl_debug_enabled().then(Instant::now);
             let (itl_prefill_tokens, itl_prefill_reqs) =
@@ -1131,22 +1117,19 @@ fn scheduler_loop(
                     )
                 });
             let itl_decode_n = active.len();
-            let itl_plan_kind = match action {
-                OverlapAction::Decode => {
-                    decode_step(&mut backend, &mut active, &mut rng);
-                    "overlap_decode"
-                }
-                OverlapAction::Wait => {
-                    finish_async_prefill(
-                        &mut backend,
-                        &mut active,
-                        &mut prefilling,
-                        inflight_prefill
-                            .take()
-                            .expect("async prefill must be present before blocking wait"),
-                    );
-                    "overlap_wait"
-                }
+            let itl_plan_kind = if active.is_empty() {
+                finish_async_prefill(
+                    &mut backend,
+                    &mut active,
+                    &mut prefilling,
+                    inflight_prefill
+                        .take()
+                        .expect("async prefill must be present before blocking wait"),
+                );
+                "overlap_wait"
+            } else {
+                decode_step(&mut backend, &mut active, &mut rng);
+                "overlap_decode"
             };
             log_itl_step(
                 itl_step_start,

--- a/pegainfer-qwen35/src/scheduler.rs
+++ b/pegainfer-qwen35/src/scheduler.rs
@@ -6,6 +6,7 @@
 
 mod plan;
 
+use std::sync::Arc;
 use std::sync::OnceLock;
 use std::sync::mpsc as std_mpsc;
 use std::thread;
@@ -14,6 +15,9 @@ use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
 use anyhow::Result;
+use cudarc::driver::CudaEvent;
+use cudarc::driver::CudaStream;
+use cudarc::driver::sys;
 use log::debug;
 use log::info;
 use log::warn;
@@ -48,6 +52,7 @@ use self::plan::max_kv_tokens;
 use self::plan::plan_prefill_chunks;
 use self::plan::prefilling_future_pages;
 use self::plan::slot_for_new_request;
+use crate::Qwen35DecodeOverlap;
 use crate::Qwen35SchedulerPolicy;
 use crate::batch_decode_graph::BatchDecodeGraphState;
 use crate::executor::DecodeRequestResult;
@@ -111,12 +116,12 @@ pub const DEFAULT_MAX_PREFILL_TOKENS: usize = 1024;
 
 /// Env-gated per-step ITL diagnostics (issue #470). When `PEGAINFER_ITL_DEBUG`
 /// is set, the scheduler emits one `ITL_STEP` line per executed step, tagging
-/// the plan kind, the *actual* prefill-chunk token count run this step, the
-/// number of active decode rows frozen behind it, and the CPU wall-time the
-/// step took. This lets the mixed-load bench attribute a background decode
-/// stall to the specific steps that truly ran a prefill chunk, instead of the
-/// coarse `[submit, last-token]` injection window that spans every step of a
-/// long chunked prefill. Off by default: no cost on the normal bench path.
+/// the plan kind, the *actual* prefill-chunk token count associated with the
+/// action, the active decode width, and the CPU wall-time. This lets the
+/// mixed-load bench separate serial Unified stalls from overlap launch,
+/// decode, completion, and wait actions instead of relying on the coarse
+/// `[submit, last-token]` injection window. Off by default: no cost on the
+/// normal bench path.
 fn itl_debug_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| std::env::var_os("PEGAINFER_ITL_DEBUG").is_some())
@@ -127,6 +132,32 @@ fn itl_debug_enabled() -> bool {
 fn itl_debug_mono_us() -> u128 {
     static ORIGIN: OnceLock<Instant> = OnceLock::new();
     ORIGIN.get_or_init(Instant::now).elapsed().as_micros()
+}
+
+fn log_itl_step(
+    step_start: Option<Instant>,
+    plan: &str,
+    prefill_tokens: usize,
+    prefill_reqs: usize,
+    decode_n: usize,
+) {
+    let Some(step_start) = step_start else {
+        return;
+    };
+    let dur_us = step_start.elapsed().as_micros();
+    let epoch_us = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_micros());
+    info!(
+        "ITL_STEP mono_us={} epoch_us={} plan={} prefill_tok={} prefill_reqs={} decode_n={} dur_us={}",
+        itl_debug_mono_us(),
+        epoch_us,
+        plan,
+        prefill_tokens,
+        prefill_reqs,
+        decode_n,
+        dur_us
+    );
 }
 
 // ── Entry point ─────────────────────────────────────────────────────────
@@ -143,6 +174,7 @@ pub fn start_with_capacity(
         max_batch,
         max_prefill_tokens,
         Qwen35SchedulerPolicy::Off,
+        Qwen35DecodeOverlap::Off,
     )
 }
 
@@ -152,6 +184,7 @@ pub(crate) fn start_with_capacity_and_policy(
     max_batch: usize,
     max_prefill_tokens: usize,
     scheduler_policy: Qwen35SchedulerPolicy,
+    decode_overlap: Qwen35DecodeOverlap,
 ) -> Result<SchedulerHandle> {
     assert!(
         max_prefill_tokens > 0,
@@ -167,7 +200,7 @@ pub(crate) fn start_with_capacity_and_policy(
         total_blocks,
         block_size,
     );
-    let backend = SingleGpuBackend::new(model, max_batch)?;
+    let backend = SingleGpuBackend::new(model, max_batch, decode_overlap)?;
 
     let (submit_tx, submit_rx) = mpsc::unbounded_channel();
     let (startup_tx, startup_rx) = std_mpsc::channel();
@@ -271,6 +304,7 @@ pub(crate) fn start_tp_with_capacity(
 struct SingleGpuBackend {
     model: Qwen35Model,
     graph_state: BatchDecodeGraphState,
+    prefill_stream: Option<Arc<CudaStream>>,
 }
 
 // One instance per scheduler; the size asymmetry costs nothing here.
@@ -280,17 +314,87 @@ enum SchedulerBackend {
     Tp(TpSchedulerBackend),
 }
 
+struct AsyncPrefillOutput {
+    logits: Option<HiddenStates>,
+    done: CudaEvent,
+    stream: Arc<CudaStream>,
+    completed: bool,
+}
+
+impl AsyncPrefillOutput {
+    fn is_ready(&mut self) -> bool {
+        match unsafe { sys::cuEventQuery(self.done.cu_event()) } {
+            sys::CUresult::CUDA_SUCCESS => {
+                self.completed = true;
+                true
+            }
+            sys::CUresult::CUDA_ERROR_NOT_READY => false,
+            err => fatal_cuda_lifecycle(&format!(
+                "query Qwen3.5 async prefill event failed: {err:?}"
+            )),
+        }
+    }
+
+    fn into_logits(mut self) -> HiddenStates {
+        if !self.completed {
+            if let Err(err) = self.done.synchronize() {
+                fatal_cuda_lifecycle(&format!("wait for Qwen3.5 async prefill failed: {err}"));
+            }
+            self.completed = true;
+        }
+        self.logits
+            .take()
+            .expect("async prefill logits must be consumed exactly once")
+    }
+}
+
+impl Drop for AsyncPrefillOutput {
+    fn drop(&mut self) {
+        if self.completed {
+            return;
+        }
+        if let Err(err) = self.stream.synchronize() {
+            fatal_cuda_lifecycle(&format!(
+                "drain Qwen3.5 async prefill during cleanup failed: {err}"
+            ));
+        }
+    }
+}
+
+fn fatal_cuda_lifecycle(message: &str) -> ! {
+    log::error!("FATAL: {message}; aborting before CUDA-referenced state is released");
+    std::process::abort();
+}
+
 struct TpSchedulerBackend {
     executor: Qwen35TpExecutor,
     next_request_id: u64,
 }
 
 impl SingleGpuBackend {
-    fn new(model: Qwen35Model, max_batch: usize) -> Result<Self> {
+    fn new(
+        model: Qwen35Model,
+        max_batch: usize,
+        decode_overlap: Qwen35DecodeOverlap,
+    ) -> Result<Self> {
         anyhow::ensure!(max_batch > 0, "Qwen3.5 max_batch must be > 0");
         let graph_capacity = crate::batch_decode_graph::bucket_for(max_batch);
         let graph_state = model.create_batch_decode_graph_state_with_capacity(graph_capacity)?;
-        Ok(Self { model, graph_state })
+        let prefill_stream = match decode_overlap {
+            Qwen35DecodeOverlap::Off => None,
+            Qwen35DecodeOverlap::SharedSm => Some(
+                model
+                    .device_ctx()
+                    .ctx
+                    .new_stream()
+                    .map_err(|err| anyhow::anyhow!("create Qwen3.5 prefill stream: {err}"))?,
+            ),
+        };
+        Ok(Self {
+            model,
+            graph_state,
+            prefill_stream,
+        })
     }
 
     fn model(&self) -> &Qwen35Model {
@@ -338,6 +442,63 @@ impl SingleGpuBackend {
         let mut rec_refs: Vec<&mut RecurrentState> = recs.iter_mut().collect();
         self.model
             .batch_prefill_logits(&window_refs, kvs, &mut rec_refs)
+    }
+
+    fn overlap_enabled(&self) -> bool {
+        self.prefill_stream.is_some()
+    }
+
+    fn launch_async_prefill(&mut self, chunk: &mut ScheduledChunk) -> Result<AsyncPrefillOutput> {
+        let prefill_stream = self
+            .prefill_stream
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("Qwen3.5 decode overlap is disabled"))?;
+
+        // Request KV/recurrent state was allocated on the model stream. Order
+        // those producers before the prefill stream without blocking the host.
+        prefill_stream
+            .join(&self.model.device_ctx().stream)
+            .map_err(|err| anyhow::anyhow!("join Qwen3.5 prefill stream: {err}"))?;
+
+        let window_refs: Vec<&[u32]> = chunk.windows.iter().map(Vec::as_slice).collect();
+        let ScheduledChunkBackendState::Single { kvs, recs } = &mut chunk.backend_state else {
+            anyhow::bail!("single-GPU async prefill received TP chunk state");
+        };
+        let mut rec_refs: Vec<&mut RecurrentState> = recs.iter_mut().collect();
+        let logits = match self.model.batch_prefill_logits_on_stream(
+            Arc::clone(&prefill_stream),
+            &window_refs,
+            kvs,
+            &mut rec_refs,
+        ) {
+            Ok(logits) => logits,
+            Err(err) => {
+                if let Err(sync_err) = prefill_stream.synchronize() {
+                    fatal_cuda_lifecycle(&format!(
+                        "Qwen3.5 async prefill failed ({err}); stream drain failed: {sync_err}"
+                    ));
+                }
+                return Err(err);
+            }
+        };
+        let done = match prefill_stream.record_event(None) {
+            Ok(done) => done,
+            Err(err) => {
+                if let Err(sync_err) = prefill_stream.synchronize() {
+                    fatal_cuda_lifecycle(&format!(
+                        "record Qwen3.5 async prefill event failed ({err}); stream drain failed: {sync_err}"
+                    ));
+                }
+                return Err(anyhow::anyhow!("record Qwen3.5 async prefill event: {err}"));
+            }
+        };
+        Ok(AsyncPrefillOutput {
+            logits: Some(logits),
+            done,
+            stream: prefill_stream,
+            completed: false,
+        })
     }
 
     fn unified_step(
@@ -389,7 +550,7 @@ impl SingleGpuBackend {
         &mut self,
         pending: &[SchedulerRequest],
         logits: &HiddenStates,
-        rng: &mut StdRng,
+        sample_seed: u64,
     ) -> Result<(Vec<u32>, Vec<Option<TokenLogprob>>)> {
         debug_assert_eq!(
             logits.seq_len,
@@ -400,7 +561,6 @@ impl SingleGpuBackend {
         let cpu_logits =
             snapshot_requested_logprobs(self.model.device_ctx(), logits, &requested_logprobs)?;
         let params_refs: Vec<&SamplingParams> = pending.iter().map(|r| &r.params).collect();
-        let sample_seed = rand::RngExt::random(rng);
         let tokens = self.model.select_tokens_from_logits_varied(
             logits,
             &mut self.graph_state.buffers,
@@ -427,7 +587,7 @@ impl SingleGpuBackend {
     fn sample_decode_logits(
         &mut self,
         active: &[ActiveRequest35],
-        rng: &mut StdRng,
+        sample_seed: u64,
     ) -> Result<(Vec<u32>, Vec<Option<TokenLogprob>>)> {
         let requested_logprobs: Vec<usize> = active.iter().map(|r| r.logprobs).collect();
         let cpu_logits = snapshot_requested_logprobs(
@@ -436,7 +596,6 @@ impl SingleGpuBackend {
             &requested_logprobs,
         )?;
         let params_refs: Vec<&SamplingParams> = active.iter().map(|r| &r.params).collect();
-        let sample_seed = rand::RngExt::random(rng);
         let tokens = self.model.select_tokens_batch_varied(
             &mut self.graph_state.buffers,
             &params_refs,
@@ -833,6 +992,7 @@ fn publish_load(
     backend: &SchedulerBackend,
     active: &[ActiveRequest35],
     prefilling: &[PrefillingRequest35],
+    inflight_prefill_reqs: usize,
     num_waiting_reqs: usize,
 ) {
     let kv_total_blocks = backend.capacity_pages_for_requests() as u64;
@@ -840,10 +1000,33 @@ fn publish_load(
         kv_used_blocks: kv_total_blocks
             .saturating_sub(backend.available_pages(active, prefilling) as u64),
         kv_total_blocks,
-        num_running_reqs: (active.len() + prefilling.len()) as u64,
+        num_running_reqs: (active.len() + prefilling.len() + inflight_prefill_reqs) as u64,
         num_waiting_reqs: num_waiting_reqs as u64,
         spec_decode: None,
     });
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OverlapAction {
+    Decode,
+    Wait,
+}
+
+fn overlap_action(inflight_prefill: bool, have_active: bool) -> Option<OverlapAction> {
+    inflight_prefill.then_some(if have_active {
+        OverlapAction::Decode
+    } else {
+        OverlapAction::Wait
+    })
+}
+
+fn should_block_on_submit(
+    active_empty: bool,
+    prefilling_empty: bool,
+    pending_empty: bool,
+    inflight_prefill: bool,
+) -> bool {
+    active_empty && prefilling_empty && pending_empty && !inflight_prefill
 }
 
 #[allow(clippy::needless_pass_by_value)]
@@ -859,6 +1042,7 @@ fn scheduler_loop(
     let mut active: Vec<ActiveRequest35> = Vec::new();
     let mut deferred: Vec<SchedulerRequest> = Vec::new();
     let mut prefilling: Vec<PrefillingRequest35> = Vec::new();
+    let mut inflight_prefill: Option<InflightPrefill> = None;
     let max_batch = backend.max_batch();
 
     info!("scheduler ready (max_batch={})", max_batch);
@@ -867,7 +1051,46 @@ fn scheduler_loop(
         // Publish the settled state between scheduler steps. If the prior step
         // retired its final requests, their KV pages have already returned via
         // RAII, so this snapshot reaches idle before the channel blocks below.
-        publish_load(&load_tx, &backend, &active, &prefilling, deferred.len());
+        publish_load(
+            &load_tx,
+            &backend,
+            &active,
+            &prefilling,
+            inflight_prefill
+                .as_ref()
+                .map_or(0, |prefill| prefill.chunk.reqs.len()),
+            deferred.len(),
+        );
+
+        if inflight_prefill
+            .as_mut()
+            .is_some_and(|prefill| prefill.output.is_ready())
+        {
+            let (prefill_tokens, prefill_reqs) =
+                inflight_prefill.as_ref().map_or((0, 0), |prefill| {
+                    (
+                        prefill.chunk.windows.iter().map(Vec::len).sum(),
+                        prefill.chunk.reqs.len(),
+                    )
+                });
+            let decode_n = active.len();
+            let step_start = itl_debug_enabled().then(Instant::now);
+            finish_async_prefill(
+                &mut backend,
+                &mut active,
+                &mut prefilling,
+                inflight_prefill
+                    .take()
+                    .expect("ready async prefill must still be present"),
+            );
+            log_itl_step(
+                step_start,
+                "overlap_complete",
+                prefill_tokens,
+                prefill_reqs,
+                decode_n,
+            );
+        }
 
         // 1. Drain all pending requests (deferred from last iteration + channel)
         let mut pending = std::mem::take(&mut deferred);
@@ -877,7 +1100,12 @@ fn scheduler_loop(
 
         // 2. Nothing in flight (no decode, no in-progress prefill) and nothing
         //    pending → block until a request arrives.
-        if active.is_empty() && prefilling.is_empty() && pending.is_empty() {
+        if should_block_on_submit(
+            active.is_empty(),
+            prefilling.is_empty(),
+            pending.is_empty(),
+            inflight_prefill.is_some(),
+        ) {
             if let Some((req, _kv_prefix)) = submit_rx.blocking_recv() {
                 pending.push(req);
             } else {
@@ -887,6 +1115,47 @@ fn scheduler_loop(
             while let Ok((req, _kv_prefix)) = submit_rx.try_recv() {
                 pending.push(req);
             }
+        }
+
+        // One async prefill owns its scheduled request state. Do not admit or
+        // launch a second chunk until it resolves. Active decode keeps moving;
+        // if it retires first, wait on the event instead of blocking on submit.
+        if let Some(action) = overlap_action(inflight_prefill.is_some(), !active.is_empty()) {
+            deferred = pending;
+            let itl_step_start = itl_debug_enabled().then(Instant::now);
+            let (itl_prefill_tokens, itl_prefill_reqs) =
+                inflight_prefill.as_ref().map_or((0, 0), |prefill| {
+                    (
+                        prefill.chunk.windows.iter().map(Vec::len).sum(),
+                        prefill.chunk.reqs.len(),
+                    )
+                });
+            let itl_decode_n = active.len();
+            let itl_plan_kind = match action {
+                OverlapAction::Decode => {
+                    decode_step(&mut backend, &mut active, &mut rng);
+                    "overlap_decode"
+                }
+                OverlapAction::Wait => {
+                    finish_async_prefill(
+                        &mut backend,
+                        &mut active,
+                        &mut prefilling,
+                        inflight_prefill
+                            .take()
+                            .expect("async prefill must be present before blocking wait"),
+                    );
+                    "overlap_wait"
+                }
+            };
+            log_itl_step(
+                itl_step_start,
+                itl_plan_kind,
+                itl_prefill_tokens,
+                itl_prefill_reqs,
+                itl_decode_n,
+            );
+            continue;
         }
 
         // 3. Admit new prompts. In-flight prefills reserve their promotion slot
@@ -995,19 +1264,35 @@ fn scheduler_loop(
         };
         if let Some(plan) = plan {
             let itl_plan_kind = match &plan {
+                ExecutionPlan::Unified { .. } if matches!(&backend, SchedulerBackend::Single(single) if single.overlap_enabled()) => {
+                    "overlap_launch"
+                }
                 ExecutionPlan::Unified { .. } => "unified",
                 ExecutionPlan::Prefill { .. } => "prefill",
                 ExecutionPlan::Decode => "decode",
             };
             let itl_step_start = itl_debug.then(Instant::now);
             match plan {
-                ExecutionPlan::Unified { pending } => unified_step_sched(
-                    &mut backend,
-                    &mut active,
-                    pending,
-                    &mut prefilling,
-                    &mut rng,
-                ),
+                ExecutionPlan::Unified { pending } => {
+                    if matches!(&backend, SchedulerBackend::Single(single) if single.overlap_enabled())
+                    {
+                        launch_overlap_step(
+                            &mut backend,
+                            &mut active,
+                            pending,
+                            &mut inflight_prefill,
+                            &mut rng,
+                        );
+                    } else {
+                        unified_step_sched(
+                            &mut backend,
+                            &mut active,
+                            pending,
+                            &mut prefilling,
+                            &mut rng,
+                        );
+                    }
+                }
                 ExecutionPlan::Prefill { pending } => prefill_batch(
                     &mut backend,
                     &mut active,
@@ -1019,27 +1304,13 @@ fn scheduler_loop(
                     decode_step(&mut backend, &mut active, &mut rng);
                 }
             }
-            if let Some(step_start) = itl_step_start {
-                // A `unified`/`prefill` step with prefill_tok>0 is the only kind
-                // that freezes active decodes behind real prefill work; a
-                // `decode` step (prefill_tok=0) is a genuine steady gap. dur_us
-                // is the CPU wall-time of the step, i.e. the per-step stall the
-                // active decodes actually eat this tick.
-                let dur_us = step_start.elapsed().as_micros();
-                let epoch_us = SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .map_or(0, |d| d.as_micros());
-                info!(
-                    "ITL_STEP mono_us={} epoch_us={} plan={} prefill_tok={} prefill_reqs={} decode_n={} dur_us={}",
-                    itl_debug_mono_us(),
-                    epoch_us,
-                    itl_plan_kind,
-                    itl_prefill_tokens,
-                    itl_prefill_reqs,
-                    itl_decode_n,
-                    dur_us
-                );
-            }
+            log_itl_step(
+                itl_step_start,
+                itl_plan_kind,
+                itl_prefill_tokens,
+                itl_prefill_reqs,
+                itl_decode_n,
+            );
         }
     }
 }
@@ -1100,7 +1371,8 @@ fn prefill_batch(
                     return;
                 }
             };
-            match single.sample_prefill_logits(&chunk.reqs, &logits, rng) {
+            let prefill_sample_seed = rand::RngExt::random(rng);
+            match single.sample_prefill_logits(&chunk.reqs, &logits, prefill_sample_seed) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("prefill sampling failed: {e}");
@@ -1121,6 +1393,63 @@ fn prefill_batch(
     };
 
     promote_or_requeue(backend, active, prefilling, chunk, &tokens, &logprobs_vec);
+}
+
+fn launch_overlap_step(
+    backend: &mut SchedulerBackend,
+    active: &mut Vec<ActiveRequest35>,
+    scheduled: Vec<PrefillingRequest35>,
+    inflight_prefill: &mut Option<InflightPrefill>,
+    rng: &mut StdRng,
+) {
+    debug_assert!(inflight_prefill.is_none());
+    let mut chunk = ScheduledChunk::from(scheduled);
+    let decode_seed = rand::RngExt::random(rng);
+    let prefill_seed = rand::RngExt::random(rng);
+    let output = match backend {
+        SchedulerBackend::Single(single) => single.launch_async_prefill(&mut chunk),
+        SchedulerBackend::Tp(_) => unreachable!("Qwen3.5 TP cannot launch async prefill"),
+    };
+    match output {
+        Ok(output) => {
+            *inflight_prefill = Some(InflightPrefill {
+                chunk,
+                output,
+                sample_seed: prefill_seed,
+            });
+        }
+        Err(err) => {
+            warn!("async prefill launch failed: {err}");
+            fail_chunk(chunk, &err.to_string());
+        }
+    }
+    decode_step_with_seed(backend, active, decode_seed);
+}
+
+fn finish_async_prefill(
+    backend: &mut SchedulerBackend,
+    active: &mut Vec<ActiveRequest35>,
+    prefilling: &mut Vec<PrefillingRequest35>,
+    inflight: InflightPrefill,
+) {
+    let InflightPrefill {
+        chunk,
+        output,
+        sample_seed,
+    } = inflight;
+    let logits = output.into_logits();
+    let SchedulerBackend::Single(single) = backend else {
+        unreachable!("Qwen3.5 TP cannot finish async prefill");
+    };
+    let (tokens, logprobs) = match single.sample_prefill_logits(&chunk.reqs, &logits, sample_seed) {
+        Ok(result) => result,
+        Err(err) => {
+            warn!("async prefill sampling failed: {err}");
+            fail_chunk(chunk, &err.to_string());
+            return;
+        }
+    };
+    promote_or_requeue(single, active, prefilling, chunk, &tokens, &logprobs);
 }
 
 // ── Unified step (prefill chunk + decode in one forward pass) ──────────────
@@ -1166,11 +1495,13 @@ fn unified_step_sched(
             return;
         }
     };
+    let decode_seed = rand::RngExt::random(rng);
+    let prefill_seed = rand::RngExt::random(rng);
 
     // Process decode results FIRST (it may retire requests and free graph slots
     // that promotion then fills densely).
     if output.decoded {
-        process_decode_logits(backend, active, rng);
+        process_decode_logits(backend, active, decode_seed);
     }
 
     let prefill_logits = output
@@ -1178,7 +1509,7 @@ fn unified_step_sched(
         .as_ref()
         .expect("scheduled prefill chunk must return prefill logits");
     let (tokens, logprobs_vec) =
-        match backend.sample_prefill_logits(&chunk.reqs, prefill_logits, rng) {
+        match backend.sample_prefill_logits(&chunk.reqs, prefill_logits, prefill_seed) {
             Ok(v) => v,
             Err(e) => {
                 warn!("unified prefill sampling failed: {e}");
@@ -1197,7 +1528,22 @@ fn decode_step(
     active: &mut Vec<ActiveRequest35>,
     rng: &mut StdRng,
 ) {
-    let sample_seed = rand::RngExt::random(rng);
+    // Preserve the historical scheduler RNG sequence: TP consumes the first
+    // seed, while single-GPU decode consumed a second seed inside sampling.
+    let first_seed = rand::RngExt::random(rng);
+    let sample_seed = if matches!(backend, SchedulerBackend::Single(_)) {
+        rand::RngExt::random(rng)
+    } else {
+        first_seed
+    };
+    decode_step_with_seed(backend, active, sample_seed);
+}
+
+fn decode_step_with_seed(
+    backend: &mut SchedulerBackend,
+    active: &mut Vec<ActiveRequest35>,
+    sample_seed: u64,
+) {
     let (tokens, logprobs_vec) = match backend {
         SchedulerBackend::Single(single) => {
             if let Err(e) = single.decode_graph(active) {
@@ -1213,7 +1559,7 @@ fn decode_step(
                 return;
             }
             // Snapshot logits to CPU BEFORE sampling (sampling may modify bufs.logits)
-            match single.sample_decode_logits(active, rng) {
+            match single.sample_decode_logits(active, sample_seed) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("decode sampling/logprobs error: {e}");
@@ -1257,9 +1603,9 @@ fn decode_step(
 fn process_decode_logits(
     backend: &mut SingleGpuBackend,
     active: &mut Vec<ActiveRequest35>,
-    rng: &mut StdRng,
+    sample_seed: u64,
 ) {
-    let (tokens, logprobs_vec) = match backend.sample_decode_logits(active, rng) {
+    let (tokens, logprobs_vec) = match backend.sample_decode_logits(active, sample_seed) {
         Ok(v) => v,
         Err(e) => {
             warn!("decode sampling/logprobs error: {e}");
@@ -1411,6 +1757,14 @@ struct ScheduledChunk {
     ends: Vec<usize>,
     /// This step's chunked token slice per request
     windows: Vec<Vec<u32>>,
+}
+
+struct InflightPrefill {
+    // Fields drop in declaration order. Drain the stream before request state
+    // can return KV pages or release recurrent/convolution buffers on unwind.
+    output: AsyncPrefillOutput,
+    chunk: ScheduledChunk,
+    sample_seed: u64,
 }
 
 enum ScheduledChunkBackendState {

--- a/pegainfer-qwen35/src/scheduler/tests.rs
+++ b/pegainfer-qwen35/src/scheduler/tests.rs
@@ -62,6 +62,16 @@ fn tp_scheduler_uses_eager_only_plan() {
 }
 
 #[test]
+fn inflight_prefill_waits_instead_of_parking_after_last_decode_retires() {
+    assert_eq!(overlap_action(true, false), Some(OverlapAction::Wait));
+    assert!(
+        !should_block_on_submit(true, true, true, true),
+        "an in-flight prefill must keep the scheduler off submit_rx.blocking_recv()"
+    );
+    assert_eq!(overlap_action(true, true), Some(OverlapAction::Decode));
+}
+
+#[test]
 fn tp_engine_rejects_cuda_graph_before_model_load() {
     let err = match crate::start_engine_with_capacity(
         Path::new("unused"),

--- a/pegainfer-qwen35/src/scheduler/tests.rs
+++ b/pegainfer-qwen35/src/scheduler/tests.rs
@@ -63,12 +63,10 @@ fn tp_scheduler_uses_eager_only_plan() {
 
 #[test]
 fn inflight_prefill_waits_instead_of_parking_after_last_decode_retires() {
-    assert_eq!(overlap_action(true, false), Some(OverlapAction::Wait));
     assert!(
         !should_block_on_submit(true, true, true, true),
         "an in-flight prefill must keep the scheduler off submit_rx.blocking_recv()"
     );
-    assert_eq!(overlap_action(true, true), Some(OverlapAction::Decode));
 }
 
 #[test]

--- a/pegainfer-qwen35/src/unified_forward.rs
+++ b/pegainfer-qwen35/src/unified_forward.rs
@@ -72,7 +72,7 @@ impl Qwen35Model {
         let cu_stream = stream.cu_stream();
         let original_stream = std::mem::replace(&mut self.ctx.stream, stream);
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let _stream_override = unsafe { StreamOverrideGuard::activate(cu_stream) };
+            let _stream_override = unsafe { StreamOverrideGuard::activate_prefill(cu_stream) };
             self.batch_prefill_logits(prompts, kv_states, recurrent_states)
         }));
         self.ctx.stream = original_stream;

--- a/pegainfer-qwen35/src/unified_forward.rs
+++ b/pegainfer-qwen35/src/unified_forward.rs
@@ -9,9 +9,14 @@
 //!   2. `batch_decode_graph` for existing decode requests (CUDA Graph for
 //!      compiled GQA groups; eager prefill fallback for uncompiled ones).
 
+use std::sync::Arc;
+
 use anyhow::Result;
+use cudarc::driver::CudaStream;
+use pegainfer_core::engine::panic_message;
 use pegainfer_core::kv_pool::KvState;
 use pegainfer_core::tensor::HiddenStates;
+use pegainfer_kernels::tensor::StreamOverrideGuard;
 
 use super::batch_decode_graph::BatchDecodeGraphState;
 use super::recurrent_state::RecurrentState;
@@ -52,6 +57,33 @@ impl Qwen35Model {
             last_hiddens.push(last_hidden);
         }
         self.batch_last_hidden_logits(&last_hiddens)
+    }
+
+    /// Run the complete prefill path on `stream`, including allocations, copies,
+    /// kernels, and stream-ordered frees. The model is scheduler-thread owned, so
+    /// the temporary context swap cannot race another host caller.
+    pub(crate) fn batch_prefill_logits_on_stream(
+        &mut self,
+        stream: Arc<CudaStream>,
+        prompts: &[&[u32]],
+        kv_states: &mut [KvState],
+        recurrent_states: &mut [&mut RecurrentState],
+    ) -> Result<HiddenStates> {
+        let cu_stream = stream.cu_stream();
+        let original_stream = std::mem::replace(&mut self.ctx.stream, stream);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _stream_override = unsafe { StreamOverrideGuard::activate(cu_stream) };
+            self.batch_prefill_logits(prompts, kv_states, recurrent_states)
+        }));
+        self.ctx.stream = original_stream;
+
+        match result {
+            Ok(result) => result,
+            Err(panic) => anyhow::bail!(
+                "Qwen3.5 async prefill panicked: {}",
+                panic_message(panic.as_ref())
+            ),
+        }
     }
 
     /// Unified step: prefill new requests and decode existing requests in one call.

--- a/pegainfer-qwen35/src/weights.rs
+++ b/pegainfer-qwen35/src/weights.rs
@@ -692,6 +692,9 @@ impl Qwen35Model {
         for &n in super::batch_decode_graph::BATCH_BUCKETS
             .iter()
             .filter(|&&bucket| {
+                // Keep in sync with MAX_SHARED_SM_DECODE_BATCH: buckets above
+                // GEMM_LT_MAX_N do not have an independent tuned decode GEMM
+                // route today, so Shared-SM overlap rejects them at startup.
                 bucket <= crate::ops::GEMM_LT_MAX_N && bucket <= self.reserved_decode_slots
             })
         {

--- a/pegainfer-qwen35/tests/e2e_scheduler.rs
+++ b/pegainfer-qwen35/tests/e2e_scheduler.rs
@@ -166,6 +166,7 @@ fn submit_repeated_token_request(
             },
             max_tokens,
             lora_adapter: None,
+            kv_transfer_params: None,
             token_tx,
             logprobs: 0,
             echo: false,

--- a/pegainfer-qwen35/tests/e2e_scheduler.rs
+++ b/pegainfer-qwen35/tests/e2e_scheduler.rs
@@ -1,17 +1,9 @@
-/// E2E scheduler integration test for Qwen3.5-4B.
-///
-/// Tests the Qwen3.5 reduced-capacity scheduler path (batch prefill +
-/// CUDA Graph decode) with sequential, concurrent, and consumer-drop requests.
+//! E2E scheduler integration test for Qwen3.5-4B.
+//!
+//! Tests the Qwen3.5 reduced-capacity scheduler path (batch prefill +
+//! CUDA Graph decode) with sequential, concurrent, and consumer-drop requests.
 use std::collections::HashSet;
-/// E2E scheduler integration test for Qwen3.5-4B.
-///
-/// Tests the Qwen3.5 reduced-capacity scheduler path (batch prefill +
-/// CUDA Graph decode) with sequential, concurrent, and consumer-drop requests.
 use std::path::Path;
-/// E2E scheduler integration test for Qwen3.5-4B.
-///
-/// Tests the Qwen3.5 reduced-capacity scheduler path (batch prefill +
-/// CUDA Graph decode) with sequential, concurrent, and consumer-drop requests.
 use std::time::Instant;
 
 use log::info;
@@ -153,15 +145,135 @@ fn generate_tokens_with_logprobs(
     collect_generation(&mut token_rx, prompt, logprobs)
 }
 
+fn submit_repeated_token_request(
+    handle: &EngineHandle,
+    request_id: &str,
+    token: u32,
+    prompt_len: usize,
+    max_tokens: usize,
+) -> TokenStreamReceiver {
+    let (token_tx, token_rx) = TokenSink::standalone();
+    handle
+        .submit(GenerateRequest {
+            trace_parent: None,
+            request_id: Some(request_id.to_string()),
+            queued_at_unix_s: None,
+            data_parallel_rank: None,
+            prompt_tokens: vec![token; prompt_len],
+            params: SamplingParams {
+                ignore_eos: true,
+                ..SamplingParams::default()
+            },
+            max_tokens,
+            lora_adapter: None,
+            token_tx,
+            logprobs: 0,
+            echo: false,
+        })
+        .unwrap_or_else(|err| panic!("submit {request_id}: {err}"));
+    token_rx
+}
+
+fn wait_for_first_token(rx: &mut TokenStreamReceiver, request_id: &str) {
+    let deadline = Instant::now() + std::time::Duration::from_secs(30);
+    loop {
+        match recv_event_before(rx, request_id, deadline) {
+            Some(TokenEvent::Token { .. }) => return,
+            Some(TokenEvent::PromptTokens { .. } | TokenEvent::Scheduled { .. }) => {}
+            Some(event) => panic!("{request_id} emitted {event:?} before its first token"),
+            None => panic!("scheduler closed before {request_id} emitted a token"),
+        }
+    }
+}
+
+fn recv_event_before(
+    rx: &mut TokenStreamReceiver,
+    request_id: &str,
+    deadline: Instant,
+) -> Option<TokenEvent> {
+    loop {
+        if let Ok((_, event)) = rx.try_recv() {
+            return Some(event);
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {request_id} scheduler event"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+}
+
+fn assert_no_generated_event(rx: &mut TokenStreamReceiver, request_id: &str) {
+    while let Ok((_, event)) = rx.try_recv() {
+        match event {
+            TokenEvent::PromptTokens { .. } | TokenEvent::Scheduled { .. } => {}
+            event => panic!("{request_id} emitted {event:?} before the overlap bound"),
+        }
+    }
+}
+
+fn drain_tokens(rx: &mut TokenStreamReceiver, request_id: &str) -> usize {
+    let mut tokens = 0;
+    while let Ok((_, event)) = rx.try_recv() {
+        match event {
+            TokenEvent::Token { .. } => tokens += 1,
+            TokenEvent::PromptTokens { .. } | TokenEvent::Scheduled { .. } => {}
+            event => panic!("{request_id} emitted {event:?} while it must remain active"),
+        }
+    }
+    tokens
+}
+
+fn wait_for_running_requests(
+    load: &mut tokio::sync::watch::Receiver<pegainfer_core::engine::LoadSnapshot>,
+    expected: u64,
+    timeout: std::time::Duration,
+) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let snapshot = *load.borrow_and_update();
+        if snapshot.num_running_reqs == expected {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {expected} running requests; last snapshot: {snapshot:?}"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+}
+
 fn collect_generation(
     token_rx: &mut TokenStreamReceiver,
     name: &str,
     logprobs: usize,
 ) -> GenerationResult {
+    collect_generation_until(token_rx, name, logprobs, None)
+}
+
+fn collect_generation_with_timeout(
+    token_rx: &mut TokenStreamReceiver,
+    name: &str,
+    logprobs: usize,
+    timeout: std::time::Duration,
+) -> GenerationResult {
+    collect_generation_until(token_rx, name, logprobs, Some(Instant::now() + timeout))
+}
+
+fn collect_generation_until(
+    token_rx: &mut TokenStreamReceiver,
+    name: &str,
+    logprobs: usize,
+    deadline: Option<Instant>,
+) -> GenerationResult {
     let mut tokens = Vec::new();
     let mut token_logprobs = Vec::new();
     loop {
-        match token_rx.blocking_recv().map(|(_, event)| event) {
+        let event = match deadline {
+            Some(deadline) => recv_event_before(token_rx, name, deadline),
+            None => token_rx.blocking_recv().map(|(_, event)| event),
+        };
+        match event {
             Some(TokenEvent::Token { id, logprob }) => {
                 if logprobs == 0 {
                     assert!(
@@ -584,6 +696,89 @@ fn test_e2e_qwen35_scheduler() {
 
     let max_context_tokens = context_limit_for(&handle, &model_path);
     run_full_scheduler_e2e(&handle, &tokenizer, max_context_tokens, "TP1");
+}
+
+#[test]
+fn test_e2e_qwen35_shared_sm_last_decoder() {
+    pegainfer_core::logging::init_default();
+    let model_path = get_model_path();
+    let tokenizer = common::load_tokenizer(&model_path);
+    let handle = pegainfer_qwen35::start_engine_with_capacity_policy_and_overlap(
+        Path::new(&model_path),
+        EngineLoadOptions {
+            enable_cuda_graph: true,
+            device_ordinals: vec![0],
+            seed: 42,
+            ..EngineLoadOptions::default()
+        },
+        4,
+        8192,
+        pegainfer_qwen35::Qwen35SchedulerPolicy::Off,
+        pegainfer_qwen35::Qwen35DecodeOverlap::SharedSm,
+    )
+    .expect("Failed to start Qwen3.5 shared-SM scheduler");
+    let mut load = handle.load_watch().expect("scheduler must expose load");
+
+    let seed_token = tokenizer
+        .encode("Hello", false)
+        .expect("encode failed")
+        .into_iter()
+        .next()
+        .expect("test prompt must contain a token");
+    let mut active_rx =
+        submit_repeated_token_request(&handle, "overlap-last-decoder", seed_token, 512, 128);
+    wait_for_first_token(&mut active_rx, "overlap-last-decoder");
+    let _ = drain_tokens(&mut active_rx, "overlap-last-decoder");
+    let mut prefill_rx =
+        submit_repeated_token_request(&handle, "overlap-inflight-prefill", seed_token, 8192, 2);
+
+    wait_for_running_requests(&mut load, 2, std::time::Duration::from_secs(10));
+    let _ = drain_tokens(&mut active_rx, "overlap-last-decoder");
+    for _ in 0..2 {
+        wait_for_first_token(&mut active_rx, "overlap-last-decoder");
+        assert_no_generated_event(&mut prefill_rx, "overlap-inflight-prefill");
+    }
+    drop(active_rx);
+    let prefill = collect_generation_with_timeout(
+        &mut prefill_rx,
+        "overlap-inflight-prefill",
+        0,
+        std::time::Duration::from_secs(30),
+    );
+    assert_eq!(
+        prefill.tokens.len(),
+        2,
+        "in-flight prefill must finish after the last decoder is cancelled"
+    );
+
+    let (tokens, finish_reason) = generate_tokens(&handle, &tokenizer, "Hello again", 2);
+    assert_eq!(
+        tokens.len(),
+        2,
+        "scheduler must accept work after overlap wait"
+    );
+    assert_eq!(finish_reason, FinishReason::Length);
+
+    let mut shutdown_active_rx =
+        submit_repeated_token_request(&handle, "overlap-shutdown-decoder", seed_token, 512, 128);
+    wait_for_first_token(&mut shutdown_active_rx, "overlap-shutdown-decoder");
+    let _ = drain_tokens(&mut shutdown_active_rx, "overlap-shutdown-decoder");
+    let mut shutdown_prefill_rx =
+        submit_repeated_token_request(&handle, "overlap-shutdown-prefill", seed_token, 8192, 2);
+    wait_for_running_requests(&mut load, 2, std::time::Duration::from_secs(10));
+    assert_no_generated_event(&mut shutdown_prefill_rx, "overlap-shutdown-prefill");
+    drop(shutdown_active_rx);
+    drop(shutdown_prefill_rx);
+
+    let (done_tx, done_rx) = std::sync::mpsc::channel();
+    let shutdown = std::thread::spawn(move || {
+        drop(handle);
+        let _ = done_tx.send(());
+    });
+    done_rx
+        .recv_timeout(std::time::Duration::from_secs(30))
+        .expect("dropping the last handle must drain in-flight prefill and return");
+    shutdown.join().expect("scheduler shutdown thread panicked");
 }
 
 #[test]

--- a/pegainfer-qwen35/tests/e2e_scheduler.rs
+++ b/pegainfer-qwen35/tests/e2e_scheduler.rs
@@ -668,12 +668,6 @@ fn run_full_scheduler_e2e(
     info!("All Qwen3.5 scheduler tests passed for {label}!");
 }
 
-fn context_limit_for(handle: &EngineHandle, model_path: &str) -> usize {
-    handle
-        .servable_len()
-        .map_or_else(|| max_position_embeddings(model_path), |len| len as usize)
-}
-
 #[test]
 fn test_e2e_qwen35_scheduler() {
     let model_path = get_model_path();
@@ -694,7 +688,7 @@ fn test_e2e_qwen35_scheduler() {
     .expect("Failed to start Qwen3.5 scheduler");
     info!("scheduler loaded in {:.2?}", start.elapsed());
 
-    let max_context_tokens = context_limit_for(&handle, &model_path);
+    let max_context_tokens = max_position_embeddings(&model_path);
     run_full_scheduler_e2e(&handle, &tokenizer, max_context_tokens, "TP1");
 }
 
@@ -703,6 +697,49 @@ fn test_e2e_qwen35_shared_sm_last_decoder() {
     pegainfer_core::logging::init_default();
     let model_path = get_model_path();
     let tokenizer = common::load_tokenizer(&model_path);
+    let seed_token = tokenizer
+        .encode("Hello", false)
+        .expect("encode failed")
+        .into_iter()
+        .next()
+        .expect("test prompt must contain a token");
+
+    let off_reference_tokens = {
+        let off_handle = pegainfer_qwen35::start_engine_with_capacity_policy_and_overlap(
+            Path::new(&model_path),
+            EngineLoadOptions {
+                enable_cuda_graph: true,
+                device_ordinals: vec![0],
+                seed: 42,
+                ..EngineLoadOptions::default()
+            },
+            4,
+            8192,
+            pegainfer_qwen35::Qwen35SchedulerPolicy::Off,
+            pegainfer_qwen35::Qwen35DecodeOverlap::Off,
+        )
+        .expect("Failed to start Qwen3.5 default-Off scheduler");
+        let mut off_rx = submit_repeated_token_request(
+            &off_handle,
+            "overlap-off-reference",
+            seed_token,
+            8192,
+            2,
+        );
+        let off = collect_generation_with_timeout(
+            &mut off_rx,
+            "overlap-off-reference",
+            0,
+            std::time::Duration::from_secs(30),
+        );
+        assert_eq!(
+            off.tokens.len(),
+            2,
+            "default-Off reference request must finish before Shared-SM parity"
+        );
+        off.tokens
+    };
+
     let handle = pegainfer_qwen35::start_engine_with_capacity_policy_and_overlap(
         Path::new(&model_path),
         EngineLoadOptions {
@@ -719,12 +756,6 @@ fn test_e2e_qwen35_shared_sm_last_decoder() {
     .expect("Failed to start Qwen3.5 shared-SM scheduler");
     let mut load = handle.load_watch().expect("scheduler must expose load");
 
-    let seed_token = tokenizer
-        .encode("Hello", false)
-        .expect("encode failed")
-        .into_iter()
-        .next()
-        .expect("test prompt must contain a token");
     let mut active_rx =
         submit_repeated_token_request(&handle, "overlap-last-decoder", seed_token, 512, 128);
     wait_for_first_token(&mut active_rx, "overlap-last-decoder");
@@ -749,6 +780,10 @@ fn test_e2e_qwen35_shared_sm_last_decoder() {
         prefill.tokens.len(),
         2,
         "in-flight prefill must finish after the last decoder is cancelled"
+    );
+    assert_eq!(
+        prefill.tokens, off_reference_tokens,
+        "Shared-SM overlapped prefill must match the greedy default-Off reference"
     );
 
     let (tokens, finish_reason) = generate_tokens(&handle, &tokenizer, "Hello again", 2);
@@ -804,6 +839,6 @@ fn test_e2e_qwen35_scheduler_tp2() {
     .expect("Failed to start Qwen3.5 TP2 scheduler");
     info!("TP2 scheduler loaded in {:.2?}", start.elapsed());
 
-    let max_context_tokens = context_limit_for(&handle, &model_path);
+    let max_context_tokens = max_position_embeddings(&model_path);
     run_full_scheduler_e2e(&handle, &tokenizer, max_context_tokens, "TP2");
 }

--- a/scripts/itl_step_agg.py
+++ b/scripts/itl_step_agg.py
@@ -4,14 +4,14 @@
 The Qwen3.5 scheduler, when run with `PEGAINFER_ITL_DEBUG` set, emits one line
 per executed step:
 
-    ITL_STEP mono_us=<u> epoch_us=<u> plan=unified|prefill|decode \
+    ITL_STEP mono_us=<u> epoch_us=<u> plan=<kind> \
         prefill_tok=<n> prefill_reqs=<n> decode_n=<n> dur_us=<n>
 
-`dur_us` is the step's CPU wall-time, which — because decode sampling forces a
-D2H sync — closely tracks the GPU time the active decode rows actually wait on
-this step. A step with `prefill_tok > 0` is the only kind that freezes active
-decodes behind real prefill work; a `plan=decode` step (`prefill_tok=0`) is a
-genuine steady gap.
+`dur_us` is the scheduler action's CPU wall-time. Decode actions include their
+D2H sampling sync. Serial `unified` steps freeze active decode behind prefill;
+`overlap_launch` and `overlap_decode` run a decode while prefill is in flight;
+`overlap_complete` measures completion sampling and state promotion; and
+`overlap_wait` blocks only after the last active decoder has retired.
 
 This script reports the *true per-step stall* distribution straight from the
 scheduler, independent of the mixed-load bench's coarse `[submit, last-token]`
@@ -98,28 +98,60 @@ def report(label, path):
     total = len(steps)
     plan_counts = Counter(s["plan"] for s in steps)
 
-    # Steps that actually ran prefill work.
-    prefill_steps = [s for s in steps if s["ptok"] > 0]
-    # Steps that froze *active decodes* behind a prefill chunk (the real ITL
-    # stall the background streams experience): prefill_tok>0 AND decode_n>0.
-    stall_steps = [s for s in prefill_steps if s["dn"] > 0]
-    # Pure decode steps (steady gaps).
-    decode_steps = [s for s in steps if s["ptok"] == 0 and s["dn"] > 0]
+    # Each forwarded chunk appears exactly once in one of these launch plans.
+    prefill_launch_steps = [
+        s for s in steps if s["plan"] in {"prefill", "unified", "overlap_launch"}
+    ]
+    serial_stall_steps = [
+        s for s in steps if s["plan"] == "unified" and s["dn"] > 0
+    ]
+    overlap_launch_steps = [s for s in steps if s["plan"] == "overlap_launch"]
+    overlap_decode_steps = [s for s in steps if s["plan"] == "overlap_decode"]
+    overlap_complete_steps = [s for s in steps if s["plan"] == "overlap_complete"]
+    overlap_wait_steps = [s for s in steps if s["plan"] == "overlap_wait"]
+    prefill_associated_steps = [
+        s
+        for s in steps
+        if s["plan"]
+        in {
+            "prefill",
+            "unified",
+            "overlap_launch",
+            "overlap_decode",
+            "overlap_complete",
+            "overlap_wait",
+        }
+    ]
+    decode_steps = [
+        s
+        for s in steps
+        if s["plan"] in {"decode", "overlap_launch", "overlap_decode"} and s["dn"] > 0
+    ]
 
     print(f"=== {label}  ({path}) ===")
     print(f"total ITL_STEP: {total}  " + "  ".join(f"{k}={v}" for k, v in sorted(plan_counts.items())))
-    print(f"prefill-executing steps (prefill_tok>0): {len(prefill_steps)}")
-    print("  per-step dur_us [ALL prefill steps]:")
-    print(fmt(summarize_us([s["dur"] for s in prefill_steps])))
-    print(f"stall steps (prefill_tok>0 AND decode_n>0) — TRUE per-step decode stall: {len(stall_steps)}")
-    print(fmt(summarize_us([s["dur"] for s in stall_steps])))
-    print("  steady decode steps (prefill_tok=0, decode_n>0):")
-    print(fmt(summarize_us([s["dur"] for s in decode_steps])))
-    ptok_dist = Counter(s["ptok"] for s in prefill_steps)
-    print("  prefill_tok distribution (chunk sizes actually forwarded):")
+    print(f"prefill chunk launches (counted once): {len(prefill_launch_steps)}")
+    ptok_dist = Counter(s["ptok"] for s in prefill_launch_steps)
+    print("  forwarded prefill_tok distribution:")
     for tok, cnt in sorted(ptok_dist.items()):
-        print(f"    prefill_tok={tok}: {cnt} step(s)")
-    dn_dist = Counter(s["dn"] for s in stall_steps)
+        print(f"    prefill_tok={tok}: {cnt} chunk(s)")
+    print(f"serial unified stalls with active decode: {len(serial_stall_steps)}")
+    print(fmt(summarize_us([s["dur"] for s in serial_stall_steps])))
+    print(f"overlap launches with decode: {len(overlap_launch_steps)}")
+    print(fmt(summarize_us([s["dur"] for s in overlap_launch_steps])))
+    print(f"in-flight overlap decode steps: {len(overlap_decode_steps)}")
+    print(fmt(summarize_us([s["dur"] for s in overlap_decode_steps])))
+    print(f"overlap completion steps: {len(overlap_complete_steps)}")
+    print(fmt(summarize_us([s["dur"] for s in overlap_complete_steps])))
+    print(f"overlap waits after decode retires: {len(overlap_wait_steps)}")
+    print(fmt(summarize_us([s["dur"] for s in overlap_wait_steps])))
+    print("  all decode-producing scheduler actions:")
+    print(fmt(summarize_us([s["dur"] for s in decode_steps])))
+    associated_dn_dist = Counter(s["dn"] for s in prefill_associated_steps)
+    print("  active decode width during prefill-associated actions (decode_n):")
+    for dn, cnt in sorted(associated_dn_dist.items()):
+        print(f"    decode_n={dn}: {cnt} action(s)")
+    dn_dist = Counter(s["dn"] for s in serial_stall_steps)
     if dn_dist:
         print("  frozen decode width during stall steps (decode_n):")
         for dn, cnt in sorted(dn_dist.items()):


### PR DESCRIPTION
## Summary

Closes #715.

Qwen3.5 previously executed Unified prefill chunks serially before active decode. This PR adds an opt-in Shared-SM overlap path so one prefill chunk can run on a dedicated CUDA stream while active decode continues on the model stream.

The default remains unchanged: `--decode-overlap off`.

## Changes

- Add `Qwen35DecodeOverlap::{Off, SharedSm}`.
- Add `--decode-overlap off|stream` to the server and serving benchmark CLI.
- Run at most one in-flight prefill on an owned CUDA stream.
- Poll completion events while decode is active and wait explicitly when the last decoder retires.
- Drain the prefill stream on error, cancellation, drop, and shutdown.
- Route prefill and decode through separate cuBLAS handles.
- Keep stream-specific routing limited to Qwen3.5 async prefill.
- Add mode-aware `ITL_STEP` actions:
  `overlap_launch`, `overlap_decode`, `overlap_complete`, and `overlap_wait`.
- Reject unsupported combinations before model loading:
  - tensor parallelism with overlap;
  - `scheduler-policy=auto` with `decode-overlap=stream`;
  - Qwen3.5 Green Context overlap.

## Results

Verified on 1x NVIDIA RTX 5090 32 GB, CUDA 12.8, `sm_120`, with Qwen3.5-4B.

| Workload | Off | Stream | Change |
| --- | ---: | ---: | ---: |
| 1024/256, c1 TPOT | 6.99 ms | 7.07 ms | +1.20% |
| 1024/256, c16 TPOT | 11.48 ms | 11.13 ms | -3.04% |
| 1024/128, QPS 8 TPOT | 12.12 ms | 11.31 ms | -6.68% |
| 1024/128, QPS 12 TPOT | 14.85 ms | 13.70 ms | -7.74% |
| 1024/128, QPS 16 TPOT | 16.88 ms | 15.52 ms | -8.05% |
| Mixed-load ITL p99 | 58.23 ms | 26.15 ms | -55.1% |

All HTTP runs completed with zero failures, timeouts, error strings, or zero-token outputs. The c1 tradeoff and higher loaded TTFT keep overlap opt-in.

Nsight Systems confirmed concurrent prefill/decode kernel execution across the two CUDA streams. The trace contained 28,082 cross-stream kernel-overlap pairs.

## Verification

- Release workspace library tests: `73 passed, 6 ignored`.
- Qwen3.5 default-off scheduler e2e: passed.
- Shared-SM lifecycle e2e: passed; observed two `overlap_wait` actions.
- Qwen3.5 HF golden gate: `2 passed, 2 ignored`.
- Qwen3 and Qwen3.5 release checks: passed.
- Stream-routing regression test: passed.
- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.

The evidence covers single-GPU Qwen3.5-4B on RTX 5090. It does not claim tensor-parallel overlap, Green Context support, prefix-cache coverage, broad hardware coverage, vLLM parity, SOTA, or production readiness.