### PR TITLE
perf(core): the weight prefetch runs only where it can help

### DIFF
--- a/pegainfer-core/src/weight_loader.rs
+++ b/pegainfer-core/src/weight_loader.rs
@@ -7,8 +7,10 @@ use std::os::unix::fs::FileExt;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU64;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
+use std::time::Instant;
 
 use anyhow::Result;
 use cudarc::driver::CudaSlice;
@@ -96,6 +98,12 @@ impl WeightPrefetch {
     pub fn spawn(shard_paths: &[String]) -> Self {
         const CHUNK: u64 = 16 << 20;
         const THREADS: usize = 8;
+        /// Below this the prefetch cannot outrun the load path it shares the
+        /// device with, so warming stops being a head start and is only
+        /// contention.
+        const FLOOR_BYTES_PER_SEC: f64 = 1e9;
+        /// Read enough that the rate is the device's and not thread start-up.
+        const PROBE_BYTES: u64 = 512 << 20;
 
         let stats = Arc::new(PrefetchStats::default());
         let mut files: Vec<(Arc<fs::File>, u64, String)> = Vec::new();
@@ -129,10 +137,13 @@ impl WeightPrefetch {
             let files = Arc::new(files);
             let chunks = Arc::new(chunks);
             let next = Arc::new(AtomicUsize::new(0));
+            let read_bytes = Arc::new(AtomicU64::new(0));
+            let started = Instant::now();
             for _ in 0..threads {
                 let worker = {
                     let (files, chunks, next) = (files.clone(), chunks.clone(), next.clone());
                     let (cancel, stats) = (cancel.clone(), stats.clone());
+                    let read_bytes = read_bytes.clone();
                     std::thread::Builder::new()
                         .name("weight-prefetch".into())
                         .spawn(move || {
@@ -144,9 +155,28 @@ impl WeightPrefetch {
                                 };
                                 let (file, len, path) = &files[file_idx];
                                 let want = CHUNK.min(len - off) as usize;
-                                if let Err(err) = file.read_exact_at(&mut buf[..want], off) {
-                                    stats.read_errors.fetch_add(1, Ordering::Relaxed);
-                                    stats.record_first_error(|| format!("{path}@{off}: {err}"));
+                                match file.read_exact_at(&mut buf[..want], off) {
+                                    Ok(()) => {
+                                        let read = want as u64;
+                                        let done =
+                                            read_bytes.fetch_add(read, Ordering::Relaxed) + read;
+                                        if done >= PROBE_BYTES && done - read < PROBE_BYTES {
+                                            let rate =
+                                                done as f64 / started.elapsed().as_secs_f64();
+                                            if rate < FLOOR_BYTES_PER_SEC {
+                                                cancel.store(true, Ordering::Relaxed);
+                                                info!(
+                                                    "Weight prefetch standing down: source reads at {:.2} GB/s, leaving the device to the load path",
+                                                    rate / 1e9
+                                                );
+                                            }
+                                        }
+                                    }
+                                    Err(err) => {
+                                        stats.read_errors.fetch_add(1, Ordering::Relaxed);
+                                        stats
+                                            .record_first_error(|| format!("{path}@{off}: {err}"));
+                                    }
                                 }
                             }
                         })

--- a/pegainfer-core/src/weight_loader.rs
+++ b/pegainfer-core/src/weight_loader.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs;
 use std::os::unix::fs::FileExt;
+use std::os::unix::io::AsRawFd;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
@@ -94,13 +95,33 @@ impl PrefetchStats {
     }
 }
 
+/// `RWF_NOWAIT` fails with `EAGAIN` for a page the kernel would have to fetch.
+/// One page stands for the chunk, and any error counts as a miss.
+fn chunk_looks_resident(file: &fs::File, off: u64) -> bool {
+    let mut page = [0u8; 4096];
+    let iov = libc::iovec {
+        iov_base: page.as_mut_ptr().cast(),
+        iov_len: page.len(),
+    };
+    // SAFETY: `iov` describes `page.len()` writable bytes that outlive the call.
+    let got = unsafe {
+        libc::preadv2(
+            file.as_raw_fd(),
+            &raw const iov,
+            1,
+            off as libc::off_t,
+            libc::RWF_NOWAIT,
+        )
+    };
+    got > 0
+}
+
 impl WeightPrefetch {
     pub fn spawn(shard_paths: &[String]) -> Self {
         const CHUNK: u64 = 16 << 20;
         const THREADS: usize = 8;
         /// Below this the prefetch cannot outrun the load path it shares the
-        /// device with, so warming stops being a head start and is only
-        /// contention.
+        /// device with, and only contends with it.
         const FLOOR_BYTES_PER_SEC: f64 = 1e9;
         /// Read enough that the rate is the device's and not thread start-up.
         const PROBE_BYTES: u64 = 512 << 20;
@@ -147,14 +168,21 @@ impl WeightPrefetch {
                     std::thread::Builder::new()
                         .name("weight-prefetch".into())
                         .spawn(move || {
-                            let mut buf = vec![0u8; CHUNK as usize];
+                            // A resident checkpoint reads no chunk at all.
+                            let mut buf = Vec::new();
                             while !cancel.load(Ordering::Relaxed) {
                                 let i = next.fetch_add(1, Ordering::Relaxed);
                                 let Some(&(file_idx, off)) = chunks.get(i) else {
                                     break;
                                 };
                                 let (file, len, path) = &files[file_idx];
+                                if chunk_looks_resident(file, off) {
+                                    continue;
+                                }
                                 let want = CHUNK.min(len - off) as usize;
+                                if buf.is_empty() {
+                                    buf = vec![0u8; CHUNK as usize];
+                                }
                                 match file.read_exact_at(&mut buf[..want], off) {
                                     Ok(()) => {
                                         let read = want as u64;


### PR DESCRIPTION

## Description

Closes #950

The prefetch this tunes is #731, which reads the whole checkpoint into the page cache on eight threads. It and the load path read the same file from the same device. When the source is fast the prefetch gets far enough ahead that the load path lands in warm cache; when it is slow the two only contend, and a checkpoint larger than the page cache loses its early pages before the load path arrives. The prefetch workers already know the device rate, because their own read rate is it, so after 512 MiB one worker compares that rate against a floor and cancels the prefetch if it is under. Nothing else changes, and there is no new knob.

The floor is 1 GB/s, sitting between the two measured sources with roughly a factor of three on either side. The probe is large enough that the rate is the device's rather than thread start-up: at 0.32 GB/s the decision lands 1.6 s into a load that runs for minutes, and at SSD speed it lands in a tenth of a second.

The same guard already exists on another axis: the qwen3 and qwen3.5 call sites only spawn the prefetch when the tensor-parallel world size is one, because several ranks warming the same file compete rather than help. The floor adds the source-speed axis to that idea, in the one place both already share.

A resident checkpoint is the second case. `RWF_NOWAIT` makes the kernel answer whether a page is in cache without ever fetching it, so each worker asks before reading and skips what is already there. This is a residency question rather than a rate threshold, which matters because the two regimes it has to separate, a cold SSD at 3.4 GB/s and a resident file at 8.2 GB/s, are only a factor of two apart on this box and would not stay apart on a faster one. Per chunk rather than once up front, so a partly resident checkpoint still gets its missing part warmed.

### Test Env

- Single GPU (sm_89, x86_64), CUDA 12.9, Gemma 4 12B checkpoint, 22.18 GiB, held on two devices.

### Verification

- `cargo fmt --check`, `clippy -p pegainfer-core --all-targets -- -D warnings`, `clippy -p pegainfer-gemma4 --features gemma4 --all-targets -- -D warnings` and `clippy -p pegainfer-qwen3 --all-targets -- -D warnings` all clean. Unit tests green for the three crates: core 33 passed, gemma4 33 passed with 23 ignored, qwen3 86 passed.
- Cold load, page cache dropped per run with `posix_fadvise(DONTNEED)`, timings from the loader's own phase report:

| source | prefetch on | prefetch off | this change |
|---|---|---|---|
| SSD | 4867 / 4873 / 4884 ms | 6263 / 6264 / 6266 ms | 4874 / 4877 / 4877 ms |
| array | 162.7 / 165.4 / 166.8 s | 136.3 / 149.3 s | 135.3 / 134.3 s |

- The change reproduces the better arm on each device without being told which one it is on: unchanged on the SSD, and a 19% cut on the array.
- Warm load, the checkpoint read into the page cache first, both arms from the same binary in the same minute: with the residency skip 1615 / 1602 / 1610 ms against 1590 / 1604 / 1566 ms for never spawning the prefetch at all, a 1.4% gap that sits inside the run-to-run spread. Before the skip the same warm load cost 1693 / 1702 / 1726 ms.
- Cold on the SSD, same binary, both arms: 4917 / 4903 ms with the prefetch against 6399 / 6394 ms without, so the 23% it is worth there survives the added probe.
- `WeightPrefetch` has four call sites across three model lines (qwen3 twice, qwen3.5, Gemma 4), so this reaches all of them. The A/B above is Gemma 4; the other two share the same loader and the same device, and their loads move the same way for the same reason, but they were not measured here.
