### PR TITLE
test(gemma4): gate tokenizer and chat-template parity against a reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3531,6 +3531,10 @@ dependencies = [
  "anyhow",
  "pegainfer-engine",
  "serde_json",
+ "sha2 0.11.0",
+ "tokio",
+ "vllm-chat",
+ "vllm-text",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,6 +185,7 @@ url = { version = "2.5", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 validator = { version = "0.20.0", features = ["derive"] }
 velo = "0.1.0"
+vllm-chat = { git = "https://github.com/vllm-project/vllm.git", rev = "8e61b646e2d157f9b93451fa048f9c8530c8a67b" }
 vllm-engine-core-client = { git = "https://github.com/vllm-project/vllm.git", rev = "8e61b646e2d157f9b93451fa048f9c8530c8a67b" }
 vllm-server = { git = "https://github.com/vllm-project/vllm.git", rev = "8e61b646e2d157f9b93451fa048f9c8530c8a67b" }
 vllm-text = { git = "https://github.com/vllm-project/vllm.git", rev = "8e61b646e2d157f9b93451fa048f9c8530c8a67b" }

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,12 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 | `models/qwen35/mixed-load-itl-470.md` | Issue #470: full cold `--max-batch 8/bg=4` matrix on RTX 4090 (24/24 valid) + starvation negative control. Qwen3.5 is not immune; chunking bounds max/per-step stall but raises p99 at low QPS (~14→~80–92ms) and pulls p99/max back from the prefill wall to the chunk wall at high load; `qps·prefill_s≳1` is a throughput wall (chunking can't fix it, and ON's +15% TTFT can trip it earlier). The old "p99 immunity" was a slot-starvation artifact. |
 | `models/qwen35/adaptive-scheduler-policy.md` | Issue #727 adaptive scheduler policy record: default `off`, opt-in `auto`, hard `--max-prefill-tokens` cap, TP `auto` rejection, and pre-review whole-prefill benchmark tradeoff retained as non-default evidence. |
 
+## models / gemma4
+
+| Path | TL;DR |
+| --- | --- |
+| `models/gemma4/tokenizer.md` | Gemma 4 tokenizer/chat-template contracts, gated against a Hugging Face reference (token ids plus all five chat renders, content flattened to strings): BOS comes only from the standalone `chat_template.jinja` (which opens a thought channel and accepts a native system role), EOS is declared three times with three values, the published defaults are sampled rather than greedy, image/audio tokens encode straight from user text so text-only serving must reject them at admission, and one divergence stays open — the server's default content format adds a trailing space to system turns. |
+
 ## models / glm52
 
 | Path | TL;DR |

--- a/docs/models/gemma4/tokenizer.md
+++ b/docs/models/gemma4/tokenizer.md
@@ -1,0 +1,146 @@
+# Gemma 4 tokenizer and chat template
+
+**TL;DR:** All five chat renders reproduce the Hugging Face reference when content is flattened to strings, and token ids agree across the layers that can differ — gated by `pegainfer-gemma4/tests/tokenizer_parity.rs` against the pinned 12B checkpoint, with the other two sizes covered by inspection rather than by running. One divergence is open: under the frontend's default content format the system turn gains a trailing space. Contracts the engine must honour: BOS comes only from the chat template, EOS is declared in three places with three different values, the published generation defaults are sampled rather than greedy, and modality tokens are reachable from plain text so text-only serving has to reject them instead of embedding them.
+
+Last touched: 2026-07
+
+## The gate runs on 12B; the result carries to the other sizes by inspection
+
+The executable gate is bound to the pinned 12B checkpoint — the fixture records that checkpoint's
+file hashes and every test checks them first, so pointing it at another size fails on the
+`tokenizer_config.json` hash before asserting anything. That binding is deliberate: it keeps the
+guard an exact-file provenance check rather than a set of semantic exceptions.
+
+What carries to 26B-A4B and 31B is the conclusion, not the run, and it carries because the files
+are the same bytes. Against the published repositories:
+
+| file | 12B | 26B-A4B | 31B |
+| --- | --- | --- | --- |
+| `tokenizer.json` | `cc8d3a0c…` (32,169,626 B) | same | same |
+| `chat_template.jinja` | `4741bf6e…` (18,683 B) | same | same |
+| `tokenizer_config.json` | `6520cdc2…` | `6068e357…` | `6068e357…` |
+
+Those are Hugging Face object ids — sha256 for the LFS-stored `tokenizer.json`, git blob hashes
+for the two small files — while the fixture records sha256 throughout, and the parity tests check
+the checkpoint against it before asserting anything.
+
+`tokenizer.json` and `chat_template.jinja` are byte-identical across all three sizes, so anything
+this suite establishes about tokenization or rendering holds for all of them. The
+`tokenizer_config.json` difference is a single field — `processor_class` is
+`Gemma4UnifiedProcessor` at 12B and `Gemma4Processor` at the other two — which names the
+multimodal processor and affects neither. Gating the other two sizes for real would mean recording
+their revisions and hash sets and running each; that is not what this suite does.
+
+## Reference fixture
+
+`test_data/gemma4-tokenizer-golden.json` is dumped by
+
+```bash
+python tools/accuracy/dump_gemma4_tokenizer_golden.py <model-dir> <out.json> \
+  --source-repo google/gemma-4-12B-it --revision <sha>
+```
+
+Repository and revision are required arguments rather than inferred: a checkpoint directory
+carries no reliable record of where it came from, and guessing from a renamed local directory
+would write a wrong name into the golden. Everything in the fixture is asserted by the tests
+except those two and the transformers version, which are provenance — they record where the
+reference came from and cannot be checked from here. No local path is recorded.
+
+Both sides tokenize with the same `tokenizers` crate — Python's fast tokenizer wraps it and
+`vllm-tokenizer` calls it directly — so broad script coverage would re-run one implementation
+twice. The probes instead target the layers that can genuinely disagree: the Python wrapper's
+added-token and `add_special_tokens` handling, and version skew between the crate this workspace
+pins and the one the transformers wheel bundles. One case per algorithm class (whitespace, digits,
+multibyte, multi-codepoint graphemes, combining marks, byte fallback), every special token
+standalone, and one embedded in a sentence to cover adjacency.
+
+The parity tests carry `#[ignore]` because they need the checkpoint; run them explicitly against
+the pinned 12B one:
+
+```bash
+OPENINFER_TEST_MODEL_PATH=<pinned-12B-checkpoint-dir> \
+  cargo test --release -p pegainfer-gemma4 --test tokenizer_parity -- --ignored
+```
+
+## The chat template lives in its own file
+
+Gemma 4 ships `chat_template.jinja` rather than embedding the template in
+`tokenizer_config.json`. The renderer's precedence is: an explicit `chat_template` override, then
+a dedicated template file, then the tokenizer config entry — so passing no override (what the
+server does) picks up the `.jinja`.
+
+Rendered structure, from the reference:
+
+```
+<bos><|turn>user\nWhat is 2 + 2?<turn|>\n<|turn>model\n<|channel>thought\n<channel|>
+```
+
+Two consequences. Gemma 4 accepts a native `system` role — unlike Gemma 3, which folded system
+prompts into the first user turn. And `add_generation_prompt` opens a **thought channel**
+(`<|channel>thought\n<channel|>`) on the model turn, so the assistant's first emission is
+reasoning content; anything parsing the stream has to expect the channel markers.
+
+## Open divergence: content format changes the system turn
+
+The renderer resolves `content` into one of two shapes, and this template branches on which it
+gets. Given a string it emits `{{ content | trim }}`; given a list of parts it emits
+`{{ item['text'] | trim + ' ' }}` per part, leaving a trailing space. The server's default
+(`Auto`) inspects the template, finds a content-item loop, and therefore selects the parts form —
+so a system prompt renders as `You are terse. <turn|>` where the reference produces
+`You are terse.<turn|>`. User turns are unaffected; only the system branch adds the space.
+
+The parity test pins the string form, which matches the reference exactly for all five cases and
+establishes that template discovery, precedence and the Jinja engine are faithful. Choosing which
+format the server should use for this line is a separate decision: the setting is global to the
+frontend today, so changing it touches every model line and needs its own review.
+
+## BOS comes from the template, not the tokenizer
+
+`add_special_tokens` is a no-op for this tokenizer: every probe encodes identically with it on
+and off. The leading `<bos>` in a chat request comes from the template. An engine that adds BOS
+itself would double it.
+
+## EOS is declared three times
+
+These three values are read from the checkpoint's config files; they are metadata observations,
+not something the parity run exercises.
+
+| source | value |
+| --- | --- |
+| `config.json` | `[1, 106]` |
+| `text_config` | `1` |
+| `generation_config.json` | `[1, 106, 50]` |
+
+`generation_config.json` carries the generation semantics and is the one to honour; taking the
+outer list silently drops token 50. Whichever precedence the loader picks must be explicit rather
+than an artefact of which file it happens to read first.
+
+## The published defaults are sampled, not greedy
+
+Also read from the checkpoint rather than gated by a test.
+
+`generation_config.json` sets `do_sample: true`, `temperature: 1.0`, `top_k: 64`, `top_p: 0.95`
+at all three sizes. Any greedy comparison against a reference implementation has to state the
+override it applies. 12B alone adds `suppress_tokens: [258883, 258882]` — the end-of-audio and
+end-of-image ids; that list must not be applied to 26B or 31B, which do not declare it.
+
+## Modality tokens are reachable from plain text
+
+| token | id |
+| --- | --- |
+| `<\|image\|>` | 258880 |
+| `<\|audio\|>` | 258881 |
+| `<\|image>` (begin image) | 255999 |
+| `<image\|>` (end image) | 258882 |
+| `<\|audio>` (begin audio) | 256000 |
+| `<audio\|>` (end audio) | 258883 |
+
+These encode as single ids straight from user text — `"before <|image|> after"` becomes
+`[15849, 236743, 258880, 1308]`. A text-only engine has no image or audio embedder, so an
+admitted request carrying one of these ids would reach the embedding table with a placeholder that
+maps to nothing meaningful.
+
+So the admission path will need a rule for them once the engine exists — rejecting the request
+naming the token is the option that fails loudly; embedding the id silently is the one to avoid.
+Nothing enforces this today, so whoever writes admission has to pick it up from here or from the
+engine issue.

--- a/pegainfer-gemma4/Cargo.toml
+++ b/pegainfer-gemma4/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 autobenches = false
 autobins = false
-autotests = false
 edition = "2024"
 license = "Apache-2.0"
 name = "pegainfer-gemma4"
@@ -15,6 +14,12 @@ default = []
 anyhow = { workspace = true }
 pegainfer-engine = { workspace = true }
 serde_json = { workspace = true }
+
+[dev-dependencies]
+sha2 = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }
+vllm-chat = { workspace = true }
+vllm-text = { workspace = true }
 
 [lints]
 workspace = true

--- a/pegainfer-gemma4/tests/common/mod.rs
+++ b/pegainfer-gemma4/tests/common/mod.rs
@@ -1,0 +1,37 @@
+use std::sync::Arc;
+
+use vllm_text::Error;
+use vllm_text::Result;
+use vllm_text::backend::hf::ResolvedModelFiles;
+use vllm_text::backend::hf::TokenizerSource;
+use vllm_text::tokenizer::DynTokenizer;
+use vllm_text::tokenizer::HuggingFaceTokenizer;
+use vllm_text::tokenizer::TekkenTokenizer;
+use vllm_text::tokenizer::TiktokenTokenizer;
+
+pub(crate) fn load_tokenizer(model_path: &str) -> DynTokenizer {
+    try_load_tokenizer(model_path)
+        .unwrap_or_else(|err| panic!("Failed to load tokenizer for {model_path}: {err}"))
+}
+
+fn try_load_tokenizer(model_path: &str) -> Result<DynTokenizer> {
+    if tokio::runtime::Handle::try_current().is_ok() {
+        return Err(Error::Tokenizer(
+            "load_tokenizer cannot be called from inside an active Tokio runtime".to_string(),
+        ));
+    }
+    // Local model resolution is exposed as async, so bridge it with a
+    // current-thread runtime rather than requiring callers to be async.
+    let files = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|err| {
+            Error::Tokenizer(format!("failed to build tokenizer resolver runtime: {err}"))
+        })?
+        .block_on(ResolvedModelFiles::new(model_path))?;
+    match &files.tokenizer {
+        TokenizerSource::HuggingFace(path) => Ok(Arc::new(HuggingFaceTokenizer::new(path)?)),
+        TokenizerSource::Tiktoken(path) => Ok(Arc::new(TiktokenTokenizer::new(path)?)),
+        TokenizerSource::Tekken(path) => Ok(Arc::new(TekkenTokenizer::new(path)?)),
+    }
+}

