### PR TITLE
chore(dynamo): bump dynamo rev 364cc8aa -> c45d976e (+620 commits)

### DIFF
--- a/openinfer-dynamo-backend/.cargo/config.toml
+++ b/openinfer-dynamo-backend/.cargo/config.toml
@@ -8,3 +8,17 @@
 # one developer's box.
 [build]
 rustflags = ["--cfg", "tokio_unstable"]
+
+# dynamo-memory's build.rs gates CUDA 13.2's `CUmemLocation` union layout
+# behind `cuda_mem_location_union`, detected from `CUDARC_CUDA_VERSION` →
+# `nvcc` on PATH → assume-latest. It cannot see that this build's cudarc
+# bindings come from the pegainfer root workspace's EXPLICIT `cuda-12090`
+# feature pin (host detection never runs for cudarc here). When its guess
+# disagrees with those bindings (no nvcc on PATH, or a >=13.2 toolkit), the
+# build fails with `E0609: no field __bindgen_anon_1 on CUmemLocation_st`.
+# Pin the same value both build scripts honor at highest precedence; must
+# match the `cuda-*` feature in the root workspace Cargo.toml. Host-
+# independent: the 12090 bindings are compiled on every host, deploy ones
+# included (12.9 bindings are ABI-forward-compatible with newer drivers).
+[env]
+CUDARC_CUDA_VERSION = "12090"

--- a/openinfer-dynamo-backend/Cargo.toml
+++ b/openinfer-dynamo-backend/Cargo.toml
@@ -23,11 +23,11 @@ openinfer-qwen3 = { path = "../openinfer-qwen3" }
 # driver, and `run()`. Pinned to the SAME rev as the dynamo deps in the main
 # pegainfer workspace so the shared git checkout (and its internal type
 # identity) stay consistent.
-dynamo-backend-common = { git = "https://github.com/ai-dynamo/dynamo", rev = "364cc8aa543d97f0563e17de3069d98ea051f33f" }
+dynamo-backend-common = { git = "https://github.com/ai-dynamo/dynamo", rev = "c45d976e4710f39d5bc63e541940167286dd65f7" }
 # KV-router event protocol types (KvCacheEvent / KvCacheStoreData / ...). Not
 # re-exported by backend-common, so depended on directly — same rev so the
 # `KvCacheEvent` we build is the exact type `KvEventPublisher::publish` accepts.
-dynamo-kv-router = { git = "https://github.com/ai-dynamo/dynamo", rev = "364cc8aa543d97f0563e17de3069d98ea051f33f" }
+dynamo-kv-router = { git = "https://github.com/ai-dynamo/dynamo", rev = "c45d976e4710f39d5bc63e541940167286dd65f7" }
 
 anyhow = "1"
 async-trait = "0.1"
@@ -42,7 +42,7 @@ tracing = "0.1"
 # Same rev as the runtime dep above; the `testing` feature unlocks
 # `dynamo_backend_common::testing::run_conformance`, the official LLMEngine
 # conformance kit the GPU integration test in `engine.rs` drives.
-dynamo-backend-common = { git = "https://github.com/ai-dynamo/dynamo", rev = "364cc8aa543d97f0563e17de3069d98ea051f33f", features = ["testing"] }
+dynamo-backend-common = { git = "https://github.com/ai-dynamo/dynamo", rev = "c45d976e4710f39d5bc63e541940167286dd65f7", features = ["testing"] }
 
 # Separate workspace on purpose. This keeps dynamo-runtime / dynamo-llm and
 # their heavy transitive deps (tonic, kube, etcd, NATS) OUT of the main

--- a/openinfer-dynamo-backend/src/engine.rs
+++ b/openinfer-dynamo-backend/src/engine.rs
@@ -15,7 +15,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::AtomicU8;
 use std::time::Duration;
 
 use async_trait::async_trait;

--- a/openinfer-dynamo-frontend/.cargo/config.toml
+++ b/openinfer-dynamo-frontend/.cargo/config.toml
@@ -3,3 +3,11 @@
 # `.cargo/config.toml`, so we set it here — same as openinfer-dynamo-backend.
 [build]
 rustflags = ["--cfg", "tokio_unstable"]
