### PR TITLE
kv-store successor: resolver-ownership design + phase-1 store surface (supersedes #830's capacity layer)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3638,6 +3638,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tokio-util",
 ]
 
 [[package]]

--- a/docs/index.md
+++ b/docs/index.md
@@ -119,6 +119,7 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 | Path | TL;DR |
 | --- | --- |
 | `subsystems/kv-cache/design.md` | 异构 KV（full attn / MLA / SWA / linear state）统一为「组 + checkpoint」模型：两类封存语义（paged 原地封 / bounded seal-by-copy）、对齐组、单索引以最稀疏 checkpointer 为准。`pegainfer-kv-store` 收编 qwen3/glm52 手写 offload 编排（resolve/seal/retire），模型侧只声明 `KvModel`。迁移：qwen3 → glm52 D → P/D 租约 → qwen35 bounded。 |
+| `subsystems/kv-cache/resolver-ownership.md` | #830 八轮评审复盘与后继设计：plain 路径合规、偏航在 native P/D 把权威分配放进 resolver（HeadroomLedger 即被警告的第二本账）；定形 radix-first + tail pad-to-boundary（keyed API 族删除、失败前置到 admission 前）、仲裁按池内 async reserve + prefetched 抵扣归位；#830 契约测试全集为后继验收。 |
 
 ## subsystems / runtime
 

