### PR TITLE
fix(qwen35): wrap the TP2 serve engine in LaunchedEngine::Handle

### DIFF
--- a/pegainfer-qwen35/tests/serving_tp2.rs
+++ b/pegainfer-qwen35/tests/serving_tp2.rs
@@ -81,7 +81,9 @@ async fn spawn_ready_server(
     let server_shutdown = shutdown.clone();
     let mut task = tokio::spawn(async move {
         pegainfer_frontend::vllm::serve(
-            std::future::ready(Ok(handle)),
+            std::future::ready(Ok(pegainfer_frontend::engine::LaunchedEngine::Handle(
+                handle,
+            ))),
             &frontend_model_path,
             vec![MODEL_NAME.to_string()],
             port,


### PR DESCRIPTION
## Description

The engine-event contract change (#861) moved `vllm::serve` to take `impl Future<Output = Result<LaunchedEngine>>`. Every launch site was migrated, but the qwen35 TP2 serving test still passes the bare `EngineHandle`, and no CI job compiles the qwen35 test targets (they need build-time Triton), so the breakage was silent.

One-line fix at the only call site.

## Test Env

Single GPU (sm_89, x86_64), CUDA 12.9.


## Verification

A/B, same command on both trees: `cargo check --release -p pegainfer-qwen35 --features qwen35 --all-targets`

| tree | result |
| --- | --- |
| main | `error[E0271]` ×4, `could not compile pegainfer-qwen35 (test "serving_tp2")` |
| this branch | clean |

On this branch, `cargo test --release -p pegainfer-qwen35 --features qwen35 --test serving_tp2 --no-run` also links. Running the test itself needs two CUDA devices (it stays behind its existing `#[ignore]`), which this machine doesn't have.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)