### PR TITLE
feat(gemma4): validate and load the 12B text tower

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3529,9 +3529,14 @@ name = "pegainfer-gemma4"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "cudarc",
+ "log",
+ "pegainfer-core",
  "pegainfer-engine",
+ "safetensors",
  "serde_json",
  "sha2 0.11.0",
+ "tempfile",
  "tokio",
  "vllm-chat",
  "vllm-text",

--- a/pegainfer-gemma4/Cargo.toml
+++ b/pegainfer-gemma4/Cargo.toml
@@ -7,16 +7,21 @@ name = "pegainfer-gemma4"
 version = "0.1.0"
 
 [features]
-gemma4 = []
+gemma4 = ["dep:cudarc", "dep:log", "dep:pegainfer-core"]
 default = []
 
 [dependencies]
 anyhow = { workspace = true }
+cudarc = { workspace = true, optional = true }
+log = { workspace = true, optional = true }
+pegainfer-core = { workspace = true, optional = true }
 pegainfer-engine = { workspace = true }
+safetensors = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
 sha2 = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
 vllm-chat = { workspace = true }
 vllm-text = { workspace = true }

--- a/pegainfer-gemma4/src/config.rs
+++ b/pegainfer-gemma4/src/config.rs
@@ -1,322 +1,107 @@
-// Fail-closed config probe: identity plus the structural facts shared by every
-// published size; no size pinning beyond the single published MoE configuration.
+//! Typed text-tower config, read only from a file the probe has accepted.
+
+#[cfg(feature = "gemma4")]
 use anyhow::Result;
+#[cfg(feature = "gemma4")]
 use anyhow::bail;
 
-const GEMMA4_LOCAL_HEAD_DIM: u64 = 256;
-const GEMMA4_GLOBAL_HEAD_DIM: u64 = 512;
-const GEMMA4_SLIDING_WINDOW: u64 = 1024;
-const GEMMA4_GLOBAL_LAYER_PERIOD: usize = 6;
-const GEMMA4_MOE_NUM_EXPERTS: u64 = 128;
-const GEMMA4_MOE_TOP_K: u64 = 8;
-const GEMMA4_MOE_INTERMEDIATE: u64 = 704;
+// Only the loader reads a config off disk.
+#[cfg(feature = "gemma4")]
+use crate::probe::probe_config_json;
 
-pub fn probe_config_json(json: &serde_json::Value) -> Result<()> {
-    let (family, text_config) = probe_identity(json)?;
-    probe_common_text(family, text_config)?;
-    probe_layer_types(family, text_config)?;
-    probe_moe(family, text_config)
+/// Selects the head dim, the KV head count, and whether the layer has a
+/// `v_proj`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum LayerKind {
+    Sliding,
+    Global,
 }
 
