### PR TITLE
feat(kernels): plain-w QK-norm and RoPE prep at head_dim 256

### DIFF
--- a/pegainfer-kernels/csrc/shared/elementwise.cu
+++ b/pegainfer-kernels/csrc/shared/elementwise.cu
@@ -273,6 +273,51 @@ __global__ void silu_mul_kernel(
 }
 
 // ============================================================================
+// GELU-tanh-mul from separate gate/up buffers: out = gelu_tanh(gate) * up
+// (Gemma 4 MLP, hidden_activation "gelu_pytorch_tanh" — the tanh
+// approximation, not erf). Matches the HF op sequence rounding: act_fn(gate)
+// materializes a bf16 tensor before the elementwise multiply, so the
+// activation is computed in f32, cast to bf16, then multiplied in f32 and
+// rounded once more.
+// ============================================================================
+
+__global__ void gelu_tanh_mul_kernel(
+    const __nv_bfloat16 *__restrict__ gate,
+    const __nv_bfloat16 *__restrict__ up,
+    __nv_bfloat16 *__restrict__ out,
+    int n) {
+  // sqrt(2/pi), the gelu_pytorch_tanh constant.
+  const float kSqrt2OverPi = 0.7978845608028654f;
+  for (int idx = blockIdx.x * blockDim.x + threadIdx.x;
+       idx < n;
+       idx += gridDim.x * blockDim.x) {
+    float g = __bfloat162float(gate[idx]);
+    float u = __bfloat162float(up[idx]);
+    float inner = kSqrt2OverPi * (g + 0.044715f * g * g * g);
+    float gelu_g = 0.5f * g * (1.0f + tanhf(inner));
+    out[idx] = __float2bfloat16(__bfloat162float(__float2bfloat16(gelu_g)) * u);
+  }
+}
+
+// ============================================================================
+// In-place multiply by a host scalar: buf[i] = bf16(f32(buf[i]) * scale).
+// Serves Gemma 4's per-layer layer_scalar, a [1] weight the model reads to
+// the host at load; f32 compute with a single rounding matches HF's bf16
+// elementwise multiply.
+// ============================================================================
+
+__global__ void scale_bf16_kernel(
+    __nv_bfloat16 *__restrict__ buf,
+    float scale,
+    int n) {
+  for (int idx = blockIdx.x * blockDim.x + threadIdx.x;
+       idx < n;
+       idx += gridDim.x * blockDim.x) {
+    buf[idx] = __float2bfloat16(__bfloat162float(buf[idx]) * scale);
+  }
+}
+
+// ============================================================================
 // Embedding lookup: out = embed[token_id, :]
 // Reads token_id from token_id[0] (CUDA Graph safe).
 // ============================================================================
@@ -646,6 +691,23 @@ CUresult silu_mul_triton_aot_cuda(
   int block = 256;
   int grid = (n + block - 1) / block;
   silu_mul_kernel<<<grid, block, 0, stream>>>(gate, up, out, n);
+  return (CUresult)cudaGetLastError();
+}
+
+CUresult gelu_tanh_mul_cuda(
+    const __nv_bfloat16 *gate, const __nv_bfloat16 *up,
+    __nv_bfloat16 *out, int n, cudaStream_t stream) {
+  int block = 256;
+  int grid = n / block + (n % block != 0);
+  gelu_tanh_mul_kernel<<<grid, block, 0, stream>>>(gate, up, out, n);
+  return (CUresult)cudaGetLastError();
+}
+
+CUresult scale_bf16_in_place_cuda(
+    __nv_bfloat16 *buf, float scale, int n, cudaStream_t stream) {
+  int block = 256;
+  int grid = n / block + (n % block != 0);
+  scale_bf16_kernel<<<grid, block, 0, stream>>>(buf, scale, n);
   return (CUresult)cudaGetLastError();
 }
 

--- a/pegainfer-kernels/csrc/shared/prefill_attention_hd256_plain.cu
+++ b/pegainfer-kernels/csrc/shared/prefill_attention_hd256_plain.cu
@@ -1,0 +1,208 @@
+// QK-norm + RoPE prep at head_dim 256 with the plain-w norm (Gemma 4 local
+// layers). The hd256 sibling under csrc/qwen35/ is not this kernel: it
+// computes the 1+w offset norm, assumes a gated Q layout twice as wide, and
+// writes K into a paged pool. All three are qwen35's choices, not the
+// family's; Gemma 4 multiplies by the plain weight and ships no gate. Q and
+// K land in contiguous token-major buffers; the attention entry's cache
+// layout (single_prefill reads HND) stays the caller's concern.
+//
+// rotary_dim is a runtime argument, checked at the launcher for positive,
+// even and <= HD256. Gemma 4 local layers rotate the full head (256); at
+// that width the pass-through tail is empty. Evenness is load-bearing: with
+// half_rotary floored, an odd value leaves index rotary_dim - 1 written by
+// neither branch.
+//
+// Positions derive from host-known start_pos, so the launcher rejects any
+// out-of-range window before launch; the device trap before the cos read is
+// a second layer, not the contract.
+
+#include "common.cuh"
+#include "ffi_guard.cuh"
+
+#define HD256_PLAIN 256
+#define THREADS_HD256_PLAIN 256
+#define NUM_WARPS_HD256_PLAIN (THREADS_HD256_PLAIN / WARP_SIZE)
+
+__device__ __forceinline__ __nv_bfloat16 rms_norm_elem_hd256_plain(
+    __nv_bfloat16 x, float rms_inv, __nv_bfloat16 weight) {
+    float w = __bfloat162float(weight);
+    return __float2bfloat16(__bfloat162float(x) * rms_inv * w);
+}
+
+__device__ __forceinline__ void apply_rope_pair_hd256_plain(
+    __nv_bfloat16& x0, __nv_bfloat16& x1,
+    __nv_bfloat16 cos_val, __nv_bfloat16 sin_val) {
+    float fx0 = __bfloat162float(x0);
+    float fx1 = __bfloat162float(x1);
+    float fc = __bfloat162float(cos_val);
+    float fs = __bfloat162float(sin_val);
+    x0 = __float2bfloat16(fx0 * fc - fx1 * fs);
+    x1 = __float2bfloat16(fx0 * fs + fx1 * fc);
+}
+
+__global__ void qk_norm_rope_prefill_hd256_plain_kernel(
+    const __nv_bfloat16* __restrict__ q_batch,      // [q_dim, seq_len]
+    const __nv_bfloat16* __restrict__ k_batch,      // [kv_dim, seq_len]
+    const __nv_bfloat16* __restrict__ q_norm_weight, // [HD256_PLAIN]
+    const __nv_bfloat16* __restrict__ k_norm_weight, // [HD256_PLAIN]
+    const __nv_bfloat16* __restrict__ cos_cache,    // [max_seq * rotary_dim]
+    const __nv_bfloat16* __restrict__ sin_cache,
+    __nv_bfloat16* __restrict__ q_batch_out,        // [q_dim, seq_len]
+    __nv_bfloat16* __restrict__ k_batch_out,        // [kv_dim, seq_len]
+    int num_q_heads,
+    int num_kv_heads,
+    int start_pos,                                  // host base position
+    int cos_max_pos,                                // rows in cos/sin tables
+    int rotary_dim,
+    float rms_eps
+) {
+    // seq_len is mapped onto grid.x (limit ~2^31) and the head index onto
+    // grid.y so prompts longer than the 65535 grid.y limit still launch.
+    int token = blockIdx.x;
+    int head_global = blockIdx.y;
+    int d = threadIdx.x;
+
+    bool is_q = head_global < num_q_heads;
+    int head_local = is_q ? head_global : (head_global - num_q_heads);
+    int q_dim = num_q_heads * HD256_PLAIN;
+    int kv_dim = num_kv_heads * HD256_PLAIN;
+
+    int src_offset = is_q
+        ? token * q_dim + head_local * HD256_PLAIN + d
+        : token * kv_dim + head_local * HD256_PLAIN + d;
+    __nv_bfloat16 x = is_q ? q_batch[src_offset] : k_batch[src_offset];
+    const __nv_bfloat16* norm_w = is_q ? q_norm_weight : k_norm_weight;
+
+    float sq = __bfloat162float(x);
+    sq *= sq;
+    float sq_sum = warp_reduce_sum(sq);
+
+    int warp_id = d / WARP_SIZE;
+    int lane_id = d % WARP_SIZE;
+    __shared__ float warp_sums[NUM_WARPS_HD256_PLAIN];
+    __shared__ float inv_rms;
+    __shared__ __nv_bfloat16 smem[HD256_PLAIN];
+
+    if (lane_id == 0) warp_sums[warp_id] = sq_sum;
+    __syncthreads();
+
+    if (d == 0) {
+        float total = 0.0f;
+        for (int i = 0; i < NUM_WARPS_HD256_PLAIN; i++) total += warp_sums[i];
+        inv_rms = 1.0f / sqrtf(total / HD256_PLAIN + rms_eps);
+    }
+    __syncthreads();
+
+    smem[d] = rms_norm_elem_hd256_plain(x, inv_rms, norm_w[d]);
+    __syncthreads();
+
+    int pos = start_pos + token;
+    // Reject before reading the cos/sin tables.
+    if (pos < 0 || pos >= cos_max_pos) __trap();
+    int half_rotary = rotary_dim / 2;
+
+    if (d < half_rotary) {
+        __nv_bfloat16 lo = smem[d];
+        __nv_bfloat16 hi = smem[d + half_rotary];
+        apply_rope_pair_hd256_plain(
+            lo,
+            hi,
+            cos_cache[pos * rotary_dim + d],
+            sin_cache[pos * rotary_dim + d]
+        );
+
+        if (is_q) {
+            int dst = token * q_dim + head_local * HD256_PLAIN;
+            q_batch_out[dst + d] = lo;
+            q_batch_out[dst + d + half_rotary] = hi;
+        } else {
+            int dst = token * kv_dim + head_local * HD256_PLAIN;
+            k_batch_out[dst + d] = lo;
+            k_batch_out[dst + d + half_rotary] = hi;
+        }
+    }
+
+    if (d >= rotary_dim) {
+        if (is_q) {
+            int dst = token * q_dim + head_local * HD256_PLAIN;
+            q_batch_out[dst + d] = smem[d];
+        } else {
+            int dst = token * kv_dim + head_local * HD256_PLAIN;
+            k_batch_out[dst + d] = smem[d];
+        }
+    }
+}
+
+extern "C" {
+
+int qk_norm_rope_prefill_hd256_plain_cuda(
+    const __nv_bfloat16* q_batch,
+    const __nv_bfloat16* k_batch,
+    const __nv_bfloat16* q_norm_weight,
+    const __nv_bfloat16* k_norm_weight,
+    const __nv_bfloat16* cos_cache,
+    const __nv_bfloat16* sin_cache,
+    __nv_bfloat16* q_batch_out,
+    __nv_bfloat16* k_batch_out,
+    int num_q_heads,
+    int num_kv_heads,
+    int seq_len,
+    int start_pos,
+    int cos_max_pos,
+    int rotary_dim,
+    float rms_eps,
+    cudaStream_t stream
+) {
+    PEGAINFER_FFI_GUARD_BEGIN
+    if (rotary_dim <= 0 || (rotary_dim & 1) != 0 || rotary_dim > HD256_PLAIN) {
+        pegainfer_ffi_set_last_error(
+            "qk_norm_rope_prefill_hd256_plain_cuda: rotary_dim must be "
+            "positive, even and <= 256");
+        return -1;
+    }
+    if (q_batch == nullptr || k_batch == nullptr || q_norm_weight == nullptr ||
+        k_norm_weight == nullptr || cos_cache == nullptr || sin_cache == nullptr ||
+        q_batch_out == nullptr || k_batch_out == nullptr) {
+        pegainfer_ffi_set_last_error(
+            "qk_norm_rope_prefill_hd256_plain_cuda: null pointer argument");
+        return -1;
+    }
+    if (num_q_heads <= 0 || num_kv_heads <= 0 || seq_len <= 0) {
+        pegainfer_ffi_set_last_error(
+            "qk_norm_rope_prefill_hd256_plain_cuda: num_q_heads, num_kv_heads "
+            "and seq_len must be positive");
+        return -1;
+    }
+    if (start_pos < 0 || start_pos + seq_len > cos_max_pos) {
+        pegainfer_ffi_set_last_error(
+            "qk_norm_rope_prefill_hd256_plain_cuda: start_pos + seq_len must "
+            "be <= cos_max_pos");
+        return -1;
+    }
+    dim3 prep_grid(seq_len, num_q_heads + num_kv_heads);
+    qk_norm_rope_prefill_hd256_plain_kernel<<<prep_grid, THREADS_HD256_PLAIN, 0, stream>>>(
+        q_batch,
+        k_batch,
+        q_norm_weight,
+        k_norm_weight,
+        cos_cache,
+        sin_cache,
+        q_batch_out,
+        k_batch_out,
+        num_q_heads,
+        num_kv_heads,
+        start_pos,
+        cos_max_pos,
+        rotary_dim,
+        rms_eps
+    );
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        pegainfer_ffi_set_last_error(cudaGetErrorString(err));
+        return -1;
+    }
+    return 0;
+    PEGAINFER_FFI_GUARD_END(-1)
+}
+
+} // extern "C"