--- a/pegainfer-gemma4/tests/tokenizer_parity.rs
+++ b/pegainfer-gemma4/tests/tokenizer_parity.rs
@@ -1,0 +1,239 @@
+//! Parity against a Hugging Face reference dumped by
+//! `tools/accuracy/dump_gemma4_tokenizer_golden.py`. Point
+//! `OPENINFER_TEST_MODEL_PATH` at the pinned 12B checkpoint the reference was
+//! dumped from and run with `--ignored`; the file-hash guard binds the suite to
+//! exactly that checkpoint.
+//!
+//! Both sides tokenize with the same `tokenizers` crate, so the token-id tests
+//! gate the Python wrapper's behaviour and version skew, not the tokenization
+//! algorithm. The render test compares two different Jinja implementations and
+//! carries the weight here.
+
+mod common;
+
+use serde_json::Value;
+use sha2::Digest;
+use sha2::Sha256;
+use vllm_chat::ChatMessage;
+use vllm_chat::ChatOptions;
+use vllm_chat::ChatRequest;
+use vllm_chat::ChatRole;
+use vllm_chat::ChatTemplateContentFormatOption;
+use vllm_chat::GenerationPromptMode;
+use vllm_chat::LoadModelBackendsOptions;
+use vllm_chat::load_model_backends;
+use vllm_text::Prompt;
+
+const GOLDEN_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../test_data/gemma4-tokenizer-golden.json"
+);
+
+fn golden() -> Value {
+    let raw = std::fs::read_to_string(GOLDEN_PATH)
+        .unwrap_or_else(|err| panic!("failed to read {GOLDEN_PATH}: {err}"));
+    serde_json::from_str(&raw).unwrap_or_else(|err| panic!("failed to parse {GOLDEN_PATH}: {err}"))
+}
+
+fn model_path() -> String {
+    std::env::var("OPENINFER_TEST_MODEL_PATH").expect(
+        "OPENINFER_TEST_MODEL_PATH must point at the pinned 12B Gemma 4 checkpoint \
+         the reference was dumped from",
+    )
+}
+
+/// Guards every parity test: the fixture only means something against the exact
+/// checkpoint it was dumped from, which is the pinned 12B one.
+fn assert_checkpoint_matches_reference(golden: &Value) {
+    let dir = model_path();
+    let expected = golden["file_sha256"]
+        .as_object()
+        .expect("golden file_sha256");
+    for (name, digest) in expected {
+        let path = std::path::Path::new(&dir).join(name);
+        let bytes = std::fs::read(&path)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+        let actual =
+            Sha256::digest(&bytes)
+                .iter()
+                .fold(String::with_capacity(64), |mut hex, byte| {
+                    use std::fmt::Write;
+                    let _ = write!(hex, "{byte:02x}");
+                    hex
+                });
+        let expected = digest.as_str().expect("sha256 must be a string");
+        assert_eq!(
+            actual, expected,
+            "{name} does not match the pinned 12B reference the fixture was dumped from \
+             ({actual} vs {expected}); this suite runs against that checkpoint only"
+        );
+    }
+}
+
+fn expected_ids(value: &Value, key: &str) -> Vec<u32> {
+    value[key]
+        .as_array()
+        .unwrap_or_else(|| panic!("golden entry missing {key}"))
+        .iter()
+        .map(|id| {
+            u32::try_from(id.as_u64().expect("token id must be a number"))
+                .expect("token id must fit u32")
+        })
+        .collect()
+}
+
+#[test]
+#[ignore = "requires the pinned 12B Gemma 4 checkpoint via OPENINFER_TEST_MODEL_PATH"]
+fn probe_ids_match_hf_reference() {
+    let golden = golden();
+    assert_checkpoint_matches_reference(&golden);
+    let tokenizer = common::load_tokenizer(&model_path());
+    let mut mismatches = Vec::new();
+
+    for probe in golden["probes"].as_array().expect("golden probes") {
+        let name = probe["name"].as_str().expect("probe name");
+        let text = probe["text"].as_str().expect("probe text");
+        for (key, add_specials) in [("ids_plain", false), ("ids_with_specials", true)] {
+            let expected = expected_ids(probe, key);
+            let actual = tokenizer
+                .encode(text, add_specials)
+                .unwrap_or_else(|err| panic!("encode failed for {name}/{key}: {err}"));
+            if actual != expected {
+                mismatches.push(format!(
+                    "{name}/{key}: expected {expected:?}, got {actual:?}"
+                ));
+            }
+        }
+    }
+
+    assert!(
+        mismatches.is_empty(),
+        "{} of {} probe encodings disagree with the reference:\n{}",
+        mismatches.len(),
+        golden["probes"].as_array().map_or(0, Vec::len) * 2,
+        mismatches.join("\n")
+    );
+}
+
+#[test]
+#[ignore = "requires the pinned 12B Gemma 4 checkpoint via OPENINFER_TEST_MODEL_PATH"]
+fn special_token_ids_match_hf_reference() {
+    let golden = golden();
+    assert_checkpoint_matches_reference(&golden);
+    let tokenizer = common::load_tokenizer(&model_path());
+    let specials = golden["special_tokens"]
+        .as_object()
+        .expect("golden special_tokens");
+    let mut mismatches = Vec::new();
+
+    for (name, entry) in specials {
+        let token = entry["token"].as_str().expect("special token text");
+        let expected = u32::try_from(entry["id"].as_u64().expect("special token id"))
+            .expect("special token id must fit u32");
+        let actual = tokenizer
+            .encode(token, false)
+            .unwrap_or_else(|err| panic!("encode failed for {name}: {err}"));
+        if actual != vec![expected] {
+            mismatches.push(format!(
+                "{name} ({token}): expected [{expected}], got {actual:?}"
+            ));
+        }
+    }
+
+    assert!(
+        mismatches.is_empty(),
+        "{} of {} special tokens disagree with the reference:\n{}",
+        mismatches.len(),
+        specials.len(),
+        mismatches.join("\n")
+    );
+}
+
+fn chat_request(case: &Value) -> ChatRequest {
+    let messages = case["messages"]
+        .as_array()
+        .expect("chat case messages")
+        .iter()
+        .map(|message| {
+            let role = match message["role"].as_str().expect("message role") {
+                "system" => ChatRole::System,
+                "user" => ChatRole::User,
+                "assistant" => ChatRole::Assistant,
+                other => panic!("unexpected role {other}"),
+            };
+            ChatMessage::text(role, message["content"].as_str().expect("message content"))
+        })
+        .collect();
+    let generation_prompt_mode = if case["add_generation_prompt"]
+        .as_bool()
+        .expect("add_generation_prompt")
+    {
+        GenerationPromptMode::StartNewAssistant
+    } else {
+        GenerationPromptMode::NoGenerationPrompt
+    };
+
+    ChatRequest {
+        messages,
+        chat_options: ChatOptions {
+            generation_prompt_mode,
+            ..ChatOptions::default()
+        },
+        ..ChatRequest::for_test()
+    }
+}
+
+/// Covers the string content form only. The frontend's default `Auto` format
+/// selects the parts form for this template, which renders system turns
+/// differently — see docs/models/gemma4/tokenizer.md.
+#[test]
+#[ignore = "requires the pinned 12B Gemma 4 checkpoint via OPENINFER_TEST_MODEL_PATH"]
+fn string_form_chat_renders_match_hf_reference() {
+    let golden = golden();
+    assert_checkpoint_matches_reference(&golden);
+    let cases = golden["chat_templates"]
+        .as_array()
+        .expect("golden chat_templates");
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+    let backends = runtime
+        .block_on(load_model_backends(
+            &model_path(),
+            LoadModelBackendsOptions {
+                language_model_only: true,
+                chat_template_content_format: ChatTemplateContentFormatOption::String,
+                ..LoadModelBackendsOptions::default()
+            },
+        ))
+        .expect("failed to load chat backends");
+    let renderer = backends.chat_backend.chat_renderer();
+
+    let mut mismatches = Vec::new();
+    for case in cases {
+        let name = case["name"].as_str().expect("chat case name");
+        let expected = case["rendered"].as_str().expect("chat case rendered");
+        let rendered = renderer
+            .render(&chat_request(case))
+            .unwrap_or_else(|err| panic!("render failed for {name}: {err}"));
+        match rendered.prompt {
+            Prompt::Text(actual) if actual == expected => {}
+            Prompt::Text(actual) => {
+                mismatches.push(format!("{name}: expected {expected:?}, got {actual:?}"));
+            }
+            Prompt::TokenIds(ids) => {
+                mismatches.push(format!("{name}: renderer returned token ids {ids:?}"));
+            }
+        }
+    }
+
+    assert!(
+        mismatches.is_empty(),
+        "{} of {} chat renders disagree with the reference:\n{}",
+        mismatches.len(),
+        cases.len(),
+        mismatches.join("\n")
+    );
+}

