### PR TITLE
feat(gemma4): serve requests through the engine contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Every model line is behind a cargo feature; only `qwen3` is a default feature, s
 | Qwen3-4B / 8B | `pegainfer-qwen3` | `qwen3` (default) | Full attention, TP support |
 | Qwen3.5-4B / 9B / 27B | `pegainfer-qwen35` | `--features qwen35` (needs build-time Python + Triton) | Hybrid Gated DeltaNet + full attention |
 | DeepSeek-V2-Lite | `pegainfer-deepseek-v2-lite` | `--features deepseek-v2-lite` | MoE + EP, 2-GPU |
-| Gemma 4 | `pegainfer-gemma4` | `--features gemma4` | Registration only — engine not yet available |
+| Gemma 4 | `pegainfer-gemma4` | `--features gemma4` | Sliding-window + global full attention, single-GPU eager (bring-up) |
 | Kimi-K2 | `pegainfer-kimi-k2` | `--features kimi-k2` | MLA + MoE + Marlin INT4, 8-GPU EP |
 | GLM5.2 | `pegainfer-glm52` | `--features glm52` | MLA + MoE + FP8, 8-GPU EP (bring-up) |
 | Kimi-K3 | `pegainfer-k3` | `--features k3` | Hybrid KDA + MLA, latent MoE + MXFP4, EP (bring-up — single-rank decode wired) |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3547,6 +3547,7 @@ dependencies = [
  "log",
  "pegainfer-core",
  "pegainfer-frontend",
+ "pegainfer-sample",
  "safetensors",
  "serde_json",
  "sha2 0.11.0",

--- a/docs/models/gemma4/tokenizer.md
+++ b/docs/models/gemma4/tokenizer.md
@@ -1,8 +1,8 @@
 # Gemma 4 tokenizer and chat template
 
-**TL;DR:** All five chat renders reproduce the Hugging Face reference when content is flattened to strings, and token ids agree across the layers that can differ — gated by `pegainfer-gemma4/tests/tokenizer_parity.rs` against the pinned 12B checkpoint, with the other two sizes covered by inspection rather than by running. One divergence is open: under the frontend's default content format the system turn gains a trailing space. Contracts the engine must honour: BOS comes only from the chat template, EOS is declared in three places with three different values, the published generation defaults are sampled rather than greedy, and modality tokens are reachable from plain text so text-only serving has to reject them instead of embedding them.
+**TL;DR:** All five chat renders reproduce the Hugging Face reference when content is flattened to strings, and token ids agree across the layers that can differ — gated by `pegainfer-gemma4/tests/tokenizer_parity.rs` against the pinned 12B checkpoint, with the other two sizes covered by inspection rather than by running. One divergence is open: under the frontend's default content format the system turn gains a trailing space. Contracts the engine must honour: BOS comes only from the chat template, EOS is declared in three places with three different values, the published generation defaults are sampled rather than greedy, and text-only serving rejects modality tokens before embedding and suppresses them before sampling.
 
-Last touched: 2026-07
+Last touched: 2026-08
 
 ## The gate runs on 12B; the result carries to the other sizes by inspection
 
@@ -122,7 +122,9 @@ Also read from the checkpoint rather than gated by a test.
 `generation_config.json` sets `do_sample: true`, `temperature: 1.0`, `top_k: 64`, `top_p: 0.95`
 at all three sizes. Any greedy comparison against a reference implementation has to state the
 override it applies. 12B alone adds `suppress_tokens: [258883, 258882]` — the end-of-audio and
-end-of-image ids; that list must not be applied to 26B or 31B, which do not declare it.
+end-of-image ids; that checkpoint-specific list must not be applied to 26B or 31B, which do not
+declare it. Independently, text-only serving suppresses all six modality placeholders at every
+size because none can be fed into the next text-tower step.
 
 ## Modality tokens are reachable from plain text
 
@@ -140,7 +142,7 @@ These encode as single ids straight from user text — `"before <|image|> after"
 admitted request carrying one of these ids would reach the embedding table with a placeholder that
 maps to nothing meaningful.
 
-So the admission path will need a rule for them once the engine exists — rejecting the request
-naming the token is the option that fails loudly; embedding the id silently is the one to avoid.
-Nothing enforces this today, so whoever writes admission has to pick it up from here or from the
-engine issue.
+The engine uses one shared six-id set at both boundaries: host-token validation rejects a prompt or
+decode input before embedding, and the effective sampling suppression set unions those ids with the
+checkpoint's own `suppress_tokens`. A placeholder therefore cannot be embedded, emitted to the
+client, or returned as the next decode input.

--- a/pegainfer-frontend/src/model_line.rs
+++ b/pegainfer-frontend/src/model_line.rs
@@ -93,7 +93,8 @@ pub struct SharedArgs {
 
     /// Enable CUDA Graph capture/replay on decode path (`--cuda-graph=false` to
     /// disable). Rejected for GLM5.2; forced off in Qwen3 LoRA mode; Qwen3.5
-    /// always captures and rejects `false`.
+    /// always captures and rejects `false`; Gemma 4 serves eagerly and rejects
+    /// `true`.
     #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
     pub cuda_graph: bool,
 

--- a/pegainfer-gemma4/Cargo.toml
+++ b/pegainfer-gemma4/Cargo.toml
@@ -7,7 +7,7 @@ name = "pegainfer-gemma4"
 version = "0.1.0"
 
 [features]
-gemma4 = ["dep:cudarc", "dep:half", "dep:log", "dep:pegainfer-core"]
+gemma4 = ["dep:cudarc", "dep:half", "dep:log", "dep:pegainfer-core", "dep:pegainfer-sample", "dep:tokio"]
 default = []
 
 [dependencies]
@@ -17,6 +17,8 @@ half = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
 pegainfer-core = { workspace = true, optional = true }
 pegainfer-frontend = { workspace = true }
+pegainfer-sample = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["sync"], optional = true }
 safetensors = { workspace = true }
 serde_json = { workspace = true }
 

--- a/pegainfer-gemma4/src/engine.rs
+++ b/pegainfer-gemma4/src/engine.rs
@@ -1,0 +1,407 @@
+//! The Gemma 4 engine: one owned thread serving requests serially through
+//! the KV-backed forward. Batching, CUDA graphs and the prefix cache are
+//! later stages; admission, generation, cancellation and release are real
+//! from day one.
+
+use std::path::Path;
+
+use anyhow::Context as AnyhowContext;
+use anyhow::Result;
+use cudarc::driver::CudaSlice;
+use half::bf16;
+use pegainfer_core::tensor::DeviceContext;
+use pegainfer_core::tensor::HiddenStates;
+use pegainfer_frontend::engine::EngineHandle;
+use pegainfer_frontend::engine::EngineLoadOptions;
+use pegainfer_frontend::engine::FinishReason;
+use pegainfer_frontend::engine::GenerateRequest;
+use pegainfer_frontend::engine::TokenEvent;
+use pegainfer_frontend::engine::unix_now_s;
+use pegainfer_sample::LogprobRequest;
+use pegainfer_sample::SampleScratch;
+use tokio::sync::mpsc;
+
+use crate::forward::MULTIMODAL_PLACEHOLDER_IDS;
+use crate::kv::PAGE_SIZE;
+use crate::kv::admit_tokens;
+use crate::serve::GemmaServe;
+use crate::serve::LogitsSpan;
+use crate::weights::Gemma4Weights;
+
+/// Serving ceiling: bounds the rope tables and the pool budget. The
+/// checkpoint's 262k `max_position_embeddings` needs a table and KV budget
+/// design of its own.
+const MAX_CONTEXT: usize = 8192;
+
+pub(crate) fn start(model_path: &Path, options: &EngineLoadOptions) -> Result<EngineHandle> {
+    let dir = model_path
+        .to_str()
+        .context("model path is not valid UTF-8")?
+        .to_string();
+    anyhow::ensure!(
+        !options.enable_cuda_graph,
+        "gemma4 serves eagerly; CUDA graph capture is not supported yet — \
+         pass enable_cuda_graph=false"
+    );
+    anyhow::ensure!(
+        options.device_ordinals.len() == 1,
+        "gemma4 is single-device; got device_ordinals {:?}",
+        options.device_ordinals
+    );
+    anyhow::ensure!(
+        options.parallel_config.is_none(),
+        "gemma4 has no parallel topology support yet"
+    );
+    let device = options.device_ordinals[0];
+    let base_seed = options.seed;
+
+    let policy = generation_policy(&dir)?;
+
+    let (submit_tx, mut submit_rx) =
+        mpsc::unbounded_channel::<pegainfer_frontend::engine::SubmittedRequest>();
+    let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<()>>();
+    let join = std::thread::Builder::new()
+        .name("gemma4-engine".into())
+        .spawn(move || {
+            let state = EngineState::load(&dir, device, policy, base_seed);
+            let mut state = match state {
+                Ok(state) => {
+                    let _ = ready_tx.send(Ok(()));
+                    state
+                }
+                Err(err) => {
+                    let _ = ready_tx.send(Err(err));
+                    return;
+                }
+            };
+            while let Some((request, prefix)) = submit_rx.blocking_recv() {
+                state.serve_request(&request, &prefix);
+            }
+        })
+        .context("spawn gemma4 engine thread")?;
+    ready_rx
+        .recv()
+        .context("gemma4 engine thread died during load")??;
+    // The checkpoint advertises 262k positions this engine cannot serve.
+    // Publishing the real ceiling is what lets the frontend refuse an
+    // over-length request with its own message instead of forwarding one the
+    // engine can only fail mid-stream.
+    Ok(EngineHandle::new_with_join_handle(submit_tx, join).with_servable_len(MAX_CONTEXT as u32))
+}
+
+struct GenerationPolicy {
+    eos: Vec<u32>,
+    suppress: Vec<u32>,
+}
+
+fn generation_policy(dir: &str) -> Result<GenerationPolicy> {
+    let path = format!("{dir}/generation_config.json");
+    let json: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(&path).with_context(|| format!("read {path}"))?,
+    )?;
+    let eos = token_ids(
+        json.get("eos_token_id")
+            .with_context(|| format!("{path} missing eos_token_id"))?,
+    )
+    .with_context(|| format!("{path} eos_token_id"))?;
+    anyhow::ensure!(!eos.is_empty(), "{path} declares an empty eos_token_id");
+    let mut suppress = match json.get("suppress_tokens") {
+        Some(value) => token_ids(value).with_context(|| format!("{path} suppress_tokens"))?,
+        None => Vec::new(),
+    };
+    suppress.extend(MULTIMODAL_PLACEHOLDER_IDS);
+    suppress.sort_unstable();
+    suppress.dedup();
+    Ok(GenerationPolicy { eos, suppress })
+}
+
+impl GenerationPolicy {
+    /// Both sets index the vocabulary, so both are checked against it once
+    /// the head is loaded: an out-of-range suppressed id would fail the first
+    /// request, and an out-of-range stop id would never match at all and turn
+    /// every request into a length stop.
+    fn check_against_vocab(&self, vocab: usize) -> Result<()> {
+        for (kind, ids) in [
+            ("eos_token_id", &self.eos),
+            ("effective suppression set", &self.suppress),
+        ] {
+            for &id in ids {
+                anyhow::ensure!(
+                    (id as usize) < vocab,
+                    "{kind} lists {id}, outside the {vocab} the checkpoint's head spans"
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+fn token_ids(value: &serde_json::Value) -> Result<Vec<u32>> {
+    fn one(value: &serde_json::Value) -> Result<u32> {
+        let raw = value
+            .as_u64()
+            .with_context(|| format!("{value} is not an unsigned integer"))?;
+        u32::try_from(raw).with_context(|| format!("token id {raw} does not fit a u32"))
+    }
+    match value {
+        serde_json::Value::Number(_) => Ok(vec![one(value)?]),
+        serde_json::Value::Array(items) => items.iter().map(one).collect(),
+        other => anyhow::bail!("unexpected token id shape: {other}"),
+    }
+}
+
+/// Drop forbidden ids before sampling and logprob normalization read the row.
+fn suppress_logits(
+    ctx: &DeviceContext,
+    blocked: &CudaSlice<bf16>,
+    logits: &mut HiddenStates,
+    ids: &[u32],
+) -> Result<()> {
+    for &id in ids {
+        let index = id as usize;
+        anyhow::ensure!(
+            index < logits.hidden_dim,
+            "suppressed token {id} is outside the {} vocabulary",
+            logits.hidden_dim
+        );
+        for row in 0..logits.seq_len {
+            let at = row * logits.hidden_dim + index;
+            let mut slot = logits.data.slice_mut(at..=at);
+            ctx.stream.memcpy_dtod(blocked, &mut slot)?;
+        }
+    }
+    Ok(())
+}
+
+/// Everything the engine thread owns for the life of the process. CUDA state
+/// is thread-affine, so it is built here rather than handed in: a context or
+/// cuBLAS handle minted on the caller thread fails with invalid-handle on the
+/// first GEMM.
+struct EngineState {
+    ctx: DeviceContext,
+    serve: GemmaServe,
+    scratch: SampleScratch,
+    policy: GenerationPolicy,
+    /// The value written into a suppressed slot, resident on the device so a
+    /// step never stages a host scalar.
+    blocked: CudaSlice<bf16>,
+    base_seed: u64,
+    /// Seedless sampling variety across requests comes from this counter
+    /// mixed into the per-call seed; a request's own `params.seed` replays
+    /// via (seed, step) regardless of it.
+    sample_nonce: u64,
+}
+
+impl EngineState {
+    fn load(dir: &str, device: usize, policy: GenerationPolicy, base_seed: u64) -> Result<Self> {
+        let (weights, _) = Gemma4Weights::from_safetensors(dir, device)?;
+        let ctx = DeviceContext::new_with_device(device)?;
+        let vocab = weights.embed_tokens.rows;
+        policy.check_against_vocab(vocab)?;
+        // One request at a time, and a prompt is prefilled in one step: both
+        // families hold every position of it before the window releases
+        // anything, so each pool is sized for a full-context request plus its
+        // padding page.
+        let pages = MAX_CONTEXT.div_ceil(PAGE_SIZE) + 1;
+        let serve = GemmaServe::new(&ctx, weights, MAX_CONTEXT, pages, pages)?;
+        let scratch = SampleScratch::new(&ctx, vocab, 1)?;
+        let blocked = ctx
+            .stream
+            .clone_htod(&[bf16::NEG_INFINITY])
+            .map_err(|err| anyhow::anyhow!("allocating the suppression sentinel failed: {err}"))?;
+        Ok(Self {
+            ctx,
+            serve,
+            scratch,
+            policy,
+            blocked,
+            base_seed,
+            sample_nonce: 0,
+        })
+    }
+
+    fn serve_request(
+        &mut self,
+        request: &GenerateRequest,
+        prefix: &pegainfer_frontend::engine::KvPrefix,
+    ) {
+        let sink = request.token_tx.clone();
+        if sink.is_closed() {
+            return;
+        }
+        let prompt_tokens = request.prompt_tokens.len();
+        let scheduled = TokenEvent::Scheduled {
+            queued_at_unix_s: request.queued_at_unix_s.unwrap_or_else(unix_now_s),
+            scheduled_at_unix_s: unix_now_s(),
+            prompt_tokens,
+            cached_tokens: 0,
+        };
+        if sink.send(scheduled).is_err() {
+            return;
+        }
+
+        let reject = |message: String| {
+            let _ = sink.send(TokenEvent::Rejected {
+                message,
+                prompt_tokens,
+                completion_tokens: 0,
+            });
+        };
+        if prompt_tokens == 0 {
+            return reject("empty prompt".into());
+        }
+        if request.max_tokens == 0 {
+            return reject("max_tokens must be positive".into());
+        }
+        let context_len = prompt_tokens.checked_add(request.max_tokens);
+        if context_len.is_none_or(|len| len > MAX_CONTEXT) {
+            return reject(format!(
+                "prompt {prompt_tokens} + max_tokens {} exceeds the serving ceiling {MAX_CONTEXT}",
+                request.max_tokens
+            ));
+        }
+        if request.lora_adapter.is_some() {
+            return reject("gemma4 has no LoRA support".into());
+        }
+        if request.echo {
+            return reject("gemma4 does not echo the prompt".into());
+        }
+        if prefix.hit_tokens() > 0 {
+            return reject(format!(
+                "gemma4 has no prefix cache yet; refusing a resolution claiming {} cached tokens",
+                prefix.hit_tokens()
+            ));
+        }
+        if request.kv_transfer_params.is_some() {
+            return reject("gemma4 has no P/D transfer support; kv_transfer_params refused".into());
+        }
+        if let Some(rank) = request.data_parallel_rank {
+            if rank != 0 {
+                return reject(format!(
+                    "gemma4 is single-partition; data_parallel_rank {rank} refused"
+                ));
+            }
+        }
+
+        match self.generate(request) {
+            Ok((finish_reason, completion_tokens)) => {
+                let _ = sink.send(TokenEvent::Finished {
+                    finish_reason,
+                    prompt_tokens,
+                    completion_tokens,
+                });
+            }
+            Err(err) => {
+                log::error!("request failed: {err:#}");
+                let _ = sink.send(TokenEvent::Error {
+                    message: format!("{err:#}"),
+                    prompt_tokens,
+                    completion_tokens: 0,
+                });
+            }
+        }
+    }
+
+    /// Run one request to completion. Cancellation is the sink refusing an
+    /// event: every emitted token checks, and the request retires mid-stream
+    /// with its KV released by drop.
+    fn generate(&mut self, request: &GenerateRequest) -> Result<(FinishReason, usize)> {
+        let sink = &request.token_tx;
+        let mut kv = self.serve.alloc_kv();
+
+        admit_tokens(
+            &self.serve.local_pool,
+            &self.serve.global_pool,
+            &mut kv,
+            request.prompt_tokens.len(),
+        )?;
+        let mut logits = self.serve.step(
+            &self.ctx,
+            &mut kv,
+            &request.prompt_tokens,
+            LogitsSpan::LastRow,
+        )?;
+
+        let mut emitted = 0usize;
+        loop {
+            suppress_logits(&self.ctx, &self.blocked, &mut logits, &self.policy.suppress)?;
+            self.sample_nonce = self.sample_nonce.wrapping_add(1);
+            let call_seed = self.base_seed ^ self.sample_nonce.rotate_left(17);
+            let next = pegainfer_sample::select_batch(
+                &self.ctx,
+                &logits,
+                &[&request.params],
+                &[emitted as u64],
+                call_seed,
+                &mut self.scratch,
+            )?[0];
+            // The stop token retires the request without being emitted: the
+            // frontend appends its own protocol sentinel for the terminal Stop
+            // and unconditionally drops the last id, so an engine that emits EOS
+            // costs the client its final visible token.
+            if !request.params.ignore_eos && self.policy.eos.contains(&next) {
+                return Ok((FinishReason::Stop, emitted));
+            }
+            let logprob = if request.logprobs > 0 {
+                pegainfer_sample::token_logprobs_batch(
+                    &self.ctx,
+                    &logits,
+                    &[LogprobRequest {
+                        row: 0,
+                        picked: next,
+                        top_k: request.logprobs,
+                    }],
+                )?
+                .pop()
+            } else {
+                None
+            };
+            emitted += 1;
+            if sink.send(TokenEvent::Token { id: next, logprob }).is_err() {
+                return Ok((FinishReason::Stop, emitted));
+            }
+            if emitted >= request.max_tokens {
+                return Ok((FinishReason::Length, emitted));
+            }
+            admit_tokens(&self.serve.local_pool, &self.serve.global_pool, &mut kv, 1)?;
+            logits = self
+                .serve
+                .step(&self.ctx, &mut kv, &[next], LogitsSpan::LastRow)?;
+        }
+    }
+}
+
+#[cfg(test)]
+mod gate {
+    use super::*;
+
+    #[test]
+    fn the_suppression_mask_writes_only_the_ids_it_is_given() {
+        let ctx = DeviceContext::new().expect("GPU required");
+        let (vocab, rows) = (8usize, 2usize);
+        let mut logits = HiddenStates::zeros(&ctx, vocab, rows).expect("logits");
+        let blocked = ctx
+            .stream
+            .clone_htod(&[bf16::NEG_INFINITY])
+            .expect("sentinel");
+        suppress_logits(&ctx, &blocked, &mut logits, &[3, 5]).expect("suppress");
+
+        let host = logits.to_host(&ctx).expect("D2H");
+        for row in 0..rows {
+            for id in 0..vocab {
+                let value = host[row * vocab + id];
+                if id == 3 || id == 5 {
+                    assert!(
+                        value == f32::NEG_INFINITY,
+                        "row {row} id {id} is {value}, not suppressed"
+                    );
+                } else {
+                    assert!(value == 0.0, "row {row} id {id} moved to {value}");
+                }
+            }
+        }
+
+        let past_the_row = suppress_logits(&ctx, &blocked, &mut logits, &[vocab as u32]);
+        assert!(past_the_row.is_err(), "an id past the row must be refused");
+    }
+}

--- a/pegainfer-gemma4/src/forward.rs
+++ b/pegainfer-gemma4/src/forward.rs
@@ -21,7 +21,8 @@ use crate::layer::global_layer_forward;
 use crate::layer::local_layer_forward;
 use crate::weights::Gemma4Weights;
 
-const MULTIMODAL_PLACEHOLDER_IDS: [u32; 6] = [255_999, 256_000, 258_880, 258_881, 258_882, 258_883];
+pub(crate) const MULTIMODAL_PLACEHOLDER_IDS: [u32; 6] =
+    [255_999, 256_000, 258_880, 258_881, 258_882, 258_883];
 
 /// The embedding multiplier is the bf16 rounding of `sqrt(hidden_size)` —
 /// the reference casts the scale buffer to the weight dtype before the

--- a/pegainfer-gemma4/src/lib.rs
+++ b/pegainfer-gemma4/src/lib.rs
@@ -6,8 +6,10 @@ mod config;
 mod manifest;
 pub mod model_line;
 mod probe;
-// Dead until an executor calls in; test targets do use them, so an
+// The engine is the live consumer; the oracles reach the rest, so an
 // `expect(dead_code)` cannot hold in every build.
+#[cfg(feature = "gemma4")]
+mod engine;
 #[cfg(feature = "gemma4")]
 #[allow(dead_code)]
 mod forward;
@@ -34,12 +36,12 @@ use pegainfer_frontend::engine::EngineLoadOptions;
 pub(crate) use probe::probe_config_json;
 
 #[cfg(feature = "gemma4")]
-fn start_engine(_model_path: &Path, _options: EngineLoadOptions) -> Result<EngineHandle> {
-    anyhow::bail!("Gemma 4 engine is not implemented yet (registration only)")
+fn start_engine(model_path: &Path, options: &EngineLoadOptions) -> Result<EngineHandle> {
+    engine::start(model_path, options)
 }
 
 #[cfg(not(feature = "gemma4"))]
-pub fn start_engine(_model_path: &Path, _options: EngineLoadOptions) -> Result<EngineHandle> {
+fn start_engine(_model_path: &Path, _options: &EngineLoadOptions) -> Result<EngineHandle> {
     anyhow::bail!(
         "Gemma 4 support is feature-gated; rebuild pegainfer-server with --features gemma4"
     )

--- a/pegainfer-gemma4/src/model_line.rs
+++ b/pegainfer-gemma4/src/model_line.rs
@@ -1,8 +1,10 @@
-//! Gemma 4's [`ModelLine`] implementation (registration only — the engine
-//! itself is not yet available).
+//! Gemma 4's [`ModelLine`] implementation.
+
+use std::collections::BTreeSet;
 
 use pegainfer_frontend::engine::EngineLoadOptions;
 use pegainfer_frontend::engine::LaunchedEngine;
+use pegainfer_frontend::model_line::CliError;
 use pegainfer_frontend::model_line::LaunchContext;
 use pegainfer_frontend::model_line::ModelLine;
 
@@ -42,12 +44,34 @@ impl ModelLine for Gemma4Line {
     }
 
     fn consumed_shared_args(&self) -> &'static [&'static str] {
-        &["cuda_graph"]
+        &["device_ordinal", "cuda_graph"]
+    }
+
+    /// `--cuda-graph` defaults to true, so only an explicit request is a
+    /// request: rejecting it here costs a message instead of a weight load.
+    fn validate(
+        &self,
+        ctx: &LaunchContext<'_>,
+        provided: &BTreeSet<String>,
+    ) -> Result<(), CliError> {
+        if provided.contains("cuda_graph") && ctx.shared.cuda_graph {
+            return Err(CliError::rule(
+                "Gemma 4 serves eagerly; --cuda-graph=true is not supported",
+            ));
+        }
+        Ok(())
     }
 
     fn launch(&self, ctx: &LaunchContext<'_>) -> anyhow::Result<LaunchedEngine> {
-        crate::start_engine(ctx.model_path, EngineLoadOptions::default())
-            .map(LaunchedEngine::Handle)
+        crate::start_engine(
+            ctx.model_path,
+            &EngineLoadOptions {
+                enable_cuda_graph: false,
+                device_ordinals: vec![ctx.shared.device_ordinal],
+                ..EngineLoadOptions::default()
+            },
+        )
+        .map(LaunchedEngine::Handle)
     }
 }
 


### PR DESCRIPTION
## Description

Closes #889.

One owned thread serves Gemma 4 requests serially through the KV-backed forward. Admission runs per step, and a request whose prompt plus requested output exceeds the serving ceiling is refused at this boundary; next-token selection and per-token logprobs go through `pegainfer-sample` on device logits; EOS and length finish reasons are real from the first request. Cancellation is the sink refusing an event: the request retires mid-stream, its KV returns by drop, and the engine serves the next one.

The stop token retires a request without being emitted, which is the protocol the frontend documents: it appends its own sentinel for the terminal `Stop` and unconditionally drops the last id, so an engine that emits EOS costs the client its final visible token. The ids the checkpoint lists under `suppress_tokens` are dropped out of contention before anything reads the logits row, so sampling and the logprob normalization see the same distribution and a placeholder id can neither reach the client nor return as the next step's input. Both sets are read from `generation_config.json` rather than assumed for the family: 12B declares the end-of-image and end-of-audio ids, 26B and 31B declare none.

At the Gemma engine boundary, everything this stage does not implement is refused loudly rather than downgraded. At load: CUDA graph capture, multi-device ordinals, parallel topologies. Per request: a resolved KV prefix, `kv_transfer_params`, a nonzero `data_parallel_rank`, a LoRA adapter, prompt echo.

The model line stops being registration only. `--cuda-graph` defaults to true for every line, so an explicit `--cuda-graph=true` is refused in `ModelLine::validate` before the weight load, and everything else launches eagerly. The handle publishes an 8192-token serving ceiling, which is what lets the frontend reject an over-length prompt with its own message; without it the frontend advertises the checkpoint's 262144 `max_position_embeddings` and forwards a request the engine can only fail mid-stream.

That ceiling is what bounds the rope tables and the pool budget: each KV pool is sized for one full-context request plus its padding page, since a prompt is prefilled in one step and both families hold every position of it before the window releases anything. The 262k the checkpoint declares needs a table and KV budget design of its own.

### Test Env

Single GPU (sm_89, x86_64), CUDA 12.9, pinned 12B checkpoint.

### Verification

- fmt; clippy `-D warnings` over all gemma4 targets with and without the feature; the CI package set with `--locked`; the `pegainfer-kernels` hd256 smoke; gemma4 lib tests; `pegainfer-server` builds with `--features gemma4`.
- Checkpoint gates (`--ignored --test-threads=1`): 8 passed, including all three certified generate fixture prompts matching token for token.
- Live server: `/v1/models` reports `max_model_len` 8192. All three certified fixture prompts, sent as `/v1/completions` text at `temperature 0`, return text byte-identical to the fixture continuations (3/3), with prompt token counts matching the fixture (18/13/16).
- Live server, routes: completions and chat each return identical text streaming and non-streaming (`'111.1.'` over 8 chunks, and `Paris` respectively); the chat turn ends with `finish_reason=stop` and no stop token in the text; per-token logprobs come back with the picked token's logprob equal to its top entry; dropping a stream mid-decode aborts the request and the next one is served normally.
- Live server, length limits: a 9001-token prompt is refused in 0.1 s with HTTP 400 and `this model's maximum context length is 8192 tokens, but the prompt contains 9001 input tokens`. A one-token prompt asking for 9000 output tokens is not refused: the frontend clamps it to the remaining budget and the request completes with `finish_reason=length` at 8191 completion tokens.
- Live server, CLI: `--cuda-graph=true` exits with `Gemma 4 serves eagerly; --cuda-graph=true is not supported` and no weight-load line in its output; `--cuda-graph=false` serves.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