+
+# Same CUDA-binding alignment as openinfer-dynamo-backend: if dynamo-memory
+# ever enters this crate's build graph, its build.rs must not guess the CUDA
+# toolkit from `nvcc`/`fallback-latest` and disagree with the explicit
+# `cuda-12090` cudarc bindings the pegainfer root workspace pins. Harmless
+# while dynamo-memory is out of the graph. See the sibling crate's config.
+[env]
+CUDARC_CUDA_VERSION = "12090"

--- a/openinfer-dynamo-frontend/Cargo.toml
+++ b/openinfer-dynamo-frontend/Cargo.toml
@@ -16,9 +16,9 @@ path = "src/main.rs"
 # never touches a GPU, so it stays a light CPU-only binary. Same dep shape the
 # Python binding uses for its no-GPU build, pinned to the SAME rev as the
 # openinfer-dynamo-backend deps so the shared git checkout / type identity hold.
-dynamo-llm = { git = "https://github.com/ai-dynamo/dynamo", rev = "364cc8aa543d97f0563e17de3069d98ea051f33f", default-features = false }
+dynamo-llm = { git = "https://github.com/ai-dynamo/dynamo", rev = "c45d976e4710f39d5bc63e541940167286dd65f7", default-features = false }
 # Worker / Runtime / DistributedRuntime + RouterMode.
-dynamo-runtime = { git = "https://github.com/ai-dynamo/dynamo", rev = "364cc8aa543d97f0563e17de3069d98ea051f33f" }
+dynamo-runtime = { git = "https://github.com/ai-dynamo/dynamo", rev = "c45d976e4710f39d5bc63e541940167286dd65f7" }
 
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
## What

Bump the five dynamo git-rev pins in `openinfer-dynamo-backend` / `openinfer-dynamo-frontend` from `364cc8aa` (2026-07-01) to `c45d976e` (origin/main, 2026-08-03, +620 commits).

## API impact: zero code changes

Pre-bump surface diff (`git diff pin..target --stat` on every dynamo file we call) showed, and the build confirmed:

- `LLMEngine` trait — +2/−1 lines; all five methods we implement intact
- `EngineConfig` — byte-identical
- `LocalModelBuilder` methods, `WorkerConfig`/`CommonArgs` — stable / additive
- `kv_router/protocols.rs` + `indexer.rs` — **zero changes** (routing semantics risk is nil)
- `PreprocessedRequest` — additive-only

## The one fight: upstream dynamo-memory vs our cudarc pin

Upstream [`ai-dynamo/dynamo#11758`](https://github.com/ai-dynamo/dynamo/pull/11758) (CUDA 13.2 build env) added a `build.rs` to `dynamo-memory` that detects the `CUmemLocation` union layout via `CUDARC_CUDA_VERSION` → `nvcc` on PATH → assume-latest. It cannot see that in our graph cudarc's bindings come from the root workspace's **explicit `cuda-12090` feature pin** (cudarc never host-detects here). On hosts without `nvcc` on PATH it guessed union against our flat bindings → `E0609`.

Fix: `[env] CUDARC_CUDA_VERSION = "12090"` in each crate's `.cargo/config.toml`. The override **must equal** the root `cuda-*` pin — any other value compiles cudarc with two binding layouts at once (166 duplicate-definition errors, observed with `12080`). Host-independent: the 12090 bindings are pinned identically on every host, ABI-forward-compatible with the 13.x deploy drivers.

## Also

- Removed a latent unused-import warning in backend `engine.rs` — invisible to main CI because both dynamo crates are excluded workspaces.
- Task doc with full RCA, lessons, follow-ups: `docs/subsystems/router/dynamo-rev-bump.md`.

## Verification

- `cargo check --all-targets` — both crates, green
- `cargo test` — backend **22 passed / 0 failed / 1 ignored** (GPU tests skip as designed: no model weights on the build host); frontend test profile green

## Follow-ups (not in this PR)

- On-GPU deploy smoke on real HW: worker registration + metrics feed + `kv_hit_rate > 0` gate. `backend-common/worker.rs` changed registration behavior (+79/−5) behind stable signatures — needs a live etcd/NATS round-trip.
- Worth upstreaming: dynamo-memory's build.rs mis-detects whenever cudarc's bindings come from an explicit feature pin rather than host detection.