--- a/pegainfer-kernels/src/ffi/shared.rs
+++ b/pegainfer-kernels/src/ffi/shared.rs
@@ -124,6 +124,21 @@ unsafe extern "C" {
         stream: CUstream,
     ) -> CUresult;
 
+    pub fn gelu_tanh_mul_cuda(
+        gate: *const Half,
+        up: *const Half,
+        out: *mut Half,
+        n: i32,
+        stream: CUstream,
+    ) -> CUresult;
+
+    pub fn scale_bf16_in_place_cuda(
+        buf: *mut Half,
+        scale: f32,
+        n: i32,
+        stream: CUstream,
+    ) -> CUresult;
+
     pub fn embedding_batched_cuda(
         embed: *const Half,
         token_ids: *const u32,
@@ -906,6 +921,25 @@ unsafe extern "C" {
 
 }
 
+// hd256 single prefill (qwen35 full-attention layers, Gemma 4 local layers):
+// csrc/shared/paged_attention.cu. K/V are a contiguous HND cache —
+// k[head, pos, dim] with max_seq_len rows per head — not token-major NHD.
+unsafe extern "C" {
+    pub fn single_prefill_cuda_hd256(
+        q: *const Half,
+        output: *mut Half,
+        k_cache: *const Half,
+        v_cache: *const Half,
+        num_qo_heads: i32,
+        num_kv_heads: i32,
+        seq_len: i32,
+        kv_len: i32,
+        max_seq_len: i32,
+        sm_scale: f32,
+        stream: CUstream,
+    ) -> i32;
+}
+
 // hd512 (Gemma 4 global layers): csrc/shared/paged_attention_hd512.cu
 unsafe extern "C" {
     pub fn single_prefill_cuda_hd512(
@@ -968,6 +1002,33 @@ unsafe extern "C" {
         padded_batch_size: i32,
         stride_page: i64,
         sm_scale: f32,
+        stream: CUstream,
+    ) -> i32;
+}
+
+// hd256 plain-w QK-norm + RoPE prep (Gemma 4 local layers):
+// csrc/shared/prefill_attention_hd256_plain.cu. Contract and validation live
+// on the Rust wrapper in ops::attention; the entry returns 0 on success, -1
+// with a diagnostic on failure.
+unsafe extern "C" {
+    // Q and K both land in contiguous buffers shaped like their inputs; there
+    // is no paged pool because no Gemma 4 KV cache consumer exists yet.
+    pub fn qk_norm_rope_prefill_hd256_plain_cuda(
+        q_batch: *const Half,
+        k_batch: *const Half,
+        q_norm_weight: *const Half,
+        k_norm_weight: *const Half,
+        cos_cache: *const Half,
+        sin_cache: *const Half,
+        q_batch_out: *mut Half,
+        k_batch_out: *mut Half,
+        num_q_heads: i32,
+        num_kv_heads: i32,
+        seq_len: i32,
+        start_pos: i32,
+        cos_max_pos: i32,
+        rotary_dim: i32,
+        rms_eps: f32,
         stream: CUstream,
     ) -> i32;
 }

--- a/pegainfer-kernels/src/ops.rs
+++ b/pegainfer-kernels/src/ops.rs
@@ -31,7 +31,9 @@ pub use attention::paged_attention_batch_decode_via_prefill_hd512_into;
 pub use attention::prefill_attention_paged_into;
 pub use attention::qk_norm_partial_rope_batched_decode_hd256_into;
 pub use attention::qk_norm_rope_batch_decode_into;
+pub use attention::qk_norm_rope_prefill_hd256_plain_into;
 pub use attention::single_decode_nhd_into;
+pub use attention::single_prefill_hd256_into;
 pub use attention::single_prefill_hd512_into;
 pub use attention::single_prefill_nhd_causal_into;
 pub use attention::single_prefill_nhd_noncausal_into;
@@ -84,8 +86,10 @@ pub use elementwise::extract_vec_ref;
 pub use elementwise::extract_vec_ref_into;
 pub use elementwise::f32_to_bf16_hidden_into;
 pub use elementwise::gather_hidden_tokens_into;
+pub use elementwise::gelu_tanh_mul_batch_into;
 pub use elementwise::mask_position_zero_rows_into;
 pub use elementwise::repeat_f32_for_reduce_scatter_into;
+pub use elementwise::scale_bf16_in_place;
 pub use elementwise::scale_f32_in_place;
 pub use elementwise::scaled_add_batch_into;
 pub use elementwise::scaled_add_rows_indexed_into;
@@ -159,6 +163,10 @@ pub use sampling::gpu_sample_batch_into;
 pub use sampling::logprob_topk_batch_bf16_into;
 pub use sampling::markov_step_argmax_into;
 pub use sampling::markov_step_argmax_partials_len;
+
+pub(crate) fn checked_i32(value: usize, what: &str) -> anyhow::Result<i32> {
+    i32::try_from(value).map_err(|_| anyhow::anyhow!("{what} {value} does not fit i32"))
+}
 
 /// Calling thread's last FFI exception message, ready to append to an error;
 /// empty unless `result` is the -1 sentinel set by the C++ guard. Public for

--- a/pegainfer-kernels/src/ops/attention.rs
+++ b/pegainfer-kernels/src/ops/attention.rs
@@ -753,27 +753,6 @@ pub fn dflash_qk_norm_rope_into(
     Ok(())
 }
 
-/// Require a capacity-backed `HiddenStates` to physically hold its logical
-/// `hidden_dim * seq_len` extent. Every `HiddenStates` field is public, so a safe
-/// caller can inflate `.seq_len` past the backing allocation; this rejects that
-/// before it reaches the kernel as an out-of-bounds read. `>=` (not `==`) keeps
-/// the capacity-backed convention where buffers are allocated at a max and
-/// `.seq_len` is rewritten to the active size per step (e.g. `batch_decode_buffers`).
-fn ensure_hidden_capacity(t: &HiddenStates, name: &str) -> Result<()> {
-    let extent = t
-        .hidden_dim
-        .checked_mul(t.seq_len)
-        .ok_or_else(|| anyhow::anyhow!("{name} logical extent overflow"))?;
-    anyhow::ensure!(
-        t.data.len() >= extent,
-        "{name} backing len {} < hidden_dim {} * seq_len {}",
-        t.data.len(),
-        t.hidden_dim,
-        t.seq_len
-    );
-    Ok(())
-}
-
 /// Validate a `[offset, offset + span)` row window into `t` and return the byte
 /// offset of `offset`, all with checked arithmetic. Release builds leave
 /// `overflow-checks` off, so an adversarial `offset` (e.g. `usize::MAX`) would
@@ -788,12 +767,24 @@ fn checked_row_offset(t: &HiddenStates, offset: usize, span: usize, name: &str) 
         "{name} row range [{offset}..{end}) exceeds seq_len {}",
         t.seq_len
     );
-    ensure_hidden_capacity(t, name)?;
+    t.checked_extent(name)?;
     let bytes = offset
         .checked_mul(t.hidden_dim)
         .and_then(|elems| elems.checked_mul(std::mem::size_of::<bf16>()))
         .ok_or_else(|| anyhow::anyhow!("{name} byte offset overflow"))?;
     Ok(bytes as u64)
+}
+
+/// `DeviceVec` fields are public too: reject a logical `len` past the backing
+/// allocation before a kernel indexes through it.
+fn ensure_vec_backed(v: &DeviceVec, name: &str) -> Result<()> {
+    anyhow::ensure!(
+        v.data.len() >= v.len,
+        "{name} backing len {} < len {}",
+        v.data.len(),
+        v.len
+    );
+    Ok(())
 }
 
 /// Plain RoPE (no QK-norm) for one EAGLE-3 draft step, because EAGLE-3 has no per-head q/k norm
