### PR TITLE
test(sim): add tool-call round-trip e2e tests

### DIFF
--- a/openinfer-sim/tests/frontend_e2e.rs
+++ b/openinfer-sim/tests/frontend_e2e.rs
@@ -67,6 +67,42 @@ impl SimServer {
         .await
     }
 
+    /// Spawn a sim server that replays `completion_ids` verbatim for every
+    /// request. Useful for protocol round-trip tests (e.g. tool calls) where
+    /// the engine output is irrelevant but the server must accept it.
+    async fn spawn_with_scripted_completion(completion_ids: Vec<u32>) -> Result<Self> {
+        let dir = model_dir_with_minimal_metadata()?;
+        let config = SimulatedEngineConfig::new(0.0, 1000.0, 0.0, 1)?
+            .with_scripted_completion(completion_ids);
+        let mut last_error = None;
+        for attempt in 1..=SERVER_START_ATTEMPTS {
+            match Self::spawn_once_with_config(&dir, config.clone(), false, 1, MODEL_NAME).await {
+                Ok(started) => {
+                    return Ok(Self {
+                        base_url: started.base_url,
+                        model_name: started.model_name,
+                        shutdown: started.shutdown,
+                        task: started.task,
+                        load_txs: started.load_txs,
+                        _model_dir: dir,
+                    });
+                }
+                Err(error) => {
+                    last_error = Some(error);
+                    if attempt < SERVER_START_ATTEMPTS {
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                    }
+                }
+            }
+        }
+        Err(last_error.unwrap_or_else(|| anyhow!("sim frontend startup was not attempted")))
+            .with_context(|| {
+                format!(
+                    "failed to start scripted sim frontend after {SERVER_START_ATTEMPTS} attempts"
+                )
+            })
+    }
+
     async fn spawn_with_model_dir(model_dir: TempDir) -> Result<Self> {
         Self::spawn_with_model_dir_and_lora_routes(model_dir, false, 1, MODEL_NAME).await
     }
