### PR TITLE
feat(glm52): prefix cache under native MTP — flat multi-turn TTFT

### DIFF
--- a/docs/models/glm52/pd-native-mtp-handoff.md
+++ b/docs/models/glm52/pd-native-mtp-handoff.md
@@ -41,7 +41,7 @@
 > of linear in history (c1 p50 ~270 ms at every turn; c8 late-turn p50
 > 1,186 → 454 ms), with byte-identical greedy outputs.
 >
-> **Last touched:** 2026-07
+> **Last touched:** 2026-08
 
 ## Preparation
 

--- a/docs/models/glm52/pd-native-mtp-handoff.md
+++ b/docs/models/glm52/pd-native-mtp-handoff.md
@@ -35,6 +35,11 @@
 > native-MTP proposal path broken by #797 is repaired (P dies on first
 > handoff on any #797..#804 build without it). Same-fleet A/B: ITL p90 −27%
 > / p99 −32% vs the pre-async binary; c64 full-stack 640/640 at 1,189 tok/s.
+> **Prefix caching now works under native MTP** (constant v2 page salt —
+> the v1 full-prompt salt had killed all cross-turn reuse) and the prefill
+> pool retains released prefixes: multi-turn per-turn TTFT is flat instead
+> of linear in history (c1 p50 ~270 ms at every turn; c8 late-turn p50
+> 1,186 → 454 ms), with byte-identical greedy outputs.
 >
 > **Last touched:** 2026-07
 
@@ -666,6 +671,39 @@ fixed-cadence DeepEP chain paces every rank at the slowest node (~+4 ms
 ITL p50 fleet-to-fleet). The c16 TTFT park tax (~+0.1 s p50) persists —
 restore pipelining (deferred in #802) is the code-side answer,
 session-affinity routing the traffic-side one.
+
+### Prefix cache under native MTP: multi-turn TTFT decoupled from history (2026-08-01)
+
+TTFT diagnosis on a 2P (TP4) + 1D (EP4) stack, multi-turn 1024 + 256/turn ×
+8 turns, 2-token outputs (`max_tokens=1` finishes at admission via anchor
+replay — it exercises the restore but skips the verify step and its admit
+log, so TTFT probes must use ≥2): per-turn TTFT p50 grew 243 → 374 ms at c1
+and 432 → 1,186 ms at c8. Decomposition: bs=1 direct-P prefill is
+`~80 ms + len/9.2K tok/s`, the handoff adds ~72 ms — the growth was P
+re-prefilling the FULL history every turn, and the c8 blowup was P's
+serial single-request pool. Root cause of both: the v1 native-MTP cache
+salt hashed the whole prompt, giving every continuation its own cache
+universe — zero cross-turn reuse anywhere (P radix, D radix, host tier).
+
+Fix (same-day): constant v2 salt + prefix matching enabled under native
+MTP + the prefill pool sized for the full slot count. Layer-78 KV rides
+the same pool page ids as the main cache, so a radix hit reuses it for
+free; the accepted alias (two prompts diverging exactly at a page boundary
+share one shifted-token L78 row) affects draft quality only — target
+verification rejects any draft it misleads. Verified on the same stack:
+
+- greedy 2-turn goldens byte-identical across the flip;
+- c1 per-turn TTFT p50 `[303, 271, 270, 270, 271, 271, 302, 281]` — flat
+  (was 243 → 374 and linear in history; at 8K histories the projected gap
+  is ~3×);
+- c8 per-turn TTFT p50 turn-7/8 `454/374` ms (was `1,186/993`), p99 flat
+  ~600–900 ms (was growing to 2,247) — concurrent prefills replace the
+  head-of-line queue;
+- 24/24 conversations, zero failures, D admits on every turn.
+
+The bare-metal P deployment also surfaced #810 (two NCCL copies corrupt
+the TP4 comm when the shared lib dir lacks the unversioned symlink) —
+fixed operationally, hardening tracked there.
 
 ## Debrief
 

