### PR TITLE
feat(glm52): EP32 serving + 16-slot/2-draft throughput profile — 626 tok/s per GPU under 20 ms TPOT (#812)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ cargo run --release --features glm52 -- --model-path models/GLM5.2
 - `OPENINFER_TEST_MODEL_PATH` — override test model path (default: `models/Qwen3-4B`)
 - `OPENINFER_BUILD_TIMING=1` — print per-phase build timings (nvcc, Triton AOT, etc.)
 - `OPENINFER_NVCC_JOBS` — override parallel nvcc job count
+- `GLM52_DECODE_SLOTS` / `GLM52_MTP_DRAFTS` — glm52 runtime profile: decode slots per rank (default 8, ceiling 16) and MTP draft span (default 5); `slots x (1+drafts)` must fit the 48-row step (validated at launch). Wide-EP throughput profile: `16` / `2`.
 
 ## Tests
 

--- a/docs/models/glm52/cross-node-scaling.md
+++ b/docs/models/glm52/cross-node-scaling.md
@@ -4,7 +4,12 @@
 > ONE NVLink/IMEX domain, so the existing single-LSA DeepEP shim works cross-tray with
 > **no GIN un-baking at all** — live-verified up to **EP32 across 8 trays**: bucket-1 solo p50
 > is flat at ~23.3-23.6 ms from EP4 loopback through EP32 (intra-rack width tax ≈ nil),
-> bucket-8 EP32 c256 9072 tok/s, greedy text coherent through the serving path (EP8). EP widths
+> bucket-8 EP32 c256 9072 tok/s, greedy text coherent through the serving path (EP8). **EP32
+> serving is production-shaped (2026-08, #812 stages 2+3):** 8-tray decode fleet + 3x TP4
+> prefill + router, throughput profile `GLM52_DECODE_SLOTS=16 GLM52_MTP_DRAFTS=2` (same 48-row
+> step as the 8x5+1 latency profile) — fleet c512 through the router: **626 tok/s per D-GPU,
+> mean TPOT 19.8 ms, zero failures** (decode-only endpoints: 522 at c64/node, 559 at 1.5x
+> oversubscription). Width remains a KV-capacity lever, not a throughput one. EP widths
 > {4,8,16,32,64} each get a constexpr shim instantiation + `Glm52MoeTopo` variant; the
 > weight-only expert chain is ABI-generic so a new width is a config header, not new code.
 > The GIN scale-out sections below remain the design for IB/RoCE clusters beyond one rack.
@@ -18,7 +23,7 @@
 > cross-tray LSA), and a remote-node teardown must `shutdown()` the socket, not just drop
 > the writer (a reader clone keeps the fd alive → no FIN → both sides hang).
 >
-> **Last touched:** 2026-07
+> **Last touched:** 2026-08
 
 ## Scope and status
 

--- a/openinfer-glm52/src/lib.rs
+++ b/openinfer-glm52/src/lib.rs
@@ -441,6 +441,17 @@ pub fn launch(model_path: &Path, options: Glm52LaunchOptions) -> Result<EngineHa
         ranks.start,
         ranks.end
     );
+    // The (slots, drafts) startup pair must fit the 48-row step budget —
+    // an over-committed pair would silently cap verify spans under full
+    // occupancy and collapse speculation (#812's original failure mode).
+    let slots = model::glm52_decode_slots();
+    let draft_len = crate::mtp::glm52_mtp_draft_len();
+    ensure!(
+        slots * (1 + draft_len) <= model::GLM52_MAX_STEP_ROWS,
+        "GLM5.2 GLM52_DECODE_SLOTS={slots} x (1 + GLM52_MTP_DRAFTS={draft_len}) exceeds the \
+         {}-row step budget; 16 slots need GLM52_MTP_DRAFTS=2",
+        model::GLM52_MAX_STEP_ROWS
+    );
     // Probe only the GPUs this process hosts (local ordinals 0..N), not the
     // global EP width — EP16 on one 4-GPU tray would otherwise try device 4+.
     ensure_blackwell_devices(ranks.end - ranks.start)?;
