### PR TITLE
refactor(frontend): rename step-contract intake vocabulary to submit/QueuedRequest

### DIFF
--- a/docs/subsystems/frontend/frontend-architecture.md
+++ b/docs/subsystems/frontend/frontend-architecture.md
@@ -12,40 +12,41 @@ An engine is a set of schedulers, each a `Scheduler` implementation driven by th
 
 ```
 pegainfer-frontend/src/engine/
-├── step.rs        # the wire: RequestId, Request, StepOutputs { Vec<RequestUpdate> },
-│                  #   RequestUpdate { scheduled, tokens, logprobs, cached_tokens,
-│                  #   prompt_echo, kv_transfer, terminal }, Terminal
-├── ticket.rs      # typestate handles: IntakeTicket ─admit→ ActiveRequest ─finish/
-│                  #   fail/defer→ consumed; every transition is by-move, a dropped
-│                  #   handle emits Failed (drop bomb); DeferredFinish; RequestControl
-├── emitter.rs     # StepEmitter: the single writer of the per-step buffer; stamps
-│                  #   timestamps, tallies prompt/completion counts, folds each
-│                  #   request's step into one RequestUpdate; commit_step sends once
-├── wiring.rs      # scheduler_pair, SchedulerHandle (submit/take_steps/load),
-│                  #   Engine { schedulers, info, lora }, LiveScheduler,
-│                  #   EngineInfo, LaunchedEngine { Handle | Stepped }
-├── control.rs     # LoRA capability — outside the contract: LoraControl vocabulary,
-│                  #   LoraClient (the `Engine.lora: Option<LoraClient>` capability)
-└── driver.rs      # trait Scheduler { intake, step, load } + spawn_scheduler:
-                   #   the contract-owned pure-polling drive loop
+├── step.rs              # the wire: RequestId, Request, StepOutputs { Vec<RequestUpdate> },
+│                        #   RequestUpdate { scheduled, tokens, logprobs, cached_tokens,
+│                        #   prompt_echo, kv_transfer, terminal }, Terminal
+├── request_lifecycle.rs # typestate handles: QueuedRequest ─admit→
+│                        #   ActiveRequest ─finish/fail/defer→ consumed; every
+│                        #   transition is by-move, a dropped handle emits Failed
+│                        #   (drop bomb); DeferredFinish; RequestControl
+├── emitter.rs           # StepEmitter: the single writer of the per-step buffer; stamps
+│                        #   timestamps, tallies prompt/completion counts, folds each
+│                        #   request's step into one RequestUpdate; commit_step sends once
+├── wiring.rs            # scheduler_pair, SchedulerHandle (submit/take_steps/load),
+│                        #   Engine { schedulers, info, lora }, LiveScheduler,
+│                        #   EngineInfo, LaunchedEngine { Handle | Stepped }
+├── control.rs           # LoRA capability — outside the contract: LoraControl vocabulary,
+│                        #   LoraClient (the `Engine.lora: Option<LoraClient>` capability)
+└── driver.rs            # trait Scheduler { submit, step, load } + spawn_scheduler:
+                         #   the contract-owned pure-polling drive loop
 ```
 
 Design decisions worth knowing before touching it:
 
 - **Step-batched wire.** One message per scheduler step, not one channel per request: the scheduler's natural output unit is the step batch, and per-request channels were tried and rejected (the scheduler for-loop over N channels was the bottleneck). The protocol stack demuxes.
 - **Flat `RequestUpdate`.** All facts a step produced for one request travel in one struct, so intra-request ordering is structure, not convention. This is what makes `defer_finish` safe: a P/D prefill executor can withhold a request's `Finished` until its KV saves are peer-visible and send it later from any thread — the deferred message carries the request's entire buffered update, so late delivery cannot reorder.
-- **Typestate lifecycle.** `IntakeTicket` (queued) and `ActiveRequest` (streaming) are owned tokens; admit/reject/retire/finish/fail consume them, so "terminal exactly once, nothing after it" cannot be miscoded — it does not compile. A handle dropped without a transition emits `Failed` from its `Drop`, which is also how a crashed scheduler answers every in-flight request: the driver drops the scheduler, the handles fall, the terminals ship.
+- **Typestate lifecycle.** `QueuedRequest` (queued) and `ActiveRequest` (streaming) are owned tokens; admit/reject/retire/finish/fail consume them, so "terminal exactly once, nothing after it" cannot be miscoded — it does not compile. A handle dropped without a transition emits `Failed` from its `Drop`, which is also how a crashed scheduler answers every in-flight request: the driver drops the scheduler, the handles fall, the terminals ship.
 - **Emitter as single writer.** Schedulers never touch the channel; they call `StepEmitter` methods against their handles. The emitter stamps `ScheduledInfo` at admission, tallies token counts (terminal counts derive from the tally, never from model-side arithmetic), and `commit_step` publishes the whole step in one send.
