### PR TITLE
feat(kernels): QK-norm and partial RoPE prep at head_dim 512

### DIFF
--- a/pegainfer-kernels/csrc/shared/prefill_attention_hd512.cu
+++ b/pegainfer-kernels/csrc/shared/prefill_attention_hd512.cu
@@ -1,0 +1,410 @@
+// QK-norm + partial RoPE prep for head_dim 512 (Gemma 4 global layers).
+// Differs from the hd256 sibling in three ways that are choices, not
+// oversights: plain w rather than the 1+w offset, no gate, no V.
+//
+// rotary_dim is a runtime argument, checked at the launcher for positive,
+// even and <= HD512. Evenness is load-bearing: with half_rotary floored, an
+// odd value leaves index rotary_dim - 1 written by neither branch.
+//
+// K is written into the paged pool, which feeds batch_prefill_paged;
+// single_prefill wants a contiguous cache instead.
+//
+// Positions and page ids are trapped on device — checking either on the
+// host would require a D2H synchronization.
+
+#include "common.cuh"
+#include "ffi_guard.cuh"
+
+#define HD512 512
+#define THREADS_HD512 512
+#define NUM_WARPS_HD512 (THREADS_HD512 / WARP_SIZE)
+
+__device__ __forceinline__ __nv_bfloat16 rms_norm_elem_hd512(
+    __nv_bfloat16 x, float rms_inv, __nv_bfloat16 weight) {
+    float w = __bfloat162float(weight);
+    return __float2bfloat16(__bfloat162float(x) * rms_inv * w);
+}
+
+__device__ __forceinline__ void apply_rope_pair_hd512(
+    __nv_bfloat16& x0, __nv_bfloat16& x1,
+    __nv_bfloat16 cos_val, __nv_bfloat16 sin_val) {
+    float fx0 = __bfloat162float(x0);
+    float fx1 = __bfloat162float(x1);
+    float fc = __bfloat162float(cos_val);
+    float fs = __bfloat162float(sin_val);
+    x0 = __float2bfloat16(fx0 * fc - fx1 * fs);
+    x1 = __float2bfloat16(fx0 * fs + fx1 * fc);
+}
+
+__device__ __forceinline__ int64_t paged_kv_offset_hd512(
+    int page_id,
+    int64_t layer_offset_elems,
+    int64_t stride_page,
+    int page_size,
+    int num_kv_heads,
+    int pos,
+    int kv_head,
+    int d) {
+    int offset_in_page = pos % page_size;
+    return static_cast<int64_t>(page_id) * stride_page
+        + layer_offset_elems
+        + static_cast<int64_t>(offset_in_page) * num_kv_heads * HD512
+        + static_cast<int64_t>(kv_head) * HD512
+        + d;
+}
+
+__global__ void qk_norm_partial_rope_paged_prefill_hd512_kernel(
+    const __nv_bfloat16* __restrict__ q_batch,      // [q_dim, seq_len]
+    const __nv_bfloat16* __restrict__ k_batch,      // [kv_dim, seq_len]
+    const __nv_bfloat16* __restrict__ q_norm_weight, // [HD512]
+    const __nv_bfloat16* __restrict__ k_norm_weight, // [HD512]
+    const __nv_bfloat16* __restrict__ cos_cache,    // [max_seq * rotary_dim]
+    const __nv_bfloat16* __restrict__ sin_cache,
+    __nv_bfloat16* __restrict__ q_batch_out,        // [q_dim, seq_len]
+    __nv_bfloat16* __restrict__ kv_data,            // paged KV pool
+    int64_t k_offset_elems,
+    const int* __restrict__ page_indices,           // request page list
+    int num_q_heads,
+    int num_kv_heads,
+    int start_pos,                                  // host base position
+    int cos_max_pos,                                // rows in cos/sin tables
+    int rotary_dim,
+    float rms_eps,
+    int page_size,
+    int num_pages,                                  // pool capacity in pages
+    int64_t stride_page
+) {
+    // seq_len is mapped onto grid.x (limit ~2^31) and the head index onto
+    // grid.y so prompts longer than the 65535 grid.y limit still launch.
+    int token = blockIdx.x;
+    int head_global = blockIdx.y;
+    int d = threadIdx.x;
+
+    bool is_q = head_global < num_q_heads;
+    int head_local = is_q ? head_global : (head_global - num_q_heads);
+    int q_dim = num_q_heads * HD512;
+    int kv_dim = num_kv_heads * HD512;
+
+    int src_offset = is_q
+        ? token * q_dim + head_local * HD512 + d
+        : token * kv_dim + head_local * HD512 + d;
+    __nv_bfloat16 x = is_q ? q_batch[src_offset] : k_batch[src_offset];
+    const __nv_bfloat16* norm_w = is_q ? q_norm_weight : k_norm_weight;
+
+    float sq = __bfloat162float(x);
+    sq *= sq;
+    float sq_sum = warp_reduce_sum(sq);
+
+    int warp_id = d / WARP_SIZE;
+    int lane_id = d % WARP_SIZE;
+    __shared__ float warp_sums[NUM_WARPS_HD512];
+    __shared__ float inv_rms;
+    __shared__ __nv_bfloat16 smem[HD512];
+
+    if (lane_id == 0) warp_sums[warp_id] = sq_sum;
+    __syncthreads();
+
+    if (d == 0) {
+        float total = 0.0f;
+        for (int i = 0; i < NUM_WARPS_HD512; i++) total += warp_sums[i];
+        inv_rms = 1.0f / sqrtf(total / HD512 + rms_eps);
+    }
+    __syncthreads();
+
+    smem[d] = rms_norm_elem_hd512(x, inv_rms, norm_w[d]);
+    __syncthreads();
+
+    int pos = start_pos + token;
+    // Reject before reading the cos/sin tables.
+    if (pos < 0 || pos >= cos_max_pos) __trap();
+    // Check the device-resident page id before the first pool write. Q
+    // threads never touch the pool.
+    int page_id = -1;
+    if (!is_q) {
+        page_id = page_indices[pos / page_size];
+        if (page_id < 0 || page_id >= num_pages) __trap();
+    }
+    int half_rotary = rotary_dim / 2;
+
+    if (d < half_rotary) {
+        __nv_bfloat16 lo = smem[d];
+        __nv_bfloat16 hi = smem[d + half_rotary];
+        apply_rope_pair_hd512(
+            lo,
+            hi,
+            cos_cache[pos * rotary_dim + d],
+            sin_cache[pos * rotary_dim + d]
+        );
+
+        if (is_q) {
+            int dst = token * q_dim + head_local * HD512;
+            q_batch_out[dst + d] = lo;
+            q_batch_out[dst + d + half_rotary] = hi;
+        } else {
+            int64_t dst = paged_kv_offset_hd512(
+                page_id, k_offset_elems, stride_page, page_size,
+                num_kv_heads, pos, head_local, d);
+            kv_data[dst] = lo;
+            kv_data[dst + half_rotary] = hi;
+        }
+    }
+
+    if (d >= rotary_dim) {
+        if (is_q) {
+            int dst = token * q_dim + head_local * HD512;
+            q_batch_out[dst + d] = smem[d];
+        } else {
+            int64_t dst = paged_kv_offset_hd512(
+                page_id, k_offset_elems, stride_page, page_size,
+                num_kv_heads, pos, head_local, d);
+            kv_data[dst] = smem[d];
+        }
+    }
+}
+
+// Batched decode prep: Q is written to contiguous q_batch_out; K is updated
+// in place. Paged scatter is caller-owned.
+__global__ void qk_norm_partial_rope_batched_decode_hd512_kernel(
+    const __nv_bfloat16* __restrict__ q_batch,      // [q_dim, batch]
+    __nv_bfloat16* __restrict__ k_batch,            // [kv_dim, batch] in-place
+    const __nv_bfloat16* __restrict__ q_norm_weight, // [HD512]
+    const __nv_bfloat16* __restrict__ k_norm_weight, // [HD512]
+    const __nv_bfloat16* __restrict__ cos_cache,    // [max_seq * rotary_dim]
+    const __nv_bfloat16* __restrict__ sin_cache,
+    const int* __restrict__ positions,              // [batch]
+    int cos_max_pos,                                // rows in cos/sin tables
+    __nv_bfloat16* __restrict__ q_batch_out,        // [q_dim, batch]
+    int num_q_heads,
+    int num_kv_heads,
+    int batch_size,
+    int rotary_dim,
+    float rms_eps
+) {
+    int head_global = blockIdx.x;
+    int token = blockIdx.y;
+    int d = threadIdx.x;
+
+    bool is_q = head_global < num_q_heads;
+    int head_local = is_q ? head_global : (head_global - num_q_heads);
+    int q_dim = num_q_heads * HD512;
+    int kv_dim = num_kv_heads * HD512;
+
+    int src_offset = is_q
+        ? token * q_dim + head_local * HD512 + d
+        : token * kv_dim + head_local * HD512 + d;
+
+    __nv_bfloat16 x = is_q ? q_batch[src_offset] : k_batch[src_offset];
+    const __nv_bfloat16* norm_w = is_q ? q_norm_weight : k_norm_weight;
+
+    float sq = __bfloat162float(x);
+    sq *= sq;
+    float sq_sum = warp_reduce_sum(sq);
+
+    int warp_id = d / WARP_SIZE;
+    int lane_id = d % WARP_SIZE;
+    __shared__ float warp_sums[NUM_WARPS_HD512];
+    __shared__ float inv_rms;
+    __shared__ __nv_bfloat16 smem[HD512];
+
+    if (lane_id == 0) warp_sums[warp_id] = sq_sum;
+    __syncthreads();
+
+    if (d == 0) {
+        float total = 0.0f;
+        for (int i = 0; i < NUM_WARPS_HD512; i++) total += warp_sums[i];
+        inv_rms = 1.0f / sqrtf(total / HD512 + rms_eps);
+    }
+    __syncthreads();
+
+    smem[d] = rms_norm_elem_hd512(x, inv_rms, norm_w[d]);
+    __syncthreads();
+
+    int pos = positions[token];
+    // Reject before reading the cos/sin tables.
+    if (pos < 0 || pos >= cos_max_pos) __trap();
+    int half_rotary = rotary_dim / 2;
+
+    if (d < half_rotary) {
+        __nv_bfloat16 lo = smem[d];
+        __nv_bfloat16 hi = smem[d + half_rotary];
+        apply_rope_pair_hd512(
+            lo,
+            hi,
+            cos_cache[pos * rotary_dim + d],
+            sin_cache[pos * rotary_dim + d]
+        );
+
+        if (is_q) {
+            int dst = token * q_dim + head_local * HD512;
+            q_batch_out[dst + d] = lo;
+            q_batch_out[dst + d + half_rotary] = hi;
+        } else {
+            int dst = token * kv_dim + head_local * HD512;
+            k_batch[dst + d] = lo;
+            k_batch[dst + d + half_rotary] = hi;
+        }
+    }
+
+    if (d >= rotary_dim) {
+        if (is_q) {
+            int dst = token * q_dim + head_local * HD512;
+            q_batch_out[dst + d] = smem[d];
+        } else {
+            int dst = token * kv_dim + head_local * HD512;
+            k_batch[dst + d] = smem[d];
+        }
+    }
+}
+
+extern "C" {
+
+int qk_norm_partial_rope_paged_prefill_hd512_cuda(
+    const __nv_bfloat16* q_batch,
+    const __nv_bfloat16* k_batch,
+    const __nv_bfloat16* q_norm_weight,
+    const __nv_bfloat16* k_norm_weight,
+    const __nv_bfloat16* cos_cache,
+    const __nv_bfloat16* sin_cache,
+    __nv_bfloat16* q_batch_out,
+    __nv_bfloat16* kv_data,
+    int64_t k_offset_elems,
+    const int* page_indices,
+    int num_q_heads,
+    int num_kv_heads,
+    int seq_len,
+    int start_pos,
+    int cos_max_pos,
+    int rotary_dim,
+    float rms_eps,
+    int page_size,
+    int num_pages,
+    int64_t stride_page,
+    cudaStream_t stream
+) {
+    PEGAINFER_FFI_GUARD_BEGIN
+    if (rotary_dim <= 0 || (rotary_dim & 1) != 0 || rotary_dim > HD512) {
+        pegainfer_ffi_set_last_error(
+            "qk_norm_partial_rope_paged_prefill_hd512_cuda: rotary_dim must be "
+            "positive, even and <= 512");
+        return -1;
+    }
+    if (q_batch == nullptr || k_batch == nullptr || q_norm_weight == nullptr ||
+        k_norm_weight == nullptr || cos_cache == nullptr || sin_cache == nullptr ||
+        q_batch_out == nullptr || kv_data == nullptr || page_indices == nullptr) {
+        pegainfer_ffi_set_last_error(
+            "qk_norm_partial_rope_paged_prefill_hd512_cuda: null pointer argument");
+        return -1;
+    }
+    if (num_q_heads <= 0 || num_kv_heads <= 0 || seq_len <= 0 || page_size <= 0 ||
+        num_pages <= 0) {
+        pegainfer_ffi_set_last_error(
+            "qk_norm_partial_rope_paged_prefill_hd512_cuda: num_q_heads, "
+            "num_kv_heads, seq_len, page_size and num_pages must be positive");
+        return -1;
+    }
+    if (start_pos < 0 || start_pos + seq_len > cos_max_pos) {
+        pegainfer_ffi_set_last_error(
+            "qk_norm_partial_rope_paged_prefill_hd512_cuda: start_pos + seq_len "
+            "must be <= cos_max_pos");
+        return -1;
+    }
+    dim3 prep_grid(seq_len, num_q_heads + num_kv_heads);
+    qk_norm_partial_rope_paged_prefill_hd512_kernel<<<prep_grid, THREADS_HD512, 0, stream>>>(
+        q_batch,
+        k_batch,
+        q_norm_weight,
+        k_norm_weight,
+        cos_cache,
+        sin_cache,
+        q_batch_out,
+        kv_data,
+        k_offset_elems,
+        page_indices,
+        num_q_heads,
+        num_kv_heads,
+        start_pos,
+        cos_max_pos,
+        rotary_dim,
+        rms_eps,
+        page_size,
+        num_pages,
+        stride_page
+    );
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        pegainfer_ffi_set_last_error(cudaGetErrorString(err));
+        return -1;
+    }
+    return 0;
+    PEGAINFER_FFI_GUARD_END(-1)
+}
+
+int qk_norm_partial_rope_batched_decode_hd512_cuda(
+    const __nv_bfloat16* q_batch,
+    __nv_bfloat16* k_batch,
+    const __nv_bfloat16* q_norm_weight,
+    const __nv_bfloat16* k_norm_weight,
+    const __nv_bfloat16* cos_cache,
+    const __nv_bfloat16* sin_cache,
+    const int* positions,
+    int cos_max_pos,
+    __nv_bfloat16* q_batch_out,
+    int num_q_heads,
+    int num_kv_heads,
+    int batch_size,
+    int rotary_dim,
+    float rms_eps,
+    cudaStream_t stream
+) {
+    PEGAINFER_FFI_GUARD_BEGIN
+    if (rotary_dim <= 0 || (rotary_dim & 1) != 0 || rotary_dim > HD512) {
+        pegainfer_ffi_set_last_error(
+            "qk_norm_partial_rope_batched_decode_hd512_cuda: rotary_dim must be "
+            "positive, even and <= 512");
+        return -1;
+    }
+    if (q_batch == nullptr || k_batch == nullptr || q_norm_weight == nullptr ||
+        k_norm_weight == nullptr || cos_cache == nullptr || sin_cache == nullptr ||
+        positions == nullptr || q_batch_out == nullptr) {
+        pegainfer_ffi_set_last_error(
+            "qk_norm_partial_rope_batched_decode_hd512_cuda: null pointer argument");
+        return -1;
+    }
+    if (num_q_heads <= 0 || num_kv_heads <= 0 || batch_size <= 0) {
+        pegainfer_ffi_set_last_error(
+            "qk_norm_partial_rope_batched_decode_hd512_cuda: num_q_heads, "
+            "num_kv_heads and batch_size must be positive");
+        return -1;
+    }
+    if (cos_max_pos <= 0) {
+        pegainfer_ffi_set_last_error(
+            "qk_norm_partial_rope_batched_decode_hd512_cuda: cos_max_pos must be positive");
+        return -1;
+    }
+    dim3 grid(num_q_heads + num_kv_heads, batch_size);
+    qk_norm_partial_rope_batched_decode_hd512_kernel<<<grid, THREADS_HD512, 0, stream>>>(
+        q_batch,
+        k_batch,
+        q_norm_weight,
+        k_norm_weight,
+        cos_cache,
+        sin_cache,
+        positions,
+        cos_max_pos,
+        q_batch_out,
+        num_q_heads,
+        num_kv_heads,
+        batch_size,
+        rotary_dim,
+        rms_eps
+    );
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        pegainfer_ffi_set_last_error(cudaGetErrorString(err));
+        return -1;
+    }
+    return 0;
+    PEGAINFER_FFI_GUARD_END(-1)
+}
+
+} // extern "C"

