### PR TITLE
refactor(gemma4): reuse the epilogue buffers the caller owns

### DIFF
--- a/docs/models/gemma4/serving.md
+++ b/docs/models/gemma4/serving.md
@@ -99,7 +99,7 @@ A row decoding in a batch does not produce the same logprobs as the same row dec
 
 Hold the trajectory fixed and replace what the other rows are — their content, their prompt lengths — and the row is bit-identical, so **no companion row contaminates it**. Change when companions arrive or retire and the row moves, because the kernels pick shapes and reduction orders by batch size. (That a row reads the *right* positions and page rows in the first place is a separate question, gated by the preps' closed-form tests rather than by this comparison.)
 
-The consequence for callers: **greedy output is reproducible for a given workload, not across workloads.** Replaying the same requests the same way returns the same tokens; sending them alongside different traffic changes the widths they decode at and can flip a near-tie.
+The consequence for callers: **greedy output is reproducible for a given workload on an otherwise idle device, not across workloads.** Replaying the same requests the same way returns the same tokens; sending them alongside different traffic changes the widths they decode at and can flip a near-tie. Another process on the same GPU does this too, by moving when each prompt's prefill lands relative to the decodes around it.
 
 ## Limits today
 

--- a/pegainfer-gemma4/src/engine.rs
+++ b/pegainfer-gemma4/src/engine.rs
@@ -29,6 +29,7 @@ use crate::kv::PAGE_SIZE;
 use crate::kv::admit_tokens;
 use crate::serve::GemmaServe;
 use crate::serve::LogitsSpan;
+use crate::serve::StepArena;
 use crate::weights::Gemma4Weights;
 
 /// Serving ceiling: bounds the rope tables and the pool budget. The
@@ -267,6 +268,7 @@ fn send_scheduled(request: &GenerateRequest, prompt_tokens: usize) -> bool {
 struct EngineState {
     ctx: DeviceContext,
     serve: GemmaServe,
+    arena: StepArena,
     scratch: SampleScratch,
     policy: GenerationPolicy,
     /// The value written into a suppressed slot, resident on the device so a
@@ -297,6 +299,7 @@ impl EngineState {
         let global_pages = MAX_CONCURRENCY * context_pages + 1;
         let serve = GemmaServe::new(&ctx, weights, MAX_CONTEXT, local_pages, global_pages)?;
         let scratch = SampleScratch::new(&ctx, vocab, MAX_CONCURRENCY)?;
+        let arena = serve.alloc_step_arena(&ctx, MAX_CONCURRENCY)?;
         let blocked = ctx
             .stream
             .clone_htod(&[bf16::NEG_INFINITY])
@@ -304,6 +307,7 @@ impl EngineState {
         Ok(Self {
             ctx,
             serve,
+            arena,
             scratch,
             policy,
             blocked,
@@ -515,7 +519,10 @@ impl EngineState {
         let tokens: Vec<u32> = active.iter().map(|entry| entry.next).collect();
         let mut logits = {
             let mut kvs: Vec<&mut GemmaKv> = active.iter_mut().map(|entry| &mut entry.kv).collect();
-            match self.serve.decode_batch_step(&self.ctx, &mut kvs, &tokens) {
+            match self
+                .serve
+                .decode_batch_step(&self.ctx, &mut self.arena, &mut kvs, &tokens)
+            {
                 Ok(logits) => logits,
                 Err(err) => return fail_batch(active, "batched decode", &err),
             }

--- a/pegainfer-gemma4/src/layer.rs
+++ b/pegainfer-gemma4/src/layer.rs
@@ -192,10 +192,66 @@ fn weightless_value_norm(
     Ok(v_normed)
 }
 
-/// Everything downstream of attention — o_proj through the `layer_scalar`
-/// multiply (applied after both residual adds, not either branch) — is
-/// identical for both layer kinds; one implementation keeps the two
-/// forwards' numerics from drifting apart.
+/// Buffers one [`attention_epilogue_into`] call needs. The serving path holds
+/// one across every layer of every step; the oracle builds a fresh one per
+/// call, which is what the allocating [`attention_epilogue`] does.
+pub(crate) struct EpilogueScratch {
+    max_rows: usize,
+    attn_proj: HiddenStates,
+    o_normed: HiddenStates,
+    h2: HiddenStates,
+    mlp_in: HiddenStates,
+    gate: HiddenStates,
+    up: HiddenStates,
+    act: HiddenStates,
+    down: HiddenStates,
+    down_normed: HiddenStates,
+}
+
+impl EpilogueScratch {
+    pub(crate) fn new(ctx: &DeviceContext, geom: &LayerGeometry, max_rows: usize) -> Result<Self> {
+        let hidden = |rows| HiddenStates::zeros(ctx, geom.hidden_size, rows);
+        let wide = |rows| HiddenStates::zeros(ctx, geom.intermediate_size, rows);
+        Ok(Self {
+            max_rows,
+            attn_proj: hidden(max_rows)?,
+            o_normed: hidden(max_rows)?,
+            h2: hidden(max_rows)?,
+            mlp_in: hidden(max_rows)?,
+            gate: wide(max_rows)?,
+            up: wide(max_rows)?,
+            act: wide(max_rows)?,
+            down: hidden(max_rows)?,
+            down_normed: hidden(max_rows)?,
+        })
+    }
+
+    /// Reshape every buffer to this step's row count, refusing one past the
+    /// allocation: the ops only assert that tensors agree with each other,
+    /// so an oversize count would reach a kernel as an out-of-bounds write.
+    pub(crate) fn set_rows(&mut self, seq_len: usize) -> Result<()> {
+        anyhow::ensure!(
+            seq_len <= self.max_rows,
+            "epilogue scratch holds {} rows, not {seq_len}",
+            self.max_rows
+        );
+        for buf in [
+            &mut self.attn_proj,
+            &mut self.o_normed,
+            &mut self.h2,
+            &mut self.mlp_in,
+            &mut self.gate,
+            &mut self.up,
+            &mut self.act,
+            &mut self.down,
+            &mut self.down_normed,
+        ] {
+            buf.seq_len = seq_len;
+        }
+        Ok(())
+    }
+}
+
 pub(crate) fn attention_epilogue(
     ctx: &DeviceContext,
     layer: &Gemma4Layer,
@@ -203,71 +259,102 @@ pub(crate) fn attention_epilogue(
     x: &HiddenStates,
     attn: &HiddenStates,
 ) -> Result<HiddenStates> {
+    let mut scratch = EpilogueScratch::new(ctx, geom, x.seq_len)?;
+    let mut out = HiddenStates::zeros(ctx, geom.hidden_size, x.seq_len)?;
+    attention_epilogue_into(ctx, layer, geom, x, attn, &mut scratch, &mut out)?;
+    Ok(out)
+}
+
+/// Everything downstream of attention — o_proj through the `layer_scalar`
+/// multiply (applied after both residual adds, not either branch) — is
+/// identical for both layer kinds; one implementation keeps the two
+/// forwards' numerics from drifting apart.
+pub(crate) fn attention_epilogue_into(
+    ctx: &DeviceContext,
+    layer: &Gemma4Layer,
+    geom: &LayerGeometry,
+    x: &HiddenStates,
+    attn: &HiddenStates,
+    scratch: &mut EpilogueScratch,
+    out: &mut HiddenStates,
+) -> Result<()> {
     let seq_len = x.seq_len;
-    let mut attn_proj = HiddenStates::zeros(ctx, geom.hidden_size, seq_len)?;
+    let scratch_rows = scratch.attn_proj.seq_len;
+    anyhow::ensure!(
+        scratch_rows == seq_len,
+        "epilogue scratch is shaped for {scratch_rows} rows, not {seq_len}"
+    );
+    let out_elems = geom
+        .hidden_size
+        .checked_mul(seq_len)
+        .context("epilogue output extent overflows")?;
+    anyhow::ensure!(
+        out.data.len() >= out_elems,
+        "epilogue output holds {} elements, not {out_elems}",
+        out.data.len()
+    );
+    out.hidden_dim = geom.hidden_size;
+    out.seq_len = seq_len;
     ops::gemm_rows_into_checked(
         ctx,
         &layer.attention.o_proj,
         0,
         geom.hidden_size,
         attn,
-        &mut attn_proj,
+        &mut scratch.attn_proj,
     )?;
-    let mut o_normed = HiddenStates::zeros(ctx, geom.hidden_size, seq_len)?;
     ops::rms_norm_batch_into(
         ctx,
-        &attn_proj,
+        &scratch.attn_proj,
         &layer.post_attention_layernorm,
         geom.rms_norm_eps,
-        &mut o_normed,
+        &mut scratch.o_normed,
     );
-    let mut h2 = HiddenStates::zeros(ctx, geom.hidden_size, seq_len)?;
-    ops::add_batch_into(ctx, x, &o_normed, &mut h2)?;
+    ops::add_batch_into(ctx, x, &scratch.o_normed, &mut scratch.h2)?;
 
-    let mut mlp_in = HiddenStates::zeros(ctx, geom.hidden_size, seq_len)?;
     ops::rms_norm_batch_into(
         ctx,
-        &h2,
+        &scratch.h2,
         &layer.pre_feedforward_layernorm,
         geom.rms_norm_eps,
-        &mut mlp_in,
+        &mut scratch.mlp_in,
     );
-    let mut gate = HiddenStates::zeros(ctx, geom.intermediate_size, seq_len)?;
-    let mut up = HiddenStates::zeros(ctx, geom.intermediate_size, seq_len)?;
     ops::gemm_rows_into_checked(
         ctx,
         &layer.mlp.gate,
         0,
         geom.intermediate_size,
-        &mlp_in,
-        &mut gate,
+        &scratch.mlp_in,
+        &mut scratch.gate,
     )?;
     ops::gemm_rows_into_checked(
         ctx,
         &layer.mlp.up,
         0,
         geom.intermediate_size,
-        &mlp_in,
-        &mut up,
+        &scratch.mlp_in,
+        &mut scratch.up,
     )?;
-    let mut act = HiddenStates::zeros(ctx, geom.intermediate_size, seq_len)?;
-    ops::gelu_tanh_mul_batch_into(ctx, &gate, &up, &mut act)?;
-    let mut down = HiddenStates::zeros(ctx, geom.hidden_size, seq_len)?;
-    ops::gemm_rows_into_checked(ctx, &layer.mlp.down, 0, geom.hidden_size, &act, &mut down)?;
-    let mut down_normed = HiddenStates::zeros(ctx, geom.hidden_size, seq_len)?;
+    ops::gelu_tanh_mul_batch_into(ctx, &scratch.gate, &scratch.up, &mut scratch.act)?;
+    ops::gemm_rows_into_checked(
+        ctx,
+        &layer.mlp.down,
+        0,
+        geom.hidden_size,
+        &scratch.act,
+        &mut scratch.down,
+    )?;
     ops::rms_norm_batch_into(
         ctx,
-        &down,
+        &scratch.down,
         &layer.post_feedforward_layernorm,
         geom.rms_norm_eps,
-        &mut down_normed,
+        &mut scratch.down_normed,
     );
 
-    let mut out = HiddenStates::zeros(ctx, geom.hidden_size, seq_len)?;
-    ops::add_batch_into(ctx, &h2, &down_normed, &mut out)?;
-    ops::scale_bf16_in_place(ctx, &mut out, layer.layer_scalar)?;
-
-    Ok(out)
+    ops::add_batch_into(ctx, &scratch.h2, &scratch.down_normed, out)?;
+    ops::scale_bf16_in_place(ctx, out, layer.layer_scalar)?;
+    Ok(())
 }
 
 /// Runs one local layer on `x` (`[hidden_size, seq_len]`), tokens at

--- a/pegainfer-gemma4/src/serve.rs
+++ b/pegainfer-gemma4/src/serve.rs
@@ -30,8 +30,9 @@ use crate::forward::validate_tokens;
 use crate::kv::GemmaKv;
 use crate::kv::PAGE_SIZE;
 use crate::kv::SlidingLocalKv;
+use crate::layer::EpilogueScratch;
 use crate::layer::LayerGeometry;
-use crate::layer::attention_epilogue;
+use crate::layer::attention_epilogue_into;
 use crate::layer::build_proportional_rope_tables;
 use crate::weights::Gemma4Layer;
 use crate::weights::Gemma4Weights;
@@ -63,6 +64,24 @@ pub(crate) struct GemmaStepPlan {
     local_plan: PrefillPagedPlan,
     global_plan: PrefillPagedPlan,
     prep: StepPrep,
+}
+
+pub(crate) struct StepArena {
+    epilogue: EpilogueScratch,
+    stream: std::sync::Arc<cudarc::driver::CudaStream>,
+}
+
+impl StepArena {
+    /// Settle the step's preconditions — the allocation stream and a row
+    /// count the buffers can hold — since neither can be safely deferred
+    /// until the epilogue, by which point the step has already written KV.
+    fn open(&mut self, ctx: &DeviceContext, rows: usize) -> Result<()> {
+        anyhow::ensure!(
+            std::sync::Arc::ptr_eq(&ctx.stream, &self.stream),
+            "a step arena must be used on the stream it was allocated on"
+        );
+        self.epilogue.set_rows(rows)
+    }
 }
 
 /// Everything a serving step needs that outlives requests.
@@ -177,6 +196,17 @@ impl GemmaServe {
         })
     }
 
+    pub(crate) fn alloc_step_arena(
+        &self,
+        ctx: &DeviceContext,
+        max_rows: usize,
+    ) -> Result<StepArena> {
+        Ok(StepArena {
+            epilogue: EpilogueScratch::new(ctx, &self.local_geom, max_rows)?,
+            stream: ctx.stream.clone(),
+        })
+    }
+
     pub(crate) fn alloc_kv(&self) -> GemmaKv {
         GemmaKv {
             local: SlidingLocalKv::new(self.local_pool.clone()),
@@ -277,6 +307,7 @@ impl GemmaServe {
     fn local_layer_serve(
         &self,
         ctx: &DeviceContext,
+        epilogue: &mut EpilogueScratch,
         layer: &Gemma4Layer,
         family_layer: usize,
         x: &HiddenStates,
@@ -391,12 +422,15 @@ impl GemmaServe {
             1.0,
             window_left,
         )?;
-        attention_epilogue(ctx, layer, geom, x, &attn)
+        let mut out = HiddenStates::zeros(ctx, geom.hidden_size, seq_len)?;
+        attention_epilogue_into(ctx, layer, geom, x, &attn, epilogue, &mut out)?;
+        Ok(out)
     }
 
     fn global_layer_serve(
         &self,
         ctx: &DeviceContext,
+        epilogue: &mut EpilogueScratch,
         layer: &Gemma4Layer,
         family_layer: usize,
         x: &HiddenStates,
@@ -501,7 +535,9 @@ impl GemmaServe {
             geom.num_q_heads,
             1.0,
         )?;
-        attention_epilogue(ctx, layer, geom, x, &attn)
+        let mut out = HiddenStates::zeros(ctx, geom.hidden_size, seq_len)?;
+        attention_epilogue_into(ctx, layer, geom, x, &attn, epilogue, &mut out)?;
+        Ok(out)
     }
 
     /// Plan one decode step for a whole batch: every request contributes one
@@ -614,6 +650,7 @@ impl GemmaServe {
     fn run_tower(
         &self,
         ctx: &DeviceContext,
+        epilogue: &mut EpilogueScratch,
         tokens: &[u32],
         plan: &GemmaStepPlan,
     ) -> Result<HiddenStates> {
@@ -634,10 +671,10 @@ impl GemmaServe {
             let family_layer = self.family_index[index];
             hidden = match kind {
                 LayerKind::Sliding => {
-                    self.local_layer_serve(ctx, layer, family_layer, &hidden, plan)?
+                    self.local_layer_serve(ctx, epilogue, layer, family_layer, &hidden, plan)?
                 }
                 LayerKind::Global => {
-                    self.global_layer_serve(ctx, layer, family_layer, &hidden, plan)?
+                    self.global_layer_serve(ctx, epilogue, layer, family_layer, &hidden, plan)?
                 }
             };
         }
@@ -650,6 +687,7 @@ impl GemmaServe {
     pub(crate) fn decode_batch_step(
         &self,
         ctx: &DeviceContext,
+        arena: &mut StepArena,
         kvs: &mut [&mut GemmaKv],
         tokens: &[u32],
     ) -> Result<HiddenStates> {
@@ -664,8 +702,9 @@ impl GemmaServe {
         let weights = &self.weights;
         validate_tokens(weights, self.local_geom.hidden_size, tokens)?;
 
+        arena.open(ctx, batch)?;
         let plan = self.plan_decode_batch(ctx, kvs)?;
-        let hidden = self.run_tower(ctx, tokens, &plan)?;
+        let hidden = self.run_tower(ctx, &mut arena.epilogue, tokens, &plan)?;
         // Every row is its own request's last position, so the whole batch is
         // the head's input.
         let logits = logits_tail(
@@ -705,7 +744,8 @@ impl GemmaServe {
             kv.global.held_pages()
         );
 
-        let hidden = self.run_tower(ctx, tokens, &plan)?;
+        let mut scratch = EpilogueScratch::new(ctx, &self.local_geom, seq_len)?;
+        let hidden = self.run_tower(ctx, &mut scratch, tokens, &plan)?;
         // Projecting every prompt row through the 262k LM head materializes
         // half a gigabyte at this path's 1024-token ceiling, so the full span
         // is for callers that actually read every position.

--- a/pegainfer-gemma4/src/serve_oracle.rs
+++ b/pegainfer-gemma4/src/serve_oracle.rs
@@ -587,6 +587,9 @@ fn a_ragged_batch_does_not_depend_on_row_order() {
     // occupies at that step; out[request][step] collects results back by
     // request, wherever it sat.
     let run = |orders: &[Vec<usize>]| -> Vec<Vec<Vec<f32>>> {
+        let mut arena = serve
+            .alloc_step_arena(&ctx, lengths.len())
+            .expect("step arena");
         let mut kvs: Vec<GemmaKv> = lengths.iter().map(|_| serve.alloc_kv()).collect();
         for (request, kv) in kvs.iter_mut().enumerate() {
             let prompt = prompt_of(request);
@@ -623,7 +626,7 @@ fn a_ragged_batch_does_not_depend_on_row_order() {
                 tokens.push(feed_of(request, step));
             }
             let logits = serve
-                .decode_batch_step(&ctx, &mut borrowed, &tokens)
+                .decode_batch_step(&ctx, &mut arena, &mut borrowed, &tokens)
                 .expect("decode");
             let host = logits.to_host(&ctx).expect("D2H");
             let vocab = logits.hidden_dim;


### PR DESCRIPTION

## Description

Closes #904 

Everything downstream of attention runs the same nine buffers through `o_proj`, two norms, the residual adds and the MLP, and each layer allocated and zeroed all nine again. A decode step advances one token, so the whole tower's width of allocation and memset repeated for every layer of every step while the shapes never changed.

Decode now allocates the nine temporaries once per engine and reshapes them once per step; prefill allocates them once per prompt step rather than once per layer. The arena itself refuses a row count it was not built for. The allocating entry point stays for the oracle path, where one layer runs at a time and there is no arena to hand in; it builds a scratch and calls the same body, so both paths share one implementation rather than drifting apart.

This is a structural change rather than a performance one. What it is for is the address stability a captured decode step needs, of which this is the epilogue's share; the attention side and the plans are still rebuilt per step, so graph capture needs the change after this one too.

At 16 rows the persistent decode arena holds 2.11 MiB of bf16 storage. Sizing the same buffers to the 8192-row serving ceiling would take 1080 MiB, which is why prefill keeps per-step scratch instead of sharing the arena; process residency was 32926 MiB in both measured arms at nvidia-smi granularity. Opening the arena for a step settles both of its preconditions before the step starts: the stream it was allocated on, and a row count it can hold. Neither can be safely deferred until the epilogue. The ops downstream assert that the tensors agree with each other, never that the allocation behind them is long enough, and by the time the epilogue is reached the step has already embedded, projected, prepped, attended and written KV.

## Test Env

Single GPU (sm_89, x86_64), CUDA 12.9, pinned 12B checkpoint.

## Verification

- fmt; `cargo build`/`clippy -D warnings` for `pegainfer-kernels` and for `pegainfer-gemma4 --features gemma4`; the CI package set with `--locked`; `pegainfer-gemma4 --lib` 26 passed, 9 ignored.
- The checkpoint oracles against the pinned 12B all pass: `serve_matches_oracle_forward`, `window_crossing_matches_hf`, `greedy_matches_hf_generate`, `eviction_is_footprint_only`. They carry tolerances and the serving path shares the implementation they exercise, so what they establish is that no regression is observable at their thresholds, not bit-level neutrality.
- A/B against the base commit, same box, same request set, three runs per arm:

  | | base | this change |
  | --- | --- | --- |
  | single stream TPOT, median | 29.37 ms | 28.79 ms |
  | one request | 32.1 tok/s | 32.6 tok/s |
  | eight requests | 128.7 tok/s | 130.9 tok/s |
  | resident with no request in flight, nvidia-smi | 32926 MiB | 32926 MiB |
- The ragged batch determinism gate lands on the base this sits on, and its one `decode_batch_step` call site is adapted to the arena parameter in this change; the gate passes on this commit — the row ownership invariant survives the arena.
- The serving behaviour checks from the batched decode change still hold: row to request mapping, in-batch retirement, queueing past the slot ceiling, cancellation, and window crossing under concurrency, with zero failed requests.
