### PR TITLE
feat(glm52): decouple the KV pool from the slot count — budget-filled pool, 131K cap on 32 slots (#812)

### DIFF
--- a/docs/models/glm52/paged-kv-prefix-cache.md
+++ b/docs/models/glm52/paged-kv-prefix-cache.md
@@ -25,20 +25,34 @@ was static:
 
 ### One pool, two arenas, shared ids
 
-Each rank's `BlockPool(page=64, blocks = 8*ceil((cap+1)/64) + 1)` hands out
-block ids; the rank's per-layer MLA packed caches (656 B/token) and index-K
-caches (full-indexer layers) are both indexed by those ids
-(`glm52_pool_blocks` is the single sizing formula shared by the pool,
-`Glm52RankModel::build`, and the `glm52_arena_bytes` VRAM ledger). The
-trailing `+1` is the reserved **padding page**: padding rows and graph
-pre-capture write there, nobody reads it meaningfully (Kimi's benign-garbage
-argument). The per-slot `cap+1` (not `cap`) keeps 8 concurrent max-shape
-requests (`prompt + max_tokens = cap + 1`) admissible: each really draws
-`ceil((cap+1)/64)` pages including its dangling-token page — a toxic-review
-finding; the naive `8*ceil(cap/64)` pool silently degraded max-shape
-concurrency to 7.
+Each rank's `BlockPool(page=64)` hands out block ids; the rank's per-layer
+MLA packed caches (656 B/token) and index-K caches (full-indexer layers) are
+both indexed by those ids, and the pool, `Glm52RankModel::finish_kv`, and the
+scheduler all share the ONE launch-decided block count.
 
-Total KV VRAM is the per-slot design's capacity + 9 pages (~30 MB); the win
+**Pool sizing is a measured launch decision, not a formula (#823).** The old
+`slots*ceil((cap+1)/64) + 1` provisioning multiplied the servable cap into
+the pool (a 200K cap forced slots×200K of KV — unaffordable — and the derived
+cap shrank as slots grew). Now the workers build everything except the
+pool-scaled slabs, report measured free VRAM, and launch min-reduces and
+fills the pool from fact at the exact per-block slab cost: the legacy
+`slots x cap` count remains the FLOOR where it fits (defaults unchanged, the
+fill only adds), an explicit big cap falls back to a one-request floor
+(`ceil((cap+1)/64) + 2`), and `GLM52_KV_POOL_BLOCKS` pins the count for A/B
+runs (rejected below the one-request floor — a smaller pool would advertise a
+cap no request can fit). The only estimate left is `GLM52_GRAPH_RESERVE_GIB`
+(default 3) for lazy graph instantiation + runtime workspaces. One page is
+the reserved **padding page**: padding rows and graph pre-capture write
+there, nobody reads it meaningfully (Kimi's benign-garbage argument). The
+`cap+1` (not `cap`) in the floors keeps max-shape requests
+(`prompt + max_tokens = cap + 1`) admissible including the dangling-token
+page — a toxic-review finding; the naive `ceil(cap/64)` variant silently
+degraded max-shape concurrency.
+
+Measured on GB300 (EP4, 16K cap): the fill lands ~1.35-1.44M pool tokens per
+rank (2.6x the old 32-slot nominal), and admission's lifetime reservation
+arbitrates mixed loads — 12 concurrent ~118K requests totalling 1.42M tokens
+against a 1.35M pool queue the overflow and all complete. The win
 is *sharing* — released requests' sealed blocks stay matchable as the prefix
 cache instead of dying with a slot.
 

--- a/openinfer-glm52/src/indexer.rs
+++ b/openinfer-glm52/src/indexer.rs
@@ -347,6 +347,14 @@ impl Glm52IndexerScratch {
         })
     }
 
+    /// Rebind the MQA shape to the launch-decided pool block count. Every
+    /// buffer here is sized by batch/logits stride, never by the block count
+    /// — `num_kv_blocks` only feeds the forward-time cache layout — so a
+    /// scratch built before the measured KV fill needs exactly this rebind.
+    pub(crate) fn set_num_kv_blocks(&mut self, num_kv_blocks: usize) {
+        self.shape.num_kv_blocks = num_kv_blocks;
+    }
+
     /// Build the paged MQA shape for one query token per batch row.
     pub(crate) fn paged_mqa_shape(
         batch: usize,
@@ -699,12 +707,11 @@ impl Glm52IndexerPrefillScratch {
         ctx: &DeviceContext,
         chunk_rows: usize,
         attn_tile: usize,
-        kv_slots: usize,
         table_width: usize,
         cache_layout: Glm52IndexerCacheLayout,
     ) -> Result<Self> {
         ensure!(
-            chunk_rows > 0 && attn_tile > 0 && kv_slots > 0 && table_width > 0,
+            chunk_rows > 0 && attn_tile > 0 && table_width > 0,
             "GLM5.2 indexer prefill scratch shapes must be positive"
         );
         let chunk = chunk_rows.next_multiple_of(4);
@@ -714,7 +721,6 @@ impl Glm52IndexerPrefillScratch {
         // prefix pages therefore cannot overflow it: the physical pool
         // admits shared pages once, while each segment re-gathers its own
         // logical view into the same buffer.
-        let _ = kv_slots;
         let kv_cap = (table_width * 64).next_multiple_of(4);
         let logits_stride = kv_cap.next_multiple_of(256) + 256;
         let tile = attn_tile.next_multiple_of(4);
@@ -755,6 +761,14 @@ impl Glm52IndexerPrefillScratch {
             host_table: vec![0; GLM52_INDEXER_PREFILL_MAX_REQUESTS * table_width],
             host_lens: vec![0; GLM52_INDEXER_PREFILL_MAX_REQUESTS],
         })
+    }
+
+    /// Rebind to the launch-decided index-K cache layout. No buffer here is
+    /// sized by `cache_blocks` (see the compact-K comment in `new`), so a
+    /// scratch built before the measured KV fill only needs the layout the
+    /// forward-time insert/gather launches read.
+    pub(crate) fn set_cache_layout(&mut self, cache_layout: Glm52IndexerCacheLayout) {
+        self.cache_layout = cache_layout;
     }
 
     /// Stage the per-chunk request plan: segment ranges, per-query kv ends,

--- a/openinfer-glm52/src/lib.rs
+++ b/openinfer-glm52/src/lib.rs
@@ -633,28 +633,52 @@ struct Glm52ContextBudget {
     arena_bytes: usize,
     reserve_bytes: usize,
     budget_bytes: usize,
+    /// The launch-decided pool block count — the budget fill's output,
+    /// published process-wide via `glm52_set_pool_blocks` before any worker
+    /// builds.
+    pool_blocks: usize,
 }
 
 /// Exact cap-scaled bytes a rank allocates for a candidate cap: the build
 /// arenas plus the selected speculative lane.
 fn glm52_cap_bytes(
     max_model_len: usize,
+    pool_blocks: usize,
     drafter: &Glm52Drafter,
     prefill_only: bool,
     moe_topo: Glm52MoeTopo,
 ) -> Result<usize> {
-    // Prefill-only sizes the full slot count too (it used to hold exactly one
-    // request): the prefix cache needs blocks to retain released prefixes
-    // across turns, and the headroom lets prefills overlap.
-    let pool_slots = model::glm52_decode_slots();
-    Ok(glm52_arena_bytes(max_model_len, pool_slots, prefill_only)?
+    Ok(glm52_arena_bytes(max_model_len, pool_blocks, prefill_only)?
         + if drafter.is_dspark() {
             crate::dspark::glm52_dspark_arena_bytes(max_model_len)
         } else if drafter.is_mtp() {
-            crate::mtp::glm52_mtp_arena_bytes(max_model_len, moe_topo)?
+            crate::mtp::glm52_mtp_arena_bytes(max_model_len, pool_blocks, moe_topo)?
         } else {
             0
         })
+}
+
+/// The smallest useful pool: one max-length request's pages plus the
+/// padding block and one spare.
+fn glm52_one_request_pool_blocks(max_model_len: usize) -> usize {
+    (max_model_len + 1).div_ceil(GLM52_MODEL_LEN_ALIGN) + 2
+}
+
+/// The budget slice the pool fill leaves unspent for ledger-invisible
+/// allocations (bucket scratch arenas, graph instantiation, workspaces).
+fn glm52_pool_fill_headroom_bytes() -> usize {
+    (std::env::var("GLM52_POOL_FILL_HEADROOM_GIB")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(8))
+        << 30
+}
+
+/// The legacy `slots x cap` pool sizing — the cap-derivation NOMINAL (the
+/// binary search finds the largest cap whose nominal-pool cost fits), and
+/// the floor the budget fill starts from.
+fn glm52_nominal_pool_blocks(max_model_len: usize) -> usize {
+    glm52_pool_blocks(max_model_len, model::glm52_decode_slots())
 }
 
 fn glm52_prefill_scratch_reservation(
@@ -709,11 +733,23 @@ fn derive_max_model_len(
             requested / GLM52_MODEL_LEN_ALIGN * GLM52_MODEL_LEN_ALIGN,
             requested.next_multiple_of(GLM52_MODEL_LEN_ALIGN),
         );
-        let required = glm52_cap_bytes(requested, drafter, prefill_only, moe_topo)?;
+        // The pool no longer multiplies the cap by the slot count (#818):
+        // an explicit cap only has to fit the fixed arenas plus a pool that
+        // can hold ONE max-length request — admission's lifetime reservation
+        // guards each request, concurrency comes from whatever pool the
+        // budget fill provides.
+        let required = glm52_cap_bytes(
+            requested,
+            glm52_one_request_pool_blocks(requested),
+            drafter,
+            prefill_only,
+            moe_topo,
+        )?;
         ensure!(
             required <= budget_bytes,
-            "GLM5.2 --max-model-len {requested} needs {} of cache per rank but only {} \
-             fits (min rank free VRAM {} - reserve {}); lower it or free VRAM",
+            "GLM5.2 --max-model-len {requested} needs {} of cache per rank (fixed arenas + a \
+             one-request pool) but only {} fits (min rank free VRAM {} - reserve {}); lower it \
+             or free VRAM",
             ByteSize(required as u64),
             ByteSize(budget_bytes as u64),
             ByteSize(min_free_vram_bytes as u64),
@@ -726,8 +762,13 @@ fn derive_max_model_len(
         let (mut lo, mut hi) = (0, GLM52_MAX_CONTEXT / GLM52_MODEL_LEN_ALIGN);
         while lo < hi {
             let mid = (lo + hi).div_ceil(2);
-            if glm52_cap_bytes(mid * GLM52_MODEL_LEN_ALIGN, drafter, prefill_only, moe_topo)?
-                <= budget_bytes
+            if glm52_cap_bytes(
+                mid * GLM52_MODEL_LEN_ALIGN,
+                glm52_nominal_pool_blocks(mid * GLM52_MODEL_LEN_ALIGN),
+                drafter,
+                prefill_only,
+                moe_topo,
+            )? <= budget_bytes
             {
                 lo = mid;
             } else {
@@ -745,9 +786,53 @@ fn derive_max_model_len(
         );
         derived
     };
+    // Fill the remaining budget with pool blocks (#818): the nominal
+    // `slots x cap` pool is only the floor — every leftover byte becomes KV
+    // capacity (and, on prefill-only ranks, prefix-cache retention). The
+    // marginal cost per block is exact (the ledger is linear in blocks), so
+    // the fill lands within one block of the budget. `GLM52_KV_POOL_BLOCKS`
+    // pins the count for A/B runs.
+    // Fill floor: the legacy nominal (`slots x cap`) where it still fits —
+    // identical defaults — otherwise a pool holding one max-length request
+    // (the explicit-big-cap shape the decoupling exists for).
+    let spendable_probe = budget_bytes.saturating_sub(glm52_pool_fill_headroom_bytes());
+    let nominal = glm52_nominal_pool_blocks(max_model_len);
+    let floor_blocks = if glm52_cap_bytes(max_model_len, nominal, drafter, prefill_only, moe_topo)?
+        <= spendable_probe
+    {
+        nominal
+    } else {
+        glm52_one_request_pool_blocks(max_model_len)
+    };
+    let floor_bytes =
+        glm52_cap_bytes(max_model_len, floor_blocks, drafter, prefill_only, moe_topo)?;
+    let marginal = glm52_cap_bytes(
+        max_model_len,
+        floor_blocks + 1,
+        drafter,
+        prefill_only,
+        moe_topo,
+    )?
+    .saturating_sub(floor_bytes);
+    // The fill spends budget MINUS a headroom for the allocations the arena
+    // ledger does not carry (per-bucket scratch arenas, whole-step graph
+    // instantiation, cuBLAS/FlashInfer workspaces) — historically these rode
+    // the never-spent slack between arena and budget, and a to-the-byte fill
+    // OOMs at build (measured on EP4). `GLM52_POOL_FILL_HEADROOM_GIB`
+    // overrides; the nominal floor is never reduced.
+    let spendable = budget_bytes.saturating_sub(glm52_pool_fill_headroom_bytes());
+    let pool_blocks = match std::env::var("GLM52_KV_POOL_BLOCKS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+    {
+        Some(pinned) => pinned.max(2),
+        None if marginal == 0 => floor_blocks,
+        None => floor_blocks + spendable.saturating_sub(floor_bytes) / marginal,
+    };
     Ok(Glm52ContextBudget {
         max_model_len,
-        arena_bytes: glm52_cap_bytes(max_model_len, drafter, prefill_only, moe_topo)?,
+        pool_blocks,
+        arena_bytes: glm52_cap_bytes(max_model_len, pool_blocks, drafter, prefill_only, moe_topo)?,
         reserve_bytes,
         budget_bytes,
     })
@@ -846,6 +931,20 @@ fn start_engine(
         );
     }
     let max_model_len = budget.max_model_len;
+    // Publish the budget-filled pool size before any worker builds a model
+    // or a scheduler constructs its BlockPool — from here on there is ONE
+    // block count in the process.
+    model::glm52_set_pool_blocks(budget.pool_blocks);
+    log::info!(
+        "GLM5.2 KV pool: {} blocks ({} tokens, {} past the {}-slot nominal) — the free-VRAM \
+         fill decouples pool capacity from the {max_model_len}-token cap (#818)",
+        budget.pool_blocks,
+        budget.pool_blocks * GLM52_MODEL_LEN_ALIGN,
+        budget
+            .pool_blocks
+            .saturating_sub(glm52_nominal_pool_blocks(max_model_len)),
+        model::glm52_decode_slots(),
+    );
     log::info!(
         "GLM5.2 max_model_len={max_model_len} ({}): min rank free VRAM {} after weights \
          (qa|kv_a twins {} + DeepGEMM post-weight delta {} charged), cap-scaled arenas {} \
@@ -928,7 +1027,7 @@ fn start_engine(
         }
     };
     let logical_ranks = moe_topo.logical_rank_count();
-    let kv_total_blocks = glm52_pool_blocks(max_model_len, model::glm52_decode_slots()) - 1;
+    let kv_total_blocks = model::glm52_configured_pool_blocks(max_model_len) - 1;
     // One autonomous engine per LOCAL logical rank (a mirrored topology
     // collapses to a single engine driving every worker). Each engine owns
     // its submit queue and load feed, so the frontend sees one scheduler
@@ -1533,7 +1632,15 @@ mod max_model_len_tests {
                 0
             }
             + prefill_scratch_bytes;
-        reserve + glm52_cap_bytes(cap, drafter, false, TEST_TOPO).expect("cap bytes")
+        reserve
+            + glm52_cap_bytes(
+                cap,
+                glm52_nominal_pool_blocks(cap),
+                drafter,
+                false,
+                TEST_TOPO,
+            )
+            .expect("cap bytes")
     }
 
     #[test]
@@ -1564,6 +1671,33 @@ mod max_model_len_tests {
     }
 
     #[test]
+    fn budget_fill_spends_the_leftover_on_pool_blocks() {
+        // The fill invariants: never below the nominal floor, total cost
+        // within budget, and one more block would overflow (exact marginal).
+        let drafter = Glm52Drafter::NativeMtp;
+        let free = free_for(50_048, &drafter, 0) + glm52_pool_fill_headroom_bytes() + (64 << 20);
+        let budget = derive_max_model_len(Some(50_048), free, &drafter, 0, false, TEST_TOPO)
+            .expect("derive");
+        let floor = glm52_nominal_pool_blocks(50_048);
+        assert!(
+            budget.pool_blocks >= floor,
+            "fill must start at the nominal floor"
+        );
+        assert!(
+            budget.pool_blocks > floor,
+            "64 MiB of slack must buy at least one block"
+        );
+        let cost = |blocks| {
+            glm52_cap_bytes(50_048, blocks, &drafter, false, TEST_TOPO).expect("cap bytes")
+        };
+        let spendable = budget
+            .budget_bytes
+            .saturating_sub(glm52_pool_fill_headroom_bytes());
+        assert!(cost(budget.pool_blocks) <= spendable.max(cost(floor)));
+        assert!(cost(budget.pool_blocks + 1) > spendable);
+    }
+
+    #[test]
     fn dspark_lane_shrinks_the_derived_cap() {
         let free = free_for(50_048, &Glm52Drafter::None, 0);
         let plain = derive_max_model_len(None, free, &Glm52Drafter::None, 0, false, TEST_TOPO)
@@ -1590,10 +1724,22 @@ mod max_model_len_tests {
             "native MTP cap-scaled KV must shrink the target context cap"
         );
         assert!(
-            glm52_cap_bytes(50_048, &Glm52Drafter::NativeMtp, false, TEST_TOPO)
-                .expect("MTP cap bytes")
-                > glm52_cap_bytes(50_048, &Glm52Drafter::None, false, TEST_TOPO)
-                    .expect("plain cap bytes"),
+            glm52_cap_bytes(
+                50_048,
+                glm52_nominal_pool_blocks(50_048),
+                &Glm52Drafter::NativeMtp,
+                false,
+                TEST_TOPO
+            )
+            .expect("MTP cap bytes")
+                > glm52_cap_bytes(
+                    50_048,
+                    glm52_nominal_pool_blocks(50_048),
+                    &Glm52Drafter::None,
+                    false,
+                    TEST_TOPO
+                )
+                .expect("plain cap bytes"),
             "native MTP must be represented in the exact memory ledger"
         );
     }
@@ -1601,10 +1747,22 @@ mod max_model_len_tests {
     #[test]
     fn tp4_native_mtp_charges_the_execution_and_wire_caches() {
         let cap = 16_384;
-        let tp4 = glm52_cap_bytes(cap, &Glm52Drafter::NativeMtp, true, Glm52MoeTopo::Tp4)
-            .expect("TP4 cap bytes");
-        let ep4 = glm52_cap_bytes(cap, &Glm52Drafter::NativeMtp, true, Glm52MoeTopo::Ep4)
-            .expect("EP4 cap bytes");
+        let tp4 = glm52_cap_bytes(
+            cap,
+            glm52_nominal_pool_blocks(cap),
+            &Glm52Drafter::NativeMtp,
+            true,
+            Glm52MoeTopo::Tp4,
+        )
+        .expect("TP4 cap bytes");
+        let ep4 = glm52_cap_bytes(
+            cap,
+            glm52_nominal_pool_blocks(cap),
+            &Glm52Drafter::NativeMtp,
+            true,
+            Glm52MoeTopo::Ep4,
+        )
+        .expect("EP4 cap bytes");
         assert!(
             tp4 > ep4,
             "TP4 must charge its additional execution-layout cache"

--- a/openinfer-glm52/src/lib.rs
+++ b/openinfer-glm52/src/lib.rs
@@ -772,12 +772,17 @@ fn derive_max_model_len(
             prefill_only,
             moe_topo,
         )?;
+        // The graph reserve must survive the fill: without it a cap in the
+        // band (budget - reserve, budget] passes here, the measured fill
+        // floors at the one-request pool anyway, and FinishKv or the lazy
+        // graph capture OOMs raw instead of failing at this door.
         ensure!(
-            required <= budget_bytes,
+            required + glm52_graph_reserve_bytes() <= budget_bytes,
             "GLM5.2 --max-model-len {requested} needs {} of cache per rank (fixed arenas + a \
-             one-request pool) but only {} fits (min rank free VRAM {} - reserve {}); lower it \
-             or free VRAM",
+             one-request pool + {} graph reserve) but only {} fits (min rank free VRAM {} - \
+             reserve {}); lower it or free VRAM",
             ByteSize(required as u64),
+            ByteSize(glm52_graph_reserve_bytes() as u64),
             ByteSize(budget_bytes as u64),
             ByteSize(min_free_vram_bytes as u64),
             ByteSize(reserve_bytes as u64),
@@ -1335,7 +1340,18 @@ fn build_rank_models(
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
     {
-        Some(pinned) => pinned.max(2),
+        Some(pinned) => {
+            // A pin below the one-request floor would advertise a cap no
+            // request can ever fit — admission then parks the impossible
+            // request at the FIFO head forever. Refuse loudly instead.
+            let one_request = glm52_one_request_pool_blocks(max_model_len);
+            ensure!(
+                pinned >= one_request,
+                "GLM52_KV_POOL_BLOCKS={pinned} is below the {one_request}-block one-request \
+                 floor for max_model_len {max_model_len}"
+            );
+            pinned
+        }
         None => glm52_measured_pool_blocks(
             min_free_bytes,
             post_finish_reserve_bytes,
@@ -1760,6 +1776,7 @@ mod max_model_len_tests {
         let free = GLM52_VRAM_RESERVE_BYTES
             + glm52_cap_bytes(cap, one_request, &Glm52Drafter::None, false, TEST_TOPO)
                 .expect("cap bytes")
+            + glm52_graph_reserve_bytes()
             + (64 << 20);
         let budget =
             derive_max_model_len(Some(cap), free, &Glm52Drafter::None, 0, false, TEST_TOPO)

--- a/openinfer-glm52/src/lib.rs
+++ b/openinfer-glm52/src/lib.rs
@@ -625,18 +625,21 @@ const GLM52_POST_BUILD_MIN_FREE_BYTES: usize = 1 << 30;
 
 /// The launch-time context-cap decision and the numbers behind it — the log
 /// line and the tests consume the same values the decision used, so they
-/// cannot drift apart.
+/// cannot drift apart. The pool block count is NOT decided here anymore:
+/// the ledger only provides the fill floor, and the authoritative count
+/// comes from the measured two-phase build (`build_rank_models`).
 #[derive(Clone, Copy, Debug)]
 struct Glm52ContextBudget {
     max_model_len: usize,
-    /// Exact bytes the cap costs a rank (build arenas + drafter lane).
+    /// Exact bytes the cap costs a rank at the floor pool (build arenas +
+    /// drafter lane) — an initial estimate for the startup log.
     arena_bytes: usize,
     reserve_bytes: usize,
     budget_bytes: usize,
-    /// The launch-decided pool block count — the budget fill's output,
-    /// published process-wide via `glm52_set_pool_blocks` before any worker
-    /// builds.
-    pool_blocks: usize,
+    /// The measured fill's floor: the legacy nominal `slots x cap` pool when
+    /// the ledger says it fits, else a one-request pool (the
+    /// explicit-big-cap shape the pool decoupling exists for).
+    floor_blocks: usize,
 }
 
 /// Exact cap-scaled bytes a rank allocates for a candidate cap: the build
@@ -664,14 +667,38 @@ fn glm52_one_request_pool_blocks(max_model_len: usize) -> usize {
     (max_model_len + 1).div_ceil(GLM52_MODEL_LEN_ALIGN) + 2
 }
 
-/// The budget slice the pool fill leaves unspent for ledger-invisible
-/// allocations (bucket scratch arenas, graph instantiation, workspaces).
-fn glm52_pool_fill_headroom_bytes() -> usize {
-    (std::env::var("GLM52_POOL_FILL_HEADROOM_GIB")
+/// Free VRAM held back from the measured KV fill on every rank — the ONLY
+/// remaining estimate in the pool sizing. Everything the fill can measure is
+/// already resident when the workers report free VRAM (the fixed build), and
+/// the exactly-known post-finish charges (DeepGEMM buffers, the DSpark lane)
+/// are subtracted separately; this covers what allocates after FinishKv and
+/// has no exact ledger — the whole-step CUDA graph instantiations (captured
+/// lazily by the engines), cuBLAS/FlashInfer workspaces, and allocator
+/// fragmentation. `GLM52_GRAPH_RESERVE_GIB` overrides.
+fn glm52_graph_reserve_bytes() -> usize {
+    (std::env::var("GLM52_GRAPH_RESERVE_GIB")
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(8))
+        .unwrap_or(3))
         << 30
+}
+
+/// The measured KV fill (#818, two-phase build): after every rank built its
+/// fixed half, the fleet-minimum free VRAM — minus the graph reserve and the
+/// exactly-known post-finish charges — is spent on pool blocks at the
+/// ledger's exact per-block slab cost. The floor is never reduced (the
+/// nominal pool where affordable, else one max-length request).
+fn glm52_measured_pool_blocks(
+    min_free_bytes: usize,
+    post_finish_bytes: usize,
+    slab_bytes_per_block: usize,
+    floor_blocks: usize,
+) -> usize {
+    let usable = min_free_bytes.saturating_sub(glm52_graph_reserve_bytes() + post_finish_bytes);
+    if slab_bytes_per_block == 0 {
+        return floor_blocks;
+    }
+    (usable / slab_bytes_per_block).max(floor_blocks)
 }
 
 /// The legacy `slots x cap` pool sizing — the cap-derivation NOMINAL (the
@@ -786,53 +813,24 @@ fn derive_max_model_len(
         );
         derived
     };
-    // Fill the remaining budget with pool blocks (#818): the nominal
-    // `slots x cap` pool is only the floor — every leftover byte becomes KV
-    // capacity (and, on prefill-only ranks, prefix-cache retention). The
-    // marginal cost per block is exact (the ledger is linear in blocks), so
-    // the fill lands within one block of the budget. `GLM52_KV_POOL_BLOCKS`
-    // pins the count for A/B runs.
-    // Fill floor: the legacy nominal (`slots x cap`) where it still fits —
-    // identical defaults — otherwise a pool holding one max-length request
-    // (the explicit-big-cap shape the decoupling exists for).
-    let spendable_probe = budget_bytes.saturating_sub(glm52_pool_fill_headroom_bytes());
+    // Fill floor for the measured pool sizing (#818): the legacy nominal
+    // (`slots x cap`) where the ledger says it still fits — identical
+    // defaults — otherwise a pool holding one max-length request (the
+    // explicit-big-cap shape the decoupling exists for). The ledger's job
+    // ends here: the authoritative block count comes from the measured
+    // two-phase fill between the workers' build phases.
     let nominal = glm52_nominal_pool_blocks(max_model_len);
     let floor_blocks = if glm52_cap_bytes(max_model_len, nominal, drafter, prefill_only, moe_topo)?
-        <= spendable_probe
+        <= budget_bytes
     {
         nominal
     } else {
         glm52_one_request_pool_blocks(max_model_len)
     };
-    let floor_bytes =
-        glm52_cap_bytes(max_model_len, floor_blocks, drafter, prefill_only, moe_topo)?;
-    let marginal = glm52_cap_bytes(
-        max_model_len,
-        floor_blocks + 1,
-        drafter,
-        prefill_only,
-        moe_topo,
-    )?
-    .saturating_sub(floor_bytes);
-    // The fill spends budget MINUS a headroom for the allocations the arena
-    // ledger does not carry (per-bucket scratch arenas, whole-step graph
-    // instantiation, cuBLAS/FlashInfer workspaces) — historically these rode
-    // the never-spent slack between arena and budget, and a to-the-byte fill
-    // OOMs at build (measured on EP4). `GLM52_POOL_FILL_HEADROOM_GIB`
-    // overrides; the nominal floor is never reduced.
-    let spendable = budget_bytes.saturating_sub(glm52_pool_fill_headroom_bytes());
-    let pool_blocks = match std::env::var("GLM52_KV_POOL_BLOCKS")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-    {
-        Some(pinned) => pinned.max(2),
-        None if marginal == 0 => floor_blocks,
-        None => floor_blocks + spendable.saturating_sub(floor_bytes) / marginal,
-    };
     Ok(Glm52ContextBudget {
         max_model_len,
-        pool_blocks,
-        arena_bytes: glm52_cap_bytes(max_model_len, pool_blocks, drafter, prefill_only, moe_topo)?,
+        floor_blocks,
+        arena_bytes: glm52_cap_bytes(max_model_len, floor_blocks, drafter, prefill_only, moe_topo)?,
         reserve_bytes,
         budget_bytes,
     })
@@ -931,23 +929,9 @@ fn start_engine(
         );
     }
     let max_model_len = budget.max_model_len;
-    // Publish the budget-filled pool size before any worker builds a model
-    // or a scheduler constructs its BlockPool — from here on there is ONE
-    // block count in the process.
-    model::glm52_set_pool_blocks(budget.pool_blocks);
-    log::info!(
-        "GLM5.2 KV pool: {} blocks ({} tokens, {} past the {}-slot nominal) — the free-VRAM \
-         fill decouples pool capacity from the {max_model_len}-token cap (#818)",
-        budget.pool_blocks,
-        budget.pool_blocks * GLM52_MODEL_LEN_ALIGN,
-        budget
-            .pool_blocks
-            .saturating_sub(glm52_nominal_pool_blocks(max_model_len)),
-        model::glm52_decode_slots(),
-    );
     log::info!(
         "GLM5.2 max_model_len={max_model_len} ({}): min rank free VRAM {} after weights \
-         (qa|kv_a twins {} + DeepGEMM post-weight delta {} charged), cap-scaled arenas {} \
+         (qa|kv_a twins {} + DeepGEMM post-weight delta {} charged), floor-pool arenas {} \
          across {} slots{}, reserve {}, budget {}{}",
         if requested_max_model_len.is_some() {
             "--max-model-len"
@@ -977,6 +961,17 @@ fn start_engine(
     );
 
     let eos_token_ids = read_eos_token_ids(model_path)?;
+    // Exactly-known VRAM that lands AFTER the workers' free-VRAM measurement
+    // (post-FinishKv): the DeepEP/DeepGEMM buffers created in SetupComm, and
+    // — when DSpark is on — the draft weights reserve plus its cap-scaled
+    // states loaded after comm setup. The measured KV fill holds these back
+    // alongside the graph reserve.
+    let post_finish_reserve_bytes = deepgemm_vram_charge_bytes
+        + if drafter.is_dspark() {
+            GLM52_DSPARK_VRAM_RESERVE_BYTES + crate::dspark::glm52_dspark_arena_bytes(max_model_len)
+        } else {
+            0
+        };
     // build_rank_models sends SetupComm, so from inside it the DeepEP
     // contexts exist and their destruction is COLLECTIVE: any startup failure
     // from here on must broadcast Shutdown to every rank BEFORE the workers'
@@ -994,6 +989,8 @@ fn start_engine(
         prefill_only.map(|options| options.chunk_size),
         &startup.ranks,
         startup.rendezvous.as_deref(),
+        budget.floor_blocks,
+        post_finish_reserve_bytes,
     ) {
         Ok(rank_arenas) => rank_arenas,
         Err(err) => {
@@ -1270,12 +1267,16 @@ fn ensure_post_build_headroom(workers: &[Glm52Worker]) -> Result<()> {
     Ok(())
 }
 
-/// Build every rank's resident model, then create the collective contexts.
-/// Two phases on purpose: the build is per-rank and can fail (OOM, packaging
-/// drift) — every rank must report success BEFORE anyone enters context
-/// creation, or a single failure strands peer ranks in a collective init with
-/// no useful error. TP4 currently stops after the per-rank build, before
-/// entering any EP/TP collective setup.
+/// Build every rank's resident model in the measured two phases, then create
+/// the collective contexts. Phases on purpose: the build is per-rank and can
+/// fail (OOM, packaging drift) — every rank must report success BEFORE
+/// anyone enters context creation, or a single failure strands peer ranks in
+/// a collective init with no useful error. Between the phases the fleet's
+/// measured free-VRAM minimum decides the KV pool block count, published
+/// process-wide (the schedulers' `BlockPool` reads it) before any FinishKv
+/// dispatch. TP4 currently stops after the per-rank build, before entering
+/// any EP/TP collective setup.
+#[allow(clippy::too_many_arguments)]
 fn build_rank_models(
     workers: &[Glm52Worker],
     max_model_len: usize,
@@ -1284,19 +1285,87 @@ fn build_rank_models(
     prefill_chunk_size: Option<usize>,
     ranks: &Range<usize>,
     rendezvous: Option<&str>,
+    floor_blocks: usize,
+    post_finish_reserve_bytes: usize,
 ) -> Result<Vec<Vec<KvArena>>> {
     let build_started = Instant::now();
+    let prefill_only = prefill_chunk_size.is_some();
     let responses = workers
         .iter()
         .map(|worker| {
-            worker.build_model_async(max_model_len, moe_topo, drafter.clone(), prefill_chunk_size)
+            worker.build_fixed_async(max_model_len, moe_topo, drafter.clone(), prefill_chunk_size)
         })
         .collect::<Result<Vec<_>>>()?;
-    let mut rank_arenas = Vec::with_capacity(responses.len());
+    let mut rank_free_bytes = Vec::with_capacity(responses.len());
     for (local_index, response) in responses.into_iter().enumerate() {
         // Label with the global rank, not the local worker slot — on a
         // multi-process fleet every process would otherwise call its first
         // worker "rank 0".
+        let rank = ranks.start + local_index;
+        rank_free_bytes.push(
+            response.recv().map_err(|_| {
+                anyhow::anyhow!("GLM5.2 rank {rank} dropped its fixed-build response")
+            })?? as usize,
+        );
+    }
+    let min_free_bytes = rank_free_bytes
+        .iter()
+        .copied()
+        .min()
+        .expect("at least one rank built");
+    // The exact per-block slab cost, taken from the SAME ledger the
+    // allocations use (linear in blocks, so one difference is the marginal):
+    // 78 MLA pages + the full-indexer index-K blocks + the MTP mirror and
+    // the prefill unpacked page, whichever of those this launch carries.
+    let slab_bytes_per_block = glm52_cap_bytes(
+        max_model_len,
+        floor_blocks + 1,
+        drafter,
+        prefill_only,
+        moe_topo,
+    )?
+    .saturating_sub(glm52_cap_bytes(
+        max_model_len,
+        floor_blocks,
+        drafter,
+        prefill_only,
+        moe_topo,
+    )?);
+    let pool_blocks = match std::env::var("GLM52_KV_POOL_BLOCKS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+    {
+        Some(pinned) => pinned.max(2),
+        None => glm52_measured_pool_blocks(
+            min_free_bytes,
+            post_finish_reserve_bytes,
+            slab_bytes_per_block,
+            floor_blocks,
+        ),
+    };
+    // Publish the measured pool size before any FinishKv dispatch and before
+    // the engines spawn (the schedulers' BlockPool reads the global) — from
+    // here on there is ONE block count in the process.
+    model::glm52_set_pool_blocks(pool_blocks);
+    log::info!(
+        "GLM5.2 KV pool: {} blocks ({} tokens, {} past the {}-slot nominal) — the measured \
+         free-VRAM fill (min rank free {} after the fixed build, graph reserve {}, post-finish \
+         charges {}, {}/block) decouples pool capacity from the {max_model_len}-token cap (#818)",
+        pool_blocks,
+        pool_blocks * GLM52_MODEL_LEN_ALIGN,
+        pool_blocks.saturating_sub(glm52_nominal_pool_blocks(max_model_len)),
+        model::glm52_decode_slots(),
+        ByteSize(min_free_bytes as u64),
+        ByteSize(glm52_graph_reserve_bytes() as u64),
+        ByteSize(post_finish_reserve_bytes as u64),
+        ByteSize(slab_bytes_per_block as u64),
+    );
+    let responses = workers
+        .iter()
+        .map(|worker| worker.finish_kv_async(pool_blocks))
+        .collect::<Result<Vec<_>>>()?;
+    let mut rank_arenas = Vec::with_capacity(responses.len());
+    for (local_index, response) in responses.into_iter().enumerate() {
         let rank = ranks.start + local_index;
         rank_arenas.push(
             response
@@ -1671,30 +1740,51 @@ mod max_model_len_tests {
     }
 
     #[test]
-    fn budget_fill_spends_the_leftover_on_pool_blocks() {
-        // The fill invariants: never below the nominal floor, total cost
-        // within budget, and one more block would overflow (exact marginal).
+    fn floor_is_the_nominal_pool_when_the_ledger_affords_it() {
+        // Identical defaults to the pre-measured fill: a budget that covers
+        // the legacy `slots x cap` pool floors the measured fill there.
         let drafter = Glm52Drafter::NativeMtp;
-        let free = free_for(50_048, &drafter, 0) + glm52_pool_fill_headroom_bytes() + (64 << 20);
+        let free = free_for(50_048, &drafter, 0) + (64 << 20);
         let budget = derive_max_model_len(Some(50_048), free, &drafter, 0, false, TEST_TOPO)
             .expect("derive");
-        let floor = glm52_nominal_pool_blocks(50_048);
-        assert!(
-            budget.pool_blocks >= floor,
-            "fill must start at the nominal floor"
+        assert_eq!(budget.floor_blocks, glm52_nominal_pool_blocks(50_048));
+    }
+
+    #[test]
+    fn floor_falls_back_to_a_one_request_pool_for_an_explicit_big_cap() {
+        // The decoupling's raison d'être: an explicit cap whose nominal
+        // `slots x cap` pool overflows the budget still launches, floored at
+        // a pool holding ONE max-length request.
+        let cap = 99_968;
+        let one_request = glm52_one_request_pool_blocks(cap);
+        let free = GLM52_VRAM_RESERVE_BYTES
+            + glm52_cap_bytes(cap, one_request, &Glm52Drafter::None, false, TEST_TOPO)
+                .expect("cap bytes")
+            + (64 << 20);
+        let budget =
+            derive_max_model_len(Some(cap), free, &Glm52Drafter::None, 0, false, TEST_TOPO)
+                .expect("derive");
+        assert_eq!(budget.floor_blocks, one_request);
+        assert!(one_request < glm52_nominal_pool_blocks(cap));
+    }
+
+    #[test]
+    fn measured_fill_spends_free_vram_at_the_exact_per_block_cost() {
+        let floor = 100;
+        let slab = 1 << 20;
+        let reserve = glm52_graph_reserve_bytes();
+        // Nothing past the reserve: the floor is never reduced.
+        assert_eq!(glm52_measured_pool_blocks(reserve, 0, slab, floor), floor);
+        // Every byte past the reserve buys blocks at the exact marginal.
+        assert_eq!(
+            glm52_measured_pool_blocks(reserve + 512 * slab, 0, slab, floor),
+            512
         );
-        assert!(
-            budget.pool_blocks > floor,
-            "64 MiB of slack must buy at least one block"
+        // Exactly-known post-finish charges are held back alongside it.
+        assert_eq!(
+            glm52_measured_pool_blocks(reserve + 512 * slab, 12 * slab, slab, floor),
+            500
         );
-        let cost = |blocks| {
-            glm52_cap_bytes(50_048, blocks, &drafter, false, TEST_TOPO).expect("cap bytes")
-        };
-        let spendable = budget
-            .budget_bytes
-            .saturating_sub(glm52_pool_fill_headroom_bytes());
-        assert!(cost(budget.pool_blocks) <= spendable.max(cost(floor)));
-        assert!(cost(budget.pool_blocks + 1) > spendable);
     }
 
     #[test]
@@ -1817,15 +1907,28 @@ mod max_model_len_tests {
 
     #[test]
     fn requested_cap_beyond_the_budget_fails_at_launch() {
+        // Post-decoupling an explicit cap only has to afford the fixed
+        // arenas plus a ONE-request pool (concurrency comes from the
+        // measured fill), so the rejection boundary is a budget too small
+        // for even that — profile-independent by construction.
+        let one_request = glm52_cap_bytes(
+            99_968,
+            glm52_one_request_pool_blocks(99_968),
+            &Glm52Drafter::None,
+            false,
+            TEST_TOPO,
+        )
+        .expect("cap bytes");
+        let reserve = GLM52_VRAM_RESERVE_BYTES;
         let err = derive_max_model_len(
             Some(99_968),
-            free_for(10_048, &Glm52Drafter::None, 0),
+            reserve + one_request - (1 << 20),
             &Glm52Drafter::None,
             0,
             false,
             TEST_TOPO,
         )
-        .expect_err("over-budget cap must fail");
+        .expect_err("a budget below the one-request pool must fail");
         assert!(err.to_string().contains("--max-model-len"), "{err}");
     }
 

--- a/openinfer-glm52/src/lib.rs
+++ b/openinfer-glm52/src/lib.rs
@@ -1344,12 +1344,28 @@ fn build_rank_models(
         Some(pinned) => {
             // A pin below the one-request floor would advertise a cap no
             // request can ever fit — admission then parks the impossible
-            // request at the FIFO head forever. Refuse loudly instead.
+            // request at the FIFO head forever. And a pin above the measured
+            // affordable count would either fail slab allocation outright or
+            // eat into the graph reserve and die at pre-capture — the A/B
+            // knob must stay inside both fences. Refuse loudly either way.
             let one_request = glm52_one_request_pool_blocks(max_model_len);
             ensure!(
                 pinned >= one_request,
                 "GLM52_KV_POOL_BLOCKS={pinned} is below the {one_request}-block one-request \
                  floor for max_model_len {max_model_len}"
+            );
+            let affordable = glm52_measured_pool_blocks(
+                min_free_bytes,
+                post_finish_reserve_bytes,
+                slab_bytes_per_block,
+                one_request,
+            );
+            ensure!(
+                pinned <= affordable,
+                "GLM52_KV_POOL_BLOCKS={pinned} exceeds the {affordable}-block measured \
+                 affordable count (min rank free {} - reserves at {} per block)",
+                ByteSize(min_free_bytes as u64),
+                ByteSize(slab_bytes_per_block as u64),
             );
             pinned
         }

--- a/openinfer-glm52/src/lib.rs
+++ b/openinfer-glm52/src/lib.rs
@@ -986,7 +986,7 @@ fn start_engine(
     // down, and the launch error surfaces only after the ~100 s DeepEP
     // device timeout. The TP LL rendezvous rejecting a topology (poison
     // pill, NVLink probe) is a real failure landing exactly in this window.
-    let rank_arenas = match build_rank_models(
+    let (rank_arenas, pool_blocks) = match build_rank_models(
         &loaded.workers,
         max_model_len,
         moe_topo,
@@ -1029,7 +1029,7 @@ fn start_engine(
         }
     };
     let logical_ranks = moe_topo.logical_rank_count();
-    let kv_total_blocks = model::glm52_configured_pool_blocks(max_model_len) - 1;
+    let kv_total_blocks = pool_blocks - 1;
     // One autonomous engine per LOCAL logical rank (a mirrored topology
     // collapses to a single engine driving every worker). Each engine owns
     // its submit queue and load feed, so the frontend sees one scheduler
@@ -1092,6 +1092,7 @@ fn start_engine(
             eos_token_ids: eos_token_ids.clone(),
             drafter: drafter.clone(),
             prefill_chunk_size: prefill_only.map(|prefill| prefill.chunk_size),
+            pool_blocks,
             max_model_len,
             no_prefix_cache,
             offload: engine_offload,
@@ -1292,7 +1293,7 @@ fn build_rank_models(
     rendezvous: Option<&str>,
     floor_blocks: usize,
     post_finish_reserve_bytes: usize,
-) -> Result<Vec<Vec<KvArena>>> {
+) -> Result<(Vec<Vec<KvArena>>, usize)> {
     let build_started = Instant::now();
     let prefill_only = prefill_chunk_size.is_some();
     let responses = workers
@@ -1359,10 +1360,6 @@ fn build_rank_models(
             floor_blocks,
         ),
     };
-    // Publish the measured pool size before any FinishKv dispatch and before
-    // the engines spawn (the schedulers' BlockPool reads the global) — from
-    // here on there is ONE block count in the process.
-    model::glm52_set_pool_blocks(pool_blocks);
     log::info!(
         "GLM5.2 KV pool: {} blocks ({} tokens, {} past the {}-slot nominal) — the measured \
          free-VRAM fill (min rank free {} after the fixed build, graph reserve {}, post-finish \
@@ -1430,7 +1427,7 @@ fn build_rank_models(
         build_started.elapsed().as_secs_f64(),
         moe_topo
     );
-    Ok(rank_arenas)
+    Ok((rank_arenas, pool_blocks))
 }
 
 /// One shared pegaflow host (one pinned pool) with each rank's arenas

--- a/openinfer-glm52/src/mla_decode.rs
+++ b/openinfer-glm52/src/mla_decode.rs
@@ -310,6 +310,14 @@ impl Glm52MlaSchedMetadata {
         Ok(Self { contract, backend })
     }
 
+    /// Rebind the plan to the launch-decided pool block count. The tile
+    /// scheduler plan depends only on `batch_size`/`topk`/`num_sm_parts`, so
+    /// the plan built before the measured KV fill stays valid — only the
+    /// cache-geometry field the attend launches read needs the real count.
+    pub(crate) fn set_num_blocks(&mut self, num_blocks: usize) {
+        self.contract.num_blocks = num_blocks;
+    }
+
     /// The sparse index-list length this plan was built for. The DSA indexer
     /// must produce its top-k with the same k — reading it from the plan makes
     /// an indexer/attend mismatch unrepresentable.

--- a/openinfer-glm52/src/model/mod.rs
+++ b/openinfer-glm52/src/model/mod.rs
@@ -79,6 +79,7 @@ mod mtp;
 mod step_body;
 use launch_ahead::Glm52SpeculatedStep;
 use mtp::Glm52NativeMtp;
+use mtp::Glm52NativeMtpFixed;
 use step_body::run_step_body;
 
 /// The compile-time slot-count CEILING: fixed arrays (`RankSlots`,
@@ -119,8 +120,8 @@ pub(crate) const GLM52_MODEL_LEN_ALIGN: usize = GLM52_FLASHMLA_SPARSE_PAGE_SIZE;
 /// more than its KV ever writes, because kvbm appends the final generated
 /// token and eagerly provisions its page (the dangling-token contract). The
 /// engine's `BlockPool` and the rank arenas
-/// ([`Glm52RankModel::build`]) MUST agree on this count: pool block ids index
-/// the arenas directly.
+/// ([`Glm52RankModel::finish_kv`]) MUST agree on this count: pool block ids
+/// index the arenas directly.
 pub(crate) fn glm52_pool_blocks(max_model_len: usize, pool_slots: usize) -> usize {
     pool_slots * (max_model_len + 1).div_ceil(GLM52_FLASHMLA_SPARSE_PAGE_SIZE) + 1
 }
@@ -132,19 +133,14 @@ pub(crate) fn glm52_table_width(max_model_len: usize) -> usize {
     max_model_len.div_ceil(GLM52_FLASHMLA_SPARSE_PAGE_SIZE)
 }
 
-/// Exact GPU bytes [`Glm52RankModel::build`] allocates on a rank for a given
-/// context cap — every `max_model_len`-scaled term of the build, computed
-/// from the same layout formulas the allocations use (the FlashMLA packed
-/// cache and index-K layouts, the device rope tables, the per-bucket indexer
-/// logits scratch with its 256-rounded stride, and the block tables). The
-/// launch-time VRAM probe sizes `max_model_len` against this, so a new
-/// len-scaled allocation in `build` MUST be added here or the probe
-/// under-charges.
-/// The rank's pool block count, decided ONCE at launch from the free-VRAM
-/// budget (#818): the servable cap no longer multiplies into the pool, so a
-/// 200K cap does not force 32 x 200K of KV provisioning — admission's
-/// lifetime reservation is the per-request guard, and the pool is simply as
-/// large as the budget allows. Unset (unit tests, direct builders) falls
+/// The rank's pool block count, decided ONCE at launch (#818) — since the
+/// two-phase build, from each rank's MEASURED free VRAM after the fixed
+/// build: the servable cap no longer multiplies into the pool, so a 200K cap
+/// does not force 32 x 200K of KV provisioning — admission's lifetime
+/// reservation is the per-request guard, and the pool is simply as large as
+/// the measured budget allows. The scheduler's `BlockPool` reads this;
+/// worker builds take the count explicitly through
+/// [`Glm52RankModel::finish_kv`]. Unset (unit tests, direct builders) falls
 /// back to the legacy `slots x cap` sizing.
 static POOL_BLOCKS: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 
@@ -159,6 +155,14 @@ pub(crate) fn glm52_configured_pool_blocks(max_model_len: usize) -> usize {
         .unwrap_or_else(|| glm52_pool_blocks(max_model_len, glm52_decode_slots()))
 }
 
+/// Exact GPU bytes the two-phase build allocates on a rank for a given cap
+/// and pool block count — every `max_model_len`- and pool-scaled term,
+/// computed from the same layout formulas the allocations use (the FlashMLA
+/// packed cache and index-K layouts, the device rope tables, the per-bucket
+/// indexer logits scratch with its 256-rounded stride, and the block
+/// tables). Linear in `num_blocks`: the launch fill derives the exact
+/// per-block slab cost as `bytes(N+1) - bytes(N)`, so a new pool-scaled
+/// allocation in `finish_kv` MUST be added here or the fill over-commits.
 pub(crate) fn glm52_arena_bytes(
     max_model_len: usize,
     num_blocks: usize,
@@ -196,7 +200,7 @@ pub(crate) fn glm52_arena_bytes(
 }
 
 /// The page-table width and index-K cache layout for a given cap — the ONE
-/// construction shared by [`Glm52RankModel::build`] and the arena ledger
+/// construction shared by the two-phase build and the arena ledger
 /// ([`glm52_arena_bytes`]), so a layout change cannot drift between them.
 fn glm52_index_cache_layout(
     max_model_len: usize,
@@ -453,6 +457,42 @@ struct Glm52BucketState {
     argmax_indices_host: PinnedHostSlice<i32>,
 }
 
+/// The output of [`Glm52RankModel::build_fixed`]: every len/chunk-scaled
+/// piece of a rank model, built BEFORE the pool block count exists so launch
+/// can measure the fixed footprint and size the pool from real free VRAM.
+/// [`Glm52RankModel::finish_kv`] consumes it. Field meanings match the
+/// [`Glm52RankModel`] fields of the same name.
+pub(crate) struct Glm52RankModelFixed {
+    layers: Vec<Glm52DecoderLayerWeights>,
+    mtp: Option<Glm52NativeMtpFixed>,
+    embed: DeviceMatrix,
+    final_norm: DeviceVec,
+    lm_head: DeviceMatrix,
+    decode_lm_head: Option<DeviceMatrix>,
+    decode_vocab_start: usize,
+    /// Built against a 1-block placeholder cache geometry (nothing in a
+    /// bucket's allocations scales with the pool); finish_kv rebinds the
+    /// sched contract and MQA shape to the decided count.
+    buckets: Vec<Glm52BucketState>,
+    table_width: usize,
+    max_model_len: usize,
+    mla_backend: crate::mla_decode::Glm52MlaBackend,
+    mla_cache_bytes_per_token: usize,
+    ep_ranks: usize,
+    slot_mapping: CudaSlice<i64>,
+    seq_lens: CudaSlice<i32>,
+    cos_table: DeviceMatrix,
+    sin_table: DeviceMatrix,
+    positions: CudaSlice<u32>,
+    cos: CudaSlice<bf16>,
+    sin: CudaSlice<bf16>,
+    token_ids: CudaSlice<u32>,
+    sampling_scratch: Option<BatchSamplingScratch>,
+    /// Chunk-scaled workspace only; its pool-scaled unpacked-KV buffers are
+    /// attached in finish_kv.
+    prefill: Option<Glm52TpPrefillExecutor>,
+}
+
 /// Attention layers occupy AR slots `0..GLM52_LAYERS`; the tail reuses the
 /// same fixed-order transport to gather vocabulary-shard top-1 candidates.
 const VOCAB_AR_SLOT: usize = GLM52_LAYERS;
@@ -573,7 +613,13 @@ impl Glm52RankModel {
         Ok(arenas)
     }
 
-    pub(crate) fn build(
+    /// Phase 1 of the two-phase build: everything NOT sized by the pool
+    /// block count — weights, rope tables, per-bucket sched/scratch/logits/
+    /// block tables (all len-scaled via [`glm52_table_width`]), and the
+    /// chunk-scaled prefill workspace. Launch measures each rank's free VRAM
+    /// after this returns and decides the pool size from it;
+    /// [`Self::finish_kv`] then allocates every pool-scaled slab.
+    pub(crate) fn build_fixed(
         ctx: &DeviceContext,
         w: &mut Glm52RankGpuWeights,
         max_model_len: usize,
@@ -581,7 +627,7 @@ impl Glm52RankModel {
         attn_shard: Option<usize>,
         drafter: &crate::Glm52Drafter,
         prefill_chunk_size: Option<usize>,
-    ) -> Result<Self> {
+    ) -> Result<Glm52RankModelFixed> {
         ensure!(
             moe_topo.uses_tensor_replicated_moe() == attn_shard.is_some(),
             "GLM5.2 attention-TP shard must ride a tensor-replicated topology (topo {moe_topo:?}, \
@@ -632,45 +678,29 @@ impl Glm52RankModel {
         } else {
             glm52_flashmla_sparse_decode_num_sm_parts()?
         };
-        // The launch-time budget decides the pool size (prefix cache included
-        // — released prefixes retain in whatever headroom the pool carries);
-        // the scheduler pool and every cache slab here share the ONE number.
-        let pool_blocks = glm52_configured_pool_blocks(max_model_len);
+        // The pool block count is decided by the measured launch fill AFTER
+        // this build; the per-bucket sched/scratch below carry the count only
+        // as launch metadata (nothing they allocate scales with it), so they
+        // are built against a 1-block placeholder that `finish_kv` rebinds.
         let contract = Glm52FlashMlaSparseDecode {
             batch_size: batch,
-            num_blocks: pool_blocks,
+            num_blocks: 1,
             topk: GLM52_FLASHMLA_SPARSE_TOPK,
             num_sm_parts,
             sm_scale: GLM52_SM_SCALE,
         };
-        let (table_width, index_cache_layout) =
-            glm52_index_cache_layout(max_model_len, pool_blocks);
+        let (table_width, index_cache_layout) = glm52_index_cache_layout(max_model_len, 1);
 
         let mut layers = Vec::with_capacity(GLM52_LAYERS);
-        let mut caches = Vec::with_capacity(GLM52_LAYERS);
         for layer in 0..GLM52_LAYERS {
             layers.push(
                 build::build_decoder_layer(ctx, w, layer, moe_topo, attn_shard)
                     .with_context(|| format!("build GLM5.2 decoder layer {layer}"))?,
             );
-            caches.push(Glm52LayerCaches {
-                mla_cache: ctx.stream.alloc_zeros::<u8>(
-                    contract.num_blocks
-                        * GLM52_FLASHMLA_SPARSE_PAGE_SIZE
-                        * mla_cache_bytes_per_token,
-                )?,
-                index_k_cache: glm52_layer_has_full_indexer(layer)
-                    .then(|| {
-                        ctx.stream
-                            .alloc_zeros::<u8>(index_cache_layout.min_cache_bytes()?)
-                            .map_err(anyhow::Error::from)
-                    })
-                    .transpose()?,
-            });
         }
         let mtp = drafter
             .is_mtp()
-            .then(|| Glm52NativeMtp::build(ctx, w, max_model_len, moe_topo, attn_shard))
+            .then(|| Glm52NativeMtp::build_fixed(ctx, w, max_model_len, moe_topo, attn_shard))
             .transpose()?;
 
         let embed_raw = w.take_tensor("model.embed_tokens.weight")?;
@@ -789,20 +819,6 @@ impl Glm52RankModel {
                 argmax_indices_host: unsafe { ctx.ctx.alloc_pinned::<i32>(rows)? },
             });
         }
-        if prefill_chunk_size.is_none()
-            && mla_backend == crate::mla_decode::Glm52MlaBackend::FlashInferFp8
-        {
-            for bucket in &mut buckets {
-                glm52_mla_backend_preflight(
-                    ctx,
-                    &bucket.sched,
-                    &mut bucket.scratch.mla_attend,
-                    &caches[0].mla_cache,
-                )?;
-            }
-            ctx.sync()?;
-        }
-
         // Crash-early pre-flight: launch the batched weight-only GEMV once
         // per bucket, so a GLM52_DECODE_BUCKETS entry without a matching CUDA
         // template instantiation (`kBatchedGemvBatch*` in glm52_moe_gemv.cu)
@@ -852,7 +868,6 @@ impl Glm52RankModel {
                 };
                 Glm52TpPrefillExecutor::new(
                     ctx,
-                    pool_blocks * GLM52_FLASHMLA_SPARSE_PAGE_SIZE,
                     table_width,
                     index_cache_layout,
                     chunk_rows,
@@ -861,9 +876,8 @@ impl Glm52RankModel {
             })
             .transpose()?;
 
-        Ok(Self {
+        Ok(Glm52RankModelFixed {
             layers,
-            caches,
             mtp,
             embed,
             final_norm,
@@ -873,7 +887,7 @@ impl Glm52RankModel {
             buckets,
             table_width,
             max_model_len,
-            pool_blocks,
+            mla_backend,
             mla_cache_bytes_per_token,
             ep_ranks: moe_topo.expected_ep_size(),
             slot_mapping: ctx.stream.alloc_zeros::<i64>(batch)?,
@@ -893,6 +907,120 @@ impl Glm52RankModel {
             sin: ctx.stream.alloc_zeros::<bf16>(batch * GLM52_ROPE_HALF)?,
             token_ids: ctx.stream.alloc_zeros::<u32>(batch)?,
             sampling_scratch: Some(BatchSamplingScratch::new(ctx, batch, GLM52_VOCAB)?),
+            prefill,
+        })
+    }
+
+    /// Phase 2 of the two-phase build: allocate every pool-scaled slab for
+    /// the launch-decided `pool_blocks` — the per-layer MLA/index-K arenas,
+    /// the native-MTP cache, and the prefill unpacked-KV pool — and rebind
+    /// the placeholder cache geometry the fixed buckets carry. The engine's
+    /// `BlockPool` and the arenas here MUST agree on this count: pool block
+    /// ids index the arenas directly.
+    pub(crate) fn finish_kv(
+        ctx: &DeviceContext,
+        fixed: Glm52RankModelFixed,
+        pool_blocks: usize,
+    ) -> Result<Self> {
+        let Glm52RankModelFixed {
+            layers,
+            mtp,
+            embed,
+            final_norm,
+            lm_head,
+            decode_lm_head,
+            decode_vocab_start,
+            mut buckets,
+            table_width,
+            max_model_len,
+            mla_backend,
+            mla_cache_bytes_per_token,
+            ep_ranks,
+            slot_mapping,
+            seq_lens,
+            cos_table,
+            sin_table,
+            positions,
+            cos,
+            sin,
+            token_ids,
+            sampling_scratch,
+            mut prefill,
+        } = fixed;
+        ensure!(pool_blocks > 0, "GLM5.2 KV pool must be non-empty");
+        let (layout_width, index_cache_layout) =
+            glm52_index_cache_layout(max_model_len, pool_blocks);
+        ensure!(
+            layout_width == table_width,
+            "GLM5.2 table width drifted between build_fixed and finish_kv"
+        );
+        for bucket in &mut buckets {
+            bucket.sched.set_num_blocks(pool_blocks);
+            bucket.scratch.idx.set_num_kv_blocks(pool_blocks);
+        }
+        let mut caches = Vec::with_capacity(layers.len());
+        for layer in 0..layers.len() {
+            caches.push(Glm52LayerCaches {
+                mla_cache: ctx.stream.alloc_zeros::<u8>(
+                    pool_blocks * GLM52_FLASHMLA_SPARSE_PAGE_SIZE * mla_cache_bytes_per_token,
+                )?,
+                index_k_cache: glm52_layer_has_full_indexer(layer)
+                    .then(|| {
+                        ctx.stream
+                            .alloc_zeros::<u8>(index_cache_layout.min_cache_bytes()?)
+                            .map_err(anyhow::Error::from)
+                    })
+                    .transpose()?,
+            });
+        }
+        let mtp = mtp
+            .map(|fixed| fixed.attach_cache(ctx, pool_blocks))
+            .transpose()?;
+        if let Some(prefill) = prefill.as_mut() {
+            prefill.attach_kv_pool(
+                ctx,
+                pool_blocks * GLM52_FLASHMLA_SPARSE_PAGE_SIZE,
+                index_cache_layout,
+            )?;
+        }
+        // The FlashInfer preflight needs a real cache arena, so it runs here
+        // rather than in build_fixed (decode-only: TP4 prefill has no decode
+        // buckets to warm).
+        if prefill.is_none() && mla_backend == crate::mla_decode::Glm52MlaBackend::FlashInferFp8 {
+            for bucket in &mut buckets {
+                glm52_mla_backend_preflight(
+                    ctx,
+                    &bucket.sched,
+                    &mut bucket.scratch.mla_attend,
+                    &caches[0].mla_cache,
+                )?;
+            }
+            ctx.sync()?;
+        }
+        Ok(Self {
+            layers,
+            caches,
+            mtp,
+            embed,
+            final_norm,
+            lm_head,
+            decode_lm_head,
+            decode_vocab_start,
+            buckets,
+            table_width,
+            max_model_len,
+            pool_blocks,
+            mla_cache_bytes_per_token,
+            ep_ranks,
+            slot_mapping,
+            seq_lens,
+            cos_table,
+            sin_table,
+            positions,
+            cos,
+            sin,
+            token_ids,
+            sampling_scratch,
             prefill,
             speculated: None,
             device_positions: [0; GLM52_MAX_STEP_ROWS],

--- a/openinfer-glm52/src/model/mod.rs
+++ b/openinfer-glm52/src/model/mod.rs
@@ -133,36 +133,6 @@ pub(crate) fn glm52_table_width(max_model_len: usize) -> usize {
     max_model_len.div_ceil(GLM52_FLASHMLA_SPARSE_PAGE_SIZE)
 }
 
-/// The rank's pool block count, decided ONCE at launch (#818) — since the
-/// two-phase build, from each rank's MEASURED free VRAM after the fixed
-/// build: the servable cap no longer multiplies into the pool, so a 200K cap
-/// does not force 32 x 200K of KV provisioning — admission's lifetime
-/// reservation is the per-request guard, and the pool is simply as large as
-/// the measured budget allows. The scheduler's `BlockPool` reads this;
-/// worker builds take the count explicitly through
-/// [`Glm52RankModel::finish_kv`]. Unset (unit tests, direct builders) falls
-/// back to the legacy `slots x cap` sizing.
-static POOL_BLOCKS: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
-
-pub(crate) fn glm52_set_pool_blocks(blocks: usize) {
-    let _ = POOL_BLOCKS.set(blocks);
-}
-
-pub(crate) fn glm52_configured_pool_blocks(max_model_len: usize) -> usize {
-    POOL_BLOCKS
-        .get()
-        .copied()
-        .unwrap_or_else(|| glm52_pool_blocks(max_model_len, glm52_decode_slots()))
-}
-
-/// Exact GPU bytes the two-phase build allocates on a rank for a given cap
-/// and pool block count — every `max_model_len`- and pool-scaled term,
-/// computed from the same layout formulas the allocations use (the FlashMLA
-/// packed cache and index-K layouts, the device rope tables, the per-bucket
-/// indexer logits scratch with its 256-rounded stride, and the block
-/// tables). Linear in `num_blocks`: the launch fill derives the exact
-/// per-block slab cost as `bytes(N+1) - bytes(N)`, so a new pool-scaled
-/// allocation in `finish_kv` MUST be added here or the fill over-commits.
 pub(crate) fn glm52_arena_bytes(
     max_model_len: usize,
     num_blocks: usize,

--- a/openinfer-glm52/src/model/mod.rs
+++ b/openinfer-glm52/src/model/mod.rs
@@ -140,18 +140,36 @@ pub(crate) fn glm52_table_width(max_model_len: usize) -> usize {
 /// launch-time VRAM probe sizes `max_model_len` against this, so a new
 /// len-scaled allocation in `build` MUST be added here or the probe
 /// under-charges.
+/// The rank's pool block count, decided ONCE at launch from the free-VRAM
+/// budget (#818): the servable cap no longer multiplies into the pool, so a
+/// 200K cap does not force 32 x 200K of KV provisioning — admission's
+/// lifetime reservation is the per-request guard, and the pool is simply as
+/// large as the budget allows. Unset (unit tests, direct builders) falls
+/// back to the legacy `slots x cap` sizing.
+static POOL_BLOCKS: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+
+pub(crate) fn glm52_set_pool_blocks(blocks: usize) {
+    let _ = POOL_BLOCKS.set(blocks);
+}
+
+pub(crate) fn glm52_configured_pool_blocks(max_model_len: usize) -> usize {
+    POOL_BLOCKS
+        .get()
+        .copied()
+        .unwrap_or_else(|| glm52_pool_blocks(max_model_len, glm52_decode_slots()))
+}
+
 pub(crate) fn glm52_arena_bytes(
     max_model_len: usize,
-    pool_slots: usize,
+    num_blocks: usize,
     prefill_only: bool,
 ) -> Result<usize> {
-    let num_blocks = glm52_pool_blocks(max_model_len, pool_slots);
     // Prefill-only is a P/D producer: persist the same fp8_ds_mla row the EP
     // decode consumer reads, even though TP4's local attention execution uses
     // a different backend.
     let cache_bytes_per_token = GLM52_FLASHMLA_SPARSE_BYTES_PER_TOKEN;
     let mla = GLM52_LAYERS * num_blocks * GLM52_FLASHMLA_SPARSE_PAGE_SIZE * cache_bytes_per_token;
-    let (table_width, index_layout) = glm52_index_cache_layout(max_model_len, pool_slots);
+    let (table_width, index_layout) = glm52_index_cache_layout(max_model_len, num_blocks);
     let index_k = (0..GLM52_LAYERS)
         .filter(|&layer| glm52_layer_has_full_indexer(layer))
         .count()
@@ -182,12 +200,12 @@ pub(crate) fn glm52_arena_bytes(
 /// ([`glm52_arena_bytes`]), so a layout change cannot drift between them.
 fn glm52_index_cache_layout(
     max_model_len: usize,
-    pool_slots: usize,
+    num_blocks: usize,
 ) -> (usize, Glm52IndexerCacheLayout) {
     // The index-K cache is indexed by the same pool block ids as the MLA
     // cache, so it holds the same block count.
     let layout = Glm52IndexerCacheLayout {
-        cache_blocks: glm52_pool_blocks(max_model_len, pool_slots),
+        cache_blocks: num_blocks,
         cache_block_size: INDEX_CACHE_BLOCK,
         cache_block_stride_bytes: INDEX_CACHE_BLOCK * (GLM52_INDEX_HEAD_DIM + 4),
     };
@@ -614,11 +632,10 @@ impl Glm52RankModel {
         } else {
             glm52_flashmla_sparse_decode_num_sm_parts()?
         };
-        // Prefill-only allocates the full slot count too — the scheduler pool
-        // is sized to match, and the prefix cache retains released prefixes
-        // in the headroom.
-        let pool_slots = glm52_decode_slots();
-        let pool_blocks = glm52_pool_blocks(max_model_len, pool_slots);
+        // The launch-time budget decides the pool size (prefix cache included
+        // — released prefixes retain in whatever headroom the pool carries);
+        // the scheduler pool and every cache slab here share the ONE number.
+        let pool_blocks = glm52_configured_pool_blocks(max_model_len);
         let contract = Glm52FlashMlaSparseDecode {
             batch_size: batch,
             num_blocks: pool_blocks,
@@ -626,7 +643,8 @@ impl Glm52RankModel {
             num_sm_parts,
             sm_scale: GLM52_SM_SCALE,
         };
-        let (table_width, index_cache_layout) = glm52_index_cache_layout(max_model_len, pool_slots);
+        let (table_width, index_cache_layout) =
+            glm52_index_cache_layout(max_model_len, pool_blocks);
 
         let mut layers = Vec::with_capacity(GLM52_LAYERS);
         let mut caches = Vec::with_capacity(GLM52_LAYERS);

--- a/openinfer-glm52/src/model/mtp.rs
+++ b/openinfer-glm52/src/model/mtp.rs
@@ -191,6 +191,98 @@ pub(super) struct Glm52NativeMtp {
     tp_moe: Option<Glm52MoeTpPrefillScratch>,
 }
 
+/// [`Glm52NativeMtp`] minus everything sized by the pool block count: the
+/// two-phase build measures free VRAM after this exists, then
+/// [`Self::attach_cache`] allocates the cache slabs with the decided count.
+pub(super) struct Glm52NativeMtpFixed {
+    bookend: Glm52MtpBookendWeights,
+    layer: Glm52DecoderLayerWeights,
+    cache_bytes_per_token: usize,
+    transfer_bytes_per_token: Option<usize>,
+    buckets: [Glm52MtpBucket; GLM52_DECODE_BUCKETS.len()],
+    max_model_len: usize,
+    table_width: usize,
+    ep_ranks: usize,
+    positions: CudaSlice<u32>,
+    cos: CudaSlice<bf16>,
+    sin: CudaSlice<bf16>,
+    token_ids: CudaSlice<u32>,
+    slot_mapping: CudaSlice<i64>,
+    seq_lens: CudaSlice<i32>,
+    tp_moe: Option<Glm52MoeTpPrefillScratch>,
+}
+
+impl Glm52NativeMtpFixed {
+    /// Allocate the L78 cache slabs for the launch-decided pool block count.
+    /// The committed region mirrors the main pool's page ids 1:1 (radix hits
+    /// reuse L78 KV by page id), so it must be the SAME block count as the
+    /// pool — the per-slot scratch pair pages sit directly after it. Any
+    /// other sizing desyncs the `glm52_mtp_arena_bytes` ledger.
+    pub(super) fn attach_cache(
+        mut self,
+        ctx: &DeviceContext,
+        pool_blocks: usize,
+    ) -> Result<Glm52NativeMtp> {
+        let committed_blocks = pool_blocks;
+        let num_blocks =
+            committed_blocks + crate::model::glm52_decode_slots() * MTP_SCRATCH_PAGES_PER_SLOT;
+        let index_layout = Glm52IndexerCacheLayout {
+            cache_blocks: num_blocks,
+            cache_block_size: INDEX_CACHE_BLOCK,
+            cache_block_stride_bytes: INDEX_CACHE_BLOCK * (GLM52_INDEX_HEAD_DIM + 4),
+        };
+        // The bucket sched/scratch were built against a placeholder count;
+        // rebind them to the real cache geometry before anything launches.
+        for bucket in &mut self.buckets {
+            bucket.sched.set_num_blocks(num_blocks);
+            bucket.scratch.idx.set_num_kv_blocks(num_blocks);
+        }
+        let cache = Glm52LayerCaches {
+            mla_cache: ctx.stream.alloc_zeros::<u8>(
+                num_blocks * GLM52_FLASHMLA_SPARSE_PAGE_SIZE * self.cache_bytes_per_token,
+            )?,
+            index_k_cache: Some(
+                ctx.stream
+                    .alloc_zeros::<u8>(index_layout.min_cache_bytes()?)?,
+            ),
+        };
+        let transfer_cache = self
+            .transfer_bytes_per_token
+            .map(|bytes_per_token| -> Result<_> {
+                Ok(Glm52LayerCaches {
+                    mla_cache: ctx.stream.alloc_zeros::<u8>(
+                        num_blocks * GLM52_FLASHMLA_SPARSE_PAGE_SIZE * bytes_per_token,
+                    )?,
+                    index_k_cache: Some(
+                        ctx.stream
+                            .alloc_zeros::<u8>(index_layout.min_cache_bytes()?)?,
+                    ),
+                })
+            })
+            .transpose()?;
+        Ok(Glm52NativeMtp {
+            bookend: self.bookend,
+            layer: self.layer,
+            cache,
+            transfer_cache,
+            cache_bytes_per_token: self.cache_bytes_per_token,
+            buckets: self.buckets,
+            max_model_len: self.max_model_len,
+            table_width: self.table_width,
+            committed_blocks,
+            ep_ranks: self.ep_ranks,
+            positions: self.positions,
+            cos: self.cos,
+            sin: self.sin,
+            token_ids: self.token_ids,
+            slot_mapping: self.slot_mapping,
+            seq_lens: self.seq_lens,
+            committed_lens: [0; GLM52_MAX_BATCH_PER_RANK],
+            tp_moe: self.tp_moe,
+        })
+    }
+}
+
 impl Glm52NativeMtp {
     pub(super) fn prefill_parts(
         &mut self,
@@ -235,13 +327,17 @@ impl Glm52NativeMtp {
         ])
     }
 
-    pub(super) fn build(
+    /// Everything not sized by the pool block count: weights, per-bucket
+    /// sched/scratch (len-scaled), and the fixed step-row buffers. The cache
+    /// slabs follow in [`Glm52NativeMtpFixed::attach_cache`] once the
+    /// measured launch fill decides the count.
+    pub(super) fn build_fixed(
         ctx: &DeviceContext,
         weights: &mut Glm52RankGpuWeights,
         max_model_len: usize,
         moe_topo: crate::Glm52MoeTopo,
         attn_shard: Option<usize>,
-    ) -> Result<Self> {
+    ) -> Result<Glm52NativeMtpFixed> {
         let prefix = format!("model.layers.{GLM52_MTP_LAYER}");
         let enorm = build::take_bf16_vec(
             ctx,
@@ -275,17 +371,13 @@ impl Glm52NativeMtp {
         let layer =
             build::build_decoder_layer(ctx, weights, GLM52_MTP_LAYER, moe_topo, attn_shard)?;
 
-        // The committed region mirrors the main pool's page ids 1:1 (radix
-        // hits reuse L78 KV by page id), so it must be the SAME launch-time
-        // block count as the pool — the scratch pair pages sit directly
-        // after it. Any other sizing desyncs the `glm52_mtp_arena_bytes`
-        // ledger.
-        let committed_blocks = crate::model::glm52_configured_pool_blocks(max_model_len);
-        let num_blocks =
-            committed_blocks + crate::model::glm52_decode_slots() * MTP_SCRATCH_PAGES_PER_SLOT;
         let table_width = glm52_table_width(max_model_len);
+        // The pool block count is measured after this build; the bucket
+        // sched/scratch below carry the count only as launch metadata, so
+        // they are built against a 1-block placeholder that `attach_cache`
+        // rebinds to the real geometry.
         let index_layout = Glm52IndexerCacheLayout {
-            cache_blocks: num_blocks,
+            cache_blocks: 1,
             cache_block_size: INDEX_CACHE_BLOCK,
             cache_block_stride_bytes: INDEX_CACHE_BLOCK * (GLM52_INDEX_HEAD_DIM + 4),
         };
@@ -294,47 +386,21 @@ impl Glm52NativeMtp {
         let (cache_bytes_per_token, transfer_bytes_per_token) = mtp_cache_bytes(moe_topo, backend);
         let contract = Glm52FlashMlaSparseDecode {
             batch_size: GLM52_MAX_BATCH_PER_RANK,
-            num_blocks,
+            num_blocks: 1,
             topk: GLM52_FLASHMLA_SPARSE_TOPK,
             num_sm_parts: glm52_flashmla_sparse_decode_num_sm_parts()?,
             sm_scale: GLM52_SM_SCALE,
         };
-        let cache = Glm52LayerCaches {
-            mla_cache: ctx.stream.alloc_zeros::<u8>(
-                num_blocks * GLM52_FLASHMLA_SPARSE_PAGE_SIZE * cache_bytes_per_token,
-            )?,
-            index_k_cache: Some(
-                ctx.stream
-                    .alloc_zeros::<u8>(index_layout.min_cache_bytes()?)?,
-            ),
-        };
-        let transfer_cache = transfer_bytes_per_token
-            .map(|bytes_per_token| -> Result<_> {
-                Ok(Glm52LayerCaches {
-                    mla_cache: ctx.stream.alloc_zeros::<u8>(
-                        num_blocks * GLM52_FLASHMLA_SPARSE_PAGE_SIZE * bytes_per_token,
-                    )?,
-                    index_k_cache: Some(
-                        ctx.stream
-                            .alloc_zeros::<u8>(index_layout.min_cache_bytes()?)?,
-                    ),
-                })
-            })
-            .transpose()?;
         log::info!(
             "GLM5.2 native MTP cache: topology={moe_topo:?} \
              execution_backend={backend:?} execution_bytes/token={cache_bytes_per_token} \
              wire_layout={} wire_bytes/token={}",
-            if transfer_cache.is_some() {
+            if transfer_bytes_per_token.is_some() {
                 "fp8_ds_mla"
             } else {
                 "execution-native"
             },
-            if transfer_cache.is_some() {
-                transfer_bytes_per_token.expect("transfer cache has a wire layout")
-            } else {
-                cache_bytes_per_token
-            },
+            transfer_bytes_per_token.unwrap_or(cache_bytes_per_token),
         );
 
         let tp_moe = match moe_topo {
@@ -383,18 +449,16 @@ impl Glm52NativeMtp {
                 compute_graph: CudaGraphState::new(),
             });
         }
-        Ok(Self {
+        Ok(Glm52NativeMtpFixed {
             bookend,
             layer,
-            cache,
-            transfer_cache,
             cache_bytes_per_token,
+            transfer_bytes_per_token,
             buckets: buckets
                 .try_into()
                 .map_err(|_| anyhow::anyhow!("GLM5.2 MTP bucket count drifted"))?,
             max_model_len,
             table_width,
-            committed_blocks,
             ep_ranks: moe_topo.expected_ep_size(),
             positions: ctx.stream.alloc_zeros(GLM52_MAX_STEP_ROWS)?,
             cos: ctx
@@ -406,7 +470,6 @@ impl Glm52NativeMtp {
             token_ids: ctx.stream.alloc_zeros(GLM52_MAX_STEP_ROWS)?,
             slot_mapping: ctx.stream.alloc_zeros(GLM52_MAX_STEP_ROWS)?,
             seq_lens: ctx.stream.alloc_zeros(GLM52_MAX_STEP_ROWS)?,
-            committed_lens: [0; GLM52_MAX_BATCH_PER_RANK],
             tp_moe,
         })
     }

--- a/openinfer-glm52/src/model/mtp.rs
+++ b/openinfer-glm52/src/model/mtp.rs
@@ -35,6 +35,7 @@ use super::GLM52_MAX_STEP_ROWS;
 use super::INDEX_CACHE_BLOCK;
 use super::NUM_SMS;
 use super::build;
+#[cfg(test)]
 use super::glm52_pool_blocks;
 use super::glm52_table_width;
 use super::step_body::glm52_moe_ep_layer;
@@ -133,9 +134,10 @@ mod tests {
             * GLM52_FLASHMLA_SPARSE_PAGE_SIZE
             * openinfer_kernels::ops::GLM52_FLASHINFER_SPARSE_BYTES_PER_TOKEN;
         let extra_index_k = blocks * INDEX_CACHE_BLOCK * (GLM52_INDEX_HEAD_DIM + size_of::<f32>());
-        let tp4 = crate::mtp::glm52_mtp_arena_bytes(cap, crate::Glm52MoeTopo::Tp4)
+        let pool = glm52_pool_blocks(cap, slots);
+        let tp4 = crate::mtp::glm52_mtp_arena_bytes(cap, pool, crate::Glm52MoeTopo::Tp4)
             .expect("TP4 arena bytes");
-        let ep4 = crate::mtp::glm52_mtp_arena_bytes(cap, crate::Glm52MoeTopo::Ep4)
+        let ep4 = crate::mtp::glm52_mtp_arena_bytes(cap, pool, crate::Glm52MoeTopo::Ep4)
             .expect("EP4 arena bytes");
         assert_eq!(tp4 - ep4, extra_execution_mla + extra_index_k);
     }
@@ -274,13 +276,13 @@ impl Glm52NativeMtp {
             build::build_decoder_layer(ctx, weights, GLM52_MTP_LAYER, moe_topo, attn_shard)?;
 
         // The committed region mirrors the main pool's page ids 1:1 (radix
-        // hits reuse L78 KV by page id), so it must be sized from the SAME
-        // runtime slot count as the pool — the scratch pair pages sit
-        // directly after it. Ceiling-sizing here would both waste VRAM and
-        // desync the ledger in `glm52_mtp_arena_bytes`.
-        let slots = crate::model::glm52_decode_slots();
-        let committed_blocks = glm52_pool_blocks(max_model_len, slots);
-        let num_blocks = committed_blocks + slots * MTP_SCRATCH_PAGES_PER_SLOT;
+        // hits reuse L78 KV by page id), so it must be the SAME launch-time
+        // block count as the pool — the scratch pair pages sit directly
+        // after it. Any other sizing desyncs the `glm52_mtp_arena_bytes`
+        // ledger.
+        let committed_blocks = crate::model::glm52_configured_pool_blocks(max_model_len);
+        let num_blocks =
+            committed_blocks + crate::model::glm52_decode_slots() * MTP_SCRATCH_PAGES_PER_SLOT;
         let table_width = glm52_table_width(max_model_len);
         let index_layout = Glm52IndexerCacheLayout {
             cache_blocks: num_blocks,

--- a/openinfer-glm52/src/mtp.rs
+++ b/openinfer-glm52/src/mtp.rs
@@ -38,7 +38,6 @@ use crate::config::GLM52_INDEX_HEAD_DIM;
 use crate::config::GLM52_RMS_EPS;
 use crate::model::GLM52_DECODE_BUCKETS;
 use crate::model::GLM52_MODEL_LEN_ALIGN;
-use crate::model::glm52_pool_blocks;
 use crate::rows::Rows;
 
 const MTP_FUSED_INPUT: usize = 2 * GLM52_HIDDEN;
@@ -69,13 +68,13 @@ pub(crate) fn glm52_mtp_draft_len() -> usize {
 /// derive the context cap before those arenas are allocated.
 pub(crate) fn glm52_mtp_arena_bytes(
     max_model_len: usize,
+    pool_blocks: usize,
     topology: crate::Glm52MoeTopo,
 ) -> Result<usize> {
     // Two private pages per slot hold unverified proposal KV. Committed
     // layer-78 rows use the target BlockPool page IDs and are transferable;
     // scratch pages sit beyond that registered range.
-    let blocks = glm52_pool_blocks(max_model_len, crate::model::glm52_decode_slots())
-        + 2 * crate::model::glm52_decode_slots();
+    let blocks = pool_blocks + 2 * crate::model::glm52_decode_slots();
     let execution_bytes_per_token = if topology == crate::Glm52MoeTopo::Tp4 {
         openinfer_kernels::ops::GLM52_FLASHINFER_SPARSE_BYTES_PER_TOKEN
     } else {

--- a/openinfer-glm52/src/prefill_tp.rs
+++ b/openinfer-glm52/src/prefill_tp.rs
@@ -129,13 +129,16 @@ struct Glm52TpPrefillLayout {
 }
 
 impl Glm52TpPrefillLayout {
-    fn new(kv_slots: usize, table_width: usize, chunk_rows: usize) -> Result<Self> {
+    /// `kv_slots` starts at 0: the pool size is decided by the measured
+    /// launch fill AFTER the fixed buffers are built, and
+    /// [`Glm52TpPrefillExecutor::attach_kv_pool`] fills it in.
+    fn new(table_width: usize, chunk_rows: usize) -> Result<Self> {
         ensure!(
-            kv_slots > 0 && table_width > 0 && chunk_rows > 0,
+            table_width > 0 && chunk_rows > 0,
             "prefill capacities must be positive"
         );
         Ok(Self {
-            kv_slots,
+            kv_slots: 0,
             table_width,
             chunk_rows: chunk_rows.next_multiple_of(4),
         })
@@ -232,8 +235,11 @@ pub(crate) struct Glm52TpPrefillExecutor {
     ckv_fp8: CudaSlice<u8>,
     ckv_scales: CudaSlice<f32>,
     slot_mapping: CudaSlice<i64>,
-    block_ids: CudaSlice<i32>,
-    unpacked_kv: CudaSlice<bf16>,
+    // ---- pool-scaled buffers, attached by `attach_kv_pool` once the
+    // measured fill decides the block count (None only between build_fixed
+    // and finish_kv — never during serving) ----
+    block_ids: Option<CudaSlice<i32>>,
+    unpacked_kv: Option<CudaSlice<bf16>>,
     fp8_gemm: Glm52Fp8GemmScratch,
     attention_v: CudaSlice<bf16>,
     attention_partial: CudaSlice<bf16>,
@@ -317,15 +323,18 @@ pub(crate) struct Glm52TpPrefillModelView<'a> {
 }
 
 impl Glm52TpPrefillExecutor {
+    /// Build everything EXCEPT the pool-scaled buffers: the KV pool size is
+    /// measured after this returns, so `index_cache_layout` here may carry a
+    /// placeholder block count — [`Self::attach_kv_pool`] installs the real
+    /// one before any forward.
     pub(crate) fn new(
         ctx: &DeviceContext,
-        kv_slots: usize,
         table_width: usize,
         index_cache_layout: Glm52IndexerCacheLayout,
         chunk_rows: usize,
         topology: openinfer_kernels::ops::Glm52TpTopology,
     ) -> Result<Self> {
-        let layout = Glm52TpPrefillLayout::new(kv_slots, table_width, chunk_rows)?;
+        let layout = Glm52TpPrefillLayout::new(table_width, chunk_rows)?;
         let chunk = layout.chunk_rows;
         let attn = PREFILL_ATTN_TILE_ROWS;
         let dense = PREFILL_DENSE_TILE_ROWS.min(chunk);
@@ -344,12 +353,8 @@ impl Glm52TpPrefillExecutor {
             ckv_fp8: ctx.stream.alloc_zeros::<u8>(chunk * GLM52_KV_LORA_RANK)?,
             ckv_scales: ctx.stream.alloc_zeros::<f32>(chunk * 4)?,
             slot_mapping: ctx.stream.alloc_zeros::<i64>(chunk)?,
-            block_ids: ctx
-                .stream
-                .alloc_zeros::<i32>(layout.kv_slots.div_ceil(64))?,
-            unpacked_kv: ctx
-                .stream
-                .alloc_zeros::<bf16>(layout.kv_slots * GLM52_KV_A_OUT)?,
+            block_ids: None,
+            unpacked_kv: None,
             fp8_gemm: Glm52Fp8GemmScratch::new(ctx, chunk, GLM52_HIDDEN)?,
             attention_v: ctx.stream.alloc_zeros::<bf16>(chunk * 16 * 256)?,
             attention_partial: ctx.stream.alloc_zeros::<bf16>(chunk * GLM52_HIDDEN)?,
@@ -361,7 +366,6 @@ impl Glm52TpPrefillExecutor {
                 ctx,
                 chunk,
                 PREFILL_ATTN_TILE_ROWS,
-                kv_slots,
                 table_width,
                 index_cache_layout,
             )?,
@@ -406,6 +410,29 @@ impl Glm52TpPrefillExecutor {
             mtp_proposal_boundary: Rows::zeros(ctx, GLM52_MAX_BATCH_PER_RANK)?,
             layout,
         })
+    }
+
+    /// Allocate the two pool-scaled buffers (the page-id upload scratch and
+    /// the unpacked bf16 KV pool) and bind the launch-decided index-K layout,
+    /// once the measured fill has fixed the pool block count. Must run before
+    /// the first forward; the executor's other buffers are len/chunk-scaled
+    /// and were already allocated by [`Self::new`].
+    pub(crate) fn attach_kv_pool(
+        &mut self,
+        ctx: &DeviceContext,
+        kv_slots: usize,
+        index_cache_layout: Glm52IndexerCacheLayout,
+    ) -> Result<()> {
+        ensure!(
+            self.layout.kv_slots == 0 && self.block_ids.is_none() && self.unpacked_kv.is_none(),
+            "GLM5.2 prefill KV pool attached twice"
+        );
+        ensure!(kv_slots > 0, "GLM5.2 prefill KV pool must be non-empty");
+        self.layout.kv_slots = kv_slots;
+        self.block_ids = Some(ctx.stream.alloc_zeros::<i32>(kv_slots.div_ceil(64))?);
+        self.unpacked_kv = Some(ctx.stream.alloc_zeros::<bf16>(kv_slots * GLM52_KV_A_OUT)?);
+        self.indexer.set_cache_layout(index_cache_layout);
+        Ok(())
     }
 
     pub(crate) fn mtp_target_boundary(&self) -> &Rows<GLM52_HIDDEN> {
@@ -481,9 +508,13 @@ impl Glm52TpPrefillExecutor {
                     ctx,
                     &cache.mla_cache,
                     cache.mla_cache.len() / self.layout.kv_slots,
-                    &self.block_ids,
+                    self.block_ids
+                        .as_ref()
+                        .context("GLM5.2 prefill KV pool is not attached")?,
                     batch.block_ids.len(),
-                    &mut self.unpacked_kv,
+                    self.unpacked_kv
+                        .as_mut()
+                        .context("GLM5.2 prefill KV pool is not attached")?,
                 )?;
                 self.profiler.stop(ctx, "kv_page_unpack", mark)?;
             }
@@ -746,9 +777,13 @@ impl Glm52TpPrefillExecutor {
                 ctx,
                 &mtp.transfer_cache.mla_cache,
                 openinfer_kernels::ops::GLM52_FLASHMLA_SPARSE_BYTES_PER_TOKEN,
-                &self.block_ids,
+                self.block_ids
+                    .as_ref()
+                    .context("GLM5.2 prefill KV pool is not attached")?,
                 batch.block_ids.len(),
-                &mut self.unpacked_kv,
+                self.unpacked_kv
+                    .as_mut()
+                    .context("GLM5.2 prefill KV pool is not attached")?,
             )?;
         }
         let Glm52LayerIndexer::Full(indexer) = &mtp.layer.indexer else {
@@ -892,13 +927,17 @@ impl Glm52TpPrefillExecutor {
             &mut self.slot_mapping.slice_mut(..rows),
         )?;
         if !batch.block_ids.is_empty() {
+            let block_ids = self
+                .block_ids
+                .as_mut()
+                .context("GLM5.2 prefill KV pool is not attached")?;
             ensure!(
-                batch.block_ids.len() <= self.block_ids.len(),
+                batch.block_ids.len() <= block_ids.len(),
                 "prefill block list exceeds scratch capacity"
             );
             ctx.stream.memcpy_htod(
                 &batch.block_ids,
-                &mut self.block_ids.slice_mut(..batch.block_ids.len()),
+                &mut block_ids.slice_mut(..batch.block_ids.len()),
             )?;
         }
         embedding_rows_into(ctx, embed, &self.token_ids, rows, &mut self.hidden)?;
@@ -978,6 +1017,10 @@ impl Glm52TpPrefillExecutor {
         weights: &Glm52MlaLayerWeights,
         rows: usize,
     ) -> Result<()> {
+        let unpacked_kv = self
+            .unpacked_kv
+            .as_ref()
+            .context("GLM5.2 prefill KV pool is not attached")?;
         let mut sub = 0usize;
         while sub < rows {
             let t = (rows - sub).min(PREFILL_ATTN_TILE_ROWS);
@@ -1002,7 +1045,7 @@ impl Glm52TpPrefillExecutor {
                 GLM52_INDEXER_TOPK,
                 0.0625,
                 &self.query_bf16,
-                &self.unpacked_kv,
+                unpacked_kv,
                 &carry,
                 Some(&lens),
                 &mut self.attention_out,

--- a/openinfer-glm52/src/runner.rs
+++ b/openinfer-glm52/src/runner.rs
@@ -22,6 +22,7 @@ use crate::dspark::Glm52DsparkSlotState;
 use crate::model::GLM52_MAX_BATCH_PER_RANK;
 use crate::model::GLM52_MAX_STEP_ROWS;
 use crate::model::Glm52RankModel;
+use crate::model::Glm52RankModelFixed;
 use crate::model::Glm52StepKv;
 use crate::model::Glm52StepShape;
 use crate::moe_ep::Glm52MoeEpRankState;
@@ -208,16 +209,26 @@ enum Glm52RankCommand {
         weight_staging: bool,
         resp: Sender<Result<Glm52RankWeightLoadReport>>,
     },
-    /// Non-collective: adopt the resident weights into the rank's model.
-    /// Every rank must report success BEFORE anyone enters SetupComm — a
-    /// build failure on one rank must never strand the others in NCCL init.
-    /// Replies with the rank's cache arena descriptors so launch can
-    /// register them with the shared KV offload host.
-    BuildModel {
+    /// Non-collective, phase 1 of the two-phase build: adopt the resident
+    /// weights into everything EXCEPT the pool-scaled KV slabs, then reply
+    /// with this rank's measured free device VRAM — launch min-reduces the
+    /// fleet's replies to size the KV pool from real headroom instead of a
+    /// ledger estimate.
+    BuildFixed {
         max_model_len: usize,
         moe_topo: crate::Glm52MoeTopo,
         drafter: crate::Glm52Drafter,
         prefill_chunk_size: Option<usize>,
+        resp: Sender<Result<u64>>,
+    },
+    /// Non-collective, phase 2: allocate the pool-scaled slabs for the
+    /// launch-decided block count and assemble the rank runtime. Every rank
+    /// must report success BEFORE anyone enters SetupComm — a build failure
+    /// on one rank must never strand the others in NCCL init. Replies with
+    /// the rank's cache arena descriptors so launch can register them with
+    /// the shared KV offload host.
+    FinishKv {
+        pool_blocks: usize,
         resp: Sender<Result<Vec<KvArena>>>,
     },
     /// Collective: create the DeepEP context (barriers across ranks). Issued
@@ -255,7 +266,7 @@ enum Glm52RankCommand {
         resp: Sender<Result<Glm52PrefillOutput>>,
     },
     /// Non-collective: load the DSpark draft model onto this rank. Issued to
-    /// every rank after BuildModel (the draft reuses the target's
+    /// every rank after FinishKv (the draft reuses the target's
     /// embed/lm_head at forward time).
     LoadDspark {
         path: PathBuf,
@@ -359,20 +370,34 @@ impl Glm52RankWorker {
         Ok(resp_rx)
     }
 
-    pub(crate) fn build_model_async(
+    pub(crate) fn build_fixed_async(
         &self,
         max_model_len: usize,
         moe_topo: crate::Glm52MoeTopo,
         drafter: crate::Glm52Drafter,
         prefill_chunk_size: Option<usize>,
-    ) -> Result<Receiver<Result<Vec<KvArena>>>> {
+    ) -> Result<Receiver<Result<u64>>> {
         let (resp_tx, resp_rx) = bounded(1);
         self.tx
-            .send(Glm52RankCommand::BuildModel {
+            .send(Glm52RankCommand::BuildFixed {
                 max_model_len,
                 moe_topo,
                 drafter,
                 prefill_chunk_size,
+                resp: resp_tx,
+            })
+            .map_err(|_| anyhow::anyhow!("GLM5.2 rank worker channel closed"))?;
+        Ok(resp_rx)
+    }
+
+    pub(crate) fn finish_kv_async(
+        &self,
+        pool_blocks: usize,
+    ) -> Result<Receiver<Result<Vec<KvArena>>>> {
+        let (resp_tx, resp_rx) = bounded(1);
+        self.tx
+            .send(Glm52RankCommand::FinishKv {
+                pool_blocks,
                 resp: resp_tx,
             })
             .map_err(|_| anyhow::anyhow!("GLM5.2 rank worker channel closed"))?;
@@ -584,6 +609,9 @@ struct Glm52RankThreadState {
     /// TP-topology slice banks (loaded with the weights), waiting for the
     /// SetupComm rendezvous to assemble the runtime `Glm52MoeTpRank`.
     tp_slices: BTreeMap<usize, Glm52MoeTpSliceBank>,
+    /// The fixed half of the two-phase model build, parked between
+    /// BuildFixed's VRAM measurement and FinishKv's pool allocation.
+    fixed: Option<Box<Glm52RankModelFixed>>,
     runtime: Option<Glm52RankRuntime>,
 }
 
@@ -599,6 +627,7 @@ impl Glm52RankThreadState {
             bundle,
             loaded: None,
             tp_slices: BTreeMap::new(),
+            fixed: None,
             runtime: None,
         }
     }
@@ -682,19 +711,22 @@ impl Glm52RankThreadState {
         Ok(report)
     }
 
-    fn build_model(
+    /// Phase 1: build everything except the pool-scaled KV slabs, then
+    /// report this device's measured free VRAM — the number launch sizes the
+    /// fleet's pool from (same probe as the FreeVram command).
+    fn build_fixed(
         &mut self,
         max_model_len: usize,
         moe_topo: crate::Glm52MoeTopo,
         drafter: crate::Glm52Drafter,
         prefill_chunk_size: Option<usize>,
-    ) -> Result<Vec<KvArena>> {
+    ) -> Result<u64> {
         let mut weights = self
             .loaded
             .take()
-            .context("GLM5.2 build_model called before weights were loaded")?;
+            .context("GLM5.2 build_fixed called before weights were loaded")?;
         let dev_ctx = self.ctx.device_context()?;
-        let model = Box::new(Glm52RankModel::build(
+        self.fixed = Some(Box::new(Glm52RankModel::build_fixed(
             &dev_ctx,
             &mut weights,
             max_model_len,
@@ -704,7 +736,19 @@ impl Glm52RankThreadState {
                 .then_some(self.placement.rank),
             &drafter,
             prefill_chunk_size,
-        )?);
+        )?));
+        Ok(self.ctx.free_vram_bytes()? as u64)
+    }
+
+    /// Phase 2: allocate the pool-scaled slabs for the launch-decided count
+    /// and assemble the rank runtime.
+    fn finish_kv(&mut self, pool_blocks: usize) -> Result<Vec<KvArena>> {
+        let fixed = self
+            .fixed
+            .take()
+            .context("GLM5.2 finish_kv called before build_fixed")?;
+        let dev_ctx = self.ctx.device_context()?;
+        let model = Box::new(Glm52RankModel::finish_kv(&dev_ctx, *fixed, pool_blocks)?);
         let arenas = model.kv_arenas(&dev_ctx.stream)?;
         let aux_ctx = self.ctx.auxiliary_device_context("decode aux")?;
         self.runtime = Some(Glm52RankRuntime {
@@ -1007,19 +1051,22 @@ fn rank_worker_loop(rx: &Receiver<Glm52RankCommand>, mut state: Glm52RankThreadS
             } => {
                 let _ = resp.send(state.load_weights(&model_path, moe_topo, weight_staging));
             }
-            Glm52RankCommand::BuildModel {
+            Glm52RankCommand::BuildFixed {
                 max_model_len,
                 moe_topo,
                 drafter,
                 prefill_chunk_size,
                 resp,
             } => {
-                let _ = resp.send(state.build_model(
+                let _ = resp.send(state.build_fixed(
                     max_model_len,
                     moe_topo,
                     drafter,
                     prefill_chunk_size,
                 ));
+            }
+            Glm52RankCommand::FinishKv { pool_blocks, resp } => {
+                let _ = resp.send(state.finish_kv(pool_blocks));
             }
             Glm52RankCommand::SetupComm {
                 unique_id,

--- a/openinfer-glm52/src/scheduler/mod.rs
+++ b/openinfer-glm52/src/scheduler/mod.rs
@@ -182,6 +182,11 @@ pub(crate) struct Glm52EngineSpec {
     pub(crate) drafter: crate::Glm52Drafter,
     pub(crate) prefill_chunk_size: Option<usize>,
     pub(crate) max_model_len: usize,
+    /// The launch-measured pool block count — the scheduler's BlockPool and
+    /// the executor slabs (FinishKv) share this ONE number; carrying it in
+    /// the spec keeps a second launch in the same process from reading a
+    /// stale value through a global.
+    pub(crate) pool_blocks: usize,
     pub(crate) no_prefix_cache: bool,
     /// This rank's offload engines (several only under a mirrored topology,
     /// which uses the first — the historical layout); they hold the shared
@@ -303,10 +308,7 @@ impl Glm52Engine {
         // blocks to RETAIN released prefixes across turns, and the headroom
         // lets admission overlap prefills instead of serializing them. MLA
         // keeps this cheap (~54 KB/token/rank -> a few GiB at 16K x 8).
-        let pool = BlockPool::new(
-            PAGE,
-            crate::model::glm52_configured_pool_blocks(spec.max_model_len),
-        )?;
+        let pool = BlockPool::new(PAGE, spec.pool_blocks)?;
         let table_width = glm52_table_width(spec.max_model_len);
         // Prefix matching policy lives in `prefix_cache_enabled`: DSpark is
         // the only drafter that forces it off (aux-hidden captures cannot be

--- a/openinfer-glm52/src/scheduler/mod.rs
+++ b/openinfer-glm52/src/scheduler/mod.rs
@@ -89,7 +89,6 @@ use crate::model::GLM52_MAX_STEP_ROWS;
 use crate::model::GLM52_MODEL_LEN_ALIGN;
 use crate::model::Glm52StepKv;
 use crate::model::Glm52StepShape;
-use crate::model::glm52_pool_blocks;
 use crate::model::glm52_table_width;
 use crate::runner::Glm52MtpAppend;
 use crate::runner::Glm52PrefillBatch;
@@ -306,7 +305,7 @@ impl Glm52Engine {
         // keeps this cheap (~54 KB/token/rank -> a few GiB at 16K x 8).
         let pool = BlockPool::new(
             PAGE,
-            glm52_pool_blocks(spec.max_model_len, crate::model::glm52_decode_slots()),
+            crate::model::glm52_configured_pool_blocks(spec.max_model_len),
         )?;
         let table_width = glm52_table_width(spec.max_model_len);
         // Prefix matching policy lives in `prefix_cache_enabled`: DSpark is

--- a/openinfer-kv-offload/src/engine.rs
+++ b/openinfer-kv-offload/src/engine.rs
@@ -169,12 +169,18 @@ impl OffloadEngine {
             &reg.kv_stride_bytes,
             &reg.segments,
             Some(reg.block_stride_bytes.as_slice()),
-            // Direct (cuMemcpyAsync on the DMA engines). The Kernel backend
-            // was A/B'd for the fragmented bulk-restore batches (#704) and
-            // measured WORSE for co-resident decode: its grid-strided copy
-            // kernels compete for SMs with decode kernels, stretching the
-            // stall (two ~110ms waves vs Direct's one).
-            pegaflow_core::TransferMode::Direct,
+            // Direct (cuMemcpyAsync on the DMA engines) by default: the
+            // Kernel backend was A/B'd for the fragmented bulk-restore
+            // batches (#704) and measured WORSE for co-resident decode (its
+            // grid-strided copy kernels compete for SMs with decode
+            // kernels). On a prefill-only rank there is no decode to
+            // protect, and Direct's per-fragment cuMemcpyAsync serializes
+            // badly on host-restore storms — OPENINFER_KV_TRANSFER_MODE
+            // selects per deployment.
+            match std::env::var("OPENINFER_KV_TRANSFER_MODE").as_deref() {
+                Ok("kernel") => pegaflow_core::TransferMode::Kernel,
+                _ => pegaflow_core::TransferMode::Direct,
+            },
             // Layer-first (false): one pegaflow layer per model layer, the
             // page-interleaved gap expressed via `block_stride_bytes` — the
             // native openinfer layout. Page-first (true) instead stores each


### PR DESCRIPTION
## Summary

Stacked on #817 (retargets to main when that merges). The KV pool stops being `slots × max_model_len`: the cap stays what it always was — the per-request servable limit, page-table width, admission bound — and the pool block count becomes a **launch-time budget decision**. Every leftover budget byte after the fixed arenas becomes KV capacity, at the exact marginal cost read from the same ledger the cap derivation uses (the ledger is linear in blocks, so the fill lands within one block of the target).

## Why

- A 200K-class cap used to force `32 × 200K` of KV provisioning — either impossible or absurdly wasteful — and the derived cap **shrank as slots grew**. Mixed-context deployments (30 × 100K + 2 × 200K) had no shape at all.
- On prefill-only ranks the pool IS the prefix cache (#811 retains released prefixes in pool headroom); slot-count sizing left most of P's HBM idle.
- Admission already had the right per-request guard: lifetime reservation (`prompt + max_tokens`, honor-or-reject, queue when full). This PR just stops pre-multiplying the worst case into the pool.

## Semantics

- **Defaults unchanged:** the cap derivation keeps its legacy nominal (`slots × cap`) as the search target and the fill floor where affordable — a default launch gets the same cap as before, plus a larger pool.
- **Explicit big caps unlock:** where the nominal doesn't fit, the floor drops to a one-request pool and the fill takes it from there. `--max-model-len 131072` on 32 slots — rejected outright before — now launches and serves.
- **The pool size is MEASURED, not estimated** (second commit): workers build everything except pool-scaled slabs (`BuildFixed`), report `cuMemGetInfo` free VRAM, launch min-reduces and sizes the pool from fact at the exact per-block slab marginal, then workers attach the slabs (`FinishKv`). Exactly-known post-measure charges (DeepGEMM comm buffers, DSpark lane) subtract precisely. The only remaining estimate is `GLM52_GRAPH_RESERVE_GIB` (default 3) for lazy whole-step graph instantiation + runtime workspaces — backstopped by the existing post-build headroom re-probe. An earlier ledger-based fill needed an 8 GiB fudge for exactly the accounting-drift reason the MTP/dspark ledgers were bitten by this week; the measured design removes that failure class. `GLM52_KV_POOL_BLOCKS` pins the count for A/B runs.
- One process-wide block count publishes via `glm52_set_pool_blocks` before any worker builds; the scheduler pool, every cache slab, the MTP page-id mirror, and `kv_total_blocks` all read it (unit tests fall back to legacy sizing).

## Validation (EP4, 32×2 profile; re-run on the measured two-phase build)

- Default 16K cap: measured fill lands **21,640 blocks = 1.38M tokens (2.6× nominal, +469 blocks over the ledger estimate — measurement beats accounting)**, VRAM 279.6/284.2 GiB, build clean, zero failures; c192 decode throughput neutral (2,977.6 tok/s, mean TPOT 32.2 ms — identical to pre-decoupling repeats); greedy smoke byte-identical. The pool log shows the whole equation: min rank free after fixed build, graph reserve, exact post-finish charges, bytes/block.
- **Pool-pressure arbitration**: 12 concurrent ~118K prompts totalling **1.416M tokens against a 1.35M-token pool** — the overflow queued at admission (lifetime reservation) and **12/12 completed, zero failures**. This is the decoupling's core claim: concurrency × context no longer pre-provisioned, arbitrated at admission instead.
- **131,072 cap × 32 slots**: launches (one-request floor; outright rejected pre-decoupling), measured pool 21,544 blocks, and a **57,316-token prompt serves correctly**.
- New solver-invariant test (`budget_fill_spends_the_leftover_on_pool_blocks`); `cargo test -p openinfer-glm52 --lib` green except the known env-only `moe_tp::scale_staging_geometry`.

## Rider

`OPENINFER_KV_TRANSFER_MODE=kernel|direct` (openinfer-kv-offload, default `direct` unchanged): the pegaflow transfer backend was hardcoded to Direct per the #704 decode-co-residency finding; the env knob makes it selectable per deployment. A/B on the prefill-only offload path showed identical curves for both backends — which exposed that host restore isn't wired on prefill-only ranks at all (evicted prefixes recompute; `host_restore` gates on `prefill_chunk_size.is_none()`). The knob stays for when P-side restore lands; the P characterization data is in #812.

## Not in scope

P-side prefix-hit-rate gains (the same fill turns idle prefill-rank HBM into prefix-cache retention) want a multi-turn bench once a P/D window is up — follow-up on #812.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