--- a/docs/subsystems/kv-cache/design.md
+++ b/docs/subsystems/kv-cache/design.md
@@ -247,9 +247,9 @@ while let Ok((req, kv_prefix)) = submit_rx.try_recv() {
 
 ## 未决
 
-- `Handoff` 租约的超时回收与释放时机（D fetch 完成即释放 vs admission 断言通过才释放）——防腐层里对 pegaflow lease 语义定。同族未定项（均随 glm52 P/D 迁移落地）：mutable tail page 的保存动词——tail 页未封存、以 SHA-256(committed prompt + anchor) 为 key、携 draft tokens 的 `KvTransfer` 信封；store 的 seal/retire 只认已注册块，尚无「按任意 key 保存一块」的 API。
+- `Handoff` 租约的超时回收与释放时机（D fetch 完成即释放 vs admission 断言通过才释放）——防腐层里对 pegaflow lease 语义定。~~mutable tail page 的保存动词~~ **已定形（见 `resolver-ownership.md`）**：tail 不再需要专用保存动词——P 侧 pad-to-boundary 后按普通块封存（save 本就按块粒度运整页 slab，padding 零字节代价），D 侧按 padded-hash 恢复进 radix + admission 时 copy-on-restore；#830 的 keyed 旁路 API（`seal_keyed`/`resolve_keyed_block`）随之删除。draft tokens 仍走 `KvTransfer` 信封（纯元数据）。
 - miss-breaker（连续冷 miss 停止 park）是跨请求策略，qwen3 迁移时决定放 store 还是 scheduler。同日归属待定：运行时 prefix_cache 开关的收编（resolve 短路 / admission 不 match / release 标记不进 inactive cache）。
-- 仲裁机制归位：骨架期的 `set_admission_floor`（store 侧原子水位）已删——无人消费的水位是臆造接口。回归时建议形态是「admission 自管预算」：resolve 已命中块的抵扣（`prefetched_blocks`）与 reserve 记在 admission 同一本账（qwen3 `reserve_floor` 先例），不恢复独立水位 API。TOCTOU 收口（池内 `async reserve_blocks(n)`，waiters 挂在唯一真相旁）随此一并议——外挂信号量镜像可用量会造第二本账，且块非同质 permit（free vs warm-evictable、分配顺序影响命中率），信号量语义只属于分配器内部。
+- 仲裁机制归位：骨架期的 `set_admission_floor`（store 侧原子水位）已删——无人消费的水位是臆造接口。回归时建议形态是「admission 自管预算」：resolve 已命中块的抵扣（`prefetched_blocks`）与 reserve 记在 admission 同一本账（qwen3 `reserve_floor` 先例），不恢复独立水位 API。TOCTOU 收口（池内 `async reserve_blocks(n)`，waiters 挂在唯一真相旁）随此一并议——外挂信号量镜像可用量会造第二本账，且块非同质 permit（free vs warm-evictable、分配顺序影响命中率），信号量语义只属于分配器内部。**该形态经 #830 评审复盘确认为唯一可行路线**（#830 的 HeadroomLedger 实证了第二本账的补丁螺旋——八轮 18 条 finding，复盘见 `resolver-ownership.md`）；本条的前提是 resolve 分配保持零义务，native P/D 的合规形态同见该文档。
 - resolve 的 key 方案：**vLLM P/D 互通将整体移除**（独立后续 PR；清单：`vllm_compat` 状态机、`VllmBlockHasher`（xxh3_128 CBOR 链）、`miss_wait` 窗口、`page_first` 注册模式及其测试），故不为外部 hasher 抽可插拔 seam；glm52 的 SHA-256 tail key 随 native P/D 迁移以单一消费者定形。
 - repack 钩子（`KvModel::repack`）设计保留、骨架不落：唯一消费者是 glm52 TP4（FlashInfer 576B 执行态 ↔ 656B wire），待 TP4 P/D 互通有真实对端时随消费落地。
 - pegaflow fork 与否：防腐层（crate 内 `HostTier`）稳定运行后再议；`Loading` 的轮询套轮询是第一改造对象。

--- a/docs/subsystems/kv-cache/resolver-ownership.md
+++ b/docs/subsystems/kv-cache/resolver-ownership.md
@@ -1,0 +1,63 @@
+# Resolver 所有权与 native tail 定形：#830 的教训与后继设计
+
+> **TL;DR:** #830（glm52 迁移 pegainfer-kv-store）八轮评审 18 条 finding 的复盘结论：**plain 路径符合 design.md 的双分配器模型，偏航只在 native P/D 路径**——它把权威级分配（RequestKv 生命周期、keyed tail 装载）放进了 resolver 任务，破坏了"resolve 分配零义务、可让步"的前提；评审补出的 HeadroomLedger 恰是 design.md 明文警告的"第二本账"。后继 PR 的设计：① native full 页改走 radix-first（与 plain 同路，零义务）；② **keyed tail 用 pad-to-boundary 消灭**（save 本就按块粒度运整页 slab，padding 零字节代价，换来 radix 身份 + 失败前置到 admission 之前）；③ 仲裁按 design.md 未决预定形态归位（池内 async reserve + admission 侧 prefetched 抵扣），台账族与 keyed API 族整体删除。#830 冻结为记录，其 20+ 契约测试作为后继的行为验收标准。
+>
+> Status: 设计评审中。前置阅读：`design.md`（尤其「请求管线：线性所有权链」与「池的并发事实」）。
+
+## 一、#830 十八条 finding 的归因
+
+| 类 | 代表 finding | 根因 |
+| --- | --- | --- |
+| 容量竞态(~9 条) | native 互饿死锁、headroom claim 生命周期、probe pin 绕账、plain 记账非原子、tail 一次性分配 | native resolver 持有**不可让步的权威级分配**,与调度器在池上竞争 |
+| 异步所有权(~5 条) | keyed-tail 无界等待、lease 泄漏 ×2、取消不穿透 | `timeout_at` 丢观察者不丢工作;其中 lease-settle/DMA-parking 是 design.md 230 行本就要求的「guard 陪 op 走到 settle」,#830 初版漏实现 |
+| 删掉的防御 | 匿名 key 序号、resolver 负载可见性、tail 等待语义 | 旧串行状态机的行为被当实现细节丢弃(见 conventions 待立项:迁移防御清单) |
+| 真边界 | handoff 静默降级、teardown arena UAF | 与所有权正交,修复直接继承 |
+
+**关键对照**:design.md 231 行早已定义了权限模型——admission 的 lifetime 预留是**权威**(honor-or-reject),resolve 的 reservation 是**机会主义**(恢复的是 radix 共享缓存块,零义务、拿不到就让步);仲裁被有意推迟,未决 252 行连回归形态都写明,并警告「外挂信号量镜像可用量会造第二本账」。#830 的 native 路径在 resolver 里 `pool.new_request` + schedule 生命周期 + tail 装进私页——私产不可让步,模型前提崩塌;评审八轮随后补出的 debt 台账正是被警告的第二本账。**补丁的形状(影子记账、锁内 verify-and-book、cancel 穿针)就是架构报警**。
+
+## 二、后继设计
+
+### 2.1 plain 路径:照抄 #830 现状(它是符合设计的)
+
+resolve task 线性持有 req:probe hold(RAII,零分配)→ guarded tier query(lease 必达 settle)→ 机会主义 reservation(可让步)→ load(已提交 DMA 不可取消,reservation 随 detached task)→ commit 入 radix → 投递 `(req, KvPrefix{hold})` 给 scheduler 收件箱。权威分配只发生在 admission。
+
+继承自 #830 的修复:`LeaseGuard`/`spawn_guarded_query`(迟到命中的 lease 自动释放)、load 的 detach 语义与 `flush_loads` 排水、`PrefixProbe::truncate_held`(hold 与 credit 钉页对齐)、resolver 负载可见性思想(waiting = pending + inflight)、handoff 能力不匹配显式拒绝、teardown 排水超时泄漏 worker。
+
+### 2.2 native P/D:radix-first + pad-to-boundary
+
+**full 页**:D 的恢复就是一次 `wait_for_full_hit` 的 `resolve_prefix`——零义务共享块,admission 断言命中长度并做全部权威分配。resolver 里不再出现 RequestKv。
+
+**tail(committed_len % 64 的半页)**:三不状态(不可封存/无 radix 身份/必须落私页)曾催生 keyed 旁路 API。定形:**P 侧 pad 到页边界**。
+
+- P:半页用词表外保留 pad id 补满 token 链 → 页封存,正常 Handoff-class save。**零字节代价**:save 按块粒度搬运,半页的 slab 本来就整页在运;padding 只是给垃圾行一个名字,换取 radix 身份。pad id 混入既有 `native_mtp_cache_salt`,杜绝与真实续写的 hash 碰撞。
+- D resolver:边界页随 full 页一起按 padded-hash 恢复进 radix(仍是零义务缓存块)。
+- D admission(native 臂):full 块自然 match;边界块按 padded-hash 匹配(~20 行,committed_len 在 handoff 元数据里)+ **copy-on-restore** 拷进请求私页(对齐组全家一起拷:mla+idxk+MTP L78 镜像,~3.3MB D2D 微秒级)。decode 从 committed_len 处 append 自然覆写 pad 位;attention 被 seq_len 界住,永远读不到 pad 行。
+- 失败语义:padded 页缺失 = 命中短缺 = **admission 拒绝,发生在占 slot 之前**,router 兜底。(对比曾考虑的"admission 后再取 tail":取回失败发生在 slot 已占之后,15s deadline × slot 数是存储抖动即冻结整 rank 的 DoS 面;及"D 重算尾巴":每请求 ≤63 行 context 挤进 decode 步流,c64 突发时 ~2000 行,违背 PD 分离的 decode 纯度——均否决。)
+- turn-2 prefix 复用终止在最后一个真 full 页,与现状一致,无损失。
+
+### 2.3 仲裁归位(design.md 未决 252 行的预定形态)
+
+- 池内 `async reserve_blocks(n)`:waiters 挂在唯一真相旁,TOCTOU 在分配器内部收口;
+- admission 自管预算:resolve 已命中块按 `prefetched_blocks` 抵扣(qwen3 先例),不设独立水位 API,**不建第二本账**。
+
+## 三、kv-store 变更清单(相对 #830 尖端 d303852)
+
+| 处置 | 内容 |
+| --- | --- |
+| **保留** | `LeaseGuard`/`GuardedQuery`/`spawn_guarded_query`;load 的 detach+`flush_loads`;`truncate_held`;mock tier 测试基建;`seal`/`retire`/`flush_saves` 主干 |
+| **删除** | `HeadroomLedger` 族(`assume_active_headroom`/`with_headroom_sync`/`settle_headroom`/`schedule_prefill_resolver` 门)、`reserve_headroom`、store 内 `CancelProbe` 穿针、**keyed 族**(`seal_keyed`/`resolve_keyed_block`/`KeyedFetchError`/`KeyedLoadParking`) |
+| **重塑** | 池内 async reserve(waiters);admission 侧 prefetched 抵扣;P 侧 pad-and-seal(落在 glm52 P 逻辑,store 无新 API) |
+
+破坏性变更成本:零——`pegainfer-kv-store` 当前唯一消费者是 glm52。
+
+## 四、验收与迁移
+
+- **行为验收 = #830 的契约测试全集**(互饿不可形成、resolver 不搁浅 active、取消及时释放、lease settle、parking、handoff 拒绝、teardown 泄漏……),机制换、断言不换;keyed 族测试随 API 删除,由 padded 路径的新契约测试接棒(padded 页缺失拒绝、copy-on-restore 对齐组完整性、pad 行不可见)。
+- 后继实现 PR 基于 main 重做(不基于 #830 分支);#830 冻结为设计论证记录。
+- 真机验收:1P1D+router 复刻 #830 迁移时的验收矩阵(GSM8K n200、multi-turn c16 头对头、240/240 零失败)+ c64 全量 trace 回放(#833 战役的 harness 现成)。
+
+## 待讨论(后续逐块)
+
+- scheduler 侧:收件箱/admission 在新形态下的结构(native 臂的 padded-match 放哪、bypass 谓词简化后的样子);
+- P 侧 pad-and-seal 的落点(prefill_tp 封存路径)与 handoff 信封变更(committed_len 语义不变,tail_len 字段退役);
+- 迁移防御清单立项(`docs/conventions/`):重写类 PR 必须逐条注明旧防御结构的接班人。

--- a/pegainfer-kv-store/Cargo.toml
+++ b/pegainfer-kv-store/Cargo.toml
@@ -28,6 +28,7 @@ pegaflow-core = { git = "https://github.com/novitalabs/pegaflow.git", rev = "141
 tokio = { workspace = true, features = ["sync", "time", "rt", "rt-multi-thread", "net"] }
 # net: wraps the P2P gRPC listener into the stream `serve_with_incoming` takes.
 tokio-stream = { workspace = true, features = ["net"] }
+tokio-util = { workspace = true, features = ["rt"] }
 
 [dev-dependencies]
 libc = { workspace = true }

--- a/pegainfer-kv-store/src/builder.rs
+++ b/pegainfer-kv-store/src/builder.rs
@@ -107,6 +107,7 @@ impl KvStoreBuilder {
                         pool,
                         tier,
                         pinned: Arc::new(AtomicUsize::new(0)),
+                        loads: tokio_util::task::TaskTracker::new(),
                     },
                 )
             })