-- **Pure polling driver.** `spawn_scheduler` owns the serve loop: drain intake, `Scheduler::step`, publish load, commit. No idle/park distinction — the scheduler owns the GPU and spinning on it costs nothing anyone else could use; async KV I/O (prefetch, decode-overlap prefill) is naturally absorbed by polling. An idle iteration ends in a `spin_loop` hint (relaxes the core's issue slots, no latency cost — busy iterations never pause). The loop exits when the frontend drops the handle and the queue drains.
+- **Pure polling driver.** `spawn_scheduler` owns the serve loop: drain submissions, `Scheduler::step`, publish load, commit. No idle/park distinction — the scheduler owns the GPU and spinning on it costs nothing anyone else could use; async KV I/O (prefetch, decode-overlap prefill) is naturally absorbed by polling. An idle iteration ends in a `spin_loop` hint (relaxes the core's issue slots, no latency cost — busy iterations never pause). The loop exits when the frontend drops the handle and the queue drains.
 - **Abort is a flag, not channel teardown.** `SchedulerHandle::submit` returns a `RequestControl`; the frontend flips its boolean abort flag and the scheduler retires the request silently on its next touch (no terminal — the frontend already dropped its state for that id).
-- **Channels:** intake is crossbeam (sync consumer on the scheduler thread), steps are tokio mpsc (async consumer in the bridge); load is a shared cell read via `SchedulerHandle::load()` — pull-only by design, "notify me on load change" is deliberately unrepresentable (the driver busy-polls, so a subscription edge would fire per spin). All channels unbounded on purpose — admission control is the scheduler's job, expressed as `Rejected`, never as backpressure on submit.
+- **Channels:** the submit channel is crossbeam (sync consumer on the scheduler thread), steps are tokio mpsc (async consumer in the bridge); load is a shared cell read via `SchedulerHandle::load()` — pull-only by design, "notify me on load change" is deliberately unrepresentable (the driver busy-polls, so a subscription edge would fire per spin). All channels unbounded on purpose — admission control is the scheduler's job, expressed as `Rejected`, never as backpressure on submit.
 - **Control plane lives outside the contract.** `Scheduler` has no control method and the contract carries no control channel. A capability like LoRA is a private channel the model crate mints *before* `spawn_scheduler` — the scheduler closes over the receiver, the `LoraClient` sender surfaces as `Engine.lora: Option<LoraClient>`, and the `Option` *is* the capability (no `bool` flag, no registry until a second capability exists). The vocabulary (`LoraControl`, `LoraClient`) is still defined in the frontend crate because the frontend must speak it without holding model structs; only the wiring is the model's business.
 
 ### Onboarding checklist for a new model line
 
 1. Implement `Scheduler` (see `Qwen3Scheduler` in `pegainfer-qwen3/src/frontend_adapter.rs` — the whole adaptation is deliberately in one file):
-   - `intake(ticket)` — ownership transfer only: take the payload (`ticket.take_request()`), mint your internal id, park the ticket in a registry. No emitter here by design — `step` is the single emission site, and the driver commits once per iteration so nothing is gained by emitting earlier.
-   - `step(emitter)` — one scheduling step: admit (consume tickets via `emitter.admit`/`reject`), execute, push tokens, finish/fail/retire. Return `Err` only for engine-fatal states.
+   - `submit(req)` — ownership transfer only: take the payload (`req.take_request()`), mint your internal id, park the handle in a registry. No emitter here by design — `step` is the single emission site, and the driver commits once per iteration so nothing is gained by emitting earlier.
+   - `step(emitter)` — one scheduling step: admit (consume queued handles via `emitter.admit`/`reject`), execute, push tokens, finish/fail/retire. Return `Err` only for engine-fatal states.
    - `load()` — KV occupancy + running/waiting counts for routers.
    - Extra capabilities (LoRA etc.) are not trait methods: mint the private channel before spawning, close the scheduler over the receiver, drain it inside `step`.
 2. `spawn_scheduler(name, scheduler)` per scheduler; return `Engine { schedulers, info: EngineInfo { kv_capacity, servable_len }, lora }` — the required-metadata fields are the checklist, and `lora: Some(client)` only when the line actually serves adapter control.
@@ -102,7 +103,7 @@ All six lines are onboarded. Adding a model line = write `model_line.rs` in the 
 | --- | --- |
 | `pegainfer-engine`, `pegainfer-vllm-frontend`, dynamo crates, `bench_serving` | see git history of this doc for the pre-2026-08 consolidation table |
 | Qwen3 `scheduler_loop` / `start_qwen3*` in `scheduler.rs` (double loop + sink plumbing) | contract driver (`driver.rs`) + `frontend_adapter.rs`; `scheduler.rs` is now contract-free mechanics |
-| `TokenSink` send-failure-as-cancellation (qwen3 path) | `RequestControl::abort` flag, observed via `IntakeTicket/ActiveRequest::aborted` |
+| `TokenSink` send-failure-as-cancellation (qwen3 path) | `RequestControl::abort` flag, observed via `QueuedRequest/ActiveRequest::is_aborted` |
 | `EngineCommand` + `EngineHandle` LoRA control methods | `LoraClient` over the model crate's private pre-spawn channel (`Engine.lora: Option<LoraClient>` is the capability); idle-drain policy lives in the qwen3 adapter (`pending_control` + `post_control_deferred`) |
 | Per-request event-order convention (`Scheduled` before tokens, one terminal, enforced by hand) | typestate handles + emitter: illegal orders don't compile; drop bombs turn scheduler bugs into `Failed` terminals instead of client hangs |
 | KV block-event feed (`KvBlockEvent`/`KvStoredBlock`, `EngineHandle::take_kv_events`, qwen3 `ExecutorKvEvents` + `enable_kv_events` plumbing) | none — it never had a consumer. Rebuild from git history when a cache-aware router lands; the natural re-home is a `RequestUpdate`/load-feed sibling on the step contract |

--- a/pegainfer-frontend/examples/echo-server.rs
+++ b/pegainfer-frontend/examples/echo-server.rs
@@ -30,9 +30,9 @@ use pegainfer_frontend::engine::ActiveRequest;
 use pegainfer_frontend::engine::Engine;
 use pegainfer_frontend::engine::EngineInfo;
 use pegainfer_frontend::engine::FinishReason;
-use pegainfer_frontend::engine::IntakeTicket;
 use pegainfer_frontend::engine::LaunchedEngine;
 use pegainfer_frontend::engine::LoadSnapshot;
+use pegainfer_frontend::engine::QueuedRequest;
 use pegainfer_frontend::engine::Scheduler;
 use pegainfer_frontend::engine::StepEmitter;
 use pegainfer_frontend::engine::spawn_scheduler;
@@ -98,7 +98,7 @@ impl ModelLine for EchoLine {
 /// streaming path warm instead of collapsing the response into one batch.
 #[derive(Default)]
 struct EchoScheduler {
-    queued: Vec<IntakeTicket>,
+    queued: Vec<QueuedRequest>,
     running: Vec<RunningRequest>,
 }
 
@@ -113,22 +113,22 @@ struct RunningRequest {
 }
 
 impl Scheduler for EchoScheduler {
-    fn intake(&mut self, ticket: IntakeTicket) {
-        self.queued.push(ticket);
+    fn submit(&mut self, req: QueuedRequest) {
+        self.queued.push(req);
     }
 
     fn step(&mut self, emitter: &mut StepEmitter) -> Result<()> {
-        for ticket in self.queued.drain(..) {
-            if ticket.is_aborted() {
-                emitter.retire_ticket(ticket);
+        for req in self.queued.drain(..) {
+            if req.is_aborted() {
+                emitter.retire_queued(req);
                 continue;
             }
-            let request = ticket.request();
+            let request = req.request();
             let echo_len = request.prompt_tokens.len().min(request.max_tokens);
             let truncated = echo_len < request.prompt_tokens.len();
             let mut pending = Vec::from(&request.prompt_tokens[..echo_len]);
             pending.reverse();
-            let active = emitter.admit(ticket);
+            let active = emitter.admit(req);
             self.running.push(RunningRequest {
                 active,
                 pending,

--- a/pegainfer-frontend/src/engine/driver.rs
+++ b/pegainfer-frontend/src/engine/driver.rs
@@ -10,7 +10,7 @@
 
 use super::emitter::StepEmitter;
 use super::handle::LoadSnapshot;
-use super::ticket::IntakeTicket;
+use super::request_lifecycle::QueuedRequest;
 use super::wiring::LiveScheduler;
 use super::wiring::SchedulerBackend;
 use super::wiring::scheduler_pair;
@@ -22,8 +22,8 @@ pub trait Scheduler: Send {
     /// every verdict (admit/reject/retire) is emitted from [`Self::step`],
     /// the single emission site. Nothing is lost by deferring: the driver
     /// commits once per iteration, so a verdict buffered in `step` lands in
-    /// the same commit an intake-time verdict would have.
-    fn intake(&mut self, ticket: IntakeTicket);
+    /// the same commit a submit-time verdict would have.
+    fn submit(&mut self, req: QueuedRequest);
 
     /// Advance one step: admission, GPU work, and per-request emission. The
     /// driver loops over this without pause — an idle scheduler returns
@@ -50,25 +50,25 @@ pub fn spawn_scheduler<S: Scheduler + 'static>(name: &str, scheduler: S) -> Live
     LiveScheduler { handle, join }
 }
 
-/// The polling loop. Exits when the frontend is gone (intake disconnected)
-/// and the scheduler reports itself drained, or when `step` reports a fatal
+/// The polling loop. Exits when the frontend is gone (submission channel
+/// disconnected) and the scheduler reports itself drained, or when `step` reports a fatal
 /// error. An idle iteration (nothing running or waiting) ends in a
 /// [`std::hint::spin_loop`] before the next probe; busy iterations never
 /// pause.
 pub fn drive<S: Scheduler>(mut scheduler: S, backend: SchedulerBackend) {
     let SchedulerBackend {
-        intake,
+        submissions,
         mut emitter,
         load,
     } = backend;
-    let mut intake_open = true;
+    let mut submissions_open = true;
     loop {
         loop {
-            match intake.try_recv() {
-                Ok(ticket) => scheduler.intake(ticket),
+            match submissions.try_recv() {
+                Ok(req) => scheduler.submit(req),
                 Err(crossbeam_channel::TryRecvError::Empty) => break,
                 Err(crossbeam_channel::TryRecvError::Disconnected) => {
-                    intake_open = false;
+                    submissions_open = false;
                     break;
                 }
             }
@@ -78,13 +78,13 @@ pub fn drive<S: Scheduler>(mut scheduler: S, backend: SchedulerBackend) {
         load.publish(snapshot);
         emitter.commit_step();
         if let Err(error) = step {
-            // Dropping the scheduler drops its held tickets/handles; their
+            // Dropping the scheduler drops its held request handles; their
             // drop bombs answer every in-flight request with `Failed`.
             log::error!("scheduler fatal, engine winding down: {error:#}");
             return;
         }
         if snapshot.num_running_reqs == 0 && snapshot.num_waiting_reqs == 0 {
-            if !intake_open {
+            if !submissions_open {
                 log::info!("scheduler drained after frontend shutdown, exiting");
                 return;
             }
@@ -98,32 +98,32 @@ pub fn drive<S: Scheduler>(mut scheduler: S, backend: SchedulerBackend) {
 
 #[cfg(test)]
 mod tests {
+    use super::super::request_lifecycle::ActiveRequest;
     use super::super::step::Request;
     use super::super::step::Terminal;
-    use super::super::ticket::ActiveRequest;
     use super::*;
     use crate::engine::FinishReason;
 
     /// Emits one token per step per request and finishes at `max_tokens`.
     #[derive(Default)]
     struct EchoScheduler {
-        queued: Vec<IntakeTicket>,
+        queued: Vec<QueuedRequest>,
         running: Vec<(ActiveRequest, usize)>,
         fatal_next_step: bool,
     }
 
     impl Scheduler for EchoScheduler {
-        fn intake(&mut self, ticket: IntakeTicket) {
-            self.queued.push(ticket);
+        fn submit(&mut self, req: QueuedRequest) {
+            self.queued.push(req);
         }
 
         fn step(&mut self, emitter: &mut StepEmitter) -> anyhow::Result<()> {
             if self.fatal_next_step {
                 anyhow::bail!("injected fatal");
             }
-            for ticket in self.queued.drain(..) {
-                let max_tokens = ticket.request().max_tokens;
-                let active = emitter.admit(ticket);
+            for req in self.queued.drain(..) {
+                let max_tokens = req.request().max_tokens;
+                let active = emitter.admit(req);
                 self.running.push((active, max_tokens));
             }
             let mut still_running = Vec::new();
@@ -196,7 +196,8 @@ mod tests {
             })
         ));
 
-        // Dropping the handle disconnects intake; a drained scheduler exits.
+        // Dropping the handle disconnects the submission channel; a drained
+        // scheduler exits.
         drop(handle);
         partition.join.join().expect("driver thread exits cleanly");
     }

--- a/pegainfer-frontend/src/engine/emitter.rs
+++ b/pegainfer-frontend/src/engine/emitter.rs
@@ -13,6 +13,11 @@ use std::time::Instant;
 
 use super::event::FinishReason;
 use super::event::TokenLogprob;
+use super::request_lifecycle::ActiveRequest;
+use super::request_lifecycle::DeferredFinish;
+use super::request_lifecycle::QueuedRequest;
+use super::request_lifecycle::StepReceiver;
+use super::request_lifecycle::StepSender;
 use super::step::PromptEcho;
 use super::step::RejectReason;
 use super::step::RequestId;
@@ -20,11 +25,6 @@ use super::step::RequestUpdate;
 use super::step::ScheduledInfo;
 use super::step::StepOutputs;
 use super::step::Terminal;
-use super::ticket::ActiveRequest;
-use super::ticket::DeferredFinish;
-use super::ticket::IntakeTicket;
-use super::ticket::StepReceiver;
-use super::ticket::StepSender;
 
 pub struct StepEmitter {
     tx: StepSender,
@@ -67,12 +67,12 @@ impl StepEmitter {
         self.buffer[slot].take()
     }
 
-    // ── IntakeTicket exits ──────────────────────────────────────────────
+    // ── QueuedRequest exits ─────────────────────────────────────────
 
     /// Admit the request: stamp `scheduled_at`, buffer the admission facts,
     /// hand back the streaming-state handle.
-    pub fn admit(&mut self, ticket: IntakeTicket) -> ActiveRequest {
-        let inner = ticket.consume();
+    pub fn admit(&mut self, req: QueuedRequest) -> ActiveRequest {
+        let inner = req.consume();
         let prompt_tokens = inner.prompt_len;
         self.entry(inner.core.id).scheduled = Some(ScheduledInfo {
             queued_at: inner.queued_at,
@@ -83,8 +83,8 @@ impl StepEmitter {
     }
 
     /// Refuse the request at admission.
-    pub fn reject(&mut self, ticket: IntakeTicket, reason: RejectReason) {
-        let inner = ticket.consume();
+    pub fn reject(&mut self, req: QueuedRequest, reason: RejectReason) {
+        let inner = req.consume();
         self.entry(inner.core.id).terminal = Some(Terminal::Rejected {
             reason,
             prompt_tokens: inner.prompt_len,
@@ -92,10 +92,10 @@ impl StepEmitter {
     }
 
     /// Retire a queued request whose frontend already gave up on it (see
-    /// [`IntakeTicket::aborted`]). Silent: the frontend dropped its state for
+    /// [`QueuedRequest::is_aborted`]). Silent: the frontend dropped its state for
     /// this id, so there is no one to address.
-    pub fn retire_ticket(&mut self, ticket: IntakeTicket) {
-        let inner = ticket.consume();
+    pub fn retire_queued(&mut self, req: QueuedRequest) {
+        let inner = req.consume();
         log::debug!("request retired before admission: {}", inner.core.id);
         self.extract(inner.core.id);
     }
@@ -226,7 +226,7 @@ impl StepEmitter {
             return;
         }
         // A closed receiver means the frontend is gone; the driver notices
-        // through the intake side and winds down.
+        // through the submission channel and winds down.
         let _ = self.tx.send(StepOutputs { updates });
     }
 }
@@ -256,9 +256,9 @@ mod tests {
     fn admission_tokens_and_finish_fold_into_one_entry() {
         let (handle, mut backend) = scheduler_pair();
         let _control = handle.submit(request(vec![1, 2, 3]));
-        let ticket = backend.intake.try_recv().expect("ticket");
+        let req = backend.submissions.try_recv().expect("req");
 
-        let mut active = backend.emitter.admit(ticket);
+        let mut active = backend.emitter.admit(req);
         backend.emitter.push_tokens(&mut active, &[10, 11], &[]);
         backend.emitter.set_cached_tokens(&mut active, 2);
         backend.emitter.finish(active, FinishReason::Stop);
@@ -289,9 +289,9 @@ mod tests {
     fn reject_carries_prompt_len_and_no_tokens() {
         let (handle, mut backend) = scheduler_pair();
         let _control = handle.submit(request(vec![1; 5]));
-        let ticket = backend.intake.try_recv().expect("ticket");
+        let req = backend.submissions.try_recv().expect("req");
         backend.emitter.reject(
-            ticket,
+            req,
             RejectReason::ContextLength {
                 prompt_tokens: 5,
                 max_tokens: 8,
@@ -317,8 +317,8 @@ mod tests {
     fn retire_discards_buffered_output() {
         let (handle, mut backend) = scheduler_pair();
         let _control = handle.submit(request(vec![1]));
-        let ticket = backend.intake.try_recv().expect("ticket");
-        let mut active = backend.emitter.admit(ticket);
+        let req = backend.submissions.try_recv().expect("req");
+        let mut active = backend.emitter.admit(req);
         backend.emitter.push_tokens(&mut active, &[9], &[]);
         backend.emitter.retire(active);
         backend.emitter.commit_step();
@@ -332,8 +332,8 @@ mod tests {
     fn defer_finish_folds_step_output_and_delivers_late() {
         let (handle, mut backend) = scheduler_pair();
         let _control = handle.submit(request(vec![1, 2]));
-        let ticket = backend.intake.try_recv().expect("ticket");
-        let mut active = backend.emitter.admit(ticket);
+        let req = backend.submissions.try_recv().expect("req");
+        let mut active = backend.emitter.admit(req);
         backend.emitter.push_tokens(&mut active, &[7], &[]);
         let deferred = backend.emitter.defer_finish(active, FinishReason::Length);
         backend.emitter.commit_step();
@@ -365,12 +365,12 @@ mod tests {
         let (handle, mut backend) = scheduler_pair();
         let _c0 = handle.submit(request(vec![1]));
         let _c1 = handle.submit(request(vec![2, 3]));
-        let dropped_ticket = backend.intake.try_recv().expect("ticket 0");
+        let dropped_req = backend.submissions.try_recv().expect("req 0");
         let admitted = backend
             .emitter
-            .admit(backend.intake.try_recv().expect("ticket 1"));
+            .admit(backend.submissions.try_recv().expect("req 1"));
 
-        drop(dropped_ticket);
+        drop(dropped_req);
         drop(admitted);
 
         let mut steps = handle_steps(handle);
@@ -387,12 +387,12 @@ mod tests {
     fn abort_flag_is_visible_through_both_states() {
         let (handle, mut backend) = scheduler_pair();
         let control = handle.submit(request(vec![1]));
-        let ticket = backend.intake.try_recv().expect("ticket");
-        assert!(!ticket.is_aborted());
+        let req = backend.submissions.try_recv().expect("req");
+        assert!(!req.is_aborted());
 
         control.abort();
-        assert!(ticket.is_aborted());
-        let active = backend.emitter.admit(ticket);
+        assert!(req.is_aborted());
+        let active = backend.emitter.admit(req);
         assert!(active.is_aborted());
         backend.emitter.retire(active);
     }

--- a/pegainfer-frontend/src/engine/handle.rs
+++ b/pegainfer-frontend/src/engine/handle.rs
@@ -280,7 +280,7 @@ pub fn panic_message(payload: &dyn Any) -> &str {
 
 /// Answer a request the handle cannot place (a `data_parallel_rank` outside
 /// the engine's partition topology) with the standard Scheduled → Rejected
-/// pair — the same surface a model scheduler's intake rejection produces.
+/// pair — the same surface a model scheduler's admission rejection produces.
 fn reject_unroutable(req: &GenerateRequest, partition: usize, partitions: usize) {
     let queued_at_unix_s = req.queued_at_unix_s.unwrap_or_else(unix_now_s);
     let _ = req.token_tx.send(TokenEvent::Scheduled {

--- a/pegainfer-frontend/src/engine/mod.rs
+++ b/pegainfer-frontend/src/engine/mod.rs
@@ -4,8 +4,9 @@
 //!
 //! - [`step`] — the wire types: `Request`, `RequestId`, `StepOutputs` with
 //!   one flat `RequestUpdate` per touched request per step.
-//! - [`ticket`] — the typestate handles (`IntakeTicket` → `ActiveRequest` →
-//!   consumed) that make the event protocol a move-checked state machine.
+//! - [`request_lifecycle`] — the typestate handles (`QueuedRequest` →
+//!   `ActiveRequest` → consumed) that make the event protocol a move-checked
+//!   state machine.
 //! - [`emitter`] — `StepEmitter`, the scheduler-side single writer of the
 //!   per-step buffer.
 //! - [`wiring`] — `scheduler_pair` wiring, `SchedulerHandle`, and the
@@ -31,9 +32,9 @@ mod event;
 mod handle;
 mod kv;
 mod request;
+mod request_lifecycle;
 mod sink;
 mod step;
-mod ticket;
 mod wiring;
 
 pub use control::*;
@@ -43,7 +44,7 @@ pub use event::*;
 pub use handle::*;
 pub use kv::*;
 pub use request::*;
+pub use request_lifecycle::*;
 pub use sink::*;
 pub use step::*;
-pub use ticket::*;
 pub use wiring::*;

--- a/pegainfer-frontend/src/engine/request_lifecycle.rs
+++ b/pegainfer-frontend/src/engine/request_lifecycle.rs
@@ -4,9 +4,9 @@
 //! protocol is enforced by move semantics instead of convention:
 //!
 //! ```text
-//! IntakeTicket ──admit──▶ ActiveRequest ──finish/fail/defer──▶ consumed
-//!      │                        │
-//!      └──reject/retire─────────┴──retire──▶ consumed (silent)
+//! QueuedRequest ──admit──▶ ActiveRequest ──finish/fail/defer──▶ consumed
+//!       │                        │
+//!       └──reject/retire─────────┴──retire──▶ consumed (silent)
 //! ```
 //!
 //! Every transition consumes the handle, so "terminal exactly once" and
@@ -57,26 +57,26 @@ impl HandleCore {
 /// A submitted request the scheduler has not yet answered. Minted only by
 /// [`super::SchedulerHandle::submit`]; consumed by exactly one of
 /// [`super::StepEmitter::admit`], [`super::StepEmitter::reject`], or
-/// [`super::StepEmitter::retire_ticket`].
-pub struct IntakeTicket {
-    /// `Some` until a transition consumes the ticket; `Drop` fires on `Some`.
-    inner: Option<TicketInner>,
+/// [`super::StepEmitter::retire_queued`].
+pub struct QueuedRequest {
+    /// `Some` until a transition consumes the handle; `Drop` fires on `Some`.
+    inner: Option<QueuedInner>,
 }
 
-pub(crate) struct TicketInner {
+pub(crate) struct QueuedInner {
     pub(crate) core: HandleCore,
-    /// Boxed so a ticket stays pointer-small in scheduler registries; `None`
-    /// after [`IntakeTicket::take_request`] moved the payload out.
+    /// Boxed so a queued request stays pointer-small in scheduler registries;
+    /// `None` after [`QueuedRequest::take_request`] moved the payload out.
     request: Option<Box<Request>>,
     /// Cached so admission facts and the drop bomb survive the payload move.
     pub(crate) prompt_len: usize,
     pub(crate) queued_at: Instant,
 }
 
-impl IntakeTicket {
+impl QueuedRequest {
     pub(crate) fn new(core: HandleCore, request: Request, queued_at: Instant) -> Self {
         Self {
-            inner: Some(TicketInner {
+            inner: Some(QueuedInner {
                 core,
                 prompt_len: request.prompt_tokens.len(),
                 request: Some(Box::new(request)),
@@ -85,14 +85,14 @@ impl IntakeTicket {
         }
     }
 
-    fn inner(&self) -> &TicketInner {
+    fn inner(&self) -> &QueuedInner {
         self.inner
             .as_ref()
-            .expect("ticket accessed after consumption")
+            .expect("queued request accessed after consumption")
     }
 
-    pub(crate) fn consume(mut self) -> TicketInner {
-        self.inner.take().expect("ticket consumed twice")
+    pub(crate) fn consume(mut self) -> QueuedInner {
+        self.inner.take().expect("queued request consumed twice")
     }
 
     pub fn id(&self) -> RequestId {
@@ -107,14 +107,14 @@ impl IntakeTicket {
             .expect("request payload already taken")
     }
 
-    /// Move the payload out, leaving a ticket that is still the request's
+    /// Move the payload out, leaving a handle that is still the request's
     /// lifecycle handle (admit/reject/retire and the drop bomb keep working
     /// off the cached prompt length). `None` on a second call — schedulers
-    /// that ingest the payload at intake take it exactly once.
+    /// that ingest the payload on submit take it exactly once.
     pub fn take_request(&mut self) -> Option<Request> {
         self.inner
             .as_mut()
-            .expect("ticket accessed after consumption")
+            .expect("queued request accessed after consumption")
             .request
             .take()
             .map(|request| *request)
@@ -125,13 +125,13 @@ impl IntakeTicket {
     }
 
     /// The frontend stopped wanting this request while it queued. The
-    /// scheduler answers by [`super::StepEmitter::retire_ticket`].
+    /// scheduler answers by [`super::StepEmitter::retire_queued`].
     pub fn is_aborted(&self) -> bool {
         self.inner().core.is_aborted()
     }
 }
 
-impl Drop for IntakeTicket {
+impl Drop for QueuedRequest {
     fn drop(&mut self) {
         let Some(inner) = self.inner.take() else {
             return;

--- a/pegainfer-frontend/src/engine/step.rs
+++ b/pegainfer-frontend/src/engine/step.rs
@@ -6,7 +6,7 @@
 //! protocol (`Scheduled` before tokens before a single terminal) are structure,
 //! not convention: a `RequestUpdate` cannot express a token after its terminal.
 //! Cross-step ordering is enforced on the producer side by the typestate
-//! handles in [`super::ticket`].
+//! handles in [`super::request_lifecycle`].
 
 use std::fmt;
 use std::time::Instant;
@@ -41,7 +41,7 @@ impl std::fmt::Display for RequestId {
 
 /// One generate request as a frontend submits it. Identity (`RequestId`),
 /// queue timestamp, and the abort flag are minted at submit time and travel in
-/// the [`super::IntakeTicket`] wrapper, not here.
+/// the [`super::QueuedRequest`] wrapper, not here.
 pub struct Request {
     pub prompt_tokens: Vec<u32>,
     pub params: crate::sampler::SamplingParams,

--- a/pegainfer-frontend/src/engine/wiring.rs
+++ b/pegainfer-frontend/src/engine/wiring.rs
@@ -4,11 +4,12 @@
 //! Both ends of a scheduler are minted together by [`scheduler_pair`], so a
 //! model crate cannot cross-wire or forget a line: the scheduler side arrives
 //! as one [`SchedulerBackend`] value, the frontend side as one
-//! [`SchedulerHandle`]. Channel choices per direction: intake is crossbeam
-//! (sync consumer on the scheduler thread; senders never block on unbounded
-//! channels), the step stream is tokio (async consumer in the protocol
-//! stack; the sync producer's send never blocks either), load is a shared
-//! cell (read-only pull, deliberately unsubscribable — see [`LoadPublisher`]).
+//! [`SchedulerHandle`]. Channel choices per direction: the submit channel is
+//! crossbeam (sync consumer on the scheduler thread; senders never block on
+//! unbounded channels), the step stream is tokio (async consumer in the
+//! protocol stack; the sync producer's send never blocks either), load is a
+//! shared cell (read-only pull, deliberately unsubscribable — see
+//! [`LoadPublisher`]).
 //!
 //! How many schedulers an engine runs and what each one means (DP replicas,
 //! anything else) is the model line's decision; the contract carries the
@@ -25,18 +26,18 @@ use std::time::Instant;
 use super::control::LoraClient;
 use super::handle::LoadSnapshot;
 use super::kv::KvCapacity;
+use super::request_lifecycle::HandleCore;
+use super::request_lifecycle::QueuedRequest;
+use super::request_lifecycle::RequestControl;
+use super::request_lifecycle::StepReceiver;
 use super::step::Request;
 use super::step::RequestId;
-use super::ticket::HandleCore;
-use super::ticket::IntakeTicket;
-use super::ticket::RequestControl;
-use super::ticket::StepReceiver;
 
 /// Everything the scheduler thread consumes and produces. The driver
 /// ([`super::drive`]) destructures this; model code only ever sees the
-/// emitter and, through trait arguments, the tickets.
+/// emitter and, through trait arguments, the request handles.
 pub struct SchedulerBackend {
-    pub(crate) intake: crossbeam_channel::Receiver<IntakeTicket>,
+    pub(crate) submissions: crossbeam_channel::Receiver<QueuedRequest>,
     pub(crate) emitter: super::emitter::StepEmitter,
     pub(crate) load: LoadPublisher,
 }
@@ -61,25 +62,26 @@ impl LoadPublisher {
 
 /// The frontend's end of one running scheduler.
 pub struct SchedulerHandle {
-    intake_tx: crossbeam_channel::Sender<IntakeTicket>,
+    submit_tx: crossbeam_channel::Sender<QueuedRequest>,
     steps: Option<StepReceiver>,
     load: Arc<Mutex<LoadSnapshot>>,
     next_id: AtomicU64,
-    /// Kept so tickets minted after the scheduler thread exits still get
-    /// their drop-bomb terminal delivered (the ticket needs a live sender).
-    step_tx: super::ticket::StepSender,
+    /// Kept so requests minted after the scheduler thread exits still get
+    /// their drop-bomb terminal delivered (the handle needs a live sender).
+    step_tx: super::request_lifecycle::StepSender,
 }
 
 impl SchedulerHandle {
     /// Mint identity, queue timestamp, and abort flag, then hand the request
-    /// to the scheduler. Never fails: if the scheduler is gone, the ticket's
-    /// drop bomb answers the request with a `Failed` terminal on the step
-    /// stream, which the caller observes like any other terminal.
+    /// to the scheduler. Never fails: if the scheduler is gone, the
+    /// `QueuedRequest`'s drop bomb answers the request with a `Failed`
+    /// terminal on the step stream, which the caller observes like any other
+    /// terminal.
     pub fn submit(&self, request: Request) -> RequestControl {
         let id = RequestId::new(self.next_id.fetch_add(1, Ordering::Relaxed));
         let abort = Arc::new(AtomicBool::new(false));
         let control = RequestControl::new(id, Arc::clone(&abort));
-        let ticket = IntakeTicket::new(
+        let request = QueuedRequest::new(
             HandleCore {
                 id,
                 abort,
@@ -88,7 +90,7 @@ impl SchedulerHandle {
             request,
             Instant::now(),
         );
-        if let Err(returned) = self.intake_tx.send(ticket) {
+        if let Err(returned) = self.submit_tx.send(request) {
             drop(returned.into_inner());
         }
         control
@@ -111,19 +113,19 @@ impl SchedulerHandle {
 /// Mint both ends of one scheduler's wiring.
 #[must_use]
 pub fn scheduler_pair() -> (SchedulerHandle, SchedulerBackend) {
-    let (intake_tx, intake_rx) = crossbeam_channel::unbounded();
+    let (submit_tx, submit_rx) = crossbeam_channel::unbounded();
     let (step_tx, step_rx) = tokio::sync::mpsc::unbounded_channel();
     let load = Arc::new(Mutex::new(LoadSnapshot::default()));
     (
         SchedulerHandle {
-            intake_tx,
+            submit_tx,
             steps: Some(step_rx),
             load: Arc::clone(&load),
             next_id: AtomicU64::new(0),
             step_tx: step_tx.clone(),
         },
         SchedulerBackend {
-            intake: intake_rx,
+            submissions: submit_rx,
             emitter: super::emitter::StepEmitter::new(step_tx),
             load: LoadPublisher(load),
         },
@@ -147,7 +149,7 @@ pub struct Engine {
 pub struct LiveScheduler {
     pub handle: SchedulerHandle,
     /// The driver thread. Joined by the server at shutdown, after the handles
-    /// (and with them the intake senders) are dropped.
+    /// (and with them the submit senders) are dropped.
     pub join: std::thread::JoinHandle<()>,
 }
 

--- a/pegainfer-frontend/src/vllm/bridge/stepped.rs
+++ b/pegainfer-frontend/src/vllm/bridge/stepped.rs
@@ -165,7 +165,7 @@ impl SteppedEngineBridge {
 
         // Flip every in-flight request's abort flag so the scheduler retires
         // them on its next touch; dropping the partition handle afterwards
-        // disconnects intake and lets the driver drain out.
+        // disconnects the submission channel and lets the driver drain out.
         for state in streams.values() {
             state.control.abort();
         }

--- a/pegainfer-frontend/src/vllm/mod.rs
+++ b/pegainfer-frontend/src/vllm/mod.rs
@@ -333,7 +333,7 @@ where
                 while bridges.join_next().await.is_some() {}
             }
             // The bridges are gone, and with them the partition handles:
-            // intake channels are disconnected, so the drivers drain and
+            // submission channels are disconnected, so the drivers drain and
             // exit. Reap their threads to surface scheduler panics.
             if !scheduler_joins.is_empty() {
                 let _ = tokio::task::spawn_blocking(move || {

--- a/pegainfer-k3/src/scheduler/mod.rs
+++ b/pegainfer-k3/src/scheduler/mod.rs
@@ -1,11 +1,11 @@
 //! How K3 plugs into the step-batched engine contract.
 //!
 //! [`K3Scheduler`] implements [`Scheduler`]: the contract's driver polls
-//! `intake` / `step` / `load`, and everything model-side sits behind
+//! `submit` / `step` / `load`, and everything model-side sits behind
 //! [`StepExecutor`]. This module owns the two contract-facing jobs:
 //!
 //! - the **handle registry**: each request's typestate handle
-//!   ([`IntakeTicket`] until admission, [`ActiveRequest`] after), keyed by the
+//!   ([`QueuedRequest`] until admission, [`ActiveRequest`] after), keyed by the
 //!   contract's [`RequestId`], plus every emitter call that moves one along;
 //! - **engine assembly**: wrapping executors in schedulers and returning the
 //!   [`Engine`] bundle a model line hands back from `launch`.
@@ -28,9 +28,9 @@ use pegainfer_frontend::engine::ActiveRequest;
 use pegainfer_frontend::engine::Engine;
 use pegainfer_frontend::engine::EngineInfo;
 use pegainfer_frontend::engine::FinishReason;
-use pegainfer_frontend::engine::IntakeTicket;
 use pegainfer_frontend::engine::KvCapacity;
 use pegainfer_frontend::engine::LoadSnapshot;
+use pegainfer_frontend::engine::QueuedRequest;
 use pegainfer_frontend::engine::RejectReason;
 use pegainfer_frontend::engine::Request;
 use pegainfer_frontend::engine::RequestId;
@@ -122,8 +122,8 @@ fn finish_or_retire(active: ActiveRequest, reason: FinishReason, emitter: &mut S
 
 /// One request's contract handle, in whichever lifecycle state it holds.
 enum HandleSlot {
-    /// Submitted, not yet admitted: reject/retire consume the ticket.
-    Queued(IntakeTicket),
+    /// Submitted, not yet admitted: reject/retire consume the handle.
+    Queued(QueuedRequest),
     /// Admitted: token pushes go through it; finish/fail/retire consume it.
     Streaming(ActiveRequest),
 }
@@ -216,22 +216,22 @@ impl<E: StepExecutor> K3Scheduler<E> {
             let Some(pending) = self.queued.pop_front() else {
                 break;
             };
-            let HandleSlot::Queued(ticket) = self
+            let HandleSlot::Queued(req) = self
                 .handles
                 .remove(&pending.id)
-                .expect("queued request holds its ticket until admission")
+                .expect("queued request holds its handle until admission")
             else {
-                unreachable!("queued request {} must hold a ticket", pending.id);
+                unreachable!("queued request {} must hold a handle", pending.id);
             };
-            if ticket.is_aborted() {
-                emitter.retire_ticket(ticket);
+            if req.is_aborted() {
+                emitter.retire_queued(req);
                 continue;
             }
             if let Some(reason) = self.admission_refusal(&pending.request) {
-                emitter.reject(ticket, reason);
+                emitter.reject(req, reason);
                 continue;
             }
-            let mut active = emitter.admit(ticket);
+            let mut active = emitter.admit(req);
             if pending.request.max_tokens == 0 {
                 // Nothing to generate: answer without occupying a slot.
                 finish_or_retire(active, FinishReason::Length, emitter);
@@ -372,15 +372,15 @@ impl<E: StepExecutor> K3Scheduler<E> {
 }
 
 impl<E: StepExecutor> Scheduler for K3Scheduler<E> {
-    fn intake(&mut self, mut ticket: IntakeTicket) {
+    fn submit(&mut self, mut req: QueuedRequest) {
         // Ownership transfer only; every verdict is emitted from `step`.
-        // Tickets already aborted at intake ride the normal path — admission
-        // re-checks the flag and retires them.
-        let id = ticket.id();
-        let request = ticket
+        // Requests already aborted when submitted ride the normal path —
+        // admission re-checks the flag and retires them.
+        let id = req.id();
+        let request = req
             .take_request()
-            .expect("intake receives tickets with their payload");
-        self.handles.insert(id, HandleSlot::Queued(ticket));
+            .expect("queued requests arrive with their payload");
+        self.handles.insert(id, HandleSlot::Queued(req));
         self.queued.push_back(PendingRequest { id, request });
     }
 

--- a/pegainfer-qwen3/src/frontend_adapter.rs
+++ b/pegainfer-qwen3/src/frontend_adapter.rs
@@ -2,13 +2,13 @@
 //! file.
 //!
 //! [`Qwen3Scheduler`] implements [`pegainfer_frontend::engine::Scheduler`]:
-//! the contract's driver polls `intake`/`step`/`load`; everything
+//! the contract's driver polls `submit`/`step`/`load`; everything
 //! south of here ([`crate::scheduler`], the executor) is contract-free and
 //! deals in internal ids and pure effect data. This file owns the only two
 //! contract-facing responsibilities:
 //!
 //! - the **handle registry**: each request's typestate handle
-//!   ([`IntakeTicket`] until admission, [`ActiveRequest`] after) keyed by the
+//!   ([`QueuedRequest`] until admission, [`ActiveRequest`] after) keyed by the
 //!   internal [`RequestId`], and every emitter call that moves one through
 //!   its lifecycle;
 //! - **engine assembly**: building the executor and returning the
@@ -36,13 +36,13 @@ use pegainfer_frontend::engine::DeferredFinish;
 use pegainfer_frontend::engine::Engine;
 use pegainfer_frontend::engine::EngineInfo;
 use pegainfer_frontend::engine::FinishReason;
-use pegainfer_frontend::engine::IntakeTicket;
 use pegainfer_frontend::engine::KvCapacity;
 use pegainfer_frontend::engine::LoadSnapshot;
 use pegainfer_frontend::engine::LoraClient;
 use pegainfer_frontend::engine::LoraControl;
 use pegainfer_frontend::engine::LoraControlReceiver;
 use pegainfer_frontend::engine::PromptEcho;
+use pegainfer_frontend::engine::QueuedRequest;
 use pegainfer_frontend::engine::RejectReason;
 use pegainfer_frontend::engine::Scheduler;
 use pegainfer_frontend::engine::StepEmitter;
@@ -218,8 +218,8 @@ where
 
 /// One request's contract handle, in whichever lifecycle state it holds.
 enum HandleSlot {
-    /// Submitted, not yet admitted: reject/retire consume the ticket.
-    Queued(IntakeTicket),
+    /// Submitted, not yet admitted: reject/retire consume the handle.
+    Queued(QueuedRequest),
     /// Admitted: token pushes go through it; finish/fail/retire consume it.
     Streaming(ActiveRequest),
 }
@@ -293,18 +293,18 @@ impl<E: ModelExecutor> Qwen3Scheduler<E> {
             && self.inflight_prefill_pending.is_none()
     }
 
-    /// Consume the request's queued ticket for admission. `false` (and full
+    /// Consume the request's queued handle for admission. `false` (and full
     /// cleanup) when the frontend aborted it while it waited.
     fn admit_or_retire(&mut self, req: &PendingRequest, emitter: &mut StepEmitter) -> bool {
-        let Some(HandleSlot::Queued(ticket)) = self.handles.remove(&req.request_id) else {
-            unreachable!("admitted request must hold a queued ticket");
+        let Some(HandleSlot::Queued(queued)) = self.handles.remove(&req.request_id) else {
+            unreachable!("admitted request must hold its queued handle");
         };
-        if ticket.is_aborted() {
-            emitter.retire_ticket(ticket);
+        if queued.is_aborted() {
+            emitter.retire_queued(queued);
             release_rejected(&mut self.executor, &mut self.tracker, req);
             return false;
         }
-        let handle = emitter.admit(ticket);
+        let handle = emitter.admit(queued);
         self.handles
             .insert(req.request_id, HandleSlot::Streaming(handle));
         true
@@ -316,10 +316,10 @@ impl<E: ModelExecutor> Qwen3Scheduler<E> {
         reason: RejectReason,
         emitter: &mut StepEmitter,
     ) {
-        let Some(HandleSlot::Queued(ticket)) = self.handles.remove(&req.request_id) else {
-            unreachable!("rejected request must hold a queued ticket");
+        let Some(HandleSlot::Queued(queued)) = self.handles.remove(&req.request_id) else {
+            unreachable!("rejected request must hold its queued handle");
         };
-        emitter.reject(ticket, reason);
+        emitter.reject(queued, reason);
         release_rejected(&mut self.executor, &mut self.tracker, req);
     }
 
@@ -666,16 +666,16 @@ impl<E: ModelExecutor> Qwen3Scheduler<E> {
 }
 
 impl<E: ModelExecutor> Scheduler for Qwen3Scheduler<E> {
-    fn intake(&mut self, mut ticket: IntakeTicket) {
-        // Already-aborted tickets ride the normal path: admission re-checks
+    fn submit(&mut self, mut req: QueuedRequest) {
+        // Already-aborted requests ride the normal path: admission re-checks
         // the abort flag and retires them (`admit_or_retire`).
-        let request = ticket
+        let request = req
             .take_request()
-            .expect("intake receives tickets with their payload");
+            .expect("queued requests arrive with their payload");
         let id = RequestId(self.next_request_id);
         self.next_request_id += 1;
         self.tracker.enter_queue(id, request.trace_parent);
-        self.handles.insert(id, HandleSlot::Queued(ticket));
+        self.handles.insert(id, HandleSlot::Queued(req));
         let pending = PendingRequest::from_request(id, request);
         if self.pending_control.is_empty() {
             self.deferred.push(pending);
@@ -759,7 +759,8 @@ impl<E: ModelExecutor> Scheduler for Qwen3Scheduler<E> {
             return Ok(());
         }
 
-        // 5. Validate + admit; every verdict consumes the request's ticket.
+        // 5. Validate + admit; every verdict consumes the request's queued
+        //    handle.
         let lora_validation =
             reject_unknown_lora_requests(std::mem::take(&mut self.deferred), &self.executor);
         for rejected in &lora_validation.rejected {

--- a/pegainfer-qwen3/src/scheduler.rs
+++ b/pegainfer-qwen3/src/scheduler.rs
@@ -4,7 +4,7 @@
 //! This module is engine-contract-free: it owns queues of [`PendingRequest`]s
 //! and produces pure [`effects::StepEffects`] data. The serve loop itself
 //! belongs to the contract's driver, and everything that touches the engine
-//! contract (tickets, emitter calls, the `Scheduler` trait) lives in
+//! contract (typestate handles, emitter calls, the `Scheduler` trait) lives in
 //! [`crate::frontend_adapter`] — read that file to see how Qwen3 plugs into
 //! the frontend.
 
@@ -38,7 +38,7 @@ pub(crate) struct ActiveRequestState {
     pub(crate) logprobs: usize,
 }
 
-/// A request between intake and promotion, `Clone` because the decode-overlap
+/// A request between submission and promotion, `Clone` because the decode-overlap
 /// path keeps a copy for async-prefill poll resolution. Its engine-contract
 /// handle lives in the adapter's registry, keyed by `request_id` — never here.
 #[derive(Clone)]

--- a/pegainfer-qwen3/tests/batch_invariance_output.rs
+++ b/pegainfer-qwen3/tests/batch_invariance_output.rs
@@ -213,7 +213,7 @@ impl Harness {
 
 impl Drop for Harness {
     fn drop(&mut self) {
-        // Closing the intake lets the scheduler drain and exit.
+        // Closing the submission channel lets the scheduler drain and exit.
         drop(self.handle.take());
         if let Some(join) = self.scheduler_join.take() {
             let _ = join.join();

--- a/pegainfer-qwen3/tests/common/harness.rs
+++ b/pegainfer-qwen3/tests/common/harness.rs
@@ -149,8 +149,8 @@ impl EngineHarness {
 
 impl Drop for EngineHarness {
     fn drop(&mut self) {
-        // Closing the intake lets the scheduler drain and exit; the step
-        // stream then closes and the pump follows.
+        // Closing the submission channel lets the scheduler drain and exit;
+        // the step stream then closes and the pump follows.
         drop(self.handle.take());
         if let Some(join) = self.scheduler_join.take() {
             let _ = join.join();


### PR DESCRIPTION
## What

Step-contract vocabulary rename, no behavior change:

| Before | After |
|---|---|
| `Scheduler::intake(ticket)` | `Scheduler::submit(req)` |
| `IntakeTicket` | `QueuedRequest` (`TicketInner` → `QueuedInner`) |
| `StepEmitter::retire_ticket` | `StepEmitter::retire_queued` |
| `engine/ticket.rs` | `engine/request_lifecycle.rs` |
| `intake_tx` / `intake` (channel) | `submit_tx` / `submissions` |

## Why

- `submit` is the verb at both ends of the channel (`SchedulerHandle::submit` → `Scheduler::submit`), matching executor-style submit semantics; verdicts stay deferred to `step()` either way.
- The pre-admission typestate handle is named by its state: the codebase already called it "queued" everywhere (`queued_at`, `HandleSlot::Queued`, the emitter doc's "queued request") — only the type name disagreed.
- `SubmittedRequest` was not available: the legacy contract already occupies it (`kv.rs` type alias), and renaming legacy code scheduled for deletion isn't worth the churn.

## Not touched

- glm52 / kv-store native "intake" vocabulary (different subsystems, not this contract).
- Legacy contract (`EngineHandle` path) unchanged.

## Verification

- `cargo check --release -p pegainfer-frontend -p pegainfer-qwen3 -p pegainfer-k3 --examples --tests`
- `pegainfer-frontend` lib: 60 passed (incl. engine contract tests)
- `pegainfer-qwen3` frontend_adapter: 7 passed
- `pegainfer-k3` scheduler: 8 passed
- pre-commit hooks (fmt, clippy) pass