### PR TITLE
fix(frontend): satisfy clippy needless_borrow in engine handle test

### DIFF
--- a/pegainfer-frontend/src/engine/handle.rs
+++ b/pegainfer-frontend/src/engine/handle.rs
@@ -579,7 +579,7 @@ mod tests {
             .iter()
             .map(|flag| {
                 let (tx, mut rx) = mpsc::unbounded_channel::<SubmittedRequest>();
-                let flag = Arc::clone(&flag);
+                let flag = Arc::clone(flag);
                 let join = thread::spawn(move || {
                     while rx.blocking_recv().is_some() {}
                     flag.store(true, Ordering::SeqCst);


### PR DESCRIPTION
## What

One-line fix in `pegainfer-frontend/src/engine/handle.rs` (test `multi_partition_drop_joins_every_thread`): `Arc::clone(&flag)` → `Arc::clone(flag)` — the extra borrow on an `&Arc` trips `clippy::needless_borrow` under CI's `-D warnings`.

## Context

The line predates the engine/ module split (#859) and was carried over verbatim. CPU Clippy is a non-required check, so #859 merged while it was still failing. Local repro: `cargo clippy -p pegainfer-frontend --all-targets -- -D warnings` (now clean, tests 56/56).