### PR TITLE
Restore the star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,3 +334,11 @@ Apache-2.0 — see [LICENSE](LICENSE) and [NOTICE](NOTICE). Components ported fr
 NVIDIA Dynamo (the `kvbm/kvbm-logical` crate) retain their original Apache-2.0 headers; see
 [NOTICE_DYNAMO](NOTICE_DYNAMO).
 
+## Star History
+
+<p align="center">
+  <a href="https://star-history.dera.page/#pegainfer-project/pegainfer&Date">
+    <img src="https://star-history.dera.page/svg?repos=pegainfer-project/pegainfer&type=Date" alt="Star History Chart">
+  </a>
+</p>
+


### PR DESCRIPTION
The star history chart was removed from the README because it had broken, not because it was unwanted. The upstream star-history.com endpoint no longer renders reliably under GitHub's stargazer API restrictions, and fixing it is necessary to keep the project's adoption visible.

This restores the Star History section to its original place after License, repointed to a working mirror that needs no API token and serves both the frontend and the chart image from the same host.