### PR TITLE
fix(metrics): stamp spec-decode counters on the stepped bridge

### DIFF
--- a/docs/subsystems/frontend/sim-step-contract.md
+++ b/docs/subsystems/frontend/sim-step-contract.md
@@ -52,6 +52,3 @@
   - Metrics e2e used `EngineHandle::with_metrics_watches` to inject snapshots. Stepped has no watch; injecting would have been a second fake contract. Replaced with occupancy the scheduler actually reports.
 - **Lessons learned**:
   - The Cargo dep was already there; "切到 frontend" here means the step contract, not adding a crate edge.
-  - Stepped `scheduler_stats_from` still drops `spec_decode`. That is a frontend gap (qwen3 already publishes counters). Do not fake it in sim.
-- **Follow-ups**:
-  - Stamp `spec_decode` on the stepped bridge when a line that actually drafts is ready to prove it.

--- a/pegainfer-frontend/src/vllm/bridge.rs
+++ b/pegainfer-frontend/src/vllm/bridge.rs
@@ -624,6 +624,30 @@ fn spec_decode_delta(last: &SpecDecodeCounters, cur: &SpecDecodeCounters) -> Spe
     }
 }
 
+#[derive(Default)]
+pub(crate) struct SpecDecodeTracker {
+    last: SpecDecodeCounters,
+}
+
+impl SpecDecodeTracker {
+    /// The delta to stamp on the next outgoing batch, or `None` when nothing
+    /// drafted. Advances the baseline, so a caller that declines to send after
+    /// calling this drops only a no-op interval.
+    pub(crate) fn interval(&mut self, snapshot: &SchedulerMetrics) -> Option<SpecDecodingStats> {
+        let Some(cur) = &snapshot.spec_decode else {
+            // Reset so a drafter loaded later diffs from zero.
+            self.last = SpecDecodeCounters::default();
+            return None;
+        };
+        let delta = spec_decode_delta(&self.last, cur);
+        self.last = *cur;
+        // A zero-draft interval would divide by zero in the frontend's
+        // acceptance-rate log, and every counter moves only inside
+        // `observe_draft`, so dropping it loses nothing.
+        (delta.num_drafts > 0).then_some(delta)
+    }
+}
+
 /// Forward every scheduler load snapshot as a stats-only output batch; the
 /// frontend records it into the shared Prometheus registry. Sends the current
 /// snapshot up front so the gauges initialize before the first step, then one