--- a/test_data/gemma4-tokenizer-golden.json
+++ b/test_data/gemma4-tokenizer-golden.json
@@ -1,0 +1,315 @@
+{
+  "source_repo": "google/gemma-4-12B-it",
+  "revision": "707f0a3b8a3c7ad586ed01e27eafbad8a27dd0f7",
+  "transformers_version": "5.11.0",
+  "file_sha256": {
+    "tokenizer.json": "cc8d3a0ce36466ccc1278bf987df5f71db1719b9ca6b4118264f45cb627bfe0f",
+    "tokenizer_config.json": "a62f4e85a47c0c136edaaa3a4f591fd6783717299a9def47e5ad03a49f6a5eb9",
+    "chat_template.jinja": "ae53464bf3be25802b3a5b37def7fd89667067d7577049b3b2d74c4d8de4c6d4"
+  },
+  "special_tokens": {
+    "bos_token": {
+      "token": "<bos>",
+      "id": 2
+    },
+    "eos_token": {
+      "token": "<eos>",
+      "id": 1
+    },
+    "pad_token": {
+      "token": "<pad>",
+      "id": 0
+    },
+    "unk_token": {
+      "token": "<unk>",
+      "id": 3
+    },
+    "mask_token": {
+      "token": "<mask>",
+      "id": 4
+    },
+    "eot_token": {
+      "token": "<turn|>",
+      "id": 106
+    },
+    "image_token": {
+      "token": "<|image|>",
+      "id": 258880
+    },
+    "audio_token": {
+      "token": "<|audio|>",
+      "id": 258881
+    },
+    "boi_token": {
+      "token": "<|image>",
+      "id": 255999
+    },
+    "eoi_token": {
+      "token": "<image|>",
+      "id": 258882
+    },
+    "boa_token": {
+      "token": "<|audio>",
+      "id": 256000
+    },
+    "eoa_token": {
+      "token": "<audio|>",
+      "id": 258883
+    },
+    "think_token": {
+      "token": "<|think|>",
+      "id": 98
+    },
+    "escape_token": {
+      "token": "<|\"|>",
+      "id": 52
+    }
+  },
+  "probes": [
+    {
+      "name": "empty",
+      "text": "",
+      "ids_plain": [],
+      "ids_with_specials": []
+    },
+    {
+      "name": "ascii_words",
+      "text": "Hello, world!",
+      "ids_plain": [
+        9259,
+        236764,
+        1902,
+        236888
+      ],
+      "ids_with_specials": [
+        9259,
+        236764,
+        1902,
+        236888
+      ]
+    },
+    {
+      "name": "multi_space",
+      "text": "a    b\tc\nd\r\ne",
+      "ids_plain": [
+        236746,
+        140,
+        236763,
+        255968,
+        236755,
+        107,
+        236753,
+        251,
+        107,
+        236744
+      ],
+      "ids_with_specials": [
+        236746,
+        140,
+        236763,
+        255968,
+        236755,
+        107,
+        236753,
+        251,
+        107,
+        236744
+      ]
+    },
+    {
+      "name": "digits_run",
+      "text": "12345",
+      "ids_plain": [
+        236770,
+        236778,
+        236800,
+        236812,
+        236810
+      ],
+      "ids_with_specials": [
+        236770,
+        236778,
+        236800,
+        236812,
+        236810
+      ]
+    },
+    {
+      "name": "cjk",
+      "text": "你好世界",
+      "ids_plain": [
+        144626,
+        12811
+      ],
+      "ids_with_specials": [
+        144626,
+        12811
+      ]
+    },
+    {
+      "name": "emoji_zwj",
+      "text": "👨‍👩‍👧‍👦",
+      "ids_plain": [
+        243874,
+        237243,
+        243767,
+        237243,
+        244814,
+        237243,
+        244990
+      ],
+      "ids_with_specials": [
+        243874,
+        237243,
+        243767,
+        237243,
+        244814,
+        237243,
+        244990
+      ]
+    },
+    {
+      "name": "combining_marks",
+      "text": "éàô",
+      "ids_plain": [
+        236744,
+        229580,
+        239101,
+        236748,
+        242238
+      ],
+      "ids_with_specials": [
+        236744,
+        229580,
+        239101,
+        236748,
+        242238
+      ]
+    },
+    {
+      "name": "control_chars",
+      "text": "a\u0000b\u0001c",
+      "ids_plain": [
+        236746,
+        238,
+        236763,
+        249732,
+        236755,
+        251541
+      ],
+      "ids_with_specials": [
+        236746,
+        238,
+        236763,
+        249732,
+        236755,
+        251541
+      ]
+    },
+    {
+      "name": "special_bos_literal",
+      "text": "<bos>",
+      "ids_plain": [
+        2
+      ],
+      "ids_with_specials": [
+        2
+      ]
+    },
+    {
+      "name": "special_image_literal",
+      "text": "<|image|>",
+      "ids_plain": [
+        258880
+      ],
+      "ids_with_specials": [
+        258880
+      ]
+    },
+    {
+      "name": "special_in_sentence",
+      "text": "before <|image|> after",
+      "ids_plain": [
+        15849,
+        236743,
+        258880,
+        1308
+      ],
+      "ids_with_specials": [
+        15849,
+        236743,
+        258880,
+        1308
+      ]
+    }
+  ],
+  "chat_templates": [
+    {
+      "name": "single_user_with_generation_prompt",
+      "messages": [
+        {
+          "role": "user",
+          "content": "What is 2 + 2?"
+        }
+      ],
+      "add_generation_prompt": true,
+      "rendered": "<bos><|turn>user\nWhat is 2 + 2?<turn|>\n<|turn>model\n<|channel>thought\n<channel|>"
+    },
+    {
+      "name": "single_user_no_generation_prompt",
+      "messages": [
+        {
+          "role": "user",
+          "content": "What is 2 + 2?"
+        }
+      ],
+      "add_generation_prompt": false,
+      "rendered": "<bos><|turn>user\nWhat is 2 + 2?<turn|>\n"
+    },
+    {
+      "name": "multi_turn",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Hello"
+        },
+        {
+          "role": "assistant",
+          "content": "Hi there."
+        },
+        {
+          "role": "user",
+          "content": "And now?"
+        }
+      ],
+      "add_generation_prompt": true,
+      "rendered": "<bos><|turn>user\nHello<turn|>\n<|turn>model\nHi there.<turn|>\n<|turn>user\nAnd now?<turn|>\n<|turn>model\n<|channel>thought\n<channel|>"
+    },
+    {
+      "name": "system_then_user",
+      "messages": [
+        {
+          "role": "system",
+          "content": "You are terse."
+        },
+        {
+          "role": "user",
+          "content": "Explain gravity."
+        }
+      ],
+      "add_generation_prompt": true,
+      "rendered": "<bos><|turn>system\nYou are terse.<turn|>\n<|turn>user\nExplain gravity.<turn|>\n<|turn>model\n<|channel>thought\n<channel|>"
+    },
+    {
+      "name": "unicode_content",
+      "messages": [
+        {
+          "role": "user",
+          "content": "翻译：🙂 と こんにちは"
+        }
+      ],
+      "add_generation_prompt": true,
+      "rendered": "<bos><|turn>user\n翻译：🙂 と こんにちは<turn|>\n<|turn>model\n<|channel>thought\n<channel|>"
+    }
+  ]
+}

