### PR TITLE
feat(kernels): add sliding-window paged attention for head_dim 256

### DIFF
--- a/pegainfer-kernels/csrc/shared/paged_attention.cu
+++ b/pegainfer-kernels/csrc/shared/paged_attention.cu
@@ -1,7 +1,8 @@
 // Thin C wrappers around FlashInfer's attention kernels.
 //
 // We include FlashInfer headers (header-only C++) and instantiate only the
-// template variants needed: bf16 Q/KV/O, HEAD_DIM=128, NHD layout, no RoPE.
+// template variants needed: bf16 Q/KV/O, NHD layout, no RoPE, at HEAD_DIM 128
+// and 256, the latter both with and without a sliding-window mask.
 //
 // FlashInfer's dispatchers internally instantiate multiple GQA group sizes
 // (1,2,3,4,8) — this covers both Qwen3-4B (GQA=4) and Qwen3.5-4B (GQA=8).
@@ -28,6 +29,13 @@ using Variant = DefaultAttention</*custom_mask=*/false,
                                  /*sliding_window=*/false,
                                  /*logits_soft_cap=*/false,
                                  /*alibi=*/false>;
+
+// `window_left` is an inclusive distance: an N-token window passes N - 1, and
+// -1 degrades to full attention.
+using WindowVariant = DefaultAttention</*custom_mask=*/false,
+                                       /*sliding_window=*/true,
+                                       /*logits_soft_cap=*/false,
+                                       /*alibi=*/false>;
 
 // Helper: build paged_kv_t from our page-first layout.
 //
@@ -67,8 +75,6 @@ static paged_kv_t<DType, IdType> make_paged_kv(
         /*rope_pos_offset=*/nullptr);
 }
 