-fn probe_identity(json: &serde_json::Value) -> Result<(&'static str, &serde_json::Value)> {
-    let outer_type = json
-        .get("model_type")
-        .and_then(serde_json::Value::as_str)
-        .unwrap_or("");
-    let (family, text_model_type, arch_class) = match outer_type {
-        "gemma4" => ("gemma4", "gemma4_text", "Gemma4ForConditionalGeneration"),
-        "gemma4_unified" => (
-            "gemma4_unified",
-            "gemma4_unified_text",
-            "Gemma4UnifiedForConditionalGeneration",
-        ),
-        unknown => bail!("not a Gemma 4 config: model_type={unknown}"),
-    };
-
-    let architectures = json
-        .get("architectures")
-        .and_then(serde_json::Value::as_array);
-    let has_arch = architectures.is_some_and(|arr| {
-        arr.iter()
-            .any(|v| v.as_str().is_some_and(|s| s == arch_class))
-    });
-    if !has_arch {
-        bail!("Gemma 4 {family}: architectures must contain {arch_class}");
-    }
-
-    let text_config = json
-        .get("text_config")
-        .ok_or_else(|| anyhow::anyhow!("Gemma 4 {family}: missing text_config"))?;
-
-    let text_type = text_config
-        .get("model_type")
-        .and_then(serde_json::Value::as_str)
-        .unwrap_or("");
-    if text_type != text_model_type {
-        bail!(
-            "Gemma 4 {family}: text_config.model_type is {text_type}, expected {text_model_type} — \
-             cross-family mismatch"
-        );
-    }
-    Ok((family, text_config))
+/// What the manifest is derived from. Only [`Gemma4Config::from_file`] is
+/// probe-backed; a value built directly is not, so consumers check what they
+/// depend on.
+#[derive(Clone, Debug)]
+pub(crate) struct Gemma4Config {
+    pub(crate) hidden_size: usize,
+    pub(crate) intermediate_size: usize,
+    pub(crate) vocab_size: usize,
+    pub(crate) num_attention_heads: usize,
+    pub(crate) num_key_value_heads: usize,
+    /// 1, 2 or 4 by size, and not derivable from `num_key_value_heads`.
+    pub(crate) num_global_key_value_heads: usize,
+    pub(crate) head_dim: usize,
+    pub(crate) global_head_dim: usize,
+    pub(crate) layer_types: Vec<LayerKind>,
+    pub(crate) tie_word_embeddings: bool,
+    /// The MoE size keeps its dense MLP and adds experts alongside it.
+    pub(crate) moe_enabled: bool,
 }
 
-fn probe_common_text(family: &str, text_config: &serde_json::Value) -> Result<()> {
-    let e4b_window = text_config
-        .get("sliding_window")
-        .and_then(serde_json::Value::as_u64)
-        == Some(512);
-    let e4b_k_neq_v = text_config
-        .get("attention_k_eq_v")
-        .and_then(serde_json::Value::as_bool)
-        == Some(false);
-    if e4b_window && e4b_k_neq_v {
-        bail!(
-            "Gemma 4 {family}: this is an E4B edge-series configuration (sliding_window 512, \
-             attention_k_eq_v false, shared KV layers), which this model line does not support; \
-             supported configurations are the 12B/26B/31B ones"
+#[cfg(feature = "gemma4")]
+impl Gemma4Config {
+    pub(crate) fn from_file(model_path: &str) -> Result<Self> {
+        let path = format!("{model_path}/config.json");
+        let text = std::fs::read_to_string(&path)
+            .map_err(|e| anyhow::anyhow!("Gemma 4: cannot read {path}: {e}"))?;
+        let json: serde_json::Value = serde_json::from_str(&text)
+            .map_err(|e| anyhow::anyhow!("Gemma 4: {path} is not valid JSON: {e}"))?;
+        probe_config_json(&json)?;
+        Self::from_json(&json)
+    }
+
+    fn from_json(json: &serde_json::Value) -> Result<Self> {
+        let tc = json
+            .get("text_config")
+            .ok_or_else(|| anyhow::anyhow!("Gemma 4: missing text_config"))?;
+        let layer_types = tc
+            .get("layer_types")
+            .and_then(serde_json::Value::as_array)
+            .ok_or_else(|| anyhow::anyhow!("Gemma 4: missing text_config.layer_types"))?
+            .iter()
+            .map(|entry| match entry.as_str() {
+                Some("sliding_attention") => Ok(LayerKind::Sliding),
+                Some("full_attention") => Ok(LayerKind::Global),
+                other => bail!("Gemma 4: unexpected layer type {other:?}"),
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let num_hidden_layers = usize_field(tc, "num_hidden_layers")?;
+        anyhow::ensure!(
+            layer_types.len() == num_hidden_layers,
+            "Gemma 4: layer_types has {} entries but num_hidden_layers is {num_hidden_layers}",
+            layer_types.len()
         );
-    }
-
-    let head_dim = text_config
-        .get("head_dim")
-        .and_then(serde_json::Value::as_u64);
-    if head_dim != Some(GEMMA4_LOCAL_HEAD_DIM) {
-        bail!("Gemma 4 {family}: head_dim must be {GEMMA4_LOCAL_HEAD_DIM}, got {head_dim:?}");
-    }
-    let global_head_dim = text_config
-        .get("global_head_dim")
-        .and_then(serde_json::Value::as_u64);
-    if global_head_dim != Some(GEMMA4_GLOBAL_HEAD_DIM) {
-        bail!(
-            "Gemma 4 {family}: global_head_dim must be {GEMMA4_GLOBAL_HEAD_DIM}, got {global_head_dim:?}"
-        );
-    }
-    let sliding_window = text_config
-        .get("sliding_window")
-        .and_then(serde_json::Value::as_u64);
-    if sliding_window != Some(GEMMA4_SLIDING_WINDOW) {
-        bail!(
-            "Gemma 4 {family}: sliding_window must be {GEMMA4_SLIDING_WINDOW}, got {sliding_window:?}"
-        );
-    }
-    let attn_k_eq_v = text_config
-        .get("attention_k_eq_v")
-        .and_then(serde_json::Value::as_bool);
-    if attn_k_eq_v != Some(true) {
-        bail!("Gemma 4 {family}: attention_k_eq_v must be true, got {attn_k_eq_v:?}");
-    }
-    let num_kv_shared = text_config
-        .get("num_kv_shared_layers")
-        .and_then(serde_json::Value::as_u64);
-    if num_kv_shared != Some(0) {
-        bail!("Gemma 4 {family}: num_kv_shared_layers must be 0, got {num_kv_shared:?}");
-    }
-    let hidden_activation = text_config
-        .get("hidden_activation")
-        .and_then(serde_json::Value::as_str);
-    if hidden_activation != Some("gelu_pytorch_tanh") {
-        bail!(
-            "Gemma 4 {family}: hidden_activation must be gelu_pytorch_tanh, got {hidden_activation:?}"
-        );
-    }
-    Ok(())
-}
-
-fn probe_layer_types(family: &str, text_config: &serde_json::Value) -> Result<()> {
-    let layer_types = text_config
-        .get("layer_types")
-        .and_then(serde_json::Value::as_array)
-        .ok_or_else(|| anyhow::anyhow!("Gemma 4 {family}: missing layer_types"))?;
-    if layer_types.is_empty() {
-        bail!("Gemma 4 {family}: layer_types is empty");
-    }
-    let last_idx = layer_types.len() - 1;
-    for (i, entry) in layer_types.iter().enumerate() {
-        let s = entry.as_str().unwrap_or("");
-        if s != "sliding_attention" && s != "full_attention" {
-            bail!(
-                "Gemma 4 {family}: layer_types[{i}] is {s:?}, must be sliding_attention or full_attention"
-            );
-        }
-        let is_full = s == "full_attention";
-        let expected_full =
-            i % GEMMA4_GLOBAL_LAYER_PERIOD == GEMMA4_GLOBAL_LAYER_PERIOD - 1 || i == last_idx;
-        if is_full != expected_full {
-            bail!(
-                "Gemma 4 {family}: layer_types[{i}] is {s:?}, expected {}",
-                if expected_full {
-                    "full_attention"
-                } else {
-                    "sliding_attention"
-                }
-            );
-        }
-    }
-    Ok(())
-}
-
-fn probe_moe(family: &str, text_config: &serde_json::Value) -> Result<()> {
-    let enable_moe = text_config.get("enable_moe_block");
-    let Some(enable_moe) = enable_moe.and_then(serde_json::Value::as_bool) else {
-        bail!("Gemma 4 {family}: enable_moe_block must be an explicit boolean, got {enable_moe:?}");
-    };
-    if enable_moe {
-        let num_experts = text_config
-            .get("num_experts")
-            .and_then(serde_json::Value::as_u64);
-        if num_experts != Some(GEMMA4_MOE_NUM_EXPERTS) {
-            bail!(
-                "Gemma 4 {family}: MoE enabled but num_experts is {num_experts:?}, expected {GEMMA4_MOE_NUM_EXPERTS}"
-            );
-        }
-        let top_k = text_config
-            .get("top_k_experts")
-            .and_then(serde_json::Value::as_u64);
-        if top_k != Some(GEMMA4_MOE_TOP_K) {
-            bail!(
-                "Gemma 4 {family}: MoE enabled but top_k_experts is {top_k:?}, expected {GEMMA4_MOE_TOP_K}"
-            );
-        }
-        let moe_intermediate = text_config
-            .get("moe_intermediate_size")
-            .and_then(serde_json::Value::as_u64);
-        if moe_intermediate != Some(GEMMA4_MOE_INTERMEDIATE) {
-            bail!(
-                "Gemma 4 {family}: MoE enabled but moe_intermediate_size is {moe_intermediate:?}, expected {GEMMA4_MOE_INTERMEDIATE}"
-            );
-        }
-    } else {
-        for field in ["num_experts", "top_k_experts", "moe_intermediate_size"] {
-            if text_config.get(field).is_some_and(|v| !v.is_null()) {
-                bail!("Gemma 4 {family}: MoE disabled but {field} is present and non-null");
-            }
-        }
-    }
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn good_12b_config() -> serde_json::Value {
-        serde_json::json!({
-            "model_type": "gemma4_unified",
-            "architectures": ["Gemma4UnifiedForConditionalGeneration"],
-            "text_config": {
-                "model_type": "gemma4_unified_text",
-                "head_dim": 256,
-                "global_head_dim": 512,
-                "sliding_window": 1024,
-                "attention_k_eq_v": true,
-                "num_kv_shared_layers": 0,
-                "hidden_activation": "gelu_pytorch_tanh",
-                "enable_moe_block": false,
-                "layer_types": [
-                    "sliding_attention", "sliding_attention", "sliding_attention",
-                    "sliding_attention", "sliding_attention", "full_attention",
-                    "sliding_attention", "sliding_attention", "sliding_attention",
-                    "sliding_attention", "sliding_attention", "full_attention"
-                ]
-            }
+        Ok(Self {
+            hidden_size: usize_field(tc, "hidden_size")?,
+            intermediate_size: usize_field(tc, "intermediate_size")?,
+            vocab_size: usize_field(tc, "vocab_size")?,
+            num_attention_heads: usize_field(tc, "num_attention_heads")?,
+            num_key_value_heads: usize_field(tc, "num_key_value_heads")?,
+            num_global_key_value_heads: usize_field(tc, "num_global_key_value_heads")?,
+            head_dim: usize_field(tc, "head_dim")?,
+            global_head_dim: usize_field(tc, "global_head_dim")?,
+            layer_types,
+            tie_word_embeddings: bool_field(tc, "tie_word_embeddings")?,
+            moe_enabled: bool_field(tc, "enable_moe_block")?,
         })
     }
+}
 
-    fn good_26b_config() -> serde_json::Value {
-        let mut cfg = good_12b_config();
-        cfg["model_type"] = serde_json::json!("gemma4");
-        cfg["architectures"] = serde_json::json!(["Gemma4ForConditionalGeneration"]);
-        let tc = &mut cfg["text_config"];
-        tc["model_type"] = serde_json::json!("gemma4_text");
-        tc["enable_moe_block"] = serde_json::json!(true);
-        tc["num_experts"] = serde_json::json!(128);
-        tc["top_k_experts"] = serde_json::json!(8);
-        tc["moe_intermediate_size"] = serde_json::json!(704);
-        tc["intermediate_size"] = serde_json::json!(2112);
-        cfg
-    }
+#[cfg(feature = "gemma4")]
+fn usize_field(text_config: &serde_json::Value, field: &str) -> Result<usize> {
+    let value = text_config
+        .get(field)
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| {
+            anyhow::anyhow!("Gemma 4: text_config.{field} missing or not a non-negative integer")
+        })?;
+    usize::try_from(value)
+        .map_err(|_| anyhow::anyhow!("Gemma 4: text_config.{field} = {value} does not fit usize"))
+}
 
-    #[test]
-    fn good_12b_passes() {
-        probe_config_json(&good_12b_config()).unwrap();
-    }
-
-    #[test]
-    fn good_26b_passes() {
-        probe_config_json(&good_26b_config()).unwrap();
-    }
-
-    #[test]
-    fn moe_width_2112_bails() {
-        let mut cfg = good_26b_config();
-        cfg["text_config"]["moe_intermediate_size"] = serde_json::json!(2112);
-        let err = probe_config_json(&cfg).unwrap_err().to_string();
-        assert!(err.contains("moe_intermediate_size"), "{err}");
-    }
-
-    #[test]
-    fn missing_enable_moe_block_bails() {
-        let mut cfg = good_12b_config();
-        cfg["text_config"]
-            .as_object_mut()
-            .unwrap()
-            .remove("enable_moe_block");
-        let err = probe_config_json(&cfg).unwrap_err().to_string();
-        assert!(err.contains("enable_moe_block"), "{err}");
-    }
-
-    #[test]
-    fn moe_disabled_with_num_experts_bails() {
-        let mut cfg = good_12b_config();
-        cfg["text_config"]["num_experts"] = serde_json::json!(128);
-        let err = probe_config_json(&cfg).unwrap_err().to_string();
-        assert!(err.contains("num_experts"), "{err}");
-    }
-
-    #[test]
-    fn moe_top_k_as_string_bails() {
-        let mut cfg = good_26b_config();
-        cfg["text_config"]["top_k_experts"] = serde_json::json!("8");
-        let err = probe_config_json(&cfg).unwrap_err().to_string();
-        assert!(err.contains("top_k_experts"), "{err}");
-    }
-
-    #[test]
-    fn e4b_edge_series_rejected_by_name() {
-        let mut cfg = good_12b_config();
-        cfg["model_type"] = serde_json::json!("gemma4");
-        cfg["architectures"] = serde_json::json!(["Gemma4ForConditionalGeneration"]);
-        let tc = &mut cfg["text_config"];
-        tc["model_type"] = serde_json::json!("gemma4_text");
-        tc["sliding_window"] = serde_json::json!(512);
-        tc["attention_k_eq_v"] = serde_json::json!(false);
-        tc["num_kv_shared_layers"] = serde_json::json!(18);
-        let err = probe_config_json(&cfg).unwrap_err().to_string();
-        assert!(err.contains("E4B"), "{err}");
-    }
-
-    #[test]
-    fn wrong_layer_at_non_6th_index_bails() {
-        let mut cfg = good_12b_config();
-        cfg["text_config"]["layer_types"][3] = serde_json::json!("full_attention");
-        let err = probe_config_json(&cfg).unwrap_err().to_string();
-        assert!(err.contains("layer_types[3]"), "{err}");
-    }
-
-    #[test]
-    fn cross_family_mismatch_bails() {
-        let mut cfg = good_12b_config();
-        cfg["architectures"] = serde_json::json!(["Gemma4ForConditionalGeneration"]);
-        let err = probe_config_json(&cfg).unwrap_err().to_string();
-        assert!(err.contains("architectures"), "{err}");
-    }
-
-    #[test]
-    fn moe_enabled_without_num_experts_bails() {
-        let mut cfg = good_12b_config();
-        cfg["text_config"]["enable_moe_block"] = serde_json::json!(true);
-        let err = probe_config_json(&cfg).unwrap_err().to_string();
-        assert!(err.contains("num_experts"), "{err}");
-    }
+#[cfg(feature = "gemma4")]
+fn bool_field(text_config: &serde_json::Value, field: &str) -> Result<bool> {
+    text_config
+        .get(field)
+        .and_then(serde_json::Value::as_bool)
+        .ok_or_else(|| anyhow::anyhow!("Gemma 4: text_config.{field} missing or not a boolean"))
 }

--- a/pegainfer-gemma4/src/lib.rs
+++ b/pegainfer-gemma4/src/lib.rs
@@ -1,11 +1,20 @@
+// The config and the manifest are CUDA-free so they test without a device, but
+// only the loader consumes them, so a gate-off library does not carry them.
+#[cfg(any(feature = "gemma4", test))]
 mod config;
+#[cfg(any(feature = "gemma4", test))]
+mod manifest;
+mod probe;
+#[cfg(feature = "gemma4")]
+#[expect(dead_code, reason = "no consumer until the executor lands")]
+mod weights;
 
 use std::path::Path;
 
 use anyhow::Result;
-pub use config::probe_config_json;
 use pegainfer_engine::engine::EngineHandle;
 use pegainfer_engine::engine::EngineLoadOptions;
+pub use probe::probe_config_json;
 
 #[cfg(feature = "gemma4")]
 pub fn start_engine(_model_path: &Path, _options: EngineLoadOptions) -> Result<EngineHandle> {

--- a/pegainfer-gemma4/src/manifest/mod.rs
+++ b/pegainfer-gemma4/src/manifest/mod.rs
@@ -1,0 +1,9 @@
+//! [`schema`] turns a config into the tensor contract the checkpoint must
+//! satisfy; [`validate`] holds that contract up against the headers it carries.
+
+use safetensors::Dtype;
+
+pub(crate) mod schema;
+pub(crate) mod validate;
+
+const EXPECTED_DTYPE: Dtype = Dtype::BF16;

--- a/pegainfer-gemma4/src/manifest/schema.rs
+++ b/pegainfer-gemma4/src/manifest/schema.rs
@@ -1,0 +1,332 @@
+//! The tensor contract a config implies.
+
+use std::collections::HashMap;
+use std::fmt;
+
+use anyhow::Result;
+
+use super::EXPECTED_DTYPE;
+use crate::config::Gemma4Config;
+use crate::config::LayerKind;
+
+/// Every text tensor lives here, which is what keeps the modality skip list
+/// from shadowing a required one.
+const TEXT_PREFIX: &str = "model.language_model.";
+
+pub(crate) struct Matrix2d {
+    pub(crate) name: String,
+    pub(crate) rows: usize,
+    pub(crate) cols: usize,
+}
+
+pub(crate) struct Vector1d {
+    pub(crate) name: String,
+    pub(crate) len: usize,
+}
+
+pub(crate) struct AttentionTensors {
+    pub(crate) q_proj: Matrix2d,
+    pub(crate) k_proj: Matrix2d,
+    /// Absent on global layers, which the checkpoint ships without one.
+    pub(crate) v_proj: Option<Matrix2d>,
+    pub(crate) o_proj: Matrix2d,
+    pub(crate) q_norm: Vector1d,
+    pub(crate) k_norm: Vector1d,
+}
+
+pub(crate) struct MlpTensors {
+    pub(crate) gate: Matrix2d,
+    pub(crate) up: Matrix2d,
+    pub(crate) down: Matrix2d,
+}
+
+pub(crate) struct LayerTensors {
+    pub(crate) input_layernorm: Vector1d,
+    pub(crate) post_attention_layernorm: Vector1d,
+    pub(crate) pre_feedforward_layernorm: Vector1d,
+    pub(crate) post_feedforward_layernorm: Vector1d,
+    pub(crate) layer_scalar: Vector1d,
+    pub(crate) attention: AttentionTensors,
+    pub(crate) mlp: MlpTensors,
+}
+
+pub(crate) struct Manifest {
+    pub(crate) embed_tokens: Matrix2d,
+    pub(crate) norm: Vector1d,
+    pub(crate) layers: Vec<LayerTensors>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum ExpectedShape {
+    Matrix { rows: usize, cols: usize },
+    Vector { len: usize },
+}
+
+impl ExpectedShape {
+    pub(super) fn matches(self, shape: &[usize]) -> bool {
+        match self {
+            Self::Matrix { rows, cols } => shape == [rows, cols],
+            Self::Vector { len } => shape == [len],
+        }
+    }
+
+    fn checked_bytes(self) -> Option<usize> {
+        let elements = match self {
+            Self::Matrix { rows, cols } => rows.checked_mul(cols)?,
+            Self::Vector { len } => len,
+        };
+        elements.checked_mul(EXPECTED_DTYPE.bitsize() / 8)
+    }
+}
+
+impl fmt::Display for ExpectedShape {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Matrix { rows, cols } => write!(f, "[{rows}, {cols}]"),
+            Self::Vector { len } => write!(f, "[{len}]"),
+        }
+    }
+}
+
+impl Matrix2d {
+    fn new(name: String, rows: usize, cols: usize) -> Self {
+        Self { name, rows, cols }
+    }
+
+    fn expected(&self) -> ExpectedShape {
+        ExpectedShape::Matrix {
+            rows: self.rows,
+            cols: self.cols,
+        }
+    }
+}
+
+impl Vector1d {
+    fn new(name: String, len: usize) -> Self {
+        Self { name, len }
+    }
+
+    fn expected(&self) -> ExpectedShape {
+        ExpectedShape::Vector { len: self.len }
+    }
+}
+
+impl Manifest {
+    pub(crate) fn from_config(config: &Gemma4Config) -> Result<Self> {
+        anyhow::ensure!(
+            !config.moe_enabled,
+            "Gemma 4: this checkpoint enables the MoE block. Its decoder layers keep their dense \
+             MLP and add routed experts, a router and three more norm sites on top; the loader \
+             describes only the dense schema, so it cannot name what those layers also carry"
+        );
+        anyhow::ensure!(
+            config.tie_word_embeddings,
+            "Gemma 4: this checkpoint unties the LM head, which the loader has no tensor name for; \
+             every published size ties it to the input embedding"
+        );
+        let hidden = config.hidden_size;
+        let layers = config
+            .layer_types
+            .iter()
+            .enumerate()
+            .map(|(index, &kind)| LayerTensors::new(config, index, kind))
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Self {
+            embed_tokens: Matrix2d::new(
+                format!("{TEXT_PREFIX}embed_tokens.weight"),
+                config.vocab_size,
+                hidden,
+            ),
+            norm: Vector1d::new(format!("{TEXT_PREFIX}norm.weight"), hidden),
+            layers,
+        })
+    }
+
+    pub(super) fn expected_shapes(&self) -> HashMap<&str, ExpectedShape> {
+        fn matrix(m: &Matrix2d) -> (&str, ExpectedShape) {
+            (m.name.as_str(), m.expected())
+        }
+        fn vector(v: &Vector1d) -> (&str, ExpectedShape) {
+            (v.name.as_str(), v.expected())
+        }
+        let mut out = HashMap::new();
+        out.extend([matrix(&self.embed_tokens), vector(&self.norm)]);
+        for layer in &self.layers {
+            out.extend([
+                vector(&layer.input_layernorm),
+                vector(&layer.post_attention_layernorm),
+                vector(&layer.pre_feedforward_layernorm),
+                vector(&layer.post_feedforward_layernorm),
+                vector(&layer.layer_scalar),
+                vector(&layer.attention.q_norm),
+                vector(&layer.attention.k_norm),
+                matrix(&layer.attention.q_proj),
+                matrix(&layer.attention.k_proj),
+                matrix(&layer.attention.o_proj),
+                matrix(&layer.mlp.gate),
+                matrix(&layer.mlp.up),
+                matrix(&layer.mlp.down),
+            ]);
+            if let Some(v_proj) = &layer.attention.v_proj {
+                out.insert(v_proj.name.as_str(), v_proj.expected());
+            }
+        }
+        out
+    }
+
+    /// Before any allocator rounding.
+    pub(crate) fn weight_bytes(&self) -> Result<usize> {
+        self.expected_shapes()
+            .values()
+            .try_fold(0usize, |total, shape| {
+                shape
+                    .checked_bytes()
+                    .and_then(|bytes| total.checked_add(bytes))
+            })
+            .ok_or_else(|| anyhow::anyhow!("Gemma 4: the manifest's total size overflows usize"))
+    }
+}
+
+impl LayerTensors {
+    fn new(config: &Gemma4Config, index: usize, kind: LayerKind) -> Result<Self> {
+        let hidden = config.hidden_size;
+        let prefix = format!("{TEXT_PREFIX}layers.{index}.");
+        let (head_dim, kv_heads) = match kind {
+            LayerKind::Sliding => (config.head_dim, config.num_key_value_heads),
+            LayerKind::Global => (config.global_head_dim, config.num_global_key_value_heads),
+        };
+        // External input, and the probe pins only the head dims.
+        let projection_dim = |heads: usize, what: &str| {
+            heads.checked_mul(head_dim).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Gemma 4 layer {index}: {what} dimension {heads} x {head_dim} overflows usize"
+                )
+            })
+        };
+        let q_dim = projection_dim(config.num_attention_heads, "query")?;
+        let kv_dim = projection_dim(kv_heads, "key/value")?;
+        Ok(Self {
+            input_layernorm: Vector1d::new(format!("{prefix}input_layernorm.weight"), hidden),
+            post_attention_layernorm: Vector1d::new(
+                format!("{prefix}post_attention_layernorm.weight"),
+                hidden,
+            ),
+            pre_feedforward_layernorm: Vector1d::new(
+                format!("{prefix}pre_feedforward_layernorm.weight"),
+                hidden,
+            ),
+            post_feedforward_layernorm: Vector1d::new(
+                format!("{prefix}post_feedforward_layernorm.weight"),
+                hidden,
+            ),
+            layer_scalar: Vector1d::new(format!("{prefix}layer_scalar"), 1),
+            attention: AttentionTensors {
+                q_proj: Matrix2d::new(format!("{prefix}self_attn.q_proj.weight"), q_dim, hidden),
+                k_proj: Matrix2d::new(format!("{prefix}self_attn.k_proj.weight"), kv_dim, hidden),
+                v_proj: match kind {
+                    LayerKind::Sliding => Some(Matrix2d::new(
+                        format!("{prefix}self_attn.v_proj.weight"),
+                        kv_dim,
+                        hidden,
+                    )),
+                    LayerKind::Global => None,
+                },
+                o_proj: Matrix2d::new(format!("{prefix}self_attn.o_proj.weight"), hidden, q_dim),
+                q_norm: Vector1d::new(format!("{prefix}self_attn.q_norm.weight"), head_dim),
+                k_norm: Vector1d::new(format!("{prefix}self_attn.k_norm.weight"), head_dim),
+            },
+            mlp: MlpTensors {
+                gate: Matrix2d::new(
+                    format!("{prefix}mlp.gate_proj.weight"),
+                    config.intermediate_size,
+                    hidden,
+                ),
+                up: Matrix2d::new(
+                    format!("{prefix}mlp.up_proj.weight"),
+                    config.intermediate_size,
+                    hidden,
+                ),
+                down: Matrix2d::new(
+                    format!("{prefix}mlp.down_proj.weight"),
+                    hidden,
+                    config.intermediate_size,
+                ),
+            },
+        })
+    }
+}
+
+/// Two sliding layers and one global, at the published 12B dimensions.
+#[cfg(test)]
+pub(super) fn sample_config() -> Gemma4Config {
+    Gemma4Config {
+        hidden_size: 3840,
+        intermediate_size: 15360,
+        vocab_size: 262_144,
+        num_attention_heads: 16,
+        num_key_value_heads: 8,
+        num_global_key_value_heads: 1,
+        head_dim: 256,
+        global_head_dim: 512,
+        layer_types: vec![LayerKind::Sliding, LayerKind::Sliding, LayerKind::Global],
+        tie_word_embeddings: true,
+        moe_enabled: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sample_config as config;
+    use super::*;
+
+    fn rejection(config: &Gemma4Config) -> String {
+        match Manifest::from_config(config) {
+            Ok(_) => panic!("expected this config to be rejected"),
+            Err(e) => e.to_string(),
+        }
+    }
+
+    #[test]
+    fn global_layers_have_no_v_proj_and_wider_heads() {
+        let config = config();
+        let manifest = Manifest::from_config(&config).unwrap();
+        let sliding = &manifest.layers[0].attention;
+        let global = &manifest.layers[2].attention;
+        assert_eq!(sliding.v_proj.as_ref().unwrap().rows, 8 * 256);
+        assert!(global.v_proj.is_none());
+        assert_eq!(sliding.q_proj.rows, 16 * 256);
+        assert_eq!(global.q_proj.rows, 16 * 512);
+        assert_eq!(global.k_proj.rows, 512);
+        assert_eq!(global.q_norm.len, 512);
+    }
+
+    #[test]
+    fn moe_and_untied_configs_are_rejected_before_any_tensor_is_named() {
+        let mut moe = config();
+        moe.moe_enabled = true;
+        let err = rejection(&moe);
+        assert!(err.contains("MoE block"), "{err}");
+
+        let mut untied = config();
+        untied.tie_word_embeddings = false;
+        let err = rejection(&untied);
+        assert!(err.contains("unties the LM head"), "{err}");
+    }
+
+    #[test]
+    fn dimensions_that_overflow_are_rejected_rather_than_wrapped() {
+        let mut wide = config();
+        wide.num_attention_heads = usize::MAX;
+        let err = rejection(&wide);
+        assert!(err.contains("overflows usize"), "{err}");
+
+        let mut deep = config();
+        deep.vocab_size = usize::MAX;
+        let err = Manifest::from_config(&deep)
+            .expect("per-tensor shapes are fine; only the total overflows")
+            .weight_bytes()
+            .expect_err("a manifest whose total overflows usize was accepted")
+            .to_string();
+        assert!(err.contains("overflows usize"), "{err}");
+    }
+}

--- a/pegainfer-gemma4/src/manifest/validate.rs
+++ b/pegainfer-gemma4/src/manifest/validate.rs
@@ -1,0 +1,257 @@
+//! The contract held up against what a checkpoint carries.
+
+use anyhow::Result;
+use safetensors::Dtype;
+
+use super::EXPECTED_DTYPE;
+use super::schema::Manifest;
+
+/// Spans every published size; a checkpoint matches only its own.
+const OPTIONAL_MODALITY_PREFIXES: &[&str] = &[
+    "model.embed_audio.",
+    "model.embed_vision.",
+    "model.vision_embedder.",
+    "model.vision_tower.",
+];
+
+pub(crate) struct ObservedTensor<'a> {
+    pub(crate) name: &'a str,
+    pub(crate) dtype: Dtype,
+    pub(crate) shape: &'a [usize],
+}
+
+impl Manifest {
+    pub(crate) fn classify(&self, observed: &[ObservedTensor]) -> ManifestReport {
+        let mut expected = self.expected_shapes();
+        let mut report = ManifestReport::default();
+        for tensor in observed {
+            let Some(shape) = expected.remove(tensor.name) else {
+                if OPTIONAL_MODALITY_PREFIXES
+                    .iter()
+                    .any(|prefix| tensor.name.starts_with(prefix))
+                {
+                    report.skipped_modality.push(tensor.name.to_string());
+                } else {
+                    report.unexpected.push(tensor.name.to_string());
+                }
+                continue;
+            };
+            if !shape.matches(tensor.shape) {
+                report.shape_mismatch.push(format!(
+                    "{}: checkpoint has {:?}, config implies {shape}",
+                    tensor.name, tensor.shape
+                ));
+            }
+            if tensor.dtype != EXPECTED_DTYPE {
+                report.dtype_mismatch.push(format!(
+                    "{}: checkpoint has {:?}, expected {EXPECTED_DTYPE:?}",
+                    tensor.name, tensor.dtype
+                ));
+            }
+        }
+        report.missing = expected.into_keys().map(str::to_string).collect();
+        report.sort();
+        report
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct ManifestReport {
+    missing: Vec<String>,
+    pub(crate) skipped_modality: Vec<String>,
+    unexpected: Vec<String>,
+    shape_mismatch: Vec<String>,
+    dtype_mismatch: Vec<String>,
+}
+
+impl ManifestReport {
+    fn sort(&mut self) {
+        self.missing.sort();
+        self.skipped_modality.sort();
+        self.unexpected.sort();
+        self.shape_mismatch.sort();
+        self.dtype_mismatch.sort();
+    }
+
+    /// Skipped modality tensors are not faults.
+    pub(crate) fn check(&self) -> Result<()> {
+        let faults: Vec<String> = [
+            ("missing required text tensor", &self.missing),
+            ("unexpected tensor", &self.unexpected),
+            ("shape mismatch", &self.shape_mismatch),
+            ("dtype mismatch", &self.dtype_mismatch),
+        ]
+        .into_iter()
+        .flat_map(|(label, entries)| {
+            entries
+                .iter()
+                .map(move |entry| format!("  {label}: {entry}"))
+        })
+        .collect();
+        if faults.is_empty() {
+            return Ok(());
+        }
+        anyhow::bail!(
+            "Gemma 4 checkpoint does not match the config, {} fault(s):\n{}",
+            faults.len(),
+            faults.join("\n")
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::schema::ExpectedShape;
+    use crate::manifest::schema::sample_config as config;
+
+    fn faultless(manifest: &Manifest) -> Vec<(String, Dtype, Vec<usize>)> {
+        manifest
+            .expected_shapes()
+            .into_iter()
+            .map(|(name, shape)| {
+                let dims = match shape {
+                    ExpectedShape::Matrix { rows, cols } => vec![rows, cols],
+                    ExpectedShape::Vector { len } => vec![len],
+                };
+                (name.to_string(), Dtype::BF16, dims)
+            })
+            .collect()
+    }
+
+    fn observe(tensors: &[(String, Dtype, Vec<usize>)]) -> Vec<ObservedTensor<'_>> {
+        tensors
+            .iter()
+            .map(|(name, dtype, shape)| ObservedTensor {
+                name,
+                dtype: *dtype,
+                shape,
+            })
+            .collect()
+    }
+
+    fn error_for(manifest: &Manifest, tensors: &[(String, Dtype, Vec<usize>)]) -> String {
+        manifest
+            .classify(&observe(tensors))
+            .check()
+            .expect_err("expected the manifest to reject this checkpoint")
+            .to_string()
+    }
+
+    #[test]
+    fn faultless_checkpoint_is_accepted() {
+        let manifest = Manifest::from_config(&config()).unwrap();
+        let tensors = faultless(&manifest);
+        let report = manifest.classify(&observe(&tensors));
+        report.check().unwrap();
+        assert!(report.skipped_modality.is_empty());
+    }
+
+    #[test]
+    fn optional_modality_tensors_are_skipped_not_faulted() {
+        let manifest = Manifest::from_config(&config()).unwrap();
+        let mut tensors = faultless(&manifest);
+        for name in [
+            "model.embed_audio.embedding_projection.weight",
+            "model.embed_vision.embedding_projection.weight",
+            "model.vision_embedder.patch_dense.weight",
+            "model.vision_tower.encoder.layers.0.mlp.fc1.weight",
+        ] {
+            tensors.push((name.to_string(), Dtype::BF16, vec![3840, 3840]));
+        }
+        let report = manifest.classify(&observe(&tensors));
+        report.check().unwrap();
+        assert_eq!(report.skipped_modality.len(), 4);
+    }
+
+    #[test]
+    fn no_modality_prefix_can_shadow_a_text_tensor() {
+        let manifest = Manifest::from_config(&config()).unwrap();
+        for name in manifest.expected_shapes().keys() {
+            for prefix in OPTIONAL_MODALITY_PREFIXES {
+                assert!(
+                    !name.starts_with(prefix),
+                    "required tensor {name} would be skipped as modality prefix {prefix}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn missing_text_tensor_is_named() {
+        let manifest = Manifest::from_config(&config()).unwrap();
+        let dropped = "model.language_model.layers.2.self_attn.k_norm.weight";
+        let tensors: Vec<_> = faultless(&manifest)
+            .into_iter()
+            .filter(|(name, ..)| name != dropped)
+            .collect();
+        let err = error_for(&manifest, &tensors);
+        assert!(err.contains("missing required text tensor"), "{err}");
+        assert!(err.contains(dropped), "{err}");
+    }
+
+    #[test]
+    fn unexpected_tensor_is_named() {
+        let manifest = Manifest::from_config(&config()).unwrap();
+        let mut tensors = faultless(&manifest);
+        let extra = "model.language_model.layers.0.self_attn.v_bias";
+        tensors.push((extra.to_string(), Dtype::BF16, vec![2048]));
+        let err = error_for(&manifest, &tensors);
+        assert!(err.contains("unexpected tensor"), "{err}");
+        assert!(err.contains(extra), "{err}");
+    }
+
+    #[test]
+    fn shape_mismatch_reports_both_shapes() {
+        let manifest = Manifest::from_config(&config()).unwrap();
+        let bent = "model.language_model.layers.0.mlp.down_proj.weight";
+        let mut tensors = faultless(&manifest);
+        let entry = tensors.iter_mut().find(|(name, ..)| name == bent).unwrap();
+        entry.2 = vec![3840, 15359];
+        let err = error_for(&manifest, &tensors);
+        assert!(err.contains("shape mismatch"), "{err}");
+        assert!(err.contains(bent), "{err}");
+        assert!(err.contains("[3840, 15359]"), "{err}");
+        assert!(err.contains("[3840, 15360]"), "{err}");
+    }
+
+    #[test]
+    fn dtype_mismatch_is_named() {
+        let manifest = Manifest::from_config(&config()).unwrap();
+        let recast = "model.language_model.norm.weight";
+        let mut tensors = faultless(&manifest);
+        let entry = tensors
+            .iter_mut()
+            .find(|(name, ..)| name == recast)
+            .unwrap();
+        entry.1 = Dtype::F32;
+        let err = error_for(&manifest, &tensors);
+        assert!(err.contains("dtype mismatch"), "{err}");
+        assert!(err.contains(recast), "{err}");
+        assert!(err.contains("F32"), "{err}");
+    }
+
+    #[test]
+    fn every_fault_is_reported_in_one_pass() {
+        let manifest = Manifest::from_config(&config()).unwrap();
+        let dropped = "model.language_model.layers.1.self_attn.v_proj.weight";
+        let mut tensors: Vec<_> = faultless(&manifest)
+            .into_iter()
+            .filter(|(name, ..)| name != dropped)
+            .collect();
+        tensors.push((
+            "model.language_model.oops".to_string(),
+            Dtype::BF16,
+            vec![1],
+        ));
+        let bent = "model.language_model.layers.0.mlp.up_proj.weight";
+        let entry = tensors.iter_mut().find(|(name, ..)| name == bent).unwrap();
+        entry.2 = vec![15360, 3839];
+        entry.1 = Dtype::F32;
+        let err = error_for(&manifest, &tensors);
+        assert!(err.contains("4 fault(s)"), "{err}");
+        for expected in [dropped, "model.language_model.oops", bent] {
+            assert!(err.contains(expected), "{err}");
+        }
+    }
+}

--- a/pegainfer-gemma4/src/probe.rs
+++ b/pegainfer-gemma4/src/probe.rs
@@ -1,0 +1,322 @@
+// Fail-closed config probe: identity plus the structural facts shared by every
+// published size; no size pinning beyond the single published MoE configuration.
+use anyhow::Result;
+use anyhow::bail;
+
+const GEMMA4_LOCAL_HEAD_DIM: u64 = 256;
+const GEMMA4_GLOBAL_HEAD_DIM: u64 = 512;
+const GEMMA4_SLIDING_WINDOW: u64 = 1024;
+const GEMMA4_GLOBAL_LAYER_PERIOD: usize = 6;
+const GEMMA4_MOE_NUM_EXPERTS: u64 = 128;
+const GEMMA4_MOE_TOP_K: u64 = 8;
+const GEMMA4_MOE_INTERMEDIATE: u64 = 704;
+
+pub fn probe_config_json(json: &serde_json::Value) -> Result<()> {
+    let (family, text_config) = probe_identity(json)?;
+    probe_common_text(family, text_config)?;
+    probe_layer_types(family, text_config)?;
+    probe_moe(family, text_config)
+}
+
+fn probe_identity(json: &serde_json::Value) -> Result<(&'static str, &serde_json::Value)> {
+    let outer_type = json
+        .get("model_type")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+    let (family, text_model_type, arch_class) = match outer_type {
+        "gemma4" => ("gemma4", "gemma4_text", "Gemma4ForConditionalGeneration"),
+        "gemma4_unified" => (
+            "gemma4_unified",
+            "gemma4_unified_text",
+            "Gemma4UnifiedForConditionalGeneration",
+        ),
+        unknown => bail!("not a Gemma 4 config: model_type={unknown}"),
+    };
+
+    let architectures = json
+        .get("architectures")
+        .and_then(serde_json::Value::as_array);
+    let has_arch = architectures.is_some_and(|arr| {
+        arr.iter()
+            .any(|v| v.as_str().is_some_and(|s| s == arch_class))
+    });
+    if !has_arch {
+        bail!("Gemma 4 {family}: architectures must contain {arch_class}");
+    }
+
+    let text_config = json
+        .get("text_config")
+        .ok_or_else(|| anyhow::anyhow!("Gemma 4 {family}: missing text_config"))?;
+
+    let text_type = text_config
+        .get("model_type")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+    if text_type != text_model_type {
+        bail!(
+            "Gemma 4 {family}: text_config.model_type is {text_type}, expected {text_model_type} — \
+             cross-family mismatch"
+        );
+    }
+    Ok((family, text_config))
+}
+
+fn probe_common_text(family: &str, text_config: &serde_json::Value) -> Result<()> {
+    let e4b_window = text_config
+        .get("sliding_window")
+        .and_then(serde_json::Value::as_u64)
+        == Some(512);
+    let e4b_k_neq_v = text_config
+        .get("attention_k_eq_v")
+        .and_then(serde_json::Value::as_bool)
+        == Some(false);
+    if e4b_window && e4b_k_neq_v {
+        bail!(
+            "Gemma 4 {family}: this is an E4B edge-series configuration (sliding_window 512, \
+             attention_k_eq_v false, shared KV layers), which this model line does not support; \
+             supported configurations are the 12B/26B/31B ones"
+        );
+    }
+
+    let head_dim = text_config
+        .get("head_dim")
+        .and_then(serde_json::Value::as_u64);
+    if head_dim != Some(GEMMA4_LOCAL_HEAD_DIM) {
+        bail!("Gemma 4 {family}: head_dim must be {GEMMA4_LOCAL_HEAD_DIM}, got {head_dim:?}");
+    }
+    let global_head_dim = text_config
+        .get("global_head_dim")
+        .and_then(serde_json::Value::as_u64);
+    if global_head_dim != Some(GEMMA4_GLOBAL_HEAD_DIM) {
+        bail!(
+            "Gemma 4 {family}: global_head_dim must be {GEMMA4_GLOBAL_HEAD_DIM}, got {global_head_dim:?}"
+        );
+    }
+    let sliding_window = text_config
+        .get("sliding_window")
+        .and_then(serde_json::Value::as_u64);
+    if sliding_window != Some(GEMMA4_SLIDING_WINDOW) {
+        bail!(
+            "Gemma 4 {family}: sliding_window must be {GEMMA4_SLIDING_WINDOW}, got {sliding_window:?}"
+        );
+    }
+    let attn_k_eq_v = text_config
+        .get("attention_k_eq_v")
+        .and_then(serde_json::Value::as_bool);
+    if attn_k_eq_v != Some(true) {
+        bail!("Gemma 4 {family}: attention_k_eq_v must be true, got {attn_k_eq_v:?}");
+    }
+    let num_kv_shared = text_config
+        .get("num_kv_shared_layers")
+        .and_then(serde_json::Value::as_u64);
+    if num_kv_shared != Some(0) {
+        bail!("Gemma 4 {family}: num_kv_shared_layers must be 0, got {num_kv_shared:?}");
+    }
+    let hidden_activation = text_config
+        .get("hidden_activation")
+        .and_then(serde_json::Value::as_str);
+    if hidden_activation != Some("gelu_pytorch_tanh") {
+        bail!(
+            "Gemma 4 {family}: hidden_activation must be gelu_pytorch_tanh, got {hidden_activation:?}"
+        );
+    }
+    Ok(())
+}
+
+fn probe_layer_types(family: &str, text_config: &serde_json::Value) -> Result<()> {
+    let layer_types = text_config
+        .get("layer_types")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("Gemma 4 {family}: missing layer_types"))?;
+    if layer_types.is_empty() {
+        bail!("Gemma 4 {family}: layer_types is empty");
+    }
+    let last_idx = layer_types.len() - 1;
+    for (i, entry) in layer_types.iter().enumerate() {
+        let s = entry.as_str().unwrap_or("");
+        if s != "sliding_attention" && s != "full_attention" {
+            bail!(
+                "Gemma 4 {family}: layer_types[{i}] is {s:?}, must be sliding_attention or full_attention"
+            );
+        }
+        let is_full = s == "full_attention";
+        let expected_full =
+            i % GEMMA4_GLOBAL_LAYER_PERIOD == GEMMA4_GLOBAL_LAYER_PERIOD - 1 || i == last_idx;
+        if is_full != expected_full {
+            bail!(
+                "Gemma 4 {family}: layer_types[{i}] is {s:?}, expected {}",
+                if expected_full {
+                    "full_attention"
+                } else {
+                    "sliding_attention"
+                }
+            );
+        }
+    }
+    Ok(())
+}
+
+fn probe_moe(family: &str, text_config: &serde_json::Value) -> Result<()> {
+    let enable_moe = text_config.get("enable_moe_block");
+    let Some(enable_moe) = enable_moe.and_then(serde_json::Value::as_bool) else {
+        bail!("Gemma 4 {family}: enable_moe_block must be an explicit boolean, got {enable_moe:?}");
+    };
+    if enable_moe {
+        let num_experts = text_config
+            .get("num_experts")
+            .and_then(serde_json::Value::as_u64);
+        if num_experts != Some(GEMMA4_MOE_NUM_EXPERTS) {
+            bail!(
+                "Gemma 4 {family}: MoE enabled but num_experts is {num_experts:?}, expected {GEMMA4_MOE_NUM_EXPERTS}"
+            );
+        }
+        let top_k = text_config
+            .get("top_k_experts")
+            .and_then(serde_json::Value::as_u64);
+        if top_k != Some(GEMMA4_MOE_TOP_K) {
+            bail!(
+                "Gemma 4 {family}: MoE enabled but top_k_experts is {top_k:?}, expected {GEMMA4_MOE_TOP_K}"
+            );
+        }
+        let moe_intermediate = text_config
+            .get("moe_intermediate_size")
+            .and_then(serde_json::Value::as_u64);
+        if moe_intermediate != Some(GEMMA4_MOE_INTERMEDIATE) {
+            bail!(
+                "Gemma 4 {family}: MoE enabled but moe_intermediate_size is {moe_intermediate:?}, expected {GEMMA4_MOE_INTERMEDIATE}"
+            );
+        }
+    } else {
+        for field in ["num_experts", "top_k_experts", "moe_intermediate_size"] {
+            if text_config.get(field).is_some_and(|v| !v.is_null()) {
+                bail!("Gemma 4 {family}: MoE disabled but {field} is present and non-null");
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn good_12b_config() -> serde_json::Value {
+        serde_json::json!({
+            "model_type": "gemma4_unified",
+            "architectures": ["Gemma4UnifiedForConditionalGeneration"],
+            "text_config": {
+                "model_type": "gemma4_unified_text",
+                "head_dim": 256,
+                "global_head_dim": 512,
+                "sliding_window": 1024,
+                "attention_k_eq_v": true,
+                "num_kv_shared_layers": 0,
+                "hidden_activation": "gelu_pytorch_tanh",
+                "enable_moe_block": false,
+                "layer_types": [
+                    "sliding_attention", "sliding_attention", "sliding_attention",
+                    "sliding_attention", "sliding_attention", "full_attention",
+                    "sliding_attention", "sliding_attention", "sliding_attention",
+                    "sliding_attention", "sliding_attention", "full_attention"
+                ]
+            }
+        })
+    }
+
+    fn good_26b_config() -> serde_json::Value {
+        let mut cfg = good_12b_config();
+        cfg["model_type"] = serde_json::json!("gemma4");
+        cfg["architectures"] = serde_json::json!(["Gemma4ForConditionalGeneration"]);
+        let tc = &mut cfg["text_config"];
+        tc["model_type"] = serde_json::json!("gemma4_text");
+        tc["enable_moe_block"] = serde_json::json!(true);
+        tc["num_experts"] = serde_json::json!(128);
+        tc["top_k_experts"] = serde_json::json!(8);
+        tc["moe_intermediate_size"] = serde_json::json!(704);
+        tc["intermediate_size"] = serde_json::json!(2112);
+        cfg
+    }
+
+    #[test]
+    fn good_12b_passes() {
+        probe_config_json(&good_12b_config()).unwrap();
+    }
+
+    #[test]
+    fn good_26b_passes() {
+        probe_config_json(&good_26b_config()).unwrap();
+    }
+
+    #[test]
+    fn moe_width_2112_bails() {
+        let mut cfg = good_26b_config();
+        cfg["text_config"]["moe_intermediate_size"] = serde_json::json!(2112);
+        let err = probe_config_json(&cfg).unwrap_err().to_string();
+        assert!(err.contains("moe_intermediate_size"), "{err}");
+    }
+
+    #[test]
+    fn missing_enable_moe_block_bails() {
+        let mut cfg = good_12b_config();
+        cfg["text_config"]
+            .as_object_mut()
+            .unwrap()
+            .remove("enable_moe_block");
+        let err = probe_config_json(&cfg).unwrap_err().to_string();
+        assert!(err.contains("enable_moe_block"), "{err}");
+    }
+
+    #[test]
+    fn moe_disabled_with_num_experts_bails() {
+        let mut cfg = good_12b_config();
+        cfg["text_config"]["num_experts"] = serde_json::json!(128);
+        let err = probe_config_json(&cfg).unwrap_err().to_string();
+        assert!(err.contains("num_experts"), "{err}");
+    }
+
+    #[test]
+    fn moe_top_k_as_string_bails() {
+        let mut cfg = good_26b_config();
+        cfg["text_config"]["top_k_experts"] = serde_json::json!("8");
+        let err = probe_config_json(&cfg).unwrap_err().to_string();
+        assert!(err.contains("top_k_experts"), "{err}");
+    }
+
+    #[test]
+    fn e4b_edge_series_rejected_by_name() {
+        let mut cfg = good_12b_config();
+        cfg["model_type"] = serde_json::json!("gemma4");
+        cfg["architectures"] = serde_json::json!(["Gemma4ForConditionalGeneration"]);
+        let tc = &mut cfg["text_config"];
+        tc["model_type"] = serde_json::json!("gemma4_text");
+        tc["sliding_window"] = serde_json::json!(512);
+        tc["attention_k_eq_v"] = serde_json::json!(false);
+        tc["num_kv_shared_layers"] = serde_json::json!(18);
+        let err = probe_config_json(&cfg).unwrap_err().to_string();
+        assert!(err.contains("E4B"), "{err}");
+    }
+
+    #[test]
+    fn wrong_layer_at_non_6th_index_bails() {
+        let mut cfg = good_12b_config();
+        cfg["text_config"]["layer_types"][3] = serde_json::json!("full_attention");
+        let err = probe_config_json(&cfg).unwrap_err().to_string();
+        assert!(err.contains("layer_types[3]"), "{err}");
+    }
+
+    #[test]
+    fn cross_family_mismatch_bails() {
+        let mut cfg = good_12b_config();
+        cfg["architectures"] = serde_json::json!(["Gemma4ForConditionalGeneration"]);
+        let err = probe_config_json(&cfg).unwrap_err().to_string();
+        assert!(err.contains("architectures"), "{err}");
+    }
+
+    #[test]
+    fn moe_enabled_without_num_experts_bails() {
+        let mut cfg = good_12b_config();
+        cfg["text_config"]["enable_moe_block"] = serde_json::json!(true);
+        let err = probe_config_json(&cfg).unwrap_err().to_string();
+        assert!(err.contains("num_experts"), "{err}");
+    }
+}

--- a/pegainfer-gemma4/src/weights.rs
+++ b/pegainfer-gemma4/src/weights.rs
@@ -1,0 +1,41 @@
+//! Resident Gemma 4 text-tower weights.
+
+use pegainfer_core::tensor::DeviceMatrix;
+use pegainfer_core::tensor::DeviceVec;
+
+use crate::config::Gemma4Config;
+
+mod load;
+
+pub(crate) struct Gemma4Weights {
+    pub(crate) config: Gemma4Config,
+    pub(crate) embed_tokens: DeviceMatrix,
+    pub(crate) norm: DeviceVec,
+    pub(crate) layers: Vec<Gemma4Layer>,
+}
+
+pub(crate) struct Gemma4Layer {
+    pub(crate) input_layernorm: DeviceVec,
+    pub(crate) post_attention_layernorm: DeviceVec,
+    pub(crate) pre_feedforward_layernorm: DeviceVec,
+    pub(crate) post_feedforward_layernorm: DeviceVec,
+    pub(crate) layer_scalar: DeviceVec,
+    pub(crate) attention: Gemma4Attention,
+    pub(crate) mlp: Gemma4Mlp,
+}
+
+pub(crate) struct Gemma4Attention {
+    pub(crate) q_proj: DeviceMatrix,
+    pub(crate) k_proj: DeviceMatrix,
+    /// Absent on global layers, which the checkpoint ships without one.
+    pub(crate) v_proj: Option<DeviceMatrix>,
+    pub(crate) o_proj: DeviceMatrix,
+    pub(crate) q_norm: DeviceVec,
+    pub(crate) k_norm: DeviceVec,
+}
+
+pub(crate) struct Gemma4Mlp {
+    pub(crate) gate: DeviceMatrix,
+    pub(crate) up: DeviceMatrix,
+    pub(crate) down: DeviceMatrix,
+}

--- a/pegainfer-gemma4/src/weights/load.rs
+++ b/pegainfer-gemma4/src/weights/load.rs
@@ -1,0 +1,394 @@
+//! Checkpoint loading: classify the whole manifest, then upload.
+
+use std::time::Instant;
+
+use anyhow::Result;
+use log::info;
+use pegainfer_core::tensor::DeviceContext;
+use pegainfer_core::weight_loader::SlotId;
+use pegainfer_core::weight_loader::StagedWeightLoader;
+use pegainfer_core::weight_loader::VecSlotId;
+use pegainfer_core::weight_loader::WeightPrefetch;
+use pegainfer_core::weight_loader::deserialize_shards;
+use pegainfer_core::weight_loader::load_shard_info;
+use pegainfer_core::weight_loader::mmap_shards;
+use safetensors::Dtype;
+use safetensors::SafeTensors;
+
+use super::Gemma4Attention;
+use super::Gemma4Layer;
+use super::Gemma4Mlp;
+use super::Gemma4Weights;
+use crate::config::Gemma4Config;
+use crate::manifest::schema::Manifest;
+use crate::manifest::schema::Matrix2d;
+use crate::manifest::schema::Vector1d;
+use crate::manifest::validate::ObservedTensor;
+
+/// The wall figures are probes, not a partition: context creation, slot
+/// redemption, prefetch join and unmap fall between them, and the allocations
+/// submitted under `record_api_wall_ms` execute under
+/// `execute_and_drain_wall_ms`. Only `elapsed_ms` is a total.
+pub(crate) struct LoadStats {
+    /// Every required tensor at its dtype.
+    pub(crate) manifest_bytes: usize,
+    /// Free-before minus free-after. Signed: this measures the device, not the
+    /// process, so anything else running on it moves the number too.
+    pub(crate) device_bytes: i64,
+    pub(crate) device_free_bytes: usize,
+    /// Config, headers, classification. No device. The advisory prefetch
+    /// workers start inside this window and keep running past it.
+    pub(crate) validate_wall_ms: f64,
+    /// Submitting one allocation and one staging plan per tensor. Wider than
+    /// the shared loader's `alloc_api_wall`, which times the allocs alone.
+    pub(crate) record_api_wall_ms: f64,
+    /// The checkpoint is consumed here, so this carries the source read as
+    /// well as the transfer.
+    pub(crate) execute_and_drain_wall_ms: f64,
+    /// The whole call, unmap included.
+    pub(crate) elapsed_ms: f64,
+    pub(crate) skipped_modality_tensors: usize,
+}
+
+struct LayerSlots {
+    input_layernorm: VecSlotId,
+    post_attention_layernorm: VecSlotId,
+    pre_feedforward_layernorm: VecSlotId,
+    post_feedforward_layernorm: VecSlotId,
+    layer_scalar: VecSlotId,
+    q_proj: SlotId,
+    k_proj: SlotId,
+    v_proj: Option<SlotId>,
+    o_proj: SlotId,
+    q_norm: VecSlotId,
+    k_norm: VecSlotId,
+    gate: SlotId,
+    up: SlotId,
+    down: SlotId,
+}
+
+struct RecordedPlan {
+    embed_tokens: SlotId,
+    norm: VecSlotId,
+    layers: Vec<LayerSlots>,
+}
+
+fn record_matrix(loader: &mut StagedWeightLoader, tensor: &Matrix2d) -> Result<SlotId> {
+    loader.matrix(&tensor.name, tensor.rows, tensor.cols)
+}
+
+fn record_vector(loader: &mut StagedWeightLoader, tensor: &Vector1d) -> Result<VecSlotId> {
+    loader.vector(&tensor.name, tensor.len)
+}
+
+fn read_headers(shards: &[SafeTensors]) -> Result<Vec<(String, Dtype, Vec<usize>)>> {
+    let mut headers = Vec::new();
+    for shard in shards {
+        for name in shard.names() {
+            let view = shard
+                .tensor(name)
+                .map_err(|e| anyhow::anyhow!("Gemma 4: cannot read header of '{name}': {e}"))?;
+            headers.push((name.to_string(), view.dtype(), view.shape().to_vec()));
+        }
+    }
+    Ok(headers)
+}
+
+fn classify_checkpoint(manifest: &Manifest, shards: &[SafeTensors]) -> Result<usize> {
+    let headers = read_headers(shards)?;
+    let observed: Vec<ObservedTensor> = headers
+        .iter()
+        .map(|(name, dtype, shape)| ObservedTensor {
+            name,
+            dtype: *dtype,
+            shape,
+        })
+        .collect();
+    let report = manifest.classify(&observed);
+    report.check()?;
+    let skipped = report.skipped_modality.len();
+    info!(
+        "Gemma 4 manifest: {} text tensors, {skipped} modality tensors skipped",
+        observed.len() - skipped
+    );
+    Ok(skipped)
+}
+
+fn record_plan(loader: &mut StagedWeightLoader, manifest: &Manifest) -> Result<RecordedPlan> {
+    let embed_tokens = record_matrix(loader, &manifest.embed_tokens)?;
+    let norm = record_vector(loader, &manifest.norm)?;
+    let mut layers = Vec::with_capacity(manifest.layers.len());
+    for layer in &manifest.layers {
+        let attention = &layer.attention;
+        layers.push(LayerSlots {
+            input_layernorm: record_vector(loader, &layer.input_layernorm)?,
+            post_attention_layernorm: record_vector(loader, &layer.post_attention_layernorm)?,
+            pre_feedforward_layernorm: record_vector(loader, &layer.pre_feedforward_layernorm)?,
+            post_feedforward_layernorm: record_vector(loader, &layer.post_feedforward_layernorm)?,
+            layer_scalar: record_vector(loader, &layer.layer_scalar)?,
+            q_proj: record_matrix(loader, &attention.q_proj)?,
+            k_proj: record_matrix(loader, &attention.k_proj)?,
+            v_proj: attention
+                .v_proj
+                .as_ref()
+                .map(|v_proj| record_matrix(loader, v_proj))
+                .transpose()?,
+            o_proj: record_matrix(loader, &attention.o_proj)?,
+            q_norm: record_vector(loader, &attention.q_norm)?,
+            k_norm: record_vector(loader, &attention.k_norm)?,
+            gate: record_matrix(loader, &layer.mlp.gate)?,
+            up: record_matrix(loader, &layer.mlp.up)?,
+            down: record_matrix(loader, &layer.mlp.down)?,
+        });
+    }
+    Ok(RecordedPlan {
+        embed_tokens,
+        norm,
+        layers,
+    })
+}
+
+/// Only valid after a successful `finish`.
+fn materialize(
+    loader: &mut StagedWeightLoader,
+    plan: RecordedPlan,
+    config: Gemma4Config,
+) -> Gemma4Weights {
+    Gemma4Weights {
+        embed_tokens: loader.take(plan.embed_tokens),
+        norm: loader.take_vec(plan.norm),
+        layers: plan
+            .layers
+            .into_iter()
+            .map(|slots| Gemma4Layer {
+                input_layernorm: loader.take_vec(slots.input_layernorm),
+                post_attention_layernorm: loader.take_vec(slots.post_attention_layernorm),
+                pre_feedforward_layernorm: loader.take_vec(slots.pre_feedforward_layernorm),
+                post_feedforward_layernorm: loader.take_vec(slots.post_feedforward_layernorm),
+                layer_scalar: loader.take_vec(slots.layer_scalar),
+                attention: Gemma4Attention {
+                    q_proj: loader.take(slots.q_proj),
+                    k_proj: loader.take(slots.k_proj),
+                    v_proj: slots.v_proj.map(|slot| loader.take(slot)),
+                    o_proj: loader.take(slots.o_proj),
+                    q_norm: loader.take_vec(slots.q_norm),
+                    k_norm: loader.take_vec(slots.k_norm),
+                },
+                mlp: Gemma4Mlp {
+                    gate: loader.take(slots.gate),
+                    up: loader.take(slots.up),
+                    down: loader.take(slots.down),
+                },
+            })
+            .collect(),
+        config,
+    }
+}
+
+fn free_device_bytes() -> Result<usize> {
+    let (free, _total) = cudarc::driver::result::mem_get_info()
+        .map_err(|e| anyhow::anyhow!("Gemma 4: cuMemGetInfo failed: {e}"))?;
+    Ok(free)
+}
+
+fn elapsed_ms(since: Instant) -> f64 {
+    since.elapsed().as_secs_f64() * 1e3
+}
+
+fn gib(bytes: i64) -> f64 {
+    bytes as f64 / (1024.0 * 1024.0 * 1024.0)
+}
+
+impl Gemma4Weights {
+    /// Loads the text tower onto one device. Config, manifest and headers are
+    /// all checked before a device context exists, so a checkpoint that does
+    /// not match its config costs no GPU.
+    pub(crate) fn from_safetensors(
+        model_path: &str,
+        device_ordinal: usize,
+    ) -> Result<(Self, LoadStats)> {
+        let started = Instant::now();
+        let config = Gemma4Config::from_file(model_path)?;
+        let manifest = Manifest::from_config(&config)?;
+        let manifest_bytes = manifest.weight_bytes()?;
+
+        let (shard_paths, weight_map) = load_shard_info(model_path)?;
+        let prefetch = WeightPrefetch::spawn(&shard_paths);
+        let mmaps = mmap_shards(&shard_paths)?;
+        let shards = deserialize_shards(&mmaps)?;
+        let skipped_modality_tensors = classify_checkpoint(&manifest, &shards)?;
+        let validate_wall_ms = elapsed_ms(started);
+
+        let ctx = DeviceContext::new_with_device(device_ordinal)?;
+        let free_before = free_device_bytes()?;
+        let mut loader = StagedWeightLoader::new(&ctx, &shards, &weight_map)?;
+
+        let recording = Instant::now();
+        let plan = record_plan(&mut loader, &manifest)?;
+        let record_api_wall_ms = elapsed_ms(recording);
+
+        let uploading = Instant::now();
+        loader.finish()?;
+        let execute_and_drain_wall_ms = elapsed_ms(uploading);
+
+        let weights = materialize(&mut loader, plan, config);
+        drop(loader);
+        drop(prefetch);
+        let device_free_bytes = free_device_bytes()?;
+        drop(shards);
+        // A few hundred ms at this size. Qwen3 backgrounds it to protect its
+        // ready time; kept synchronous here so the reported total is the whole
+        // cost. Lift that spawn into core once an executor wants it too.
+        drop(mmaps);
+
+        let stats = LoadStats {
+            manifest_bytes,
+            device_bytes: free_before as i64 - device_free_bytes as i64,
+            device_free_bytes,
+            validate_wall_ms,
+            record_api_wall_ms,
+            execute_and_drain_wall_ms,
+            elapsed_ms: elapsed_ms(started),
+            skipped_modality_tensors,
+        };
+        info!(
+            "Gemma 4 weights resident: {:.2} GiB manifest, {:.2} GiB device, {:.2} GiB free; \
+             {:.0} ms total, of which {:.0} validate, {:.0} record-api, {:.0} execute-and-drain",
+            gib(stats.manifest_bytes as i64),
+            gib(stats.device_bytes),
+            gib(stats.device_free_bytes as i64),
+            stats.elapsed_ms,
+            stats.validate_wall_ms,
+            stats.record_api_wall_ms,
+            stats.execute_and_drain_wall_ms
+        );
+        Ok((weights, stats))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Context;
+
+    use super::*;
+    use crate::config::LayerKind;
+
+    const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+
+    /// Out of range on any host, so opening a device becomes a visible failure.
+    /// Not `usize::MAX`, whose cast to the driver's `int` is -1 by accident.
+    const UNOPENABLE_DEVICE: usize = 1024;
+
+    fn model_path() -> Result<String> {
+        std::env::var("PEGAINFER_TEST_MODEL_PATH")
+            .context("PEGAINFER_TEST_MODEL_PATH must point to a Gemma 4 checkpoint directory")
+    }
+
+    /// No forward pass; residency only.
+    ///
+    /// ```text
+    /// PEGAINFER_TEST_MODEL_PATH=/path/to/gemma-4-12B-it cargo test --release \
+    ///   -p pegainfer-gemma4 --features gemma4 --lib -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "needs a Gemma 4 checkpoint and a device"]
+    fn loads_the_text_tower_and_reports_residency() -> Result<()> {
+        let path = model_path()?;
+        let (weights, stats) = Gemma4Weights::from_safetensors(&path, 0)?;
+
+        let config = &weights.config;
+        assert_eq!(weights.layers.len(), config.layer_types.len());
+        for (layer, &kind) in weights.layers.iter().zip(&config.layer_types) {
+            let attention = &layer.attention;
+            match kind {
+                LayerKind::Sliding => {
+                    assert!(attention.v_proj.is_some(), "sliding layer without a v_proj");
+                    assert_eq!(attention.q_norm.len, config.head_dim);
+                }
+                LayerKind::Global => {
+                    assert!(attention.v_proj.is_none(), "global layer with a v_proj");
+                    assert_eq!(attention.q_norm.len, config.global_head_dim);
+                }
+            }
+            assert_eq!(attention.q_proj.cols, config.hidden_size);
+            assert_eq!(attention.o_proj.rows, config.hidden_size);
+            assert_eq!(layer.layer_scalar.len, 1);
+        }
+        assert_eq!(weights.embed_tokens.rows, config.vocab_size);
+        assert_eq!(weights.embed_tokens.cols, config.hidden_size);
+
+        let globals = config
+            .layer_types
+            .iter()
+            .filter(|&&kind| kind == LayerKind::Global)
+            .count();
+        println!(
+            "layers {} ({globals} global), {} modality tensors skipped\n\
+             manifest {:.2} GiB, device {:.2} GiB, free {:.2} GiB\n\
+             {:.0} ms total, of which {:.0} validate, {:.0} record-api, {:.0} execute-and-drain",
+            weights.layers.len(),
+            stats.skipped_modality_tensors,
+            stats.manifest_bytes as f64 / GIB,
+            stats.device_bytes as f64 / GIB,
+            stats.device_free_bytes as f64 / GIB,
+            stats.elapsed_ms,
+            stats.validate_wall_ms,
+            stats.record_api_wall_ms,
+            stats.execute_and_drain_wall_ms,
+        );
+        Ok(())
+    }
+
+    /// Every faulty tensor named, before a device exists — hence the unopenable
+    /// ordinal: a load that created its context first would fail with a driver
+    /// error instead of the manifest's.
+    #[test]
+    #[ignore = "needs a Gemma 4 checkpoint"]
+    fn a_disagreeing_config_names_every_faulty_tensor() -> Result<()> {
+        let path = model_path()?;
+        let staged = tempfile::tempdir()?;
+        for entry in std::fs::read_dir(&path)? {
+            let entry = entry?;
+            // Original name, resolved path: a Hugging Face snapshot points its
+            // entries at `blobs/<hash>`, whose name is not the tensor file's.
+            let target = entry.path().canonicalize()?;
+            std::os::unix::fs::symlink(&target, staged.path().join(entry.file_name()))?;
+        }
+
+        let config_path = staged.path().join("config.json");
+        let text = std::fs::read_to_string(format!("{path}/config.json"))?;
+        let mut config: serde_json::Value = serde_json::from_str(&text)?;
+        let width = config["text_config"]["intermediate_size"]
+            .as_u64()
+            .context("config.json has no text_config.intermediate_size")?;
+        let hidden = config["text_config"]["hidden_size"]
+            .as_u64()
+            .context("config.json has no text_config.hidden_size")?;
+        config["text_config"]["intermediate_size"] = serde_json::json!(width - 1);
+        // Drop the symlink first: writing through it would edit the checkpoint.
+        std::fs::remove_file(&config_path)?;
+        std::fs::write(&config_path, serde_json::to_string(&config)?)?;
+
+        let staged_path = staged.path().to_str().context("temp path is not UTF-8")?;
+        let err = Gemma4Weights::from_safetensors(staged_path, UNOPENABLE_DEVICE)
+            .err()
+            .context("a config that disagrees with the checkpoint was accepted")?
+            .to_string();
+
+        let layers = config["text_config"]["layer_types"]
+            .as_array()
+            .context("config.json has no text_config.layer_types")?
+            .len();
+        assert!(
+            err.contains(&format!("{} fault(s)", layers * 3)),
+            "expected one fault per MLP tensor per layer: {err}"
+        );
+        let named = format!(
+            "model.language_model.layers.0.mlp.down_proj.weight: checkpoint has [{hidden}, \
+             {width}], config implies [{hidden}, {}]",
+            width - 1
+        );
+        assert!(err.contains(&named), "expected `{named}` in:\n{err}");
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Description

Closes #826

Four modules. `probe.rs` is the existing fail-closed JSON probe, moved unchanged; `config.rs` is the typed config it gates; `manifest/schema.rs` turns that config into the tensor contract and `manifest/validate.rs` holds the contract up against real headers; `weights/` is the only part needing CUDA.

The contract is built as two layer kinds. Sliding layers are head dim 256 with eight KV heads and a `v_proj`; global layers are 512 with one KV head and no `v_proj` at all, which is read off the checkpoint rather than inferred from `attention_k_eq_v` — the 12B's eight `full_attention` layers carry one fewer tensor than its forty sliding ones.

Classification runs after the config, shard discovery, prefetch spawn and mmap, but before a device context exists, so a mismatched checkpoint costs no GPU. One pass fills five categories — missing, skipped modality, unexpected, shape mismatch, dtype mismatch — which are report buckets, not a partition of the observed tensors. What matters is that everything wrong comes back together, since the shared staged loader stops at its first fault.

The modality skip list is plural because the prefix differs by size. Text tensors all live under `model.language_model.`, which is what keeps the skip list from shadowing a required tensor; a test asserts that against the generated contract.

Two configurations are refused before any tensor is named: the MoE size, which keeps its dense MLP and adds routed experts, a router and three more norm sites on top, and an untied LM head, whose tensor name no published size exercises. Separately, the config is external input and the probe pins only the head dims, so the projection widths and the byte total use checked arithmetic.

Projections are recorded unfused, as the checkpoint stores them. Fusing is a GEMM decision belonging to an executor that does not exist yet. The weights module is private like every other model line's, for the same reason: the layout mirrors the checkpoint and should be able to change without being an API change. The checkpoint gate therefore lives in-crate, `#[ignore]`d so the pure-logic tests stay runnable without weights or a device.

`LoadStats` carries three wall probes next to the total. They are probes, not a partition, and the type says so: context creation, slot redemption, prefetch join and unmap fall between them, and the stream-ordered allocations submitted under `record_api_wall_ms` execute under `execute_and_drain_wall_ms`. Only `elapsed_ms` is a total, taken last so the unmap is inside it.


## Verification

Single GPU (sm_89, x86_64), against the published 12B checkpoint.

**Unit tests, no GPU** — 21 passed, 0 failed. Ten are the probe's, moved as-is; eleven are new: a faultless checkpoint accepted; each fault kind reported and named, with a shape mismatch printing both shapes; all kinds back from one pass with the count asserted; modality tensors skipped for each of the four prefixes; no prefix shadowing a required tensor; global layers without `v_proj` and with wider heads; MoE and untied configs refused; dimensions that overflow rejected rather than wrapped.

**Checkpoint gate**, in-crate and `#[ignore]`d — `--features gemma4 --lib -- --ignored` gives 2 passed, 0 failed. The real checkpoint loads: 48 layers, the eight global ones without a `v_proj` and with 512-wide QK-norms, 11 modality tensors skipped. The same checkpoint against a config whose `intermediate_size` is one short is rejected with 144 faults — three MLP tensors in each of 48 layers — each naming its tensor and both shapes. That staging directory symlinks the checkpoint and rewrites only `config.json`, and it asks for a device ordinal that cannot be opened, so the ordering is asserted and not just the message.

**Residency:** contract 22.18 GiB, device 22.19 GiB, 24.48 GiB free of the card's 48. They agree to the printed precision, so what the 666 allocations round up to is under 0.02 GiB. That is the peak as well as the steady state — every device allocation happens while the plan is recorded, and staging is pinned host memory.

**Load time, with caveats:** 2.0–4.4 s from NVMe against 214 s for the same checkpoint on a bulk array. The probes put it in one phase — 214 s reads 3 ms validate, 49 ms record-api, 213.9 s execute-and-drain — so it is the source read, not the classification or the plan. On NVMe that phase moves 22.18 GiB in 3.97 s, an end-to-end effective 6.0 GB/s; that includes the read, so it is a floor on the transfer rate rather than PCIe H2D bandwidth. It does not say *which* read: `dd bs=8M` gets 317 MB/s off the array where the loader consumes 111 MB/s, but eight prefetch `pread` workers and the upload path's mmap faults run at once, so the claim is a consumption rate. Neither figure is a controlled cold start — the host caches the whole checkpoint — though both sides were measured the same way. Unmapping is a measured 411 ms of the total, kept synchronous so the reported total is the whole cost; Qwen3 backgrounds the same teardown to protect its ready time, and lifting that spawn into `openinfer-core` is the right move once an executor wants it too.

`cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean with the feature and without. No CI change: the loader is behind the crate's feature and nothing in CI enables it, so CI green does not cover the gated half. That gap is real, but not worth closing before there is more of a model line to protect.


## Type of Change

- [x] New feature (non-breaking change which adds functionality)