--- a/pegainfer-kernels/src/ffi/shared.rs
+++ b/pegainfer-kernels/src/ffi/shared.rs
@@ -1033,6 +1033,58 @@ unsafe extern "C" {
     ) -> i32;
 }
 
+// hd512 QK-norm + partial RoPE prep (Gemma 4 global layers):
+// csrc/shared/prefill_attention_hd512.cu. Contract and validation live on
+// the Rust wrappers in ops::attention; both entries return 0 on success,
+// -1 with a diagnostic on failure.
+unsafe extern "C" {
+    // Prefill: Q → contiguous q_batch_out; K → straight into the paged KV
+    // pool at k_offset_elems (feeds batch_prefill_paged, not single_prefill).
+    pub fn qk_norm_partial_rope_paged_prefill_hd512_cuda(
+        q_batch: *const Half,
+        k_batch: *const Half,
+        q_norm_weight: *const Half,
+        k_norm_weight: *const Half,
+        cos_cache: *const Half,
+        sin_cache: *const Half,
+        q_batch_out: *mut Half,
+        kv_data: *mut Half,
+        k_offset_elems: i64,
+        page_indices: *const i32,
+        num_q_heads: i32,
+        num_kv_heads: i32,
+        seq_len: i32,
+        start_pos: i32,
+        cos_max_pos: i32,
+        rotary_dim: i32,
+        rms_eps: f32,
+        page_size: i32,
+        num_pages: i32,
+        stride_page: i64,
+        stream: CUstream,
+    ) -> i32;
+
+    // Batched decode: Q → contiguous q_batch_out; K normalised + partially
+    // rotated in place (caller scatters it into the paged pool afterwards).
+    pub fn qk_norm_partial_rope_batched_decode_hd512_cuda(
+        q_batch: *const Half,
+        k_batch: *mut Half,
+        q_norm_weight: *const Half,
+        k_norm_weight: *const Half,
+        cos_cache: *const Half,
+        sin_cache: *const Half,
+        positions: *const i32,
+        cos_max_pos: i32,
+        q_batch_out: *mut Half,
+        num_q_heads: i32,
+        num_kv_heads: i32,
+        batch_size: i32,
+        rotary_dim: i32,
+        rms_eps: f32,
+        stream: CUstream,
+    ) -> i32;
+}
+
 unsafe extern "C" {
     pub fn pegainfer_kernels_last_error() -> *const std::os::raw::c_char;
 }

