### PR TITLE
feat(glm52): 96-row step — 32 decode slots, 1,027 tok/s per GPU at 26 ms TPOT (#812 stage 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ cargo run --release --features glm52 -- --model-path models/GLM5.2
 - `OPENINFER_TEST_MODEL_PATH` — override test model path (default: `models/Qwen3-4B`)
 - `OPENINFER_BUILD_TIMING=1` — print per-phase build timings (nvcc, Triton AOT, etc.)
 - `OPENINFER_NVCC_JOBS` — override parallel nvcc job count
-- `GLM52_DECODE_SLOTS` / `GLM52_MTP_DRAFTS` — glm52 runtime profile: decode slots per rank (default 8, ceiling 16) and MTP draft span (default 5); `slots x (1+drafts)` must fit the 48-row step (validated at launch). Wide-EP throughput profile: `16` / `2`.
+- `GLM52_DECODE_SLOTS` / `GLM52_MTP_DRAFTS` — glm52 runtime profile: decode slots per rank (default 8, ceiling 32) and MTP draft span (default 5); `slots x (1+drafts)` must fit the 96-row step (validated at launch; MTP only). Throughput ceiling profile: `32` / `2`.
 
 ## Tests
 

--- a/openinfer-glm52/src/dspark.rs
+++ b/openinfer-glm52/src/dspark.rs
@@ -100,7 +100,9 @@ pub(crate) fn glm52_dspark_arena_bytes(max_model_len: usize) -> usize {
     let context = 2 * GLM52_HIDDEN * cache_len * bf16;
     let tail = (GLM52_HIDDEN + 2 * DSPARK_QKV_DIM) * cache_len * bf16;
     let rope = 2 * cache_len * DSPARK_HEAD_DIM * bf16;
-    GLM52_MAX_BATCH_PER_RANK * (kv + pending + context) + tail + rope
+    // Cap-scaled term: like the native-MTP arena, charge the RUNTIME slot
+    // count — the aux-hidden lanes are per admitted slot, not per ceiling.
+    crate::model::glm52_decode_slots() * (kv + pending + context) + tail + rope
 }
 
 const DSPARK_LAYERS: usize = 5;

--- a/openinfer-glm52/src/lib.rs
+++ b/openinfer-glm52/src/lib.rs
@@ -455,7 +455,7 @@ pub fn launch(model_path: &Path, options: Glm52LaunchOptions) -> Result<EngineHa
     ensure!(
         slots * (1 + draft_len) <= model::GLM52_MAX_STEP_ROWS,
         "GLM5.2 GLM52_DECODE_SLOTS={slots} x (1 + GLM52_MTP_DRAFTS={draft_len}) exceeds the \
-         {}-row step budget; 16 slots need GLM52_MTP_DRAFTS=2",
+         {}-row step budget; 32 slots need GLM52_MTP_DRAFTS=2",
         model::GLM52_MAX_STEP_ROWS
     );
     // Probe only the GPUs this process hosts (local ordinals 0..N), not the

--- a/openinfer-glm52/src/model/mod.rs
+++ b/openinfer-glm52/src/model/mod.rs
@@ -89,11 +89,11 @@ use step_body::run_step_body;
 /// (slots, drafts) must satisfy `slots * (1 + drafts) <= GLM52_MAX_STEP_ROWS`
 /// (validated at engine build), so the ceiling is only reachable with a
 /// shortened draft span.
-pub(crate) const GLM52_MAX_BATCH_PER_RANK: usize = 16;
+pub(crate) const GLM52_MAX_BATCH_PER_RANK: usize = 32;
 
 /// The per-rank decode slot count: `GLM52_DECODE_SLOTS` (1..=ceiling),
 /// default 8 — the latency-lean P/D profile. Wide-EP throughput deployments
-/// run 16 slots with `GLM52_MTP_DRAFTS=2` to stay inside the 48-row step.
+/// run 32 slots with `GLM52_MTP_DRAFTS=2` to stay inside the 96-row step.
 pub(crate) fn glm52_decode_slots() -> usize {
     static SLOTS: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     *SLOTS.get_or_init(|| {
@@ -212,10 +212,13 @@ fn glm52_persistent_mla_bytes_per_token(
 /// under full occupancy and collapsed speculation (measured: TPOT == ITL at
 /// c32 on EP4). Since the slot count and draft length became startup knobs
 /// this is a standalone budget the runtime pair must fit
-/// (`slots * (1 + drafts) <= 48`, validated at engine build): 8 slots ride
-/// the full 5-draft span, 16 slots ride a 2-draft span — same row ceiling,
-/// so every #813 bucket, graph, and kernel instantiation is shared.
-pub(crate) const GLM52_MAX_STEP_ROWS: usize = 48;
+/// (`slots * (1 + drafts) <= 96`, validated at engine build): 16 slots ride
+/// the full 5-draft span, 32 slots ride a 2-draft span — the same row
+/// ceiling, so bucket/graph/kernel instantiations are shared across
+/// profiles. 96 (not more) because the min-gemv token split, the MQA AOT
+/// batch guard, and the decode-feed slot kernel are all extended exactly
+/// this far (#817).
+pub(crate) const GLM52_MAX_STEP_ROWS: usize = 96;
 
 /// The decode batch buckets, ascending. Each bucket has its own captured
 /// CUDA graphs, scratch arena, and FlashMLA plans, and the batched GEMV
@@ -224,7 +227,8 @@ pub(crate) const GLM52_MAX_STEP_ROWS: usize = 48;
 /// engine picks the smallest bucket covering its own demand, so a
 /// lightly-loaded rank keeps the small-step cost; discrete buckets (not a
 /// continuum) keep the whole-step graphs' fixed-shape contract.
-pub(crate) const GLM52_DECODE_BUCKETS: [usize; 7] = [1, 2, 4, 8, 16, 32, GLM52_MAX_STEP_ROWS];
+pub(crate) const GLM52_DECODE_BUCKETS: [usize; 9] =
+    [1, 2, 4, 8, 16, 32, 48, 64, GLM52_MAX_STEP_ROWS];
 
 // NOTE (#812): the MTP round shares GLM52_DECODE_BUCKETS. The draft leg
 // never exceeds one row per slot, but the CONTEXT leg ingests every

--- a/openinfer-glm52/src/moe_ep.rs
+++ b/openinfer-glm52/src/moe_ep.rs
@@ -500,35 +500,35 @@ mod tests {
 
     #[test]
     fn masked_cap_covers_every_supported_ep_width() {
-        // ranks x GLM52_MAX_STEP_ROWS (48 since #812), aligned up to 128.
-        assert_eq!(deepgemm_masked_cap(4), 256);
-        assert_eq!(deepgemm_masked_cap(8), 384);
-        assert_eq!(deepgemm_masked_cap(16), 768);
-        assert_eq!(deepgemm_masked_cap(32), 1536);
-        assert_eq!(deepgemm_masked_cap(64), 3072);
+        // ranks x GLM52_MAX_STEP_ROWS (96 since #817), aligned up to 128.
+        assert_eq!(deepgemm_masked_cap(4), 384);
+        assert_eq!(deepgemm_masked_cap(8), 768);
+        assert_eq!(deepgemm_masked_cap(16), 1536);
+        assert_eq!(deepgemm_masked_cap(32), 3072);
+        assert_eq!(deepgemm_masked_cap(64), 6144);
     }
 
     #[test]
     fn post_weight_vram_charge_tracks_topology_and_native_mtp() {
         assert_eq!(
             glm52_deepgemm_vram_charge_bytes(Glm52MoeTopo::Ep4, false).expect("EP4 charge"),
-            1_746_500_100
+            1_984_001_028
         );
         assert_eq!(
             glm52_deepgemm_vram_charge_bytes(Glm52MoeTopo::Ep8, false).expect("EP8 charge"),
-            916_132_996
+            1_272_383_620
         );
         assert_eq!(
             glm52_deepgemm_vram_charge_bytes(Glm52MoeTopo::Ep16, false).expect("EP16 charge"),
-            485_242_948
+            841_490_500
         );
         assert_eq!(
             glm52_deepgemm_vram_charge_bytes(Glm52MoeTopo::Ep32, false).expect("EP32 charge"),
-            118_847_524
+            475_088_932
         );
         assert_eq!(
             glm52_deepgemm_vram_charge_bytes(Glm52MoeTopo::Ep64, false).expect("EP64 charge"),
-            36_271_124
+            392_500_244
         );
         assert_eq!(
             glm52_deepgemm_vram_charge_bytes(Glm52MoeTopo::Tp4, false).expect("TP4 charge"),

--- a/openinfer-glm52/src/runner.rs
+++ b/openinfer-glm52/src/runner.rs
@@ -570,7 +570,10 @@ struct Glm52RankRuntime {
 struct Glm52DsparkRank {
     model: Glm52DsparkModel,
     scratch: Glm52DsparkScratch,
-    slots: [Glm52DsparkSlotState; GLM52_MAX_BATCH_PER_RANK],
+    // Sized to the RUNTIME slot count (admission never fills past it) — the
+    // cache-length-scaled states are exactly what the dspark arena ledger
+    // charges, and a ceiling-sized array would allocate unledgered GiBs.
+    slots: Vec<Glm52DsparkSlotState>,
 }
 
 struct Glm52RankThreadState {
@@ -728,16 +731,15 @@ impl Glm52RankThreadState {
         );
         let model = Glm52DsparkModel::load(&dev_ctx, path, runtime.model.max_model_len())?;
         let scratch = Glm52DsparkScratch::new(&dev_ctx, model.cache_len())?;
-        let mut slots = Vec::with_capacity(GLM52_MAX_BATCH_PER_RANK);
-        for _ in 0..GLM52_MAX_BATCH_PER_RANK {
+        let slot_count = crate::model::glm52_decode_slots();
+        let mut slots = Vec::with_capacity(slot_count);
+        for _ in 0..slot_count {
             slots.push(Glm52DsparkSlotState::new(&dev_ctx, model.cache_len())?);
         }
         runtime.dspark = Some(Glm52DsparkRank {
             model,
             scratch,
-            slots: slots
-                .try_into()
-                .map_err(|_| anyhow::anyhow!("GLM5.2 dspark slot state count drifted"))?,
+            slots,
         });
         Ok(())
     }

--- a/openinfer-glm52/src/scheduler/plan.rs
+++ b/openinfer-glm52/src/scheduler/plan.rs
@@ -135,11 +135,22 @@ pub(super) fn lease_flags(
         && slots.iter().flatten().all(|active| {
             takes_argmax(&active.req.params) && lease_ok(&active.state, max_model_len)
         });
+    // `GLM52_EAGER_DECODE=1` runs every decode step through the eager path
+    // (same step body, no graph capture/replay) — the stage-3 measurement
+    // switch for the graph-vs-padding trade at wide buckets. Eager steps
+    // cannot ride launch-ahead replays, so the lease is withheld too.
+    let eager = eager_decode_forced();
     Glm52StepFlags {
         consume,
-        lease,
-        eager: false,
+        lease: lease && !eager,
+        eager,
     }
+}
+
+/// Whether `GLM52_EAGER_DECODE=1` forces the eager (graph-free) decode path.
+pub(super) fn eager_decode_forced() -> bool {
+    static EAGER: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *EAGER.get_or_init(|| std::env::var("GLM52_EAGER_DECODE").as_deref() == Ok("1"))
 }
 
 /// Whether a request's committed rows take the fused argmax — the shared
@@ -584,8 +595,8 @@ mod tests {
         wants[3] = 3000;
         wants[6] = 3000;
         let mut expect = vec![0u8];
-        expect.extend(std::iter::repeat_n(3u8, 24));
-        expect.extend(std::iter::repeat_n(6u8, 23));
+        expect.extend(std::iter::repeat_n(3u8, 48));
+        expect.extend(std::iter::repeat_n(6u8, 47));
         assert_eq!(
             forwarded(&plan_step_shape(&wants)),
             (GLM52_MAX_STEP_ROWS, expect)
@@ -598,17 +609,21 @@ mod tests {
     /// (measured as TPOT == ITL at full occupancy).
     #[test]
     fn full_occupancy_verify_spans_fit_the_max_bucket() {
-        // The latency profile: 8 slots riding the full 5-draft span.
+        // The latency profile: 16 slots riding the full 5-draft span fill
+        // the max bucket exactly (8 slots land on the 48 bucket unchanged).
         let mut wants = [0usize; GLM52_MAX_BATCH_PER_RANK];
-        wants[..8].fill(6);
+        wants[..16].fill(6);
         let shape = plan_step_shape(&wants);
         assert_eq!(shape.bucket, GLM52_MAX_STEP_ROWS);
         assert_eq!(shape.active_rows, GLM52_MAX_STEP_ROWS);
         let mut expect = Vec::new();
-        for slot in 0..8 {
+        for slot in 0..16 {
             expect.extend(std::iter::repeat_n(slot as u8, 6));
         }
         assert_eq!(shape.slots[..GLM52_MAX_STEP_ROWS].to_vec(), expect);
+        let mut eight = [0usize; GLM52_MAX_BATCH_PER_RANK];
+        eight[..8].fill(6);
+        assert_eq!(plan_step_shape(&eight).bucket, 48);
     }
 
     #[test]

--- a/openinfer-kernels/csrc/glm52/glm52_deepgemm_mqa.cu
+++ b/openinfer-kernels/csrc/glm52/glm52_deepgemm_mqa.cu
@@ -51,7 +51,7 @@ constexpr int kAotNumSms = 132;
 // Launcher guard only — batch is a runtime argument of both kernels (the
 // grid-stride scheduler walks q atoms); no template arg depends on it.
 // 64 covers the verify-span row ceiling (48, #812).
-constexpr int kAotAlignedBatchSize = 64;
+constexpr int kAotAlignedBatchSize = 96;
 
 const auto kMetadataKernel = &deep_gemm::sched::sm100_paged_mqa_logits_metadata<
     kAotNextN, /*kIsContextLens2D=*/false, /*kIsVarlen=*/false,

--- a/openinfer-kernels/csrc/glm52/glm52_min_gemv.cuh
+++ b/openinfer-kernels/csrc/glm52/glm52_min_gemv.cuh
@@ -16,8 +16,12 @@
 namespace glm52_min_gemv {
 
 constexpr int kHidden = 6144;
-constexpr int kMaxTokens = 48;  // = GLM52_MAX_STEP_ROWS (#812); dispatch
-                                // covers 1..=8 plus the bucket sizes.
+constexpr int kMaxTokens = 96;  // = GLM52_MAX_STEP_ROWS (#812/#817);
+                                // dispatch covers 1..=8 plus the bucket
+                                // sizes. 64/96 decompose into two sub-launches
+                                // (token-major out lets the tile split on the
+                                // token axis) — a 96-wide accumulator tile
+                                // would spill far past 255 regs/thread.
 
 // out[token * kNumRows + row] = dot(hidden[token], weight[row]); weight is
 // row-major [kNumRows, kHidden].
@@ -124,6 +128,22 @@ cudaError_t launch_tokens(OutT* out, const __nv_bfloat16* hidden,
     case 16: return launch<16, kNumRows>(out, hidden, weight, stream);
     case 32: return launch<32, kNumRows>(out, hidden, weight, stream);
     case 48: return launch<48, kNumRows>(out, hidden, weight, stream);
+    case 64: {
+      const cudaError_t first =
+          launch<32, kNumRows>(out, hidden, weight, stream);
+      if (first != cudaSuccess) return first;
+      return launch<32, kNumRows>(out + 32 * static_cast<size_t>(kNumRows),
+                                  hidden + 32 * static_cast<size_t>(kHidden),
+                                  weight, stream);
+    }
+    case 96: {
+      const cudaError_t first =
+          launch<48, kNumRows>(out, hidden, weight, stream);
+      if (first != cudaSuccess) return first;
+      return launch<48, kNumRows>(out + 48 * static_cast<size_t>(kNumRows),
+                                  hidden + 48 * static_cast<size_t>(kHidden),
+                                  weight, stream);
+    }
     default: return cudaErrorInvalidValue;
   }
 }

--- a/openinfer-kernels/src/ops/glm52/indexer.rs
+++ b/openinfer-kernels/src/ops/glm52/indexer.rs
@@ -226,13 +226,13 @@ pub fn glm52_indexer_local_topk_to_slots_launch(
 }
 
 /// Token bound baked into `glm52_min_gemv.cuh`'s `launch_tokens` switch.
-pub const GLM52_MIN_GEMV_MAX_TOKENS: usize = 48;
+pub const GLM52_MIN_GEMV_MAX_TOKENS: usize = 96;
 
 /// The token counts `glm52_min_gemv.cuh` instantiates: 1..=8 plus the
 /// verify-span decode bucket sizes (#812) — token counts always land on a
 /// bucket member.
 pub fn glm52_min_gemv_tokens_supported(tokens: usize) -> bool {
-    (1..=8).contains(&tokens) || matches!(tokens, 16 | 32 | 48)
+    (1..=8).contains(&tokens) || matches!(tokens, 16 | 32 | 48 | 64 | 96)
 }
 
 /// weights_proj min-latency GEMV: `out[t, h] = dot(hidden[t], weights[h])`,

--- a/openinfer-kernels/src/ops/glm52/moe_gemv.rs
+++ b/openinfer-kernels/src/ops/glm52/moe_gemv.rs
@@ -263,6 +263,10 @@ fn gemv_batched_launch(
         out.len(),
         rows * n
     );
+    ensure!(
+        ksplit_out.is_none() || rows <= 48,
+        "GLM5.2 linear GEMV partials path is not token-split past 48 rows (got {rows})"
+    );
     let (act_ptr, _a) = activation.device_ptr(&ctx.stream);
     let (w_ptr, _w) = weight.device_ptr(&ctx.stream);
     let (s_ptr, _s) = scale_bytes.device_ptr(&ctx.stream);
@@ -280,20 +284,38 @@ fn gemv_batched_launch(
     // bucket, not bit-identical to m=1). The CUDA side whitelists the
     // supported batches — a drifted GLM52_DECODE_BUCKETS crashes here.
     match ksplit_out {
-        None => unsafe {
-            ffi::glm52_fp8_weight_only_gemv_batched_cuda(
-                act_ptr as *const ffi::Half,
-                w_ptr as *const u8,
-                s_ptr as *const f32,
-                out_ptr as *mut ffi::Half,
-                scr_ptr,
-                scr_floats,
-                rows as i32,
-                n as i32,
-                k as i32,
-                ctx.stream.cu_stream(),
-            )
-        },
+        None => {
+            // 64/96-row buckets (#817) split on the token axis into two
+            // whitelisted sub-batches — the register tile at those widths
+            // would spill (the #813 lesson), and the activation/out layouts
+            // are token-major so the split is a pointer offset.
+            let halves: &[(usize, usize)] = match rows {
+                64 => &[(32, 0), (32, 32)],
+                96 => &[(48, 0), (48, 48)],
+                _ => &[(rows, 0)],
+            };
+            let mut result = cudarc::driver::sys::CUresult::CUDA_SUCCESS;
+            for &(sub, off) in halves {
+                result = unsafe {
+                    ffi::glm52_fp8_weight_only_gemv_batched_cuda(
+                        (act_ptr as *const ffi::Half).add(off * k),
+                        w_ptr as *const u8,
+                        s_ptr as *const f32,
+                        (out_ptr as *mut ffi::Half).add(off * n),
+                        scr_ptr,
+                        scr_floats,
+                        sub as i32,
+                        n as i32,
+                        k as i32,
+                        ctx.stream.cu_stream(),
+                    )
+                };
+                if result != cudarc::driver::sys::CUresult::CUDA_SUCCESS {
+                    break;
+                }
+            }
+            result
+        }
         Some(ksplit) => unsafe {
             ffi::glm52_fp8_weight_only_gemv_partials_cuda(
                 act_ptr as *const ffi::Half,


### PR DESCRIPTION
## Summary

#812 stage 3: the verify-span step budget doubles 48 → 96 rows, unlocking the **32-slot × 2-draft throughput profile** (`GLM52_DECODE_SLOTS=32 GLM52_MTP_DRAFTS=2`). Existing profiles are untouched — 8×(5+1) and 16×(1+2) land on the same 48 bucket as before, and 16×(5+1) becomes newly valid at exactly 96 rows.

## The graph-vs-padding question, measured first

Before extending graphs to 96 rows we measured whether they still earn their keep at wide buckets: the step body's (pre-existing, never-enabled) eager path was wired to a `GLM52_EAGER_DECODE=1` switch and A/B'd at 48-row saturation — **eager costs 3.0–3.8% throughput** (the ~4,155 launches per step still bite even under 30 ms steps). Since the throughput ceiling lives at oversubscribed saturation where demand pins the max bucket and padding is ~zero, graphs win where it matters; the switch stays in-tree as a measurement tool, and the mid-band (49–95 active rows) gets a 64 bucket to cap transient padding.

## What the doubling touched

- `GLM52_DECODE_BUCKETS` gains 64 and 96, each with its own whole-step graph.
- The min-latency GEMV (`glm52_min_gemv.cuh`) and the batched linear GEMV (`glm52_moe_gemv.cu` consumers) cover 64/96 by **token-splitting into two whitelisted sub-launches** — a 96-wide accumulator register tile would spill far past 255 regs/thread (the #813 lesson, applied instead of re-learned).
- DeepGEMM MQA AOT batch guard 64 → 96 (runtime arg, smem check holds at 768 B).
- The decode-feed slot kernel's 32-slot cap is now exactly the ceiling.
- The dspark cap-scaled arena charges the runtime slot count (the compile ceiling quadrupled under it), and the DeepGEMM VRAM ledger goldens track the doubled masked-rows scratch.

## Results (256 in / 1024 out, temp 0, ignore-eos, zero failures, greedy smoke byte-identical)

| topology | profile | conc/node | per-GPU tok/s | mean TPOT |
|---|---|---|---|---|
| EP4 (1 node) | 16×2 (prev) | c96 | 440 | 28.1 ms |
| EP4 (1 node) | **32×2** | c192 | **761** | 32.5 ms |
| EP16 (4 nodes) | **32×2** | c128 | 834 | 26.8 ms |
| EP16 (4 nodes) | **32×2** | c192 | **1,027** | 25.7 ms |

vs the 16-slot profile at the same width: **+73% (EP4)** and **+84% (EP16 vs the 559/GPU 48-row measurement)**. TPOT stays inside the 35 ms budget with ~9 ms to spare at EP16. Interesting datum: c192 oversubscription *lowers* TPOT vs c128 (26.8 → 25.7) — fuller 96-row buckets amortize the step better.

**EP32 ceiling (appended after the cluster window opened)** — 8-node EP32 decode fleet + 3× TP4 prefill through the P/D router, zero failures, greedy smoke byte-identical:

| fleet conc | fleet tok/s | per-GPU (D) | mean TPOT | TTFT |
|---|---|---|---|---|
| c1024 (= slots) | 31,584 | **987.0** | 24.9 ms | ~2.9 s avg |
| c1536 (1.5×) | 33,339 | **1,041.8** | 24.4 ms | ~9.7 s median (queue wait) |

The per-GPU ceiling: **1,042 tok/s under a 24.4 ms mean TPOT** — 10.5 ms of the 35 ms budget still unspent. Progression across this line of work: 175 (pre-#813) → 387 (#813) → 626 (#816) → **1,042 (#817)**, a 6.0× cumulative gain with greedy output byte-identical throughout.

## Testing

- `cargo test --release -p openinfer-glm52 --lib` under three profiles (default, 32×2, 16-slot) — all pass except the known env-only `moe_tp::scale_staging_geometry`
- Startup preflight caught the one missed GEMV consumer on first hardware contact; fixed with the same token-split pattern
- Hardware: EP4 and EP16 runs above; 9-bucket graph capture clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