--- a/pegainfer-kv-store/src/pool.rs
+++ b/pegainfer-kv-store/src/pool.rs
@@ -261,6 +261,14 @@ impl PrefixProbe {
     pub fn cpu_query_window(&self) -> usize {
         self.cacheable.saturating_sub(self.gpu_hit)
     }
+
+    /// Drop the anti-eviction pins on every held block past the first
+    /// `blocks` (they fall to the inactive — evictable, still matchable —
+    /// pool). `held` is in prefix order, so the surviving pins cover exactly
+    /// the leading `blocks` blocks of the prefix.
+    pub fn truncate_held(&mut self, blocks: usize) {
+        self.held.truncate(blocks);
+    }
 }
 
 /// An opaque strong pin on one registered KV block. While held it keeps the

--- a/pegainfer-kv-store/src/store.rs
+++ b/pegainfer-kv-store/src/store.rs
@@ -9,7 +9,9 @@ use std::time::Duration;
 
 use pegainfer_engine::engine::KvPrefix;
 use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
 use tokio::time::Instant;
+use tokio_util::task::TaskTracker;
 
 use crate::BlockPool;
 use crate::CacheScope;
@@ -22,6 +24,7 @@ use crate::ResolvePolicy;
 use crate::SaveClass;
 use crate::SaveCursor;
 use crate::tier::HostTier;