--- a/pegainfer-kernels/src/ops.rs
+++ b/pegainfer-kernels/src/ops.rs
@@ -30,6 +30,8 @@ pub use attention::paged_attention_batch_decode_via_prefill_hd256_into;
 pub use attention::paged_attention_batch_decode_via_prefill_hd512_into;
 pub use attention::prefill_attention_paged_into;
 pub use attention::qk_norm_partial_rope_batched_decode_hd256_into;
+pub use attention::qk_norm_partial_rope_batched_decode_hd512_into;
+pub use attention::qk_norm_partial_rope_paged_prefill_hd512_into;
 pub use attention::qk_norm_rope_batch_decode_into;
 pub use attention::qk_norm_rope_prefill_hd256_plain_into;
 pub use attention::single_decode_nhd_into;

--- a/pegainfer-kernels/src/ops/attention.rs
+++ b/pegainfer-kernels/src/ops/attention.rs
@@ -2560,3 +2560,342 @@ pub fn single_prefill_hd256_into(
     }
     Ok(())
 }
+
+/// QK RMSNorm + partial RoPE for the hd512 paged-prefill prep (Gemma 4
+/// global layers). Q is normalised + partially rotated into a contiguous
+/// `q_out`; K is normalised + partially rotated straight into the paged KV
+/// pool at layer `layer`'s K block (feeds `batch_prefill_paged`, not
+/// `single_prefill`). No gate, no V; plain-w RMSNorm (not the (1+w) offset
+/// of hd256).
+///
+/// Validated here: layout geometry consistency (the derived fields are pub
+/// and hand-constructible), `layer < layout.num_layers`, `kv_pool` holding
+/// whole pages (its capacity in pages becomes the kernel's page bound),
+/// `page_indices` covering `[start_pos, start_pos + seq_len)`,
+/// `start_pos + seq_len <= cos_max_pos` (host-side layer of the position
+/// defence; the kernel `__trap()`s on any out-of-range pos or page id as
+/// the second), table lengths, and 512-element norm weights. `rotary_dim`
+/// must be positive, even and <= 512 — enforced by the launcher, which
+/// returns -1; propagated here as `Err`.
+#[allow(clippy::too_many_arguments)]
+pub fn qk_norm_partial_rope_paged_prefill_hd512_into(
+    ctx: &DeviceContext,
+    q: &HiddenStates,
+    k: &HiddenStates,
+    q_out: &mut HiddenStates,
+    kv_pool: &CudaSlice<bf16>,
+    layout: &PagedKvLayout,
+    q_norm_weight: &DeviceVec,
+    k_norm_weight: &DeviceVec,
+    cos_cache: &DeviceVec,
+    sin_cache: &DeviceVec,
+    layer: usize,
+    page_indices: &CudaSlice<i32>,
+    start_pos: usize,
+    cos_max_pos: usize,
+    num_q_heads: usize,
+    num_kv_heads: usize,
+    rotary_dim: usize,
+    rms_eps: f32,
+) -> Result<()> {
+    let seq_len = q.seq_len;
+    anyhow::ensure!(
+        q.hidden_dim == num_q_heads * 512,
+        "hd512 prefill prep q.hidden_dim {} != num_q_heads {} * 512",
+        q.hidden_dim,
+        num_q_heads
+    );
+    anyhow::ensure!(
+        q_out.hidden_dim == q.hidden_dim,
+        "hd512 prefill prep q_out.hidden_dim {} != q.hidden_dim {}",
+        q_out.hidden_dim,
+        q.hidden_dim
+    );
+    anyhow::ensure!(
+        q_out.seq_len == seq_len,
+        "hd512 prefill prep q_out.seq_len {} != q.seq_len {seq_len}",
+        q_out.seq_len
+    );
+    anyhow::ensure!(
+        k.hidden_dim == num_kv_heads * 512,
+        "hd512 prefill prep k.hidden_dim {} != num_kv_heads {} * 512",
+        k.hidden_dim,
+        num_kv_heads
+    );
+    anyhow::ensure!(
+        k.seq_len == seq_len,
+        "hd512 prefill prep k.seq_len {} != q.seq_len {seq_len}",
+        k.seq_len
+    );
+    anyhow::ensure!(
+        layout.head_dim == 512,
+        "hd512 prefill prep layout.head_dim {} != 512",
+        layout.head_dim
+    );
+    anyhow::ensure!(
+        layout.num_kv_heads == num_kv_heads,
+        "hd512 prefill prep layout.num_kv_heads {} != num_kv_heads {num_kv_heads}",
+        layout.num_kv_heads
+    );
+    // Keep the pool-capacity division below defined for public layouts.
+    anyhow::ensure!(
+        layout.page_size > 0 && layout.num_kv_heads > 0,
+        "hd512 prefill prep layout.page_size {} / num_kv_heads {} must be positive",
+        layout.page_size,
+        layout.num_kv_heads
+    );
+    let kv_block_len = layout.page_size * layout.num_kv_heads * layout.head_dim;
+    anyhow::ensure!(
+        layout.kv_block_len == kv_block_len,
+        "hd512 prefill prep layout.kv_block_len {} != page_size {} * num_kv_heads \
+         {} * head_dim {}",
+        layout.kv_block_len,
+        layout.page_size,
+        layout.num_kv_heads,
+        layout.head_dim
+    );
+    anyhow::ensure!(
+        layout.layer_stride == 2 * kv_block_len,
+        "hd512 prefill prep layout.layer_stride {} != 2 * kv_block_len {kv_block_len}",
+        layout.layer_stride
+    );
+    anyhow::ensure!(
+        layout.page_stride == layout.num_layers * layout.layer_stride,
+        "hd512 prefill prep layout.page_stride {} != num_layers {} * layer_stride {}",
+        layout.page_stride,
+        layout.num_layers,
+        layout.layer_stride
+    );
+    anyhow::ensure!(
+        layer < layout.num_layers,
+        "hd512 prefill prep layer {layer} >= layout.num_layers {}",
+        layout.num_layers
+    );
+    let num_pages = kv_pool.len() / layout.page_stride;
+    anyhow::ensure!(
+        kv_pool.len().is_multiple_of(layout.page_stride),
+        "hd512 prefill prep kv_pool.len {} is not a multiple of layout.page_stride {}",
+        kv_pool.len(),
+        layout.page_stride
+    );
+    anyhow::ensure!(
+        num_pages >= 1,
+        "hd512 prefill prep kv_pool.len {} holds no whole page (page_stride {})",
+        kv_pool.len(),
+        layout.page_stride
+    );
+    anyhow::ensure!(
+        q_norm_weight.len == 512,
+        "hd512 prefill prep q_norm_weight len {} != 512",
+        q_norm_weight.len
+    );
+    anyhow::ensure!(
+        k_norm_weight.len == 512,
+        "hd512 prefill prep k_norm_weight len {} != 512",
+        k_norm_weight.len
+    );
+    anyhow::ensure!(
+        page_indices.len() * layout.page_size >= start_pos + seq_len,
+        "hd512 prefill prep pages cover {} tokens (len {} * page_size {}), need \
+         start_pos {start_pos} + seq_len {seq_len}",
+        page_indices.len() * layout.page_size,
+        page_indices.len(),
+        layout.page_size
+    );
+    anyhow::ensure!(
+        start_pos + seq_len <= cos_max_pos,
+        "hd512 prefill prep start_pos {start_pos} + seq_len {seq_len} > \
+         cos_max_pos {cos_max_pos}"
+    );
+    anyhow::ensure!(
+        cos_cache.len >= cos_max_pos * rotary_dim,
+        "hd512 prefill prep cos_cache len {} < cos_max_pos {cos_max_pos} * \
+         rotary_dim {rotary_dim}",
+        cos_cache.len
+    );
+    anyhow::ensure!(
+        sin_cache.len >= cos_max_pos * rotary_dim,
+        "hd512 prefill prep sin_cache len {} < cos_max_pos {cos_max_pos} * \
+         rotary_dim {rotary_dim}",
+        sin_cache.len
+    );
+    q.checked_extent("hd512 prefill prep q")?;
+    q_out.checked_extent("hd512 prefill prep q_out")?;
+    k.checked_extent("hd512 prefill prep k")?;
+
+    // Derive raw offsets from the validated layout.
+    let k_offset_elems = (layer * layout.layer_stride) as i64;
+    let page_size = layout.page_size;
+    let stride_page = layout.page_stride as i64;
+
+    let (q_ptr, _gq) = q.data.device_ptr(&ctx.stream);
+    let (k_ptr, _gk) = k.data.device_ptr(&ctx.stream);
+    let (qo_ptr, _gqo) = q_out.data.device_ptr_mut(&ctx.stream);
+    // The KV state owns mutation; this call borrows its shared pool handle.
+    let (pool_ptr, _gp) = kv_pool.device_ptr(&ctx.stream);
+    let (qn_ptr, _gqn) = q_norm_weight.data.device_ptr(&ctx.stream);
+    let (kn_ptr, _gkn) = k_norm_weight.data.device_ptr(&ctx.stream);
+    let (cos_ptr, _gc) = cos_cache.data.device_ptr(&ctx.stream);
+    let (sin_ptr, _gs) = sin_cache.data.device_ptr(&ctx.stream);
+    let (pi_ptr, _gpi) = page_indices.device_ptr(&ctx.stream);
+
+    let result = unsafe {
+        ffi::qk_norm_partial_rope_paged_prefill_hd512_cuda(
+            q_ptr as *const ffi::Half,
+            k_ptr as *const ffi::Half,
+            qn_ptr as *const ffi::Half,
+            kn_ptr as *const ffi::Half,
+            cos_ptr as *const ffi::Half,
+            sin_ptr as *const ffi::Half,
+            qo_ptr as *mut ffi::Half,
+            pool_ptr as *mut ffi::Half,
+            k_offset_elems,
+            pi_ptr as *const i32,
+            num_q_heads as i32,
+            num_kv_heads as i32,
+            seq_len as i32,
+            start_pos as i32,
+            cos_max_pos as i32,
+            rotary_dim as i32,
+            rms_eps,
+            page_size as i32,
+            num_pages as i32,
+            stride_page,
+            crate::tensor::active_cu_stream(ctx),
+        )
+    };
+    if result != 0 {
+        anyhow::bail!(
+            "qk_norm_partial_rope_paged_prefill_hd512_cuda failed with error \
+             {result}{}",
+            crate::ops::ffi_exception_message(result)
+        );
+    }
+    Ok(())
+}
+
+/// Batched QK RMSNorm + partial RoPE for the hd512 decode prep (Gemma 4
+/// global layers). Q is normalised + partially rotated into a contiguous
+/// `q_out`; K is normalised + partially rotated in place (the caller
+/// scatters it into the paged pool afterwards). No gate, no V; plain-w
+/// RMSNorm.
+///
+/// Reading `positions_d` on the host would require a D2H synchronization,
+/// so the kernel `__trap()`s on positions outside [0, cos_max_pos).
+/// Validated here: table lengths, `positions_d.len() == batch_size`, and
+/// 512-element norm weights. `rotary_dim` must be positive, even and <= 512
+/// — enforced by the launcher; propagated here as `Err`.
+#[allow(clippy::too_many_arguments)]
+pub fn qk_norm_partial_rope_batched_decode_hd512_into(
+    ctx: &DeviceContext,
+    q: &HiddenStates,
+    q_out: &mut HiddenStates,
+    k: &mut HiddenStates,
+    q_norm_weight: &DeviceVec,
+    k_norm_weight: &DeviceVec,
+    cos_cache: &DeviceVec,
+    sin_cache: &DeviceVec,
+    positions_d: &CudaSlice<i32>,
+    cos_max_pos: usize,
+    num_q_heads: usize,
+    num_kv_heads: usize,
+    rotary_dim: usize,
+    rms_eps: f32,
+) -> Result<()> {
+    let batch_size = q.seq_len;
+    anyhow::ensure!(
+        q.hidden_dim == num_q_heads * 512,
+        "hd512 decode prep q.hidden_dim {} != num_q_heads {} * 512",
+        q.hidden_dim,
+        num_q_heads
+    );
+    anyhow::ensure!(
+        q_out.hidden_dim == q.hidden_dim,
+        "hd512 decode prep q_out.hidden_dim {} != q.hidden_dim {}",
+        q_out.hidden_dim,
+        q.hidden_dim
+    );
+    anyhow::ensure!(
+        q_out.seq_len == batch_size,
+        "hd512 decode prep q_out.seq_len {} != q.seq_len {batch_size}",
+        q_out.seq_len
+    );
+    anyhow::ensure!(
+        k.hidden_dim == num_kv_heads * 512,
+        "hd512 decode prep k.hidden_dim {} != num_kv_heads {} * 512",
+        k.hidden_dim,
+        num_kv_heads
+    );
+    anyhow::ensure!(
+        k.seq_len == batch_size,
+        "hd512 decode prep k.seq_len {} != q.seq_len {batch_size}",
+        k.seq_len
+    );
+    anyhow::ensure!(
+        q_norm_weight.len == 512,
+        "hd512 decode prep q_norm_weight len {} != 512",
+        q_norm_weight.len
+    );
+    anyhow::ensure!(
+        k_norm_weight.len == 512,
+        "hd512 decode prep k_norm_weight len {} != 512",
+        k_norm_weight.len
+    );
+    anyhow::ensure!(
+        positions_d.len() == batch_size,
+        "hd512 decode prep positions len {} != batch_size {batch_size}",
+        positions_d.len()
+    );
+    anyhow::ensure!(
+        cos_cache.len >= cos_max_pos * rotary_dim,
+        "hd512 decode prep cos_cache len {} < cos_max_pos {cos_max_pos} * \
+         rotary_dim {rotary_dim}",
+        cos_cache.len
+    );
+    anyhow::ensure!(
+        sin_cache.len >= cos_max_pos * rotary_dim,
+        "hd512 decode prep sin_cache len {} < cos_max_pos {cos_max_pos} * \
+         rotary_dim {rotary_dim}",
+        sin_cache.len
+    );
+    q.checked_extent("hd512 decode prep q")?;
+    q_out.checked_extent("hd512 decode prep q_out")?;
+    k.checked_extent("hd512 decode prep k")?;
+
+    let (q_ptr, _gq) = q.data.device_ptr(&ctx.stream);
+    let (qo_ptr, _gqo) = q_out.data.device_ptr_mut(&ctx.stream);
+    let (k_ptr, _gk) = k.data.device_ptr_mut(&ctx.stream);
+    let (qn_ptr, _gqn) = q_norm_weight.data.device_ptr(&ctx.stream);
+    let (kn_ptr, _gkn) = k_norm_weight.data.device_ptr(&ctx.stream);
+    let (cos_ptr, _gc) = cos_cache.data.device_ptr(&ctx.stream);
+    let (sin_ptr, _gs) = sin_cache.data.device_ptr(&ctx.stream);
+    let (pos_ptr, _gp) = positions_d.device_ptr(&ctx.stream);
+
+    let result = unsafe {
+        ffi::qk_norm_partial_rope_batched_decode_hd512_cuda(
+            q_ptr as *const ffi::Half,
+            k_ptr as *mut ffi::Half,
+            qn_ptr as *const ffi::Half,
+            kn_ptr as *const ffi::Half,
+            cos_ptr as *const ffi::Half,
+            sin_ptr as *const ffi::Half,
+            pos_ptr as *const i32,
+            cos_max_pos as i32,
+            qo_ptr as *mut ffi::Half,
+            num_q_heads as i32,
+            num_kv_heads as i32,
+            batch_size as i32,
+            rotary_dim as i32,
+            rms_eps,
+            crate::tensor::active_cu_stream(ctx),
+        )
+    };
+    if result != 0 {
+        anyhow::bail!(
+            "qk_norm_partial_rope_batched_decode_hd512_cuda failed with error \
+             {result}{}",
+            crate::ops::ffi_exception_message(result)
+        );
+    }
+    Ok(())
+}

