### PR TITLE
fix(frontend): refuse the ec_transfer_params the engine would silently drop

### DIFF
--- a/pegainfer-frontend/src/vllm/bridge.rs
+++ b/pegainfer-frontend/src/vllm/bridge.rs
@@ -267,11 +267,8 @@ impl LocalEngineBridge {
             return Ok(());
         };
 
-        // Fail loud on sampling parameters the engine cannot honor yet —
-        // silently ignoring a requested seed or penalty changes outputs
-        // without telling the client.
-        if let Some(unsupported) = crate::vllm::wire::unsupported_sampling(&sampling_params) {
-            warn!("request {request_id} rejected: unsupported sampling params: {unsupported}");
+        if let Some(unsupported) = crate::vllm::wire::unsupported_request_params(&sampling_params) {
+            warn!("request {request_id} rejected: {unsupported}");
             send_terminal_output(
                 self.engine_index,
                 output_tx,

--- a/pegainfer-frontend/src/vllm/bridge/stepped.rs
+++ b/pegainfer-frontend/src/vllm/bridge/stepped.rs
@@ -321,11 +321,8 @@ impl SteppedEngineBridge {
             );
         };
 
-        // Fail loud on sampling parameters the engine cannot honor yet —
-        // silently ignoring a requested seed or penalty changes outputs
-        // without telling the client.
-        if let Some(unsupported) = crate::vllm::wire::unsupported_sampling(&sampling_params) {
-            warn!("request {request_id} rejected: unsupported sampling params: {unsupported}");
+        if let Some(unsupported) = crate::vllm::wire::unsupported_request_params(&sampling_params) {
+            warn!("request {request_id} rejected: {unsupported}");
             return send_terminal_output(
                 self.engine_index,
                 output_tx,

--- a/pegainfer-frontend/src/vllm/wire.rs
+++ b/pegainfer-frontend/src/vllm/wire.rs
@@ -76,14 +76,14 @@ pub(crate) fn convert_sampling(params: &EngineCoreSamplingParams) -> SamplingPar
     }
 }
 
-/// Reject sampling parameters the engine would otherwise silently ignore.
+/// Reject request parameters the engine would otherwise silently ignore.
 /// Returns the offending description; `None` means the request is servable.
 ///
 /// The float comparisons are exact on purpose: they detect "the client sent
 /// anything other than the wire default", not numeric closeness — a request
 /// carrying 1.0000001 wants a penalty and must be rejected, not rounded away.
 #[allow(clippy::float_cmp)]
-pub(crate) fn unsupported_sampling(params: &EngineCoreSamplingParams) -> Option<String> {
+pub(crate) fn unsupported_request_params(params: &EngineCoreSamplingParams) -> Option<String> {
     if !(0.0..1.0).contains(&params.min_p) || !params.min_p.is_finite() {
         return Some(format!("min_p {} outside [0, 1)", params.min_p));
     }
@@ -107,6 +107,26 @@ pub(crate) fn unsupported_sampling(params: &EngineCoreSamplingParams) -> Option<
             "repetition_penalty {} is not supported yet",
             params.repetition_penalty
         ));
+    }
+    // The server lowers the client's ec_transfer_params into extra_args, and
+    // this engine has no encoder cache connector to hand it to.
+    if let Some(ec) = params
+        .extra_args
+        .as_ref()
+        .and_then(|args| args.get("ec_transfer_params"))
+    {
+        let requested = match ec {
+            serde_json::Value::Null => false,
+            serde_json::Value::Object(map) => !map.is_empty(),
+            _ => true,
+        };
+        if requested {
+            return Some(
+                "ec_transfer_params is not supported yet: this engine has no encoder cache \
+                 connector"
+                    .to_string(),
+            );
+        }
     }
     None
 }
@@ -197,33 +217,55 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_sampling_rejects_what_the_engine_would_ignore() {
+    fn unsupported_sampling_params_are_refused() {
         let mut params = EngineCoreSamplingParams::for_test();
         params.repetition_penalty = 1.0;
-        assert_eq!(unsupported_sampling(&params), None);
+        assert_eq!(unsupported_request_params(&params), None);
 
         params.min_p = 0.2;
-        assert_eq!(unsupported_sampling(&params), None);
+        assert_eq!(unsupported_request_params(&params), None);
         params.min_p = 1.5;
-        assert!(unsupported_sampling(&params).is_some());
+        assert!(unsupported_request_params(&params).is_some());
         params.min_p = 0.0;
 
         params.temperature = 0.8;
         params.seed = Some(7);
-        assert!(unsupported_sampling(&params).is_some());
+        assert!(unsupported_request_params(&params).is_some());
         // A greedy request's seed is a no-op, not a lie — allowed.
         params.temperature = 0.0;
-        assert_eq!(unsupported_sampling(&params), None);
+        assert_eq!(unsupported_request_params(&params), None);
         params.seed = None;
 
         params.frequency_penalty = 0.5;
-        assert!(unsupported_sampling(&params).is_some());
+        assert!(unsupported_request_params(&params).is_some());
         params.frequency_penalty = 0.0;
         params.presence_penalty = -0.5;
-        assert!(unsupported_sampling(&params).is_some());
+        assert!(unsupported_request_params(&params).is_some());
         params.presence_penalty = 0.0;
         params.repetition_penalty = 1.2;
-        assert!(unsupported_sampling(&params).is_some());
+        assert!(unsupported_request_params(&params).is_some());
+    }
+
+    #[test]
+    fn nonempty_ec_transfer_params_is_refused_not_dropped() {
+        let mut params = EngineCoreSamplingParams::for_test();
+        params.extra_args = Some(HashMap::from([(
+            "ec_transfer_params".to_string(),
+            serde_json::json!({"requested": true}),
+        )]));
+        let refusal = unsupported_request_params(&params).expect("must refuse");
+        assert!(refusal.contains("ec_transfer_params"));
+
+        params.extra_args = Some(HashMap::from([(
+            "ec_transfer_params".to_string(),
+            serde_json::json!({}),
+        )]));
+        assert_eq!(unsupported_request_params(&params), None);
+        params.extra_args = Some(HashMap::from([(
+            "ec_transfer_params".to_string(),
+            serde_json::Value::Null,
+        )]));
+        assert_eq!(unsupported_request_params(&params), None);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Closes #906 

The dependency bump that crossed the encoder cache protocol change left the request schema accepting `ec_transfer_params`, and the server injects it into `extra_args` the way Python vLLM does. Both bridge paths consume `kv_transfer_params` and the LoRA adapter xarg from that map but neither consumes `ec_transfer_params`, so a request asking for an encoder cache transfer was accepted, served without it, and returned `ec_transfer_params: null`.

The gate both bridges already pass through now refuses a non-empty `ec_transfer_params` before scheduler submission: this engine has no encoder cache connector, and serving the request without the transfer it asked for is not an answer. The gate checked sampling and now checks more, so it is renamed to `unsupported_request_params` and the bridges' rejection logs carry the gate's reason verbatim instead of labelling everything a sampling problem. An empty map or an explicit null asks for nothing and still passes, as do `kv_transfer_params` and the LoRA xarg. The `ec_transfer_params: null` in the response stays: it is the output shape the protocol requires, not a claim.

## Test Env

x86_64, CUDA 12.9 toolchain for the workspace build; the change itself is host-only.

## Verification

- fmt; `cargo clippy --release -p pegainfer-frontend --all-targets -- -D warnings`; the CI package set with `--locked`.
- `cargo test --release -p pegainfer-frontend --lib`: 65 passed, including the new case — the predicate returns a field-specific rejection reason for a non-empty `ec_transfer_params`; an empty map and an explicit null pass.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)