@@ -636,23 +660,11 @@ async fn publish_scheduler_stats(
     output_tx: mpsc::UnboundedSender<EngineCoreOutputs>,
     shutdown: CancellationToken,
 ) -> Result<()> {
-    let mut last_spec = SpecDecodeCounters::default();
+    let mut spec = SpecDecodeTracker::default();
     loop {
         let snapshot = *load_rx.borrow_and_update();
-        let spec_decoding_stats = if let Some(cur) = &snapshot.spec_decode {
-            let delta = spec_decode_delta(&last_spec, cur);
-            last_spec = *cur;
-            // A zero-draft interval would divide by zero in the frontend's
-            // acceptance-rate log, and every counter moves only inside
-            // `observe_draft`, so dropping it loses nothing.
-            (delta.num_drafts > 0).then_some(delta)
-        } else {
-            // Reset so a drafter loaded later diffs from zero
-            last_spec = SpecDecodeCounters::default();
-            None
-        };
         let mut stats = scheduler_stats_from(&snapshot);
-        stats.spec_decoding_stats = spec_decoding_stats;
+        stats.spec_decoding_stats = spec.interval(&snapshot);
         let outputs = RequestBatchOutputs {
             engine_index,
             scheduler_stats: Some(Box::new(stats)),

--- a/pegainfer-frontend/src/vllm/bridge/stepped.rs
+++ b/pegainfer-frontend/src/vllm/bridge/stepped.rs
@@ -32,11 +32,13 @@ use vllm_engine_core_client::protocol::output::StopReason;
 use vllm_engine_core_client::protocol::request::EngineCoreRequest;
 use vllm_engine_core_client::protocol::request::EngineCoreRequestType;
 use vllm_engine_core_client::protocol::stats::PrefillStats;
+use vllm_engine_core_client::protocol::stats::SchedulerStats;
 use vllm_engine_core_client::protocol::utility::UtilityCallId;
 use zeromq::ZmqMessage;
 use zeromq::prelude::SocketRecv;
 
 use super::BridgeLink;
+use super::SpecDecodeTracker;
 use super::connect_link;
 use super::engine_output;
 use super::now_secs_f64;
@@ -76,6 +78,7 @@ impl SteppedEngineBridge {
             .scheduler
             .take_steps()
             .context("partition step stream already taken")?;
+        let mut spec = SpecDecodeTracker::default();
         // Stats are pull-at-send: no push task, the load cell is read when a
         // batch goes out (and once here, so the frontend's gauges initialize
         // before any traffic). An idle engine publishes nothing.
@@ -98,7 +101,7 @@ impl SteppedEngineBridge {
             &output_tx,
             RequestBatchOutputs {
                 engine_index: self.engine_index,
-                scheduler_stats: Some(Box::new(scheduler_stats_from(&self.scheduler.metrics()))),
+                scheduler_stats: Some(Box::new(self.stats(&mut spec))),
                 timestamp: now_secs_f64(),
                 ..Default::default()
             }
@@ -141,6 +144,7 @@ impl SteppedEngineBridge {
                         &anchor,
                         &mut streams,
                         &mut names,
+                        &mut spec,
                         &output_tx,
                     ) {
                         break Err(error).context("failed to dispatch local engine step");
@@ -176,12 +180,22 @@ impl SteppedEngineBridge {
         run_result
     }
 
+    /// Stats for an outgoing batch; the spec delta runs from the last batch
+    /// stamped, not the last step run.
+    fn stats(&self, spec: &mut SpecDecodeTracker) -> SchedulerStats {
+        let snapshot = self.scheduler.metrics();
+        let mut stats = scheduler_stats_from(&snapshot);
+        stats.spec_decoding_stats = spec.interval(&snapshot);
+        stats
+    }
+
     fn dispatch_step(
         &self,
         step: StepOutputs,
         anchor: &UnixAnchor,
         streams: &mut HashMap<RequestId, SteppedStream>,
         names: &mut HashMap<String, RequestId>,
+        spec: &mut SpecDecodeTracker,
         output_tx: &tokio::sync::mpsc::UnboundedSender<
             vllm_engine_core_client::protocol::output::EngineCoreOutputs,
         >,
@@ -209,6 +223,21 @@ impl SteppedEngineBridge {
         }
 
         if outputs.is_empty() {
+            // A drafted step with no batch to ride would strand its increment
+            // until the next batch, which may never come.
+            let stats = self.stats(spec);
+            if stats.spec_decoding_stats.is_some() {
+                send_outputs(
+                    output_tx,
+                    RequestBatchOutputs {
+                        engine_index: self.engine_index,
+                        scheduler_stats: Some(Box::new(stats)),
+                        timestamp: now_secs_f64(),
+                        ..Default::default()
+                    }
+                    .into(),
+                )?;
+            }
             return Ok(());
         }
         // The cell already holds this step's snapshot (the driver publishes
@@ -221,7 +250,7 @@ impl SteppedEngineBridge {
                 engine_index: self.engine_index,
                 outputs,
                 finished_requests: (!finished_requests.is_empty()).then_some(finished_requests),
-                scheduler_stats: Some(Box::new(scheduler_stats_from(&self.scheduler.metrics()))),
+                scheduler_stats: Some(Box::new(self.stats(spec))),
                 timestamp: now_secs_f64(),
             }
             .into(),

--- a/pegainfer-sim/src/lib.rs
+++ b/pegainfer-sim/src/lib.rs
@@ -12,6 +12,7 @@ use pegainfer_frontend::engine::RequestId;
 use pegainfer_frontend::engine::RequestLedger;
 use pegainfer_frontend::engine::Scheduler;
 use pegainfer_frontend::engine::SchedulerMetrics;
+use pegainfer_frontend::engine::SpecDecodeCounters;
 use pegainfer_frontend::engine::TokenLogprob;
 use pegainfer_frontend::engine::spawn_scheduler;
 
@@ -29,6 +30,8 @@ pub struct SimulatedEngineConfig {
     /// Explicit completion token-id sequence to replay verbatim. Empty (the
     /// default) keeps the legacy behaviour of cycling the prompt tokens.
     scripted_completion: Vec<u32>,
+    /// A pretend drafter: `(K, accepted per verify step)`; `None` is no drafter.
+    spec_decode: Option<(usize, usize)>,
 }
 
 impl SimulatedEngineConfig {
@@ -57,7 +60,25 @@ impl SimulatedEngineConfig {
             tpot_ms,
             fallback_token_id,
             scripted_completion: Vec::new(),
+            spec_decode: None,
         })
+    }
+
+    /// Make every decode step a verify step, so the metrics path has a drafter
+    /// without a GPU or a checkpoint. Panics on a `K` past `MAX_SPEC_TOKENS`.
+    #[must_use]
+    pub fn with_speculative_decoding(
+        mut self,
+        num_spec_tokens: usize,
+        num_accepted: usize,
+    ) -> Self {
+        assert!(
+            num_accepted <= num_spec_tokens,
+            "a verify step cannot accept more draft tokens than it proposed"
+        );
+        SpecDecodeCounters::new(num_spec_tokens).expect("K within MAX_SPEC_TOKENS");
+        self.spec_decode = Some((num_spec_tokens, num_accepted));
+        self
     }
 
     /// Replay `ids` verbatim as the completion for every request
@@ -84,6 +105,7 @@ impl Default for SimulatedEngineConfig {
             tpot_ms: 12.0,
             fallback_token_id: 0,
             scripted_completion: Vec::new(),
+            spec_decode: None,
         }
     }
 }
@@ -120,6 +142,7 @@ struct SimScheduler {
     config: SimulatedEngineConfig,
     queued: Vec<QueuedRequest>,
     running: Vec<RunningRequest>,
+    spec_decode: Option<SpecDecodeCounters>,
 }
 
 struct RunningRequest {
@@ -133,10 +156,14 @@ struct RunningRequest {
 
 impl SimScheduler {
     fn new(config: SimulatedEngineConfig) -> Self {
+        let spec_decode = config
+            .spec_decode
+            .map(|(k, _)| SpecDecodeCounters::new(k).expect("K checked at config time"));
         Self {
             config,
             queued: Vec::new(),
             running: Vec::new(),
+            spec_decode,
         }
     }
 
@@ -212,6 +239,12 @@ impl Scheduler for SimScheduler {
                 Some(lp) => vec![Some(lp)],
                 None => Vec::new(),
             };
+            // Every decode step of a drafted engine is one verify step.
+            if let (Some(counters), Some((k, accepted))) =
+                (self.spec_decode.as_mut(), self.config.spec_decode)
+            {
+                counters.observe_draft(k, accepted);
+            }
             ledger.push_tokens(running.id, &[token], &logprobs);
             if running.pending.is_empty() {
                 ledger.finish(running.id, running.finish_reason);
@@ -229,6 +262,7 @@ impl Scheduler for SimScheduler {
         SchedulerMetrics {
             num_running_reqs: self.running.len() as u64,
             num_waiting_reqs: self.queued.len() as u64,
+            spec_decode: self.spec_decode,
             ..SchedulerMetrics::default()
         }
     }

--- a/pegainfer-sim/tests/frontend_e2e.rs
+++ b/pegainfer-sim/tests/frontend_e2e.rs
@@ -20,6 +20,11 @@ const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 const MODEL_NAME: &str = "pegainfer-sim-e2e";
 const METRICS_MODEL_NAME: &str = "pegainfer-sim-e2e-metrics";
 const SLOW_METRICS_MODEL_NAME: &str = "pegainfer-sim-e2e-slow-metrics";
+const SPEC_METRICS_MODEL_NAME: &str = "pegainfer-sim-e2e-spec-metrics";
+/// The pretend drafter the spec-metrics server runs: `K` and how many of those
+/// draft tokens each verify step accepts.
+const SPEC_K: usize = 3;
+const SPEC_ACCEPTED: usize = 2;
 const SERVER_START_ATTEMPTS: usize = 5;
 
 struct SimServer {
@@ -41,6 +46,19 @@ impl SimServer {
             2,
             METRICS_MODEL_NAME,
             SimulatedEngineConfig::new(0.0, 1000.0, 0.0, 1)?,
+        )
+        .await
+    }
+
+    /// A single engine whose every decode step is a verify step, so the
+    /// stepped bridge has spec-decode counters to stamp onto its batches.
+    async fn spawn_with_drafter() -> Result<Self> {
+        Self::spawn_with_config(
+            model_dir_with_minimal_metadata()?,
+            1,
+            SPEC_METRICS_MODEL_NAME,
+            SimulatedEngineConfig::new(0.0, 1000.0, 0.0, 1)?
+                .with_speculative_decoding(SPEC_K, SPEC_ACCEPTED),
         )
         .await
     }
@@ -226,6 +244,104 @@ async fn one_http_endpoint_exports_per_engine_scheduler_metrics() -> Result<()> 
         &server.model_name,
     )
     .await?;
+
+    server.shutdown().await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stepped_bridge_reports_spec_decode_counters_to_prometheus() -> Result<()> {
+    // One verify step per decode step, so the totals are the drafter's shape
+    // times the tokens generated: 4 drafts, 4 x 3 = 12 proposed, 4 x 2 = 8
+    // accepted, and positions 0 and 1 credited every step.
+    const SPEC_MAX_TOKENS: usize = 4;
+
+    let server = SimServer::spawn_with_drafter().await?;
+    let client = test_client()?;
+
+    let body = json!({
+        "model": server.model_name,
+        "prompt": [1, 2],
+        "max_tokens": SPEC_MAX_TOKENS,
+        "temperature": 0.0,
+        "ignore_eos": true,
+    });
+    client
+        .post(format!("{}/v1/completions", server.base_url))
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(body.to_string())
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let drafts = SPEC_MAX_TOKENS as f64;
+    // `_total` is appended at exposition; the registered name scrapes empty.
+    wait_for_metrics(
+        &client,
+        &server.base_url,
+        &[
+            ("vllm:spec_decode_num_drafts_total", "0", drafts),
+            (
+                "vllm:spec_decode_num_draft_tokens_total",
+                "0",
+                drafts * SPEC_K as f64,
+            ),
+            (
+                "vllm:spec_decode_num_accepted_tokens_total",
+                "0",
+                drafts * SPEC_ACCEPTED as f64,
+            ),
+        ],
+        &server.model_name,
+    )
+    .await?;
+
+    wait_for_labeled_metrics(
+        &client,
+        &server.base_url,
+        &[
+            (
+                "vllm:spec_decode_num_accepted_tokens_per_pos_total",
+                "0",
+                &[("position", "0")][..],
+                drafts,
+            ),
+            (
+                "vllm:spec_decode_num_accepted_tokens_per_pos_total",
+                "0",
+                &[("position", "1")][..],
+                drafts,
+            ),
+            (
+                "vllm:spec_decode_num_accepted_tokens_per_pos_total",
+                "0",
+                &[("position", "2")][..],
+                0.0,
+            ),
+        ],
+        &server.model_name,
+    )
+    .await?;
+
+    // Exposition is one series per draft slot the drafter has, so the fixed
+    // `MAX_SPEC_TOKENS` array width must not leak past `K`.
+    let metrics = client
+        .get(format!("{}/metrics", server.base_url))
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+    let leaked: Vec<_> = metrics
+        .lines()
+        .filter(|line| {
+            line.contains(&format!("model_name=\"{}\"", server.model_name))
+                && line.contains(&format!("position=\"{SPEC_K}\""))
+        })
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "per-position series past K={SPEC_K} were exposed: {leaked:?}"
+    );
 
     server.shutdown().await
 }


### PR DESCRIPTION
Issue #896 

## Type of Change

Bug fix (non-breaking change which fixes an issue)

## what's new

- Extract `SpecDecodeTracker::interval`: one cumulative-to-per-interval converter shared by both bridges to report SD status update. 
- Stamp `spec_decoding_stats` on the `SteppedEngineBridge`
- Add an opt-in pretend drafter to (`with_speculative_decoding(K, accepted)`) `pegainfer-sim` 
- New e2e `stepped_bridge_reports_spec_decode_counters_to_prometheus` test 
- remove spec-decode counters bug on document

## correctness check

green CI

E2E:
- model qwen3 4b+dflash
- Dataset/Protocol: ShareGPT 20 prompts、c4、--temperature 0 --ignore-eos、seed 0 via vllm bench.

The correctness check is our vllm frontend is wired to vllm bench:

```shell
vllm bench
Drafts:              1040
Draft tokens:        7023
Accepted tokens:     1500
Per-position acceptance (%):
  Position 0:  65.19    Position 4:   5.87
  Position 1:  36.83    Position 5:   3.27
  Position 2:  20.67    Position 6:   1.73
  Position 3:  10.67
```






## Checklist

- [ ] My code follows the style guidelines of this project (see `docs/conventions/coding-style.md`).
- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my commits according to Commitizen conventions.
- [ ] I have run the local test suite and all tests pass (see `CLAUDE.md`).