--- a/pegainfer-kernels/src/ops/attention.rs
+++ b/pegainfer-kernels/src/ops/attention.rs
@@ -2722,6 +2722,10 @@ pub fn qk_norm_partial_rope_paged_prefill_hd512_into(
     q.checked_extent("hd512 prefill prep q")?;
     q_out.checked_extent("hd512 prefill prep q_out")?;
     k.checked_extent("hd512 prefill prep k")?;
+    ensure_vec_backed(q_norm_weight, "hd512 prefill prep q_norm_weight")?;
+    ensure_vec_backed(k_norm_weight, "hd512 prefill prep k_norm_weight")?;
+    ensure_vec_backed(cos_cache, "hd512 prefill prep cos_cache")?;
+    ensure_vec_backed(sin_cache, "hd512 prefill prep sin_cache")?;
 
     // Derive raw offsets from the validated layout.
     let k_offset_elems = (layer * layout.layer_stride) as i64;
@@ -2861,6 +2865,10 @@ pub fn qk_norm_partial_rope_batched_decode_hd512_into(
     q.checked_extent("hd512 decode prep q")?;
     q_out.checked_extent("hd512 decode prep q_out")?;
     k.checked_extent("hd512 decode prep k")?;
+    ensure_vec_backed(q_norm_weight, "hd512 decode prep q_norm_weight")?;
+    ensure_vec_backed(k_norm_weight, "hd512 decode prep k_norm_weight")?;
+    ensure_vec_backed(cos_cache, "hd512 decode prep cos_cache")?;
+    ensure_vec_backed(sin_cache, "hd512 decode prep sin_cache")?;
 
     let (q_ptr, _gq) = q.data.device_ptr(&ctx.stream);
     let (qo_ptr, _gqo) = q_out.data.device_ptr_mut(&ctx.stream);

--- a/pegainfer-kernels/tests/hd512_qk_rope_smoke.rs
+++ b/pegainfer-kernels/tests/hd512_qk_rope_smoke.rs
@@ -1,0 +1,492 @@
+//! Device gate for csrc/shared/prefill_attention_hd512.cu.
+//!
+//! Manual gate: CI compiles this but never runs it. Run on a GPU box with
+//! PEGAINFER_REQUIRE_GPU=1, which turns a missing device into a failure
+//! rather than a skip. Traps are in their own binaries — __trap() poisons
+//! the context for whatever runs next.
+
+mod common;
+
+use cudarc::driver::CudaSlice;
+use half::bf16;
+use pegainfer_kernels::ops::qk_norm_partial_rope_batched_decode_hd512_into;
+use pegainfer_kernels::ops::qk_norm_partial_rope_paged_prefill_hd512_into;
+use pegainfer_kernels::paged_kv::PagedKvLayout;
+use pegainfer_kernels::tensor::DeviceContext;
+use pegainfer_kernels::tensor::DeviceVec;
+use pegainfer_kernels::tensor::HiddenStates;
+
+const HD: usize = 512;
+const ROTARY_DIM: usize = 128;
+const HALF_ROTARY: usize = ROTARY_DIM / 2;
+const EPS: f32 = 1e-6;
+const NUM_Q_HEADS: usize = 16;
+const NUM_KV_HEADS: usize = 1;
+// Distinct inputs make a Q/K pointer swap observable.
+const Q_INPUT: f32 = 1.0;
+const K_INPUT: f32 = 3.0;
+const Q_DIM: usize = NUM_Q_HEADS * HD;
+const KV_DIM: usize = NUM_KV_HEADS * HD;
+const SEQ_LEN: usize = 4;
+const PAGE_SIZE: usize = 2;
+// Exercise nonzero positions and more than one RoPE row.
+const START_POS: usize = 1;
+// Positions 1..=4 map to pages 3, 7, 7, 5; page 9 is unreferenced.
+const PAGE_INDICES: [i32; 4] = [3, 7, 5, 9];
+// Non-monotonic rows distinguish request positions from token indices.
+const POSITIONS: [i32; 4] = [0, 1, 3, 1];
+// Two layers make a wrong K-layer offset observable.
+const NUM_LAYERS: usize = 2;
+const PAGE_STRIDE: i64 = 8 * HD as i64;
+// Covers page 7 while leaving unreferenced pages to check for stray writes.
+const POOL_LEN: usize = 8 * PAGE_STRIDE as usize;
+
+/// Constant rows make mean(x^2) exact in f32, so the kernel's 512-way
+/// reduction collapses to a constant and never needs reproducing here.
+fn inv_rms(x: f32) -> f32 {
+    1.0f32 / (x * x + EPS).sqrt()
+}
+
+fn normed(x: f32, w: &[bf16], inv: f32, d: usize) -> f32 {
+    bf16::from_f32(x * inv * w[d].to_f32()).to_f32()
+}
+
+/// Period 3, so every in-bounds row maps to a well-defined transform:
+///   0 → ( 1, 0) identity     1 → ( 0, 1) swap-negate     2 → (-1, 0) negate
+/// Unit coefficients keep every expectation exact in bf16.
+fn rope_row(row: usize) -> (f32, f32) {
+    match row % 3 {
+        0 => (1.0, 0.0),
+        1 => (0.0, 1.0),
+        _ => (-1.0, 0.0),
+    }
+}
+
+/// Laid out as the kernel indexes them: [pos * rotary_dim + d].
+fn cos_sin_tables(ctx: &DeviceContext, rows: usize) -> (DeviceVec, DeviceVec) {
+    let mut cos = Vec::with_capacity(rows * ROTARY_DIM);
+    let mut sin = Vec::with_capacity(rows * ROTARY_DIM);
+    for row in 0..rows {
+        let (c, s) = rope_row(row);
+        cos.extend(vec![bf16::from_f32(c); ROTARY_DIM]);
+        sin.extend(vec![bf16::from_f32(s); ROTARY_DIM]);
+    }
+    (
+        DeviceVec::from_host(ctx, &cos).expect("cos H2D"),
+        DeviceVec::from_host(ctx, &sin).expect("sin H2D"),
+    )
+}
+
+fn expected_prep(x: f32, w: &[bf16], inv: f32, d: usize, row: usize) -> f32 {
+    if d < HALF_ROTARY {
+        let lo = normed(x, w, inv, d);
+        let hi = normed(x, w, inv, d + HALF_ROTARY);
+        match row % 3 {
+            0 => lo,
+            1 => -hi,
+            _ => -lo,
+        }
+    } else if d < ROTARY_DIM {
+        let lo = normed(x, w, inv, d - HALF_ROTARY);
+        let hi = normed(x, w, inv, d);
+        match row % 3 {
+            0 => hi,
+            1 => lo,
+            _ => -hi,
+        }
+    } else {
+        normed(x, w, inv, d)
+    }
+}
+
+fn expected_full(
+    x: f32,
+    w: &[bf16],
+    inv: f32,
+    dim: usize,
+    row_of: impl Fn(usize) -> usize,
+) -> Vec<f32> {
+    let mut full = vec![0.0f32; dim * SEQ_LEN];
+    for t in 0..SEQ_LEN {
+        let row = row_of(t);
+        for d in 0..dim {
+            full[t * dim + d] = expected_prep(x, w, inv, d % HD, row);
+        }
+    }
+    full
+}
+
+/// K side only; everything else stays 0.0. The layer offset is derived
+/// from the layout, so oracle and kernel share no hand-picked raw offset.
+fn expected_pool(x: f32, w: &[bf16], inv: f32, layout: &PagedKvLayout, layer: usize) -> Vec<f32> {
+    let mut exp = vec![0.0f32; POOL_LEN];
+    let layer_offset = (layer * layout.layer_stride) as i64;
+    for t in 0..SEQ_LEN {
+        let pos = START_POS + t;
+        let page = PAGE_INDICES[pos / PAGE_SIZE] as i64;
+        for h in 0..NUM_KV_HEADS {
+            let base = page * PAGE_STRIDE
+                + layer_offset
+                + (pos % PAGE_SIZE) as i64 * KV_DIM as i64
+                + h as i64 * HD as i64;
+            for d in 0..HD {
+                exp[(base + d as i64) as usize] = expected_prep(x, w, inv, d, pos);
+            }
+        }
+    }
+    exp
+}
+
+fn assert_close(got: &[f32], expected: &[f32], what: &str) {
+    assert_eq!(got.len(), expected.len());
+    for (i, (&g, &e)) in got.iter().zip(expected).enumerate() {
+        assert!(
+            (g - e).abs() < 0.02,
+            "{what}[{i}]: got {g}, expected {e} (tolerance 0.02)"
+        );
+    }
+}
+
+/// Exact zero is the assertion, not sloppiness: it marks a slot the kernel
+/// must never have written. That covers the V blocks too, so they get no
+/// separate check.
+#[allow(clippy::float_cmp)]
+fn assert_pool(got: &[f32], expected: &[f32]) {
+    assert_eq!(got.len(), expected.len());
+    for (i, (&g, &e)) in got.iter().zip(expected).enumerate() {
+        if e == 0.0 {
+            assert_eq!(g, 0.0, "pool[{i}]: expected untouched, got {g}");
+        } else {
+            assert!(
+                (g - e).abs() < 0.02,
+                "pool[{i}]: got {g}, expected {e} (tolerance 0.02)"
+            );
+        }
+    }
+}
+
+/// Starts at 1: w[0] = 0 would make dim 0 normalise to 0.0, which
+/// assert_pool cannot tell from an untouched slot.
+fn q_norm_weights() -> Vec<bf16> {
+    (1..=HD).map(|d| bf16::from_f32(d as f32)).collect()
+}
+
+/// Negated relative to the Q side, so swapping the two weight pointers is
+/// a sign flip in every slot. bf16 rounds some magnitudes, which does not
+/// matter: oracle and kernel read back the same converted value.
+fn k_norm_weights() -> Vec<bf16> {
+    (1..=HD).map(|d| bf16::from_f32(-(d as f32))).collect()
+}
+
+#[test]
+fn prefill_prep_matches_closed_form() {
+    let Some(ctx) = common::device_or_skip() else {
+        return;
+    };
+    let ctx = &ctx;
+    let qw = q_norm_weights();
+    let kw = k_norm_weights();
+    let layer = 1;
+    let layout = PagedKvLayout::new(NUM_LAYERS, NUM_KV_HEADS, HD, PAGE_SIZE);
+    assert_eq!(
+        layout.page_stride as i64, PAGE_STRIDE,
+        "test geometry drift: layout page_stride must match PAGE_STRIDE"
+    );
+    let ones_q = vec![bf16::from_f32(Q_INPUT); Q_DIM * SEQ_LEN];
+    let q = HiddenStates::from_host(ctx, &ones_q, Q_DIM, SEQ_LEN).expect("q H2D");
+    let ones_k = vec![bf16::from_f32(K_INPUT); KV_DIM * SEQ_LEN];
+    let k = HiddenStates::from_host(ctx, &ones_k, KV_DIM, SEQ_LEN).expect("k H2D");
+    let mut q_out = HiddenStates::zeros(ctx, Q_DIM, SEQ_LEN).expect("q_out alloc");
+
+    let (cos_dev, sin_dev) = cos_sin_tables(ctx, 8);
+    let qn = DeviceVec::from_host(ctx, &qw).expect("q_norm_weight H2D");
+    let kn = DeviceVec::from_host(ctx, &kw).expect("k_norm_weight H2D");
+    let pool: CudaSlice<bf16> = ctx.stream.alloc_zeros(POOL_LEN).expect("pool alloc");
+    let page_indices: CudaSlice<i32> = ctx
+        .stream
+        .clone_htod(&PAGE_INDICES)
+        .expect("page_indices H2D");
+
+    qk_norm_partial_rope_paged_prefill_hd512_into(
+        ctx,
+        &q,
+        &k,
+        &mut q_out,
+        &pool,
+        &layout,
+        &qn,
+        &kn,
+        &cos_dev,
+        &sin_dev,
+        layer,
+        &page_indices,
+        START_POS,
+        8, // cos_max_pos
+        NUM_Q_HEADS,
+        NUM_KV_HEADS,
+        ROTARY_DIM,
+        EPS,
+    )
+    .expect("prefill prep launch");
+
+    let qo = q_out.to_host(ctx).expect("q_out D2H");
+    assert_close(
+        &qo,
+        &expected_full(Q_INPUT, &qw, inv_rms(Q_INPUT), Q_DIM, |t| START_POS + t),
+        "prefill pairing/tail L1",
+    );
+    let pool_host: Vec<bf16> = ctx.stream.clone_dtoh(&pool).expect("pool D2H");
+    let pool_f: Vec<f32> = pool_host.iter().map(|x| x.to_f32()).collect();
+    assert_pool(
+        &pool_f,
+        &expected_pool(K_INPUT, &kw, inv_rms(K_INPUT), &layout, layer),
+    );
+}
+
+#[test]
+fn decode_prep_matches_closed_form() {
+    let Some(ctx) = common::device_or_skip() else {
+        return;
+    };
+    let ctx = &ctx;
+    let qw = q_norm_weights();
+    let kw = k_norm_weights();
+    let ones_q = vec![bf16::from_f32(Q_INPUT); Q_DIM * SEQ_LEN];
+    let q = HiddenStates::from_host(ctx, &ones_q, Q_DIM, SEQ_LEN).expect("q H2D");
+    let ones_k = vec![bf16::from_f32(K_INPUT); KV_DIM * SEQ_LEN];
+    let mut k = HiddenStates::from_host(ctx, &ones_k, KV_DIM, SEQ_LEN).expect("k H2D");
+    let mut q_out = HiddenStates::zeros(ctx, Q_DIM, SEQ_LEN).expect("q_out alloc");
+
+    let (cos_dev, sin_dev) = cos_sin_tables(ctx, 4);
+    let qn = DeviceVec::from_host(ctx, &qw).expect("q_norm_weight H2D");
+    let kn = DeviceVec::from_host(ctx, &kw).expect("k_norm_weight H2D");
+    let positions: CudaSlice<i32> = ctx.stream.clone_htod(&POSITIONS).expect("positions H2D");
+
+    qk_norm_partial_rope_batched_decode_hd512_into(
+        ctx,
+        &q,
+        &mut q_out,
+        &mut k,
+        &qn,
+        &kn,
+        &cos_dev,
+        &sin_dev,
+        &positions,
+        4, // cos_max_pos
+        NUM_Q_HEADS,
+        NUM_KV_HEADS,
+        ROTARY_DIM,
+        EPS,
+    )
+    .expect("decode prep launch");
+
+    let qo = q_out.to_host(ctx).expect("q_out D2H");
+    assert_close(
+        &qo,
+        &expected_full(Q_INPUT, &qw, inv_rms(Q_INPUT), Q_DIM, |t| {
+            POSITIONS[t] as usize
+        }),
+        "decode pairing/tail",
+    );
+    let k_host = k.to_host(ctx).expect("k D2H");
+    assert_close(
+        &k_host,
+        &expected_full(K_INPUT, &kw, inv_rms(K_INPUT), KV_DIM, |t| {
+            POSITIONS[t] as usize
+        }),
+        "decode pairing/tail",
+    );
+}
+
+#[test]
+fn rejects_bad_rotary_dim() {
+    let Some(ctx) = common::device_or_skip() else {
+        return;
+    };
+    let ctx = &ctx;
+    // Zeroed buffers suffice: the launcher must reject before touching any
+    // device memory. Tables are sized for the worst case checked here
+    // (8 x 1024), so the wrapper's table checks pass and both values
+    // actually reach the launcher.
+    let q = HiddenStates::zeros(ctx, Q_DIM, SEQ_LEN).expect("q alloc");
+    let k = HiddenStates::zeros(ctx, KV_DIM, SEQ_LEN).expect("k alloc");
+    let mut q_out = HiddenStates::zeros(ctx, Q_DIM, SEQ_LEN).expect("q_out alloc");
+    let mut k_mut = HiddenStates::zeros(ctx, KV_DIM, SEQ_LEN).expect("k_mut alloc");
+    let pool: CudaSlice<bf16> = ctx.stream.alloc_zeros(POOL_LEN).expect("pool alloc");
+    let layout = PagedKvLayout::new(NUM_LAYERS, NUM_KV_HEADS, HD, PAGE_SIZE);
+    let cos_dev = DeviceVec::zeros(ctx, 8 * 1024).expect("cos alloc");
+    let sin_dev = DeviceVec::zeros(ctx, 8 * 1024).expect("sin alloc");
+    let qn = DeviceVec::zeros(ctx, HD).expect("qn alloc");
+    let kn = DeviceVec::zeros(ctx, HD).expect("kn alloc");
+    let page_indices: CudaSlice<i32> = ctx
+        .stream
+        .clone_htod(&PAGE_INDICES)
+        .expect("page_indices H2D");
+    let positions: CudaSlice<i32> = ctx.stream.clone_htod(&POSITIONS).expect("positions H2D");
+
+    // 127: odd — index 126 would never be written. 1024: wider than the
+    // head — smem and the output slices would walk past 512. Both must be
+    // rejected, not silently accepted.
+    for bad in [127, 1024] {
+        let prefill_err = qk_norm_partial_rope_paged_prefill_hd512_into(
+            ctx,
+            &q,
+            &k,
+            &mut q_out,
+            &pool,
+            &layout,
+            &qn,
+            &kn,
+            &cos_dev,
+            &sin_dev,
+            0, // layer
+            &page_indices,
+            0, // start_pos
+            8, // cos_max_pos
+            NUM_Q_HEADS,
+            NUM_KV_HEADS,
+            bad,
+            EPS,
+        );
+        assert!(
+            prefill_err.is_err(),
+            "prefill: rotary_dim={bad} must be rejected"
+        );
+        let decode_err = qk_norm_partial_rope_batched_decode_hd512_into(
+            ctx,
+            &q,
+            &mut q_out,
+            &mut k_mut,
+            &qn,
+            &kn,
+            &cos_dev,
+            &sin_dev,
+            &positions,
+            8, // cos_max_pos
+            NUM_Q_HEADS,
+            NUM_KV_HEADS,
+            bad,
+            EPS,
+        );
+        assert!(
+            decode_err.is_err(),
+            "decode: rotary_dim={bad} must be rejected"
+        );
+    }
+}
+
+#[test]
+fn prefill_rejects_position_beyond_cos_table() {
+    let Some(ctx) = common::device_or_skip() else {
+        return;
+    };
+    let ctx = &ctx;
+    // Zeroed buffers suffice: rejected on the host, before any launch.
+    // With cos_max_pos 4, start_pos 1 + seq_len 4 reaches row 5 — past the
+    // tables; the page check passes (8 >= 5 slots), so the position check
+    // is the one that fires.
+    let q = HiddenStates::zeros(ctx, Q_DIM, SEQ_LEN).expect("q alloc");
+    let k = HiddenStates::zeros(ctx, KV_DIM, SEQ_LEN).expect("k alloc");
+    let mut q_out = HiddenStates::zeros(ctx, Q_DIM, SEQ_LEN).expect("q_out alloc");
+    let pool: CudaSlice<bf16> = ctx.stream.alloc_zeros(POOL_LEN).expect("pool alloc");
+    let layout = PagedKvLayout::new(NUM_LAYERS, NUM_KV_HEADS, HD, PAGE_SIZE);
+    let cos_dev = DeviceVec::zeros(ctx, 4 * ROTARY_DIM).expect("cos alloc");
+    let sin_dev = DeviceVec::zeros(ctx, 4 * ROTARY_DIM).expect("sin alloc");
+    let qn = DeviceVec::zeros(ctx, HD).expect("qn alloc");
+    let kn = DeviceVec::zeros(ctx, HD).expect("kn alloc");
+    let page_indices: CudaSlice<i32> = ctx
+        .stream
+        .clone_htod(&PAGE_INDICES)
+        .expect("page_indices H2D");
+
+    let err = qk_norm_partial_rope_paged_prefill_hd512_into(
+        ctx,
+        &q,
+        &k,
+        &mut q_out,
+        &pool,
+        &layout,
+        &qn,
+        &kn,
+        &cos_dev,
+        &sin_dev,
+        0, // layer
+        &page_indices,
+        1, // start_pos
+        4, // cos_max_pos
+        NUM_Q_HEADS,
+        NUM_KV_HEADS,
+        ROTARY_DIM,
+        EPS,
+    );
+    assert!(
+        err.is_err(),
+        "prefill start_pos + seq_len beyond cos_max_pos must be rejected on the host"
+    );
+}
+
+#[test]
+fn prefill_rejects_undersized_kv_pool() {
+    let Some(ctx) = common::device_or_skip() else {
+        return;
+    };
+    let ctx = &ctx;
+    // The wrapper validates pool CAPACITY, not just page-table coverage:
+    // the kernel would otherwise write 512 K elements per token into a
+    // 1-element pool. Two checks guard this, and the cases are chosen so
+    // each is reachable on its own — otherwise deleting one would leave
+    // the test green because the other still fires: 0 is a multiple of
+    // page_stride, so only the num_pages >= 1 check can reject it;
+    // page_stride + 1 is over a page (num_pages = 1) but not a multiple,
+    // so only divisibility can.
+    let q = HiddenStates::zeros(ctx, Q_DIM, SEQ_LEN).expect("q alloc");
+    let k = HiddenStates::zeros(ctx, KV_DIM, SEQ_LEN).expect("k alloc");
+    let mut q_out = HiddenStates::zeros(ctx, Q_DIM, SEQ_LEN).expect("q_out alloc");
+    let layout = PagedKvLayout::new(NUM_LAYERS, NUM_KV_HEADS, HD, PAGE_SIZE);
+    let cos_dev = DeviceVec::zeros(ctx, 8 * ROTARY_DIM).expect("cos alloc");
+    let sin_dev = DeviceVec::zeros(ctx, 8 * ROTARY_DIM).expect("sin alloc");
+    let qn = DeviceVec::zeros(ctx, HD).expect("qn alloc");
+    let kn = DeviceVec::zeros(ctx, HD).expect("kn alloc");
+    let page_indices: CudaSlice<i32> = ctx
+        .stream
+        .clone_htod(&PAGE_INDICES)
+        .expect("page_indices H2D");
+
+    for bad_len in [0usize, PAGE_STRIDE as usize + 1] {
+        let pool: CudaSlice<bf16> = ctx.stream.alloc_zeros(bad_len).expect("pool alloc");
+        let err = qk_norm_partial_rope_paged_prefill_hd512_into(
+            ctx,
+            &q,
+            &k,
+            &mut q_out,
+            &pool,
+            &layout,
+            &qn,
+            &kn,
+            &cos_dev,
+            &sin_dev,
+            0, // layer
+            &page_indices,
+            0, // start_pos
+            8, // cos_max_pos
+            NUM_Q_HEADS,
+            NUM_KV_HEADS,
+            ROTARY_DIM,
+            EPS,
+        );
+        let Err(e) = err else {
+            panic!("kv_pool len {bad_len} must be rejected on the host");
+        };
+        // 0 IS a multiple of page_stride: without the num_pages check the
+        // call would still fail — but from the kernel's page trap, which
+        // poisons the context. Pin the host message so that regression
+        // cannot pass as "still an error".
+        if bad_len == 0 {
+            let msg = format!("{e:#}");
+            assert!(
+                msg.contains("no whole page"),
+                "len 0 must be rejected on the host, not by the device trap; got: {msg}"
+            );
+        }
+    }
+}

--- a/pegainfer-kernels/tests/hd512_qk_rope_trap.rs
+++ b/pegainfer-kernels/tests/hd512_qk_rope_trap.rs
@@ -1,0 +1,65 @@
+//! The hd512 decode position trap. One trap per binary: `__trap()` leaves
+//! the context in a sticky error state, so anything sharing the process
+//! afterwards would fail for the wrong reason.
+//!
+//! Manual gate — CI compiles this but never runs it.
+
+mod common;
+
+use cudarc::driver::CudaSlice;
+use pegainfer_kernels::ops::qk_norm_partial_rope_batched_decode_hd512_into;
+use pegainfer_kernels::tensor::DeviceVec;
+use pegainfer_kernels::tensor::HiddenStates;
+
+const HD: usize = 512;
+const ROTARY_DIM: usize = 128;
+const EPS: f32 = 1e-6;
+const NUM_Q_HEADS: usize = 2;
+const NUM_KV_HEADS: usize = 2;
+const Q_DIM: usize = NUM_Q_HEADS * HD;
+const KV_DIM: usize = NUM_KV_HEADS * HD;
+const SEQ_LEN: usize = 4;
+
+/// The launch is async, so the trap may surface at the launcher or at the
+/// next sync — either counts; a silent `Ok` does not.
+#[test]
+fn decode_position_trap_is_visible() {
+    let Some(ctx) = common::device_or_skip() else {
+        return;
+    };
+    let ctx = &ctx;
+    // Inputs are zeroed but every wrapper check must PASS so the launch
+    // actually happens and the kernel traps: weights [512], tables 4 rows
+    // (cos_max_pos 4), positions [0, 1, 5, 1] — token 1 reads row 5.
+    let q = HiddenStates::zeros(ctx, Q_DIM, SEQ_LEN).expect("q alloc");
+    let mut q_out = HiddenStates::zeros(ctx, Q_DIM, SEQ_LEN).expect("q_out alloc");
+    let mut k = HiddenStates::zeros(ctx, KV_DIM, SEQ_LEN).expect("k alloc");
+    let qn = DeviceVec::zeros(ctx, HD).expect("qn alloc");
+    let kn = DeviceVec::zeros(ctx, HD).expect("kn alloc");
+    let cos_dev = DeviceVec::zeros(ctx, 4 * ROTARY_DIM).expect("cos alloc");
+    let sin_dev = DeviceVec::zeros(ctx, 4 * ROTARY_DIM).expect("sin alloc");
+    let positions: CudaSlice<i32> = ctx.stream.clone_htod(&[0, 1, 5, 1]).expect("positions H2D");
+
+    let res = qk_norm_partial_rope_batched_decode_hd512_into(
+        ctx,
+        &q,
+        &mut q_out,
+        &mut k,
+        &qn,
+        &kn,
+        &cos_dev,
+        &sin_dev,
+        &positions,
+        4, // cos_max_pos
+        NUM_Q_HEADS,
+        NUM_KV_HEADS,
+        ROTARY_DIM,
+        EPS,
+    );
+    if res.is_ok() {
+        assert!(
+            ctx.sync().is_err(),
+            "out-of-range position (5 >= cos_max_pos 4) must fail visibly"
+        );
+    }
+}

--- a/pegainfer-kernels/tests/hd512_qk_rope_trap_page.rs
+++ b/pegainfer-kernels/tests/hd512_qk_rope_trap_page.rs
@@ -1,0 +1,78 @@
+//! The hd512 paged-KV page-id trap. One trap per binary, for the reason
+//! given in hd512_qk_rope_trap.rs.
+//!
+//! Manual gate — CI compiles this but never runs it.
+
+mod common;
+
+use cudarc::driver::CudaSlice;
+use half::bf16;
+use pegainfer_kernels::ops::qk_norm_partial_rope_paged_prefill_hd512_into;
+use pegainfer_kernels::paged_kv::PagedKvLayout;
+use pegainfer_kernels::tensor::DeviceVec;
+use pegainfer_kernels::tensor::HiddenStates;
+
+const HD: usize = 512;
+const ROTARY_DIM: usize = 128;
+const EPS: f32 = 1e-6;
+const NUM_Q_HEADS: usize = 2;
+const NUM_KV_HEADS: usize = 2;
+const Q_DIM: usize = NUM_Q_HEADS * HD;
+const KV_DIM: usize = NUM_KV_HEADS * HD;
+const SEQ_LEN: usize = 4;
+
+/// Checking `page_indices` on the host would require a D2H synchronization.
+/// The async trap may surface at the launcher or the next sync; either
+/// counts, while a silent `Ok` does not.
+#[test]
+fn paged_page_id_trap_is_visible() {
+    let Some(ctx) = common::device_or_skip() else {
+        return;
+    };
+    let ctx = &ctx;
+    // One page in the pool → num_pages = 1; page_indices = [5] is out of
+    // range, but every wrapper check must still PASS so the launch happens
+    // and the kernel traps: coverage 1 page * 4 slots >= start_pos 0 +
+    // seq_len 4, tables 4 rows (cos_max_pos 4), positions 0..=3 all read
+    // page_indices[0] = 5.
+    let layout = PagedKvLayout::new(1, NUM_KV_HEADS, HD, 4);
+    let q = HiddenStates::zeros(ctx, Q_DIM, SEQ_LEN).expect("q alloc");
+    let k = HiddenStates::zeros(ctx, KV_DIM, SEQ_LEN).expect("k alloc");
+    let mut q_out = HiddenStates::zeros(ctx, Q_DIM, SEQ_LEN).expect("q_out alloc");
+    let pool: CudaSlice<bf16> = ctx
+        .stream
+        .alloc_zeros(layout.page_stride)
+        .expect("pool alloc");
+    let qn = DeviceVec::zeros(ctx, HD).expect("qn alloc");
+    let kn = DeviceVec::zeros(ctx, HD).expect("kn alloc");
+    let cos_dev = DeviceVec::zeros(ctx, 4 * ROTARY_DIM).expect("cos alloc");
+    let sin_dev = DeviceVec::zeros(ctx, 4 * ROTARY_DIM).expect("sin alloc");
+    let page_indices: CudaSlice<i32> = ctx.stream.clone_htod(&[5]).expect("page_indices H2D");
+
+    let res = qk_norm_partial_rope_paged_prefill_hd512_into(
+        ctx,
+        &q,
+        &k,
+        &mut q_out,
+        &pool,
+        &layout,
+        &qn,
+        &kn,
+        &cos_dev,
+        &sin_dev,
+        0, // layer
+        &page_indices,
+        0, // start_pos
+        4, // cos_max_pos
+        NUM_Q_HEADS,
+        NUM_KV_HEADS,
+        ROTARY_DIM,
+        EPS,
+    );
+    if res.is_ok() {
+        assert!(
+            ctx.sync().is_err(),
+            "page id 5 beyond num_pages 1 must fail visibly"
+        );
+    }
+}


### PR DESCRIPTION
## Description

Closes #837


#784 instantiated attention at head_dim 512 but nothing prepares its inputs: Gemma 4's global layers would reach it un-normed and un-rotated. This adds the prep at the same width, with device gates. No caller yet, on the same grounds as #784.

Not a wholesale copy of the hd256 sibling. Of its four structural features exactly one transfers verbatim — the partial-RoPE branch geometry, because qwen35 runs `rotary_dim` 64 at head_dim 256 and Gemma 4 runs 128 at 512, the same quarter ratio. The other three are qwen35's, not the family's.

**The norm weight convention differs.** hd256 computes `1 + w`, the Gemma 1/2/3 convention — the `_offset_` in `rms_norm_elem_offset_hd256` is that plus one. `Gemma4UnifiedRMSNorm` multiplies by the weight directly and initialises it to ones rather than zeros, so this kernel multiplies by plain `w` and carries no offset in its name.

**There is no gate.** hd256 assumes a doubled Q stride and has a companion kernel applying `sigmoid(gate)`; Gemma 4's `q_proj` emits exactly `num_q_heads * head_dim`.

**There is no V.** Global layers ship no `v_proj`, so value is `k_proj`'s own output forked after the GEMM: key takes `k_norm` then RoPE, value takes a scale-free norm — `with_scale=False`, no weight parameter — and no RoPE. That fork belongs to the future layer caller.

The prefill entry writes K into the paged pool consumed by `batch_prefill_paged`. This is also the route used for the 12B global layer's group-16 GQA, since the direct decode dispatcher instantiates groups 1, 2, 3, 4 and 8 only.

`rotary_dim` remains runtime-defined while head_dim is fixed at 512. Both launchers reject non-positive, odd or oversized values and return a diagnostic instead of launching. The Rust wrappers validate tensor lengths, public `PagedKvLayout` derivations, layer-derived K offsets, whole-page pool capacity and host-known prefill bounds. Device-resident decode positions and page ids are checked in the kernel before their first table read or pool write.

The device gates use constant input rows, exact three-state RoPE tables and distinct per-dimension Q/K weights. That keeps the RMS denominator closed-form while making the plain-weight convention, RoPE pairing/tail, Q/K pointer wiring, 16-over-1 GQA geometry, per-request positions and paged layer offsets independently observable. Slots outside the expected K destinations remain exact zero, including V blocks.

The two intentional `__trap()` cases run in separate integration-test binaries because a trap leaves the process's CUDA context in a sticky error state. An earlier gate interpreted the resulting context failure as a missing device and reported later tests as passed; process isolation prevents cross-test contamination. The shared helper now panics when CUDA reports a present device whose context cannot be created. Formal GPU receipts set `OPENINFER_REQUIRE_GPU=1`, removing skip from the allowed outcomes even when device discovery itself is ambiguous.

### Test Env

Single GPU (sm_89, x86_64), CUDA 12.9, `OPENINFER_REQUIRE_GPU=1`:

- `cargo build --release -p openinfer-kernels` — clean.
- `cargo clippy --release -p openinfer-kernels --all-targets -- -D warnings` — clean, zero diagnostics and zero errors.
- `cargo test --release -p openinfer-kernels` over the three gate targets — `hd512_qk_rope_smoke` 5 passed, `hd512_qk_rope_trap` 1 passed, `hd512_qk_rope_trap_page` 1 passed, with zero tests skipped.
- Both entries export with C linkage; their Rust/C parameter order and widths were checked source-to-source, and both calls execute through the public wrappers. C linkage does not encode pointer constness.
- `ptxas`: 28 registers and 1092 bytes of shared memory per block. At 512 threads this is 14,336 registers against the 65,536 per-block budget.
- Eleven targeted mutations were caught: `1 + w`; the tail boundary; token-indexed RoPE rows; query-derived `kv_dim`; transposed Q/K norm weights; transposed Q/K inputs; block-derived K offset; either pool-capacity check; the position trap; and the page trap.


CI compiles this shared CUDA translation unit in the Qwen3 sm80 CUDA compile and Clippy lanes, but it does not execute the GPU numeric or trap tests. The three device gates therefore remain manual execution receipts.

There is no end-to-end numeric comparison because no Gemma 4 caller exists yet. The future 12B global-layer comparison against the Hugging Face reference owns that boundary; these tests cover the OpenInfer kernel's arithmetic, FFI and layout contracts.


## Type of Change

- [x] New feature (non-breaking change which adds functionality)