### PR TITLE
perf(gemma4): overlapped async prefill on an SM capped lane

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,8 @@ cargo run --release --features glm52 -- --model-path models/GLM5.2
 - `PEGAINFER_TEST_MODEL_PATH` — override test model path (default: `models/Qwen3-4B`)
 - `PEGAINFER_BUILD_TIMING=1` — print per-phase build timings (nvcc, Triton AOT, etc.)
 - `PEGAINFER_NVCC_JOBS` — override parallel nvcc job count
+- `PEGAINFER_PREFIX_CACHE` — gemma4 opt-in conversation prefix cache: `K` entries of captured prompt state resume multi-turn prompts (pre-allocated page budget; unset = off, byte-identical serving)
+- `PEGAINFER_ASYNC_PREFILL` — gemma4 opt-in overlap lane: `green:NN` prefills live-batch admissions on an SM-capped stream to protect decode tails (`shared` for comparison; unset = off; bad values refuse to start)
 - `GLM52_DECODE_SLOTS` / `GLM52_MTP_DRAFTS` — glm52 runtime profile: decode slots per rank (default 8, ceiling 32) and MTP draft span (default 5); `slots x (1+drafts)` must fit the 96-row step (validated at launch; MTP only). Throughput ceiling profile: `32` / `2`.
 
 ## Tests

--- a/docs/models/gemma4/serving.md
+++ b/docs/models/gemma4/serving.md
@@ -1,12 +1,12 @@
 # Gemma 4 serving
 
-**TL;DR:** The engine schedules per iteration: up to 16 requests hold decode slots, each prompt prefills whole at a step boundary, and every active request advances one token per batched step. Prompt plus output past 8192 tokens is refused at admission, while a request that only has to wait for a decode slot queues instead. The two KV families are budgeted separately (7.27 GiB sliding + 2.00 GiB global at 12B). **This needs a 48 GiB card**: the engine sits at 32.2 GiB before it serves anything, so a 32 GiB device cannot start it. A row's output moves with the bucket widths it decodes at, but not with what its companions contain. An opt-in conversation prefix cache (`PEGAINFER_PREFIX_CACHE=K`) resumes multi-turn prompts at the cost of a pre-allocated page budget.
+**TL;DR:** The engine schedules per iteration: up to 16 requests hold decode slots, each prompt prefills whole at a step boundary, and every active request advances one token per batched step. Prompt plus output past 8192 tokens is refused at admission, while a request that only has to wait for a decode slot queues instead. The two KV families are budgeted separately (7.27 GiB sliding + 2.00 GiB global at 12B). **This needs a 48 GiB card**: the engine sits at 32.2 GiB before it serves anything, so a 32 GiB device cannot start it. A row's output moves with the bucket widths it decodes at, but not with what its companions contain. An opt-in conversation prefix cache (`PEGAINFER_PREFIX_CACHE=K`) resumes multi-turn prompts at the cost of a pre-allocated page budget, and an opt-in overlap lane (`PEGAINFER_ASYNC_PREFILL=green:NN`) trades prefill latency for decode-tail protection under long-prompt admissions.
 
 Last touched: 2026-08
 
 ## What a step is
 
-The engine thread runs one loop. Each turn it admits whatever the pools can hold, up to the slot ceiling. With streams in flight, each admitted prompt shares one mixed step with them — the prompt's rows sit in the step's row prefix while every active request advances its token in the suffix; a prompt that arrives with nothing active prefills alone as its own step. Between admissions, every active request advances exactly one token in a single batched decode step that shares the weight pass. A request that arrives while all slots are taken waits at the head of the queue. It is refused only when nothing is active — when there is no other request whose pages could free up, the pools genuinely cannot hold it and saying so is the honest answer.
+The engine thread runs one loop. Each turn it admits whatever the pools can hold, up to the slot ceiling. With streams in flight, each admitted prompt shares one mixed step with them — the prompt's rows sit in the step's row prefix while every active request advances its token in the suffix; a prompt that arrives with nothing active prefills alone as its own step. With the opt-in overlap lane enabled (below), an admission into a live batch prefills asynchronously on its own stream instead of sharing the mixed step. Between admissions, every active request advances exactly one token in a single batched decode step that shares the weight pass. A request that arrives while all slots are taken waits at the head of the queue. It is refused only when nothing is active — when there is no other request whose pages could free up, the pools genuinely cannot hold it and saying so is the honest answer.
 
 Rows retire independently. Requests in one batch have their own frontiers, their own page tables and, for the sliding family, their own released window front, so a short request finishing does not disturb the rows that continue.
 
@@ -80,6 +80,14 @@ When a request's prefill completes, the engine copies its prompt-state pages —
 The cache brings its own page budget, added to the pool lines above at startup. A prompt longer than half the serving context (4096 tokens today) is not captured — that bound is what keeps the cache's pool share equal to what its entries paid for. A new turn's capture supersedes its conversation's older entry, capacity evicts LRU, and an admission that cannot reserve pages evicts cache entries before waiting.
 
 At `PEGAINFER_PREFIX_CACHE=16` the idle footprint measured **39242 MiB** against the 33034 MiB baseline — the difference is the pre-allocated cache budget.
+
+## The async prefill lane (opt-in)
+
+`PEGAINFER_ASYNC_PREFILL` (unset by default) moves a live-batch admission's prefill onto its own stream, so decode steps keep replaying while the prompt computes. `green:NN` pins the lane to roughly NN% of the SMs via a Green Context — the cap is the mechanism: a `shared` lane's full-width prefill grids starve decode steps, and is kept only for comparison. An unrecognized value or an unviable SM partition refuses to start rather than silently degrading.
+
+One prefill is in flight at most; further arrivals wait while decode keeps stepping, a prompt arriving with nothing active takes the sync path, a restored prefix-cache hit prefills only its unseen suffix, and the sliding window's front release is deferred to the join so no page can be re-allocated under in-flight reads.
+
+Measured (a streaming request, then sixteen ~1900-token prompts admitted at once; two runs per arm): the stream's worst inter-token gap under the flood drops from 387-452 ms — one mixed step at that prompt length — to 75-76 ms with `green:35`, p99 385-432 → 39-40 ms, while the flood's own TTFT p50 grows 3.3-3.7 → 9.8-10.3 s and its wall about 2.4×. The quiet stream and idle footprint are unchanged, so an idle lane costs nothing. That trade is the positioning: a high-concurrency, decode-tail-sensitive profile, not a default — at light load the capped lane only costs TTFT.
 
 ## Measured behaviour
 

--- a/pegainfer-gemma4/src/engine.rs
+++ b/pegainfer-gemma4/src/engine.rs
@@ -1279,20 +1279,23 @@ mod lane_tests {
             .collect()
     }
 
