### PR TITLE
chore(project): update GitHub org references openinfer-project -> pegainfer-project

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/deepseek-ai/FlashMLA
 [submodule "pegainfer-kernels/third_party/DeepGEMM"]
 	path = pegainfer-kernels/third_party/DeepGEMM
-	url = https://github.com/openinfer-project/DeepGEMM
+	url = https://github.com/pegainfer-project/DeepGEMM

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ NVIDIA Dynamo (the `kvbm/kvbm-logical` crate) retain their original Apache-2.0 h
 ## Star History
 
 <p align="center">
-  <a href="https://star-history.com/#openinfer-project/openinfer&Date">
-    <img src="https://api.star-history.com/svg?repos=openinfer-project/openinfer&type=Date" alt="Star History Chart">
+  <a href="https://star-history.com/#pegainfer-project/pegainfer&Date">
+    <img src="https://api.star-history.com/svg?repos=pegainfer-project/pegainfer&type=Date" alt="Star History Chart">
   </a>
 </p>

--- a/docs/benchmarks/deepseek-v2-lite-vllm-tp2-ep2.md
+++ b/docs/benchmarks/deepseek-v2-lite-vllm-tp2-ep2.md
@@ -4,7 +4,7 @@
 
 **TL;DR**: 2026-06-28 DeepSeek-V2-Lite EP2 run on 2x RTX 5090. HF, PegaInfer host-staged, and PegaInfer NCCL matched exactly on the committed case set; PegaInfer host-staged/NCCL completed direct diagnostics, HTTP pressure, and trace rows. Stock vLLM TP2 and TP2+EP2 failed at server startup on the FlashInfer SM120/CUDA 12.8 path. A separate FlashInfer #3633-equivalent validation completed the vLLM HTTP rows under the same client/workload contract. Treat this as a retained benchmark snapshot and setup-gap record, not a vLLM parity or production serving claim.
 
