### PR TITLE
perf(glm52): packed q_a|kv_a GEMM on the wide-bucket route (#812)

### DIFF
--- a/docs/models/glm52/ep4-gb300.md
+++ b/docs/models/glm52/ep4-gb300.md
@@ -422,6 +422,30 @@ Mechanics:
   twin + split-reduce against separate launches at t=8; dense/EP4/bookend
   oracles green.
 
+### Wide-bucket packed route (2026-08, PR #815)
+
+The 16/32/48-row verify-span buckets (#813) route projections through the
+fp8 groupwise GEMM instead of the mma table, and the same packed twin now
+serves that route too — a DISTINCT execution path from the batch-8
+split-reduce above:
+
+- **One** activation quant + **one** n=2624 groupwise GEMM on the packed
+  twin, then a new `extract_hidden_rows` kernel (the inverse of
+  `copy_hidden_rows`) splits the packed `[T, 2624]` output into the compact
+  q_a `[T, 2048]` and ckv `[T, 576]` buffers; `front_rest` skips its kv_a
+  launch under the same `qa_kva_packed_wide` predicate. This replaces two
+  quants + two skinny GEMMs per layer (the #812 profile's 18.4%-at-7%-MFU
+  cutlass item plus the 6.6% double-quant).
+- Scale-tile validity: q_a's n=2048 is 16 whole 128-tiles, so kv_a's scale
+  tiles start tile-aligned inside the pack, and the plain groupwise entry
+  only requires `m % 4` and `k % 128` (n=2624 is fine at n%8).
+- The twin still builds only where the batch-8 mma table routes the packed
+  shape (all layers on Blackwell), so wide-route coverage is full whenever
+  the split-reduce route exists; neither route changes greedy output
+  (byte-identical smoke vs main).
+- Measured (EP4 saturation, 256in/1024out, temp 0, zero failures):
+  c48 1,547 → 1,589 tok/s (+2.7%, TPOT 17.1 → 17.0 ms); c32 flat in noise.
+
 ## Pitfalls
 
 - `EP_DISABLE_GIN=1` is required on NIC-less nodes or `ctx_create` fails

--- a/openinfer-glm52/src/mla_front.rs
+++ b/openinfer-glm52/src/mla_front.rs
@@ -9,6 +9,7 @@ use anyhow::ensure;
 use cudarc::driver::CudaSlice;
 use half::bf16;
 use openinfer_kernels::ops::GLM52_GEMV_MMA_SCRATCH_FLOATS_PER_ROW;
+use openinfer_kernels::ops::extract_hidden_rows_raw_into;
 use openinfer_kernels::ops::glm52_gemv_mma_routes;
 use openinfer_kernels::ops::glm52_gemv_split_reduce_launch;
 use openinfer_kernels::ops::glm52_mla_ckv_split_launch;
@@ -71,7 +72,9 @@ pub(crate) struct Glm52MlaLayerWeights {
     // alone (7.3 vs 7.1 us at batch 8 on GB300 — the kv_a bytes ride free).
     // Built only where the mma table routes the packed shape (Blackwell batch
     // 8); everywhere else the separate weights above stay the launch path, so
-    // the twin costs ~15.4 MiB/layer only where it earns its keep.
+    // the twin costs ~15.4 MiB/layer only where it earns its keep. The
+    // wide-bucket GEMM route (#812) reuses the same pack: one GEMM + one
+    // activation quant replace the separate q_a/kv_a pair there too.
     qa_kva: Option<ProjWeight>,
     pub(crate) heads: usize,
 }
@@ -477,7 +480,34 @@ pub(crate) fn glm52_mla_front_q_into(
             &mut front.ckv,
         )?;
     } else if let Some(wide) = front.wide.as_mut() {
-        fp8_linear_large_m_into(ctx, &w.q_a, t, hidden.data(), wide, &mut front.q_a)?;
+        if let Some(qa_kva) = w.qa_kva.as_ref() {
+            // One packed GEMM computes q_a AND kv_a from ONE quantization of
+            // `hidden` — the #812 profile showed the wide step dominated by
+            // skinny per-projection GEMMs plus their activation quants; the
+            // pack halves both for this pair. `front_rest` skips its kv_a
+            // launch (same `qa_kva_packed_wide` predicate).
+            fp8_linear_large_m_into(ctx, qa_kva, t, hidden.data(), wide, &mut front.qa_kva_out)?;
+            extract_hidden_rows_raw_into(
+                ctx,
+                &front.qa_kva_out,
+                Q_LORA + KV_A_OUT,
+                &mut front.q_a,
+                Q_LORA,
+                0,
+                t,
+            )?;
+            extract_hidden_rows_raw_into(
+                ctx,
+                &front.qa_kva_out,
+                Q_LORA + KV_A_OUT,
+                &mut front.ckv,
+                KV_A_OUT,
+                Q_LORA,
+                t,
+            )?;
+        } else {
+            fp8_linear_large_m_into(ctx, &w.q_a, t, hidden.data(), wide, &mut front.q_a)?;
+        }
     } else {
         fp8_linear_into(
             ctx,
@@ -507,6 +537,12 @@ fn qa_kva_fused(w: &Glm52MlaLayerWeights, t: usize) -> Result<Option<&ProjWeight
         return Ok(None);
     };
     Ok(glm52_gemv_mma_routes(t, qa_kva.n, qa_kva.k)?.then_some(qa_kva))
+}
+
+/// Whether the wide-bucket route already computed kv_a through the packed
+/// q_a|kv_a GEMM (#812) — front_rest's twin of [`qa_kva_fused`].
+fn qa_kva_packed_wide(w: &Glm52MlaLayerWeights, front: &Glm52MlaFront) -> bool {
+    w.qa_kva.is_some() && front.wide.is_some()
 }
 
 /// The remainder of the MLA front: q_b + kv_a projections and the kv_c/k_pe
@@ -548,7 +584,7 @@ pub(crate) fn glm52_mla_front_rest_into(
             &mut front.q_full,
         )?; // [T, heads, 256]
     }
