### PR TITLE
feat(core): split the RoPE frequency denominator from the rotary extent 

### DIFF
--- a/pegainfer-core/src/lib.rs
+++ b/pegainfer-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod kv_pool;
 pub mod logging;
 pub mod ops;
 pub mod page_pool;
+pub mod rope;
 pub mod tensor;
 pub mod tracing;
 pub mod weight_loader;

--- a/pegainfer-core/src/rope.rs
+++ b/pegainfer-core/src/rope.rs
@@ -1,0 +1,232 @@
+//! RoPE cos/sin table generation.
+
+use anyhow::Result;
+use half::bf16;
+
+use crate::tensor::DeviceContext;
+use crate::tensor::DeviceVec;
+
+/// Geometry of a RoPE cos/sin cache.
+pub struct RopeTableSpec {
+    /// Components that get rotated. Drives the cache extent and the half-split.
+    pub rotary_dim: usize,
+    /// Denominator of `theta^(2i / frequency_dim)`, and nothing else.
+    pub frequency_dim: usize,
+    pub max_seq_len: usize,
+    pub theta: f32,
+}
+
+impl RopeTableSpec {
+    /// Everything the table generation assumes. Each rejected case would
+    /// otherwise yield a table that looks well-formed and is wrong.
+    fn validate(&self) -> Result<usize> {
+        let RopeTableSpec {
+            rotary_dim: r,
+            frequency_dim: f,
+            max_seq_len: n,
+            theta,
+        } = *self;
+        anyhow::ensure!(r > 0, "RoPE rotary_dim must be positive");
+        anyhow::ensure!(r % 2 == 0, "RoPE rotary_dim must be even, got {r}");
+        anyhow::ensure!(
+            r <= f,
+            "RoPE rotary_dim ({r}) must not exceed frequency_dim ({f})"
+        );
+        anyhow::ensure!(n > 0, "RoPE max_seq_len must be positive");
+        anyhow::ensure!(
+            theta.is_finite() && theta > 0.0,
+            "RoPE theta must be finite and positive, got {theta}"
+        );
+        n.checked_mul(r)
+            .ok_or_else(|| anyhow::anyhow!("RoPE table size {n} x {r} overflows usize"))
+    }
+}
+
+/// Upload a spec's tables as contiguous GPU buffers.
+pub fn precompute_rope(
+    ctx: &DeviceContext,
+    spec: &RopeTableSpec,
+) -> Result<(DeviceVec, DeviceVec)> {
+    let (cos_host, sin_host) = spec.tables()?;
+    Ok((
+        DeviceVec::from_host(ctx, &cos_host)?,
+        DeviceVec::from_host(ctx, &sin_host)?,
+    ))
+}
+
+impl RopeTableSpec {
+    /// Host-side cos/sin tables, laid out `[max_seq_len * rotary_dim]` with
+    /// position `pos` at offset `pos * rotary_dim`.
+    fn tables(&self) -> Result<(Vec<bf16>, Vec<bf16>)> {
+        let total = self.validate()?;
+        let RopeTableSpec {
+            rotary_dim,
+            frequency_dim,
+            max_seq_len,
+            theta,
+        } = *self;
+        let half_dim = rotary_dim / 2;
+
+        let inv_freq: Vec<f32> = (0..half_dim)
+            .map(|i| 1.0 / theta.powf(i as f32 * 2.0 / frequency_dim as f32))
+            .collect();
+
+        let mut cos_host = vec![bf16::ZERO; total];
+        let mut sin_host = vec![bf16::ZERO; total];
+
+        for pos in 0..max_seq_len {
+            let base = pos * rotary_dim;
+            for i in 0..half_dim {
+                let freq = pos as f32 * inv_freq[i];
+                let cos_val = bf16::from_f32(freq.cos());
+                let sin_val = bf16::from_f32(freq.sin());
+                // Half-split layout: [cos(0)..cos(half-1), cos(0)..cos(half-1)]
+                cos_host[base + i] = cos_val;
+                cos_host[base + i + half_dim] = cos_val;
+                sin_host[base + i] = sin_val;
+                sin_host[base + i + half_dim] = sin_val;
+            }
+        }
+
+        Ok((cos_host, sin_host))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use half::bf16;
+
+    use super::RopeTableSpec;
+
+    const THETA: f32 = 1e6;
+
+    fn spec(rotary_dim: usize, frequency_dim: usize, max_seq_len: usize) -> RopeTableSpec {
+        RopeTableSpec {
+            rotary_dim,
+            frequency_dim,
+            max_seq_len,
+            theta: THETA,
+        }
+    }
+
+    fn tables(
+        rotary_dim: usize,
+        frequency_dim: usize,
+        max_seq_len: usize,
+    ) -> (Vec<bf16>, Vec<bf16>) {
+        spec(rotary_dim, frequency_dim, max_seq_len)
+            .tables()
+            .expect("test geometry must be valid")
+    }
+
+    #[test]
+    fn rope_tables_backward_compatible_with_single_param() {
+        // Reference comes from the formula, not from a second call.
+        let (d, n) = (512usize, 2048usize);
+        let (cos, sin) = tables(d, d, n);
+
+        let half = d / 2;
+        let inv_freq: Vec<f32> = (0..half)
+            .map(|i| 1.0 / THETA.powf(i as f32 * 2.0 / d as f32))
+            .collect();
+        for pos in 0..n {
+            let base = pos * d;
+            for i in 0..half {
+                let freq = pos as f32 * inv_freq[i];
+                let c = bf16::from_f32(freq.cos());
+                let s = bf16::from_f32(freq.sin());
+                assert_eq!(cos[base + i].to_bits(), c.to_bits(), "cos pos={pos} i={i}");
+                assert_eq!(
+                    cos[base + i + half].to_bits(),
+                    c.to_bits(),
+                    "cos dup pos={pos} i={i}"
+                );
+                assert_eq!(sin[base + i].to_bits(), s.to_bits(), "sin pos={pos} i={i}");
+                assert_eq!(
+                    sin[base + i + half].to_bits(),
+                    s.to_bits(),
+                    "sin dup pos={pos} i={i}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rope_tables_proportional_matches_full_rope_leading_half() {
+        // The two rows duplicate at different offsets — 64 and 256 — so the
+        // identity covers the first rotary_dim / 2 entries, not a whole-row
+        // prefix. Exact arithmetic on both sides, so 1024 rows suffice.
+        let n = 1024usize;
+        let (prop_cos, prop_sin) = tables(128, 512, n);
+        let (full_cos, full_sin) = tables(512, 512, n);
+
+        for pos in [0usize, 1023] {
+            let (pb, fb) = (pos * 128, pos * 512);
+            assert_eq!(
+                prop_cos[pb..pb + 64],
+                full_cos[fb..fb + 64],
+                "cos leading half diverged at pos={pos}"
+            );
+            assert_eq!(
+                prop_sin[pb..pb + 64],
+                full_sin[fb..fb + 64],
+                "sin leading half diverged at pos={pos}"
+            );
+            if pos > 0 {
+                assert_ne!(
+                    prop_cos[pb + 64..pb + 128],
+                    full_cos[fb + 64..fb + 128],
+                    "expected the second halves to diverge at pos={pos}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rope_tables_proportional_is_not_ordinary_partial() {
+        // Only i = 0 is denominator-independent (theta^0 both ways). From i = 1
+        // the two formulas separate immediately: at pos = 1 the cos entries
+        // differ by ~0.109, some 28 bf16 ulps.
+        let (prop_cos, _) = tables(128, 512, 2);
+        let (partial_cos, _) = tables(128, 128, 2);
+
+        assert_eq!(
+            prop_cos[128].to_bits(),
+            partial_cos[128].to_bits(),
+            "i=0 must agree"
+        );
+        assert_ne!(
+            prop_cos[129].to_bits(),
+            partial_cos[129].to_bits(),
+            "i=1 at pos=1 must separate the two denominators"
+        );
+    }
+
+    #[test]
+    fn rope_spec_rejects_unusable_geometry() {
+        for (r, f, what) in [
+            (0usize, 512usize, "zero rotary_dim"),
+            (127, 512, "odd rotary_dim"),
+            (512, 128, "rotary_dim above frequency_dim"),
+        ] {
+            assert!(spec(r, f, 8).tables().is_err(), "{what} must be rejected");
+        }
+        assert!(spec(128, 512, 0).tables().is_err(), "zero max_seq_len");
+        assert!(
+            spec(128, 512, usize::MAX).tables().is_err(),
+            "table size overflow"
+        );
+        for (theta, what) in [
+            (0.0f32, "zero theta"),
+            (-1e6, "negative theta"),
+            (f32::NAN, "NaN theta"),
+            (f32::INFINITY, "infinite theta"),
+        ] {
+            let s = RopeTableSpec {
+                theta,
+                ..spec(128, 512, 8)
+            };
+            assert!(s.tables().is_err(), "{what} must be rejected");
+        }
+    }
+}

--- a/pegainfer-core/src/weight_loader.rs
+++ b/pegainfer-core/src/weight_loader.rs
@@ -1,4 +1,4 @@
-//! Safetensors weight loading and RoPE precomputation.
+//! Safetensors weight loading.
 
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -723,44 +723,6 @@ pub fn load_tensor_2d_col_shard(
     let elems = tensor_bf16_cow(&tensor, name)?;
     let host = gather_cols(&elems, rows, total_cols, col_offset, cols);
     DeviceMatrix::from_host(ctx, &host, rows, cols)
-}
-
-/// Precompute RoPE cos/sin cache as contiguous GPU buffers.
-/// Layout: [max_seq_len * head_dim] — position `pos` at offset `pos * head_dim`.
-pub fn precompute_rope(
-    ctx: &DeviceContext,
-    head_dim: usize,
-    max_seq_len: usize,
-    theta: f32,
-) -> Result<(DeviceVec, DeviceVec)> {
-    let half_dim = head_dim / 2;
-
-    let inv_freq: Vec<f32> = (0..half_dim)
-        .map(|i| 1.0 / theta.powf(i as f32 * 2.0 / head_dim as f32))
-        .collect();
-
-    let total = max_seq_len * head_dim;
-    let mut cos_host = vec![bf16::ZERO; total];
-    let mut sin_host = vec![bf16::ZERO; total];
-
-    for pos in 0..max_seq_len {
-        let base = pos * head_dim;
-        for i in 0..half_dim {
-            let freq = pos as f32 * inv_freq[i];
-            let cos_val = bf16::from_f32(freq.cos());
-            let sin_val = bf16::from_f32(freq.sin());
-            // Half-split layout: [cos(0)..cos(63), cos(0)..cos(63)]
-            cos_host[base + i] = cos_val;
-            cos_host[base + i + half_dim] = cos_val;
-            sin_host[base + i] = sin_val;
-            sin_host[base + i + half_dim] = sin_val;
-        }
-    }
-
-    let cos_cache = DeviceVec::from_host(ctx, &cos_host)?;
-    let sin_cache = DeviceVec::from_host(ctx, &sin_host)?;
-
-    Ok((cos_cache, sin_cache))
 }
 
 #[allow(clippy::cast_ptr_alignment)]

--- a/pegainfer-glm52/src/dspark.rs
+++ b/pegainfer-glm52/src/dspark.rs
@@ -28,12 +28,13 @@ use anyhow::ensure;
 use cudarc::driver::CudaSlice;
 use cudarc::driver::DevicePtr;
 use pegainfer_core::cuda_graph::CudaGraphState;
+use pegainfer_core::rope::RopeTableSpec;
+use pegainfer_core::rope::precompute_rope;
 use pegainfer_core::weight_loader::deserialize_shards;
 use pegainfer_core::weight_loader::load_shard_info;
 use pegainfer_core::weight_loader::load_tensor_1d;
 use pegainfer_core::weight_loader::load_tensor_2d;
 use pegainfer_core::weight_loader::mmap_shards;
-use pegainfer_core::weight_loader::precompute_rope;
 use pegainfer_kernels::ops::add_batch_into;
 use pegainfer_kernels::ops::copy_hidden_token_range_into;
 use pegainfer_kernels::ops::dflash_qk_norm_rope_into;
@@ -325,8 +326,15 @@ impl Glm52DsparkModel {
         // embed_tokens / lm_head / confidence_head are intentionally not
         // loaded: the first two are byte-identical to the target's, the
         // confidence head is Phase 2.
-        let (cos_cache, sin_cache) =
-            precompute_rope(ctx, DSPARK_HEAD_DIM, cache_len, DSPARK_ROPE_THETA)?;
+        let (cos_cache, sin_cache) = precompute_rope(
+            ctx,
+            &RopeTableSpec {
+                rotary_dim: DSPARK_HEAD_DIM,
+                frequency_dim: DSPARK_HEAD_DIM,
+                max_seq_len: cache_len,
+                theta: DSPARK_ROPE_THETA,
+            },
+        )?;
         ctx.sync()?;
 
         Ok(Self {

--- a/pegainfer-glm52/src/dspark_test_support.rs
+++ b/pegainfer-glm52/src/dspark_test_support.rs
@@ -4,7 +4,8 @@
 
 use anyhow::Result;
 use cudarc::driver::CudaSlice;
-use pegainfer_core::weight_loader::precompute_rope;
+use pegainfer_core::rope::RopeTableSpec;
+use pegainfer_core::rope::precompute_rope;
 use pegainfer_kernels::tensor::DeviceContext;
 use pegainfer_kernels::tensor::DeviceMatrix;
 use pegainfer_kernels::tensor::DeviceVec;
@@ -36,8 +37,15 @@ impl Glm52DsparkModel {
                 down: mat(GLM52_HIDDEN, DSPARK_INTER)?,
             });
         }
-        let (cos_cache, sin_cache) =
-            precompute_rope(ctx, DSPARK_HEAD_DIM, cache_len, DSPARK_ROPE_THETA)?;
+        let (cos_cache, sin_cache) = precompute_rope(
+            ctx,
+            &RopeTableSpec {
+                rotary_dim: DSPARK_HEAD_DIM,
+                frequency_dim: DSPARK_HEAD_DIM,
+                max_seq_len: cache_len,
+                theta: DSPARK_ROPE_THETA,
+            },
+        )?;
         Ok(Self {
             layers,
             norm: DeviceVec::zeros(ctx, GLM52_HIDDEN)?,

--- a/pegainfer-qwen3/src/dflash/loading.rs
+++ b/pegainfer-qwen3/src/dflash/loading.rs
@@ -1,6 +1,8 @@
 use anyhow::Context;
 use anyhow::Result;
 use log::debug;
+use pegainfer_core::rope::RopeTableSpec;
+use pegainfer_core::rope::precompute_rope;
 use pegainfer_core::tensor::DeviceContext;
 use pegainfer_core::tensor::DeviceMatrix;
 use pegainfer_core::weight_loader::deserialize_shards;
@@ -8,7 +10,6 @@ use pegainfer_core::weight_loader::load_shard_info;
 use pegainfer_core::weight_loader::load_tensor_1d;
 use pegainfer_core::weight_loader::load_tensor_2d;
 use pegainfer_core::weight_loader::mmap_shards;
-use pegainfer_core::weight_loader::precompute_rope;
 
 use super::DFlashDraftModel;
 use crate::config::DFlashConfig;
@@ -154,9 +155,12 @@ impl DFlashDraftModel {
 
         let (cos_cache, sin_cache) = precompute_rope(
             ctx,
-            config.head_dim,
-            config.max_position_embeddings,
-            config.rope_theta,
+            &RopeTableSpec {
+                rotary_dim: config.head_dim,
+                frequency_dim: config.head_dim,
+                max_seq_len: config.max_position_embeddings,
+                theta: config.rope_theta,
+            },
         )?;
         ctx.sync()?;
 

--- a/pegainfer-qwen3/src/eagle3/loading.rs
+++ b/pegainfer-qwen3/src/eagle3/loading.rs
@@ -1,6 +1,8 @@
 use anyhow::Context;
 use anyhow::Result;
 use log::debug;
+use pegainfer_core::rope::RopeTableSpec;
+use pegainfer_core::rope::precompute_rope;
 use pegainfer_core::tensor::DeviceContext;
 use pegainfer_core::tensor::DeviceMatrix;
 use pegainfer_core::tensor::DeviceVec;
@@ -11,7 +13,6 @@ use pegainfer_core::weight_loader::load_tensor_2d;
 use pegainfer_core::weight_loader::load_tensor_bool_host;
 use pegainfer_core::weight_loader::load_tensor_i64_host;
 use pegainfer_core::weight_loader::mmap_shards;
-use pegainfer_core::weight_loader::precompute_rope;
 
 use super::Eagle3DraftModel;
 use super::Eagle3Layer;
@@ -163,9 +164,12 @@ impl Eagle3DraftModel {
 
         let (cos_cache, sin_cache) = precompute_rope(
             ctx,
-            config.head_dim,
-            config.max_position_embeddings,
-            config.rope_theta,
+            &RopeTableSpec {
+                rotary_dim: config.head_dim,
+                frequency_dim: config.head_dim,
+                max_seq_len: config.max_position_embeddings,
+                theta: config.rope_theta,
+            },
         )?;
         ctx.sync()?;
 

--- a/pegainfer-qwen3/src/kernel_bench.rs
+++ b/pegainfer-qwen3/src/kernel_bench.rs
@@ -11,6 +11,8 @@ use cudarc::driver::DevicePtr;
 use cudarc::driver::DevicePtrMut;
 use cudarc::driver::sys;
 use half::bf16;
+use pegainfer_core::rope::RopeTableSpec;
+use pegainfer_core::rope::precompute_rope;
 use pegainfer_kernels::ffi;
 use pegainfer_kernels::ops::PrefillPagedPlan;
 use pegainfer_kernels::ops::prefill_attention_paged_into;
@@ -603,8 +605,15 @@ impl AttentionPrefillCase {
         let output = HiddenStates::zeros(&ctx, q_dim, batch_size * seq_len)?;
         let q_norm = DeviceVec::from_host(&ctx, &vec![bf16::from_f32(1.0); HEAD_DIM])?;
         let k_norm = DeviceVec::from_host(&ctx, &vec![bf16::from_f32(1.0); HEAD_DIM])?;
-        let cos_cache = DeviceVec::from_host(&ctx, &rope_cache_bf16(seq_len, true))?;
-        let sin_cache = DeviceVec::from_host(&ctx, &rope_cache_bf16(seq_len, false))?;
+        let (cos_cache, sin_cache) = precompute_rope(
+            &ctx,
+            &RopeTableSpec {
+                rotary_dim: HEAD_DIM,
+                frequency_dim: HEAD_DIM,
+                max_seq_len: seq_len,
+                theta: 1e6,
+            },
+        )?;
         let kv_buffer = ctx
             .stream
             .clone_htod(&patterned_bf16(total_pages * layout.page_stride, 0.001))?;
@@ -1297,19 +1306,22 @@ impl DenseCase {
                 let positions: Vec<i32> = (0..rows)
                     .map(|i| ((i * 997) % DENSE_ROPE_CACHE_TOKENS) as i32)
                     .collect();
+                let (cos_cache, sin_cache) = precompute_rope(
+                    &ctx,
+                    &RopeTableSpec {
+                        rotary_dim: HEAD_DIM,
+                        frequency_dim: HEAD_DIM,
+                        max_seq_len: DENSE_ROPE_CACHE_TOKENS,
+                        theta: 1e6,
+                    },
+                )?;
                 DenseBuffers::QkRope {
                     q: hidden_of(&ctx, Q_DIM, rows, 0.01)?,
                     k: hidden_of(&ctx, KV_DIM, rows, 0.01)?,
                     q_norm: ones_vec(&ctx, HEAD_DIM)?,
                     k_norm: ones_vec(&ctx, HEAD_DIM)?,
-                    cos_cache: DeviceVec::from_host(
-                        &ctx,
-                        &rope_cache_bf16(DENSE_ROPE_CACHE_TOKENS, true),
-                    )?,
-                    sin_cache: DeviceVec::from_host(
-                        &ctx,
-                        &rope_cache_bf16(DENSE_ROPE_CACHE_TOKENS, false),
-                    )?,
+                    cos_cache,
+                    sin_cache,
                     positions: ctx.stream.clone_htod(&positions)?,
                 }
             }
@@ -1489,23 +1501,4 @@ fn patterned_bf16(len: usize, scale: f32) -> Vec<bf16> {
     (0..len)
         .map(|i| bf16::from_f32((((i % 251) as f32) - 125.0) * scale))
         .collect()
-}
-
-fn rope_cache_bf16(seq_len: usize, cos: bool) -> Vec<bf16> {
-    let half_dim = HEAD_DIM / 2;
-    let inv_freq: Vec<f32> = (0..half_dim)
-        .map(|i| 1.0 / 1_000_000.0f32.powf(i as f32 * 2.0 / HEAD_DIM as f32))
-        .collect();
-    let mut out = vec![bf16::ZERO; seq_len * HEAD_DIM];
-    for pos in 0..seq_len {
-        let base = pos * HEAD_DIM;
-        for (i, inv_freq) in inv_freq.iter().copied().enumerate() {
-            let angle = pos as f32 * inv_freq;
-            let value = if cos { angle.cos() } else { angle.sin() };
-            let value = bf16::from_f32(value);
-            out[base + i] = value;
-            out[base + i + half_dim] = value;
-        }
-    }
-    out
 }

--- a/pegainfer-qwen3/src/weights/load.rs
+++ b/pegainfer-qwen3/src/weights/load.rs
@@ -6,6 +6,8 @@ use std::time::Instant;
 use anyhow::Result;
 use log::debug;
 use log::info;
+use pegainfer_core::rope::RopeTableSpec;
+use pegainfer_core::rope::precompute_rope;
 use pegainfer_core::tensor::DeviceContext;
 use pegainfer_core::weight_loader::FusedPart;
 use pegainfer_core::weight_loader::SlotId;
@@ -15,7 +17,6 @@ use pegainfer_core::weight_loader::WeightPrefetch;
 use pegainfer_core::weight_loader::deserialize_shards;
 use pegainfer_core::weight_loader::load_shard_info;
 use pegainfer_core::weight_loader::mmap_shards;
-use pegainfer_core::weight_loader::precompute_rope;
 
 use super::Attention;
 use super::MLP;
@@ -208,9 +209,12 @@ impl Qwen3Model {
         debug!("Precomputing RoPE cache on GPU");
         let (cos_cache, sin_cache) = precompute_rope(
             &ctx,
-            config.head_dim,
-            config.max_position_embeddings,
-            config.rope_theta,
+            &RopeTableSpec {
+                rotary_dim: config.head_dim,
+                frequency_dim: config.head_dim,
+                max_seq_len: config.max_position_embeddings,
+                theta: config.rope_theta,
+            },
         )?;
 
         loader.finish()?;

--- a/pegainfer-qwen35/benches/ops/common/mod.rs
+++ b/pegainfer-qwen35/benches/ops/common/mod.rs
@@ -178,34 +178,3 @@ pub(crate) fn decode_token_id(ctx: &DeviceContext, token_id: u32) -> Result<Cuda
         .clone_htod(&[token_id])
         .map_err(|e| anyhow!("H2D copy failed: {}", e))
 }
-
-pub(crate) fn rope_cache(
-    ctx: &DeviceContext,
-    max_seq_len: usize,
-    dim: usize,
-    theta: f32,
-) -> Result<(DeviceVec, DeviceVec)> {
-    assert_eq!(dim % 2, 0, "RoPE dimension must be even");
-    let half = dim / 2;
-    let inv_freq: Vec<f32> = (0..half)
-        .map(|idx| 1.0 / theta.powf(idx as f32 * 2.0 / dim as f32))
-        .collect();
-    let mut cos_host = vec![bf16::ZERO; max_seq_len * dim];
-    let mut sin_host = vec![bf16::ZERO; max_seq_len * dim];
-    for pos in 0..max_seq_len {
-        for idx in 0..half {
-            let freq = pos as f32 * inv_freq[idx];
-            let cos = bf16::from_f32(freq.cos());
-            let sin = bf16::from_f32(freq.sin());
-            cos_host[pos * dim + idx] = cos;
-            cos_host[pos * dim + idx + half] = cos;
-            sin_host[pos * dim + idx] = sin;
-            sin_host[pos * dim + idx + half] = sin;
-        }
-    }
-
-    Ok((
-        DeviceVec::from_host(ctx, &cos_host)?,
-        DeviceVec::from_host(ctx, &sin_host)?,
-    ))
-}

--- a/pegainfer-qwen35/src/weights.rs
+++ b/pegainfer-qwen35/src/weights.rs
@@ -7,6 +7,8 @@ use cudarc::nccl::safe::Comm;
 use cudarc::nccl::safe::ReduceOp;
 use log::debug;
 use log::info;
+use pegainfer_core::rope::RopeTableSpec;
+use pegainfer_core::rope::precompute_rope;
 use pegainfer_core::tensor::DeviceContext;
 use pegainfer_core::tensor::DeviceMatrix;
 use pegainfer_core::tensor::DeviceVec;
@@ -20,7 +22,6 @@ use pegainfer_core::weight_loader::load_tensor_2d;
 use pegainfer_core::weight_loader::load_tensor_2d_col_shard;
 use pegainfer_core::weight_loader::load_tensor_2d_row_shard;
 use pegainfer_core::weight_loader::mmap_shards;
-use pegainfer_core::weight_loader::precompute_rope;
 use safetensors::SafeTensors;
 
 use super::config::Config35;
@@ -466,9 +467,12 @@ impl Qwen35Model {
         );
         let (cos_cache, sin_cache) = precompute_rope(
             &ctx,
-            config.rotary_dim,
-            config.max_position_embeddings,
-            config.rope_theta,
+            &RopeTableSpec {
+                rotary_dim: config.rotary_dim,
+                frequency_dim: config.rotary_dim,
+                max_seq_len: config.max_position_embeddings,
+                theta: config.rope_theta,
+            },
         )?;
 
         ctx.sync()?;


### PR DESCRIPTION
## Description

Closes #820 


Gemma 4's global attention layers use proportional RoPE: only the first `rotary_dim` components are rotated, but the inverse-frequency denominator stays at the full head dim instead of shrinking with the rotated span. `precompute_rope` could not express that — one `head_dim` parameter drove both the cache extent (`pos * head_dim`, and the half-split point) and the denominator in `theta^(2i/head_dim)`. `theta` is the base of that power; the new parameter is its exponent's denominator, which is why it is named `frequency_dim` rather than anything with "base" in it.

The geometry now travels as a named `RopeTableSpec { rotary_dim, frequency_dim, max_seq_len, theta }` rather than as positional arguments. Three of those are `usize`, so a positional signature lets a caller transpose them and still compile — `(128, max_seq_len, 512, theta)` would pass validation and quietly build a cache of the wrong length. Named fields close that at the type level, which no test can. All six existing call sites give `rotary_dim` and `frequency_dim` the same value; writing it twice, named, is what puts the coincidence in front of whoever reads the call site, and Qwen3.5's is the one that benefits — it reads as ordinary until you notice the rotary dim is also serving as the denominator.

Geometry that cannot produce a usable table is rejected rather than silently producing one: `rotary_dim` positive and even and not above `frequency_dim`, `max_seq_len` positive, `theta` finite and positive, and the table extent checked for overflow. Two of those are worth spelling out. An odd rotary dim truncates in `half_dim = rotary_dim / 2`, so the final table component silently remains zero while the corresponding kernel output component is written by neither branch. A non-positive or non-finite `theta` produces non-finite or degenerate frequencies that silently propagate into the RoPE cache.

RoPE table generation moves out of `weight_loader` into its own `openinfer-core::rope` — the spec, its contract, the generation, the upload entry point and their tests are one unit, and `weight_loader` was already over a thousand lines of unrelated safetensors work. Within it the arithmetic is a private function that `precompute_rope` calls and uploads, so it is testable on a machine without a GPU.

No Gemma 4 caller yet — the crate has no weight loader. The head_dim 512 RoPE-prep kernel instantiation is separate work and wants #783's attention instantiation landed first.

A second commit removes two copies of the same formula that predate this one. The Qwen3 kernel bench built its own cos/sin cache with the same `theta^(-2i/head_dim)`, the same half-split layout and the same bf16 conversion, behind a `cos: bool` flag that made both of its call sites run the whole nested loop twice — once for cos, once for sin. Both sites uploaded the result immediately, which is what `precompute_rope` does, so they call that. The Qwen3.5 bench had the formula a third time with no caller at all, hidden by that file's `#![allow(dead_code)]`; it is deleted rather than rewritten, since a bench that needs RoPE tables later can call `precompute_rope` directly.

Neither is in a timed region — both are benchmark setup — so nothing measured changes. The reason to remove them is not tidiness: a later correction to the layout, the bf16 handling or the input contract would leave the benches feeding kernels a cache the production path no longer produces, and the benchmark would then be measuring the wrong input.

The `RopeTableSpec` literals at the two bench call sites are written out rather than wrapped in a local helper, for the same reason the production call sites are — a helper would hide that `rotary_dim` and `frequency_dim` coincide there.


## Verification

Single GPU (sm_89, x86_64).

Four unit tests in `openinfer-core::rope`, no GPU required — 4 passed, 0 failed:

- A spec whose two dims are equal reproduces the old single-parameter formula bit-for-bit, against a reference computed in the test from `theta^(-2i/d)` rather than by calling the function again.
- The rotated half of `(128, 512)` equals the leading half of a full 512-dim RoPE. The two rows duplicate at different offsets — 64 and 256 — so the identity covers the first `rotary_dim / 2` entries, not a whole-row prefix.
- `(128, 512)` differs from ordinary partial `(128, 128)`. `i = 0` is asserted equal, since `theta^0` does not depend on the denominator; `i = 1` is asserted different, and at `pos = 1` the two cosines already differ by 0.109 — some 28 bf16 ulps — so two rows of table are enough to separate the formulas.
- Every rejected geometry is rejected: zero, odd and above-`frequency_dim` rotary dims, zero `max_seq_len`, an extent that overflows `usize`, and zero, negative, NaN and infinite `theta`.

The unit tests cover the arithmetic, not the call sites. Those are exercised only where a model line has an accuracy gate:

| call site | executed by a gate below |
| --- | --- |
| Qwen3 main | yes |
| Qwen3 DFlash | no |
| Qwen3 EAGLE-3 | no |
| Qwen3.5 | yes |
| GLM5.2 Dspark | no |
| GLM5.2 Dspark test support | no |

- `openinfer-qwen3 --test hf_golden_gate` — 1 passed, 0 failed. It builds a plain `Qwen3Executor`, so it reaches the main loader and neither draft model.
- `openinfer-qwen35 --features qwen35 --test hf_golden_gate` — 2 passed, 0 failed, 2 ignored (TP2, needs two devices). This is the partial-RoPE call site, the one where the two fields carry different meanings today.

The other four are mechanical repetitions of the dimension they already passed, and none is executed by a gate. What can be said about each is different, so:

- The two Qwen3 draft-model sites are compiled by the `-p openinfer-qwen3 --all-targets` clippy above, which passes. They are compiled but not executed.
- The two GLM5.2 Dspark sites have no passing gate to claim. That crate requires sm_100+, so on this sm_89 box it only builds under `OPENINFER_CUDA_SM=100`, and clippy on it is blocked by 42 pre-existing diagnostics — the same command on the base commit reports the same 42. Neither file this change touches contributes one, so the change adds nothing; but a run that exits non-zero is not a gate, and is not reported as one.

Reviewing those four by eye is what the naming buys — the transposition that would have made execution necessary is no longer expressible.

`cargo fmt --check` and `cargo clippy --release -p openinfer-core -p openinfer-qwen3 -p openinfer-qwen35 --all-targets -- -D warnings` clean.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)