--- a/openinfer-glm52/src/lib.rs
+++ b/openinfer-glm52/src/lib.rs
@@ -626,11 +626,10 @@ fn glm52_cap_bytes(
     prefill_only: bool,
     moe_topo: Glm52MoeTopo,
 ) -> Result<usize> {
-    let pool_slots = if prefill_only {
-        1
-    } else {
-        model::GLM52_MAX_BATCH_PER_RANK
-    };
+    // Prefill-only sizes the full slot count too (it used to hold exactly one
+    // request): the prefix cache needs blocks to retain released prefixes
+    // across turns, and the headroom lets prefills overlap.
+    let pool_slots = model::GLM52_MAX_BATCH_PER_RANK;
     Ok(glm52_arena_bytes(max_model_len, pool_slots, prefill_only)?
         + if drafter.is_dspark() {
             crate::dspark::glm52_dspark_arena_bytes(max_model_len)
@@ -912,12 +911,7 @@ fn start_engine(
         }
     };
     let logical_ranks = moe_topo.logical_rank_count();
-    let kv_pool_slots = if prefill_only.is_some() {
-        1
-    } else {
-        model::GLM52_MAX_BATCH_PER_RANK
-    };
-    let kv_total_blocks = glm52_pool_blocks(max_model_len, kv_pool_slots) - 1;
+    let kv_total_blocks = glm52_pool_blocks(max_model_len, model::GLM52_MAX_BATCH_PER_RANK) - 1;
     // One autonomous engine per LOCAL logical rank (a mirrored topology
     // collapses to a single engine driving every worker). Each engine owns
     // its submit queue and load feed, so the frontend sees one scheduler
@@ -1674,7 +1668,7 @@ mod max_model_len_tests {
     }
 
     #[test]
-    fn shared_prefill_pool_outgrows_eight_slot_decode_cap() {
+    fn prefill_pool_budgets_the_full_slot_count_plus_scratch() {
         let prefill = Glm52PrefillOnlyOptions {
             chunk_size: GLM52_DEFAULT_PREFILL_CHUNK_SIZE,
         };
@@ -1686,9 +1680,15 @@ mod max_model_len_tests {
         let prefill =
             derive_max_model_len(None, free, &Glm52Drafter::None, scratch, true, TEST_TOPO)
                 .expect("prefill budget");
+        // Prefill-only budgets the full slot count too (the prefix cache
+        // retains released prefixes in the pool headroom), so its cap can
+        // only trail the decode cap — by exactly the scratch reservation.
         assert!(
-            prefill.max_model_len > decode.max_model_len,
-            "one shared prefill pool must fit a larger per-request cap than eight decode maxima"
+            prefill.max_model_len <= decode.max_model_len,
+            "prefill cap {} must not exceed the decode cap {} once both \
+             budget the full slot count",
+            prefill.max_model_len,
+            decode.max_model_len,
         );
         assert_eq!(prefill.reserve_bytes, GLM52_VRAM_RESERVE_BYTES + scratch);
     }

--- a/openinfer-glm52/src/model/mod.rs
+++ b/openinfer-glm52/src/model/mod.rs
@@ -552,11 +552,10 @@ impl Glm52RankModel {
         } else {
             glm52_flashmla_sparse_decode_num_sm_parts()?
         };
-        let pool_slots = if prefill_chunk_size.is_some() {
-            1
-        } else {
-            GLM52_MAX_BATCH_PER_RANK
-        };
+        // Prefill-only allocates the full slot count too — the scheduler pool
+        // is sized to match, and the prefix cache retains released prefixes
+        // in the headroom.
+        let pool_slots = GLM52_MAX_BATCH_PER_RANK;
         let pool_blocks = glm52_pool_blocks(max_model_len, pool_slots);
         let contract = Glm52FlashMlaSparseDecode {
             batch_size: batch,

--- a/openinfer-glm52/src/scheduler/admission.rs
+++ b/openinfer-glm52/src/scheduler/admission.rs
@@ -318,11 +318,10 @@ pub(super) fn admit_from_queue(
                 _ => None,
             };
             let mut kv = if native_mtp_prefill {
-                let cache_salt = super::native_mtp_cache_salt(&req.prompt_tokens);
                 pool.new_request_with_cache_salt(
                     req.prompt_tokens.clone(),
                     req.max_tokens,
-                    Some(&cache_salt),
+                    Some(super::native_mtp_cache_salt()),
                     None,
                 )
             } else {

--- a/openinfer-glm52/src/scheduler/mod.rs
+++ b/openinfer-glm52/src/scheduler/mod.rs
@@ -105,7 +105,17 @@ const PAGE: usize = GLM52_MODEL_LEN_ALIGN;
 const GLM52_SAMPLE_SEED: u64 = 42;
 
 fn prefix_cache_enabled(drafter: &crate::Glm52Drafter, no_prefix_cache: bool) -> bool {
-    !drafter.enabled() && !no_prefix_cache
+    match drafter {
+        // DSpark consumes aux-hidden captures produced by exactly the target
+        // forwards a prefix hit skips — missing state, not stale state (#590).
+        crate::Glm52Drafter::Dspark(_) => false,
+        // Native MTP's layer-78 KV rides the same pool page ids as the main
+        // cache, so a GPU radix hit reuses it for free: a hit means the pages
+        // were never recycled, and their L78 rows are exactly the ones written
+        // when the main KV was. See `native_mtp_cache_salt` for the
+        // shifted-token page-boundary caveat this accepts.
+        crate::Glm52Drafter::NativeMtp | crate::Glm52Drafter::None => !no_prefix_cache,
+    }
 }
 
 #[cfg(test)]
@@ -113,9 +123,15 @@ mod prefix_cache_policy_tests {
     use super::*;
 
     #[test]
-    fn native_mtp_never_matches_target_only_prefix_state() {
+    fn native_mtp_matches_prefixes_dspark_never_does() {
+        // Native MTP page identity is prefix-stable (constant salt) and its
+        // L78 KV lives at the matched pages themselves, so radix hits are
+        // sound; DSpark stays excluded — its aux-hidden captures cannot be
+        // recovered from a hit at all.
+        assert!(prefix_cache_enabled(&crate::Glm52Drafter::NativeMtp, false));
+        assert!(!prefix_cache_enabled(&crate::Glm52Drafter::NativeMtp, true));
         assert!(!prefix_cache_enabled(
-            &crate::Glm52Drafter::NativeMtp,
+            &crate::Glm52Drafter::Dspark(std::path::PathBuf::from("draft")),
             false
         ));
         assert!(prefix_cache_enabled(&crate::Glm52Drafter::None, false));
@@ -282,28 +298,30 @@ impl Glm52Engine {
         // for `glm52_pool_blocks` blocks). Block 0-equivalent is the reserved
         // padding page. Under mirrored TP the single pool drives every executor — the
         // mirrored steps write the identical block ids on all 8 arenas.
+        // The prefill-only pool sizes for the full slot count too (it used to
+        // hold exactly one request's lifetime): the prefix cache needs spare
+        // blocks to RETAIN released prefixes across turns, and the headroom
+        // lets admission overlap prefills instead of serializing them. MLA
+        // keeps this cheap (~54 KB/token/rank -> a few GiB at 16K x 8).
         let pool = BlockPool::new(
             PAGE,
-            glm52_pool_blocks(
-                spec.max_model_len,
-                if prefill_only {
-                    1
-                } else {
-                    GLM52_MAX_BATCH_PER_RANK
-                },
-            ),
+            glm52_pool_blocks(spec.max_model_len, GLM52_MAX_BATCH_PER_RANK),
         )?;
         let table_width = glm52_table_width(spec.max_model_len);
-        // A cache-hit prefix skips state required by either speculative lane:
-        // DSpark loses the aux-hidden captures it consumes. Native MTP loses
-        // continuity in its separate KV cache; TP4 P additionally restores only
-        // the 656-byte wire cache, not its 576-byte local proposal cache. Prefix
-        // matching therefore stays off while any drafter is active.
+        // Prefix matching policy lives in `prefix_cache_enabled`: DSpark is
+        // the only drafter that forces it off (aux-hidden captures cannot be
+        // recovered from a hit).
         let prefix_cache = prefix_cache_enabled(&spec.drafter, spec.no_prefix_cache);
         if spec.drafter.enabled() && !prefix_cache && !spec.no_prefix_cache {
-            log::info!("GLM5.2 prefix cache disabled: speculative decoding is on");
+            log::info!("GLM5.2 prefix cache disabled: DSpark drafting is on");
         }
-        let host_restore = (offload.is_some() && prefix_cache).then(offload::HostRestoreState::new);
+        // The prefill-only engine keeps host-tier restore off: a restore
+        // recovers the 656-byte wire arenas but neither the 576-byte
+        // FlashInfer proposal cache (unregistered) nor the mirrors on the
+        // other three ranks (the H2D lands on one rank's arena) — GPU radix
+        // hits have neither problem, so plain prefix matching stays on.
+        let host_restore = (offload.is_some() && prefix_cache && spec.prefill_chunk_size.is_none())
+            .then(offload::HostRestoreState::new);
         Ok(Self {
             rank: spec.rank,
             submit_rx: spec.submit_rx,
@@ -1377,19 +1395,25 @@ fn take_boundary_drafts<'a>(
     if boundary { drafts.next() } else { None }
 }
 
-/// Scope every lineage-hashed page in one native-MTP P/D request by its full
-/// committed prompt. Layer 78 consumes shifted tokens, so the last row of a
-/// page depends on the first token of the following page; token-only per-page
-/// hashes would otherwise alias MTP bytes across diverging continuations.
-fn native_mtp_cache_salt(committed_prompt: &[u32]) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(b"openinfer-glm52-native-mtp-pages-v1");
-    hasher.update((committed_prompt.len() as u64).to_le_bytes());
-    for token in committed_prompt {
-        hasher.update(token.to_le_bytes());
-    }
-    let digest = hasher.finalize();
-    hex::encode(&digest[..16])
+/// Partition lineage-hashed native-MTP pages from plain (drafterless) pages:
+/// layer-78 rows ride the same pool pages, so an MTP request must never match
+/// a block whose L78 arenas were never written — and vice versa.
+///
+/// The salt is CONSTANT, which makes page identity prefix-stable across
+/// requests and turns (v1 hashed the full prompt into the salt, which made
+/// every continuation its own cache universe and killed all cross-turn
+/// reuse). The accepted trade: layer 78 consumes shifted tokens, so the last
+/// MTP row of page k depends on the first token of page k+1. Two prompts
+/// that share pages and diverge EXACTLY at a page boundary therefore share
+/// one L78 row whose shifted input came from the other continuation. That
+/// row only feeds draft proposals — target verification rejects any draft it
+/// misleads, so output text is never affected. Same-conversation multi-turn
+/// extensions agree on every shared token and never alias at all; the
+/// anchor-dependent final row always lives in the tail page, which is
+/// excluded from lineage hashing (`native_pd_tail_len` keeps it explicit,
+/// `native_mtp_tail_key` scopes it by prompt + anchor).
+fn native_mtp_cache_salt() -> &'static str {
+    "openinfer-glm52-native-mtp-pages-v2"
 }
 
 fn native_mtp_tail_key(committed_prompt: &[u32], anchor_token: u32) -> [u8; 16] {
@@ -1442,21 +1466,18 @@ mod tp_prefill_output_tests {
     }
 
     #[test]
-    fn token_after_a_full_page_is_part_of_the_native_mtp_page_identity() {
-        let mut first = vec![7; PAGE + 1];
-        let mut second = first.clone();
-        first[PAGE] = 10;
-        second[PAGE] = 11;
-
-        assert_ne!(
-            native_mtp_cache_salt(&first),
-            native_mtp_cache_salt(&second),
-            "the last MTP row in page 0 consumes token PAGE through shifted input"
-        );
-        assert_eq!(
-            native_mtp_cache_salt(&first),
-            native_mtp_cache_salt(&first),
-            "P and D must derive the same cache scope from the committed prompt"
+    fn native_mtp_page_identity_is_prefix_stable() {
+        // The salt is constant: a turn that extends its predecessor derives
+        // identical block hashes for the shared prefix, so radix / host-tier
+        // reuse works across turns and requests. The v1 full-prompt salt made
+        // every continuation its own cache universe (zero reuse); the
+        // page-boundary shifted-token alias this accepts is draft-quality
+        // only — see `native_mtp_cache_salt`.
+        assert_eq!(native_mtp_cache_salt(), native_mtp_cache_salt());
+        assert!(
+            !native_mtp_cache_salt().is_empty(),
+            "the constant salt must still partition MTP pages from plain \
+             (drafterless) pages, whose L78 arenas were never written"
         );
     }
 }

--- a/openinfer-glm52/src/scheduler/offload.rs
+++ b/openinfer-glm52/src/scheduler/offload.rs
@@ -626,7 +626,7 @@ pub(super) fn admit_native_mtp_pd(
 
     let query_key = state.parked(rank, req).query_key.clone();
     let prompt_kv = &req.prompt_tokens[..handoff.committed_len];
-    let cache_salt = super::native_mtp_cache_salt(prompt_kv);
+    let cache_salt = super::native_mtp_cache_salt();
     let full_len = handoff.committed_len - handoff.tail_len;
 
     // Settle what this front parked for: its in-flight query or H2D load.
@@ -828,7 +828,7 @@ pub(super) fn admit_native_mtp_pd(
         // reports them as GPU-hit and the query window is empty.
         if full_hold.is_none() {
             let probe =
-                pool.probe_prefix_with_cache_salt(prompt_kv.to_vec(), Some(&cache_salt), None);
+                pool.probe_prefix_with_cache_salt(prompt_kv.to_vec(), Some(cache_salt), None);
             let hashes = probe.cpu_query_hashes();
             if !hashes.is_empty() {
                 // Decode-only can't recompute a miss: hold the query in
@@ -868,7 +868,7 @@ pub(super) fn admit_native_mtp_pd(
         let mut kv = pool.new_request_with_cache_salt(
             logical_prompt,
             kv_shape.max_output_tokens,
-            Some(&cache_salt),
+            Some(cache_salt),
             None,
         );
         let cached_tokens = kv.match_and_add_prefix(pool)?;


### PR DESCRIPTION
## Summary

Multi-turn agent traffic (long prompts, high prefix-hit ratio) was paying full-history prefill on **every turn**: with any drafter active, prefix matching was globally disabled, and the native-MTP cache salt (v1) hashed the entire prompt — every continuation lived in its own cache universe, so nothing (P radix, D radix, host tier) could ever be reused across turns. On top of that, the prefill-only pool held exactly one request, serializing P's prefills.

### Changes

- **`prefix_cache_enabled`**: only DSpark forces the cache off (its aux-hidden captures cannot be recovered from a hit — missing state, not stale state). Native MTP's layer-78 KV rides the same pool page ids as the main cache, so a GPU radix hit reuses it for free: a hit proves the pages were never recycled, and their L78 rows are exactly the ones written alongside the main KV.
- **`native_mtp_cache_salt` becomes constant (v2)**, making page identity prefix-stable. The accepted trade: layer 78 consumes shifted tokens, so two prompts that diverge *exactly at a page boundary* share one L78 row whose shifted input came from the other continuation. That row only feeds draft proposals — target verification rejects any draft it misleads — so output text is never affected. Same-conversation extensions agree on every shared token and never alias; the anchor-dependent final row always lives in the explicitly-keyed tail page (excluded from lineage hashing).
- **Prefill-only pool sizes the full slot count** (arena allocation, VRAM budget, and capacity report aligned): the prefix cache needs headroom to retain released prefixes across turns, and prefills overlap instead of queueing head-of-line. MLA keeps this cheap (~54 KB/token/rank).
- Host-tier restore stays **off** on the prefill-only engine: a restore recovers the 656-byte wire arenas but neither the 576-byte FlashInfer proposal cache (unregistered) nor the mirrors on the other ranks. Radix hits have neither problem.

## Validation (2P TP4 + 1D EP4, multi-turn 1024+256/turn × 8 turns, temp 0)

- **Greedy goldens byte-identical** across the flip (2-turn conversation through the router).
- **c1 per-turn TTFT p50**: `303, 271, 270, 270, 271, 271, 302, 281` ms — flat. Before: `243 → 374` ms, linear in history (projected ~3× gap at 8K-token histories).
- **c8 per-turn TTFT p50**: late turns `454/374` ms, **was `1,186/993`**; p99 flat ~600–900 ms, was growing to 2,247 — concurrent prefills replace the serial queue.
- 24/24 conversations, zero failures, D admits on every turn; `cargo test -p openinfer-glm52 --lib` green (known no-GPU env failure only).
- Salt v2 is a cache-format break with v1 saves: cold start only, both P and D must run the same build (deployed and verified together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)