@@ -629,7 +640,7 @@ fn glm52_cap_bytes(
     // Prefill-only sizes the full slot count too (it used to hold exactly one
     // request): the prefix cache needs blocks to retain released prefixes
     // across turns, and the headroom lets prefills overlap.
-    let pool_slots = model::GLM52_MAX_BATCH_PER_RANK;
+    let pool_slots = model::glm52_decode_slots();
     Ok(glm52_arena_bytes(max_model_len, pool_slots, prefill_only)?
         + if drafter.is_dspark() {
             crate::dspark::glm52_dspark_arena_bytes(max_model_len)
@@ -842,7 +853,7 @@ fn start_engine(
         ByteSize(qa_kva_twin_bytes as u64),
         ByteSize(deepgemm_vram_charge_bytes as u64),
         ByteSize(budget.arena_bytes as u64),
-        model::GLM52_MAX_BATCH_PER_RANK,
+        model::glm52_decode_slots(),
         if drafter.enabled() {
             " (draft lane included)"
         } else {
@@ -911,7 +922,7 @@ fn start_engine(
         }
     };
     let logical_ranks = moe_topo.logical_rank_count();
-    let kv_total_blocks = glm52_pool_blocks(max_model_len, model::GLM52_MAX_BATCH_PER_RANK) - 1;
+    let kv_total_blocks = glm52_pool_blocks(max_model_len, model::glm52_decode_slots()) - 1;
     // One autonomous engine per LOCAL logical rank (a mirrored topology
     // collapses to a single engine driving every worker). Each engine owns
     // its submit queue and load feed, so the frontend sees one scheduler

--- a/openinfer-glm52/src/lib.rs
+++ b/openinfer-glm52/src/lib.rs
@@ -444,8 +444,14 @@ pub fn launch(model_path: &Path, options: Glm52LaunchOptions) -> Result<EngineHa
     // The (slots, drafts) startup pair must fit the 48-row step budget —
     // an over-committed pair would silently cap verify spans under full
     // occupancy and collapse speculation (#812's original failure mode).
+    // Only native MTP rides verify spans; without a drafter every slot is a
+    // single decode row and any slot count within the ceiling fits.
     let slots = model::glm52_decode_slots();
-    let draft_len = crate::mtp::glm52_mtp_draft_len();
+    let draft_len = if drafter.is_mtp() {
+        crate::mtp::glm52_mtp_draft_len()
+    } else {
+        0
+    };
     ensure!(
         slots * (1 + draft_len) <= model::GLM52_MAX_STEP_ROWS,
         "GLM5.2 GLM52_DECODE_SLOTS={slots} x (1 + GLM52_MTP_DRAFTS={draft_len}) exceeds the \

--- a/openinfer-glm52/src/mla_front.rs
+++ b/openinfer-glm52/src/mla_front.rs
@@ -201,11 +201,7 @@ fn pack_qa_kva(
     q_a: &ProjWeight,
     kv_a: &ProjWeight,
 ) -> Result<Option<ProjWeight>> {
-    if !glm52_gemv_mma_routes(
-        crate::model::GLM52_MAX_BATCH_PER_RANK,
-        q_a.n + kv_a.n,
-        q_a.k,
-    )? {
+    if !glm52_gemv_mma_routes(crate::fp8::FP8_GEMV_MAX_ROWS, q_a.n + kv_a.n, q_a.k)? {
         return Ok(None);
     }
     Ok(Some(pack_proj_pair(ctx, q_a, kv_a)?))
@@ -220,7 +216,7 @@ fn pack_qa_kva(
 /// headroom re-probe is the backstop.
 pub(crate) fn glm52_qa_kva_twin_bytes() -> Result<usize> {
     let n = Q_LORA + KV_A_OUT;
-    if !glm52_gemv_mma_routes(crate::model::GLM52_MAX_BATCH_PER_RANK, n, HIDDEN)? {
+    if !glm52_gemv_mma_routes(crate::fp8::FP8_GEMV_MAX_ROWS, n, HIDDEN)? {
         return Ok(0);
     }
     let scale = n.div_ceil(FP8_BLOCK) * HIDDEN.div_ceil(FP8_BLOCK) * 4;

--- a/openinfer-glm52/src/model/mod.rs
+++ b/openinfer-glm52/src/model/mod.rs
@@ -81,10 +81,29 @@ use launch_ahead::Glm52SpeculatedStep;
 use mtp::Glm52NativeMtp;
 use step_body::run_step_body;
 
-/// The per-rank slot count and the largest decode bucket. A slot is a batch
-/// lane (and the draft lane's state key), not a cache region — KV pages come
-/// from the rank's shared pool.
-pub(crate) const GLM52_MAX_BATCH_PER_RANK: usize = 8;
+/// The compile-time slot-count CEILING: fixed arrays (`RankSlots`,
+/// launch-ahead seen-sets, contiguity walks) are sized to it. A slot is a
+/// batch lane (and the draft lane's state key), not a cache region — KV
+/// pages come from the rank's shared pool. The count actually admitted and
+/// sized for is [`glm52_decode_slots`], a startup knob; the pair
+/// (slots, drafts) must satisfy `slots * (1 + drafts) <= GLM52_MAX_STEP_ROWS`
+/// (validated at engine build), so the ceiling is only reachable with a
+/// shortened draft span.
+pub(crate) const GLM52_MAX_BATCH_PER_RANK: usize = 16;
+
+/// The per-rank decode slot count: `GLM52_DECODE_SLOTS` (1..=ceiling),
+/// default 8 — the latency-lean P/D profile. Wide-EP throughput deployments
+/// run 16 slots with `GLM52_MTP_DRAFTS=2` to stay inside the 48-row step.
+pub(crate) fn glm52_decode_slots() -> usize {
+    static SLOTS: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *SLOTS.get_or_init(|| {
+        std::env::var("GLM52_DECODE_SLOTS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .map(|v| v.clamp(1, GLM52_MAX_BATCH_PER_RANK))
+            .unwrap_or(8)
+    })
+}
 
 /// Cache geometry is carved in units of the 64-token FlashMLA page (== the
 /// index-K cache block), so the per-request context cap must sit on a page
@@ -188,13 +207,15 @@ fn glm52_persistent_mla_bytes_per_token(
     }
 }
 
-/// The step-row ceiling: every slot verifying at the full native-MTP span
-/// (1 anchor + `GLM52_MTP_DRAFTS` drafts). Step rows and slots are SEPARATE
-/// dimensions — they were both 8 until #812, which silently capped verify
-/// spans at 1 row/slot under full occupancy and collapsed speculation
-/// (measured: TPOT == ITL at c32 on EP4).
-pub(crate) const GLM52_MAX_STEP_ROWS: usize =
-    GLM52_MAX_BATCH_PER_RANK * (1 + crate::mtp::GLM52_MTP_DRAFTS);
+/// The step-row ceiling. Step rows and slots are SEPARATE dimensions — they
+/// were both 8 until #812, which silently capped verify spans at 1 row/slot
+/// under full occupancy and collapsed speculation (measured: TPOT == ITL at
+/// c32 on EP4). Since the slot count and draft length became startup knobs
+/// this is a standalone budget the runtime pair must fit
+/// (`slots * (1 + drafts) <= 48`, validated at engine build): 8 slots ride
+/// the full 5-draft span, 16 slots ride a 2-draft span — same row ceiling,
+/// so every #813 bucket, graph, and kernel instantiation is shared.
+pub(crate) const GLM52_MAX_STEP_ROWS: usize = 48;
 
 /// The decode batch buckets, ascending. Each bucket has its own captured
 /// CUDA graphs, scratch arena, and FlashMLA plans, and the batched GEMV
@@ -211,13 +232,11 @@ pub(crate) const GLM52_DECODE_BUCKETS: [usize; 7] = [1, 2, 4, 8, 16, 32, GLM52_M
 // bucket list must match the decode buckets.
 
 // DeepEP protocol worst-case: each source token contributes ≤1 row per
-// local expert, so fleet_ranks × max_batch must fit the per-expert slab.
-// Compile-time so a future GLM52_MAX_BATCH_PER_RANK bump fails here, not at
-// graph capture.
-const _: () = assert!(
-    crate::weights::GLM52_EP_RANKS * GLM52_MAX_BATCH_PER_RANK
-        <= openinfer_kernels::ops::GLM52_DEEPGEMM_MASKED_CAP
-);
+// local expert. The per-expert recv slab is sized at RUNTIME from the launch
+// topology (`deepgemm_masked_cap(num_ranks)` = ranks × GLM52_MAX_STEP_ROWS,
+// alignment-padded), so no compile-time rank×batch bound exists anymore —
+// the EP8-flavored `GLM52_DEEPGEMM_MASKED_CAP` assert that stood here
+// predated verify-span rows and under-counted every fleet wider than EP8.
 
 // The min-latency GEMV (router logits, indexer weights_proj) dispatches
 // tokens 1..=8 plus the decode bucket sizes; a bucket bump must extend
@@ -594,7 +613,7 @@ impl Glm52RankModel {
         // Prefill-only allocates the full slot count too — the scheduler pool
         // is sized to match, and the prefix cache retains released prefixes
         // in the headroom.
-        let pool_slots = GLM52_MAX_BATCH_PER_RANK;
+        let pool_slots = glm52_decode_slots();
         let pool_blocks = glm52_pool_blocks(max_model_len, pool_slots);
         let contract = Glm52FlashMlaSparseDecode {
             batch_size: batch,

--- a/openinfer-glm52/src/model/mtp.rs
+++ b/openinfer-glm52/src/model/mtp.rs
@@ -273,8 +273,14 @@ impl Glm52NativeMtp {
         let layer =
             build::build_decoder_layer(ctx, weights, GLM52_MTP_LAYER, moe_topo, attn_shard)?;
 
-        let committed_blocks = glm52_pool_blocks(max_model_len, GLM52_MAX_BATCH_PER_RANK);
-        let num_blocks = committed_blocks + GLM52_MAX_BATCH_PER_RANK * MTP_SCRATCH_PAGES_PER_SLOT;
+        // The committed region mirrors the main pool's page ids 1:1 (radix
+        // hits reuse L78 KV by page id), so it must be sized from the SAME
+        // runtime slot count as the pool — the scratch pair pages sit
+        // directly after it. Ceiling-sizing here would both waste VRAM and
+        // desync the ledger in `glm52_mtp_arena_bytes`.
+        let slots = crate::model::glm52_decode_slots();
+        let committed_blocks = glm52_pool_blocks(max_model_len, slots);
+        let num_blocks = committed_blocks + slots * MTP_SCRATCH_PAGES_PER_SLOT;
         let table_width = glm52_table_width(max_model_len);
         let index_layout = Glm52IndexerCacheLayout {
             cache_blocks: num_blocks,

--- a/openinfer-glm52/src/model/mtp.rs
+++ b/openinfer-glm52/src/model/mtp.rs
@@ -127,8 +127,8 @@ mod tests {
     #[test]
     fn tp4_mtp_arena_ledger_charges_the_second_cache() {
         let cap = 16_384;
-        let blocks =
-            glm52_pool_blocks(cap, GLM52_MAX_BATCH_PER_RANK) + 2 * GLM52_MAX_BATCH_PER_RANK;
+        let slots = crate::model::glm52_decode_slots();
+        let blocks = glm52_pool_blocks(cap, slots) + 2 * slots;
         let extra_execution_mla = blocks
             * GLM52_FLASHMLA_SPARSE_PAGE_SIZE
             * openinfer_kernels::ops::GLM52_FLASHINFER_SPARSE_BYTES_PER_TOKEN;
@@ -594,7 +594,7 @@ impl Glm52NativeMtp {
         for (span, &row) in spans.iter_mut().zip(&last_rows) {
             span[0] = context_tokens[row];
         }
-        for iteration in 1..GLM52_MTP_DRAFTS {
+        for iteration in 1..crate::mtp::glm52_mtp_draft_len() {
             let inputs: Vec<(usize, u32, usize, Option<&[i32]>)> = proposal_slots
                 .iter()
                 .enumerate()

--- a/openinfer-glm52/src/mtp.rs
+++ b/openinfer-glm52/src/mtp.rs
@@ -37,13 +37,30 @@ use crate::config::GLM52_HIDDEN;
 use crate::config::GLM52_INDEX_HEAD_DIM;
 use crate::config::GLM52_RMS_EPS;
 use crate::model::GLM52_DECODE_BUCKETS;
-use crate::model::GLM52_MAX_BATCH_PER_RANK;
 use crate::model::GLM52_MODEL_LEN_ALIGN;
 use crate::model::glm52_pool_blocks;
 use crate::rows::Rows;
 
 const MTP_FUSED_INPUT: usize = 2 * GLM52_HIDDEN;
 pub(crate) const GLM52_MTP_DRAFTS: usize = 5;
+
+/// The draft span length actually proposed and verified: `GLM52_MTP_DRAFTS`
+/// (1..=5), default the full 5. Every wire/array shape stays at the compile
+/// ceiling — a shorter span just leaves the tail rows unproposed, so P and D
+/// may even disagree on this knob (D truncates to its own length; a longer
+/// D span verifies zero-filled rows that simply fail the prefix match).
+/// Wide-EP throughput deployments pair 2 drafts with 16 decode slots: fewer
+/// sequential proposal forwards per step, same 48-row verify ceiling.
+pub(crate) fn glm52_mtp_draft_len() -> usize {
+    static LEN: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *LEN.get_or_init(|| {
+        std::env::var("GLM52_MTP_DRAFTS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .map(|v| v.clamp(1, GLM52_MTP_DRAFTS))
+            .unwrap_or(GLM52_MTP_DRAFTS)
+    })
+}
 
 /// Context-scaled device memory owned by the native MTP lane: one execution
 /// cache, TP4's additional P/D wire cache, and one set of per-bucket indexer
@@ -57,8 +74,8 @@ pub(crate) fn glm52_mtp_arena_bytes(
     // Two private pages per slot hold unverified proposal KV. Committed
     // layer-78 rows use the target BlockPool page IDs and are transferable;
     // scratch pages sit beyond that registered range.
-    let blocks =
-        glm52_pool_blocks(max_model_len, GLM52_MAX_BATCH_PER_RANK) + 2 * GLM52_MAX_BATCH_PER_RANK;
+    let blocks = glm52_pool_blocks(max_model_len, crate::model::glm52_decode_slots())
+        + 2 * crate::model::glm52_decode_slots();
     let execution_bytes_per_token = if topology == crate::Glm52MoeTopo::Tp4 {
         openinfer_kernels::ops::GLM52_FLASHINFER_SPARSE_BYTES_PER_TOKEN
     } else {

--- a/openinfer-glm52/src/prefill_tp.rs
+++ b/openinfer-glm52/src/prefill_tp.rs
@@ -858,6 +858,31 @@ impl Glm52TpPrefillExecutor {
             batch.positions.len() == rows && batch.slot_mapping.len() == rows,
             "prefill chunk rows/positions mismatch"
         );
+        // The cache-pack kernel traps (unrecoverable launch failure with no
+        // context) on any out-of-window slot. Catch a poisoned batch here
+        // with context instead — this is the contract that the scheduler's
+        // pool and the executor's cache slab are sized from the SAME slot
+        // count (a drift once shipped page ids past the slab, #816).
+        let kv_slots = self.layout.kv_slots as i64;
+        for (row, &slot) in batch.slot_mapping.iter().enumerate() {
+            ensure!(
+                (0..kv_slots).contains(&slot),
+                "prefill chunk slot_mapping[{row}] = {slot} outside the {kv_slots}-slot cache \
+                 window: position={} request_indptr={:?} block_indptr={:?} block_ids(head)={:?}",
+                batch.positions[row],
+                batch.request_indptr,
+                batch.block_indptr,
+                &batch.block_ids[..batch.block_ids.len().min(24)],
+            );
+        }
+        for (i, &page) in batch.block_ids.iter().enumerate() {
+            ensure!(
+                page >= 0 && (page as i64 + 1) * 64 <= kv_slots,
+                "prefill chunk block_ids[{i}] = {page} outside the {kv_slots}-slot cache window \
+                 (indptr {:?})",
+                batch.block_indptr,
+            );
+        }
         ctx.stream
             .memcpy_htod(&batch.token_ids, &mut self.token_ids.slice_mut(..rows))?;
         ctx.stream

--- a/openinfer-glm52/src/scheduler/admission.rs
+++ b/openinfer-glm52/src/scheduler/admission.rs
@@ -51,12 +51,12 @@ pub(super) fn validate_request(
         ));
     }
     if native_mtp_prefill
-        && req.prompt_tokens.len() + crate::mtp::GLM52_MTP_DRAFTS - 1 > max_model_len
+        && req.prompt_tokens.len() + crate::mtp::glm52_mtp_draft_len() - 1 > max_model_len
     {
         return Err(format!(
             "GLM5.2 native-MTP prefill requires {} positions of proposal headroom: \
              prompt {} exceeds max_model_len {max_model_len}",
-            crate::mtp::GLM52_MTP_DRAFTS - 1,
+            crate::mtp::glm52_mtp_draft_len() - 1,
             req.prompt_tokens.len()
         ));
     }
@@ -190,7 +190,12 @@ pub(super) fn admit_from_queue(
     let usable =
         usable_blocks.saturating_sub(offload.map_or(0, offload::RankOffload::pinned_blocks));
 
-    while let Some(slot) = slots.iter().position(Option::is_none) {
+    // Admission fills only the configured slot count; the fixed array's tail
+    // beyond `glm52_decode_slots()` stays permanently empty.
+    while let Some(slot) = slots[..crate::model::glm52_decode_slots()]
+        .iter()
+        .position(Option::is_none)
+    {
         let Some(front) = pending.front() else {
             break;
         };
@@ -401,7 +406,10 @@ pub(super) fn admit_from_queue(
             } else {
                 state.seed_native_pd_anchor();
             }
-            state.set_drafts(handoff.draft_tokens.to_vec(), crate::mtp::GLM52_MTP_DRAFTS);
+            state.set_drafts(
+                handoff.draft_tokens.to_vec(),
+                crate::mtp::glm52_mtp_draft_len(),
+            );
             log::info!(
                 "GLM5.2 native P/D admitted: rank={rank} slot={slot} \
                  committed_len={} drafts={} first_step=verify",
@@ -559,14 +567,16 @@ mod tests {
 
     #[test]
     fn native_mtp_prefill_reserves_the_fixed_proposal_positions() {
-        let fits = request(vec![10; 4092], SamplingParams::default(), 1);
+        // Headroom tracks the configured draft span, not the compile ceiling.
+        let headroom = crate::mtp::glm52_mtp_draft_len() - 1;
+        let fits = request(vec![10; 4096 - headroom], SamplingParams::default(), 1);
         assert!(validate_request(&fits, 4096, true, true).is_ok());
 
-        let overflows = request(vec![10; 4093], SamplingParams::default(), 1);
+        let overflows = request(vec![10; 4096 - headroom + 1], SamplingParams::default(), 1);
         let error = validate_request(&overflows, 4096, true, true)
             .expect_err("fixed MTP proposal must fit inside the context cap");
         assert!(
-            error.contains("4 positions of proposal headroom"),
+            error.contains(&format!("{headroom} positions of proposal headroom")),
             "{error}"
         );
 

--- a/openinfer-glm52/src/scheduler/mod.rs
+++ b/openinfer-glm52/src/scheduler/mod.rs
@@ -929,7 +929,9 @@ impl Glm52Engine {
                     }
                 }
                 let wants_drafts = if self.drafter.is_mtp() {
-                    active.state.wants_full_draft(crate::mtp::GLM52_MTP_DRAFTS)
+                    active
+                        .state
+                        .wants_full_draft(crate::mtp::glm52_mtp_draft_len())
                 } else {
                     active.state.wants_drafts()
                 };

--- a/openinfer-glm52/src/scheduler/mod.rs
+++ b/openinfer-glm52/src/scheduler/mod.rs
@@ -306,7 +306,7 @@ impl Glm52Engine {
         // keeps this cheap (~54 KB/token/rank -> a few GiB at 16K x 8).
         let pool = BlockPool::new(
             PAGE,
-            glm52_pool_blocks(spec.max_model_len, GLM52_MAX_BATCH_PER_RANK),
+            glm52_pool_blocks(spec.max_model_len, crate::model::glm52_decode_slots()),
         )?;
         let table_width = glm52_table_width(spec.max_model_len);
         // Prefix matching policy lives in `prefix_cache_enabled`: DSpark is

--- a/openinfer-glm52/src/scheduler/mtp.rs
+++ b/openinfer-glm52/src/scheduler/mtp.rs
@@ -71,7 +71,7 @@ pub(super) fn run_mtp_round(
             super::slot::record_mtp_proposal(active.req.request_id.as_deref(), &span);
             active
                 .state
-                .set_drafts(span.to_vec(), crate::mtp::GLM52_MTP_DRAFTS);
+                .set_drafts(span.to_vec(), crate::mtp::glm52_mtp_draft_len());
         }
     }
     Ok(())

--- a/openinfer-glm52/src/scheduler/plan.rs
+++ b/openinfer-glm52/src/scheduler/plan.rs
@@ -598,15 +598,50 @@ mod tests {
     /// (measured as TPOT == ITL at full occupancy).
     #[test]
     fn full_occupancy_verify_spans_fit_the_max_bucket() {
-        let wants = [6usize; GLM52_MAX_BATCH_PER_RANK];
+        // The latency profile: 8 slots riding the full 5-draft span.
+        let mut wants = [0usize; GLM52_MAX_BATCH_PER_RANK];
+        wants[..8].fill(6);
+        let shape = plan_step_shape(&wants);
+        assert_eq!(shape.bucket, GLM52_MAX_STEP_ROWS);
+        assert_eq!(shape.active_rows, GLM52_MAX_STEP_ROWS);
+        let mut expect = Vec::new();
+        for slot in 0..8 {
+            expect.extend(std::iter::repeat_n(slot as u8, 6));
+        }
+        assert_eq!(shape.slots[..GLM52_MAX_STEP_ROWS].to_vec(), expect);
+    }
+
+    #[test]
+    fn wide_occupancy_two_draft_spans_fit_the_max_bucket() {
+        // The throughput profile: 16 slots riding a 2-draft span — the
+        // ceiling slot count saturates the same 48-row budget exactly.
+        let wants = [3usize; GLM52_MAX_BATCH_PER_RANK];
         let shape = plan_step_shape(&wants);
         assert_eq!(shape.bucket, GLM52_MAX_STEP_ROWS);
         assert_eq!(shape.active_rows, GLM52_MAX_STEP_ROWS);
         let mut expect = Vec::new();
         for slot in 0..GLM52_MAX_BATCH_PER_RANK {
-            expect.extend(std::iter::repeat_n(slot as u8, 6));
+            expect.extend(std::iter::repeat_n(slot as u8, 3));
         }
-        assert_eq!(shape.slots[..].to_vec(), expect);
+        assert_eq!(shape.slots[..GLM52_MAX_STEP_ROWS].to_vec(), expect);
+    }
+
+    #[test]
+    fn over_committed_wants_shrink_round_robin_not_collapse() {
+        // A mis-paired (slots, drafts) config (launch() rejects it, but the
+        // planner must still be safe): 16 slots each wanting the 6-row span
+        // get round-robined down to 3 rows apiece, never to a bare anchor.
+        let wants = [6usize; GLM52_MAX_BATCH_PER_RANK];
+        let shape = plan_step_shape(&wants);
+        assert_eq!(shape.bucket, GLM52_MAX_STEP_ROWS);
+        assert_eq!(shape.active_rows, GLM52_MAX_STEP_ROWS);
+        for slot in 0..GLM52_MAX_BATCH_PER_RANK {
+            let rows = shape.slots[..GLM52_MAX_STEP_ROWS]
+                .iter()
+                .filter(|&&s| s as usize == slot)
+                .count();
+            assert_eq!(rows, 3, "slot {slot} should get an even 3-row share");
+        }
     }
 
     #[test]
@@ -622,6 +657,8 @@ mod tests {
             spans[0].abs_diff(spans[3]) <= 1,
             "long requests must share the remaining rows: {spans:?}"
         );
-        assert_eq!(plan_prefill_spans(&wants, 2), [1, 0, 0, 1, 0, 0, 0, 0]);
+        let mut tight = [0; GLM52_MAX_BATCH_PER_RANK];
+        (tight[0], tight[3]) = (1, 1);
+        assert_eq!(plan_prefill_spans(&wants, 2), tight);
     }
 }


### PR DESCRIPTION
## Summary

Closes out #812 stages 2+3 and takes GLM5.2 to production-shaped EP32 serving: an 8-node decode fleet (32 ranks, 8 experts/rank) fed by multiple TP4 prefill instances through the P/D router, benched end-to-end at fleet concurrency 512–768 with **zero failed requests**.

### Runtime profile knobs (stages 2+3)

`GLM52_DECODE_SLOTS` (default 8, compile ceiling 16) and `GLM52_MTP_DRAFTS` (default 5, ceiling 5) become startup knobs; `launch()` rejects any pair that overflows the 48-row step budget — the exact silent-cap failure mode #812 was opened for. The **throughput profile 16×2** saturates the same 48 rows as the latency profile 8×(5+1), so every #813 bucket, CUDA graph, and kernel instantiation is reused — no new kernel work. Wire/array shapes stay at compile ceilings; a shorter draft span just leaves tail rows unproposed, so P and D can even disagree on the knob (D truncates; longer-D verifies zero rows that fail prefix match).

Draft 2 also removes 3 of 5 sequential proposal forwards per MTP round — at 16 slots the step's verify rows carry more anchors and fewer speculative rows, which is the right trade at high occupancy where verify-row acceptance amortizes worse.

### Fixed along the way

- **Pool/slab size drift (introduced mid-branch, caught by hardware):** the scheduler's BlockPool was sized from the compile ceiling while the executor's cache slab took the runtime slot count. kvbm legitimately allocated page ids past the slab under deep queue pressure and the cache-pack kernel trapped with no context — surfacing as `unspecified launch failure` at whatever launch checked next (fp8 GEMM, SiLU, MoE gather: one crash, four faces). Deterministic repro: single prefill-only instance at c176 died in under a minute; c96 never did (the allocator only wanders high under pressure). The stage-time page-window check that pinpointed it stays as a permanent pool==slab contract guard with real diagnostics.
- Retired the stale EP8-era `GLM52_DEEPGEMM_MASKED_CAP` compile assert (recv slab is runtime-sized from topology since #813) and pinned the q_a|kv_a mma pack gate to the batch-8 GEMV route boundary instead of the (now larger) slot ceiling.

### EP32 bring-up

32-rank DeepEP came up first-try on the runtime-sized protocol (all collective buffers scale with `num_ranks`); no code changes needed beyond the knobs. Greedy smoke through the full P/D router path is byte-identical to the decode-only path.

## Results (256 in / 1024 out, temp 0, ignore-eos, zero failures everywhere)

**Decode-only endpoints (32 GPUs, 16 slots × 2 drafts):**

| per-node conc | fleet tok/s | per-GPU | mean TPOT |
|---|---|---|---|
| c64 (=slots) | 16,687 | 521.5 | 19.1 ms |
| c96 (1.5×) | 17,886 | 558.9 | 19.1 ms |

**P/D disaggregated (3× TP4 prefill + router + 8-node EP32 decode):**

| fleet conc | fleet tok/s | per-GPU (D) | mean TPOT | median TTFT |
|---|---|---|---|---|
| c512 | 20,041 | **626.3** | 19.8 ms | ~0.7–1.3 s |
| c768 | 21,655 | **676.7** | 19.7 ms | ~4.4 s (queue wait) |

Prefill disaggregation is worth ~12% over decode-only (the inline-prefill tax), and oversubscription another ~8% (admission refills slots with no step gap). TPOT is flat at ~19.7 ms against the 35 ms budget — the remaining lever toward that budget is 32 slots/rank (needs 96-row buckets, #812 stage 3 scale-up).

vs. the pre-#813 baseline (175 tok/s/GPU at 8×1 collapsed spans): **3.9×**; vs. #813 (387): **1.75×**.

## Testing

- `cargo test --release -p openinfer-glm52 --lib` under both profiles (default and `GLM52_DECODE_SLOTS=16 GLM52_MTP_DRAFTS=2`) — all pass except the known env-only `moe_tp::scale_staging_geometry`
- New plan tests: 8×6 and 16×3 full-occupancy span shapes + over-committed round-robin degradation
- Hardware: the c176 crash repro passes clean post-fix (704/704); full E2E benches above

🤖 Generated with [Claude Code](https://claude.com/claude-code)