### PR TITLE
feat(gemma4): register the model line behind a fail-closed probe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ Every model line is behind a cargo feature; only `qwen3` is a default feature, s
 | Qwen3-4B / 8B | `openinfer-qwen3` | `qwen3` (default) | Full attention, TP support |
 | Qwen3.5-4B / 9B / 27B | `openinfer-qwen35` | `--features qwen35` (needs build-time Python + Triton) | Hybrid Gated DeltaNet + full attention |
 | DeepSeek-V2-Lite | `openinfer-deepseek-v2-lite` | `--features deepseek-v2-lite` | MoE + EP, 2-GPU |
+| Gemma 4 | `openinfer-gemma4` | `--features gemma4` | Registration only — engine not yet available |
 | Kimi-K2 | `openinfer-kimi-k2` | `--features kimi-k2` | MLA + MoE + Marlin INT4, 8-GPU EP |
 | GLM5.2 | `openinfer-glm52` | `--features glm52` | MLA + MoE + FP8, 8-GPU EP (bring-up) |
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3206,6 +3206,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "openinfer-gemma4"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "openinfer-engine",
+ "serde_json",
+]
+
+[[package]]
 name = "openinfer-glm52"
 version = "0.1.0"
 dependencies = [
@@ -3377,6 +3386,7 @@ dependencies = [
  "log",
  "openinfer-core",
  "openinfer-deepseek-v2-lite",
+ "openinfer-gemma4",
  "openinfer-glm52",
  "openinfer-kimi-k2",
  "openinfer-qwen3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "openinfer-bench",
   "openinfer-build",
   "openinfer-deepseek-v2-lite",
+  "openinfer-gemma4",
   "openinfer-glm52",
   "openinfer-kimi-k2",
   "openinfer-qwen3",
@@ -126,6 +127,7 @@ openinfer-core = { path = "openinfer-core" }
 openinfer-cupti = { path = "openinfer-cupti" }
 openinfer-deepseek-v2-lite = { path = "openinfer-deepseek-v2-lite" }
 openinfer-engine = { path = "openinfer-engine" }
+openinfer-gemma4 = { path = "openinfer-gemma4" }
 openinfer-glm52 = { path = "openinfer-glm52" }
 openinfer-kernels = { path = "openinfer-kernels" }
 openinfer-kimi-k2 = { path = "openinfer-kimi-k2" }

--- a/openinfer-gemma4/Cargo.toml
+++ b/openinfer-gemma4/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+autobenches = false
+autobins = false
+autotests = false
+edition = "2024"
+license = "Apache-2.0"
+name = "openinfer-gemma4"
+version = "0.1.0"
+
+[features]
+gemma4 = []
+default = []
+
+[dependencies]
+anyhow = { workspace = true }
+openinfer-engine = { workspace = true }
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/openinfer-gemma4/src/config.rs
+++ b/openinfer-gemma4/src/config.rs
@@ -1,0 +1,322 @@
+// Fail-closed config probe: identity plus the structural facts shared by every
+// published size; no size pinning beyond the single published MoE configuration.
+use anyhow::Result;
+use anyhow::bail;
+
+const GEMMA4_LOCAL_HEAD_DIM: u64 = 256;
+const GEMMA4_GLOBAL_HEAD_DIM: u64 = 512;
+const GEMMA4_SLIDING_WINDOW: u64 = 1024;
+const GEMMA4_GLOBAL_LAYER_PERIOD: usize = 6;
+const GEMMA4_MOE_NUM_EXPERTS: u64 = 128;
+const GEMMA4_MOE_TOP_K: u64 = 8;
+const GEMMA4_MOE_INTERMEDIATE: u64 = 704;
+
+pub fn probe_config_json(json: &serde_json::Value) -> Result<()> {
+    let (family, text_config) = probe_identity(json)?;
+    probe_common_text(family, text_config)?;
+    probe_layer_types(family, text_config)?;
+    probe_moe(family, text_config)
+}
+
+fn probe_identity(json: &serde_json::Value) -> Result<(&'static str, &serde_json::Value)> {
+    let outer_type = json
+        .get("model_type")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+    let (family, text_model_type, arch_class) = match outer_type {
+        "gemma4" => ("gemma4", "gemma4_text", "Gemma4ForConditionalGeneration"),
+        "gemma4_unified" => (
+            "gemma4_unified",
+            "gemma4_unified_text",
+            "Gemma4UnifiedForConditionalGeneration",
+        ),
+        unknown => bail!("not a Gemma 4 config: model_type={unknown}"),
+    };
+
+    let architectures = json
+        .get("architectures")
+        .and_then(serde_json::Value::as_array);
+    let has_arch = architectures.is_some_and(|arr| {
+        arr.iter()
+            .any(|v| v.as_str().is_some_and(|s| s == arch_class))
+    });
+    if !has_arch {
+        bail!("Gemma 4 {family}: architectures must contain {arch_class}");
+    }
+
+    let text_config = json
+        .get("text_config")
+        .ok_or_else(|| anyhow::anyhow!("Gemma 4 {family}: missing text_config"))?;
+
+    let text_type = text_config
+        .get("model_type")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+    if text_type != text_model_type {
+        bail!(
+            "Gemma 4 {family}: text_config.model_type is {text_type}, expected {text_model_type} — \
+             cross-family mismatch"
+        );
+    }
+    Ok((family, text_config))
+}
+
+fn probe_common_text(family: &str, text_config: &serde_json::Value) -> Result<()> {
+    let e4b_window = text_config
+        .get("sliding_window")
+        .and_then(serde_json::Value::as_u64)
+        == Some(512);
+    let e4b_k_neq_v = text_config
+        .get("attention_k_eq_v")
+        .and_then(serde_json::Value::as_bool)
+        == Some(false);
+    if e4b_window && e4b_k_neq_v {
+        bail!(
+            "Gemma 4 {family}: this is an E4B edge-series configuration (sliding_window 512, \
+             attention_k_eq_v false, shared KV layers), which this model line does not support; \
+             supported configurations are the 12B/26B/31B ones"
+        );
+    }
+
+    let head_dim = text_config
+        .get("head_dim")
+        .and_then(serde_json::Value::as_u64);
+    if head_dim != Some(GEMMA4_LOCAL_HEAD_DIM) {
+        bail!("Gemma 4 {family}: head_dim must be {GEMMA4_LOCAL_HEAD_DIM}, got {head_dim:?}");
+    }
+    let global_head_dim = text_config
+        .get("global_head_dim")
+        .and_then(serde_json::Value::as_u64);
+    if global_head_dim != Some(GEMMA4_GLOBAL_HEAD_DIM) {
+        bail!(
+            "Gemma 4 {family}: global_head_dim must be {GEMMA4_GLOBAL_HEAD_DIM}, got {global_head_dim:?}"
+        );
+    }
+    let sliding_window = text_config
+        .get("sliding_window")
+        .and_then(serde_json::Value::as_u64);
+    if sliding_window != Some(GEMMA4_SLIDING_WINDOW) {
+        bail!(
+            "Gemma 4 {family}: sliding_window must be {GEMMA4_SLIDING_WINDOW}, got {sliding_window:?}"
+        );
+    }
+    let attn_k_eq_v = text_config
+        .get("attention_k_eq_v")
+        .and_then(serde_json::Value::as_bool);
+    if attn_k_eq_v != Some(true) {
+        bail!("Gemma 4 {family}: attention_k_eq_v must be true, got {attn_k_eq_v:?}");
+    }
+    let num_kv_shared = text_config
+        .get("num_kv_shared_layers")
+        .and_then(serde_json::Value::as_u64);
+    if num_kv_shared != Some(0) {
+        bail!("Gemma 4 {family}: num_kv_shared_layers must be 0, got {num_kv_shared:?}");
+    }
+    let hidden_activation = text_config
+        .get("hidden_activation")
+        .and_then(serde_json::Value::as_str);
+    if hidden_activation != Some("gelu_pytorch_tanh") {
+        bail!(
+            "Gemma 4 {family}: hidden_activation must be gelu_pytorch_tanh, got {hidden_activation:?}"
+        );
+    }
+    Ok(())
+}
+
+fn probe_layer_types(family: &str, text_config: &serde_json::Value) -> Result<()> {
+    let layer_types = text_config
+        .get("layer_types")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("Gemma 4 {family}: missing layer_types"))?;
+    if layer_types.is_empty() {
+        bail!("Gemma 4 {family}: layer_types is empty");
+    }
+    let last_idx = layer_types.len() - 1;
+    for (i, entry) in layer_types.iter().enumerate() {
+        let s = entry.as_str().unwrap_or("");
+        if s != "sliding_attention" && s != "full_attention" {
+            bail!(
+                "Gemma 4 {family}: layer_types[{i}] is {s:?}, must be sliding_attention or full_attention"
+            );
+        }
+        let is_full = s == "full_attention";
+        let expected_full =
+            i % GEMMA4_GLOBAL_LAYER_PERIOD == GEMMA4_GLOBAL_LAYER_PERIOD - 1 || i == last_idx;
+        if is_full != expected_full {
+            bail!(
+                "Gemma 4 {family}: layer_types[{i}] is {s:?}, expected {}",
+                if expected_full {
+                    "full_attention"
+                } else {
+                    "sliding_attention"
+                }
+            );
+        }
+    }
+    Ok(())
+}
+
+fn probe_moe(family: &str, text_config: &serde_json::Value) -> Result<()> {
+    let enable_moe = text_config.get("enable_moe_block");
+    let Some(enable_moe) = enable_moe.and_then(serde_json::Value::as_bool) else {
+        bail!("Gemma 4 {family}: enable_moe_block must be an explicit boolean, got {enable_moe:?}");
+    };
+    if enable_moe {
+        let num_experts = text_config
+            .get("num_experts")
+            .and_then(serde_json::Value::as_u64);
+        if num_experts != Some(GEMMA4_MOE_NUM_EXPERTS) {
+            bail!(
+                "Gemma 4 {family}: MoE enabled but num_experts is {num_experts:?}, expected {GEMMA4_MOE_NUM_EXPERTS}"
+            );
+        }
+        let top_k = text_config
+            .get("top_k_experts")
+            .and_then(serde_json::Value::as_u64);
+        if top_k != Some(GEMMA4_MOE_TOP_K) {
+            bail!(
+                "Gemma 4 {family}: MoE enabled but top_k_experts is {top_k:?}, expected {GEMMA4_MOE_TOP_K}"
+            );
+        }
+        let moe_intermediate = text_config
+            .get("moe_intermediate_size")
+            .and_then(serde_json::Value::as_u64);
+        if moe_intermediate != Some(GEMMA4_MOE_INTERMEDIATE) {
+            bail!(
+                "Gemma 4 {family}: MoE enabled but moe_intermediate_size is {moe_intermediate:?}, expected {GEMMA4_MOE_INTERMEDIATE}"
+            );
+        }
+    } else {
+        for field in ["num_experts", "top_k_experts", "moe_intermediate_size"] {
+            if text_config.get(field).is_some_and(|v| !v.is_null()) {
+                bail!("Gemma 4 {family}: MoE disabled but {field} is present and non-null");
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn good_12b_config() -> serde_json::Value {
+        serde_json::json!({
+            "model_type": "gemma4_unified",
+            "architectures": ["Gemma4UnifiedForConditionalGeneration"],
+            "text_config": {
+                "model_type": "gemma4_unified_text",
+                "head_dim": 256,
+                "global_head_dim": 512,
+                "sliding_window": 1024,
+                "attention_k_eq_v": true,
+                "num_kv_shared_layers": 0,
+                "hidden_activation": "gelu_pytorch_tanh",
+                "enable_moe_block": false,
+                "layer_types": [
+                    "sliding_attention", "sliding_attention", "sliding_attention",
+                    "sliding_attention", "sliding_attention", "full_attention",
+                    "sliding_attention", "sliding_attention", "sliding_attention",
+                    "sliding_attention", "sliding_attention", "full_attention"
+                ]
+            }
+        })
+    }
+
+    fn good_26b_config() -> serde_json::Value {
+        let mut cfg = good_12b_config();
+        cfg["model_type"] = serde_json::json!("gemma4");
+        cfg["architectures"] = serde_json::json!(["Gemma4ForConditionalGeneration"]);
+        let tc = &mut cfg["text_config"];
+        tc["model_type"] = serde_json::json!("gemma4_text");
+        tc["enable_moe_block"] = serde_json::json!(true);
+        tc["num_experts"] = serde_json::json!(128);
+        tc["top_k_experts"] = serde_json::json!(8);
+        tc["moe_intermediate_size"] = serde_json::json!(704);
+        tc["intermediate_size"] = serde_json::json!(2112);
+        cfg
+    }
+
+    #[test]
+    fn good_12b_passes() {
+        probe_config_json(&good_12b_config()).unwrap();
+    }
+
+    #[test]
+    fn good_26b_passes() {
+        probe_config_json(&good_26b_config()).unwrap();
+    }
+
+    #[test]
+    fn moe_width_2112_bails() {
+        let mut cfg = good_26b_config();
+        cfg["text_config"]["moe_intermediate_size"] = serde_json::json!(2112);
+        let err = probe_config_json(&cfg).unwrap_err().to_string();
+        assert!(err.contains("moe_intermediate_size"), "{err}");
+    }
+
+    #[test]
+    fn missing_enable_moe_block_bails() {
+        let mut cfg = good_12b_config();
+        cfg["text_config"]
+            .as_object_mut()
+            .unwrap()
+            .remove("enable_moe_block");
+        let err = probe_config_json(&cfg).unwrap_err().to_string();
+        assert!(err.contains("enable_moe_block"), "{err}");
+    }
+
+    #[test]
+    fn moe_disabled_with_num_experts_bails() {
+        let mut cfg = good_12b_config();
+        cfg["text_config"]["num_experts"] = serde_json::json!(128);
+        let err = probe_config_json(&cfg).unwrap_err().to_string();
+        assert!(err.contains("num_experts"), "{err}");
+    }
+
+    #[test]
+    fn moe_top_k_as_string_bails() {
+        let mut cfg = good_26b_config();
+        cfg["text_config"]["top_k_experts"] = serde_json::json!("8");
+        let err = probe_config_json(&cfg).unwrap_err().to_string();
+        assert!(err.contains("top_k_experts"), "{err}");
+    }
+
+    #[test]
+    fn e4b_edge_series_rejected_by_name() {
+        let mut cfg = good_12b_config();
+        cfg["model_type"] = serde_json::json!("gemma4");
+        cfg["architectures"] = serde_json::json!(["Gemma4ForConditionalGeneration"]);
+        let tc = &mut cfg["text_config"];
+        tc["model_type"] = serde_json::json!("gemma4_text");
+        tc["sliding_window"] = serde_json::json!(512);
+        tc["attention_k_eq_v"] = serde_json::json!(false);
+        tc["num_kv_shared_layers"] = serde_json::json!(18);
+        let err = probe_config_json(&cfg).unwrap_err().to_string();
+        assert!(err.contains("E4B"), "{err}");
+    }
+
+    #[test]
+    fn wrong_layer_at_non_6th_index_bails() {
+        let mut cfg = good_12b_config();
+        cfg["text_config"]["layer_types"][3] = serde_json::json!("full_attention");
+        let err = probe_config_json(&cfg).unwrap_err().to_string();
+        assert!(err.contains("layer_types[3]"), "{err}");
+    }
+
+    #[test]
+    fn cross_family_mismatch_bails() {
+        let mut cfg = good_12b_config();
+        cfg["architectures"] = serde_json::json!(["Gemma4ForConditionalGeneration"]);
+        let err = probe_config_json(&cfg).unwrap_err().to_string();
+        assert!(err.contains("architectures"), "{err}");
+    }
+
+    #[test]
+    fn moe_enabled_without_num_experts_bails() {
+        let mut cfg = good_12b_config();
+        cfg["text_config"]["enable_moe_block"] = serde_json::json!(true);
+        let err = probe_config_json(&cfg).unwrap_err().to_string();
+        assert!(err.contains("num_experts"), "{err}");
+    }
+}

--- a/openinfer-gemma4/src/lib.rs
+++ b/openinfer-gemma4/src/lib.rs
@@ -1,0 +1,20 @@
+mod config;
+
+use std::path::Path;
+
+use anyhow::Result;
+pub use config::probe_config_json;
+use openinfer_engine::engine::EngineHandle;
+use openinfer_engine::engine::EngineLoadOptions;
+
+#[cfg(feature = "gemma4")]
+pub fn start_engine(_model_path: &Path, _options: EngineLoadOptions) -> Result<EngineHandle> {
+    anyhow::bail!("Gemma 4 engine is not implemented yet (registration only)")
+}
+
+#[cfg(not(feature = "gemma4"))]
+pub fn start_engine(_model_path: &Path, _options: EngineLoadOptions) -> Result<EngineHandle> {
+    anyhow::bail!(
+        "Gemma 4 support is feature-gated; rebuild openinfer-server with --features gemma4"
+    )
+}

--- a/openinfer-server/Cargo.toml
+++ b/openinfer-server/Cargo.toml
@@ -31,6 +31,7 @@ cudarc = { workspace = true }
 log = { workspace = true }
 openinfer-core = { workspace = true }
 openinfer-deepseek-v2-lite = { workspace = true, optional = true }
+openinfer-gemma4 = { workspace = true, optional = true }
 openinfer-glm52 = { workspace = true, optional = true }
 openinfer-kimi-k2 = { workspace = true, optional = true }
 openinfer-qwen3 = { workspace = true, optional = true }
@@ -56,6 +57,7 @@ deepseek-v2-lite = [
   "dep:openinfer-deepseek-v2-lite",
   "openinfer-deepseek-v2-lite/deepseek-v2-lite",
 ]
+gemma4 = ["dep:openinfer-gemma4", "openinfer-gemma4/gemma4"]
 glm52 = ["dep:openinfer-glm52"]
 kimi-k2 = ["dep:openinfer-kimi-k2", "openinfer-kimi-k2/kimi-k2"]
 qwen35 = ["dep:openinfer-qwen35", "openinfer-qwen35/qwen35"]

--- a/openinfer-server/src/bin/bench_serving/main.rs
+++ b/openinfer-server/src/bin/bench_serving/main.rs
@@ -14,7 +14,8 @@
         feature = "deepseek-v2-lite",
         feature = "kimi-k2",
         feature = "qwen3",
-        feature = "qwen35"
+        feature = "qwen35",
+        feature = "gemma4",
     )),
     allow(unused_imports, unused_variables, dead_code)
 )]
