### PR TITLE
feat(sim): migrate pegainfer-sim onto the step contract

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -164,8 +164,10 @@ Organized by domain (model line / subsystem / playbook / lesson) instead of by l
 
 | Path | TL;DR |
 | --- | --- |
-| `subsystems/frontend/frontend-architecture.md` | `pegainfer-frontend` owns everything north of the model schedulers. Two contract generations coexist: the step contract (`StepOutputs` wire + typestate handles + contract-owned polling driver; qwen3 fully migrated via `frontend_adapter.rs`) and the legacy `EngineHandle`/`TokenEvent` path (other five lines). Next: migrate glm52, then delete the legacy contract. |
-| `subsystems/frontend/simulated-inference-engine.md` | CPU-only simulated model crate for vLLM/OpenAI frontend and `vllm bench serve` validation without CUDA, real model weights, or real-model performance claims. |
+| `subsystems/frontend/frontend-architecture.md` | `pegainfer-frontend` owns everything north of the model schedulers. Two contract generations coexist: the step contract (qwen3 + pegainfer-sim migrated) and the legacy `EngineHandle`/`TokenEvent` path (other five lines). Next: migrate glm52, then delete the legacy contract. |
+| `subsystems/frontend/simulated-inference-engine.md` | CPU-only simulated model crate on the step contract (`SimScheduler` → `LaunchedEngine::Stepped`) for vLLM/OpenAI frontend and `vllm bench serve` validation without CUDA or weights. |
+| `subsystems/frontend/sim-step-contract.md` | Cut `pegainfer-sim` from the legacy `EngineHandle`/`TokenEvent` path onto the step contract. |
+| `subsystems/frontend/sim-high-concurrency-bench.md` | Same-session A/B vs main: feat TPOT ~30–180× better, TTFT worse and linear in C; E2EL/throughput win at c=64 and c=1024. |
 | `subsystems/frontend/cpu-profiling-baseline.md` | Frontend CPU profiling baseline using `pegainfer-sim` with fixed TTFT=5ms/TPOT=12ms: 200 req / concurrency=16 shows ~150ms TTFT overhead (no dominant hotspot), heap allocation ~10%, stream polling ~7.5%, IPC ~1%; reproducible benchmark command and perf evidence documented. |
 | `subsystems/frontend/startup-time.md` | Qwen3-4B warm startup-to-ready: frontend tokenizer load runs concurrently with the engine load (HTTP still binds only after the engine registers); mmap teardown is paid at the end of load since #377; pinned-staging upload (2026-07) cuts warm ready 5.22s → 4.66s on sm_89, and the remaining floor is the engine's own post-load startup work. |
 | `subsystems/frontend/prometheus-metrics.md` | `/metrics` request histograms work for every model; Qwen3, Qwen3.5, and GLM5.2 schedulers also publish running/waiting/KV engine gauges through `LoadSnapshot` watches. |

--- a/docs/subsystems/frontend/dashboards/README.md
+++ b/docs/subsystems/frontend/dashboards/README.md
@@ -19,7 +19,7 @@ The dashboard intentionally omits prefix-cache query/hit, speculative-decode, re
 
 ### CPU validation
 
-- `cargo test --release -p pegainfer-sim --test frontend_e2e`: 9 passed, including request serving and per-engine scheduler metric coverage.
+- `cargo test --release -p pegainfer-sim --test frontend_e2e`: request serving plus per-engine scheduler gauges from the stepped path (idle settle after a request; running rises on a slow request).
 - Sent two batches of 8 concurrent completion requests through a standalone `pegainfer-sim` server. The first scrape recorded 8 completed requests, 64 prompt tokens, 128 generated tokens, HTTP handler/status counters, and non-empty TTFT, ITL, E2E, queue, prefill, and decode histograms.
 - Prometheus 2.51.2 scraped the simulator at one-second intervals with target health `up`. All 21 dashboard PromQL targets returned `status=success` and at least one series after substituting a 30-second rate interval and the simulator model name.
 

--- a/docs/subsystems/frontend/frontend-architecture.md
+++ b/docs/subsystems/frontend/frontend-architecture.md
@@ -1,6 +1,6 @@
 # Frontend architecture: pegainfer-frontend and the engine boundary
 
-**TL;DR:** `pegainfer-frontend` owns everything north of the model schedulers: the engine contract, the vLLM protocol stack, and the `ModelLine` dispatch trait. The contract now has two generations living side by side: the **step contract** (`StepOutputs` wire + typestate request handles + a contract-owned polling driver — Qwen3 is fully migrated, see `pegainfer-qwen3/src/frontend_adapter.rs`) and the **legacy handle contract** (`EngineHandle` + `TokenEvent` per-request events — glm52/qwen35/kimi-k2/deepseek-v2-lite/gemma4 still launch through it). **Next step: migrate glm52, then delete the legacy contract.**
+**TL;DR:** `pegainfer-frontend` owns everything north of the model schedulers: the engine contract, the vLLM protocol stack, and the `ModelLine` dispatch trait. The contract now has two generations living side by side: the **step contract** (`StepOutputs` wire + typestate request handles + a contract-owned polling driver — Qwen3 and `pegainfer-sim` are migrated) and the **legacy handle contract** (`EngineHandle` + `TokenEvent` per-request events — glm52/qwen35/kimi-k2/deepseek-v2-lite/gemma4 still launch through it). **Next step: migrate glm52, then delete the legacy contract.**
 
 Last touched: 2026-08
 
@@ -50,7 +50,7 @@ Design decisions worth knowing before touching it:
    - `load()` — KV occupancy + running/waiting counts for routers.
    - Extra capabilities (LoRA etc.) are not trait methods: mint the private channel before spawning, close the scheduler over the receiver, drain it inside `step`.
 2. `spawn_scheduler(name, scheduler)` per scheduler; return `Engine { schedulers, info: EngineInfo { kv_capacity, servable_len }, lora }` — the required-metadata fields are the checklist, and `lora: Some(client)` only when the line actually serves adapter control.
-3. `ModelLine::launch` returns `LaunchedEngine::Stepped(engine)`.
+3. `ModelLine::launch` returns `LaunchedEngine::Stepped(engine)`. `pegainfer-sim` is the CPU-only reference (`SimScheduler` in `pegainfer-sim/src/lib.rs`); it has no `ModelLine` and hands the `Engine` to `vllm::serve` directly.
 
 The contract's own invariants are tested in `emitter.rs`/`driver.rs` tests; the qwen3 adapter's contract tests (`frontend_adapter/tests.rs`) are the reference for testing a model's protocol behaviour end to end with a fake executor. GPU integration tests drive the contract through `pegainfer-qwen3/tests/common/harness.rs`.
 