-    if t != 1 && qa_kva_fused(w, t)?.is_none() {
+    if t != 1 && qa_kva_fused(w, t)?.is_none() && !qa_kva_packed_wide(w, front) {
         if let Some(wide) = front.wide.as_mut() {
             fp8_linear_large_m_into(ctx, &w.kv_a, t, hidden.data(), wide, &mut front.ckv)?;
         } else {

--- a/openinfer-kernels/csrc/shared/elementwise.cu
+++ b/openinfer-kernels/csrc/shared/elementwise.cu
@@ -101,6 +101,28 @@ __global__ void copy_hidden_rows_kernel(
   }
 }
 
+// Inverse of copy_hidden_rows_kernel: extract a column window
+// [col_offset, col_offset + rows) of each token's wide src row into a
+// compact dst row (the packed-projection split, #812).
+__global__ void extract_hidden_rows_kernel(
+    const __nv_bfloat16 *__restrict__ src,
+    __nv_bfloat16 *__restrict__ dst,
+    int src_hidden_dim,
+    int dst_hidden_dim,
+    int col_offset,
+    int rows,
+    int seq_len) {
+  int total = rows * seq_len;
+  for (int idx = blockIdx.x * blockDim.x + threadIdx.x;
+       idx < total;
+       idx += gridDim.x * blockDim.x) {
+    int token = idx / rows;
+    int row = idx % rows;
+    dst[(size_t)token * dst_hidden_dim + row] =
+        src[(size_t)token * src_hidden_dim + col_offset + row];
+  }
+}
+
 __global__ void mask_position_zero_rows_kernel(
     const __nv_bfloat16 *__restrict__ src,
     const uint32_t *__restrict__ positions,
@@ -445,6 +467,28 @@ CUresult gather_hidden_tokens_cuda(
   int grid = (total + block - 1) / block;
   gather_hidden_tokens_kernel<<<grid, block, 0, stream>>>(
       input, token_indices, out, hidden_dim, token_count, input_seq_len);
+  return (CUresult)cudaGetLastError();
+}
+
+CUresult extract_hidden_rows_cuda(
+    const __nv_bfloat16 *src,
+    __nv_bfloat16 *dst,
+    int src_hidden_dim,
+    int dst_hidden_dim,
+    int col_offset,
+    int rows,
+    int seq_len,
+    cudaStream_t stream) {
+  if (src == nullptr || dst == nullptr || src_hidden_dim <= 0 ||
+      dst_hidden_dim <= 0 || col_offset < 0 || rows <= 0 || seq_len <= 0 ||
+      rows > dst_hidden_dim || col_offset + rows > src_hidden_dim) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  int total = rows * seq_len;
+  int block = 256;
+  int grid = (total + block - 1) / block;
+  extract_hidden_rows_kernel<<<grid, block, 0, stream>>>(
+      src, dst, src_hidden_dim, dst_hidden_dim, col_offset, rows, seq_len);
   return (CUresult)cudaGetLastError();
 }
 

--- a/openinfer-kernels/src/ffi/shared.rs
+++ b/openinfer-kernels/src/ffi/shared.rs
@@ -41,6 +41,17 @@ unsafe extern "C" {
         stream: CUstream,
     ) -> CUresult;
 
+    pub fn extract_hidden_rows_cuda(
+        src: *const Half,
+        dst: *mut Half,
+        src_hidden_dim: i32,
+        dst_hidden_dim: i32,
+        col_offset: i32,
+        rows: i32,
+        seq_len: i32,
+        stream: CUstream,
+    ) -> CUresult;
+
     pub fn copy_hidden_rows_cuda(
         src: *const Half,
         dst: *mut Half,

--- a/openinfer-kernels/src/ops.rs
+++ b/openinfer-kernels/src/ops.rs
@@ -72,6 +72,7 @@ pub use elementwise::bf16_hidden_to_f32_into;
 pub use elementwise::copy_hidden_rows_into;
 pub use elementwise::copy_hidden_rows_raw_into;
 pub use elementwise::copy_hidden_token_range_into;
+pub use elementwise::extract_hidden_rows_raw_into;
 pub use elementwise::extract_vec;
 pub use elementwise::extract_vec_into;
 pub use elementwise::extract_vec_ref;

--- a/openinfer-kernels/src/ops/elementwise.rs
+++ b/openinfer-kernels/src/ops/elementwise.rs
@@ -282,6 +282,53 @@ pub fn copy_hidden_rows_into(
 /// [`copy_hidden_rows_into`] over raw device slices: per token, copy the
 /// `src_dim` features of `src` (row stride `src_dim`) into `dst` at feature
 /// offset `row_offset` (row stride `dst_dim`), for `tokens` tokens.
+/// Inverse of [`copy_hidden_rows_raw_into`]: extract the column window
+/// `[col_offset, col_offset + dst_dim)` of each token's `src_dim`-wide row
+/// into a compact `dst_dim`-wide destination row — the packed-projection
+/// output split (#812).
+pub fn extract_hidden_rows_raw_into(
+    ctx: &DeviceContext,
+    src: &CudaSlice<half::bf16>,
+    src_dim: usize,
+    dst: &mut CudaSlice<half::bf16>,
+    dst_dim: usize,
+    col_offset: usize,
+    tokens: usize,
+) -> Result<()> {
+    assert!(
+        col_offset + dst_dim <= src_dim,
+        "column window [{}..{}) exceeds source hidden_dim {}",
+        col_offset,
+        col_offset + dst_dim,
+        src_dim
+    );
+    assert!(
+        tokens * src_dim <= src.len() && tokens * dst_dim <= dst.len(),
+        "extract_hidden_rows_raw_into token count {} exceeds src {} / dst {} capacity",
+        tokens,
+        src.len(),
+        dst.len()
+    );
+
+    let (src_ptr, _gs) = src.device_ptr(&ctx.stream);
+    let (dst_ptr, _gd) = dst.device_ptr_mut(&ctx.stream);
+    let result = unsafe {
+        ffi::extract_hidden_rows_cuda(
+            src_ptr as *const ffi::Half,
+            dst_ptr as *mut ffi::Half,
+            src_dim as i32,
+            dst_dim as i32,
+            col_offset as i32,
+            dst_dim as i32,
+            tokens as i32,
+            crate::tensor::active_cu_stream(ctx),
+        )
+    };
+    result
+        .result()
+        .map_err(|err| anyhow!("extract_hidden_rows launch failed: {err}"))
+}
+
 pub fn copy_hidden_rows_raw_into(
     ctx: &DeviceContext,
     src: &CudaSlice<half::bf16>,


### PR DESCRIPTION
## Summary

Low-hanging fruit from the #812 kernel profile: at wide decode buckets, the MLA front ran two skinny fp8 projections (`q_a` [2048×6144], `kv_a` [576×6144]) back-to-back, each with its own activation quant — and the profile showed these cutlass wide projections at 18.4% of GPU time at ~7% MFU, plus 6.6% spent quantizing the **same** hidden activations twice per layer.

Both projections read `hidden`, and the horizontally packed `q_a|kv_a` weight twin ([2624, 6144]) already exists for the batch-8 mma route. This PR reuses it on the wide-bucket GEMM route: **one** quant + **one** n=2624 groupwise GEMM, then a new `extract_hidden_rows` kernel (the inverse of `copy_hidden_rows`) splits the packed output into the compact `q_a` / `ckv` buffers downstream code expects. `front_rest` skips its `kv_a` launch under the same predicate, mirroring the existing mma-fused contract.

Scale-tile correctness: `q_a.n = 2048` is 16 whole 128-tiles, so `kv_a`'s scale tiles start on a tile boundary in the pack, and the plain groupwise GEMM entry only requires `m % 4 == 0` and `k % 128 == 0` (n = 2624 is fine at n % 8).

## Results (EP4 saturation, 256 in / 1024 out, temp 0, ignore-eos)

| conc | baseline (main) | this PR | Δ |
|---|---|---|---|
| c48 | 1,547 tok/s, TPOT 17.14 ms | **1,589 tok/s, TPOT 16.95 ms** | **+2.7%** |
| c32 | 1,449 tok/s, TPOT 17.29 ms | 1,430 tok/s, TPOT 16.93 ms | noise |

Zero failed requests; greedy smoke output byte-identical to main. The packed twin builds on all layers on Blackwell (mma-table gate hits at max batch), so this is full-coverage yield.

## SwiGLU→fp8 fusion descoped

The other candidate from the profile (fusing silu+mul with the fp8 quant in `fp8_mlp_into`) was dropped: that path only serves the **dense** layers (~1/79 of the step). The routed and shared experts already run the fused masked silu+quant inside the EP chain, so a new fused kernel there cannot pay for itself. Next fruit is #812 stage 2 (configurable draft length 5→2).

## Testing

- `cargo test --release -p openinfer-glm52 --lib` — 112 pass (known env-only failure `moe_tp::scale_staging_geometry` unrelated)
- EP4 hardware A/B above; greedy smoke byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)