@@ -818,7 +809,7 @@ pub fn eagle3_rope_into(
     // `q`/`k` are capacity-backed and reachable from safe re-exported code;
     // validate the row window and backing length before deriving raw pointers.
     let q_byte_offset = checked_row_offset(q, q_row_offset, q_seq_len, "eagle3_rope q")?;
-    ensure_hidden_capacity(k, "eagle3_rope k")?;
+    k.checked_extent("eagle3_rope k")?;
     // The kernel indexes both caches with the same `pos * head_dim + d`, and
     // `cos_max_pos` is derived from `cos_cache` alone; a shorter `sin_cache`
     // would let the kernel read out of bounds.
@@ -972,10 +963,10 @@ pub fn single_decode_nhd_into(
     // Shape asserts only relate the public metadata; validate it against the
     // backing allocations too, since safe callers can inflate `.seq_len` past a
     // small buffer (all `HiddenStates` fields are public).
-    ensure_hidden_capacity(q, "single_decode q")?;
-    ensure_hidden_capacity(k_cache, "single_decode k_cache")?;
-    ensure_hidden_capacity(v_cache, "single_decode v_cache")?;
-    ensure_hidden_capacity(output, "single_decode output")?;
+    q.checked_extent("single_decode q")?;
+    k_cache.checked_extent("single_decode k_cache")?;
+    v_cache.checked_extent("single_decode v_cache")?;
+    output.checked_extent("single_decode output")?;
 
     let (q_ptr, _gq) = q.data.device_ptr(&ctx.stream);
     let (k_ptr, _gk) = k_cache.data.device_ptr(&ctx.stream);
@@ -1035,9 +1026,9 @@ pub fn single_prefill_nhd_causal_into(
     // Validate the row window with checked arithmetic and every backing
     // allocation before deriving pointers; `q`/`output` share the row sub-range.
     let byte_offset = checked_row_offset(q, row_offset, q_seq_len, "single_prefill_causal q")?;
-    ensure_hidden_capacity(output, "single_prefill_causal output")?;
-    ensure_hidden_capacity(k_cache, "single_prefill_causal k_cache")?;
-    ensure_hidden_capacity(v_cache, "single_prefill_causal v_cache")?;
+    output.checked_extent("single_prefill_causal output")?;
+    k_cache.checked_extent("single_prefill_causal k_cache")?;
+    v_cache.checked_extent("single_prefill_causal v_cache")?;
     let (q_ptr, _gq) = q.data.device_ptr(&ctx.stream);
     let q_ptr = q_ptr + byte_offset;
     let (k_ptr, _gk) = k_cache.data.device_ptr(&ctx.stream);
@@ -1792,10 +1783,10 @@ pub fn paged_attention_batch_decode_hd512_into(
         "hd512 decode layer {layer} >= layout.num_layers {}",
         layout.num_layers
     );
-    ensure_hidden_capacity(q, "batch_decode_hd512 q")?;
-    ensure_hidden_capacity(output, "batch_decode_hd512 output")?;
-    ensure_hidden_capacity(k, "batch_decode_hd512 k")?;
-    ensure_hidden_capacity(v, "batch_decode_hd512 v")?;
+    q.checked_extent("batch_decode_hd512 q")?;
+    output.checked_extent("batch_decode_hd512 output")?;
+    k.checked_extent("batch_decode_hd512 k")?;
+    v.checked_extent("batch_decode_hd512 v")?;
     let page_size = layout.page_size;
 
     let k_offset = (layer * layout.layer_stride) as i64;
@@ -1914,8 +1905,8 @@ pub fn paged_attention_batch_decode_via_prefill_hd512_into(
         "hd512 decode-via-prefill layer {layer} >= layout.num_layers {}",
         layout.num_layers
     );
-    ensure_hidden_capacity(q, "decode_via_prefill_hd512 q")?;
-    ensure_hidden_capacity(output, "decode_via_prefill_hd512 output")?;
+    q.checked_extent("decode_via_prefill_hd512 q")?;
+    output.checked_extent("decode_via_prefill_hd512 output")?;
     anyhow::ensure!(
         positions_d.len() >= plan.batch_size() as usize,
         "hd512 decode-via-prefill positions_d length {} must be >= plan.batch_size {}",
@@ -1947,8 +1938,8 @@ pub fn paged_attention_batch_decode_via_prefill_hd512_into(
         v.seq_len,
         batch_size
     );
-    ensure_hidden_capacity(k, "decode_via_prefill_hd512 k")?;
-    ensure_hidden_capacity(v, "decode_via_prefill_hd512 v")?;
+    k.checked_extent("decode_via_prefill_hd512 k")?;
+    v.checked_extent("decode_via_prefill_hd512 v")?;
     anyhow::ensure!(
         plan.head_dim == 512,
         "plan built for head_dim {}, expected 512",
@@ -2117,8 +2108,8 @@ pub fn batch_prefill_paged_hd512_into(
         "hd512 prefill layer {layer} >= layout.num_layers {}",
         layout.num_layers
     );
-    ensure_hidden_capacity(q, "batch_prefill_paged_hd512 q")?;
-    ensure_hidden_capacity(output, "batch_prefill_paged_hd512 output")?;
+    q.checked_extent("batch_prefill_paged_hd512 q")?;
+    output.checked_extent("batch_prefill_paged_hd512 output")?;
     anyhow::ensure!(
         plan.head_dim == 512,
         "plan built for head_dim {}, expected 512",
@@ -2241,9 +2232,9 @@ pub fn single_prefill_hd512_into(
         "causal prefill q_seq_len {q_seq_len} exceeds kv_len {kv_len}"
     );
     let byte_offset = checked_row_offset(q, row_offset, q_seq_len, "single_prefill_hd512 q")?;
-    ensure_hidden_capacity(output, "single_prefill_hd512 output")?;
-    ensure_hidden_capacity(k_cache, "single_prefill_hd512 k_cache")?;
-    ensure_hidden_capacity(v_cache, "single_prefill_hd512 v_cache")?;
+    output.checked_extent("single_prefill_hd512 output")?;
+    k_cache.checked_extent("single_prefill_hd512 k_cache")?;
+    v_cache.checked_extent("single_prefill_hd512 v_cache")?;
     let (q_ptr, _gq) = q.data.device_ptr(&ctx.stream);
     let q_ptr = q_ptr + byte_offset;
     let (k_ptr, _gk) = k_cache.data.device_ptr(&ctx.stream);
@@ -2268,6 +2259,302 @@ pub fn single_prefill_hd512_into(
     if result != 0 {
         anyhow::bail!(
             "single_prefill_cuda_hd512 failed with error {result}{}",
+            crate::ops::ffi_exception_message(result)
+        );
+    }
+    Ok(())
+}
+
+/// Plain-w QK RMSNorm + RoPE prep at head_dim 256 (Gemma 4 local layers):
+/// Q and K each land in a contiguous token-major output shaped like its
+/// input. No gate, no V, and the plain weight multiply — not the (1+w)
+/// offset of the qwen35 hd256 sibling. `single_prefill` consumes a
+/// contiguous **HND** cache, so these outputs are reassembled per head
+/// before attention, not fed directly. `rotary_dim` must be positive, even
+/// and <= 256 (launcher-enforced, surfaced here as `Err`); Gemma 4 local
+/// layers pass 256, and a smaller even width keeps the hd512 sibling's
+/// partial-RoPE tail semantics.
+#[allow(clippy::too_many_arguments)]
+pub fn qk_norm_rope_prefill_hd256_plain_into(
+    ctx: &DeviceContext,
+    q: &HiddenStates,
+    k: &HiddenStates,
+    q_out: &mut HiddenStates,
+    k_out: &mut HiddenStates,
+    q_norm_weight: &DeviceVec,
+    k_norm_weight: &DeviceVec,
+    cos_cache: &DeviceVec,
+    sin_cache: &DeviceVec,
+    start_pos: usize,
+    cos_max_pos: usize,
+    num_q_heads: usize,
+    num_kv_heads: usize,
+    rotary_dim: usize,
+    rms_eps: f32,
+) -> Result<()> {
+    let seq_len = q.seq_len;
+    let q_dim = num_q_heads
+        .checked_mul(256)
+        .ok_or_else(|| anyhow::anyhow!("hd256 plain prep num_q_heads {num_q_heads} overflows"))?;
+    let kv_dim = num_kv_heads
+        .checked_mul(256)
+        .ok_or_else(|| anyhow::anyhow!("hd256 plain prep num_kv_heads {num_kv_heads} overflows"))?;
+    anyhow::ensure!(
+        q.hidden_dim == q_dim,
+        "hd256 plain prep q.hidden_dim {} != num_q_heads {} * 256",
+        q.hidden_dim,
+        num_q_heads
+    );
+    anyhow::ensure!(
+        k.hidden_dim == kv_dim,
+        "hd256 plain prep k.hidden_dim {} != num_kv_heads {} * 256",
+        k.hidden_dim,
+        num_kv_heads
+    );
+    anyhow::ensure!(
+        q_out.hidden_dim == q.hidden_dim,
+        "hd256 plain prep q_out.hidden_dim {} != q.hidden_dim {}",
+        q_out.hidden_dim,
+        q.hidden_dim
+    );
+    anyhow::ensure!(
+        k_out.hidden_dim == k.hidden_dim,
+        "hd256 plain prep k_out.hidden_dim {} != k.hidden_dim {}",
+        k_out.hidden_dim,
+        k.hidden_dim
+    );
+    anyhow::ensure!(
+        k.seq_len == seq_len,
+        "hd256 plain prep k.seq_len {} != q.seq_len {seq_len}",
+        k.seq_len
+    );
+    anyhow::ensure!(
+        q_out.seq_len == seq_len,
+        "hd256 plain prep q_out.seq_len {} != q.seq_len {seq_len}",
+        q_out.seq_len
+    );
+    anyhow::ensure!(
+        k_out.seq_len == seq_len,
+        "hd256 plain prep k_out.seq_len {} != q.seq_len {seq_len}",
+        k_out.seq_len
+    );
+    anyhow::ensure!(
+        q_norm_weight.len == 256,
+        "hd256 plain prep q_norm_weight len {} != 256",
+        q_norm_weight.len
+    );
+    anyhow::ensure!(
+        k_norm_weight.len == 256,
+        "hd256 plain prep k_norm_weight len {} != 256",
+        k_norm_weight.len
+    );
+    let end_pos = start_pos.checked_add(seq_len).ok_or_else(|| {
+        anyhow::anyhow!("hd256 plain prep start_pos {start_pos} + seq_len {seq_len} overflows")
+    })?;
+    anyhow::ensure!(
+        end_pos <= cos_max_pos,
+        "hd256 plain prep start_pos {start_pos} + seq_len {seq_len} > \
+         cos_max_pos {cos_max_pos}"
+    );
+    let table_len = cos_max_pos.checked_mul(rotary_dim).ok_or_else(|| {
+        anyhow::anyhow!(
+            "hd256 plain prep cos_max_pos {cos_max_pos} * rotary_dim {rotary_dim} overflows"
+        )
+    })?;
+    anyhow::ensure!(
+        cos_cache.len >= table_len,
+        "hd256 plain prep cos_cache len {} < cos_max_pos {cos_max_pos} * \
+         rotary_dim {rotary_dim}",
+        cos_cache.len
+    );
+    anyhow::ensure!(
+        sin_cache.len >= table_len,
+        "hd256 plain prep sin_cache len {} < cos_max_pos {cos_max_pos} * \
+         rotary_dim {rotary_dim}",
+        sin_cache.len
+    );
+    ensure_vec_backed(q_norm_weight, "hd256 plain prep q_norm_weight")?;
+    ensure_vec_backed(k_norm_weight, "hd256 plain prep k_norm_weight")?;
+    ensure_vec_backed(cos_cache, "hd256 plain prep cos_cache")?;
+    ensure_vec_backed(sin_cache, "hd256 plain prep sin_cache")?;
+    // The kernel indexes token-major offsets and `pos * rotary_dim + d` in
+    // i32, so the extents and the rope table extent must fit.
+    let q_extent = q.checked_extent("hd256 plain prep q")?;
+    let k_extent = k.checked_extent("hd256 plain prep k")?;
+    q_out.checked_extent("hd256 plain prep q_out")?;
+    k_out.checked_extent("hd256 plain prep k_out")?;
+    super::checked_i32(q_extent, "hd256 plain prep q extent")?;
+    super::checked_i32(k_extent, "hd256 plain prep k extent")?;
+    super::checked_i32(table_len, "hd256 plain prep rope table extent")?;
+    let num_q_heads = super::checked_i32(num_q_heads, "hd256 plain prep num_q_heads")?;
+    let num_kv_heads = super::checked_i32(num_kv_heads, "hd256 plain prep num_kv_heads")?;
+    let seq_len = super::checked_i32(seq_len, "hd256 plain prep seq_len")?;
+    let start_pos = super::checked_i32(start_pos, "hd256 plain prep start_pos")?;
+    let cos_max_pos = super::checked_i32(cos_max_pos, "hd256 plain prep cos_max_pos")?;
+    let rotary_dim = super::checked_i32(rotary_dim, "hd256 plain prep rotary_dim")?;
+
+    let (q_ptr, _gq) = q.data.device_ptr(&ctx.stream);
+    let (k_ptr, _gk) = k.data.device_ptr(&ctx.stream);
+    let (qo_ptr, _gqo) = q_out.data.device_ptr_mut(&ctx.stream);
+    let (ko_ptr, _gko) = k_out.data.device_ptr_mut(&ctx.stream);
+    let (qn_ptr, _gqn) = q_norm_weight.data.device_ptr(&ctx.stream);
+    let (kn_ptr, _gkn) = k_norm_weight.data.device_ptr(&ctx.stream);
+    let (cos_ptr, _gc) = cos_cache.data.device_ptr(&ctx.stream);
+    let (sin_ptr, _gs) = sin_cache.data.device_ptr(&ctx.stream);
+
+    let result = unsafe {
+        ffi::qk_norm_rope_prefill_hd256_plain_cuda(
+            q_ptr as *const ffi::Half,
+            k_ptr as *const ffi::Half,
+            qn_ptr as *const ffi::Half,
+            kn_ptr as *const ffi::Half,
+            cos_ptr as *const ffi::Half,
+            sin_ptr as *const ffi::Half,
+            qo_ptr as *mut ffi::Half,
+            ko_ptr as *mut ffi::Half,
+            num_q_heads,
+            num_kv_heads,
+            seq_len,
+            start_pos,
+            cos_max_pos,
+            rotary_dim,
+            rms_eps,
+            crate::tensor::active_cu_stream(ctx),
+        )
+    };
+    if result != 0 {
+        anyhow::bail!(
+            "qk_norm_rope_prefill_hd256_plain_cuda failed with error \
+             {result}{}",
+            crate::ops::ffi_exception_message(result)
+        );
+    }
+    Ok(())
+}
+
+/// Causal single-sequence prefill at head_dim 256 over a contiguous **HND**
+/// K/V cache — `k[head, pos, dim]` with `k_cache.seq_len` allocated rows per
+/// head — matching `single_prefill_cuda_hd256`'s stride contract. Q and the
+/// output stay token-major (`[num_q_heads * 256, seq_len]`).
+///
+/// `sm_scale` is explicit because it is model policy, not geometry: qwen35
+/// wants the conventional `rsqrt(head_dim)`, but Gemma 4 runs unscaled
+/// attention (`scaling = 1.0` in the HF reference), and a hardcoded rsqrt
+/// would silently mis-scale its logits by 16x.
+#[allow(clippy::too_many_arguments)]
+pub fn single_prefill_hd256_into(
+    ctx: &DeviceContext,
+    q: &HiddenStates,
+    row_offset: usize,
+    q_seq_len: usize,
+    k_cache: &HiddenStates,
+    v_cache: &HiddenStates,
+    output: &mut HiddenStates,
+    num_q_heads: usize,
+    num_kv_heads: usize,
+    kv_len: usize,
+    sm_scale: f32,
+) -> Result<()> {
+    anyhow::ensure!(
+        sm_scale.is_finite(),
+        "single_prefill_hd256 sm_scale {sm_scale} must be finite"
+    );
+    anyhow::ensure!(
+        num_q_heads > 0 && num_kv_heads > 0 && q_seq_len > 0,
+        "single_prefill_hd256 num_q_heads {num_q_heads}, num_kv_heads \
+         {num_kv_heads} and q_seq_len {q_seq_len} must be positive"
+    );
+    anyhow::ensure!(
+        num_q_heads.is_multiple_of(num_kv_heads)
+            && SUPPORTED_GQA_GROUP_SIZES.contains(&(num_q_heads / num_kv_heads)),
+        "single_prefill_hd256 GQA group {num_q_heads} q / {num_kv_heads} kv \
+         heads not in the instantiated sizes {SUPPORTED_GQA_GROUP_SIZES:?}"
+    );
+    let q_dim = num_q_heads.checked_mul(256).ok_or_else(|| {
+        anyhow::anyhow!("single_prefill_hd256 num_q_heads {num_q_heads} overflows")
+    })?;
+    let kv_dim = num_kv_heads.checked_mul(256).ok_or_else(|| {
+        anyhow::anyhow!("single_prefill_hd256 num_kv_heads {num_kv_heads} overflows")
+    })?;
+    anyhow::ensure!(
+        q.hidden_dim == q_dim,
+        "single_prefill_hd256 q.hidden_dim {} != num_q_heads {} * 256",
+        q.hidden_dim,
+        num_q_heads
+    );
+    anyhow::ensure!(
+        output.hidden_dim == q.hidden_dim && output.seq_len == q.seq_len,
+        "single_prefill_hd256 output {}x{} != q {}x{}",
+        output.hidden_dim,
+        output.seq_len,
+        q.hidden_dim,
+        q.seq_len
+    );
+    anyhow::ensure!(
+        k_cache.hidden_dim == kv_dim,
+        "single_prefill_hd256 k_cache.hidden_dim {} != num_kv_heads {} * 256",
+        k_cache.hidden_dim,
+        num_kv_heads
+    );
+    anyhow::ensure!(
+        v_cache.hidden_dim == k_cache.hidden_dim && v_cache.seq_len == k_cache.seq_len,
+        "single_prefill_hd256 v_cache {}x{} != k_cache {}x{}",
+        v_cache.hidden_dim,
+        v_cache.seq_len,
+        k_cache.hidden_dim,
+        k_cache.seq_len
+    );
+    anyhow::ensure!(
+        kv_len <= k_cache.seq_len,
+        "single_prefill_hd256 kv_len {kv_len} exceeds cache rows {}",
+        k_cache.seq_len
+    );
+    anyhow::ensure!(
+        q_seq_len <= kv_len,
+        "causal prefill q_seq_len {q_seq_len} exceeds kv_len {kv_len}"
+    );
+    let byte_offset = checked_row_offset(q, row_offset, q_seq_len, "single_prefill_hd256 q")?;
+    // The C entry builds its 32-bit strides q_stride_n = num_q_heads * 256
+    // and kv_stride_h = cache rows * 256; with positive head counts and
+    // rows, each stride is bounded by its buffer's extent, so extents
+    // fitting i32 cover the stride products too.
+    let q_extent = q.checked_extent("single_prefill_hd256 q")?;
+    let out_extent = output.checked_extent("single_prefill_hd256 output")?;
+    let k_extent = k_cache.checked_extent("single_prefill_hd256 k_cache")?;
+    let v_extent = v_cache.checked_extent("single_prefill_hd256 v_cache")?;
+    super::checked_i32(q_extent, "single_prefill_hd256 q extent")?;
+    super::checked_i32(out_extent, "single_prefill_hd256 output extent")?;
+    super::checked_i32(k_extent, "single_prefill_hd256 k_cache extent")?;
+    super::checked_i32(v_extent, "single_prefill_hd256 v_cache extent")?;
+    let num_q_heads = super::checked_i32(num_q_heads, "single_prefill_hd256 num_q_heads")?;
+    let num_kv_heads = super::checked_i32(num_kv_heads, "single_prefill_hd256 num_kv_heads")?;
+    let q_seq_len = super::checked_i32(q_seq_len, "single_prefill_hd256 q_seq_len")?;
+    let kv_len = super::checked_i32(kv_len, "single_prefill_hd256 kv_len")?;
+    let kv_stride = super::checked_i32(k_cache.seq_len, "single_prefill_hd256 cache rows")?;
+    let (q_ptr, _gq) = q.data.device_ptr(&ctx.stream);
+    let q_ptr = q_ptr + byte_offset;
+    let (k_ptr, _gk) = k_cache.data.device_ptr(&ctx.stream);
+    let (v_ptr, _gv) = v_cache.data.device_ptr(&ctx.stream);
+    let (out_ptr, _go) = output.data.device_ptr_mut(&ctx.stream);
+    let out_ptr = out_ptr + byte_offset;
+    let result = unsafe {
+        ffi::single_prefill_cuda_hd256(
+            q_ptr as *const ffi::Half,
+            out_ptr as *mut ffi::Half,
+            k_ptr as *const ffi::Half,
+            v_ptr as *const ffi::Half,
+            num_q_heads,
+            num_kv_heads,
+            q_seq_len,
+            kv_len,
+            kv_stride,
+            sm_scale,
+            crate::tensor::active_cu_stream(ctx),
+        )
+    };
+    if result != 0 {
+        anyhow::bail!(
+            "single_prefill_cuda_hd256 failed with error {result}{}",
             crate::ops::ffi_exception_message(result)
         );
     }

--- a/pegainfer-kernels/src/ops/elementwise.rs
+++ b/pegainfer-kernels/src/ops/elementwise.rs
@@ -861,6 +861,81 @@ pub fn write_vec_into(
     Ok(())
 }
 
+/// Batched GELU-tanh+mul into a pre-allocated output buffer:
+/// `out = gelu_tanh(gate) * up` (Gemma 4 MLP, `gelu_pytorch_tanh`). The
+/// kernel matches HF's op-sequence rounding: activation in f32, cast to
+/// bf16, then multiplied in f32 and rounded once more.
+pub fn gelu_tanh_mul_batch_into(
+    ctx: &DeviceContext,
+    gate: &HiddenStates,
+    up: &HiddenStates,
+    out: &mut HiddenStates,
+) -> Result<()> {
+    anyhow::ensure!(
+        gate.hidden_dim == up.hidden_dim && gate.seq_len == up.seq_len,
+        "gelu_tanh_mul gate {}x{} != up {}x{}",
+        gate.hidden_dim,
+        gate.seq_len,
+        up.hidden_dim,
+        up.seq_len
+    );
+    anyhow::ensure!(
+        out.hidden_dim == gate.hidden_dim && out.seq_len == gate.seq_len,
+        "gelu_tanh_mul out {}x{} != gate {}x{}",
+        out.hidden_dim,
+        out.seq_len,
+        gate.hidden_dim,
+        gate.seq_len
+    );
+    let n = gate.checked_extent("gelu_tanh_mul gate")?;
+    up.checked_extent("gelu_tanh_mul up")?;
+    out.checked_extent("gelu_tanh_mul out")?;
+    let n = super::checked_i32(n, "gelu_tanh_mul extent")?;
+    let (g_ptr, _gg) = gate.data.device_ptr(&ctx.stream);
+    let (u_ptr, _gu) = up.data.device_ptr(&ctx.stream);
+    let (out_ptr, _go) = out.data.device_ptr_mut(&ctx.stream);
+
+    let result = unsafe {
+        ffi::gelu_tanh_mul_cuda(
+            g_ptr as *const ffi::Half,
+            u_ptr as *const ffi::Half,
+            out_ptr as *mut ffi::Half,
+            n,
+            crate::tensor::active_cu_stream(ctx),
+        )
+    };
+    result
+        .result()
+        .map_err(|e| anyhow!("gelu_tanh_mul_cuda failed: {e}"))?;
+
+    Ok(())
+}
+
+/// In-place multiply by a host scalar — Gemma 4's per-layer `layer_scalar`,
+/// a `[1]` weight the model reads to the host at load.
+pub fn scale_bf16_in_place(ctx: &DeviceContext, buf: &mut HiddenStates, scale: f32) -> Result<()> {
+    if !scale.is_finite() {
+        return Err(anyhow!("scale_bf16_in_place scale must be finite"));
+    }
+    let n = buf.checked_extent("scale_bf16 buf")?;
+    let n = super::checked_i32(n, "scale_bf16 extent")?;
+    let (buf_ptr, _gb) = buf.data.device_ptr_mut(&ctx.stream);
+
+    let result = unsafe {
+        ffi::scale_bf16_in_place_cuda(
+            buf_ptr as *mut ffi::Half,
+            scale,
+            n,
+            crate::tensor::active_cu_stream(ctx),
+        )
+    };
+    result
+        .result()
+        .map_err(|e| anyhow!("scale_bf16_in_place_cuda failed: {e}"))?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use half::bf16;

--- a/pegainfer-kernels/src/tensor.rs
+++ b/pegainfer-kernels/src/tensor.rs
@@ -475,6 +475,27 @@ impl HiddenStates {
         }
     }
 
+    /// Logical extent `hidden_dim * seq_len`, checked to fit the backing
+    /// allocation (`>=`, not `==`: buffers allocate at a max and rewrite
+    /// `seq_len` to the active size per step). Fields are public, so a safe
+    /// caller can shape a logical size past the backing; launch wrappers
+    /// call this to reject that before it reaches a kernel.
+    pub(crate) fn checked_extent(&self, what: &str) -> Result<usize> {
+        let extent = self
+            .hidden_dim
+            .checked_mul(self.seq_len)
+            .ok_or_else(|| anyhow!("{what} logical extent overflow"))?;
+        if self.data.len() < extent {
+            return Err(anyhow!(
+                "{what} backing len {} < hidden_dim {} * seq_len {}",
+                self.data.len(),
+                self.hidden_dim,
+                self.seq_len
+            ));
+        }
+        Ok(extent)
+    }
+
     /// Create zeroed batch
     pub fn zeros(ctx: &DeviceContext, hidden_dim: usize, seq_len: usize) -> Result<Self> {
         let data: CudaSlice<bf16> = ctx

--- a/pegainfer-kernels/tests/common/mod.rs
+++ b/pegainfer-kernels/tests/common/mod.rs
@@ -1,0 +1,34 @@
+//! Shared device gate for the kernel GPU gate binaries.
+
+use pegainfer_kernels::tensor::DeviceContext;
+
+/// Never infer "no device" from an arbitrary error — a broken driver, a
+/// failed stream or a context poisoned by an earlier `__trap()` all look
+/// like one. The context attempt comes first because it also initialises
+/// the driver; only its failure is diagnosed by `get_count()`, which is
+/// itself ambiguous between "no driver" and "broken driver". A formal gate
+/// must therefore set `PEGAINFER_REQUIRE_GPU=1` so skipping is impossible.
+pub(crate) fn device_or_skip() -> Option<DeviceContext> {
+    match DeviceContext::new() {
+        Ok(ctx) => Some(ctx),
+        Err(e) => {
+            let count = cudarc::driver::result::device::get_count();
+            match count {
+                Err(_) | Ok(0) => {
+                    assert!(
+                        std::env::var("PEGAINFER_REQUIRE_GPU").as_deref() != Ok("1"),
+                        "PEGAINFER_REQUIRE_GPU=1 but no usable CUDA device \
+                         (context error: {e}; get_count: {count:?})"
+                    );
+                    eprintln!("skipping: no usable CUDA device (get_count: {count:?})");
+                    None
+                }
+                Ok(n) => panic!(
+                    "CUDA device present (get_count = {n}) but context creation \
+                     failed: {e}. This is a broken environment or a poisoned \
+                     context, not a missing device, and must not be skipped"
+                ),
+            }
+        }
+    }
+}

--- a/pegainfer-kernels/tests/gelu_scale_smoke.rs
+++ b/pegainfer-kernels/tests/gelu_scale_smoke.rs
@@ -1,0 +1,112 @@
+//! Device gate for the Gemma 4 elementwise additions in
+//! csrc/shared/elementwise.cu: gelu_tanh_mul and scale_bf16.
+//!
+//! Manual gate: CI compiles this but never runs it. Run on a GPU box with
+//! PEGAINFER_REQUIRE_GPU=1, which turns a missing device into a failure
+//! rather than a skip.
+//!
+//! Scope note: on the bf16 grid the tanh approximation and the erf GELU are
+//! numerically indistinguishable (their worst-case gap is below half a bf16
+//! ulp), and the 2-ulp tolerance that absorbs device-vs-host tanh drift also
+//! absorbs the kernel's intermediate bf16 round — this gate pins the formula
+//! (a SiLU swap, a dropped cubic term), not the variant or the op-sequence
+//! rounding. The variant question rides on the Gemma 4 layer oracle against
+//! the HF fixture.
+
+mod common;
+
+use half::bf16;
+use pegainfer_kernels::ops::gelu_tanh_mul_batch_into;
+use pegainfer_kernels::ops::scale_bf16_in_place;
+use pegainfer_kernels::tensor::HiddenStates;
+
+/// Mirrors the kernel arithmetic: activation in f32, cast to bf16, then
+/// multiplied in f32 and rounded once more.
+fn host_gelu_tanh_mul(g: f32, u: f32) -> f32 {
+    let inner = 0.797_884_6_f32 * (g + 0.044_715_f32 * g * g * g);
+    let gelu_g = 0.5_f32 * g * (1.0_f32 + inner.tanh());
+    let gelu_bf16 = bf16::from_f32(gelu_g).to_f32();
+    bf16::from_f32(gelu_bf16 * u).to_f32()
+}
+
+#[test]
+fn gelu_tanh_mul_matches_host_reference() {
+    let Some(ctx) = common::device_or_skip() else {
+        return;
+    };
+    let ctx = &ctx;
+    // x = 2.0 is the constant-sensitive case: dropping the 0.044715 cubic
+    // term shifts gelu(2) by ~1.7%, and at up 2.0 the product moves 0.0625 —
+    // twice the 0.031 tolerance there; x = 1.0 separates GELU from a SiLU
+    // swap (0.8412 vs 0.7311). Negatives cover the branch where GELU
+    // saturates toward zero.
+    let gate_vals = [-8.0f32, -2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0, 8.0];
+    let up_vals = [2.0f32, -1.5, 1.0, 3.0, 2.0, -2.0, 1.0, 2.0, 2.0];
+
+    let gate_host: Vec<bf16> = gate_vals.iter().map(|&v| bf16::from_f32(v)).collect();
+    let up_host: Vec<bf16> = up_vals.iter().map(|&v| bf16::from_f32(v)).collect();
+    let n = gate_vals.len();
+    let gate = HiddenStates::from_host(ctx, &gate_host, n, 1).expect("gate H2D");
+    let up = HiddenStates::from_host(ctx, &up_host, n, 1).expect("up H2D");
+    let mut out = HiddenStates::zeros(ctx, n, 1).expect("out alloc");
+
+    gelu_tanh_mul_batch_into(ctx, &gate, &up, &mut out).expect("gelu launch");
+
+    let got = out.to_host(ctx).expect("out D2H");
+    for (i, (&g, &u)) in gate_vals.iter().zip(&up_vals).enumerate() {
+        let e = host_gelu_tanh_mul(g, u);
+        // Two bf16 ulp relative, floored for near-zero expectations: host
+        // tanh and device tanhf may differ in the last f32 ulp, which after
+        // the bf16 round can move one grid step on boundary values.
+        let tol = (e.abs() * 0.008).max(0.02);
+        assert!(
+            (got[i] - e).abs() <= tol,
+            "gelu_tanh_mul[{i}] (gate {g}, up {u}): got {}, expected {e} \
+             (tolerance {tol})",
+            got[i]
+        );
+    }
+}
+
+/// Powers of two times small integers stay exactly representable in bf16
+/// under a power-of-two scale, so the assertion is bitwise equality — an
+/// off-by-one bound that skips the last element cannot pass.
+#[test]
+#[allow(clippy::float_cmp)]
+fn scale_bf16_scales_exactly() {
+    let Some(ctx) = common::device_or_skip() else {
+        return;
+    };
+    let ctx = &ctx;
+    let vals = [-4.0f32, -1.5, -0.5, 0.0, 0.25, 1.0, 3.0, 8.0];
+    let host: Vec<bf16> = vals.iter().map(|&v| bf16::from_f32(v)).collect();
+    let mut buf = HiddenStates::from_host(ctx, &host, vals.len(), 1).expect("buf H2D");
+
+    scale_bf16_in_place(ctx, &mut buf, 2.0).expect("scale launch");
+
+    let got = buf.to_host(ctx).expect("buf D2H");
+    for (i, &v) in vals.iter().enumerate() {
+        assert_eq!(
+            got[i],
+            v * 2.0,
+            "scale_bf16[{i}]: got {}, expected {}",
+            got[i],
+            v * 2.0
+        );
+    }
+}
+
+#[test]
+fn scale_bf16_rejects_non_finite_scale() {
+    let Some(ctx) = common::device_or_skip() else {
+        return;
+    };
+    let ctx = &ctx;
+    let mut buf = HiddenStates::zeros(ctx, 4, 1).expect("buf alloc");
+    for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+        assert!(
+            scale_bf16_in_place(ctx, &mut buf, bad).is_err(),
+            "scale {bad} must be rejected"
+        );
+    }
+}

--- a/pegainfer-kernels/tests/hd256_qk_rope_plain_smoke.rs
+++ b/pegainfer-kernels/tests/hd256_qk_rope_plain_smoke.rs
@@ -1,0 +1,319 @@
+//! Device gate for csrc/shared/prefill_attention_hd256_plain.cu.
+//!
+//! Manual gate: CI compiles this but never runs it. Run on a GPU box with
+//! PEGAINFER_REQUIRE_GPU=1, which turns a missing device into a failure
+//! rather than a skip. Unlike the hd512 sibling there are no trap binaries:
+//! this entry has no device-resident indices — the only out-of-range axis
+//! (the position window) is host-known and rejected by the wrapper, so the
+//! kernel's position trap is unreachable through the public path.
+
+mod common;
+
+use half::bf16;
+use pegainfer_kernels::ops::qk_norm_rope_prefill_hd256_plain_into;
+use pegainfer_kernels::tensor::DeviceContext;
+use pegainfer_kernels::tensor::DeviceVec;
+use pegainfer_kernels::tensor::HiddenStates;
+
+const HD: usize = 256;
+const EPS: f32 = 1e-6;
+// The Gemma 4 12B local-layer geometry: 16 query heads over 8 KV heads.
+const NUM_Q_HEADS: usize = 16;
+const NUM_KV_HEADS: usize = 8;
+// The norm collapses a constant row to sign(x) * w[d] (x / sqrt(x^2 + eps)
+// is ±1 up to eps), so input magnitude cannot tell heads or tokens apart
+// after normalisation — only sign survives. The per-(head, token) sign
+// patterns below carry source identity through the norm, so a source-stride
+// error (always reading head 0 or token 0, the qwen35 gated 2x head stride,
+// an off-by-one head) lands a wrong sign somewhere. K uses the leading
+// 8 entries; the pattern is aperiodic under h -> 2h, h % 8 and h ± 1.
+const Q_BASE: f32 = 1.0;
+const K_BASE: f32 = 3.0;
+const HEAD_SIGNS: [f32; NUM_Q_HEADS] = [
+    1.0, 1.0, -1.0, 1.0, -1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, 1.0, -1.0, 1.0, -1.0, -1.0,
+];
+const Q_DIM: usize = NUM_Q_HEADS * HD;
+const KV_DIM: usize = NUM_KV_HEADS * HD;
+const SEQ_LEN: usize = 4;
+// Exercise nonzero positions and more than one RoPE row.
+const START_POS: usize = 1;
+const COS_MAX_POS: usize = 8;
+
+fn signed(base: f32, head: usize, token: usize) -> f32 {
+    let tok_sign = if token.is_multiple_of(2) { 1.0 } else { -1.0 };
+    base * HEAD_SIGNS[head] * tok_sign
+}
+
+/// Rows are constant within each (token, head), so mean(x^2) is exact in f32
+/// and the kernel's 256-way reduction collapses to a constant.
+fn inv_rms(x: f32) -> f32 {
+    1.0f32 / (x * x + EPS).sqrt()
+}
+
+fn normed(x: f32, w: &[bf16], inv: f32, d: usize) -> f32 {
+    bf16::from_f32(x * inv * w[d].to_f32()).to_f32()
+}
+
+/// Period 3, so every in-bounds row maps to a well-defined transform:
+///   0 → ( 1, 0) identity     1 → ( 0, 1) swap-negate     2 → (-1, 0) negate
+/// Unit coefficients keep every expectation exact in bf16.
+fn rope_row(row: usize) -> (f32, f32) {
+    match row % 3 {
+        0 => (1.0, 0.0),
+        1 => (0.0, 1.0),
+        _ => (-1.0, 0.0),
+    }
+}
+
+/// Laid out as the kernel indexes them: [pos * rotary_dim + d].
+fn cos_sin_tables(ctx: &DeviceContext, rows: usize, rotary_dim: usize) -> (DeviceVec, DeviceVec) {
+    let mut cos = Vec::with_capacity(rows * rotary_dim);
+    let mut sin = Vec::with_capacity(rows * rotary_dim);
+    for row in 0..rows {
+        let (c, s) = rope_row(row);
+        cos.extend(vec![bf16::from_f32(c); rotary_dim]);
+        sin.extend(vec![bf16::from_f32(s); rotary_dim]);
+    }
+    (
+        DeviceVec::from_host(ctx, &cos).expect("cos H2D"),
+        DeviceVec::from_host(ctx, &sin).expect("sin H2D"),
+    )
+}
+
+fn expected_prep(x: f32, w: &[bf16], inv: f32, d: usize, row: usize, rotary_dim: usize) -> f32 {
+    let half_rotary = rotary_dim / 2;
+    if d < half_rotary {
+        let lo = normed(x, w, inv, d);
+        let hi = normed(x, w, inv, d + half_rotary);
+        match row % 3 {
+            0 => lo,
+            1 => -hi,
+            _ => -lo,
+        }
+    } else if d < rotary_dim {
+        let lo = normed(x, w, inv, d - half_rotary);
+        let hi = normed(x, w, inv, d);
+        match row % 3 {
+            0 => hi,
+            1 => lo,
+            _ => -hi,
+        }
+    } else {
+        normed(x, w, inv, d)
+    }
+}
+
+fn expected_full(base: f32, w: &[bf16], dim: usize, rotary_dim: usize) -> Vec<f32> {
+    let num_heads = dim / HD;
+    let mut full = vec![0.0f32; dim * SEQ_LEN];
+    for t in 0..SEQ_LEN {
+        let row = START_POS + t;
+        for h in 0..num_heads {
+            let x = signed(base, h, t);
+            let inv = inv_rms(x);
+            for d in 0..HD {
+                full[t * dim + h * HD + d] = expected_prep(x, w, inv, d, row, rotary_dim);
+            }
+        }
+    }
+    full
+}
+
+fn assert_close(got: &[f32], expected: &[f32], what: &str) {
+    assert_eq!(got.len(), expected.len());
+    for (i, (&g, &e)) in got.iter().zip(expected).enumerate() {
+        assert!(
+            (g - e).abs() < 0.02,
+            "{what}[{i}]: got {g}, expected {e} (tolerance 0.02)"
+        );
+    }
+}
+
+/// Starts at 1: w[0] = 0 would make dim 0 normalise to 0.0, which an
+/// uninitialised output slot could imitate.
+fn q_norm_weights() -> Vec<bf16> {
+    (1..=HD).map(|d| bf16::from_f32(d as f32)).collect()
+}
+
+/// Negated relative to the Q side, so swapping the two weight pointers is
+/// a sign flip in every slot. bf16 rounds some magnitudes, which does not
+/// matter: oracle and kernel read back the same converted value.
+fn k_norm_weights() -> Vec<bf16> {
+    (1..=HD).map(|d| bf16::from_f32(-(d as f32))).collect()
+}
+
+fn hidden_input(ctx: &DeviceContext, base: f32, num_heads: usize) -> HiddenStates {
+    let mut host = Vec::with_capacity(num_heads * HD * SEQ_LEN);
+    for t in 0..SEQ_LEN {
+        for h in 0..num_heads {
+            host.extend(vec![bf16::from_f32(signed(base, h, t)); HD]);
+        }
+    }
+    HiddenStates::from_host(ctx, &host, num_heads * HD, SEQ_LEN).expect("input H2D")
+}
+
+fn run_prep(ctx: &DeviceContext, rotary_dim: usize) -> (Vec<f32>, Vec<f32>) {
+    let qw = q_norm_weights();
+    let kw = k_norm_weights();
+    let q = hidden_input(ctx, Q_BASE, NUM_Q_HEADS);
+    let k = hidden_input(ctx, K_BASE, NUM_KV_HEADS);
+    let mut q_out = HiddenStates::zeros(ctx, Q_DIM, SEQ_LEN).expect("q_out alloc");
+    let mut k_out = HiddenStates::zeros(ctx, KV_DIM, SEQ_LEN).expect("k_out alloc");
+
+    let (cos_dev, sin_dev) = cos_sin_tables(ctx, COS_MAX_POS, rotary_dim);
+    let qn = DeviceVec::from_host(ctx, &qw).expect("q_norm_weight H2D");
+    let kn = DeviceVec::from_host(ctx, &kw).expect("k_norm_weight H2D");
+
+    qk_norm_rope_prefill_hd256_plain_into(
+        ctx,
+        &q,
+        &k,
+        &mut q_out,
+        &mut k_out,
+        &qn,
+        &kn,
+        &cos_dev,
+        &sin_dev,
+        START_POS,
+        COS_MAX_POS,
+        NUM_Q_HEADS,
+        NUM_KV_HEADS,
+        rotary_dim,
+        EPS,
+    )
+    .expect("prep launch");
+
+    let qo = q_out.to_host(ctx).expect("q_out D2H");
+    let ko = k_out.to_host(ctx).expect("k_out D2H");
+    (qo, ko)
+}
+
+/// rotary_dim = 256 is the Gemma 4 local-layer case: the full head rotates
+/// and the pass-through tail is empty.
+#[test]
+fn full_rotation_matches_closed_form() {
+    let Some(ctx) = common::device_or_skip() else {
+        return;
+    };
+    let ctx = &ctx;
+    let qw = q_norm_weights();
+    let kw = k_norm_weights();
+    let (qo, ko) = run_prep(ctx, HD);
+    assert_close(
+        &qo,
+        &expected_full(Q_BASE, &qw, Q_DIM, HD),
+        "full-rotation Q pairing",
+    );
+    assert_close(
+        &ko,
+        &expected_full(K_BASE, &kw, KV_DIM, HD),
+        "full-rotation K pairing",
+    );
+}
+
+/// rotary_dim = 128 exercises the pass-through tail, which the full-width
+/// case never reaches; a tail written rotated (or not written) fails here.
+#[test]
+fn partial_rotation_exercises_tail() {
+    let Some(ctx) = common::device_or_skip() else {
+        return;
+    };
+    let ctx = &ctx;
+    let qw = q_norm_weights();
+    let kw = k_norm_weights();
+    let (qo, ko) = run_prep(ctx, 128);
+    assert_close(
+        &qo,
+        &expected_full(Q_BASE, &qw, Q_DIM, 128),
+        "partial-rotation Q pairing/tail",
+    );
+    assert_close(
+        &ko,
+        &expected_full(K_BASE, &kw, KV_DIM, 128),
+        "partial-rotation K pairing/tail",
+    );
+}
+
+#[test]
+fn rejects_bad_rotary_dim() {
+    let Some(ctx) = common::device_or_skip() else {
+        return;
+    };
+    let ctx = &ctx;
+    // Zeroed buffers suffice: the launcher must reject before touching any
+    // device memory. Tables are sized for the worst case checked here
+    // (8 x 512), so the wrapper's table checks pass and both values
+    // actually reach the launcher.
+    let q = HiddenStates::zeros(ctx, Q_DIM, SEQ_LEN).expect("q alloc");
+    let k = HiddenStates::zeros(ctx, KV_DIM, SEQ_LEN).expect("k alloc");
+    let mut q_out = HiddenStates::zeros(ctx, Q_DIM, SEQ_LEN).expect("q_out alloc");
+    let mut k_out = HiddenStates::zeros(ctx, KV_DIM, SEQ_LEN).expect("k_out alloc");
+    let cos_dev = DeviceVec::zeros(ctx, COS_MAX_POS * 512).expect("cos alloc");
+    let sin_dev = DeviceVec::zeros(ctx, COS_MAX_POS * 512).expect("sin alloc");
+    let qn = DeviceVec::zeros(ctx, HD).expect("qn alloc");
+    let kn = DeviceVec::zeros(ctx, HD).expect("kn alloc");
+
+    // 127: odd — index 126 would never be written. 512: wider than the
+    // head — smem and the output slices would walk past 256. Both must be
+    // rejected, not silently accepted.
+    for bad in [127, 512] {
+        let err = qk_norm_rope_prefill_hd256_plain_into(
+            ctx,
+            &q,
+            &k,
+            &mut q_out,
+            &mut k_out,
+            &qn,
+            &kn,
+            &cos_dev,
+            &sin_dev,
+            0, // start_pos
+            COS_MAX_POS,
+            NUM_Q_HEADS,
+            NUM_KV_HEADS,
+            bad,
+            EPS,
+        );
+        assert!(err.is_err(), "rotary_dim={bad} must be rejected");
+    }
+}
+
+#[test]
+fn rejects_position_beyond_cos_table() {
+    let Some(ctx) = common::device_or_skip() else {
+        return;
+    };
+    let ctx = &ctx;
+    // Rejected on the host, before any launch: with cos_max_pos 4,
+    // start_pos 1 + seq_len 4 reaches row 5 — past the tables.
+    let q = HiddenStates::zeros(ctx, Q_DIM, SEQ_LEN).expect("q alloc");
+    let k = HiddenStates::zeros(ctx, KV_DIM, SEQ_LEN).expect("k alloc");
+    let mut q_out = HiddenStates::zeros(ctx, Q_DIM, SEQ_LEN).expect("q_out alloc");
+    let mut k_out = HiddenStates::zeros(ctx, KV_DIM, SEQ_LEN).expect("k_out alloc");
+    let cos_dev = DeviceVec::zeros(ctx, 4 * HD).expect("cos alloc");
+    let sin_dev = DeviceVec::zeros(ctx, 4 * HD).expect("sin alloc");
+    let qn = DeviceVec::zeros(ctx, HD).expect("qn alloc");
+    let kn = DeviceVec::zeros(ctx, HD).expect("kn alloc");
+
+    let err = qk_norm_rope_prefill_hd256_plain_into(
+        ctx,
+        &q,
+        &k,
+        &mut q_out,
+        &mut k_out,
+        &qn,
+        &kn,
+        &cos_dev,
+        &sin_dev,
+        1, // start_pos
+        4, // cos_max_pos
+        NUM_Q_HEADS,
+        NUM_KV_HEADS,
+        HD,
+        EPS,
+    );
+    assert!(
+        err.is_err(),
+        "start_pos + seq_len beyond cos_max_pos must be rejected on the host"
+    );
+}


### PR DESCRIPTION
## Description

Closes #852 


The prep for Gemma 4's local layers, plus the two elementwise pieces their layer graph needs, plus one wrapper seam. Not a copy of the qwen35 hd256 sibling: that kernel's 1+w offset norm, doubled gated-Q stride and paged K write are qwen35's choices, and carrying any of them over produces plausible numbers that are wrong. The new translation unit multiplies by the plain weight, takes ungated Q, and writes both Q and K to contiguous token-major buffers — there is no Gemma 4 KV cache consumer yet. They do not feed `single_prefill` directly: that entry reads a contiguous HND cache, which the layer assembles per head from these outputs. `rotary_dim` stays a runtime argument, validated positive, even and <= 256; Gemma 4 local layers pass 256, so the pass-through tail is empty in production and a narrower width keeps partial-RoPE tail semantics for the pending hd512 sibling prep stacked above this PR.

`gelu_tanh_mul` sits beside `silu_mul` with the same rounding contract, documented against the HF op sequence: the activation materializes a bf16 tensor before the elementwise multiply. `scale_bf16_in_place` serves the per-layer `layer_scalar` epilogue; the model reads the `[1]` weight to the host once at load, so the op takes a host f32 and the serving loop performs no per-step readback.

The hd256 `single_prefill` instantiation existed with no safe wrapper — and the NHD entry that looks generic is not: its head_dim is a runtime parameter validated against 128 in the C entry. Add `single_prefill_hd256_into`, with `sm_scale` explicit rather than hardcoded. Gemma 4 runs unscaled attention — `scaling = 1.0` in the HF reference, unconditionally, for both layer kinds — so the `rsqrt(head_dim)` the sibling wrappers bake in would silently shrink its logits to 1/16 of their correct value. The scale is model policy, not geometry. K/V follow the entry's contiguous HND cache contract (`k[head, pos, dim]`), documented on the wrapper.

Both wrappers close the C entries' index contract rather than only their shapes: logical extents (via `HiddenStates::checked_extent`, a tensor invariant that also guards the public-field `seq_len` inflation hazard), the rope table extent, and the stride products under the C side's 32-bit stride/index contract must all fit 32 bits; zero head counts, zero lengths and GQA groups outside the instantiated sizes are rejected before launch. The new elementwise launchers compute their grid with an overflow-free ceil-div.

There are no trap binaries, and that is an argument rather than an omission: this prep entry has no device-resident indices. The only out-of-range axis — the position window — is host-known and rejected by the wrapper before launch, so the kernel's in-kernel position check is defence in depth that the public path cannot reach.

## Test Env

Single GPU (sm_89, x86_64), CUDA 12.9, `PEGAINFER_REQUIRE_GPU=1`:

- `cargo build --release -p pegainfer-kernels` — clean (1m34s).
- `cargo clippy --release -p pegainfer-kernels --all-targets -- -D warnings` — clean, zero diagnostics and zero error lines.
- `cargo test --release -p pegainfer-kernels --test hd256_qk_rope_plain_smoke --test gelu_scale_smoke` — 4 + 3 passed, zero skipped.
- `ptxas` (cuobjdump): the prep kernel uses 22 registers and 548 bytes of shared memory per block — exactly the predicted 8x4 + 4 + 256x2 — which at 256 threads is 5,632 registers against the 65,536 per-block budget. gelu_tanh_mul uses 15 registers, scale_bf16 8, neither with shared memory.
- All three new entries export with C linkage; Rust/C parameter order and widths checked source-to-source. C linkage does not encode pointer constness.
- Ten targeted mutations were each caught (the two whose fixture inputs changed in review — the dropped cubic term and the head-stride aliasing — were re-demonstrated after the final head): 1+w reintroduced; the pair boundary; token used as position; transposed Q/K weights; transposed Q/K inputs; gelu swapped for silu; the dropped cubic term; the scale skipping its last element; and both rotary rejections (odd and oversized) accepted. Every injection was verified to hit its target before the run counted.

`cargo fmt --all --check` passes locally.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)