--- a/docs/subsystems/frontend/sim-high-concurrency-bench.md
+++ b/docs/subsystems/frontend/sim-high-concurrency-bench.md
@@ -1,0 +1,79 @@
+# pegainfer-sim high-concurrency vllm-bench
+
+> **TL;DR:** Same-session rust `vllm-bench` A/B: stepped sim vs `main` (legacy handle). Both 0-fail to c=1024. Feat TTFT is worse (serialized admit); TPOT is ~30–180× better. E2EL/throughput win at c=64 and c=1024; mid-band is a wash.
+>
+> **Last touched:** 2026-08
+
+## Preparation
+
+- **Read**:
+  - `docs/index.md` — sim and frontend CPU baseline live under subsystems/frontend.
+  - `docs/subsystems/frontend/simulated-inference-engine.md` — sim is a step-contract CPU harness; TTFT/TPOT are configured delays, not model time.
+  - `docs/subsystems/frontend/cpu-profiling-baseline.md` — old path at c=16 added ~150ms TTFT over a 5ms floor; no single CPU hotspot.
+  - `docs/subsystems/frontend/sim-step-contract.md` — sim now emits one token per request per step and parks ≤1ms.
+- **Relevant history**:
+  - Previous baseline used Python `bench_http_serving.py` at c=16, not rust vllm-bench, and ran on the legacy per-request tokio tasks.
+- **Plan**:
+  1. Start `pegainfer-sim` with TTFT=0 / TPOT=0 so any latency is frontend + scheduler-loop overhead.
+  2. Smoke with rust `vllm-bench`.
+  3. Scale concurrency 64 → 256 → 1024 on `/v1/completions`.
+  4. Record TTFT/TPOT/failures and server CPU; name the limiter if one shows up.
+- **Risks**:
+  - Zero-delay sim still emits one token per step with a 1ms park when anything is waiting; that itself can cap output tok/s.
+
+## Execution Log
+
+### Setup
+- `pegainfer-sim` on a loopback port, Qwen3-4B tokenizer only (no weights), `--base-ttft-ms 0 --tpot-ms 0` so any latency is frontend + scheduler loop.
+- Client: rust `vllm-bench`, `--backend openai`, 128-in / 64-out, `--ignore-eos`, `--extra-body '{"min_tokens":null}'`.
+
+### Smoke
+- c=4, 8 prompts: 0 fail, TTFT p50 1.38ms, TPOT 0.01ms, 17k req/s (too short to trust throughput).
+
+### Sweep (prompts = 4 × concurrency)
+
+| c | ok/fail | req/s | out tok/s | TTFT p50 / p90 / p99 (ms) | TPOT p50 (ms) |
+| --- | --- | --- | --- | --- | --- |
+| 64 | 256/0 | 743 | 47.6k | 35 / 190 / 262 | 0.05 |
+| 256 | 1024/0 | 1591 | 102k | 138 / 168 / 245 | 0.04 |
+| 512 | 2048/0 | 1493 | 96k | 327 / 403 / 418 | 0.05 |
+| 1024 | 4096/0 | 1709 | 109k | 581 / 644 / 682 | 0.05 |
+
+Throughput plateaus from c=256. TTFT ≈ 0.55 ms × concurrency. TPOT does not move.
+
+### Thread sample at c=1024
+- `pegainfer-sim-0` (the contract driver thread) is **100% even when idle** (`spin_loop`).
+- Mid-burst still only that one thread at 100%. tokio workers and `vllm-zmq-*` stay ~1%.
+- Process CPU ~1.2–1.5 cores, RSS peak ~690 MiB. 48-core box is not compute-bound.
+
+### A/B vs `main` (same session, same client, 128/64, zero-delay)
+
+`main` = per-request tokio tasks + `EngineHandle`. Feat = `SimScheduler` + stepped driver. Both binaries built `--release`; feat re-run immediately after main so the numbers are paired.
+
+| c | side | req/s | out tok/s | TTFT p50 | TPOT p50 | E2EL p50 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 64 | main | 639 | 41k | 3.7 | 1.31 | 86 |
+| 64 | feat | 1713 | 110k | 31.3 | 0.04 | 35 |
+| 256 | main | 1662 | 106k | 11.5 | 1.61 | 116 |
+| 256 | feat | 1725 | 110k | 134 | 0.05 | 137 |
+| 512 | main | 1514 | 97k | 51 | 3.97 | 292 |
+| 512 | feat | 1570 | 100k | 305 | 0.05 | 309 |
+| 1024 | main | 1358 | 87k | 287 | 7.49 | 733 |
+| 1024 | feat | 1691 | 108k | 571 | 0.04 | 574 |
+
+`vllm-bench --compare` (A=main, B=feat): c=64 throughput **+168%**, E2EL p50 **−60%**, TTFT p50 **+757%**. c=1024 throughput **+25%**, E2EL p50 **−22%**, TTFT p50 **+99%**. Failures 0/0 both sides.
+
+CPU: feat pins `pegainfer-sim-0` at 100% even idle; main idles cheap (tokio workers ~7% residual after the sweep). Burst CPU similar (~1.3–1.6 cores).
+
+### Unexpected
+- `perf` is blocked (`perf_event_paranoid=4`). Attribution is from `ps -L` + the latency shape, not a flamegraph.
+- Idle driver spin is by design for GPU engines; on a CPU-only sim it just burns a core.
+
+## Debrief
+
+- **Outcome**: Versus `main`, stepped sim **trades TTFT for TPOT**. Decode is ~30–180× cheaper and stays flat; first token is serialized on the driver and grows ~linear with C. Net E2EL/throughput: feat wins the ends (c=64, c=1024), mid-band is a wash.
+- **Pitfalls encountered**: Zero-delay sim still emits one token per request per step; a burst of N admits + first tokens is O(N) work on one thread, which is exactly the linear TTFT. Main spreads that across tokio tasks, so TTFT stays low until the per-request sleep/wake tax shows up as TPOT.
+- **Lessons learned**: Do not call the stepped path a frontend win from throughput alone — look at TTFT and E2EL together. The idle `spin_loop` is a sim-only tax.
+- **Follow-ups**:
+  - Park the driver when idle if sim stays a bench harness.
+  - Measure qwen3 the same way before treating the TTFT slope as a production bottleneck.

--- a/docs/subsystems/frontend/sim-step-contract.md
+++ b/docs/subsystems/frontend/sim-step-contract.md
@@ -1,0 +1,57 @@
+# pegainfer-sim onto the step contract
+
+> **TL;DR:** `pegainfer-sim` now launches as `LaunchedEngine::Stepped`: one `SimScheduler` per partition, driven by the contract's polling loop. Legacy `EngineHandle` / `TokenEvent` is gone from this crate.
+>
+> **Last touched:** 2026-08
+
+## Preparation
+
+- **Read**:
+  - `docs/index.md` — sim lives under subsystems/frontend; architecture doc is the contract source of truth.
+  - `docs/subsystems/frontend/frontend-architecture.md` — onboarding checklist: implement `Scheduler`, `spawn_scheduler`, return `LaunchedEngine::Stepped`. Echo-server and qwen3 `frontend_adapter.rs` are the references.
+  - `docs/subsystems/frontend/simulated-inference-engine.md` — sim is a CPU-only frontend/bench harness with fixed TTFT/TPOT; still that, different wire.
+  - `docs/conventions/migration-defense.md` — every old defensive structure needs an heir.
+- **Relevant history**:
+  - Qwen3 already migrated (`pegainfer-qwen3/src/frontend_adapter.rs`).
+  - `pegainfer-frontend/examples/echo-server.rs` is the minimal Scheduler.
+  - Sim e2e currently injects metrics through `EngineHandle::with_metrics_watches` (legacy watch publisher). Stepped stamps stats onto step batches; there is no watch to inject into.
+- **Plan**:
+  1. Rewrite `pegainfer-sim/src/lib.rs` as a `Scheduler`: admit queued, emit one token per due request per step, finish/stop as today.
+  2. `start_engine` returns `Engine`; CLI and tests pass `engine.into()` (`LaunchedEngine::Stepped`).
+  3. Timing stays deadline-based inside `step` (sleep until next due token) so a CPU-only sim does not spin a core the way a GPU scheduler can.
+  4. Rewrite unit tests to collect `StepOutputs` / `Terminal`. Keep HTTP/chat/tool-call e2e. Replace watch-injection metrics tests with stepped-path gauges. Drop the closed-feed test (no feed). Update partition-mismatch to the Stepped error string.
+  5. Update living docs.
+- **Risks / open questions**:
+  - Stepped `scheduler_stats_from` still drops `spec_decode`. That is a frontend gap (qwen3 already publishes counters the stepped bridge does not stamp). Sim will not pretend to close it.
+
+## Execution Log
+
+### Step 1: Rewrite `pegainfer-sim` as a `Scheduler`
+- `src/lib.rs` is now `SimScheduler` + `start_engine` / `start_engine_with_partitions` returning `Engine`.
+- Timing is deadline-based inside `step`; parks at most 1ms so admission is not stalled for a full TPOT.
+- `src/main.rs` passes `engine.into()` (`LaunchedEngine::Stepped`).
+- Result: compile-ready; unit tests drive the step stream instead of `TokenEvent`.
+
+### Step 2: Rewrite HTTP e2e
+- Dropped watch-injection (`publish_metrics`, closed-feed, spec-decode inject). Those tested the legacy handle publisher; frontend unit tests in `bridge/tests.rs` still cover that path.
+- Kept two-engine idle-gauge settle, added a slow-request test that the running gauge rises then drains.
+- Partition-mismatch now matches the Stepped error string.
+- Result: e2e follows the contract the crate actually speaks.
+
+### Step 3: Verify
+- `cargo clippy --release -p pegainfer-sim --all-targets -- -D warnings` clean.
+- `cargo test --release -p pegainfer-sim`: lib 6, frontend_e2e 12, tool_call_roundtrip 3.
+
+### Unexpected
+- `pegainfer-sim/Cargo.toml` already had `pegainfer-frontend = { workspace = true }` before this cut. The missing piece was the engine contract, not the Cargo edge.
+
+## Debrief
+
+- **Outcome**: `pegainfer-sim` launches only as `LaunchedEngine::Stepped`. Legacy `EngineHandle` / `TokenEvent` is gone from this crate.
+- **Pitfalls encountered**:
+  - Metrics e2e used `EngineHandle::with_metrics_watches` to inject snapshots. Stepped has no watch; injecting would have been a second fake contract. Replaced with occupancy the scheduler actually reports.
+- **Lessons learned**:
+  - The Cargo dep was already there; "切到 frontend" here means the step contract, not adding a crate edge.
+  - Stepped `scheduler_stats_from` still drops `spec_decode`. That is a frontend gap (qwen3 already publishes counters). Do not fake it in sim.
+- **Follow-ups**:
+  - Stamp `spec_decode` on the stepped bridge when a line that actually drafts is ready to prove it.