@@ -111,10 +147,28 @@ impl SimServer {
         engine_count: usize,
         model_name: &str,
     ) -> Result<StartedSimServer> {
+        let config = SimulatedEngineConfig::new(0.0, 1000.0, 0.0, 1)?;
+        Self::spawn_once_with_config(
+            model_dir,
+            config,
+            enable_lora_routes,
+            engine_count,
+            model_name,
+        )
+        .await
+    }
+
+    async fn spawn_once_with_config(
+        model_dir: &TempDir,
+        config: SimulatedEngineConfig,
+        enable_lora_routes: bool,
+        engine_count: usize,
+        model_name: &str,
+    ) -> Result<StartedSimServer> {
         let port = reserve_loopback_port()?;
         let base_url = format!("http://127.0.0.1:{port}");
         let shutdown = CancellationToken::new();
-        let mut engine = start_engine(SimulatedEngineConfig::new(0.0, 1000.0, 0.0, 1)?);
+        let mut engine = start_engine(config);
         let load_txs = if engine_count > 1 {
             let (load_txs, load_watches) = (0..engine_count)
                 .map(|_| watch::channel(LoadSnapshot::default()))
@@ -575,6 +629,141 @@ async fn chat_completions_returns_correct_format() -> Result<()> {
         total_tokens,
         prompt_tokens + completion_tokens,
         "total_tokens must equal prompt + completion: {response}"
+    );
+
+    server.shutdown().await
+}
+
+/// Round-trip test for the OpenAI tool-call protocol through the simulated
+/// frontend. The sim engine replays a fixed token-id sequence, so this does
+/// not assert that the model *emits* a tool call — it verifies that the
+/// frontend accepts `tools` + `tool_choice` on the way in and that the
+/// response keeps a well-formed chat-completion envelope (no `tool_calls`
+/// when `tool_choice` forces a normal reply). This is the protocol-level
+/// contract that real model backends must satisfy.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn chat_completions_tool_choice_none_round_trips() -> Result<()> {
+    let server = SimServer::spawn_with_scripted_completion(vec![11, 22, 33, 44]).await?;
+    let client = test_client()?;
+
+    let tools = json!([
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get the current weather for a city",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string", "description": "City name"}
+                    },
+                    "required": ["city"]
+                }
+            }
+        }
+    ]);
+
+    let response: Value = client
+        .post(format!("{}/v1/chat/completions", server.base_url))
+        .json(&json!({
+            "model": MODEL_NAME,
+            "messages": [{"role": "user", "content": "what is the weather in paris?"}],
+            "tools": tools,
+            "tool_choice": "none",
+            "max_tokens": 4,
+            "temperature": 0.0
+        }))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    assert_eq!(
+        response["object"].as_str(),
+        Some("chat.completion"),
+        "tool-call request must still return a chat.completion envelope: {response}"
+    );
+
+    let choice = &response["choices"][0];
+    assert_eq!(
+        choice["message"]["role"].as_str(),
+        Some("assistant"),
+        "message role must be assistant: {response}"
+    );
+    // With tool_choice=none the server must not attach tool_calls.
+    assert!(
+        choice["message"]["tool_calls"].is_null(),
+        "tool_choice=none must not produce tool_calls: {response}"
+    );
+
+    let usage = &response["usage"];
+    assert!(
+        usage["prompt_tokens"].as_u64().is_some_and(|t| t > 0),
+        "prompt_tokens must be positive: {response}"
+    );
+    assert_eq!(
+        usage["completion_tokens"].as_u64(),
+        Some(4),
+        "completion_tokens must equal max_tokens: {response}"
+    );
+
+    server.shutdown().await
+}
+
+/// A simulated engine ships no registered tool parser (its temporary model id
+/// matches no parser pattern), and the upstream frontend validates tool parsing
+/// availability at request-submission time. Any request that carries `tools`
+/// (regardless of `tool_choice`) is therefore rejected. This test guards that the
+/// rejection is a *structured* error response rather than a panic or empty body,
+/// so the protocol path stays safe for the real backends that do register parsers.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn chat_completions_tools_without_parser_rejected_structured() -> Result<()> {
+    let server = SimServer::spawn_with_scripted_completion(vec![11, 22, 33, 44]).await?;
+    let client = test_client()?;
+
+    let tools = json!([
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get the current weather for a city",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string", "description": "City name"}
+                    },
+                    "required": ["city"]
+                }
+            }
+        }
+    ]);
+
+    let response = client
+        .post(format!("{}/v1/chat/completions", server.base_url))
+        .json(&json!({
+            "model": MODEL_NAME,
+            "messages": [{"role": "user", "content": "what is the weather in paris?"}],
+            "tools": tools,
+            "tool_choice": "auto",
+            "max_tokens": 4,
+            "temperature": 0.0
+        }))
+        .send()
+        .await?;
+
+    assert!(
+        !response.status().is_success(),
+        "request with tools but no parser must not be accepted"
+    );
+
+    let body_text = response.text().await?;
+    let body: Value = serde_json::from_str(&body_text).unwrap_or(Value::Null);
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .is_some_and(|m| !m.is_empty()),
+        "error response must carry a non-empty message: {body}"
     );
 
     server.shutdown().await


### PR DESCRIPTION
# PR: test(sim): add tool-call round-trip e2e tests

> Local draft, not tracked in git. After pushing to `myfork`, use this to open a PR against `openinfer-project/openinfer`.

---

## PR Title

```
test(sim): add tool-call round-trip e2e tests
```

---

## Base Branch

`main` of `openinfer-project/openinfer`

## Source Branch

`test/sim-toolcall-roundtrip` (committed as `0f32a3e`)

---

## Summary

