### PR TITLE
fix(glm52): chunk FlashInfer sparse MLA over the batch — TP4 MTP proposal survives batches above 8

### DIFF
--- a/pegainfer-glm52/src/model/mod.rs
+++ b/pegainfer-glm52/src/model/mod.rs
@@ -34,6 +34,7 @@ use pegainfer_kernels::ops::GLM52_FLASHMLA_SPARSE_BYTES_PER_TOKEN;
 use pegainfer_kernels::ops::GLM52_FLASHMLA_SPARSE_PAGE_SIZE;
 use pegainfer_kernels::ops::GLM52_FLASHMLA_SPARSE_TOPK;
 use pegainfer_kernels::ops::GLM52_GEMV_MMA_SCRATCH_FLOATS_PER_ROW;
+use pegainfer_kernels::ops::GLM52_TP_TOKENS;
 use pegainfer_kernels::ops::Glm52FlashMlaSparseDecode;
 use pegainfer_kernels::ops::Glm52IndexerCacheLayout;
 use pegainfer_kernels::ops::embedding_rows_into;
@@ -1119,36 +1120,48 @@ impl Glm52RankModel {
             "GLM5.2 MTP boundary metadata count {boundary} != target outputs {}",
             output.target_tokens.len()
         );
-        let bucket = GLM52_DECODE_BUCKETS
-            .into_iter()
-            .find(|&bucket| bucket >= appends.len())
-            .context("GLM5.2 TP4 prefill proposal exceeds decode bucket capacity")?;
         mtp.reset_slots(&proposal_slots)?;
         mtp.resume_reset_slots(&proposal_slots, &appends)?;