+use crate::tier::LeasedBlocks;
 use crate::tier::TierQuery;
 
 /// One rank's KV surfaces. `pool` is the same logical pool the rank's
@@ -35,6 +38,51 @@ pub(crate) struct RankState {
     /// its budget. `Arc`: the per-save watcher tasks decrement it after the
     /// store's borrow ends.
     pub(crate) pinned: Arc<AtomicUsize>,
+    /// In-flight restore H2Ds, including deadline-abandoned ones. Drained
+    /// by [`KvStore::flush_loads`] before the GPU arenas are freed.
+    pub(crate) loads: TaskTracker,
+}
+
+/// A tier hit whose lease releases on drop unless the caller takes it. The
+/// detached query task returns its hit through this guard, which carries the
+/// invariant: a query, once submitted, always settles and always releases
+/// any lease the caller will never consume — a wait abandoned at the
+/// deadline drops the task's output unread, and the drop releases.
+struct LeaseGuard {
+    tier: Arc<dyn HostTier>,
+    hit: Option<LeasedBlocks>,
+}
+
+impl LeaseGuard {
+    fn blocks(&self) -> usize {
+        self.hit
+            .as_ref()
+            .expect("guard holds its hit until taken")
+            .blocks
+    }
+
+    /// Consume the guard, taking over the lease (no release on drop).
+    fn take(mut self) -> LeasedBlocks {
+        self.hit.take().expect("guard holds its hit until taken")
+    }
+}
+
+impl Drop for LeaseGuard {
+    fn drop(&mut self) {
+        if let Some(hit) = self.hit.take() {
+            self.tier.release(hit);
+        }
+    }
+}
+
+/// One tier query's outcome, flat: the wait's three failure layers
+/// (deadline, task panic, tier error) fold into `TimedOut`/`Failed`.
+enum QueryOutcome {
+    Miss,
+    Loading,
+    Hit(LeaseGuard),
+    TimedOut,
+    Failed(anyhow::Error),
 }
 
 /// The process-wide KV store: one instance, `Arc`-shared. Knows token