-Source benchmark for [#279](https://github.com/openinfer-project/openinfer/issues/279) and the DeepSeek-V2-Lite status ledger.
+Source benchmark for [#279](https://github.com/pegainfer-project/pegainfer/issues/279) and the DeepSeek-V2-Lite status ledger.
 
 ## References
 
@@ -18,7 +18,7 @@ Source benchmark for [#279](https://github.com/openinfer-project/openinfer/issue
 
 | Field | Value |
 | --- | --- |
-| Tracking issue | [#279](https://github.com/openinfer-project/openinfer/issues/279) |
+| Tracking issue | [#279](https://github.com/pegainfer-project/pegainfer/issues/279) |
 | Model path | `models/DeepSeek-V2-Lite` |
 | Prompt source | `vllm bench serve --dataset-name random` |
 | HTTP shape | `input_len=64`, `output_len=64`, `num_prompts=32`, `num_warmups=4` |

--- a/docs/benchmarks/mixed-load-itl.md
+++ b/docs/benchmarks/mixed-load-itl.md
@@ -109,7 +109,7 @@ gap — `max` confirms it (459 / 906 / 1408ms ≈ the prefill wall, throttle-che
 below).
 
 p99 stays at baseline as a **measurement artifact**, not architectural immunity.
-**Primary cause (issue [#470](https://github.com/openinfer-project/openinfer/issues/470)):**
+**Primary cause (issue [#470](https://github.com/pegainfer-project/pegainfer/issues/470)):**
 `bench_serving` hardcoded `max_batch=4` for Qwen3.5, so `--bg-concurrency 4` filled
 every slot and the injector could not admit until a background stream died —
 injected prefill never overlapped a full decode batch (`ITL_STEP` `decode_n` never

--- a/docs/benchmarks/qwen-mixed-sampling-http.md
+++ b/docs/benchmarks/qwen-mixed-sampling-http.md
@@ -13,14 +13,14 @@ Qwen3.5-4B passed the same workload as supplemental evidence.
 
 | Item | Value |
 | --- | --- |
-| Issue | [#412](https://github.com/openinfer-project/openinfer/issues/412) |
+| Issue | [#412](https://github.com/pegainfer-project/pegainfer/issues/412) |
 | GPU | 1x NVIDIA GeForce RTX 5090, 32607 MiB, driver 580.105.08 |
 | Primary model | Qwen3-4B BF16 safetensors, TP1, text-only serving |
 | Supplemental model | Qwen3.5-4B BF16 safetensors, TP1, text-only serving |
 | Server | Existing PegaInfer release binary; `RUST_LOG=info`; not rebuilt during the 2026-06-21 rerun |
 | Client | This branch's `scripts/bench_http_serving.py`, rebased onto `upstream/main` `b66f845` |
 
-PR [#424](https://github.com/openinfer-project/openinfer/pull/424) is the
+PR [#424](https://github.com/pegainfer-project/pegainfer/pull/424) is the
 benchmark-snapshot format precedent; its multi-turn workload is separate. The
 client uses the OpenAI-compatible `temperature`, `top_k`, and `top_p` request
 fields used by `vllm bench serve`, without adding a vLLM dependency.

--- a/docs/models/deepseek-v2-lite/status.md
+++ b/docs/models/deepseek-v2-lite/status.md
@@ -69,7 +69,7 @@ The current-source #466 aggregate is retained under `artifacts/bench/dsv2-lite/<
 
 ### Retained vLLM TP2/EP2 Matrix
 
-The retained matrix lives in `docs/benchmarks/deepseek-v2-lite-vllm-tp2-ep2.md` and tracks [#279](https://github.com/openinfer-project/openinfer/issues/279). It is the current source for PegaInfer host-staged/NCCL versus vLLM TP2/TP2+EP2 under the `prompt_words=64`, `max_tokens=64`, `num_prompts=32`, `max_concurrency=1/4/8`, `temperature=0`, `ignore_eos=true` HTTP pressure contract. Prompt words are a workload-generator input, not a token count.
+The retained matrix lives in `docs/benchmarks/deepseek-v2-lite-vllm-tp2-ep2.md` and tracks [#279](https://github.com/pegainfer-project/pegainfer/issues/279). It is the current source for PegaInfer host-staged/NCCL versus vLLM TP2/TP2+EP2 under the `prompt_words=64`, `max_tokens=64`, `num_prompts=32`, `max_concurrency=1/4/8`, `temperature=0`, `ignore_eos=true` HTTP pressure contract. Prompt words are a workload-generator input, not a token count.
 
 Latest 2026-06-28 result on 2x RTX 5090:
 

--- a/docs/roadmap/roadmap-2026-h2.md
+++ b/docs/roadmap/roadmap-2026-h2.md
@@ -14,7 +14,7 @@ pegainfer's near-term market is narrow and deliberate: **small-to-mid models, si
 
 ### 1. Website as the product surface
 
-Today the site has three pages of real content while the engine's actual capabilities live scattered in repo docs. The website (openinfer-project/website) becomes the canonical user-facing surface, in the style of [recipes.vllm.ai](https://recipes.vllm.ai/): one verified, copy-pasteable recipe per model line, kept current as flags change.
+Today the site has three pages of real content while the engine's actual capabilities live scattered in repo docs. The website (pegainfer-project/website) becomes the canonical user-facing surface, in the style of [recipes.vllm.ai](https://recipes.vllm.ai/): one verified, copy-pasteable recipe per model line, kept current as flags change.
 
 - **Per-model recipe pages.** For each served line: exact launch command, required hardware, the CLI flags that matter for that model (`--kv-offload`, `--dflash-draft-model-path`, TP flags, …), expected TTFT/TPOT on the tested GPUs, and a benchmark snapshot. Only Qwen3-4B has a page today; Qwen3.5 and DeepSeek-V2-Lite are next. Every command on a page is run before it is committed — same rule as repo docs.
 - **CLI / server reference.** A maintained page for `pegainfer-server` args and env vars (`PEGAINFER_CUDA_SM`, `PEGAINFER_TRITON_PYTHON`, …). This must not rot: once the page exists, a flag change without a website update is an incomplete PR.


### PR DESCRIPTION
After the org rename (`openinfer-project` → `pegainfer-project`), refresh every URL checked into the repo so nothing depends on the (now unprotected) old-org redirect.

## Changes

- `.gitmodules` — DeepGEMM fork submodule URL (the only functional reference; `git submodule sync` already run locally)
- `README.md` — star-history badge org/repo slug (`openinfer-project/openinfer` → `pegainfer-project/pegainfer`, also picking up the earlier repo rename)
- `docs/benchmarks/{qwen-mixed-sampling-http,mixed-load-itl,deepseek-v2-lite-vllm-tp2-ep2}.md`, `docs/models/deepseek-v2-lite/status.md` — issue/PR links to the new canonical path
- `docs/roadmap/roadmap-2026-h2.md` — `openinfer-project/website` → `pegainfer-project/website` (repo verified to exist in the new org)

## Intentionally left alone

`docs/subsystems/kernels/build-rs-submodule-init.md` records commands as actually executed at the time (a token-permission debugging session under the old names) — it is a historical log, not a live reference, so rewriting the names would falsify the record.

## Verification

- `gh repo list pegainfer-project` confirms `pegainfer` / `website` / `DeepGEMM` all exist under the new org
- `rg openinfer-project` now only matches the historical log above