Adds two tokio end-to-end tests to the `openinfer-sim` `frontend_e2e` suite that cover the OpenAI tool-call protocol path, closing the gap where `openinfer-vllm-frontend` had no test coverage for tool-call requests (roadmap Now #5). Both tests are GPU-free and CI-friendly.

---

## Motivation

`openinfer-vllm-frontend` already implements `tool_call_parser` to support `tools` / `tool_choice`, but the repo had **no tests exercising the tool-call request path**. The frontend validates tool-parsing availability at request-submission time, and the `/v1/chat/completions` tool-call behavior can silently regress on protocol-layer changes. The CPU-only sim engine fully covers this protocol path without needing a GPU or model weights.

---

## Changes

**`openinfer-sim/tests/frontend_e2e.rs`** (+190 / -1)

1. **Refactor** `SimServer::spawn_once` to delegate to a new `spawn_once_with_config(model_dir, config, enable_lora_routes, engine_count, model_name)`, enabling reuse of the same startup logic with an injected `SimulatedEngineConfig`.
2. **Add** `SimServer::spawn_with_scripted_completion(completion_ids: Vec<u32>)` — starts a sim server that replays a fixed token sequence (via `SimulatedEngineConfig::new(...).with_scripted_completion(...)`).
3. **New test** `chat_completions_tool_choice_none_round_trips`:
   - Sends `tool_choice: "none"` + `tools`.
   - Asserts: 200 OK, object is `chat.completion`, role is `assistant`, `tool_calls` is null, `usage.prompt_tokens > 0`, `usage.completion_tokens == 4`.
4. **New test** `chat_completions_tools_without_parser_rejected_structured`:
   - Sends a request carrying `tools` with `tool_choice: "auto"` (the sim model's temp id matches no registered parser).
   - Asserts: the request is rejected with a non-2xx status and a **structured error JSON** (`error.message` non-empty), rather than a panic / empty body — guarding the upstream tool-parsing validation path.

---

## Design Notes

- The upstream vLLM frontend validates tool-parsing availability at **request-submission time**: any request carrying `tools` on a model with no matching parser is rejected regardless of `tool_choice` (returns `tool parsing is not available for model`). This is upstream behavior, not an openinfer defect.
- The sim engine's served model id is a temp directory path that can never match a parser pattern, so under sim only two paths are verifiable: `tool_choice: "none"` (accepted) and "tools present → structured rejection".
- A true end-to-end tool call (model replays structured `tool_calls`) is covered by the real backends that register a parser (e.g. qwen3) in their own test lines; this PR focuses on keeping the protocol layer intact.

---

## Verification

This environment had no Rust toolchain and restricted network, so we installed from the pre-staged `rust-nightly-x86_64-unknown-linux-gnu.tar.xz` (nightly 2026-07-30), borrowed openssl/protoc dev packages from conda, and set `OPENINFER_CUDA_SM=80`.

```bash
# Toolchain (no network needed; see PROGRESS.md §5.2)
R=~/.rust-nightly/rust-nightly-x86_64-unknown-linux-gnu
export PATH="$R/rustfmt-preview/bin:$R/clippy-preview/bin:$R/cargo/bin:$R/rustc/bin:$PATH"
export LD_LIBRARY_PATH="$R/rustc/lib:$LD_LIBRARY_PATH"
export OPENSSL_DIR=/data/home/nieyuntao/anaconda3
export PKG_CONFIG_PATH=/data/home/nieyuntao/anaconda3/lib/pkgconfig:$PKG_CONFIG_PATH
export PROTOC=/data/home/nieyuntao/anaconda3/lib/python3.12/site-packages/torch/bin/protoc
export PROTOC_INCLUDE=/data/home/nieyuntao/anaconda3/include
export OPENINFER_CUDA_SM=80

cargo fmt -p openinfer-sim -- --check                 # clean
cargo clippy --release --locked -p openinfer-sim      # clean (only an unrelated 3rd-party proc-macro-error2 future-incompat note)
cargo test --release -p openinfer-sim --test frontend_e2e   # 15/15 passed
```

Both new tests plus the 13 existing tests pass with no regressions.

---

## Impact / Risk

- Only adds tests and a test-helper refactor; **no runtime/engine code is changed**, minimal blast radius.
- The `spawn_once` refactor delegates to `spawn_once_with_config` with an unchanged signature, so existing call sites are unaffected (verified by the full existing test suite).

---

## Follow-up (out of scope for this PR)

- A true end-to-end tool-call test where the model replays structured `tool_calls` (against a parser-registered backend with weights) can be a separate PR.
- Optionally let the sim engine accept an injected model id (containing a parser pattern substring, e.g. `qwen3`) so sim can also round-trip real tool calls — requires exposing a model-id override in `start_engine`, beyond this PR's scope.
