### PR TITLE
test(gemma4): a ragged decode batch must replay and reorder identically

### DIFF
--- a/pegainfer-gemma4/src/serve_oracle.rs
+++ b/pegainfer-gemma4/src/serve_oracle.rs
@@ -559,3 +559,111 @@ fn argmax_last(ctx: &DeviceContext, logits: &HiddenStates) -> Result<u32> {
         .context("non-empty vocab")?;
     u32::try_from(argmax).context("token id fits u32")
 }
+
+/// A fixed-width ragged batch must preserve each request's logits as rows move
+/// between steps. Distinct token streams make cross-row reads observable.
+#[test]
+#[ignore = "requires the pinned 12B checkpoint and a GPU"]
+fn a_ragged_batch_does_not_depend_on_row_order() {
+    const STEPS: usize = 10;
+    let lengths = [1100usize, 40, 300, 17];
+    // Exactly the pages the four requests reach by the last step, plus the
+    // pool's padding page.
+    let pages = lengths
+        .iter()
+        .map(|len| (len + STEPS).div_ceil(PAGE_SIZE))
+        .sum::<usize>()
+        + 1;
+    let (ctx, serve, _dir) = stack_with(2048, pages);
+
+    let prompt_of = |request: usize| -> Vec<u32> {
+        (0..lengths[request] as u32)
+            .map(|i| 1000 + request as u32 * 2000 + i)
+            .collect()
+    };
+    let feed_of = |request: usize, step: usize| -> u32 { 20000 + (request * STEPS + step) as u32 };
+
+    // `orders[step % orders.len()]` lists request ids by the row each one
+    // occupies at that step; out[request][step] collects results back by
+    // request, wherever it sat.
+    let run = |orders: &[Vec<usize>]| -> Vec<Vec<Vec<f32>>> {
+        let mut kvs: Vec<GemmaKv> = lengths.iter().map(|_| serve.alloc_kv()).collect();
+        for (request, kv) in kvs.iter_mut().enumerate() {
+            let prompt = prompt_of(request);
+            admit_tokens(&serve.local_pool, &serve.global_pool, kv, prompt.len())
+                .expect("admit prompt");
+            serve
+                .step(&ctx, kv, &prompt, LogitsSpan::LastRow)
+                .expect("prefill");
+        }
+        assert!(
+            kvs[0].local.origin_pages() > 0,
+            "the {} token row should have released its window front",
+            lengths[0]
+        );
+        for (request, kv) in kvs.iter().enumerate().skip(1) {
+            assert_eq!(
+                kv.local.origin_pages(),
+                0,
+                "request {request} ({} prompt tokens) should still hold its front",
+                lengths[request]
+            );
+        }
+        let mut out = vec![Vec::with_capacity(STEPS); lengths.len()];
+        for step in 0..STEPS {
+            let order = &orders[step % orders.len()];
+            for kv in &mut kvs {
+                admit_tokens(&serve.local_pool, &serve.global_pool, kv, 1).expect("admit token");
+            }
+            let mut slots: Vec<Option<&mut GemmaKv>> = kvs.iter_mut().map(Some).collect();
+            let mut borrowed = Vec::with_capacity(order.len());
+            let mut tokens = Vec::with_capacity(order.len());
+            for &request in order {
+                borrowed.push(slots[request].take().expect("each request once"));
+                tokens.push(feed_of(request, step));
+            }
+            let logits = serve
+                .decode_batch_step(&ctx, &mut borrowed, &tokens)
+                .expect("decode");
+            let host = logits.to_host(&ctx).expect("D2H");
+            let vocab = logits.hidden_dim;
+            for (row, &request) in order.iter().enumerate() {
+                out[request].push(host[row * vocab..(row + 1) * vocab].to_vec());
+            }
+        }
+        out
+    };
+
+    let forward: Vec<usize> = (0..lengths.len()).collect();
+    let reversed: Vec<usize> = forward.iter().rev().copied().collect();
+    let first = run(std::slice::from_ref(&forward));
+    let replayed = run(std::slice::from_ref(&forward));
+    let shuffled = run(&[forward, reversed]);
+
+    for (label, other) in [
+        ("replaying", &replayed),
+        ("moving its row between steps", &shuffled),
+    ] {
+        for (request, (rows_a, rows_b)) in first.iter().zip(other).enumerate() {
+            for (step, (x, y)) in rows_a.iter().zip(rows_b).enumerate() {
+                let differing = x
+                    .iter()
+                    .zip(y)
+                    .enumerate()
+                    .find(|(_, (p, q))| p.to_bits() != q.to_bits());
+                assert!(
+                    differing.is_none(),
+                    "request {request} ({} prompt tokens) step {step}: {label} changed its \
+                     logits at {:?}",
+                    lengths[request],
+                    differing.map(|(i, (p, q))| (i, *p, *q))
+                );
+            }
+        }
+    }
+    println!(
+        "ragged batch: {} rows at {:?} tokens replay identically and survive per step row moves",
+        lengths.len(),
+        lengths
+    );
+}


### PR DESCRIPTION

## Description

Closes #900

Submitting the same eight requests twice returns the same tokens on a quiet machine and sometimes does not on a busy one. That is the signature of the schedule moving, and it is also the signature of a row reading metadata that is not its own — the page tables and the position array are indexed by a row's place in the batch, and the engine moves that place when a request retires out of the middle. The serving path cannot tell the two apart, so this asks with the composition pinned.

The probe pins the composition in the one shape that can hide an indexing error: a ragged batch. Rows at 1100, 40, 300 and 17 prompt tokens — the first past the sliding window with its front released — decode together three times over. Every request's prompt and every fed token is distinct at every position, so a read of another row's page cannot return the right bytes by coincidence; uniform or prefix-shared content would leave exactly that blind spot. The first two runs share one order, so any nondeterminism in the step itself shows; in the third the rows swap places between steps, the way survivors move when a neighbour retires out of the middle, with width and membership held fixed — a row's place is what the page tables, positions and origins are keyed by. Every request must get bit-identical logits in all three runs.

What it establishes on this checkpoint: under this pinned composition — ragged KV, a released window front, replay, and rows moving between steps — no row contamination appears, and the step is bit-deterministic. That is consistent with the API-level drift being schedule-driven, and the diagnostic yardsticks measured during the investigation point the same way: batch width alone moves a single logit by up to 0.84 in the measured single-step width probe, and differences that accumulate through the KV cache can flip a decision whose top two sat 1.94 nats apart by the ninth token. 

### Test Env

Single GPU (sm_89, x86_64), CUDA 12.9, pinned 12B checkpoint, with an unrelated training job holding the card at 50 to 60 percent utilization throughout; the probe passed in three launches under that load.

### Verification

- fmt; `cargo build`/`clippy -D warnings` for `pegainfer-kernels` and for `pegainfer-gemma4 --features gemma4`; the CI package set with `--locked`; `pegainfer-gemma4 --lib` 26 passed, 9 ignored.
- The probe itself, three consecutive process launches on the busy card: the ragged batch replays identically and survives per-step row moves every time.
- During the investigation the same rig also established the yardsticks quoted above: uniform 8-row batches replay bit-identically, and batch width alone moves a single logit by 0.72 to 0.84. Those instruments did the diagnosis and are not shipped; what ships is the one test that guards the isolated row-ownership invariant.