--- a/docs/subsystems/frontend/simulated-inference-engine.md
+++ b/docs/subsystems/frontend/simulated-inference-engine.md
@@ -1,62 +1,41 @@
 # Simulated Inference Engine
 
-**Created**: 2026-05-16
-**Status**: ready for PR review
-**Last touched**: 2026-05
-**TL;DR**: `pegainfer-sim` is a CPU-only simulated model crate that serves through the existing vLLM/OpenAI frontend with configurable TTFT/TPOT and lightweight HTTP e2e coverage. It is a benchmark and frontend validation harness, not a real-model performance path.
+> **TL;DR:** `pegainfer-sim` is a CPU-only `Scheduler` that serves through the vLLM/OpenAI frontend with configurable TTFT/TPOT. It launches as `LaunchedEngine::Stepped`. It is a frontend/bench harness, not a real-model performance path.
+>
+> **Last touched:** 2026-08
 
 ## Scope
 
-Issue #125 needs a server path that can run `vllm bench serve` without GPU or model weights while still exercising the same HTTP frontend used by real pegainfer models.
-
-This PR keeps that boundary narrow:
-
-- Add `pegainfer-engine` for the lightweight `EngineHandle`, `GenerateRequest`, `TokenEvent`, and `SamplingParams` contract.
-- Re-export that contract from `pegainfer-core` so existing model crates keep their current imports.
-- Move the vLLM bridge into `pegainfer-vllm-frontend`, leaving `pegainfer-server/src/vllm_frontend.rs` as a compatibility re-export.
-- Add `pegainfer-sim` as an independently maintained model crate with a thin CLI binary.
+A server path that can run `vllm bench serve` and the frontend HTTP e2e suite without GPU or model weights, while still exercising the same `pegainfer-frontend` stack used by real model lines.
 
 Out of scope:
 
-- No CUDA, kernel, KV-cache, or real model execution changes.
+- No CUDA, kernel, KV-cache, or real model execution.
 - No claim about real model serving throughput.
-- No jitter, tail-latency distribution, or batching realism beyond fixed TTFT/TPOT timing.
+- No jitter, tail-latency distribution, or batching realism beyond fixed TTFT/TPOT.
 
 ## Behavior
 
-`pegainfer-sim` exposes CLI knobs for model id, port, max model length, base TTFT, prefill throughput, TPOT, and fallback token id.
+CLI knobs: model id, port, max model length, base TTFT, prefill throughput, TPOT, fallback token id.
 
-The timing model is intentionally simple: TTFT is `base_ttft_ms + prompt_len / prefill_tokens_per_ms`, and TPOT is a fixed delay between generated tokens. Output token ids cycle through the prompt tokens, using the fallback id for empty prompts.
+Timing: TTFT is `base_ttft_ms + prompt_len / prefill_tokens_per_ms`; TPOT is a fixed delay between generated tokens. `SimScheduler::step` emits at most one token per request per step and parks up to 1ms while waiting, so a CPU-only sim does not spin a core the way a GPU scheduler can.
 
-The frontend still needs tokenizer/model metadata, but the simulator never loads model weights.
+Output token ids cycle through the prompt tokens, or replay a scripted sequence (tool-call tests). Empty prompts use the fallback id.
+
+The frontend still needs tokenizer/model metadata; the simulator never loads weights.
 
 ## Frontend Metadata Contract
 
-`pegainfer-sim` does not load model weights, but serving it through the
-vLLM/OpenAI frontend still constructs the normal text/chat backend. That
-frontend path requires enough local model metadata to initialize tokenization
-and detokenization.
+Serving through the vLLM/OpenAI frontend still constructs the normal text/chat backend. That path needs enough local metadata to tokenize and detokenize.
 
-For CPU-only tests that do not intend to exercise tokenizer encoding, use
-token-id prompts. Generated token ids still pass through detokenization, so the
-test fixture must provide at least a tokenizer source such as `tokenizer.json`.
-`tokenizer_config.json` and `config.json` are useful for EOS and context-window
-metadata, but no weight files are required.
+For CPU-only tests that do not intend to exercise tokenizer encoding, use token-id prompts. Generated token ids still pass through detokenization, so the fixture must provide at least `tokenizer.json`. `tokenizer_config.json` and `config.json` are useful for EOS and context-window metadata; no weight files are required.
 
-Chat-completions tests also need a `chat_template` in
-`tokenizer_config.json`. Keep the minimal template deterministic and ensure it
-renders at least one token that the simulated engine can stream as observable
-content; otherwise response-shape tests can pass without exercising
-`delta.content`.
+Chat-completions tests also need a `chat_template` in `tokenizer_config.json`. Keep the template deterministic and ensure it renders at least one token the simulated engine can stream as observable content; otherwise response-shape tests can pass without exercising `delta.content`.
 
-## Implementation Details
+## Implementation
 
-- `pegainfer-engine` owns the shared engine contract, while `pegainfer-core` only re-exports it for existing model crates.
-- `pegainfer-vllm-frontend` owns the bridge logic; `pegainfer-server/src/vllm_frontend.rs` stays as a compatibility re-export.
-- `pegainfer-sim` is kept as a separate model crate so future simulation changes do not have to live inside the real model crates.
+`SimScheduler` implements the step-contract `Scheduler` (same shape as `pegainfer-frontend/examples/echo-server.rs`). `start_engine` / `start_engine_with_partitions` return an `Engine`; the CLI and tests pass `engine.into()` into `vllm::serve` as `LaunchedEngine::Stepped`.
 
-## Future Plans
+`pegainfer-sim` stays a separate crate so simulation changes do not live inside real model crates. It already depends on `pegainfer-frontend` (`pegainfer-sim/Cargo.toml`).
 
-Frontend e2e and CPU profiling are the next useful follow-ups for this crate boundary.
-
-If reviewers want richer simulation, add jitter, tail distributions, and batching behavior in follow-up PRs after this crate boundary lands.
+The cutover record is `sim-step-contract.md`.

--- a/pegainfer-sim/src/lib.rs
+++ b/pegainfer-sim/src/lib.rs
@@ -1,15 +1,24 @@
 use std::time::Duration;
-use std::time::SystemTime;
-use std::time::UNIX_EPOCH;
+use std::time::Instant;
 
 use anyhow::Result;
 use anyhow::ensure;
-use pegainfer_frontend::engine::EngineHandle;
+use pegainfer_frontend::engine::Engine;
+use pegainfer_frontend::engine::EngineInfo;
 use pegainfer_frontend::engine::FinishReason;