-    /// The whole async lifecycle against one live engine: a streamer decodes
-    /// while a long prompt rides the lane, a second arrival queues behind
-    /// the busy lane, a warm prefix-cache hit launches the lane with only
-    /// its unseen suffix (the join gate refuses a pass that processed the
-    /// wrong one), a dropped sink cancels cleanly, and the engine still
-    /// serves afterwards.
-    #[test]
-    #[ignore = "requires the pinned 12B checkpoint via PEGAINFER_TEST_MODEL_PATH, a GPU, and --test-threads=1"]
-    fn the_lane_engine_lifecycle_completes() {
+    /// The whole async lifecycle against one live engine, with every
+    /// interleaving pinned by construction: the streamer's budget outlasts
+    /// the script and its sink is dropped only at the end, so the decode
+    /// batch is never empty and every admission below takes the lane. A
+    /// long prompt rides the lane while a second arrival waits out the busy
+    /// lane; a warm prefix-cache hit launches with only its unseen suffix
+    /// (the join gate refuses a pass that processed the wrong one); a
+    /// request cancelled after `Scheduled` — past every sync-path exit, so
+    /// the drop lands while its pass is in flight — exits through the join;
+    /// an out-of-vocab prompt fails the launch itself and the lane drains;
+    /// and the engine still serves after all of it.
+    fn lane_lifecycle_script(mode: &str) {
         let dir = std::env::var("PEGAINFER_TEST_MODEL_PATH").expect("PEGAINFER_TEST_MODEL_PATH");
         // SAFETY: the on-box harness runs single-threaded (--test-threads=1),
         // so no other thread reads the environment concurrently.
         unsafe {
-            std::env::set_var("PEGAINFER_ASYNC_PREFILL", "shared");
+            std::env::set_var("PEGAINFER_ASYNC_PREFILL", mode);
             std::env::set_var("PEGAINFER_PREFIX_CACHE", "4");
         }
         let handle = super::start(Path::new(&dir), &EngineLoadOptions::default());
@@ -1303,7 +1306,10 @@ mod lane_tests {
         }
         let handle = handle.expect("engine start");
 
-        let mut streamer = submit(&handle, ids(40, 0), 96);
+        // The streamer pins the decode batch non-empty for the whole
+        // script: its budget is far past the script's round count, and its
+        // sink drops only after the last assertion.
+        let mut streamer = submit(&handle, ids(40, 0), 1024);
         let mut seen = 0;
         while seen < 2 {
             match streamer.blocking_recv().map(|(_, event)| event) {
@@ -1334,18 +1340,59 @@ mod lane_tests {
             "the warm admission must resume at the captured frontier"
         );
 
-        // A cancelled request: drop the sink right after submitting a lane
-        // prompt; the engine must survive and keep serving.
-        drop(submit(&handle, ids(1500, 23), 8));
-        let mut after_rx = submit(&handle, ids(40, 29), 4);
-        let after = drain(&mut after_rx, "after the cancelled lane prompt");
-        assert_eq!((after.tokens, after.finish), (4, FinishReason::Length));
+        // In-flight cancellation: `Scheduled` is sent past every sync-path
+        // exit, so a sink dropped after it lands while the lane pass runs.
+        let mut cancel_rx = submit(&handle, ids(1500, 23), 8);
+        loop {
+            match cancel_rx.blocking_recv().map(|(_, event)| event) {
+                Some(TokenEvent::Scheduled { .. }) => break,
+                Some(TokenEvent::Error { message, .. }) => panic!("cancel arm: {message}"),
+                Some(_) => {}
+                None => panic!("cancel arm closed before Scheduled"),
+            }
+        }
+        drop(cancel_rx);
 
-        let streamer_done = drain(&mut streamer, "streamer");
-        assert_eq!(
-            (streamer_done.tokens + 2, streamer_done.finish),
-            (96, FinishReason::Length)
-        );
+        // Launch failure: an out-of-vocab id passes admission and fails
+        // inside the lane pass; the lane drains and reports, loudly.
+        let mut bad = ids(200, 31);
+        bad[100] = 300_000;
+        let mut bad_rx = submit(&handle, bad, 4);
+        loop {
+            match bad_rx.blocking_recv().map(|(_, event)| event) {
+                Some(TokenEvent::Error { message, .. }) => {
+                    assert!(
+                        message.contains("prefill failed"),
+                        "launch failure must name the prefill: {message}"
+                    );
+                    break;
+                }
+                Some(TokenEvent::Token { .. } | TokenEvent::Finished { .. }) => {
+                    panic!("an out-of-vocab prompt must not produce tokens")
+                }
+                Some(_) => {}
+                None => panic!("launch failure lost its error event"),
+            }
+        }
+
+        let mut after_rx = submit(&handle, ids(40, 29), 4);
+        let after = drain(&mut after_rx, "after the cancelled and failed lanes");
+        assert_eq!((after.tokens, after.finish), (4, FinishReason::Length));
+        drop(streamer);
+    }
+
+    #[test]
+    #[ignore = "requires the pinned 12B checkpoint via PEGAINFER_TEST_MODEL_PATH, a GPU, and --test-threads=1"]
+    fn the_lane_engine_lifecycle_completes() {
+        lane_lifecycle_script("shared");
+    }
+
+    /// The green twin exercises the partitioned completion path —
+    /// `cuGreenCtxRecordEvent` rather than the plain stream record.
+    #[test]
+    #[ignore = "requires the pinned 12B checkpoint via PEGAINFER_TEST_MODEL_PATH, a GPU, and --test-threads=1"]
+    fn the_green_lane_engine_lifecycle_completes() {
+        lane_lifecycle_script("green:35");
     }
 
     #[test]

--- a/pegainfer-gemma4/src/engine.rs
+++ b/pegainfer-gemma4/src/engine.rs
@@ -1204,8 +1204,149 @@ mod gate {
 
 #[cfg(test)]
 mod lane_tests {
+    use std::path::Path;
+
+    use pegainfer_frontend::engine::EngineLoadOptions;
+    use pegainfer_frontend::engine::FinishReason;
+    use pegainfer_frontend::engine::GenerateRequest;
+    use pegainfer_frontend::engine::TokenEvent;
+    use pegainfer_frontend::engine::TokenSink;
+    use pegainfer_frontend::engine::TokenStreamReceiver;
+    use pegainfer_frontend::sampler::SamplingParams;
+
     use super::AsyncPrefillMode;
     use super::parse_async_prefill_mode;
+
+    fn submit(
+        handle: &pegainfer_frontend::engine::EngineHandle,
+        prompt_tokens: Vec<u32>,
+        max_tokens: usize,
+    ) -> TokenStreamReceiver {
+        let (token_tx, token_rx) = TokenSink::standalone();
+        handle
+            .submit(GenerateRequest {
+                trace_parent: None,
+                request_id: None,
+                queued_at_unix_s: None,
+                data_parallel_rank: None,
+                prompt_tokens,
+                params: SamplingParams {
+                    ignore_eos: true,
+                    ..SamplingParams::default()
+                },
+                max_tokens,
+                lora_adapter: None,
+                kv_transfer_params: None,
+                token_tx,
+                logprobs: 0,
+                echo: false,
+            })
+            .expect("submit");
+        token_rx
+    }
+
+    struct Drained {
+        tokens: usize,
+        cached: usize,
+        finish: FinishReason,
+    }
+
+    fn drain(rx: &mut TokenStreamReceiver, name: &str) -> Drained {
+        let mut tokens = 0;
+        let mut cached = 0;
+        loop {
+            match rx.blocking_recv().map(|(_, event)| event) {
+                Some(TokenEvent::Token { .. }) => tokens += 1,
+                Some(TokenEvent::Scheduled { cached_tokens, .. }) => cached = cached_tokens,
+                Some(TokenEvent::PromptTokens { .. } | TokenEvent::KvTransfer { .. }) => {}
+                Some(TokenEvent::Finished { finish_reason, .. }) => {
+                    return Drained {
+                        tokens,
+                        cached,
+                        finish: finish_reason,
+                    };
+                }
+                Some(TokenEvent::Error { message, .. }) => panic!("{name}: error: {message}"),
+                Some(TokenEvent::Rejected { message, .. }) => panic!("{name}: rejected: {message}"),
+                None => panic!("{name}: channel closed without Finished"),
+            }
+        }
+    }
+
+    fn ids(len: usize, salt: u32) -> Vec<u32> {
+        (0..len as u32)
+            .map(|i| 1000 + (i * 37 + salt) % 50000)
+            .collect()
+    }
+
+    /// The whole async lifecycle against one live engine: a streamer decodes
+    /// while a long prompt rides the lane, a second arrival queues behind
+    /// the busy lane, a warm prefix-cache hit launches the lane with only
+    /// its unseen suffix (the join gate refuses a pass that processed the
+    /// wrong one), a dropped sink cancels cleanly, and the engine still
+    /// serves afterwards.
+    #[test]
+    #[ignore = "requires the pinned 12B checkpoint via PEGAINFER_TEST_MODEL_PATH, a GPU, and --test-threads=1"]
+    fn the_lane_engine_lifecycle_completes() {
+        let dir = std::env::var("PEGAINFER_TEST_MODEL_PATH").expect("PEGAINFER_TEST_MODEL_PATH");
+        // SAFETY: the on-box harness runs single-threaded (--test-threads=1),
+        // so no other thread reads the environment concurrently.
+        unsafe {
+            std::env::set_var("PEGAINFER_ASYNC_PREFILL", "shared");
+            std::env::set_var("PEGAINFER_PREFIX_CACHE", "4");
+        }
+        let handle = super::start(Path::new(&dir), &EngineLoadOptions::default());
+        // SAFETY: as above.
+        unsafe {
+            std::env::remove_var("PEGAINFER_ASYNC_PREFILL");
+            std::env::remove_var("PEGAINFER_PREFIX_CACHE");
+        }
+        let handle = handle.expect("engine start");
+
+        let mut streamer = submit(&handle, ids(40, 0), 96);
+        let mut seen = 0;
+        while seen < 2 {
+            match streamer.blocking_recv().map(|(_, event)| event) {
+                Some(TokenEvent::Token { .. }) => seen += 1,
+                Some(TokenEvent::Error { message, .. }) => panic!("streamer: {message}"),
+                Some(_) => {}
+                None => panic!("streamer closed early"),
+            }
+        }
+
+        let long_prompt = ids(1500, 7);
+        let mut lane_rx = submit(&handle, long_prompt.clone(), 4);
+        let mut queued_rx = submit(&handle, ids(60, 3), 4);
+        let lane = drain(&mut lane_rx, "lane prefill");
+        assert_eq!((lane.tokens, lane.finish), (4, FinishReason::Length));
+        let queued = drain(&mut queued_rx, "queued behind the lane");
+        assert_eq!((queued.tokens, queued.finish), (4, FinishReason::Length));
+
+        // Warm hit: the long prompt plus a new turn resumes at the captured
+        // frontier and rides the lane with only the suffix.
+        let mut warm_prompt = long_prompt;
+        warm_prompt.extend(ids(60, 11));
+        let mut warm_rx = submit(&handle, warm_prompt, 4);
+        let warm = drain(&mut warm_rx, "warm suffix on the lane");
+        assert_eq!((warm.tokens, warm.finish), (4, FinishReason::Length));
+        assert_eq!(
+            warm.cached, 1500,
+            "the warm admission must resume at the captured frontier"
+        );
+
+        // A cancelled request: drop the sink right after submitting a lane
+        // prompt; the engine must survive and keep serving.
+        drop(submit(&handle, ids(1500, 23), 8));
+        let mut after_rx = submit(&handle, ids(40, 29), 4);
+        let after = drain(&mut after_rx, "after the cancelled lane prompt");
+        assert_eq!((after.tokens, after.finish), (4, FinishReason::Length));
+
+        let streamer_done = drain(&mut streamer, "streamer");
+        assert_eq!(
+            (streamer_done.tokens + 2, streamer_done.finish),
+            (96, FinishReason::Length)
+        );
+    }
 
     #[test]
     fn async_prefill_mode_parses_or_refuses() {

--- a/pegainfer-gemma4/src/engine.rs
+++ b/pegainfer-gemma4/src/engine.rs
@@ -745,12 +745,15 @@ impl EngineState {
     ) -> Admitted {
         let lane = self.lane.as_mut().expect("gated by the caller");
         debug_assert!(lane.inflight.is_none());
+        // A restored prefix is already in the KV: the lane prefills only the
+        // unseen suffix, exactly like the sync and mixed paths.
+        let resume = kv.local.seq_len();
         let launched = {
             let _guard = unsafe {
                 pegainfer_core::tensor::StreamOverrideGuard::activate(lane.stream.stream)
             };
             self.serve
-                .prefill_into_logits(&self.ctx, &mut kv, &request.prompt_tokens)
+                .prefill_into_logits(&self.ctx, &mut kv, &request.prompt_tokens[resume..])
         };
         let recorded = launched.and_then(|pass| {
             lane.stream
@@ -796,6 +799,21 @@ impl EngineState {
             mut pass,
             resumed,
         } = inflight;
+        // The frontier after any prefill equals the prompt length; a lane
+        // pass that processed the wrong suffix cannot pass this gate.
+        if kv.local.seq_len() != request.prompt_tokens.len() {
+            log::error!(
+                "gemma4 async prefill frontier {} != prompt {}",
+                kv.local.seq_len(),
+                request.prompt_tokens.len()
+            );
+            let _ = request.token_tx.send(TokenEvent::Error {
+                message: "async prefill frontier mismatch".into(),
+                prompt_tokens: request.prompt_tokens.len(),
+                completion_tokens: 0,
+            });
+            return;
+        }
         if let Err(err) = self.serve.release_prefill_window(&mut kv) {
             let _ = request.token_tx.send(TokenEvent::Error {
                 message: format!("prefill window release failed: {err:#}"),

--- a/pegainfer-gemma4/src/engine.rs
+++ b/pegainfer-gemma4/src/engine.rs
@@ -430,8 +430,10 @@ impl EngineState {
         base_seed: u64,
         graph_enabled: bool,
     ) -> Result<Self> {
-        // Refuse an unservable global GQA shape before the multi-GiB load.
+        // Refuse an unservable global GQA shape or a bad lane mode before
+        // the multi-GiB load.
         crate::serve::global_split_factor(&crate::config::Gemma4Config::from_file(dir)?)?;
+        let lane_mode = async_prefill_mode()?;
         let (weights, _) = Gemma4Weights::from_safetensors(dir, device)?;
         let ctx = DeviceContext::new_with_device(device)?;
         let vocab = weights.embed_tokens.rows;
@@ -473,7 +475,7 @@ impl EngineState {
             .stream
             .clone_htod(&[bf16::NEG_INFINITY])
             .map_err(|err| anyhow::anyhow!("allocating the suppression sentinel failed: {err}"))?;
-        let lane = match async_prefill_mode()? {
+        let lane = match lane_mode {
             AsyncPrefillMode::Off => None,
             mode => Some(AsyncPrefillLane::new(&ctx, mode)?),
         };

--- a/pegainfer-gemma4/src/engine.rs
+++ b/pegainfer-gemma4/src/engine.rs
@@ -94,7 +94,28 @@ pub(crate) fn start(model_path: &Path, options: &EngineLoadOptions) -> Result<En
                         }
                     }
                 }
-                if active.is_empty() && pending.is_empty() {
+                // Join a finished overlapped prefill: poll while other work
+                // exists, block on the lane when it is the only work left.
+                let lane_ready = match state.lane.as_mut() {
+                    Some(lane) if lane.inflight.is_some() => {
+                        let lane_is_only_work = active.is_empty() && pending.is_empty();
+                        if lane_is_only_work {
+                            lane.drain_or_abort();
+                        }
+                        lane_is_only_work || lane.inflight_complete()
+                    }
+                    _ => false,
+                };
+                if lane_ready {
+                    state.join_async_prefill(&mut active);
+                }
+                if active.is_empty()
+                    && pending.is_empty()
+                    && state
+                        .lane
+                        .as_ref()
+                        .is_none_or(|lane| lane.inflight.is_none())
+                {
                     if disconnected {
                         break 'engine;
                     }
@@ -112,6 +133,15 @@ pub(crate) fn start(model_path: &Path, options: &EngineLoadOptions) -> Result<En
                 // token however deep it is.
                 let mut attempts = 0;
                 while attempts < MAX_CONCURRENCY && active.len() < MAX_CONCURRENCY {
+                    // With the lane busy, arrivals wait in `pending` while
+                    // decode keeps stepping.
+                    if state
+                        .lane
+                        .as_ref()
+                        .is_some_and(|lane| lane.inflight.is_some())
+                    {
+                        break;
+                    }
                     let Some(item) = pending.pop_front() else {
                         break;
                     };
@@ -230,6 +260,114 @@ type Submitted = pegainfer_frontend::engine::SubmittedRequest;
 
 /// One in-flight request between decode steps: its KV, the token that feeds
 /// the next step, and its progress counters.
+/// Overlapped admission: with the lane on, a prompt arriving into a live
+/// decode batch prefills on its own stream while decode steps keep
+/// replaying on `ctx.stream` — the admission costs the streams a slowdown
+/// instead of a mixed step per prompt. `shared` lets the prefill grids
+/// compete for every SM; `green:NN` pins the lane to NN% of them, which is
+/// what actually protects decode ITL.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AsyncPrefillMode {
+    Off,
+    Shared,
+    Green(u32),
+}
+
+fn async_prefill_mode() -> Result<AsyncPrefillMode> {
+    match std::env::var("PEGAINFER_ASYNC_PREFILL") {
+        Ok(raw) => parse_async_prefill_mode(&raw),
+        Err(_) => Ok(AsyncPrefillMode::Off),
+    }
+}
+
+fn parse_async_prefill_mode(raw: &str) -> Result<AsyncPrefillMode> {
+    let v = raw.trim().to_ascii_lowercase();
+    match v.as_str() {
+        "" | "0" | "false" | "off" => Ok(AsyncPrefillMode::Off),
+        "shared" => Ok(AsyncPrefillMode::Shared),
+        other => match other.strip_prefix("green:").and_then(|p| p.parse().ok()) {
+            Some(pct) if (1..=99).contains(&pct) => Ok(AsyncPrefillMode::Green(pct)),
+            _ => anyhow::bail!(
+                "PEGAINFER_ASYNC_PREFILL={raw:?} not recognized (off | shared | green:NN, 1..=99)"
+            ),
+        },
+    }
+}
+
+/// One in-flight overlapped prefill, parked until the lane's completion
+/// event fires: the request, its KV, and the pass owning every device
+/// buffer the in-flight kernels still read.
+struct InflightPrefill {
+    request: GenerateRequest,
+    kv: GemmaKv,
+    pass: crate::serve::PrefillPass,
+    /// The cache entry this request resumed from, if any — its stale
+    /// ancestor at capture time.
+    resumed: Option<u64>,
+}
+
+/// The overlap lane: a dedicated prefill stream and a reusable completion
+/// event. At most one prefill is in flight; while it runs, later arrivals
+/// wait in the queue and decode keeps stepping — which is the point.
+struct AsyncPrefillLane {
+    stream: crate::green_ctx::PrefillLaneStream,
+    event: cudarc::driver::CudaEvent,
+    inflight: Option<InflightPrefill>,
+}
+
+impl AsyncPrefillLane {
+    fn new(ctx: &DeviceContext, mode: AsyncPrefillMode) -> Result<Self> {
+        let stream = match mode {
+            AsyncPrefillMode::Off => anyhow::bail!("async prefill lane built with mode Off"),
+            AsyncPrefillMode::Shared => crate::green_ctx::PrefillLaneStream::shared()?,
+            AsyncPrefillMode::Green(pct) => {
+                crate::green_ctx::PrefillLaneStream::green(ctx.device_ordinal, pct)?
+            }
+        };
+        let event = ctx
+            .ctx
+            .new_event(None)
+            .map_err(|e| anyhow::anyhow!("prefill completion event create failed: {e}"))?;
+        Ok(Self {
+            stream,
+            event,
+            inflight: None,
+        })
+    }
+
+    /// True once the in-flight prefill's event has fired. An unexpected
+    /// query error aborts: the pass's buffers may still be in use and no
+    /// safe recovery exists.
+    fn inflight_complete(&self) -> bool {
+        debug_assert!(self.inflight.is_some());
+        let query = unsafe { cudarc::driver::sys::cuEventQuery(self.event.cu_event()) };
+        match query {
+            cudarc::driver::sys::CUresult::CUDA_SUCCESS => true,
+            cudarc::driver::sys::CUresult::CUDA_ERROR_NOT_READY => false,
+            other => {
+                log::error!("FATAL: cuEventQuery(prefill) failed ({other:?}); aborting");
+                std::process::abort();
+            }
+        }
+    }
+
+    /// Block until the lane stream is drained; abort on failure rather
+    /// than let the pass's buffers be reused under in-flight kernels.
+    fn drain_or_abort(&self) {
+        let sync = unsafe { cudarc::driver::sys::cuStreamSynchronize(self.stream.stream) };
+        if sync != cudarc::driver::sys::CUresult::CUDA_SUCCESS {
+            log::error!("FATAL: cuStreamSynchronize(prefill) failed ({sync:?}); aborting");
+            std::process::abort();
+        }
+    }
+}
+
+impl Drop for AsyncPrefillLane {
+    fn drop(&mut self) {
+        self.drain_or_abort();
+    }
+}
+
 struct Active {
     request: GenerateRequest,
     kv: GemmaKv,
@@ -279,6 +417,9 @@ struct EngineState {
     /// mixed into the per-call seed; a request's own `params.seed` replays
     /// via (seed, step) regardless of it.
     sample_nonce: u64,
+    /// The overlap lane; `None` unless `PEGAINFER_ASYNC_PREFILL` opted in
+    /// at startup.
+    lane: Option<AsyncPrefillLane>,
 }
 
 impl EngineState {
@@ -332,6 +473,10 @@ impl EngineState {
             .stream
             .clone_htod(&[bf16::NEG_INFINITY])
             .map_err(|err| anyhow::anyhow!("allocating the suppression sentinel failed: {err}"))?;
+        let lane = match async_prefill_mode()? {
+            AsyncPrefillMode::Off => None,
+            mode => Some(AsyncPrefillLane::new(&ctx, mode)?),
+        };
         Ok(Self {
             ctx,
             serve,
@@ -342,6 +487,7 @@ impl EngineState {
             blocked,
             base_seed,
             sample_nonce: 0,
+            lane,
         })
     }
 
@@ -457,6 +603,15 @@ impl EngineState {
             return Admitted::Done;
         }
 
+        // Overlapped admission: the prefill launches onto the lane stream
+        // and this call returns immediately — decode steps continue while it
+        // runs. A prompt arriving with nothing active stays on the sync
+        // path: there is nothing to protect, and full-SM speed wins the head
+        // of every refill burst.
+        if self.lane.is_some() && !active.is_empty() {
+            return self.launch_async_prefill(request, kv, resumed);
+        }
+
         // Mixed admission: with a live decode batch, the prompt rides its
         // weight scan — one step prefills the newcomer and advances every
         // active row.
@@ -493,9 +648,29 @@ impl EngineState {
                 cache.insert(entry, resumed);
             }
         }
-        if let Err(err) =
-            suppress_logits(&self.ctx, &self.blocked, &mut logits, &self.policy.suppress)
-        {
+        self.first_token_flow(request, kv, &mut logits)
+    }
+
+    /// Suppress, sample and emit a prefill's first token from logits row 0,
+    /// then finish the request or hand it to the decode batch — the shared
+    /// tail of a sync admission and an overlapped-prefill join.
+    fn first_token_flow(
+        &mut self,
+        request: GenerateRequest,
+        kv: GemmaKv,
+        logits: &mut HiddenStates,
+    ) -> Admitted {
+        let sink = request.token_tx.clone();
+        let prompt_tokens = request.prompt_tokens.len();
+        let fail = |message: String| {
+            let _ = sink.send(TokenEvent::Error {
+                message,
+                prompt_tokens,
+                completion_tokens: 0,
+            });
+            Admitted::Done
+        };
+        if let Err(err) = suppress_logits(&self.ctx, &self.blocked, logits, &self.policy.suppress) {
             return fail(format!("{err:#}"));
         }
 
@@ -503,7 +678,7 @@ impl EngineState {
         let call_seed = self.base_seed ^ self.sample_nonce.rotate_left(17);
         let next = match pegainfer_sample::select_batch(
             &self.ctx,
-            &logits,
+            logits,
             &[&request.params],
             &[0],
             call_seed,
@@ -530,7 +705,7 @@ impl EngineState {
         let logprob = if request.logprobs > 0 {
             match pegainfer_sample::token_logprobs_batch(
                 &self.ctx,
-                &logits,
+                logits,
                 &[LogprobRequest {
                     row: 0,
                     picked: next,
@@ -556,6 +731,90 @@ impl EngineState {
             emitted: 1,
             prompt_tokens,
         }))
+    }
+
+    /// Launch one whole-prompt prefill onto the lane stream and record the
+    /// completion event. On a launch error the lane stream is drained
+    /// before the KV reservation drops, so no returned page can still be
+    /// written by a stale kernel.
+    fn launch_async_prefill(
+        &mut self,
+        request: GenerateRequest,
+        mut kv: GemmaKv,
+        resumed: Option<u64>,
+    ) -> Admitted {
+        let lane = self.lane.as_mut().expect("gated by the caller");
+        debug_assert!(lane.inflight.is_none());
+        let launched = {
+            let _guard = unsafe {
+                pegainfer_core::tensor::StreamOverrideGuard::activate(lane.stream.stream)
+            };
+            self.serve
+                .prefill_into_logits(&self.ctx, &mut kv, &request.prompt_tokens)
+        };
+        let recorded = launched.and_then(|pass| {
+            lane.stream
+                .record_event(lane.event.cu_event())
+                .map(|()| pass)
+        });
+        match recorded {
+            Ok(pass) => {
+                lane.inflight = Some(InflightPrefill {
+                    request,
+                    kv,
+                    pass,
+                    resumed,
+                });
+                Admitted::Done
+            }
+            Err(err) => {
+                log::error!("gemma4 async prefill launch failed: {err:#}");
+                lane.drain_or_abort();
+                let _ = request.token_tx.send(TokenEvent::Error {
+                    message: format!("prefill failed: {err:#}"),
+                    prompt_tokens: request.prompt_tokens.len(),
+                    completion_tokens: 0,
+                });
+                Admitted::Done
+            }
+        }
+    }
+
+    /// Join a completed overlapped prefill: run the deferred window
+    /// release, capture into the prefix cache, and take the first-token
+    /// flow the sync path uses.
+    fn join_async_prefill(&mut self, active: &mut Vec<Active>) {
+        let Some(lane) = self.lane.as_mut() else {
+            return;
+        };
+        let Some(inflight) = lane.inflight.take() else {
+            return;
+        };
+        let InflightPrefill {
+            request,
+            mut kv,
+            mut pass,
+            resumed,
+        } = inflight;
+        if let Err(err) = self.serve.release_prefill_window(&mut kv) {
+            let _ = request.token_tx.send(TokenEvent::Error {
+                message: format!("prefill window release failed: {err:#}"),
+                prompt_tokens: request.prompt_tokens.len(),
+                completion_tokens: 0,
+            });
+            return;
+        }
+        if let Some(cache) = self.prefix_cache.as_mut() {
+            if let Some(entry) =
+                self.serve
+                    .capture_checkpoint(&self.ctx, &kv, request.prompt_tokens.clone())
+            {
+                cache.insert(entry, resumed);
+            }
+        }
+        if let Admitted::Active(entry) = self.first_token_flow(request, kv, &mut pass.logits) {
+            active.push(*entry);
+        }
     }
 
     /// Retire every active request the next step cannot serve — a closed
@@ -920,5 +1179,43 @@ mod gate {
 
         let past_the_row = suppress_logits(&ctx, &blocked, &mut logits, &[vocab as u32]);
         assert!(past_the_row.is_err(), "an id past the row must be refused");
+    }
+}
+
+#[cfg(test)]
+mod lane_tests {
+    use super::AsyncPrefillMode;
+    use super::parse_async_prefill_mode;
+
+    #[test]
+    fn async_prefill_mode_parses_or_refuses() {
+        for off in ["", "0", "false", "off", " OFF "] {
+            assert_eq!(
+                parse_async_prefill_mode(off).unwrap(),
+                AsyncPrefillMode::Off
+            );
+        }
+        assert_eq!(
+            parse_async_prefill_mode("shared").unwrap(),
+            AsyncPrefillMode::Shared
+        );
+        assert_eq!(
+            parse_async_prefill_mode("green:35").unwrap(),
+            AsyncPrefillMode::Green(35)
+        );
+        for bad in [
+            "1",
+            "true",
+            "on",
+            "green",
+            "green:0",
+            "green:100",
+            "green:x",
+        ] {
+            assert!(
+                parse_async_prefill_mode(bad).is_err(),
+                "{bad:?} must refuse, not silently degrade"
+            );
+        }
     }
 }

--- a/pegainfer-gemma4/src/green_ctx.rs
+++ b/pegainfer-gemma4/src/green_ctx.rs
@@ -1,0 +1,192 @@
+//! SM-capped prefill stream for the async-prefill overlap (qwen3's
+//! green-context machinery, asymmetric form): the overlapped prefill runs on
+//! a Green Context stream pinned to a fraction of the SMs, while decode
+//! stays on the primary-context stream with the full device. Capping the
+//! prefill footprint is what protects decode ITL — the naive shared-SM
+//! overlap lets prefill's large grids starve decode steps.
+
+use anyhow::Result;
+use anyhow::bail;
+use cudarc::driver::sys;
+use cudarc::driver::sys::CUdevice;
+use cudarc::driver::sys::CUstream;
+
+fn check_cu(result: sys::CUresult, msg: &str) -> Result<()> {
+    if result != sys::CUresult::CUDA_SUCCESS {
+        bail!("{msg} failed: {result:?}");
+    }
+    Ok(())
+}
+
+struct GreenContexts {
+    gctx_prefill: sys::CUgreenCtx,
+    _ctx_prefill: sys::CUcontext,
+}
+
+/// The prefill lane's stream, either a plain primary-context stream
+/// (shared SMs) or a Green Context stream pinned to `prefill_pct`% of them.
+pub(crate) struct PrefillLaneStream {
+    pub(crate) stream: CUstream,
+    green: Option<GreenContexts>,
+}
+
+impl PrefillLaneStream {
+    /// A plain primary-context stream — both engines share every SM.
+    pub(crate) fn shared() -> Result<Self> {
+        let mut stream: CUstream = std::ptr::null_mut();
+        check_cu(
+            unsafe {
+                sys::cuStreamCreate(
+                    &raw mut stream,
+                    sys::CUstream_flags::CU_STREAM_NON_BLOCKING as u32,
+                )
+            },
+            "cuStreamCreate (prefill lane)",
+        )?;
+        log::info!("gemma4 async prefill: shared-SM lane stream");
+        Ok(Self {
+            stream,
+            green: None,
+        })
+    }
+
+    /// A Green Context stream pinned to roughly `prefill_pct`% of the SMs
+    /// (rounded down to the split granularity). Fails loudly rather than
+    /// falling back to shared SMs, so benchmarks stay honest.
+    pub(crate) fn green(device_ordinal: usize, prefill_pct: u32) -> Result<Self> {
+        let device: CUdevice = device_ordinal as i32;
+        let mut sm_res: sys::CUdevResource = unsafe { std::mem::zeroed() };
+        check_cu(
+            unsafe {
+                sys::cuDeviceGetDevResource(
+                    device,
+                    &raw mut sm_res,
+                    sys::CUdevResourceType::CU_DEV_RESOURCE_TYPE_SM,
+                )
+            },
+            "cuDeviceGetDevResource",
+        )?;
+        let total_sm = unsafe { sm_res.__bindgen_anon_1.sm.smCount };
+
+        let mut nb: u32 = 1;
+        let mut probe_grp: sys::CUdevResource = unsafe { std::mem::zeroed() };
+        let mut probe_rem: sys::CUdevResource = unsafe { std::mem::zeroed() };
+        check_cu(
+            unsafe {
+                sys::cuDevSmResourceSplitByCount(
+                    &raw mut probe_grp,
+                    &raw mut nb,
+                    &raw const sm_res,
+                    &raw mut probe_rem,
+                    0,
+                    1,
+                )
+            },
+            "probe split",
+        )?;
+        let min_sm = unsafe { probe_grp.__bindgen_anon_1.sm.smCount };
+
+        let sm_for_prefill = (total_sm * prefill_pct / 100 / min_sm) * min_sm;
+        if sm_for_prefill < min_sm || total_sm - sm_for_prefill < min_sm {
+            bail!(
+                "green-ctx prefill partition not viable: total={total_sm} min={min_sm} \
+                 prefill_pct={prefill_pct} prefill_target={sm_for_prefill}"
+            );
+        }
+
+        let mut grp_prefill: sys::CUdevResource = unsafe { std::mem::zeroed() };
+        let mut grp_rest: sys::CUdevResource = unsafe { std::mem::zeroed() };
+        nb = 1;
+        check_cu(
+            unsafe {
+                sys::cuDevSmResourceSplitByCount(
+                    &raw mut grp_prefill,
+                    &raw mut nb,
+                    &raw const sm_res,
+                    &raw mut grp_rest,
+                    0,
+                    sm_for_prefill,
+                )
+            },
+            "cuDevSmResourceSplitByCount",
+        )?;
+        let sm_prefill = unsafe { grp_prefill.__bindgen_anon_1.sm.smCount };
+
+        let mut desc_prefill: sys::CUdevResourceDesc = std::ptr::null_mut();
+        check_cu(
+            unsafe {
+                sys::cuDevResourceGenerateDesc(&raw mut desc_prefill, &raw mut grp_prefill, 1)
+            },
+            "cuDevResourceGenerateDesc (prefill)",
+        )?;
+        let mut gctx_prefill: sys::CUgreenCtx = std::ptr::null_mut();
+        check_cu(
+            unsafe {
+                sys::cuGreenCtxCreate(
+                    &raw mut gctx_prefill,
+                    desc_prefill,
+                    device,
+                    sys::CUgreenCtxCreate_flags::CU_GREEN_CTX_DEFAULT_STREAM as u32,
+                )
+            },
+            "cuGreenCtxCreate (prefill)",
+        )?;
+        let mut ctx_prefill: sys::CUcontext = std::ptr::null_mut();
+        check_cu(
+            unsafe { sys::cuCtxFromGreenCtx(&raw mut ctx_prefill, gctx_prefill) },
+            "cuCtxFromGreenCtx (prefill)",
+        )?;
+
+        let mut stream: CUstream = std::ptr::null_mut();
+        let create = unsafe {
+            sys::cuGreenCtxStreamCreate(
+                &raw mut stream,
+                gctx_prefill,
+                sys::CUstream_flags::CU_STREAM_NON_BLOCKING as u32,
+                0,
+            )
+        };
+        if create != sys::CUresult::CUDA_SUCCESS {
+            unsafe {
+                sys::cuGreenCtxDestroy(gctx_prefill);
+            }
+            bail!("cuGreenCtxStreamCreate failed ({create:?})");
+        }
+
+        log::info!(
+            "gemma4 async prefill: green-ctx lane pinned to {sm_prefill}/{total_sm} SMs \
+             (decode keeps the primary context)"
+        );
+        Ok(Self {
+            stream,
+            green: Some(GreenContexts {
+                gctx_prefill,
+                _ctx_prefill: ctx_prefill,
+            }),
+        })
+    }
+
+    /// Record `event` on the lane stream. Green Context streams need the
+    /// event recorded through their green context; primary streams take the
+    /// plain record.
+    pub(crate) fn record_event(&self, event: sys::CUevent) -> Result<()> {
+        let record = unsafe {
+            match &self.green {
+                Some(g) => sys::cuGreenCtxRecordEvent(g.gctx_prefill, event),
+                None => sys::cuEventRecord(event, self.stream),
+            }
+        };
+        check_cu(record, "record prefill completion event")
+    }
+}
+
+impl Drop for PrefillLaneStream {
+    fn drop(&mut self) {
+        unsafe {
+            sys::cuStreamDestroy_v2(self.stream);
+            if let Some(green) = &self.green {
+                sys::cuGreenCtxDestroy(green.gctx_prefill);
+            }
+        }
+    }
+}

--- a/pegainfer-gemma4/src/kv.rs
+++ b/pegainfer-gemma4/src/kv.rs
@@ -81,9 +81,10 @@ impl SlidingLocalKv {
         self.resident.extend(pages);
     }
 
-    /// Move the frontier without releasing anything. Only the eviction A/B
-    /// takes this path; serving goes through [`Self::advance_and_release`].
-    #[cfg(test)]
+    /// Move the frontier without releasing anything: the overlapped
+    /// prefill defers its release to join time, and the eviction A/B pins
+    /// the footprint. Everything else goes through
+    /// [`Self::advance_and_release`].
     pub(crate) fn advance(&mut self, count: usize) {
         self.frontier += count;
     }

--- a/pegainfer-gemma4/src/lib.rs
+++ b/pegainfer-gemma4/src/lib.rs
@@ -14,6 +14,8 @@ mod engine;
 #[allow(dead_code)]
 mod forward;
 #[cfg(feature = "gemma4")]
+mod green_ctx;
+#[cfg(feature = "gemma4")]
 #[allow(dead_code)]
 mod kv;
 #[cfg(feature = "gemma4")]

--- a/pegainfer-gemma4/src/serve.rs
+++ b/pegainfer-gemma4/src/serve.rs
@@ -203,6 +203,49 @@ impl AttnScratch {
 /// The tower's whole working set for one step: attention buffers, epilogue
 /// buffers, and the hidden pair the layers alternate between so no layer
 /// writes the buffer it is reading.
+/// Order `ctx.stream` producers (plan uploads, token-id H2D, buffer
+/// allocations) before the override stream consumes them. No-op without an
+/// override.
+fn fence_producers_before_override(ctx: &DeviceContext) -> Result<()> {
+    use cudarc::driver::sys;
+    if !pegainfer_core::tensor::has_stream_override() {
+        return Ok(());
+    }
+    let override_stream = pegainfer_core::tensor::active_cu_stream(ctx);
+    let producer = ctx.stream.cu_stream();
+    unsafe {
+        let mut event: sys::CUevent = std::ptr::null_mut();
+        let create = sys::cuEventCreate(
+            &raw mut event,
+            sys::CUevent_flags_enum::CU_EVENT_DISABLE_TIMING as u32,
+        );
+        anyhow::ensure!(
+            create == sys::CUresult::CUDA_SUCCESS,
+            "cuEventCreate (producer fence) failed: {create:?}"
+        );
+        let record = sys::cuEventRecord(event, producer);
+        let wait = if record == sys::CUresult::CUDA_SUCCESS {
+            sys::cuStreamWaitEvent(override_stream, event, 0)
+        } else {
+            record
+        };
+        let destroy = sys::cuEventDestroy_v2(event);
+        anyhow::ensure!(
+            record == sys::CUresult::CUDA_SUCCESS,
+            "cuEventRecord (producer fence) failed: {record:?}"
+        );
+        anyhow::ensure!(
+            wait == sys::CUresult::CUDA_SUCCESS,
+            "cuStreamWaitEvent (producer fence) failed: {wait:?}"
+        );
+        anyhow::ensure!(
+            destroy == sys::CUresult::CUDA_SUCCESS,
+            "cuEventDestroy (producer fence) failed: {destroy:?}"
+        );
+    }
+    Ok(())
+}
+
 struct TowerScratch {
     attn: AttnScratch,
     epilogue: EpilogueScratch,
@@ -2076,6 +2119,100 @@ impl GemmaServe {
         kv.global.advance(seq_len);
         Ok(logits)
     }
+
+    /// Whole-prompt prefill left in flight on the active stream — the
+    /// overlap-safe form of [`GemmaServe::step`] at `LogitsSpan::LastRow`.
+    /// Every host-side producer (plan upload, token-id H2D, buffer
+    /// allocation) runs on `ctx.stream` before one producer fence;
+    /// everything after is kernel work over buffers the returned pass owns,
+    /// so the caller may launch it under a stream override and leave it in
+    /// flight while decode steps continue on `ctx.stream`. The
+    /// append-then-attend window release is deferred to
+    /// [`GemmaServe::release_prefill_window`] at join time — a page
+    /// released here could be re-allocated to a decoding request's frontier
+    /// and written on `ctx.stream` while the in-flight layers still read
+    /// it.
+    pub(crate) fn prefill_into_logits(
+        &self,
+        ctx: &DeviceContext,
+        kv: &mut GemmaKv,
+        tokens: &[u32],
+    ) -> Result<PrefillPass> {
+        let seq_len = tokens.len();
+        anyhow::ensure!(seq_len > 0, "prefill needs at least one token");
+        self.check_stream(ctx)?;
+        let weights = &self.weights;
+        validate_tokens(weights, self.local_geom.hidden_size, tokens)?;
+        let start_pos = kv.local.seq_len();
+        self.check_step_bounds(kv, start_pos + seq_len)?;
+        let plan = self.plan_step(ctx, kv, start_pos, seq_len)?;
+        let mut tower = TowerScratch::new(ctx, &self.local_geom, &self.global_geom, seq_len)?;
+        let ids = ctx
+            .stream
+            .clone_htod(tokens)
+            .map_err(|e| anyhow::anyhow!("token ids H2D failed: {e}"))?;
+        let mut last = HiddenStates::zeros(ctx, self.local_geom.hidden_size, 1)?;
+        let mut normed = HiddenStates::zeros(ctx, self.local_geom.hidden_size, 1)?;
+        let mut logits = HiddenStates::zeros(ctx, weights.embed_tokens.rows, 1)?;
+        fence_producers_before_override(ctx)?;
+        let src = self.run_tower(
+            ctx,
+            &mut tower,
+            &ids,
+            seq_len,
+            &plan.local_plan,
+            PrepRef::Single {
+                start_pos: plan.start_pos,
+                local_page_origin: plan.local_page_origin,
+                global_plan: &plan.global_plan,
+            },
+            None,
+        )?;
+        let hidden = &tower.hidden[src];
+        ops::copy_hidden_token_range_into(ctx, hidden, seq_len - 1, &mut last, 0, 1)?;
+        logits_tail_into(
+            ctx,
+            weights,
+            &last,
+            self.local_geom.rms_norm_eps,
+            self.final_logit_softcapping,
+            &mut normed,
+            &mut logits,
+        )?;
+        kv.local.advance(seq_len);
+        kv.global.advance(seq_len);
+        Ok(PrefillPass {
+            logits,
+            _tower: tower,
+            _plan: plan,
+            _ids: ids,
+            _last: last,
+            _normed: normed,
+        })
+    }
+
+    /// The deferred append-then-attend release for an overlapped prefill:
+    /// call once its completion event has fired, before the request joins
+    /// the decode batch.
+    pub(crate) fn release_prefill_window(&self, kv: &mut GemmaKv) -> Result<()> {
+        #[cfg(test)]
+        if !self.release_enabled {
+            return Ok(());
+        }
+        kv.local.advance_and_release(0, self.sliding_window)
+    }
+}
+
+/// Everything an overlapped prefill keeps alive while its kernels are in
+/// flight on the lane stream: dropping any of it before the completion
+/// event fires would free device memory the pass still reads.
+pub(crate) struct PrefillPass {
+    pub(crate) logits: HiddenStates,
+    _tower: TowerScratch,
+    _plan: GemmaStepPlan,
+    _ids: CudaSlice<u32>,
+    _last: HiddenStates,
+    _normed: HiddenStates,
 }
 
 #[path = "serve_oracle.rs"]

--- a/pegainfer-gemma4/src/serve_oracle.rs
+++ b/pegainfer-gemma4/src/serve_oracle.rs
@@ -831,6 +831,109 @@ fn mixed_step_crosses_the_window_like_serial() {
     }
 }
 
+/// The overlap-safe prefill under a lane-stream override must be bit-equal
+/// to the sync step: identical row-0 logits, the same released-window
+/// shape after the deferred release, and greedy decode over the
+/// lane-written KV matching the sync arm token for token — for a short
+/// prompt and one crossing the sliding window.
+#[test]
+#[ignore = "requires the pinned 12B checkpoint via PEGAINFER_TEST_MODEL_PATH and a GPU"]
+fn overlapped_prefill_matches_the_sync_step() {
+    let (ctx, serve, _dir) = stack_with(2048, 512);
+    let mut arena = serve.alloc_step_arena(&ctx, 1, false).expect("step arena");
+    let budgets = [13usize];
+    for (name, len) in [("short", 40usize), ("crossing", 1500)] {
+        let prompt: Vec<u32> = (0..len as u32).map(|i| 1000 + (i * 37) % 50000).collect();
+
+        let mut kv_sync = serve.alloc_kv();
+        admit_tokens(
+            &serve.local_pool,
+            &serve.global_pool,
+            &mut kv_sync,
+            prompt.len(),
+        )
+        .expect("admit sync");
+        let logits_sync = serve
+            .step(&ctx, &mut kv_sync, &prompt, LogitsSpan::LastRow)
+            .expect("sync prefill");
+        let bits_sync: Vec<u32> = logits_sync
+            .to_host(&ctx)
+            .expect("sync logits D2H")
+            .iter()
+            .map(|v| v.to_bits())
+            .collect();
+
+        let mut kv_lane = serve.alloc_kv();
+        admit_tokens(
+            &serve.local_pool,
+            &serve.global_pool,
+            &mut kv_lane,
+            prompt.len(),
+        )
+        .expect("admit lane");
+        let lane = crate::green_ctx::PrefillLaneStream::shared().expect("lane stream");
+        let pass = {
+            let _guard =
+                unsafe { pegainfer_core::tensor::StreamOverrideGuard::activate(lane.stream) };
+            serve
+                .prefill_into_logits(&ctx, &mut kv_lane, &prompt)
+                .expect("lane prefill")
+        };
+        let sync = unsafe { cudarc::driver::sys::cuStreamSynchronize(lane.stream) };
+        assert_eq!(
+            sync,
+            cudarc::driver::sys::CUresult::CUDA_SUCCESS,
+            "{name}: lane stream drain"
+        );
+        serve
+            .release_prefill_window(&mut kv_lane)
+            .expect("deferred release");
+        let bits_lane: Vec<u32> = pass
+            .logits
+            .to_host(&ctx)
+            .expect("lane logits D2H")
+            .iter()
+            .map(|v| v.to_bits())
+            .collect();
+
+        assert_eq!(
+            bits_lane, bits_sync,
+            "{name}: overlapped prefill logits diverged from the sync step"
+        );
+        assert_eq!(
+            (kv_lane.local.origin_pages(), kv_lane.local.seq_len()),
+            (kv_sync.local.origin_pages(), kv_sync.local.seq_len()),
+            "{name}: released-window shape diverged"
+        );
+
+        let mut tokens = [Vec::new(), Vec::new()];
+        for (slot, kv) in [kv_sync, kv_lane].into_iter().enumerate() {
+            let first = argmax_last(&ctx, &logits_sync).expect("first token");
+            let mut lanes = vec![(0usize, kv, first)];
+            let mut produced: Vec<Vec<u32>> = vec![vec![first]];
+            mixed_gate_decode_rounds(
+                &ctx,
+                &serve,
+                &mut arena,
+                &mut lanes,
+                &mut produced,
+                &budgets,
+                usize::MAX,
+            );
+            tokens[slot] = produced.swap_remove(0);
+        }
+        assert_eq!(
+            tokens[1], tokens[0],
+            "{name}: greedy decode over the lane-written KV diverged"
+        );
+        eprintln!(
+            "{name}: {} prompt tokens, logits bit-equal, {} greedy tokens equal",
+            prompt.len(),
+            tokens[0].len()
+        );
+    }
+}
+
 /// The prefix cache's GPU halves, gated bit-level: two arms run the same
 /// kernel sequence — prefill turn 1, then a suffix step and greedy decode —
 /// and differ only in that the cache arm captures after turn 1, drops its


### PR DESCRIPTION
## Description


Closes #922

A long prompt's admission still stalls every live stream for one mixed step — about 0.4 s at 1900 prompt tokens — because prefill and decode share every SM. This adds an opt-in overlap lane, `PEGAINFER_ASYNC_PREFILL` (default off, byte-identical behavior unset): with a live decode batch, a whole-prompt prefill launches onto a dedicated lane stream and this admission returns immediately while decode steps keep replaying; `green:NN` pins the lane to NN% of the SMs via a Green Context, which is what actually protects decode ITL. `shared` runs the lane on a plain stream for comparison. An unrecognized mode or an unviable SM partition refuses to start rather than silently degrading.

One prefill is in flight at most; later arrivals wait while decode keeps stepping, and a prompt arriving with nothing active stays on the sync path (full-SM speed wins the head of a refill burst). The pass owns every device buffer its in-flight kernels read — plans, token ids, tower scratch, logits — until join, and its host-side producers run on the primary stream before a single producer fence, so nothing the lane reads is unordered. The append-then-attend window release is deferred to join time: a page released mid-flight could be re-allocated to a decoding request's frontier and written while the in-flight layers still read it. At join, the first-token flow is the same code the sync admission uses, and the prefix cache captures with the same lineage identity.

The positioning is a high-concurrency tail-latency profile, not a default: the capped lane serializes prefills and pays for decode protection with prefill TTFT and flood wall (measured below), and at light load it only costs TTFT.

### Test Env

Single GPU (sm_89, x86_64), CUDA 12.9, Gemma 4 12B checkpoint.

### Verification

- Build/lint/test gates green (fmt, builds, clippy `-D warnings` incl. the CI crate set with `--all-targets`, gemma4 lib tests incl. a mode-parse refusal test); checkpoint oracles, ragged determinism, mixed-admission and prefix-cache gates green on the same tip.
- Lane gate green: under a real lane-stream override, the overlapped prefill's logits are bit-equal to the sync step, the deferred release leaves the same window shape, and greedy decode over the lane-written KV matches token for token — for a short prompt and one crossing the sliding window.
- Live serving checks green in all three modes; the `green:35` server log confirms the partition (48 of 142 SMs pinned to the lane, decode keeps the primary context).
- Long-prompt flood A/B (a 480-token stream, then 16 admissions of ~1900-token prompts at once; two runs per arm, reversed order; ranges span the runs):

| arm | quiet stream p50 | stream p50 / p99 / max under the flood | flood TTFT p50 / p99 | flood wall |
| --- | --- | --- | --- | --- |
| default | 27.5-27.6 ms | 28.1 / 385-432 / 387-452 ms | 3.3-3.7 / 6.5-7.3 s | 6.2-6.9 s |
| `green:35` | 27.6 ms | 33-34 / **39-40 / 75-76 ms** | 9.8-10.3 / 16.0-16.5 s | 15.7-16.1 s |

  The default arm's ~0.4 s worst gap is one mixed step at this prompt length; the lane dissolves it into a mild slowdown. The trade is explicit: the flood's own TTFT and wall grow ~2.4× — decode-tail protection, paid on the prefill side. Idle resident and the quiet stream are unchanged, so an idle lane costs nothing.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)