@@ -192,6 +193,20 @@ fn main() -> Result<()> {
             let load_ms = dur_ms(load_start.elapsed());
             let mut bench = DeepSeekV2LiteBenchModel { generator };
             dispatch(&cli, model_type, load_ms, false, &mut bench, &tokenizer)
+        }
+        #[cfg(feature = "gemma4")]
+        ModelType::Gemma4 => {
+            let handle = openinfer_gemma4::start_engine(
+                Path::new(&cli.model_path),
+                EngineLoadOptions {
+                    enable_cuda_graph: cli.cuda_graph,
+                    device_ordinals: vec![0],
+                    parallel_config: None,
+                    ep_backend: EpBackend::Nccl,
+                    seed: command_seed(&cli),
+                },
+            )?;
+            finish(handle, cli.cuda_graph)
         }
         #[cfg(feature = "glm52")]
         ModelType::Glm52 => {

--- a/openinfer-server/src/config.rs
+++ b/openinfer-server/src/config.rs
@@ -355,6 +355,8 @@ fn consumed_args(model_type: ModelType) -> &'static [&'static str] {
     match model_type {
         #[cfg(feature = "deepseek-v2-lite")]
         ModelType::DeepSeekV2Lite => &["cuda_graph"],
+        #[cfg(feature = "gemma4")]
+        ModelType::Gemma4 => &["cuda_graph"],
         #[cfg(feature = "glm52")]
         ModelType::Glm52 => &[
             "tp_size",
@@ -764,6 +766,8 @@ mod tests {
         [
             #[cfg(feature = "deepseek-v2-lite")]
             ModelType::DeepSeekV2Lite,
+            #[cfg(feature = "gemma4")]
+            ModelType::Gemma4,
             #[cfg(feature = "glm52")]
             ModelType::Glm52,
             #[cfg(feature = "kimi-k2")]

--- a/openinfer-server/src/main.rs
+++ b/openinfer-server/src/main.rs
@@ -11,6 +11,8 @@ use openinfer::logging;
 use openinfer::server_engine::ModelType;
 use openinfer::server_engine::detect_model_type;
 use openinfer_core::engine::EngineHandle;
+#[cfg(feature = "gemma4")]
+use openinfer_core::engine::EngineLoadOptions;
 #[cfg(feature = "qwen3")]
 use openinfer_qwen3::Qwen3LaunchOptions;
 #[cfg(feature = "qwen3")]
@@ -169,6 +171,11 @@ fn load_engine(args: &Args, model_type: ModelType) -> anyhow::Result<EngineHandl
         ModelType::DeepSeekV2Lite => {
             openinfer_deepseek_v2_lite::launch(&args.model_path, args.cuda_graph)
                 .context("failed to start DeepSeek V2 Lite engine")?
+        }
+        #[cfg(feature = "gemma4")]
+        ModelType::Gemma4 => {
+            openinfer_gemma4::start_engine(&args.model_path, EngineLoadOptions::default())
+                .context("failed to start Gemma 4 engine")?
         }
         #[cfg(feature = "glm52")]
         ModelType::Glm52 => {

--- a/openinfer-server/src/server_engine.rs
+++ b/openinfer-server/src/server_engine.rs
@@ -12,6 +12,8 @@ pub use openinfer_core::engine::TokenLogprob;
 pub enum ModelType {
     #[cfg(feature = "deepseek-v2-lite")]
     DeepSeekV2Lite,
+    #[cfg(feature = "gemma4")]
+    Gemma4,
     #[cfg(feature = "glm52")]
     Glm52,
     #[cfg(feature = "kimi-k2")]
@@ -29,6 +31,8 @@ impl fmt::Display for ModelType {
         match *self {
             #[cfg(feature = "deepseek-v2-lite")]
             Self::DeepSeekV2Lite => write!(f, "DeepSeek-V2-Lite"),
+            #[cfg(feature = "gemma4")]
+            Self::Gemma4 => write!(f, "Gemma 4"),
             #[cfg(feature = "glm52")]
             Self::Glm52 => write!(f, "GLM5.2"),
             #[cfg(feature = "kimi-k2")]
@@ -59,6 +63,7 @@ fn seen_config_field(json: &serde_json::Value, key: &str) -> String {
 fn unrecognized_config_error(json: &serde_json::Value) -> anyhow::Error {
     let families = [
         ("DeepSeek-V2-Lite", cfg!(feature = "deepseek-v2-lite")),
+        ("Gemma 4", cfg!(feature = "gemma4")),
         ("GLM5.2", cfg!(feature = "glm52")),
         ("Kimi-K2.6", cfg!(feature = "kimi-k2")),
         ("Qwen3", cfg!(feature = "qwen3")),
@@ -124,6 +129,23 @@ pub fn detect_model_type(model_path: impl AsRef<Path>) -> Result<ModelType> {
         );
     }
 
+    if matches!(config_model_type(&json), Some("gemma4" | "gemma4_unified"))
+        || matches!(
+            text_config_model_type(&json),
+            Some("gemma4_text" | "gemma4_unified_text")
+        )
+    {
+        #[cfg(feature = "gemma4")]
+        {
+            openinfer_gemma4::probe_config_json(&json)?;
+            return Ok(ModelType::Gemma4);
+        }
+        #[cfg(not(feature = "gemma4"))]
+        anyhow::bail!(
+            "Gemma 4 support is feature-gated; rebuild openinfer-server with --features gemma4"
+        );
+    }
+
     if config_model_type(&json) == Some("qwen3_5")
         || text_config_model_type(&json) == Some("qwen3_5_text")
     {
@@ -178,17 +200,33 @@ mod tests {
     }
 
     #[test]
-    fn gemma4_12b_rejected() {
+    #[cfg(not(feature = "gemma4"))]
+    fn gemma4_12b_feature_gated() {
         let json = r#"{"model_type":"gemma4_unified","architectures":["Gemma4UnifiedForConditionalGeneration"],"text_config":{"model_type":"gemma4_unified_text"}}"#;
         let err = detect(json).unwrap_err().to_string();
-        assert!(err.contains("gemma4_unified"));
+        assert!(err.contains("feature-gated"));
+        assert!(err.contains("--features gemma4"));
     }
 
     #[test]
-    fn gemma4_26b_rejected() {
-        let json = r#"{"model_type":"gemma4","architectures":["Gemma4ForConditionalGeneration"],"text_config":{"model_type":"gemma4_text"}}"#;
+    #[cfg(feature = "gemma4")]
+    fn gemma4_12b_identity_routes_to_gemma4() {
+        let json = r#"{"model_type":"gemma4_unified","architectures":["Gemma4UnifiedForConditionalGeneration"],"text_config":{"model_type":"gemma4_unified_text","head_dim":256,"global_head_dim":512,"sliding_window":1024,"attention_k_eq_v":true,"num_kv_shared_layers":0,"hidden_activation":"gelu_pytorch_tanh","enable_moe_block":false,"layer_types":["sliding_attention","sliding_attention","sliding_attention","sliding_attention","sliding_attention","full_attention","sliding_attention","sliding_attention","sliding_attention","sliding_attention","sliding_attention","full_attention"]}}"#;
+        assert_eq!(detect(json).unwrap(), ModelType::Gemma4);
+    }
+
+    #[test]
+    #[cfg(feature = "gemma4")]
+    fn gemma4_26b_identity_routes_to_gemma4() {
+        let json = r#"{"model_type":"gemma4","architectures":["Gemma4ForConditionalGeneration"],"text_config":{"model_type":"gemma4_text","head_dim":256,"global_head_dim":512,"sliding_window":1024,"attention_k_eq_v":true,"num_kv_shared_layers":0,"hidden_activation":"gelu_pytorch_tanh","enable_moe_block":true,"num_experts":128,"top_k_experts":8,"moe_intermediate_size":704,"intermediate_size":2112,"layer_types":["sliding_attention","sliding_attention","sliding_attention","sliding_attention","sliding_attention","full_attention","sliding_attention","sliding_attention","sliding_attention","sliding_attention","sliding_attention","full_attention"]}}"#;
+        assert_eq!(detect(json).unwrap(), ModelType::Gemma4);
+    }
+
+    #[test]
+    fn gemma3_previous_generation_rejected() {
+        let json = r#"{"model_type":"gemma3","architectures":["Gemma3ForConditionalGeneration"],"text_config":{"model_type":"gemma3_text"}}"#;
         let err = detect(json).unwrap_err().to_string();
-        assert!(err.contains("gemma4"));
+        assert!(err.contains("gemma3"), "{err}");
     }
 
     #[test]


### PR DESCRIPTION


## Description

Fixes #788 


Registers the Gemma 4 model line end to end short of an engine:

- `openinfer-gemma4` crate skeleton behind a `gemma4` feature; `start_engine` bails "not implemented yet" with the feature on and reports the feature gate without it.
- `ModelType::Gemma4` and a detection branch accepting both published config families (`gemma4_unified` / `Gemma4UnifiedForConditionalGeneration` at 12B; `gemma4` / `Gemma4ForConditionalGeneration` at 26B/31B), probed before routing like every other family.
- `probe_config_json` asserts identity plus the structural facts shared by all three published sizes — local/global head dims 256/512, sliding window 1024, the every-sixth-layer-plus-last `full_attention` rule over `sliding_attention`, `attention_k_eq_v`, zero shared KV layers, `gelu_pytorch_tanh` — and the MoE schema (`enable_moe_block` must be an explicit boolean; enabled requires 128 experts / top-k 8 / expert width 704, disabled rejects non-null `num_experts`, `top_k_experts`, or `moe_intermediate_size`). No size pinning; the values were read from the three published `config.json`s.
- The detection tests that previously pinned "Gemma 4 is rejected" now assert the feature-gate message without the feature and real routing with it; previous-generation Gemma (`gemma3`) stays rejected on every build. `ModelType` matches in the CLI/bench paths carry cfg-gated arms.
- Supported-model table gains a registration-only row ("engine not yet available").

## Test Env

Verification on Single GPU (sm_89, x86_64): `cargo fmt --check`; `cargo test --release -p openinfer-server --lib` under default features (8 tests) and `--features gemma4` (8 tests, so the routing tests really ran); `cargo test --release -p openinfer-gemma4 --lib` (9 probe tests, including the moe-width and malformed-field negative controls); `cargo clippy --release --all-targets -- -D warnings` for openinfer-server (default and `--features gemma4`) and openinfer-gemma4.


## Type of Change

- [x] New feature (non-breaking change which adds functionality)