--- a/tools/accuracy/dump_gemma4_tokenizer_golden.py
+++ b/tools/accuracy/dump_gemma4_tokenizer_golden.py
@@ -1,0 +1,182 @@
+"""Dump a Gemma 4 tokenizer/chat-template golden from a local checkpoint.
+
+    python tools/accuracy/dump_gemma4_tokenizer_golden.py <model-dir> <out.json> \
+        --source-repo google/gemma-4-12B-it --revision <sha>
+
+Provenance is required rather than inferred: a checkpoint directory carries no
+reliable record of where it came from, and guessing from the path would write a
+wrong repository name into the golden. Every chat case is expected to render; a
+template error aborts the dump rather than being written into the golden.
+"""
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import transformers
+from transformers import AutoTokenizer
+
+PROBES = [
+    # Both sides run the same `tokenizers` crate, so these probe the layers that
+    # can actually differ: the Python wrapper's added-token and
+    # add_special_tokens handling, and version skew in the shared library. One
+    # case per algorithm class rather than broad script coverage.
+    ("empty", ""),
+    ("ascii_words", "Hello, world!"),
+    ("multi_space", "a    b\tc\nd\r\ne"),
+    ("digits_run", "12345"),
+    ("cjk", "\u4f60\u597d\u4e16\u754c"),
+    ("emoji_zwj", "\U0001f468\u200d\U0001f469\u200d\U0001f467\u200d\U0001f466"),
+    ("combining_marks", "e\u0301a\u0300o\u0302"),
+    ("control_chars", "a\x00b\x01c\x7f"),
+    ("special_bos_literal", "<bos>"),
+    ("special_image_literal", "<|image|>"),
+    ("special_in_sentence", "before <|image|> after"),
+]
+
+SPECIAL_TOKEN_KEYS = [
+    "bos_token",
+    "eos_token",
+    "pad_token",
+    "unk_token",
+    "mask_token",
+    "eot_token",
+    "image_token",
+    "audio_token",
+    "boi_token",
+    "eoi_token",
+    "boa_token",
+    "eoa_token",
+    "think_token",
+    "escape_token",
+]
+
+CHAT_CASES = [
+    (
+        "single_user_with_generation_prompt",
+        [{"role": "user", "content": "What is 2 + 2?"}],
+        True,
+    ),
+    (
+        "single_user_no_generation_prompt",
+        [{"role": "user", "content": "What is 2 + 2?"}],
+        False,
+    ),
+    (
+        "multi_turn",
+        [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there."},
+            {"role": "user", "content": "And now?"},
+        ],
+        True,
+    ),
+    (
+        "system_then_user",
+        [
+            {"role": "system", "content": "You are terse."},
+            {"role": "user", "content": "Explain gravity."},
+        ],
+        True,
+    ),
+    (
+        "unicode_content",
+        [{"role": "user", "content": "翻译：🙂 と こんにちは"}],
+        True,
+    ),
+]
+
+HASHED_FILES = ("tokenizer.json", "tokenizer_config.json", "chat_template.jinja")
+
+
+def token_value(raw):
+    return raw["content"] if isinstance(raw, dict) else raw
+
+
+def dump_file_hashes(model_dir: Path) -> dict:
+    hashes = {}
+    for name in HASHED_FILES:
+        path = model_dir / name
+        if not path.exists():
+            raise SystemExit(f"required file missing from the checkpoint: {name}")
+        hashes[name] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return hashes
+
+
+def dump_special_tokens(tokenizer, tokenizer_config: dict) -> dict:
+    specials = {}
+    for key in SPECIAL_TOKEN_KEYS:
+        value = token_value(tokenizer_config.get(key))
+        if value is None:
+            raise SystemExit(
+                f"required special token missing from tokenizer_config: {key}"
+            )
+        specials[key] = {"token": value, "id": tokenizer.convert_tokens_to_ids(value)}
+    return specials
+
+
+def dump_probes(tokenizer) -> list:
+    return [
+        {
+            "name": name,
+            "text": text,
+            "ids_plain": tokenizer(text, add_special_tokens=False)["input_ids"],
+            "ids_with_specials": tokenizer(text, add_special_tokens=True)["input_ids"],
+        }
+        for name, text in PROBES
+    ]
+
+
+def dump_chat_templates(tokenizer) -> list:
+    cases = []
+    for name, messages, add_generation_prompt in CHAT_CASES:
+        rendered = tokenizer.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=add_generation_prompt,
+        )
+        cases.append(
+            {
+                "name": name,
+                "messages": messages,
+                "add_generation_prompt": add_generation_prompt,
+                "rendered": rendered,
+            }
+        )
+    return cases
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("model_dir")
+    parser.add_argument("out")
+    parser.add_argument("--source-repo", required=True)
+    parser.add_argument("--revision", required=True)
+    args = parser.parse_args()
+
+    model_dir = Path(args.model_dir)
+    tokenizer = AutoTokenizer.from_pretrained(str(model_dir))
+    tokenizer_config = json.loads((model_dir / "tokenizer_config.json").read_text())
+
+    golden = {
+        "source_repo": args.source_repo,
+        "revision": args.revision,
+        "transformers_version": transformers.__version__,
+        "file_sha256": dump_file_hashes(model_dir),
+        "special_tokens": dump_special_tokens(tokenizer, tokenizer_config),
+        "probes": dump_probes(tokenizer),
+        "chat_templates": dump_chat_templates(tokenizer),
+    }
+
+    Path(args.out).write_text(json.dumps(golden, ensure_ascii=False, indent=2) + "\n")
+    print(
+        f"wrote {args.out}: {len(golden['probes'])} probes, "
+        f"{len(golden['chat_templates'])} chat cases"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

Closes #793 

Gemma 4's chat template branches on whether message content arrives as a string or as structured parts, and the frontend picks that shape with a heuristic over the template source. When the heuristic and the reference disagree, every prompt of the affected role changes silently — nothing errors, and the difference only surfaces later as unexplained drift in accuracy comparisons. The engine for this model line does not exist yet, so this is preflight work: what can be pinned today is the shared machinery Gemma 4 will run on, against the checkpoint's own tokenizer and template assets.

`tools/accuracy/dump_gemma4_tokenizer_golden.py` produces `test_data/gemma4-tokenizer-golden.json` from a local checkpoint: eleven probes, every special token, five chat renders, and the sha256 of the tokenizer, tokenizer config and template files. `openinfer-gemma4/tests/tokenizer_parity.rs` replays it — token ids through `openinfer_vllm_support::load_tokenizer`, renders through the `vllm-chat` backend `load_model_backends` returns, so template discovery, precedence and the Jinja engine are compared rather than assumed. Each test first checks the checkpoint's file hashes against the fixture, since a reference only means something against the weights it came from. The tests are `#[ignore]`d because they need the checkpoint.

The probe set is deliberately narrow. Both sides tokenize with the same `tokenizers` crate — Python's fast tokenizer wraps it, `vllm-tokenizer` calls it directly — so broad script coverage would re-run one implementation twice. The probes target what can genuinely disagree: the Python wrapper's added-token and `add_special_tokens` handling, and version skew between the crate this workspace pins and the one the transformers wheel bundles. The render comparison is where the weight sits, because minijinja and jinja2 are two different implementations.

`docs/models/gemma4/tokenizer.md` records what the run established: `add_special_tokens` is a no-op so `<bos>` comes only from the template; the template accepts a native `system` role unlike Gemma 3 and opens a thought channel on the model turn; `eos_token_id` is declared three times with three different values and the precedence must be explicit; the published defaults are sampled rather than greedy; and image/audio tokens encode as single ids straight from user text, which the admission path will have to reject once the engine exists. The result covers all three published sizes — `tokenizer.json` and `chat_template.jinja` are byte-identical across 12B, 26B-A4B and 31B, and `tokenizer_config.json` differs only in `processor_class`.

The crate manifest also drops `autotests = false`, which had made the `tests` directory invisible to Cargo.


## Test Env

- x86_64 host, no GPU involved — the tests are tokenizer and template work only.
- Checkpoint `google/gemma-4-12B-it` at revision `707f0a3b8a3c`, verified by the fixture's file hashes at the start of every test.
- Reference dumped with transformers 5.11.0 (tokenizers 0.22.2).

```
cargo fmt --check
cargo test --release -p openinfer-gemma4 --lib
OPENINFER_TEST_MODEL_PATH=<checkpoint-dir> \
  cargo test --release -p openinfer-gemma4 --test tokenizer_parity -- --ignored
cargo clippy --release -p openinfer-gemma4 --all-targets -- -D warnings
```

All green: 10 crate tests, and 3 parity tests covering 22 probe encodings, 14 special tokens and 5 string-form chat renders.

## Verification

The render gate found a divergence on its first run. Rendering the same five cases through the same backend, varying only the content format:

| content format | renders matching the reference |
| --- | --- |
| `String` (pinned by the tests) | 5 / 5 |
| `Auto` (the frontend's default) | 4 / 5 |

The one failure, verbatim:

```
system_then_user:
  expected "<bos><|turn>system\nYou are terse.<turn|>\n..."
  got      "<bos><|turn>system\nYou are terse. <turn|>\n..."
```

`Auto` inspects the template, finds a content-item loop, and selects the parts form; the template's system branch then emits `{{ item['text'] | trim + ' ' }}` per part and leaves a trailing space, where the string branch emits `{{ content | trim }}`. User turns are unaffected. The tests pin `String`, which reproduces the reference exactly; choosing the format for this line is global to the frontend today, so it belongs in its own change.

As a control on the gate itself, corrupting a single reference token id turns the suite red naming the offending probe and printing both id sequences.
