### PR TITLE
fix(frontend): arm the injected fatal only once a request is in the scheduler

### DIFF
--- a/pegainfer-frontend/src/engine/driver.rs
+++ b/pegainfer-frontend/src/engine/driver.rs
@@ -125,7 +125,7 @@ mod tests {
         }
 
         fn step(&mut self, ledger: &mut RequestLedger) -> anyhow::Result<()> {
-            if self.fatal_next_step {
+            if self.fatal_next_step && !(self.queued.is_empty() && self.running.is_empty()) {
                 anyhow::bail!("injected fatal");
             }
             for (id, max_tokens) in self.queued.drain(..) {


### PR DESCRIPTION
## Description

`engine::driver::tests::fatal_step_fails_in_flight_requests_with_the_error` is flaky: the driver's step loop free-runs against the submission channel, so the mock's unconditional `bail!("injected fatal")` races the test's `submit`. When the fatal fires first, `fail_all` sweeps an empty ledger, the driver exits, and the still-queued request surfaces through the teardown sweep as "request dropped by the engine before it was answered" instead of the real error — which is exactly what the assertion rejects.

The fix arms the injected fatal only once the scheduler holds a request, so the fatal always finds the request in the ledger and the write-off deterministically carries the real error. Driver code is untouched.

### Verification

- Before: 36 failures in 200 runs of the single test (unloaded machine; CI reproduces the same message).
- After: 0 failures in 200 runs.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)