-        let round = crate::runner::Glm52MtpRound {
-            source_bucket: bucket,
-            context_bucket: bucket,
-            draft_bucket: bucket,
-            resets: Vec::new(),
-            appends,
-            proposal_slots,
-        };
-        output.mtp_drafts = mtp.propose(
-            ctx,
-            aux,
-            None,
-            Some(tp),
-            &self.embed,
-            &self.lm_head,
-            &self.cos_table,
-            &self.sin_table,
-            executor.mtp_target_boundary(),
-            &round,
-            Some(mtp::Glm52MtpProposalSeed {
-                previous: executor.mtp_proposal_boundary(),
-                draft1: &output.mtp_draft1,
-            }),
-        )?;
+        // The proposal rounds run the decode-bucket machinery, whose TP MoE
+        // path bridges through the fixed GLM52_TP_TOKENS-row buffers — but
+        // one prefill batch can complete more boundaries than that. Split
+        // the batch into bridge-sized rounds; the surplus boundaries simply
+        // ride the later rounds. TP-safe: all four executors walk the same
+        // deterministic split, so their collective chains stay aligned.
+        let mut drafts = Vec::with_capacity(appends.len());
+        for start in (0..appends.len()).step_by(GLM52_TP_TOKENS) {
+            let end = appends.len().min(start + GLM52_TP_TOKENS);
+            let bucket = GLM52_DECODE_BUCKETS
+                .into_iter()
+                .find(|&bucket| bucket >= end - start)
+                .context("GLM5.2 TP4 prefill proposal exceeds decode bucket capacity")?;
+            let round = crate::runner::Glm52MtpRound {
+                source_bucket: bucket,
+                context_bucket: bucket,
+                draft_bucket: bucket,
+                resets: Vec::new(),
+                appends: appends[start..end].to_vec(),
+                proposal_slots: proposal_slots[start..end].to_vec(),
+            };
+            drafts.extend(mtp.propose(
+                ctx,
+                aux,
+                None,
+                Some(&mut *tp),
+                &self.embed,
+                &self.lm_head,
+                &self.cos_table,
+                &self.sin_table,
+                executor.mtp_target_boundary(),
+                &round,
+                Some(mtp::Glm52MtpProposalSeed {
+                    previous: executor.mtp_proposal_boundary(),
+                    draft1: &output.mtp_draft1[start..end],
+                    rows_before: start,
+                }),
+            )?);
+        }
+        output.mtp_drafts = drafts;
         ensure!(
             output
                 .mtp_drafts

--- a/pegainfer-glm52/src/model/mtp.rs
+++ b/pegainfer-glm52/src/model/mtp.rs
@@ -87,6 +87,11 @@ struct Glm52MtpBucket {
 pub(super) struct Glm52MtpProposalSeed<'a> {
     pub(super) previous: &'a Rows<GLM52_HIDDEN>,
     pub(super) draft1: &'a [u32],
+    /// Row in `previous` where this round's boundaries start. The TP4
+    /// prefill caller splits one prefill batch's boundaries into
+    /// `GLM52_TP_TOKENS`-row rounds, so a later round reads `previous`
+    /// at its own offset while `draft1` arrives pre-sliced.
+    pub(super) rows_before: usize,
 }
 
 fn mtp_cache_bytes(
@@ -611,7 +616,8 @@ impl Glm52NativeMtp {
         let context_tokens = match seed.as_ref() {
             Some(seed) => {
                 ensure!(
-                    seed.draft1.len() == appends.len() && seed.previous.tokens() >= appends.len(),
+                    seed.draft1.len() == appends.len()
+                        && seed.previous.tokens() >= seed.rows_before + appends.len(),
                     "GLM5.2 TP prefill MTP proposal seed shape mismatch"
                 );
                 seed.draft1.to_vec()
@@ -626,10 +632,12 @@ impl Glm52NativeMtp {
         let mut partial_backups = Vec::with_capacity(proposal_slots.len());
         for (packed, (&slot, &context_row)) in proposal_slots.iter().zip(&last_rows).enumerate() {
             let src_hidden = match seed.as_ref() {
-                Some(seed) => seed
-                    .previous
-                    .data()
-                    .slice(packed * GLM52_HIDDEN..(packed + 1) * GLM52_HIDDEN),
+                Some(seed) => {
+                    let row = seed.rows_before + packed;
+                    seed.previous
+                        .data()
+                        .slice(row * GLM52_HIDDEN..(row + 1) * GLM52_HIDDEN)
+                }
                 None => self.buckets[context_index]
                     .scratch
                     .final_normed

--- a/pegainfer-kernels/src/ops/glm52/flashinfer_sparse.rs
+++ b/pegainfer-kernels/src/ops/glm52/flashinfer_sparse.rs
@@ -24,12 +24,17 @@ pub struct Glm52FlashInferSparseDecode {
     pub sm_scale: f32,
 }
 
+/// Cubin-validated per-launch batch sizes, largest first. Bigger batches are
+/// decomposed greedily into these and issued as consecutive same-stream
+/// launches (rows are independent; the multi-CTA counters self-reset, so the
+/// shared workspace serializes safely).
+const GLM52_FLASHINFER_SPARSE_LAUNCH_BATCHES: [usize; 4] = [8, 4, 2, 1];
+
 impl Glm52FlashInferSparseDecode {
     fn validate(self) -> Result<()> {
         ensure!(
-            matches!(self.batch_size, 1 | 2 | 4 | 8),
-            "GLM5.2 FlashInfer sparse batch {} is not a decode bucket",
-            self.batch_size
+            self.batch_size >= 1,
+            "GLM5.2 FlashInfer sparse batch must be at least 1"
         );
         ensure!(
             self.heads == GLM52_FLASHINFER_SPARSE_HEADS,
@@ -127,27 +132,40 @@ pub fn glm52_flashinfer_sparse_mla_fp8_launch(
     let (seq_lens_ptr, _g3) = seq_lens.device_ptr(&ctx.stream);
     let (out_ptr, _g4) = out.device_ptr_mut(&ctx.stream);
     let (workspace_ptr, _g5) = workspace.device_ptr_mut(&ctx.stream);
-    let result = unsafe {
-        ffi::glm52_flashinfer_sparse_mla_fp8_cuda(
-            query_ptr as *const u8,
-            cache_ptr as *const u8,
-            indices_ptr as *const i32,
-            seq_lens_ptr as *const i32,
-            out_ptr as *mut ffi::Half,
-            workspace_ptr as *mut u8,
-            workspace_bytes,
-            contract.batch_size as i32,
-            contract.heads as i32,
-            contract.num_blocks as i32,
-            contract.topk as i32,
-            contract.sm_scale,
-            ctx.stream.cu_stream(),
-        )
-    };
-    ensure!(
-        result == 0,
-        "GLM5.2 FlashInfer sparse MLA launch failed with error {result}{}",
-        crate::ops::ffi_exception_message(result)
-    );
+    let mut start = 0usize;
+    while start < contract.batch_size {
+        let chunk = GLM52_FLASHINFER_SPARSE_LAUNCH_BATCHES
+            .into_iter()
+            .find(|&c| c <= contract.batch_size - start)
+            .expect("launch batches end at 1");
+        let query_off = start * contract.heads * GLM52_FLASHINFER_SPARSE_QK_HEAD_DIM;
+        let out_off = start * contract.heads * GLM52_FLASHINFER_SPARSE_V_HEAD_DIM;
+        let result = unsafe {
+            ffi::glm52_flashinfer_sparse_mla_fp8_cuda(
+                (query_ptr as usize + query_off) as *const u8,
+                cache_ptr as *const u8,
+                (indices_ptr as usize + start * contract.topk * size_of::<i32>()) as *const i32,
+                (seq_lens_ptr as usize + start * size_of::<i32>()) as *const i32,
+                (out_ptr as usize + out_off * size_of::<bf16>()) as *mut ffi::Half,
+                workspace_ptr as *mut u8,
+                workspace_bytes,
+                chunk as i32,
+                contract.heads as i32,
+                contract.num_blocks as i32,
+                contract.topk as i32,
+                contract.sm_scale,
+                ctx.stream.cu_stream(),
+            )
+        };
+        ensure!(
+            result == 0,
+            "GLM5.2 FlashInfer sparse MLA launch failed with error {result}{} \
+             (rows {start}..{} of {})",
+            crate::ops::ffi_exception_message(result),
+            start + chunk,
+            contract.batch_size
+        );
+        start += chunk;
+    }
     Ok(())
 }

--- a/pegainfer-kernels/tests/glm52_flashinfer_sparse_smoke.rs
+++ b/pegainfer-kernels/tests/glm52_flashinfer_sparse_smoke.rs
@@ -1,6 +1,6 @@
 //! Focused numerical gate for the GLM5.2 TP4 FlashInfer sparse MLA wrapper.
 //!
-//! Both cases keep the query exactly zero so softmax is uniform; the value
+//! Every case keeps the query exactly zero so softmax is uniform; the value
 //! cache then makes the expected output computable exactly:
 //! - uniform: every FP8 value element is one -> every output element is one.
 //! - paged ramp: page p holds value 2^(p % 4), pages balanced -> every output
@@ -26,7 +26,7 @@ fn glm52_flashinfer_sparse_fp8_uniform_value() {
     }
 
     for topk_size in [256usize, 2048] {
-        for batch_size in [1usize, 2, 4, 8] {
+        for batch_size in [1usize, 2, 4, 8, 16, 32] {
             let contract = Glm52FlashInferSparseDecode {
                 batch_size,
                 heads: 16,
@@ -102,7 +102,7 @@ fn glm52_flashinfer_sparse_fp8_paged_ramp_value() {
     }
 
     for topk_size in [256usize, 2048] {
-        for batch_size in [1usize, 2, 4, 8] {
+        for batch_size in [1usize, 2, 4, 8, 16, 32] {
             let contract = Glm52FlashInferSparseDecode {
                 batch_size,
                 heads: 16,
@@ -154,6 +154,97 @@ fn glm52_flashinfer_sparse_fp8_paged_ramp_value() {
             assert!(
                 max_error <= 0.04,
                 "batch {batch_size} topk {topk_size} max error {max_error} (expected {EXPECTED})"
+            );
+        }
+    }
+}
+
+#[test]
+fn glm52_flashinfer_sparse_fp8_chunked_batch_row_placement() {
+    // Batches above 8 are decomposed into consecutive {8, 4, 2, 1} launches.
+    // Give every row its own expected value — row r's top-k gathers only the
+    // pages of residue class r % 4, whose values cycle 1/2/4/8 — so a wrong
+    // per-chunk query/indices/seq_lens/output offset lands a value in the
+    // wrong row and fails loudly. 3 and 6 exercise remainder decomposition.
+    const PAGE_VALUES: [u8; 4] = [0x38, 0x40, 0x48, 0x50];
+    const EXPECTED: [f32; 4] = [1.0, 2.0, 4.0, 8.0];
+    const PAGE_TOKENS: usize = 64;
+    const NUM_BLOCKS: usize = 16;
+    const TOPK: usize = 256;
+
+    let Ok(ctx) = DeviceContext::new() else {
+        eprintln!("skip: no CUDA device");
+        return;
+    };
+    if !glm52_flashinfer_sparse_mla_supported(16).expect("query FlashInfer support") {
+        eprintln!("skip: GLM5.2 FlashInfer sparse MLA requires SM100/SM103");
+        return;
+    }
+
+    for batch_size in [3usize, 6, 16, 32] {
+        let contract = Glm52FlashInferSparseDecode {
+            batch_size,
+            heads: 16,
+            num_blocks: NUM_BLOCKS,
+            topk: TOPK,
+            sm_scale: 0.0625,
+        };
+        let query = ctx
+            .stream
+            .clone_htod(&vec![0x00u8; contract.query_len()])
+            .expect("query H2D");
+        let token_bytes = contract.cache_len() / (NUM_BLOCKS * PAGE_TOKENS);
+        let cache_host: Vec<u8> = (0..contract.cache_len())
+            .map(|byte| PAGE_VALUES[byte / (PAGE_TOKENS * token_bytes) % PAGE_VALUES.len()])
+            .collect();
+        let cache = ctx.stream.clone_htod(&cache_host).expect("cache H2D");
+        // Row r: the 4 pages p with p % 4 == r % 4, token-granular indices.
+        let topk_host: Vec<i32> = (0..batch_size)
+            .flat_map(|row| {
+                (0..NUM_BLOCKS / 4).flat_map(move |group| {
+                    let page = group * 4 + row % 4;
+                    (0..PAGE_TOKENS as i32).map(move |t| (page * PAGE_TOKENS) as i32 + t)
+                })
+            })
+            .collect();
+        assert_eq!(topk_host.len(), batch_size * TOPK);
+        let topk = ctx.stream.clone_htod(&topk_host).expect("topk H2D");
+        let seq_lens = ctx
+            .stream
+            .clone_htod(&vec![TOPK as i32; batch_size])
+            .expect("seq_lens H2D");
+        let mut out = ctx
+            .stream
+            .alloc_zeros(contract.output_len())
+            .expect("output alloc");
+        let mut workspace = ctx
+            .stream
+            .alloc_zeros::<u8>(GLM52_FLASHINFER_SPARSE_WORKSPACE_BYTES)
+            .expect("workspace alloc");
+
+        glm52_flashinfer_sparse_mla_fp8_launch(
+            &ctx,
+            contract,
+            &query,
+            &cache,
+            &topk,
+            &seq_lens,
+            &mut out,
+            &mut workspace,
+        )
+        .expect("FlashInfer sparse MLA launch");
+        let host = ctx.stream.clone_dtoh(&out).expect("output D2H");
+        ctx.sync().expect("CUDA sync");
+        let row_len = contract.output_len() / batch_size;
+        for (row, chunk) in host.chunks(row_len).enumerate() {
+            let expected = EXPECTED[row % 4];
+            let max_error = chunk
+                .iter()
+                .map(|value| (value.to_f32() - expected).abs())
+                .fold(0.0f32, f32::max);
+            assert!(
+                max_error <= 0.04 * expected,
+                "batch {batch_size} row {row} max error {max_error} (expected {expected})"
             );
         }
     }


### PR DESCRIPTION
## What

The TP4 attention backend (16 heads/rank → `FlashInferFp8`) launches sparse MLA through the trtllm-gen fmha cubins, whitelisted at batch {1,2,4,8} on both the Rust and C sides. But the TP4 prefill engine batches its MTP proposal round by *boundaries completing in one prefill batch*, capped only by `GLM52_DECODE_SLOTS` — at slots=32 it plans proposal rounds of 16/32 rows, and the round dies. Twice, as it turns out:

```
GLM5.2 FlashInfer sparse batch 16 is not a decode bucket          (attention whitelist)
copy_hidden_rows_raw_into token count 16 exceeds … 49152 capacity (fixed 8-row TP MoE bridge)
```

…and either panic is **engine-fatal** — the whole P engine exits. Found live: a 3P+EP8 agent-trace replay at concurrency 256 killed all three P engines ~30 s after the first prefill wave. The validated 2P1D config had only ever run c16 / 2P = 8 concurrent per node — exactly on the boundary — so this never fired before. The P side cannot simply drop MTP either: `--glm52-prefill-only` + KV offload hard-requires `--glm52-native-mtp`.

## Fix (two commits)

**1. `af391bf6` — kernel layer:** decompose the FlashInfer sparse launch greedily into {8,4,2,1} sub-launches with per-chunk row offsets, inside `glm52_fp8_launch`. Every sub-launch stays on the cubin-validated whitelist; no C/cubin changes. Rows are independent and the multi-CTA counters self-reset, so consecutive same-stream launches share the workspace safely.

**2. `6bd27545` — the actual guarantee:** split the TP4 prefill proposal round at the source. One prefill batch's boundaries now go through ≤`GLM52_TP_TOKENS`(=8)-row rounds; every bucket lands back inside the established eight-row contract (TP MoE bridge, attention whitelist) and surplus boundaries simply ride the later rounds. All four TP executors walk the same deterministic split, so their collective chains stay aligned — and the EP proposal path is untouched (the free-running fixed-chain discipline forbids load-dependent round counts there; this split is TP-prefill-local). The proposal seed gains `rows_before` so a later round reads the boundary hidden states at its own offset.

With (2) in place the production TP4 path never exceeds batch 8; (1) remains the kernel-layer contract fix — the wrapper is honest about arbitrary batch instead of hiding a whitelist that callers must telepathically know.

## Validation

- `glm52_flashinfer_sparse_smoke`: both existing value cases extended to batches 16/32, plus a new **chunked row-placement case** (batches 3/6/16/32) where every row has a distinct expected value — any per-chunk query/indices/seq_lens/output offset mistake lands a value in the wrong row and fails loudly. 3/3 pass on GB300 (sm_103).
- `pegainfer-glm52` lib tests: 113/113 pass.
- E2E: the failing 3P+EP8 replay (codex_swebenchpro_traces, conc 256, P at slots=32 with native MTP) pending on this build — will report on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