@@ -58,6 +106,40 @@ impl KvStore {
 
     pub fn stats(&self) -> &KvStoreStats {
         &self.stats
+    }
+
+    /// One tier query, run to settlement in a detached task so an abandoned
+    /// wait leaves the settlement — and a late hit's lease release — to the
+    /// task ([`LeaseGuard`] drops unread). Never await `tier.query` directly:
+    /// dropping its future detaches only the observer, not the tier's work.
+    async fn guarded_query(
+        &self,
+        tier: &Arc<dyn HostTier>,
+        req_id: &str,
+        block_hashes: Vec<Vec<u8>>,
+        wait_full: bool,
+        deadline: Instant,
+    ) -> QueryOutcome {
+        let tier = Arc::clone(tier);
+        let req_id = req_id.to_string();
+        let join = self.runtime.spawn(async move {
+            match tier.query(&req_id, block_hashes, wait_full).await {
+                Ok(TierQuery::Miss) => QueryOutcome::Miss,
+                Ok(TierQuery::Loading) => QueryOutcome::Loading,
+                Ok(TierQuery::Hit(hit)) => QueryOutcome::Hit(LeaseGuard {
+                    tier,
+                    hit: Some(hit),
+                }),
+                Err(err) => QueryOutcome::Failed(err),
+            }
+        });
+        match tokio::time::timeout_at(deadline, join).await {
+            Err(_elapsed) => QueryOutcome::TimedOut,
+            Ok(Err(join_err)) => {
+                QueryOutcome::Failed(anyhow::anyhow!("tier query task failed: {join_err}"))
+            }
+            Ok(Ok(outcome)) => outcome,
+        }
     }
 
     /// The whole read path. Resolves `prompt_tokens`' cached prefix on
@@ -90,11 +172,17 @@ impl KvStore {
         // outside the reusable prefix.
         let cacheable_blocks = prompt_tokens.len().saturating_sub(1) / block_size;
 
-        let finish = |probe: PrefixProbe| {
+        let finish = |mut probe: PrefixProbe| {
             let hit_blocks = probe.held_blocks().min(cacheable_blocks);
             if hit_blocks == 0 {
                 return KvPrefix::none();
             }
+            // Credit/pin parity: admission credits the hold with exactly
+            // `hit_tokens / block_size` blocks, so the hold must pin exactly
+            // that many. A page-aligned full match holds one block past the
+            // cacheable cap; keeping it pinned would let a front at exact
+            // pool capacity wait forever on the very block its own hold pins.
+            probe.truncate_held(hit_blocks);
             self.stats.resolve_hits.fetch_add(1, Ordering::Relaxed);
             KvPrefix::resolved(hit_blocks * block_size, rank, Box::new(probe))
         };
@@ -122,29 +210,37 @@ impl KvStore {
         // prefill while degrading would buy a full recompute for the same
         // wait. The lease is released before every pause (host pins + TTL
         // must not ride out a pool wait; a re-query re-establishes it
-        // instantly from the host tier).
+        // instantly from the host tier). Each query runs detached (see
+        // `spawn_guarded_query`): a wait abandoned at the deadline leaves
+        // the settlement — and the release of a late hit's lease — to the
+        // detached task.
         let deadline = Instant::now() + self.resolve_deadline;
         let (hit, reservation) = loop {
             if cancel.is_cancelled() {
                 self.stats.record_degrade(req_id, DegradeReason::Cancelled);
                 return KvPrefix::none();
             }
-            let query = tokio::time::timeout_at(
-                deadline,
-                tier.query(req_id, host_hashes.clone(), policy.wait_for_full_hit),
-            );
-            match query.await {
-                Err(_elapsed) => {
+            let outcome = self
+                .guarded_query(
+                    tier,
+                    req_id,
+                    host_hashes.clone(),
+                    policy.wait_for_full_hit,
+                    deadline,
+                )
+                .await;
+            match outcome {
+                QueryOutcome::TimedOut => {
                     self.stats
                         .record_degrade(req_id, DegradeReason::DeadlineExceeded);
                     return finish(probe);
                 }
-                Ok(Err(err)) => {
+                QueryOutcome::Failed(err) => {
                     log::warn!("kv-store resolve {req_id}: tier query failed: {err:#}");
                     self.stats.record_degrade(req_id, DegradeReason::TierError);
                     return finish(probe);
                 }
-                Ok(Ok(TierQuery::Miss)) => {
+                QueryOutcome::Miss => {
                     // Plain restore: a miss is a cold cache, conclude. Full-
                     // hit mode: the producer's registration may not have
                     // landed yet — keep waiting under the deadline.
@@ -158,7 +254,7 @@ impl KvStore {
                     }
                     tokio::time::sleep(self.requery_interval).await;
                 }
-                Ok(Ok(TierQuery::Loading)) => {
+                QueryOutcome::Loading => {
                     if Instant::now() >= deadline {
                         self.stats
                             .record_degrade(req_id, DegradeReason::DeadlineExceeded);
@@ -166,14 +262,14 @@ impl KvStore {
                     }
                     tokio::time::sleep(self.requery_interval).await;
                 }
-                Ok(Ok(TierQuery::Hit(hit))) => {
+                QueryOutcome::Hit(guard) => {
                     // The lease is all-or-nothing, so a hit that doesn't fit
-                    // the pool right now is declined (release, not TTL-parked)
-                    // and retried after a pause.
-                    if let Some(reservation) = pool.reserve_loaded_blocks(hit.blocks) {
-                        break (hit, reservation);
+                    // the pool right now is declined (the guard's drop
+                    // releases, not TTL-parked) and retried after a pause.
+                    if let Some(reservation) = pool.reserve_loaded_blocks(guard.blocks()) {
+                        break (guard.take(), reservation);
                     }
-                    tier.release(hit);
+                    drop(guard);
                     if Instant::now() >= deadline {
                         self.stats
                             .record_degrade(req_id, DegradeReason::PoolPressure);
@@ -189,18 +285,15 @@ impl KvStore {
             return KvPrefix::none();
         }
 
-        // The DMA is an uncancellable section: the reservation must outlive
-        // the copy. A spawned task owns both the load future and the
-        // reservation, so the deadline below abandons only the *wait* — an
-        // abandoned reservation is dropped by the task once the tier settles,
-        // never while the DMA may still write into its blocks.
+        // The DMA is uncancellable: the tracked task owns the reservation
+        // until the tier settles; the deadline abandons only the wait.
         let loaded = hit.blocks;
         let page_ids = reservation.page_ids();
         let load = tier.load(hit, page_ids);
-        let join = self.runtime.spawn(async move {
+        let join = self.runtime.spawn(state.loads.track_future(async move {
             let result = load.await;
             (result, reservation)
-        });
+        }));
         match tokio::time::timeout_at(deadline, join).await {
             Ok(Ok((Ok(()), reservation))) => {
                 pool.commit_loaded_blocks(&mut probe, reservation);
@@ -342,6 +435,15 @@ impl KvStore {
         }
     }
 
+    /// Terminal barrier: resolves once every restore H2D on `rank` has
+    /// settled. Call before freeing the GPU arenas; bound with a caller-side
+    /// timeout (a hung tier never settles). Closes the rank's tracker.
+    pub async fn flush_loads(&self, rank: usize) {
+        let loads = &self.rank(rank).loads;
+        loads.close();
+        loads.wait().await;
+    }
+
     /// The rank table is frozen at build, so an unknown rank is a wiring
     /// bug — masking it (e.g. silently no-op'ing a Handoff seal) would
     /// violate the no-silent-drop contract. Fail fast instead.
@@ -366,3 +468,246 @@ const _: () = {
     const fn assert_send_sync<T: Send + Sync>() {}
     assert_send_sync::<KvStore>();
 };
+
+#[cfg(test)]
+mod tests {
+    use pegaflow_core::QueryLeaseId;
+    use tokio::sync::Notify;
+
+    use super::*;
+    use crate::BlockPool;
+    use crate::KvBlockGuard;
+    use crate::NeverCancelled;
+    use crate::tier::HostTier;
+    use crate::tier::LeasedBlocks;
+    use crate::tier::TierFuture;
+    use crate::tier::TierQuery;
+
+    /// A tier whose query always hits but whose load stalls until the test
+    /// fires `release_load` — the hung-storage-worker shape the load
+    /// deadline exists for.
+    struct StallLoadTier {
+        release_load: Arc<Notify>,
+    }
+
+    impl HostTier for StallLoadTier {
+        fn query(
+            &self,
+            _req_id: &str,
+            block_hashes: Vec<Vec<u8>>,
+            _wait_full: bool,
+        ) -> TierFuture<anyhow::Result<TierQuery>> {
+            let blocks = block_hashes.len();
+            Box::pin(std::future::ready(Ok(TierQuery::Hit(LeasedBlocks {
+                blocks,
+                lease: QueryLeaseId::fresh(),
+            }))))
+        }
+
+        fn load(
+            &self,
+            _hit: LeasedBlocks,
+            _dst_page_ids: Vec<i32>,
+        ) -> TierFuture<anyhow::Result<()>> {
+            let release = Arc::clone(&self.release_load);
+            Box::pin(async move {
+                release.notified().await;
+                Ok(())
+            })
+        }
+
+        fn release(&self, _hit: LeasedBlocks) {}
+
+        fn save(
+            &self,
+            _block_ids: Vec<i32>,
+            _block_hashes: Vec<Vec<u8>>,
+            _guards: Vec<KvBlockGuard>,
+        ) -> TierFuture<anyhow::Result<()>> {
+            Box::pin(std::future::ready(Ok(())))
+        }
+
+        fn flush(&self) -> TierFuture<anyhow::Result<()>> {
+            Box::pin(std::future::ready(Ok(())))
+        }
+    }
+
+    /// A tier whose query stalls until the test fires `release_query`, then
+    /// answers with a lease-carrying hit — the shape where the caller's
+    /// deadline passes while the tier still owes a settlement. `released`
+    /// counts every lease handed back.
+    struct StallQueryTier {
+        release_query: Arc<Notify>,
+        released: Arc<AtomicUsize>,
+    }
+
+    impl HostTier for StallQueryTier {
+        fn query(
+            &self,
+            _req_id: &str,
+            block_hashes: Vec<Vec<u8>>,
+            _wait_full: bool,
+        ) -> TierFuture<anyhow::Result<TierQuery>> {
+            let release = Arc::clone(&self.release_query);
+            let blocks = block_hashes.len();
+            Box::pin(async move {
+                release.notified().await;
+                Ok(TierQuery::Hit(LeasedBlocks {
+                    blocks,
+                    lease: QueryLeaseId::fresh(),
+                }))
+            })
+        }
+
+        fn load(
+            &self,
+            _hit: LeasedBlocks,
+            _dst_page_ids: Vec<i32>,
+        ) -> TierFuture<anyhow::Result<()>> {
+            Box::pin(std::future::ready(Ok(())))
+        }
+
+        fn release(&self, _hit: LeasedBlocks) {
+            self.released.fetch_add(1, Ordering::AcqRel);
+        }
+
+        fn save(
+            &self,
+            _block_ids: Vec<i32>,
+            _block_hashes: Vec<Vec<u8>>,
+            _guards: Vec<KvBlockGuard>,
+        ) -> TierFuture<anyhow::Result<()>> {
+            Box::pin(std::future::ready(Ok(())))
+        }
+
+        fn flush(&self) -> TierFuture<anyhow::Result<()>> {
+            Box::pin(std::future::ready(Ok(())))
+        }
+    }
+
+    fn tier_store_with_deadline(
+        runtime: tokio::runtime::Handle,
+        tier: Arc<dyn HostTier>,
+        resolve_deadline: Duration,
+    ) -> KvStore {
+        let mut ranks = HashMap::new();
+        ranks.insert(
+            0,
+            RankState {
+                pool: Arc::new(BlockPool::new(16, 8)),
+                tier: Some(tier),
+                pinned: Arc::new(AtomicUsize::new(0)),
+                loads: TaskTracker::new(),
+            },
+        );
+        KvStore {
+            runtime,
+            requery_interval: Duration::from_millis(1),
+            resolve_deadline,
+            ranks,
+            stats: Arc::new(KvStoreStats::default()),
+        }
+    }
+
+    fn tier_store(runtime: tokio::runtime::Handle, tier: Arc<dyn HostTier>) -> KvStore {
+        tier_store_with_deadline(runtime, tier, Duration::from_millis(50))
+    }
+
+    fn stalled_store(runtime: tokio::runtime::Handle, release_load: Arc<Notify>) -> KvStore {
+        tier_store(runtime, Arc::new(StallLoadTier { release_load }))
+    }
+
+    /// The plain-path query invariant: `resolve_prefix`'s
+    /// host query abandoned at the deadline leaves settlement to the
+    /// detached task, and a late hit's lease is released — a storage stall
+    /// never pins host blocks until the lease TTL.
+    #[test]
+    fn plain_query_timeout_releases_the_late_hits_lease() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime");
+        let release_query = Arc::new(Notify::new());
+        let released = Arc::new(AtomicUsize::new(0));
+        let store = tier_store(
+            rt.handle().clone(),
+            Arc::new(StallQueryTier {
+                release_query: Arc::clone(&release_query),
+                released: Arc::clone(&released),
+            }),
+        );
+
+        // One cacheable block past the (empty) GPU hit, so the plain resolve
+        // reaches the host-tier query.
+        let prompt: Vec<u32> = (0..17).collect();
+        let prefix = rt.block_on(store.resolve_prefix(
+            0,
+            "plain",
+            &prompt,
+            crate::CacheScope::default(),
+            crate::ResolvePolicy::default(),
+            &NeverCancelled,
+        ));
+        assert_eq!(prefix.hit_tokens(), 0, "a stalled query degrades to no hit");
+        assert_eq!(store.stats.resolve_degraded.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            released.load(Ordering::Acquire),
+            0,
+            "nothing to release while the query is unsettled"
+        );
+
+        release_query.notify_one();
+        rt.block_on(async {
+            tokio::time::timeout(Duration::from_secs(5), async {
+                while released.load(Ordering::Acquire) == 0 {
+                    tokio::time::sleep(Duration::from_millis(1)).await;
+                }
+            })
+            .await
+        })
+        .expect("the settled query releases the unconsumed lease");
+        assert_eq!(released.load(Ordering::Acquire), 1);
+    }
+
+    /// The plain-path load invariant: a stalled load abandons only the WAIT
+    /// at the deadline (the resolve degrades to no hit; the resolver task is
+    /// never wedged), while the detached task keeps owning the load — and
+    /// its destination reservation — until the tier settles, visible through
+    /// `loads_pending` and drained by `flush_loads`.
+    #[test]
+    fn plain_load_timeout_detaches_and_flush_loads_drains() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime");
+        let release_load = Arc::new(Notify::new());
+        let store = stalled_store(rt.handle().clone(), Arc::clone(&release_load));
+
+        // One cacheable block past the (empty) GPU hit, so the plain resolve
+        // reaches the tier: the query hits instantly, the load stalls.
+        let prompt: Vec<u32> = (0..17).collect();
+        let prefix = rt.block_on(store.resolve_prefix(
+            0,
+            "plain",
+            &prompt,
+            crate::CacheScope::default(),
+            crate::ResolvePolicy::default(),
+            &NeverCancelled,
+        ));
+        assert_eq!(prefix.hit_tokens(), 0, "a stalled load degrades to no hit");
+        assert_eq!(store.stats.resolve_degraded.load(Ordering::Relaxed), 1);
+        assert_eq!(store.stats.loads_abandoned.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            store.rank(0).loads.len(),
+            1,
+            "the detached task owns the load"
+        );
+
+        release_load.notify_one();
+        rt.block_on(async {
+            tokio::time::timeout(Duration::from_secs(5), store.flush_loads(0)).await
+        })
+        .expect("the load settles once the tier releases it");
+        assert_eq!(store.rank(0).loads.len(), 0, "flush_loads drained the load");
+    }
+}


### PR DESCRIPTION
## What

Design-first successor to #830 (now frozen as draft), produced from its eight review rounds / 18 findings. Three documents:

- **`subsystems/kv-cache/resolver-ownership.md`** (new): the post-mortem and the successor design.
  - Diagnosis: the plain resolve path conforms to `design.md`'s two-allocator model (authoritative admission vs zero-obligation resolve); the deviation was the **native P/D path making authoritative allocations inside the resolver** (RequestKv lifetime, keyed-tail install into a private page). The review-loop's HeadroomLedger is exactly the "second book" `design.md` warns against — the patch spiral was the architecture alarm.
  - Successor: native full pages restore **radix-first** (zero obligation, same path as plain, `wait_for_full_hit`); the **keyed tail is eliminated by pad-to-boundary** — block-granular saves already ship the full page slab, so padding costs zero wire bytes and buys radix identity, copy-on-restore at admission, and failure-before-slot semantics. The keyed API family (`seal_keyed`/`resolve_keyed_block`/`KeyedFetchError`/`KeyedLoadParking`) and the ledger family are deleted; lease-settlement, DMA parking for plain loads, hold/credit parity, and the orthogonal fixes (handoff rejection, teardown leak discipline) carry over.
  - Arbitration returns as `design.md`'s open item prescribed: pool-internal `async reserve_blocks` (waiters beside the single truth) + admission-side `prefetched_blocks` offset. No second book.
- **`subsystems/kv-cache/design.md`**: resolves two open items (tail save verb → pad-to-boundary; arbitration form confirmed by the #830 evidence).
- `index.md`: routing row.

## Why a docs PR first

The #830 experience: porting a serialized design to concurrent resolvers without re-deriving the capacity invariants cost eight review rounds of compensating patches. This PR locks the invariants before the implementation PR (built on main, not on #830's branch). #830's 20+ contract tests remain the acceptance suite — mechanisms change, assertions don't.

## Review focus

1. The pad-to-boundary decision (§2.2): pad-id + salt collision story, copy-on-restore covering the aligned-group family (mla + idxk + MTP L78), pre-admission failure semantics.
2. The keep/delete/reshape inventory (§3) — anything you'd keep that's marked delete?
3. Scheduler-side design intentionally deferred to the next discussion block (§待讨论).

🤖 Generated with [Claude Code](https://claude.com/claude-code)