-extern "C" {
-
 // ---------------------------------------------------------------------------
 // Paged attention decode — wraps FlashInfer BatchDecodeWithPagedKVCache.
 //
@@ -76,7 +82,8 @@ extern "C" {
 // No RoPE applied inside (caller does RoPE beforehand).
 // No partition-KV (single block per batch×head) for Phase 1 simplicity.
 // ---------------------------------------------------------------------------
-int paged_attention_decode_cuda(
+template <uint32_t HEAD_DIM, typename VariantT>
+static int decode_launch(
     // Q and output
     void*    q,                    // [num_qo_heads * head_dim] bf16, device
     void*    output,               // [num_qo_heads * head_dim] bf16, device
@@ -100,6 +107,7 @@ int paged_attention_decode_cuda(
     int32_t  batch_size,           // 1 for Phase 1
     int64_t  stride_page,          // KvLayout.page_stride
     float    sm_scale,             // typically 1/sqrt(head_dim)
+    int32_t  window_left,
     // Stream
     void*    stream)
 {
@@ -119,7 +127,7 @@ int paged_attention_decode_cuda(
         num_qo_heads,
         /*q_stride_n=*/num_qo_heads * head_dim,
         /*q_stride_h=*/head_dim,
-        /*window_left=*/-1,
+        window_left,
         /*logits_soft_cap=*/0.0f,
         sm_scale,
         /*rope_scale=*/1.0f,
@@ -136,9 +144,9 @@ int paged_attention_decode_cuda(
     // tmp_v = nullptr → non-partition path (no merge step)
     return static_cast<int>(
         BatchDecodeWithPagedKVCacheDispatched<
-            /*HEAD_DIM=*/128,
+            HEAD_DIM,
             PosEncodingMode::kNone,
-            Variant,
+            VariantT,
             ParamsT>(
             params,
             /*tmp_v=*/nullptr,
@@ -146,6 +154,25 @@ int paged_attention_decode_cuda(
             /*enable_pdl=*/false,
             reinterpret_cast<cudaStream_t>(stream)));
   PEGAINFER_FFI_GUARD_END(-1)
+}
+
+extern "C" {
+
+int paged_attention_decode_cuda(
+    void* q, void* output, void* kv_data,
+    int64_t k_offset_elems, int64_t v_offset_elems,
+    int32_t* page_indices, int32_t* page_indptr, int32_t* last_page_len_d,
+    int32_t* request_indices, int32_t* kv_tile_indices, int32_t* kv_chunk_size_ptr,
+    int32_t num_qo_heads, int32_t num_kv_heads, int32_t head_dim,
+    int32_t page_size, int32_t batch_size, int64_t stride_page,
+    float sm_scale, void* stream)
+{
+  return decode_launch</*HEAD_DIM=*/128, Variant>(
+      q, output, kv_data, k_offset_elems, v_offset_elems,
+      page_indices, page_indptr, last_page_len_d,
+      request_indices, kv_tile_indices, kv_chunk_size_ptr,
+      num_qo_heads, num_kv_heads, head_dim, page_size, batch_size,
+      stride_page, sm_scale, /*window_left=*/-1, stream);
 }
 
 // ---------------------------------------------------------------------------
@@ -407,7 +434,10 @@ int32_t batch_prefill_cta_tile_q_with_override(
         packed_qo_len, head_dim, cta_tile_q_override));
 }
 
-int batch_prefill_paged_cuda_with_cta_tile_q(
+} // extern "C"
+
+template <uint32_t HEAD_DIM, typename VariantT>
+static int prefill_paged_launch(
     // Q and output (HiddenStates col-major: [q_dim, total_seq_len])
     void*    q,
     void*    output,
@@ -437,6 +467,7 @@ int batch_prefill_paged_cuda_with_cta_tile_q(
     int64_t  stride_page,
     float    sm_scale,
     int32_t  cta_tile_q_override,
+    int32_t  window_left,
     // Stream
     void*    stream)
 {
@@ -462,7 +493,7 @@ int batch_prefill_paged_cuda_with_cta_tile_q(
         num_qo_heads,
         q_stride_n,
         q_stride_h,
-        /*window_left=*/-1,
+        window_left,
         /*logits_soft_cap=*/0.0f,
         sm_scale,
         /*rope_scale=*/1.0f,
@@ -496,12 +527,12 @@ int batch_prefill_paged_cuda_with_cta_tile_q(
         result = static_cast<int>(
             BatchPrefillWithPagedKVCacheDispatched<
                 CTA_TILE_Q,
-                /*HEAD_DIM_QK=*/128,
-                /*HEAD_DIM_VO=*/128,
+                /*HEAD_DIM_QK=*/HEAD_DIM,
+                /*HEAD_DIM_VO=*/HEAD_DIM,
                 PosEncodingMode::kNone,
                 /*USE_FP16_QK_REDUCTION=*/false,
                 MaskMode::kCausal,
-                Variant,
+                VariantT,
                 BatchPrefillParamsT>(
                 params,
                 /*tmp_v=*/nullptr,
@@ -511,6 +542,28 @@ int batch_prefill_paged_cuda_with_cta_tile_q(
     });
     return result;
   PEGAINFER_FFI_GUARD_END(-1)
+}
+
+extern "C" {
+
+int batch_prefill_paged_cuda_with_cta_tile_q(
+    void* q, void* output, void* kv_data,
+    int64_t k_offset_elems, int64_t v_offset_elems,
+    int32_t* page_indices, int32_t* page_indptr, int32_t* last_page_len_d,
+    int32_t* q_indptr, int32_t* request_indices, int32_t* qo_tile_indices,
+    int32_t* kv_tile_indices, int32_t* kv_chunk_size_ptr, uint32_t* total_num_rows,
+    int32_t num_qo_heads, int32_t num_kv_heads, int32_t head_dim,
+    int32_t page_size, int32_t seq_len, int32_t batch_size,
+    int32_t padded_batch_size, int64_t stride_page, float sm_scale,
+    int32_t cta_tile_q_override, void* stream)
+{
+  return prefill_paged_launch</*HEAD_DIM=*/128, Variant>(
+      q, output, kv_data, k_offset_elems, v_offset_elems,
+      page_indices, page_indptr, last_page_len_d, q_indptr,
+      request_indices, qo_tile_indices, kv_tile_indices, kv_chunk_size_ptr,
+      total_num_rows, num_qo_heads, num_kv_heads, head_dim, page_size,
+      seq_len, batch_size, padded_batch_size, stride_page, sm_scale,
+      cta_tile_q_override, /*window_left=*/-1, stream);
 }
 
 int batch_prefill_paged_cuda(
@@ -964,169 +1017,81 @@ int single_prefill_cuda_hd256(
 }
 
 // ---------------------------------------------------------------------------
-// Paged attention decode for HEAD_DIM=256 — identical to paged_attention_decode_cuda
-// but dispatched with HEAD_DIM=256.  Used by Qwen3.5-4B full-attention layers.
+// HEAD_DIM=256 paged entry points.  Qwen3.5-4B uses the full-attention pair;
+// the windowed pair applies the sliding-window mask for Gemma 4's local layers.
 // ---------------------------------------------------------------------------
 int paged_attention_decode_cuda_hd256(
-    void*    q,
-    void*    output,
-    void*    kv_data,
-    int64_t  k_offset_elems,
-    int64_t  v_offset_elems,
-    int32_t* page_indices,
-    int32_t* page_indptr,
-    int32_t* last_page_len_d,
-    int32_t* request_indices,
-    int32_t* kv_tile_indices,
-    int32_t* kv_chunk_size_ptr,
-    int32_t  num_qo_heads,
-    int32_t  num_kv_heads,
-    int32_t  head_dim,
-    int32_t  page_size,
-    int32_t  batch_size,
-    int64_t  stride_page,
-    float    sm_scale,
-    void*    stream)
+    void* q, void* output, void* kv_data,
+    int64_t k_offset_elems, int64_t v_offset_elems,
+    int32_t* page_indices, int32_t* page_indptr, int32_t* last_page_len_d,
+    int32_t* request_indices, int32_t* kv_tile_indices, int32_t* kv_chunk_size_ptr,
+    int32_t num_qo_heads, int32_t num_kv_heads, int32_t head_dim,
+    int32_t page_size, int32_t batch_size, int64_t stride_page,
+    float sm_scale, void* stream)
 {
-  PEGAINFER_FFI_GUARD_BEGIN
-    auto paged_kv = make_paged_kv(
-        kv_data, k_offset_elems, v_offset_elems,
-        page_indices, page_indptr, last_page_len_d,
-        num_kv_heads, head_dim, page_size, batch_size, stride_page);
-
-    ParamsT params(
-        reinterpret_cast<DType*>(q),
-        /*q_rope_offset=*/nullptr,
-        paged_kv,
-        reinterpret_cast<DType*>(output),
-        /*lse=*/nullptr,
-        /*maybe_alibi_slopes=*/nullptr,
-        num_qo_heads,
-        /*q_stride_n=*/num_qo_heads * head_dim,
-        /*q_stride_h=*/head_dim,
-        /*window_left=*/-1,
-        /*logits_soft_cap=*/0.0f,
-        sm_scale,
-        /*rope_scale=*/1.0f,
-        /*rope_theta=*/1e6f);
-
-    params.padded_batch_size = batch_size;
-    params.request_indices   = request_indices;
-    params.kv_tile_indices   = kv_tile_indices;
-    params.o_indptr          = nullptr;
-    params.kv_chunk_size_ptr = kv_chunk_size_ptr;
-    params.block_valid_mask  = nullptr;
-    params.partition_kv      = false;
-
-    return static_cast<int>(
-        BatchDecodeWithPagedKVCacheDispatched<
-            /*HEAD_DIM=*/256,
-            PosEncodingMode::kNone,
-            Variant,
-            ParamsT>(
-            params,
-            /*tmp_v=*/nullptr,
-            /*tmp_s=*/nullptr,
-            /*enable_pdl=*/false,
-            reinterpret_cast<cudaStream_t>(stream)));
-  PEGAINFER_FFI_GUARD_END(-1)
+  return decode_launch</*HEAD_DIM=*/256, Variant>(
+      q, output, kv_data, k_offset_elems, v_offset_elems,
+      page_indices, page_indptr, last_page_len_d,
+      request_indices, kv_tile_indices, kv_chunk_size_ptr,
+      num_qo_heads, num_kv_heads, head_dim, page_size, batch_size,
+      stride_page, sm_scale, /*window_left=*/-1, stream);
 }
 
-// ---------------------------------------------------------------------------
-// Batch prefill with paged KV for HEAD_DIM=256 — identical to batch_prefill_paged_cuda
-// but dispatched with HEAD_DIM_QK/VO=256.  Used by Qwen3.5-4B multi-token prefill.
-// ---------------------------------------------------------------------------
-int batch_prefill_paged_cuda_hd256(
-    void*    q,
-    void*    output,
-    void*    kv_data,
-    int64_t  k_offset_elems,
-    int64_t  v_offset_elems,
-    int32_t* page_indices,
-    int32_t* page_indptr,
-    int32_t* last_page_len_d,
-    int32_t* q_indptr,
-    int32_t* request_indices,
-    int32_t* qo_tile_indices,
-    int32_t* kv_tile_indices,
-    int32_t* kv_chunk_size_ptr,
-    uint32_t* total_num_rows,
-    int32_t  num_qo_heads,
-    int32_t  num_kv_heads,
-    int32_t  head_dim,
-    int32_t  page_size,
-    int32_t  seq_len,
-    int32_t  batch_size,
-    int32_t  padded_batch_size,
-    int64_t  stride_page,
-    float    sm_scale,
-    void*    stream)
+int paged_attention_decode_window_cuda_hd256(
+    void* q, void* output, void* kv_data,
+    int64_t k_offset_elems, int64_t v_offset_elems,
+    int32_t* page_indices, int32_t* page_indptr, int32_t* last_page_len_d,
+    int32_t* request_indices, int32_t* kv_tile_indices, int32_t* kv_chunk_size_ptr,
+    int32_t num_qo_heads, int32_t num_kv_heads, int32_t head_dim,
+    int32_t page_size, int32_t batch_size, int64_t stride_page,
+    float sm_scale, int32_t window_left, void* stream)
 {
-  PEGAINFER_FFI_GUARD_BEGIN
-    auto paged_kv = make_paged_kv(
-        kv_data, k_offset_elems, v_offset_elems,
-        page_indices, page_indptr, last_page_len_d,
-        num_kv_heads, head_dim, page_size, batch_size, stride_page);
+  return decode_launch</*HEAD_DIM=*/256, WindowVariant>(
+      q, output, kv_data, k_offset_elems, v_offset_elems,
+      page_indices, page_indptr, last_page_len_d,
+      request_indices, kv_tile_indices, kv_chunk_size_ptr,
+      num_qo_heads, num_kv_heads, head_dim, page_size, batch_size,
+      stride_page, sm_scale, window_left, stream);
+}
 
-    uint32_t q_stride_n = num_qo_heads * head_dim;
-    uint32_t q_stride_h = head_dim;
+int batch_prefill_paged_cuda_hd256(
+    void* q, void* output, void* kv_data,
+    int64_t k_offset_elems, int64_t v_offset_elems,
+    int32_t* page_indices, int32_t* page_indptr, int32_t* last_page_len_d,
+    int32_t* q_indptr, int32_t* request_indices, int32_t* qo_tile_indices,
+    int32_t* kv_tile_indices, int32_t* kv_chunk_size_ptr, uint32_t* total_num_rows,
+    int32_t num_qo_heads, int32_t num_kv_heads, int32_t head_dim,
+    int32_t page_size, int32_t seq_len, int32_t batch_size,
+    int32_t padded_batch_size, int64_t stride_page, float sm_scale,
+    void* stream)
+{
+  return prefill_paged_launch</*HEAD_DIM=*/256, Variant>(
+      q, output, kv_data, k_offset_elems, v_offset_elems,
+      page_indices, page_indptr, last_page_len_d, q_indptr,
+      request_indices, qo_tile_indices, kv_tile_indices, kv_chunk_size_ptr,
+      total_num_rows, num_qo_heads, num_kv_heads, head_dim, page_size,
+      seq_len, batch_size, padded_batch_size, stride_page, sm_scale,
+      /*cta_tile_q_override=*/0, /*window_left=*/-1, stream);
+}
 
-    BatchPrefillParamsT params(
-        reinterpret_cast<DType*>(q),
-        paged_kv,
-        /*maybe_custom_mask=*/nullptr,
-        q_indptr,
-        /*maybe_mask_indptr=*/nullptr,
-        /*maybe_q_rope_offset=*/nullptr,
-        reinterpret_cast<DType*>(output),
-        /*lse=*/nullptr,
-        /*maybe_alibi_slopes=*/nullptr,
-        num_qo_heads,
-        q_stride_n,
-        q_stride_h,
-        /*window_left=*/-1,
-        /*logits_soft_cap=*/0.0f,
-        sm_scale,
-        /*rope_scale=*/1.0f,
-        /*rope_theta=*/1e6f);
-
-    params.request_indices   = request_indices;
-    params.qo_tile_indices   = qo_tile_indices;
-    params.kv_tile_indices   = kv_tile_indices;
-    params.merge_indptr      = nullptr;
-    params.o_indptr          = q_indptr;
-    params.block_valid_mask  = nullptr;
-    params.kv_chunk_size_ptr = kv_chunk_size_ptr;
-    params.max_total_num_rows = seq_len;
-    params.total_num_rows    = total_num_rows;
-    params.padded_batch_size = padded_batch_size;
-    params.partition_kv      = false;
-
-    uint32_t group_size = num_qo_heads / num_kv_heads;
-    int64_t packed_qo_len = static_cast<int64_t>(seq_len) * group_size;
-    uint32_t cta_tile_q = FA2DetermineCtaTileQ(packed_qo_len, head_dim);
-
-    cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);
-    int result = 0;
-    DISPATCH_CTA_TILE_Q(cta_tile_q, CTA_TILE_Q, {
-        result = static_cast<int>(
-            BatchPrefillWithPagedKVCacheDispatched<
-                CTA_TILE_Q,
-                /*HEAD_DIM_QK=*/256,
-                /*HEAD_DIM_VO=*/256,
-                PosEncodingMode::kNone,
-                /*USE_FP16_QK_REDUCTION=*/false,
-                MaskMode::kCausal,
-                Variant,
-                BatchPrefillParamsT>(
-                params,
-                /*tmp_v=*/nullptr,
-                /*tmp_s=*/nullptr,
-                /*enable_pdl=*/false,
-                s));
-    });
-    return result;
-  PEGAINFER_FFI_GUARD_END(-1)
+int batch_prefill_paged_window_cuda_hd256(
+    void* q, void* output, void* kv_data,
+    int64_t k_offset_elems, int64_t v_offset_elems,
+    int32_t* page_indices, int32_t* page_indptr, int32_t* last_page_len_d,
+    int32_t* q_indptr, int32_t* request_indices, int32_t* qo_tile_indices,
+    int32_t* kv_tile_indices, int32_t* kv_chunk_size_ptr, uint32_t* total_num_rows,
+    int32_t num_qo_heads, int32_t num_kv_heads, int32_t head_dim,
+    int32_t page_size, int32_t seq_len, int32_t batch_size,
+    int32_t padded_batch_size, int64_t stride_page, float sm_scale,
+    int32_t window_left, void* stream)
+{
+  return prefill_paged_launch</*HEAD_DIM=*/256, WindowVariant>(
+      q, output, kv_data, k_offset_elems, v_offset_elems,
+      page_indices, page_indptr, last_page_len_d, q_indptr,
+      request_indices, qo_tile_indices, kv_tile_indices, kv_chunk_size_ptr,
+      total_num_rows, num_qo_heads, num_kv_heads, head_dim, page_size,
+      seq_len, batch_size, padded_batch_size, stride_page, sm_scale,
+      /*cta_tile_q_override=*/0, window_left, stream);
 }
 
 } // extern "C"

--- a/pegainfer-kernels/src/ffi/qwen35.rs
+++ b/pegainfer-kernels/src/ffi/qwen35.rs
@@ -5,7 +5,8 @@ use cudarc::driver::sys::CUstream;
 use super::Half;
 
 // Qwen3.5-4B private kernels (hybrid linear + HD256 full attention).
-// Sources: csrc/qwen35/*.cu; the *_hd256 paged variants live in csrc/shared/paged_attention.cu.
+// Sources: csrc/qwen35/*.cu. The paged HD256 attention entry points are shared
+// with Gemma 4 and are declared in `shared.rs`.
 unsafe extern "C" {
     // Qwen3.5 full-attention prefill prep that writes K/V directly into paged KV.
     pub fn prefill_attention_hd256_prep_paged_cuda(
@@ -215,57 +216,4 @@ unsafe extern "C" {
         scale: f32,
         stream: CUstream,
     ) -> CUresult;
-}
-
-unsafe extern "C" {
-    // Paged attention decode for HEAD_DIM=256 (Qwen3.5-4B full-attention layers).
-    pub fn paged_attention_decode_cuda_hd256(
-        q: *const Half,
-        output: *mut Half,
-        kv_data: *const Half,
-        k_offset_elems: i64,
-        v_offset_elems: i64,
-        page_indices: *const i32,
-        page_indptr: *const i32,
-        last_page_len_d: *const i32,
-        request_indices: *const i32,
-        kv_tile_indices: *const i32,
-        kv_chunk_size_ptr: *const i32,
-        num_qo_heads: i32,
-        num_kv_heads: i32,
-        head_dim: i32,
-        page_size: i32,
-        batch_size: i32,
-        stride_page: i64,
-        sm_scale: f32,
-        stream: CUstream,
-    ) -> i32;
-
-    // Batch prefill with paged KV for HEAD_DIM=256 (Qwen3.5-4B multi-token prefill).
-    pub fn batch_prefill_paged_cuda_hd256(
-        q: *const Half,
-        output: *mut Half,
-        kv_data: *const Half,
-        k_offset_elems: i64,
-        v_offset_elems: i64,
-        page_indices: *const i32,
-        page_indptr: *const i32,
-        last_page_len_d: *const i32,
-        q_indptr: *const i32,
-        request_indices: *const i32,
-        qo_tile_indices: *const i32,
-        kv_tile_indices: *const i32,
-        kv_chunk_size_ptr: *const i32,
-        total_num_rows: *const u32,
-        num_qo_heads: i32,
-        num_kv_heads: i32,
-        head_dim: i32,
-        page_size: i32,
-        seq_len: i32,
-        batch_size: i32,
-        padded_batch_size: i32,
-        stride_page: i64,
-        sm_scale: f32,
-        stream: CUstream,
-    ) -> i32;
 }

--- a/pegainfer-kernels/src/ffi/shared.rs
+++ b/pegainfer-kernels/src/ffi/shared.rs
@@ -646,6 +646,112 @@ unsafe extern "C" {
     ) -> i32;
 }
 
+// HEAD_DIM=256 paged attention. Qwen3.5-4B calls the full-attention pair; the
+// windowed pair carries the sliding-window mask for Gemma 4's local layers and
+// has no caller yet. `window_left` is an inclusive distance: an N-token window
+// passes N - 1, and -1 degrades to full attention.
+unsafe extern "C" {
+    pub fn paged_attention_decode_cuda_hd256(
+        q: *const Half,
+        output: *mut Half,
+        kv_data: *const Half,
+        k_offset_elems: i64,
+        v_offset_elems: i64,
+        page_indices: *const i32,
+        page_indptr: *const i32,
+        last_page_len_d: *const i32,
+        request_indices: *const i32,
+        kv_tile_indices: *const i32,
+        kv_chunk_size_ptr: *const i32,
+        num_qo_heads: i32,
+        num_kv_heads: i32,
+        head_dim: i32,
+        page_size: i32,
+        batch_size: i32,
+        stride_page: i64,
+        sm_scale: f32,
+        stream: CUstream,
+    ) -> i32;
+
+    pub fn paged_attention_decode_window_cuda_hd256(
+        q: *const Half,
+        output: *mut Half,
+        kv_data: *const Half,
+        k_offset_elems: i64,
+        v_offset_elems: i64,
+        page_indices: *const i32,
+        page_indptr: *const i32,
+        last_page_len_d: *const i32,
+        request_indices: *const i32,
+        kv_tile_indices: *const i32,
+        kv_chunk_size_ptr: *const i32,
+        num_qo_heads: i32,
+        num_kv_heads: i32,
+        head_dim: i32,
+        page_size: i32,
+        batch_size: i32,
+        stride_page: i64,
+        sm_scale: f32,
+        window_left: i32,
+        stream: CUstream,
+    ) -> i32;
+
+    pub fn batch_prefill_paged_cuda_hd256(
+        q: *const Half,
+        output: *mut Half,
+        kv_data: *const Half,
+        k_offset_elems: i64,
+        v_offset_elems: i64,
+        page_indices: *const i32,
+        page_indptr: *const i32,
+        last_page_len_d: *const i32,
+        q_indptr: *const i32,
+        request_indices: *const i32,
+        qo_tile_indices: *const i32,
+        kv_tile_indices: *const i32,
+        kv_chunk_size_ptr: *const i32,
+        total_num_rows: *const u32,
+        num_qo_heads: i32,
+        num_kv_heads: i32,
+        head_dim: i32,
+        page_size: i32,
+        seq_len: i32,
+        batch_size: i32,
+        padded_batch_size: i32,
+        stride_page: i64,
+        sm_scale: f32,
+        stream: CUstream,
+    ) -> i32;
+
+    pub fn batch_prefill_paged_window_cuda_hd256(
+        q: *const Half,
+        output: *mut Half,
+        kv_data: *const Half,
+        k_offset_elems: i64,
+        v_offset_elems: i64,
+        page_indices: *const i32,
+        page_indptr: *const i32,
+        last_page_len_d: *const i32,
+        q_indptr: *const i32,
+        request_indices: *const i32,
+        qo_tile_indices: *const i32,
+        kv_tile_indices: *const i32,
+        kv_chunk_size_ptr: *const i32,
+        total_num_rows: *const u32,
+        num_qo_heads: i32,
+        num_kv_heads: i32,
+        head_dim: i32,
+        page_size: i32,
+        seq_len: i32,
+        batch_size: i32,
+        padded_batch_size: i32,
+        stride_page: i64,
+        sm_scale: f32,
+        window_left: i32,
+        stream: CUstream,
+    ) -> i32;
+}
+
 // Added during rebase onto main: generic dtype/scale helpers, batched argmax/top1,
 // rms-norm-round variant, gemm-per-token.
 unsafe extern "C" {


### PR DESCRIPTION
## Description

Fixes #818 

Gemma 4's local layers attend over a 1024-token window at head_dim 256. FlashInfer carries the mask in its attention variant, but nothing here instantiated it: all eleven `window_left` arguments in the paged entry points were hardcoded to `-1`, which degrades to full attention.

This adds a windowed sibling for each of the two head_dim 256 paged entry points, decode and batch prefill. Kernel and FFI only — there is no safe wrapper and no caller. The Gemma 4 executor that would own this API does not exist yet and its decode route is not settled, so defining the safe wrapper surface here would be premature.

`window_left` is an inclusive distance. `variants.cuh` masks on `kv_idx + qo_len + window_left >= kv_len + qo_idx`, after `window_left = (params.window_left >= 0) ? params.window_left : kv_len`. So a W-token window is passed as `W - 1`, and `-1` keeps full attention. Every existing entry point still passes `-1` and is unchanged.

The two head_dim 256 bodies were copies of their head_dim 128 counterparts — their own comments said as much. Rather than copy them a third time for the windowed pair, both launch paths are now templated on head dimension as well as attention variant, and all six entry points forward into them. Dispatch is unchanged: `resolve_prefill_cta_tile_q` with a zero override returns exactly what `FA2DetermineCtaTileQ` returned before. A side effect worth having is that Qwen3.5's full-attention layers now go through those templates, so its accuracy gate covers the refactor.

Only the non-partitioned windowed decode path is added, which is what establishes correctness. Whether Gemma 4 also wants a windowed SplitKv path is a performance question, and `SplitKv` is selected by CTA count against SM count rather than by context length (`docs/models/qwen3/decode-attention.md`) — so a 1024-token window does not rule it out, and at bs=1 with 8 local KV heads it is exactly the underfilled case that doc describes. That decision is deferred until the executor exists and there are representative decode benchmarks to judge it on.

The head_dim 256 declarations move from `ffi/qwen35.rs` to `ffi/shared.rs`, matching where they are defined now that they have two consumers.

## Verification

Single GPU (sm_89, x86_64).

No test ships with this change. FlashInfer's own `tests/attention/test_sliding_window.py` already covers the mask numerics on exactly these specializations — head_dim 256, paged decode and paged batch prefill, page size 16, GQA group 2 — so a host-reference suite here would re-derive vendor behaviour, and with no caller yet it would be maintaining a CUDA fixture for a call boundary that does not exist. The caller-owned parts — the `sliding_window - 1` conversion, symbol and dispatch selection, page layout and metadata — are testable once the executor performs them, and belong to that change.

The boundary was checked once on hardware during bring-up, against a scratch harness not included here: a 1024-token window over 4096 cached keys at head_dim 256 and GQA group 2, paged with `num_kv_heads > 1`, driving each windowed entry point once. Q and K zero make softmax uniform over whatever survives the mask, and marked V rows straddling the window edge make one output component read back as attended probes over attended keys. Decode agreed with the host reference on every query head; prefill agreed on the last row, on a mid-sequence row whose window is disjoint from it, and on a row shorter than the window, which stayed causal from the sequence start.

Non-regression for the refactor — the entry points these templates now serve:

- `openinfer-qwen3 --test hf_golden_gate` — 1 passed, 0 failed. Covers the head_dim 128 launch paths.
- `openinfer-qwen35 --features qwen35 --test hf_golden_gate` — 2 passed, 0 failed, 2 ignored (TP2, needs two devices). Covers the head_dim 256 launch paths, which is where the entry points were rewritten.

`cargo clippy --release -p openinfer-kernels --all-targets -- -D warnings` clean.


## Type of Change

- [x] New feature (non-breaking change which adds functionality)