-use pegainfer_frontend::engine::GenerateRequest;
-use pegainfer_frontend::engine::TokenEvent;
+use pegainfer_frontend::engine::PromptEcho;
+use pegainfer_frontend::engine::QueuedRequest;
+use pegainfer_frontend::engine::RequestId;
+use pegainfer_frontend::engine::RequestLedger;
+use pegainfer_frontend::engine::Scheduler;
+use pegainfer_frontend::engine::SchedulerMetrics;
 use pegainfer_frontend::engine::TokenLogprob;
-use tokio::sync::mpsc;
+use pegainfer_frontend::engine::spawn_scheduler;
+
+/// Cap on how long `step` parks while waiting for the next due token. New
+/// submissions only drain between steps, so a full TTFT/TPOT sleep would
+/// stall admission; 1ms keeps the CPU-only sim from spinning a core.
+const WAIT_SLICE: Duration = Duration::from_millis(1);
 
 #[derive(Clone, Debug)]
 pub struct SimulatedEngineConfig {
@@ -79,91 +88,179 @@ impl Default for SimulatedEngineConfig {
     }
 }
 
-pub fn start_engine(config: SimulatedEngineConfig) -> EngineHandle {
-    let (submit_tx, mut submit_rx) = mpsc::unbounded_channel();
-    tokio::spawn(async move {
-        while let Some((req, _kv_prefix)) = submit_rx.recv().await {
-            tokio::spawn(run_simulated_request(req, config.clone()));
-        }
-    });
-    EngineHandle::new(submit_tx)
+/// One scheduler, no KV, no LoRA. `partitions` is the frontend-visible engine
+/// count (tests that declare N engines must spawn N schedulers).
+pub fn start_engine(config: &SimulatedEngineConfig) -> Engine {
+    start_engine_with_partitions(config, 1)
 }
 
-async fn run_simulated_request(req: GenerateRequest, config: SimulatedEngineConfig) {
-    let queued_at_unix_s = req.queued_at_unix_s.unwrap_or_else(now_secs_f64);
-    let prompt_len = req.prompt_tokens.len();
-    let mut completion_tokens = 0;
-
-    if req
-        .token_tx
-        .send(TokenEvent::Scheduled {
-            queued_at_unix_s,
-            scheduled_at_unix_s: now_secs_f64(),
-            prompt_tokens: prompt_len,
-            cached_tokens: 0,
-        })
-        .is_err()
-    {
-        return;
-    }
-
-    if req.echo
-        && req
-            .token_tx
-            .send(TokenEvent::PromptTokens {
-                ids: req.prompt_tokens.clone(),
-                logprobs: vec![None; req.prompt_tokens.len()],
+pub fn start_engine_with_partitions(config: &SimulatedEngineConfig, partitions: usize) -> Engine {
+    assert!(
+        partitions > 0,
+        "an engine must expose at least one scheduler"
+    );
+    Engine {
+        schedulers: (0..partitions)
+            .map(|index| {
+                spawn_scheduler(
+                    &format!("pegainfer-sim-{index}"),
+                    SimScheduler::new(config.clone()),
+                )
             })
-            .is_err()
-    {
-        return;
+            .collect(),
+        info: EngineInfo {
+            kv_capacity: None,
+            servable_len: None,
+        },
+        lora: None,
     }
+}
 
-    let script = &config.scripted_completion;
-    let emit_count = if script.is_empty() {
-        req.max_tokens
-    } else {
-        req.max_tokens.min(script.len())
-    };
+struct SimScheduler {
+    config: SimulatedEngineConfig,
+    queued: Vec<QueuedRequest>,
+    running: Vec<RunningRequest>,
+}
 
-    if emit_count > 0 {
-        tokio::time::sleep(config.ttft(prompt_len)).await;
-    }
+struct RunningRequest {
+    id: RequestId,
+    /// Tokens not yet emitted, stored reversed for cheap pops.
+    pending: Vec<u32>,
+    next_token_at: Instant,
+    finish_reason: FinishReason,
+    logprobs: usize,
+}
 
-    for index in 0..emit_count {
-        if index > 0 {
-            tokio::time::sleep(config.tpot()).await;
+impl SimScheduler {
+    fn new(config: SimulatedEngineConfig) -> Self {
+        Self {
+            config,
+            queued: Vec::new(),
+            running: Vec::new(),
         }
+    }
 
-        let logprob = (req.logprobs > 0).then_some(TokenLogprob {
-            logprob: 0.0,
-            top_logprobs: Vec::new(),
-        });
-        let id = if script.is_empty() {
-            fake_token_id(&req.prompt_tokens, index, config.fallback_token_id)
-        } else {
-            script[index]
+    fn park_if_waiting(&self) {
+        let Some(next) = self.running.iter().map(|r| r.next_token_at).min() else {
+            return;
         };
-        if req
-            .token_tx
-            .send(TokenEvent::Token { id, logprob })
-            .is_err()
-        {
+        let now = Instant::now();
+        if next <= now {
             return;
         }
-        completion_tokens += 1;
+        std::thread::sleep((next - now).min(WAIT_SLICE));
+    }
+}
+
+impl Scheduler for SimScheduler {
+    fn submit(&mut self, request: QueuedRequest) {
+        self.queued.push(request);
     }
 
+    fn step(&mut self, ledger: &mut RequestLedger) -> Result<()> {
+        for QueuedRequest { id, request } in self.queued.drain(..) {
+            if ledger.is_aborted(id) {
+                ledger.retire(id);
+                continue;
+            }
+            if request.echo {
+                ledger.echo_prompt(
+                    id,
+                    PromptEcho {
+                        ids: request.prompt_tokens.clone(),
+                        logprobs: vec![None; request.prompt_tokens.len()],
+                    },
+                );
+            }
+            let prompt_len = request.prompt_tokens.len();
+            let (pending, finish_reason) =
+                planned_completion(&self.config, &request.prompt_tokens, request.max_tokens);
+            ledger.admit(id);
+            if pending.is_empty() {
+                ledger.finish(id, finish_reason);
+                continue;
+            }
+            self.running.push(RunningRequest {
+                id,
+                pending,
+                next_token_at: Instant::now() + self.config.ttft(prompt_len),
+                finish_reason,
+                logprobs: request.logprobs,
+            });
+        }
+
+        let now = Instant::now();
+        let mut still_running = Vec::new();
+        for mut running in self.running.drain(..) {
+            if ledger.is_aborted(running.id) {
+                ledger.retire(running.id);
+                continue;
+            }
+            if now < running.next_token_at {
+                still_running.push(running);
+                continue;
+            }
+            let Some(token) = running.pending.pop() else {
+                ledger.finish(running.id, running.finish_reason);
+                continue;
+            };
+            let logprob = (running.logprobs > 0).then_some(TokenLogprob {
+                logprob: 0.0,
+                top_logprobs: Vec::new(),
+            });
+            let logprobs = match logprob {
+                Some(lp) => vec![Some(lp)],
+                None => Vec::new(),
+            };
+            ledger.push_tokens(running.id, &[token], &logprobs);
+            if running.pending.is_empty() {
+                ledger.finish(running.id, running.finish_reason);
+            } else {
+                running.next_token_at = Instant::now() + self.config.tpot();
+                still_running.push(running);
+            }
+        }
+        self.running = still_running;
+        self.park_if_waiting();
+        Ok(())
+    }
+
+    fn metrics(&self) -> SchedulerMetrics {
+        SchedulerMetrics {
+            num_running_reqs: self.running.len() as u64,
+            num_waiting_reqs: self.queued.len() as u64,
+            ..SchedulerMetrics::default()
+        }
+    }
+}
+
+/// Remaining tokens (reversed) plus the terminal reason. Empty pending means
+/// finish immediately after admit.
+fn planned_completion(
+    config: &SimulatedEngineConfig,
+    prompt_tokens: &[u32],
+    max_tokens: usize,
+) -> (Vec<u32>, FinishReason) {
+    let script = &config.scripted_completion;
+    let emit_count = if script.is_empty() {
+        max_tokens
+    } else {
+        max_tokens.min(script.len())
+    };
     let finish_reason = if !script.is_empty() && emit_count == script.len() {
         FinishReason::Stop
     } else {
         FinishReason::Length
     };
-    let _ = req.token_tx.send(TokenEvent::Finished {
-        finish_reason,
-        prompt_tokens: prompt_len,
-        completion_tokens,
-    });
+    let mut pending: Vec<u32> = if script.is_empty() {
+        (0..emit_count)
+            .map(|index| fake_token_id(prompt_tokens, index, config.fallback_token_id))
+            .collect()
+    } else {
+        script[..emit_count].to_vec()
+    };
+    pending.reverse();
+    (pending, finish_reason)
 }
 
 fn fake_token_id(prompt_tokens: &[u32], index: usize, fallback_token_id: u32) -> u32 {
@@ -177,19 +274,57 @@ fn duration_from_ms(ms: f64) -> Duration {
     Duration::from_secs_f64(ms / 1000.0)
 }
 
-fn now_secs_f64() -> f64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system clock before unix epoch")
-        .as_secs_f64()
-}
-
 #[cfg(test)]
 mod tests {
-    use pegainfer_frontend::engine::TokenSink;
+    use pegainfer_frontend::engine::Request;
+    use pegainfer_frontend::engine::Terminal;
     use pegainfer_frontend::sampler::SamplingParams;
 
     use super::*;
+
+    fn request(prompt_tokens: Vec<u32>, max_tokens: usize, logprobs: usize) -> Request {
+        Request {
+            prompt_tokens,
+            params: SamplingParams::default(),
+            max_tokens,
+            lora_adapter: None,
+            kv_transfer_params: None,
+            logprobs,
+            echo: false,
+            trace_parent: None,
+            client_label: None,
+        }
+    }
+
+    fn collect_completion(
+        config: &SimulatedEngineConfig,
+        req: Request,
+    ) -> (Vec<u32>, Option<usize>, Terminal) {
+        let mut engine = start_engine(config);
+        assert_eq!(engine.schedulers.len(), 1);
+        let mut partition = engine.schedulers.remove(0);
+        let mut steps = partition.handle.take_steps().expect("step stream");
+        let _control = partition.handle.submit(req);
+
+        let mut tokens = Vec::new();
+        let mut prompt_tokens = None;
+        let mut terminal = None;
+        while terminal.is_none() {
+            let step = steps.blocking_recv().expect("step message");
+            for update in step.updates {
+                if let Some(scheduled) = update.scheduled {
+                    prompt_tokens = Some(scheduled.prompt_tokens);
+                }
+                tokens.extend(update.tokens);
+                if let Some(t) = update.terminal {
+                    terminal = Some(t);
+                }
+            }
+        }
+        drop(partition.handle);
+        partition.join.join().expect("driver thread exits");
+        (tokens, prompt_tokens, terminal.expect("terminal"))
+    }
 
     #[test]
     fn fake_token_id_cycles_prompt_tokens() {
@@ -199,97 +334,37 @@ mod tests {
         assert_eq!(fake_token_id(&[], 0, 42), 42);
     }
 
-    #[tokio::test]
-    async fn scripted_completion_replays_ids_and_stops() {
+    #[test]
+    fn scripted_completion_replays_ids_and_stops() {
         let config = SimulatedEngineConfig::new(0.0, 100.0, 0.0, 0)
             .unwrap()
             .with_scripted_completion(vec![11, 22, 33]);
-        let (token_tx, mut token_rx) = TokenSink::standalone();
-
-        run_simulated_request(
-            GenerateRequest {
-                trace_parent: None,
-                request_id: Some("req-scripted".to_string()),
-                queued_at_unix_s: Some(1.0),
-                data_parallel_rank: None,
-                // Prompt is irrelevant in scripted mode; output ignores it.
-                prompt_tokens: vec![7, 9],
-                params: SamplingParams::default(),
-                max_tokens: 8,
-                lora_adapter: None,
-                kv_transfer_params: None,
-                token_tx,
-                logprobs: 0,
-                echo: false,
-            },
-            config,
-        )
-        .await;
-
+        let (tokens, _, terminal) = collect_completion(&config, request(vec![7, 9], 8, 0));
+        assert_eq!(tokens, [11, 22, 33]);
         assert!(matches!(
-            token_rx.recv().await.map(|(_, e)| e),
-            Some(TokenEvent::Scheduled { .. })
-        ));
-        for expected in [11u32, 22, 33] {
-            assert!(matches!(
-                token_rx.recv().await.map(|(_, e)| e),
-                Some(TokenEvent::Token { id, .. }) if id == expected
-            ));
-        }
-        // Whole script fit inside max_tokens -> Stop, not Length.
-        assert!(matches!(
-            token_rx.recv().await.map(|(_, e)| e),
-            Some(TokenEvent::Finished {
-                finish_reason: FinishReason::Stop,
+            terminal,
+            Terminal::Finished {
+                reason: FinishReason::Stop,
                 completion_tokens: 3,
                 ..
-            })
+            }
         ));
     }
 
-    #[tokio::test]
-    async fn scripted_completion_truncated_by_max_tokens_is_length() {
+    #[test]
+    fn scripted_completion_truncated_by_max_tokens_is_length() {
         let config = SimulatedEngineConfig::new(0.0, 100.0, 0.0, 0)
             .unwrap()
             .with_scripted_completion(vec![11, 22, 33]);
-        let (token_tx, mut token_rx) = TokenSink::standalone();
-
-        run_simulated_request(
-            GenerateRequest {
-                trace_parent: None,
-                request_id: Some("req-trunc".to_string()),
-                queued_at_unix_s: Some(1.0),
-                data_parallel_rank: None,
-                prompt_tokens: vec![7],
-                params: SamplingParams::default(),
-                max_tokens: 2,
-                lora_adapter: None,
-                kv_transfer_params: None,
-                token_tx,
-                logprobs: 0,
-                echo: false,
-            },
-            config,
-        )
-        .await;
-
+        let (tokens, _, terminal) = collect_completion(&config, request(vec![7], 2, 0));
+        assert_eq!(tokens, [11, 22]);
         assert!(matches!(
-            token_rx.recv().await.map(|(_, e)| e),
-            Some(TokenEvent::Scheduled { .. })
-        ));
-        for expected in [11u32, 22] {
-            assert!(matches!(
-                token_rx.recv().await.map(|(_, e)| e),
-                Some(TokenEvent::Token { id, .. }) if id == expected
-            ));
-        }
-        assert!(matches!(
-            token_rx.recv().await.map(|(_, e)| e),
-            Some(TokenEvent::Finished {
-                finish_reason: FinishReason::Length,
+            terminal,
+            Terminal::Finished {
+                reason: FinishReason::Length,
                 completion_tokens: 2,
                 ..
-            })
+            }
         ));
     }
 
@@ -303,65 +378,26 @@ mod tests {
         assert!(SimulatedEngineConfig::new(5.0, 100.0, f64::INFINITY, 0).is_err());
     }
 
-    #[tokio::test]
-    async fn simulated_request_emits_scheduled_tokens_and_finished() {
+    #[test]
+    fn simulated_request_emits_scheduled_tokens_and_finished() {
         let config = SimulatedEngineConfig::new(0.0, 100.0, 0.0, 42).unwrap();
-        let (token_tx, mut token_rx) = TokenSink::standalone();
-
-        run_simulated_request(
-            GenerateRequest {
-                trace_parent: None,
-                request_id: Some("req-1".to_string()),
-                queued_at_unix_s: Some(1.0),
-                data_parallel_rank: None,
-                prompt_tokens: vec![7, 9],
-                params: SamplingParams::default(),
-                max_tokens: 3,
-                lora_adapter: None,
-                kv_transfer_params: None,
-                token_tx,
-                logprobs: 1,
-                echo: false,
-            },
-            config,
-        )
-        .await;
-
+        let (tokens, prompt_tokens, terminal) =
+            collect_completion(&config, request(vec![7, 9], 3, 1));
+        assert_eq!(prompt_tokens, Some(2));
+        assert_eq!(tokens, [7, 9, 7]);
         assert!(matches!(
-            token_rx.recv().await.map(|(_, event)| event),
-            Some(TokenEvent::Scheduled {
+            terminal,
+            Terminal::Finished {
+                reason: FinishReason::Length,
                 prompt_tokens: 2,
-                ..
-            })
+                completion_tokens: 3,
+            }
         ));
-        assert!(matches!(
-            token_rx.recv().await.map(|(_, event)| event),
-            Some(TokenEvent::Token {
-                id: 7,
-                logprob: Some(_)
-            })
-        ));
-        assert!(matches!(
-            token_rx.recv().await.map(|(_, event)| event),
-            Some(TokenEvent::Token {
-                id: 9,
-                logprob: Some(_)
-            })
-        ));
-        assert!(matches!(
-            token_rx.recv().await.map(|(_, event)| event),
-            Some(TokenEvent::Token {
-                id: 7,
-                logprob: Some(_)
-            })
-        ));
-        assert!(matches!(
-            token_rx.recv().await.map(|(_, event)| event),
-            Some(TokenEvent::Finished {
-                finish_reason: FinishReason::Length,
-                prompt_tokens: 2,
-                completion_tokens: 3
-            })
-        ));
+    }
+
+    #[test]
+    fn start_engine_with_partitions_exposes_that_many_schedulers() {
+        let engine = start_engine_with_partitions(&SimulatedEngineConfig::default(), 3);
+        assert_eq!(engine.schedulers.len(), 3);
     }
 }

--- a/pegainfer-sim/src/main.rs
+++ b/pegainfer-sim/src/main.rs
@@ -51,10 +51,10 @@ async fn main() -> Result<()> {
         args.tpot_ms,
         args.fallback_token_id,
     )?;
-    let handle = start_engine(config);
+    let engine = start_engine(&config);
 
     pegainfer_frontend::vllm::serve(
-        std::future::ready(Ok(handle.into())),
+        std::future::ready(Ok(engine.into())),
         Path::new(&args.model_id),
         Vec::new(),
         args.port,

--- a/pegainfer-sim/tests/frontend_e2e.rs
+++ b/pegainfer-sim/tests/frontend_e2e.rs
@@ -6,23 +6,20 @@ use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
 use anyhow::bail;
-use pegainfer_frontend::engine::SchedulerMetrics;
-use pegainfer_frontend::engine::SpecDecodeCounters;
 use pegainfer_sim::SimulatedEngineConfig;
 use pegainfer_sim::start_engine;
+use pegainfer_sim::start_engine_with_partitions;
 use reqwest::Client;
 use serde_json::Value;
 use serde_json::json;
 use tempfile::TempDir;
-use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 const MODEL_NAME: &str = "pegainfer-sim-e2e";
 const METRICS_MODEL_NAME: &str = "pegainfer-sim-e2e-metrics";
-const CLOSED_FEED_MODEL_NAME: &str = "pegainfer-sim-e2e-closed-feed";
-const SPEC_METRICS_MODEL_NAME: &str = "pegainfer-sim-e2e-spec-metrics";
+const SLOW_METRICS_MODEL_NAME: &str = "pegainfer-sim-e2e-slow-metrics";
 const SERVER_START_ATTEMPTS: usize = 5;
 
 struct SimServer {
@@ -30,7 +27,6 @@ struct SimServer {
     model_name: String,
     shutdown: CancellationToken,
     task: JoinHandle<Result<()>>,
-    metrics_txs: Vec<watch::Sender<SchedulerMetrics>>,
     _model_dir: TempDir,
 }
 
@@ -40,51 +36,50 @@ impl SimServer {
     }
 
     async fn spawn_partitioned() -> Result<Self> {
-        Self::spawn_with_model_dir_and_engine_count(
+        Self::spawn_with_config(
             model_dir_with_minimal_metadata()?,
             2,
             METRICS_MODEL_NAME,
+            SimulatedEngineConfig::new(0.0, 1000.0, 0.0, 1)?,
         )
         .await
     }
 
-    async fn spawn_with_spec_metrics() -> Result<Self> {
-        Self::spawn_with_model_dir_and_engine_count(
+    async fn spawn_slow() -> Result<Self> {
+        Self::spawn_with_config(
             model_dir_with_minimal_metadata()?,
-            2,
-            SPEC_METRICS_MODEL_NAME,
-        )
-        .await
-    }
-
-    async fn spawn_with_closed_load_feed() -> Result<Self> {
-        Self::spawn_with_model_dir_and_engine_count(
-            model_dir_with_minimal_metadata()?,
-            2,
-            CLOSED_FEED_MODEL_NAME,
+            1,
+            SLOW_METRICS_MODEL_NAME,
+            SimulatedEngineConfig::new(0.0, 1000.0, 80.0, 1)?,
         )
         .await
     }
 
     async fn spawn_with_model_dir(model_dir: TempDir) -> Result<Self> {
-        Self::spawn_with_model_dir_and_engine_count(model_dir, 1, MODEL_NAME).await
+        Self::spawn_with_config(
+            model_dir,
+            1,
+            MODEL_NAME,
+            SimulatedEngineConfig::new(0.0, 1000.0, 0.0, 1)?,
+        )
+        .await
     }
 
-    async fn spawn_with_model_dir_and_engine_count(
+    async fn spawn_with_config(
         model_dir: TempDir,
         engine_count: usize,
         model_name: &str,
+        config: SimulatedEngineConfig,
     ) -> Result<Self> {
         let mut last_error = None;
         for attempt in 1..=SERVER_START_ATTEMPTS {
-            match Self::spawn_once(&model_dir, engine_count, model_name).await {
+            match Self::spawn_once(&model_dir, engine_count, model_name, config.clone()).await {
                 Ok(started) => {
                     return Ok(Self {
                         base_url: started.base_url,
                         model_name: started.model_name,
                         shutdown: started.shutdown,
                         task: started.task,
-                        metrics_txs: started.metrics_txs,
                         _model_dir: model_dir,
                     });
                 }
@@ -107,20 +102,12 @@ impl SimServer {
         model_dir: &TempDir,
         engine_count: usize,
         model_name: &str,
+        config: SimulatedEngineConfig,
     ) -> Result<StartedSimServer> {
         let port = reserve_loopback_port()?;
         let base_url = format!("http://127.0.0.1:{port}");
         let shutdown = CancellationToken::new();
-        let mut engine = start_engine(SimulatedEngineConfig::new(0.0, 1000.0, 0.0, 1)?);
-        let metrics_txs = if engine_count > 1 {
-            let (metrics_txs, metrics_watches) = (0..engine_count)
-                .map(|_| watch::channel(SchedulerMetrics::default()))
-                .unzip();
-            engine = engine.with_metrics_watches(metrics_watches);
-            metrics_txs
-        } else {
-            Vec::new()
-        };
+        let engine = start_engine_with_partitions(&config, engine_count);
         let server_shutdown = shutdown.clone();
         let served_model_name = model_name.to_string();
         let started_model_name = served_model_name.clone();
@@ -161,17 +148,7 @@ impl SimServer {
             model_name: started_model_name,
             shutdown,
             task,
-            metrics_txs,
         })
-    }
-
-    fn publish_metrics(&self, partition: usize, snapshot: &SchedulerMetrics) -> Result<()> {
-        let sender = self
-            .metrics_txs
-            .get(partition)
-            .ok_or_else(|| anyhow!("sim frontend has no load feed for partition {partition}"))?;
-        let _ = sender.send_replace(*snapshot);
-        Ok(())
     }
 
     async fn shutdown(self) -> Result<()> {
@@ -188,7 +165,6 @@ struct StartedSimServer {
     model_name: String,
     shutdown: CancellationToken,
     task: JoinHandle<Result<()>>,
-    metrics_txs: Vec<watch::Sender<SchedulerMetrics>>,
 }
 
 fn empty_model_dir() -> Result<TempDir> {
@@ -234,91 +210,8 @@ async fn one_http_endpoint_exports_per_engine_scheduler_metrics() -> Result<()> 
 
     assert_non_streaming_completion_has_output(&client, &server.base_url, &server.model_name)
         .await?;
-    wait_for_metrics(
-        &client,
-        &server.base_url,
-        &[
-            ("vllm:num_requests_running", "0", 0.0),
-            ("vllm:num_requests_running", "1", 0.0),
-            ("vllm:num_requests_waiting", "0", 0.0),
-            ("vllm:num_requests_waiting", "1", 0.0),
-            ("vllm:kv_cache_usage_perc", "0", 0.0),
-            ("vllm:kv_cache_usage_perc", "1", 0.0),
-        ],
-        &server.model_name,
-    )
-    .await?;
-
-    server.publish_metrics(
-        0,
-        &SchedulerMetrics {
-            kv_used_blocks: 25,
-            kv_total_blocks: 100,
-            num_running_reqs: 1,
-            num_waiting_reqs: 0,
-            spec_decode: None,
-        },
-    )?;
-    server.publish_metrics(
-        1,
-        &SchedulerMetrics {
-            kv_used_blocks: 50,
-            kv_total_blocks: 100,
-            num_running_reqs: 0,
-            num_waiting_reqs: 2,
-            spec_decode: None,
-        },
-    )?;
-    wait_for_metrics(
-        &client,
-        &server.base_url,
-        &[
-            ("vllm:num_requests_running", "0", 1.0),
-            ("vllm:num_requests_waiting", "1", 2.0),
-            ("vllm:kv_cache_usage_perc", "0", 0.25),
-            ("vllm:kv_cache_usage_perc", "1", 0.5),
-        ],
-        &server.model_name,
-    )
-    .await?;
-
-    server.publish_metrics(
-        0,
-        &SchedulerMetrics {
-            kv_used_blocks: 75,
-            kv_total_blocks: 100,
-            num_running_reqs: 3,
-            num_waiting_reqs: 4,
-            spec_decode: None,
-        },
-    )?;
-    server.publish_metrics(
-        1,
-        &SchedulerMetrics {
-            kv_used_blocks: 25,
-            kv_total_blocks: 100,
-            num_running_reqs: 5,
-            num_waiting_reqs: 6,
-            spec_decode: None,
-        },
-    )?;
-    wait_for_metrics(
-        &client,
-        &server.base_url,
-        &[
-            ("vllm:num_requests_running", "0", 3.0),
-            ("vllm:num_requests_running", "1", 5.0),
-            ("vllm:num_requests_waiting", "0", 4.0),
-            ("vllm:num_requests_waiting", "1", 6.0),
-            ("vllm:kv_cache_usage_perc", "0", 0.75),
-            ("vllm:kv_cache_usage_perc", "1", 0.25),
-        ],
-        &server.model_name,
-    )
-    .await?;
-
-    server.publish_metrics(0, &SchedulerMetrics::default())?;
-    server.publish_metrics(1, &SchedulerMetrics::default())?;
+    // Two real schedulers: a finishing step stamps drained occupancy, so both
+    // engines settle at zero. There is no watch to inject fake KV/running.
     wait_for_metrics(
         &client,
         &server.base_url,
@@ -338,145 +231,50 @@ async fn one_http_endpoint_exports_per_engine_scheduler_metrics() -> Result<()> 
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn spec_decode_counters_reach_prometheus_as_cumulative_totals() -> Result<()> {
-    let server = SimServer::spawn_with_spec_metrics().await?;
+async fn running_gauge_rises_during_a_slow_request() -> Result<()> {
+    let server = SimServer::spawn_slow().await?;
     let client = test_client()?;
 
-    let mut totals = SpecDecodeCounters::new(2).expect("K within bounds");
-    totals.observe_draft(2, 1);
-    server.publish_metrics(
-        0,
-        &SchedulerMetrics {
-            spec_decode: Some(totals),
-            ..SchedulerMetrics::default()
-        },
-    )?;
-    // `_total` is appended at exposition; the registered name scrapes empty.
-    wait_for_metrics(
-        &client,
-        &server.base_url,
-        &[
-            ("vllm:spec_decode_num_drafts_total", "0", 1.0),
-            ("vllm:spec_decode_num_draft_tokens_total", "0", 2.0),
-            ("vllm:spec_decode_num_accepted_tokens_total", "0", 1.0),
-        ],
-        &server.model_name,
-    )
-    .await?;
-
-    // Two verify steps coalesced into one snapshot, as the watch would. What
-    // must come back is the scheduler's cumulative, not this interval's delta:
-    // a delta counted twice or dropped breaks that equality, and nothing below
-    // the exposition layer can see it.
-    totals.observe_draft(2, 2);
-    totals.observe_draft(2, 2);
-    server.publish_metrics(
-        0,
-        &SchedulerMetrics {
-            spec_decode: Some(totals),
-            ..SchedulerMetrics::default()
-        },
-    )?;
-    wait_for_metrics(
-        &client,
-        &server.base_url,
-        &[
-            (
-                "vllm:spec_decode_num_drafts_total",
-                "0",
-                totals.num_drafts as f64,
-            ),
-            (
-                "vllm:spec_decode_num_draft_tokens_total",
-                "0",
-                totals.num_draft_tokens as f64,
-            ),
-            (
-                "vllm:spec_decode_num_accepted_tokens_total",
-                "0",
-                totals.num_accepted_tokens as f64,
-            ),
-        ],
-        &server.model_name,
-    )
-    .await?;
-
-    wait_for_labeled_metrics(
-        &client,
-        &server.base_url,
-        &[
-            (
-                "vllm:spec_decode_num_accepted_tokens_per_pos_total",
-                "0",
-                &[("position", "0")][..],
-                totals.num_accepted_tokens_per_pos[0] as f64,
-            ),
-            (
-                "vllm:spec_decode_num_accepted_tokens_per_pos_total",
-                "0",
-                &[("position", "1")][..],
-                totals.num_accepted_tokens_per_pos[1] as f64,
-            ),
-        ],
-        &server.model_name,
-    )
-    .await?;
-
-    // Exposition is one series per draft slot the drafter actually has, so the
-    // fixed `MAX_SPEC_TOKENS` array width must not leak past `K = 2`.
-    let metrics = client
-        .get(format!("{}/metrics", server.base_url))
-        .send()
-        .await?
-        .error_for_status()?
-        .text()
-        .await?;
-    let leaked: Vec<_> = metrics
-        .lines()
-        .filter(|line| {
-            line.contains(&format!("model_name=\"{}\"", server.model_name))
-                && line.contains("position=\"2\"")
+    let inflight = {
+        let client = client.clone();
+        let url = format!("{}/v1/completions", server.base_url);
+        let body = json!({
+            "model": server.model_name,
+            "prompt": [1, 2],
+            "max_tokens": 4,
+            "temperature": 0.0,
+            "ignore_eos": true,
+        });
+        tokio::spawn(async move {
+            client
+                .post(url)
+                .header(reqwest::header::CONTENT_TYPE, "application/json")
+                .body(body.to_string())
+                .send()
+                .await?
+                .error_for_status()?;
+            Ok::<_, anyhow::Error>(())
         })
-        .collect();
-    assert!(
-        leaked.is_empty(),
-        "per-position series past K=2 were exposed: {leaked:?}"
-    );
+    };
 
-    // Engine 1 never drafted. Its counters are pre-registered, so they must be
-    // present and zero — which is also what pins each delta to one engine
-    // instead of being applied to both.
     wait_for_metrics(
         &client,
         &server.base_url,
-        &[
-            ("vllm:spec_decode_num_drafts_total", "1", 0.0),
-            ("vllm:spec_decode_num_draft_tokens_total", "1", 0.0),
-            ("vllm:spec_decode_num_accepted_tokens_total", "1", 0.0),
-        ],
+        &[("vllm:num_requests_running", "0", 1.0)],
+        &server.model_name,
+    )
+    .await?;
+
+    inflight.await.context("slow completion task panicked")??;
+    wait_for_metrics(
+        &client,
+        &server.base_url,
+        &[("vllm:num_requests_running", "0", 0.0)],
         &server.model_name,
     )
     .await?;
 
     server.shutdown().await
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn closed_scheduler_load_feed_stops_the_endpoint() -> Result<()> {
-    let mut server = SimServer::spawn_with_closed_load_feed().await?;
-    drop(server.metrics_txs.remove(0));
-
-    let service_result = tokio::time::timeout(Duration::from_secs(10), &mut server.task)
-        .await
-        .context("frontend did not stop after a scheduler load feed closed")?
-        .context("sim frontend task panicked")?;
-    let error = service_result.expect_err("closed scheduler load feed must fail the endpoint");
-    let message = format!("{error:#}");
-    if !message.contains("scheduler load feed closed") {
-        bail!("closed scheduler load feed returned unexpected error: {message}");
-    }
-
-    Ok(())
 }
 
 async fn wait_for_metrics(
@@ -549,7 +347,7 @@ async fn wait_for_labeled_metrics(
 async fn frontend_rejects_engine_partition_mismatch() -> Result<()> {
     let model_dir = model_dir_with_minimal_metadata()?;
     let port = reserve_loopback_port()?;
-    let engine = start_engine(SimulatedEngineConfig::new(0.0, 1000.0, 0.0, 1)?);
+    let engine = start_engine(&SimulatedEngineConfig::new(0.0, 1000.0, 0.0, 1)?);
     let result = tokio::time::timeout(
         Duration::from_secs(10),
         pegainfer_frontend::vllm::serve_with_engine_count(
@@ -567,7 +365,7 @@ async fn frontend_rejects_engine_partition_mismatch() -> Result<()> {
     let error = result.expect_err("one scheduler partition cannot register as two engines");
     if !error
         .to_string()
-        .contains("declared 2 engines but the resolved handle exposes 1 scheduler partitions")
+        .contains("declared 2 engines but the launched engine exposes 1 schedulers")
     {
         bail!("unexpected partition-mismatch error: {error:#}");
     }
@@ -577,7 +375,7 @@ async fn frontend_rejects_engine_partition_mismatch() -> Result<()> {
 // The old "mounted LoRA routes report unsupported" sim test is gone by
 // construction: `serve_model_with_lora_routes` now requires an `Engine` whose
 // `lora` capability is `Some(LoraClient)` — the `Option` is the capability —
-// and the simulated handle engine cannot provide one. The gone-engine HTTP
+// and the simulated engine does not mint a LoRA channel. The gone-engine HTTP
 // mapping is pinned by the `vllm::lora` route tests.
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/pegainfer-sim/tests/tool_call_roundtrip.rs
+++ b/pegainfer-sim/tests/tool_call_roundtrip.rs
@@ -220,7 +220,7 @@ impl ToolCallSimServer {
         let shutdown = CancellationToken::new();
         let server_shutdown = shutdown.clone();
         let engine = start_engine(
-            SimulatedEngineConfig::new(0.0, 1000.0, 0.0, 0)?.with_scripted_completion(script),
+            &SimulatedEngineConfig::new(0.0, 1000.0, 0.0, 0)?.with_scripted_completion(script),
         );
         let model_path = model_dir.path().to_path_buf();
         let mut task = tokio::spawn(async move {


### PR DESCRIPTION
## Description

Move `pegainfer-sim` onto the step contract. It now implements `Scheduler` (`SimScheduler`), launches as `LaunchedEngine::Stepped`, and no longer speaks `EngineHandle` / `TokenEvent`.

The CPU harness stays a separate crate. CLI and HTTP tests pass `engine.into()` into `vllm::serve`. Timing is deadline-based inside `step` (park at most 1 ms) so a zero-delay sim does not spin between tokens the way a full-TTFT sleep would.

HTTP e2e follows the contract it actually speaks: two-engine idle gauges settle after a request, and a slow request raises then drains `vllm:num_requests_running`. Watch-injection, closed-feed, and spec-decode inject tests are gone — they tested the legacy handle publisher, which this crate no longer uses. Frontend unit tests in `pegainfer-frontend` still cover that publisher.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

Breaking for in-crate callers only: `start_engine` now returns `Engine` and takes `&SimulatedEngineConfig`.

## Migration defense

| Old structure | Failure mode | Heir |
| --- | --- | --- |
| `TokenEvent` order (`Scheduled` → tokens → one terminal) | Client sees tokens before schedule, or hangs without a terminal | **Replace**: `RequestLedger` typestate — `admit` / `push_tokens` / `finish` (`pegainfer-sim/src/lib.rs`). Illegal order does not compile. |
| `token_tx.send` err = cancel | Dropped client left as a ghost request | **Replace**: `ledger.is_aborted` + `retire` on queued and running |
| Per-request tokio task + `sleep` | Concurrent TTFT/TPOT independent of each other | **Replace**: per-request `next_token_at`; one token per due request per step |
| `EngineHandle::with_metrics_watches` inject | `/metrics` never moved without a watch | **Replace**: live `Scheduler::metrics`; e2e asserts idle settle + running rises on a slow request |
| Closed load-feed stops the endpoint | Stale gauges / routing black hole | **Abolish**: stepped path has no watch; losing the feed is unrepresentable |
| Spec-decode inject via watch | Prometheus totals / per-pos width | **Abolish** on sim (no drafter). Stepped `scheduler_stats_from` still drops `spec_decode` — frontend gap, not faked here. Handle-path unit tests remain. |
| Partition count vs `engine_count` | One scheduler registered as N engines | **Inherit**: same check, Stepped error string (`exposes 1 schedulers`) |

## High-concurrency A/B vs `main`

Same-session rust `vllm-bench`, `/v1/completions`, 128-in / 64-out, sim TTFT=0 / TPOT=0 (so latency is frontend + scheduler loop). Both sides 0 failures through concurrency 1024.

| c | side | req/s | out tok/s | TTFT p50 | TPOT p50 | E2EL p50 |
| --- | --- | --- | --- | --- | --- | --- |
| 64 | main | 639 | 41k | **3.7 ms** | 1.31 ms | 86 ms |
| 64 | feat | **1713** | **110k** | 31 ms | **0.04 ms** | **35 ms** |
| 256 | main | 1662 | 106k | **12 ms** | 1.61 ms | **116 ms** |
| 256 | feat | 1725 | 110k | 134 ms | **0.05 ms** | 137 ms |
| 512 | main | 1514 | 97k | **51 ms** | 3.97 ms | **292 ms** |
| 512 | feat | 1570 | 100k | 305 ms | **0.05 ms** | 309 ms |
| 1024 | main | 1358 | 87k | **287 ms** | 7.49 ms | 733 ms |
| 1024 | feat | **1691** | **108k** | 571 ms | **0.04 ms** | **574 ms** |

`vllm-bench --compare` (A=`main`, B=this PR):

- c=64: throughput **+168%**, E2EL p50 **−60%**, TTFT p50 **+757%**
- c=1024: throughput **+25%**, E2EL p50 **−22%**, TTFT p50 **+99%**

Shape, not a one-way win: stepped decode stays flat (~0.05 ms TPOT) because one step emits every due request; first-token work is serialized on the single driver thread, so TTFT grows ~linear in C. `main` spreads admit across tokio tasks (better TTFT) and pays per-request wake tax as TPOT.

The driver thread (`pegainfer-sim-0`) is 100% even when idle (`spin_loop`). That is the GPU-engine convention; on a CPU-only sim it just pins a core. tokio / ZMQ stay ~1% under load. Full write-up: `docs/subsystems/frontend/sim-high-concurrency-bench.md`.

## Checklist

- [x] My code follows the style guidelines of this project (see `docs/conventions/coding-style.md`).
- [x] I have performed a self-review of my own code.
- [x] I have formatted my commits according to Commitizen conventions.
- [x] I have run the local test suite and all tests pass (see `CLAUDE.md`).

`cargo test --release -p pegainfer-sim`: lib 6, frontend_e2e 12, tool_call_roundtrip 3.
`cargo clippy --release -p pegainfer-sim --all-targets -- -D warnings` clean.