### PR TITLE
feat(observability): report real prefix-cache query/hit counters in /metrics

### DIFF
--- a/pegainfer-frontend/src/engine/metrics.rs
+++ b/pegainfer-frontend/src/engine/metrics.rs
@@ -29,8 +29,11 @@ pub struct SchedulerMetrics {
     /// Cumulative prefix-cache queries (one per request that reached its first
     /// prefill chunk). Monotonic; mapped to vLLM `PrefixCacheStats.queries`.
     pub prefix_cache_queries: u64,
-    /// Cumulative prefix-cache hits, in tokens. Monotonic; mapped to vLLM
-    /// `PrefixCacheStats.hits`.
+    /// Cumulative prefix-cache hits, token-granularity (the total number of
+    /// queried prompt tokens already cached). Same unit as
+    /// `prefix_cache_queries`, so `hit_rate = hits/queries` stays in [0, 1].
+    /// Monotonic; mapped to vLLM `PrefixCacheStats.hits` as a per-send delta
+    /// (see `scheduler_stats_from`), never as the running total.
     pub prefix_cache_hits: u64,
 }
 

--- a/pegainfer-frontend/src/engine/metrics.rs
+++ b/pegainfer-frontend/src/engine/metrics.rs
@@ -26,6 +26,12 @@ pub struct SchedulerMetrics {
     pub num_waiting_reqs: u64,
     /// Cumulative spec-decode counters, or `None` when no draft model is loaded.
     pub spec_decode: Option<SpecDecodeCounters>,
+    /// Cumulative prefix-cache queries (one per request that reached its first
+    /// prefill chunk). Monotonic; mapped to vLLM `PrefixCacheStats.queries`.
+    pub prefix_cache_queries: u64,
+    /// Cumulative prefix-cache hits, in tokens. Monotonic; mapped to vLLM
+    /// `PrefixCacheStats.hits`.
+    pub prefix_cache_hits: u64,
 }
 
 /// Upper bound on a drafter's `K`, fixing the width of

--- a/pegainfer-frontend/src/engine/metrics.rs
+++ b/pegainfer-frontend/src/engine/metrics.rs
@@ -26,15 +26,26 @@ pub struct SchedulerMetrics {
     pub num_waiting_reqs: u64,
     /// Cumulative spec-decode counters, or `None` when no draft model is loaded.
     pub spec_decode: Option<SpecDecodeCounters>,
-    /// Cumulative prefix-cache queries (one per request that reached its first
-    /// prefill chunk). Monotonic; mapped to vLLM `PrefixCacheStats.queries`.
+    /// Cumulative prefix-cache queries, in tokens: how many prompt tokens were
+    /// looked up. Monotonic; mapped to vLLM `PrefixCacheStats.queries`.
     pub prefix_cache_queries: u64,
-    /// Cumulative prefix-cache hits, token-granularity (the total number of
-    /// queried prompt tokens already cached). Same unit as
-    /// `prefix_cache_queries`, so `hit_rate = hits/queries` stays in [0, 1].
-    /// Monotonic; mapped to vLLM `PrefixCacheStats.hits` as a per-send delta
-    /// (see `scheduler_stats_from`), never as the running total.
+    /// Cumulative prefix-cache hits, in tokens: how many of the queried tokens
+    /// were already cached locally. Same unit as `prefix_cache_queries`, so
+    /// `hit_rate = hits/queries` stays in [0, 1].
     pub prefix_cache_hits: u64,
+    /// Cumulative queries against the external/connector side (CPU-offload and
+    /// P2P restore), in tokens. These are looked up alongside the local cache,
+    /// so the count tracks `prefix_cache_queries`.
+    pub prefix_cache_external_queries: u64,
+    /// Cumulative hits served from the external/connector side rather than from
+    /// local KV, in tokens. Mapped to
+    /// `vllm:external_prefix_cache_queries/hits` via
+    /// `SchedulerStats.connector_prefix_cache_stats`.
+    ///
+    /// Note for both pairs: these are running totals because the load cell only
+    /// ever exposes the latest snapshot. The wire carries per-send deltas —
+    /// see [`PrefixCacheTracker`](crate::vllm::bridge::PrefixCacheTracker).
+    pub prefix_cache_external_hits: u64,
 }
 
 /// Upper bound on a drafter's `K`, fixing the width of

--- a/pegainfer-frontend/src/vllm/bridge.rs
+++ b/pegainfer-frontend/src/vllm/bridge.rs
@@ -37,7 +37,6 @@ use vllm_engine_core_client::protocol::request::EngineCoreRequest;
 use vllm_engine_core_client::protocol::request::EngineCoreRequestType;
 use vllm_engine_core_client::protocol::stats::BaseCacheStats;
 use vllm_engine_core_client::protocol::stats::PrefillStats;
-use vllm_engine_core_client::protocol::stats::PrefixCacheStats;
 use vllm_engine_core_client::protocol::stats::SchedulerStats;
 use vllm_engine_core_client::protocol::stats::SpecDecodingStats;
 use vllm_engine_core_client::protocol::utility::UtilityCallId;
@@ -591,6 +590,14 @@ fn stop_sentinel_id(eos_token_id: Option<u32>, stop_token_ids: &[u32]) -> Option
 /// vLLM `SchedulerStats` view of a load snapshot — what the frontend's
 /// Prometheus gauges (`scheduler_running`, `scheduler_waiting`,
 /// `kv_cache_usage`) and DP load balancer consume.
+///
+/// `prefix_cache_stats` is left at zero here on purpose: the running totals in
+/// `SchedulerMetrics` must NOT be shipped as-is, because the frontend's
+/// Prometheus logger increments its `prefix_cache_*_total` counters by the
+/// value of *every* `SchedulerStats` it receives. The bridge therefore exports
+/// per-send **deltas** (see [`PrefixCacheTracker`]) so a cached request does
+/// not re-add the whole history on each subsequent token batch. Callers fill
+/// `prefix_cache_stats` from [`PrefixCacheTracker::interval`] after this call.
 pub(crate) fn scheduler_stats_from(snapshot: &SchedulerMetrics) -> SchedulerStats {
     SchedulerStats {
         num_running_reqs: snapshot.num_running_reqs,
@@ -600,15 +607,37 @@ pub(crate) fn scheduler_stats_from(snapshot: &SchedulerMetrics) -> SchedulerStat
         } else {
             snapshot.kv_used_blocks as f64 / snapshot.kv_total_blocks as f64
         },
-        prefix_cache_stats: PrefixCacheStats {
-            base: BaseCacheStats {
-                queries: snapshot.prefix_cache_queries,
-                hits: snapshot.prefix_cache_hits,
-                ..BaseCacheStats::default()
-            },
-            ..PrefixCacheStats::default()
-        },
         ..SchedulerStats::default()
+    }
+}
+
+/// Prefix-cache counterpart of [`SpecDecodeTracker`]: the scheduler holds
+/// running totals while the wire must carry per-interval deltas, because the
+/// frontend increments its `prefix_cache_*_total` counters by the value of
+/// *every* `SchedulerStats` it receives. Shipping the running total would
+/// re-add the whole history on each subsequent batch, so both bridges convert
+/// through this type and cannot drift.
+#[derive(Default)]
+pub(crate) struct PrefixCacheTracker {
+    last_queries: u64,
+    last_hits: u64,
+}
+
+impl PrefixCacheTracker {
+    /// The delta to stamp on the next outgoing batch. Advances the baseline, so
+    /// a caller that declines to send after calling this drops only a no-op
+    /// interval.
+    pub(crate) fn interval(&mut self, snapshot: &SchedulerMetrics) -> BaseCacheStats {
+        let delta = BaseCacheStats {
+            queries: snapshot
+                .prefix_cache_queries
+                .saturating_sub(self.last_queries),
+            hits: snapshot.prefix_cache_hits.saturating_sub(self.last_hits),
+            ..BaseCacheStats::default()
+        };
+        self.last_queries = snapshot.prefix_cache_queries;
+        self.last_hits = snapshot.prefix_cache_hits;
+        delta
     }
 }
 
@@ -672,9 +701,11 @@ async fn publish_scheduler_stats(
     shutdown: CancellationToken,
 ) -> Result<()> {
     let mut spec = SpecDecodeTracker::default();
+    let mut prefix = PrefixCacheTracker::default();
     loop {
         let snapshot = *load_rx.borrow_and_update();
         let mut stats = scheduler_stats_from(&snapshot);
+        stats.prefix_cache_stats.base = prefix.interval(&snapshot);
         stats.spec_decoding_stats = spec.interval(&snapshot);
         let outputs = RequestBatchOutputs {
             engine_index,

--- a/pegainfer-frontend/src/vllm/bridge.rs
+++ b/pegainfer-frontend/src/vllm/bridge.rs
@@ -35,7 +35,9 @@ use vllm_engine_core_client::protocol::output::StopReason;
 use vllm_engine_core_client::protocol::output::UtilityCallOutput;
 use vllm_engine_core_client::protocol::request::EngineCoreRequest;
 use vllm_engine_core_client::protocol::request::EngineCoreRequestType;
+use vllm_engine_core_client::protocol::stats::BaseCacheStats;
 use vllm_engine_core_client::protocol::stats::PrefillStats;
+use vllm_engine_core_client::protocol::stats::PrefixCacheStats;
 use vllm_engine_core_client::protocol::stats::SchedulerStats;
 use vllm_engine_core_client::protocol::stats::SpecDecodingStats;
 use vllm_engine_core_client::protocol::utility::UtilityCallId;
@@ -597,6 +599,14 @@ pub(crate) fn scheduler_stats_from(snapshot: &SchedulerMetrics) -> SchedulerStat
             0.0
         } else {
             snapshot.kv_used_blocks as f64 / snapshot.kv_total_blocks as f64
+        },
+        prefix_cache_stats: PrefixCacheStats {
+            base: BaseCacheStats {
+                queries: snapshot.prefix_cache_queries,
+                hits: snapshot.prefix_cache_hits,
+                ..BaseCacheStats::default()
+            },
+            ..PrefixCacheStats::default()
         },
         ..SchedulerStats::default()
     }

--- a/pegainfer-frontend/src/vllm/bridge.rs
+++ b/pegainfer-frontend/src/vllm/bridge.rs
@@ -37,6 +37,7 @@ use vllm_engine_core_client::protocol::request::EngineCoreRequest;
 use vllm_engine_core_client::protocol::request::EngineCoreRequestType;
 use vllm_engine_core_client::protocol::stats::BaseCacheStats;
 use vllm_engine_core_client::protocol::stats::PrefillStats;
+use vllm_engine_core_client::protocol::stats::PrefixCacheStats;
 use vllm_engine_core_client::protocol::stats::SchedulerStats;
 use vllm_engine_core_client::protocol::stats::SpecDecodingStats;
 use vllm_engine_core_client::protocol::utility::UtilityCallId;
@@ -621,12 +622,14 @@ pub(crate) fn scheduler_stats_from(snapshot: &SchedulerMetrics) -> SchedulerStat
 pub(crate) struct PrefixCacheTracker {
     last_queries: u64,
     last_hits: u64,
+    last_external_queries: u64,
+    last_external_hits: u64,
 }
 
 impl PrefixCacheTracker {
-    /// The delta to stamp on the next outgoing batch. Advances the baseline, so
-    /// a caller that declines to send after calling this drops only a no-op
-    /// interval.
+    /// The local delta to stamp on the next outgoing batch. Advances the
+    /// baseline, so a caller that declines to send after calling this drops
+    /// only a no-op interval.
     pub(crate) fn interval(&mut self, snapshot: &SchedulerMetrics) -> BaseCacheStats {
         let delta = BaseCacheStats {
             queries: snapshot
@@ -638,6 +641,32 @@ impl PrefixCacheTracker {
         self.last_queries = snapshot.prefix_cache_queries;
         self.last_hits = snapshot.prefix_cache_hits;
         delta
+    }
+
+    /// The same conversion for the external (connector) side — blocks restored
+    /// from CPU offload or over P2P rather than found in local KV. Kept on a
+    /// separate baseline so the two families cannot pollute each other, and
+    /// `None` when nothing was restored: a line with no connector leaves
+    /// `connector_prefix_cache_stats` unset instead of reporting zeros.
+    pub(crate) fn external_interval(
+        &mut self,
+        snapshot: &SchedulerMetrics,
+    ) -> Option<PrefixCacheStats> {
+        let base = BaseCacheStats {
+            queries: snapshot
+                .prefix_cache_external_queries
+                .saturating_sub(self.last_external_queries),
+            hits: snapshot
+                .prefix_cache_external_hits
+                .saturating_sub(self.last_external_hits),
+            ..BaseCacheStats::default()
+        };
+        self.last_external_queries = snapshot.prefix_cache_external_queries;
+        self.last_external_hits = snapshot.prefix_cache_external_hits;
+        (base.queries > 0 || base.hits > 0).then(|| PrefixCacheStats {
+            base,
+            ..PrefixCacheStats::default()
+        })
     }
 }
 
@@ -706,6 +735,7 @@ async fn publish_scheduler_stats(
         let snapshot = *load_rx.borrow_and_update();
         let mut stats = scheduler_stats_from(&snapshot);
         stats.prefix_cache_stats.base = prefix.interval(&snapshot);
+        stats.connector_prefix_cache_stats = prefix.external_interval(&snapshot);
         stats.spec_decoding_stats = spec.interval(&snapshot);
         let outputs = RequestBatchOutputs {
             engine_index,

--- a/pegainfer-frontend/src/vllm/bridge.rs
+++ b/pegainfer-frontend/src/vllm/bridge.rs
@@ -592,13 +592,9 @@ fn stop_sentinel_id(eos_token_id: Option<u32>, stop_token_ids: &[u32]) -> Option
 /// Prometheus gauges (`scheduler_running`, `scheduler_waiting`,
 /// `kv_cache_usage`) and DP load balancer consume.
 ///
-/// `prefix_cache_stats` is left at zero here on purpose: the running totals in
-/// `SchedulerMetrics` must NOT be shipped as-is, because the frontend's
-/// Prometheus logger increments its `prefix_cache_*_total` counters by the
-/// value of *every* `SchedulerStats` it receives. The bridge therefore exports
-/// per-send **deltas** (see [`PrefixCacheTracker`]) so a cached request does
-/// not re-add the whole history on each subsequent token batch. Callers fill
-/// `prefix_cache_stats` from [`PrefixCacheTracker::interval`] after this call.
+/// `prefix_cache_stats` is left at zero here: callers fill it from
+/// [`PrefixCacheTracker::interval`], which owns the totals-to-deltas
+/// conversion and the reason for it.
 pub(crate) fn scheduler_stats_from(snapshot: &SchedulerMetrics) -> SchedulerStats {
     SchedulerStats {
         num_running_reqs: snapshot.num_running_reqs,

--- a/pegainfer-frontend/src/vllm/bridge/stepped.rs
+++ b/pegainfer-frontend/src/vllm/bridge/stepped.rs
@@ -38,6 +38,7 @@ use zeromq::ZmqMessage;
 use zeromq::prelude::SocketRecv;
 
 use super::BridgeLink;
+use super::PrefixCacheTracker;
 use super::SpecDecodeTracker;
 use super::connect_link;
 use super::engine_output;
@@ -79,6 +80,7 @@ impl SteppedEngineBridge {
             .take_steps()
             .context("partition step stream already taken")?;
         let mut spec = SpecDecodeTracker::default();
+        let mut prefix = PrefixCacheTracker::default();
         // Stats are pull-at-send: no push task, the load cell is read when a
         // batch goes out (and once here, so the frontend's gauges initialize
         // before any traffic). An idle engine publishes nothing.
@@ -97,11 +99,14 @@ impl SteppedEngineBridge {
             &shutdown,
         )
         .await?;
+        // Seed the gauges before any traffic. Ship the delta since last send
+        // (zero here, the first interval) so the frontend's *_total counters
+        // accumulate deltas, never the running total.
         send_outputs(
             &output_tx,
             RequestBatchOutputs {
                 engine_index: self.engine_index,
-                scheduler_stats: Some(Box::new(self.stats(&mut spec))),
+                scheduler_stats: Some(Box::new(self.stats(&mut prefix, &mut spec))),
                 timestamp: now_secs_f64(),
                 ..Default::default()
             }
@@ -144,6 +149,7 @@ impl SteppedEngineBridge {
                         &anchor,
                         &mut streams,
                         &mut names,
+                        &mut prefix,
                         &mut spec,
                         &output_tx,
                     ) {
@@ -182,9 +188,14 @@ impl SteppedEngineBridge {
 
     /// Stats for an outgoing batch; the spec delta runs from the last batch
     /// stamped, not the last step run.
-    fn stats(&self, spec: &mut SpecDecodeTracker) -> SchedulerStats {
+    fn stats(
+        &self,
+        prefix: &mut PrefixCacheTracker,
+        spec: &mut SpecDecodeTracker,
+    ) -> SchedulerStats {
         let snapshot = self.scheduler.metrics();
         let mut stats = scheduler_stats_from(&snapshot);
+        stats.prefix_cache_stats.base = prefix.interval(&snapshot);
         stats.spec_decoding_stats = spec.interval(&snapshot);
         stats
     }
@@ -195,6 +206,7 @@ impl SteppedEngineBridge {
         anchor: &UnixAnchor,
         streams: &mut HashMap<RequestId, SteppedStream>,
         names: &mut HashMap<String, RequestId>,
+        prefix: &mut PrefixCacheTracker,
         spec: &mut SpecDecodeTracker,
         output_tx: &tokio::sync::mpsc::UnboundedSender<
             vllm_engine_core_client::protocol::output::EngineCoreOutputs,
@@ -224,9 +236,16 @@ impl SteppedEngineBridge {
 
         if outputs.is_empty() {
             // A drafted step with no batch to ride would strand its increment
-            // until the next batch, which may never come.
-            let stats = self.stats(spec);
-            if stats.spec_decoding_stats.is_some() {
+            // until the next batch, which may never come. A prefix-cache delta
+            // is stranded the same way, so ship on either one: `stats()` has
+            // already advanced both trackers, and anything not sent here is
+            // dropped for good.
+            let stats = self.stats(prefix, spec);
+            let prefix_delta = &stats.prefix_cache_stats.base;
+            if stats.spec_decoding_stats.is_some()
+                || prefix_delta.queries > 0
+                || prefix_delta.hits > 0
+            {
                 send_outputs(
                     output_tx,
                     RequestBatchOutputs {
@@ -244,13 +263,16 @@ impl SteppedEngineBridge {
         // load before committing the step), so the batch carries stats that
         // match its own tokens — a finishing batch reports the drained state
         // and the gauges settle instead of freezing at the last busy value.
+        // Ship only the delta since the last send so the frontend's
+        // `prefix_cache_*_total` counters accumulate increments, not the whole
+        // running total on every batch.
         send_outputs(
             output_tx,
             RequestBatchOutputs {
                 engine_index: self.engine_index,
                 outputs,
                 finished_requests: (!finished_requests.is_empty()).then_some(finished_requests),
-                scheduler_stats: Some(Box::new(self.stats(spec))),
+                scheduler_stats: Some(Box::new(self.stats(prefix, spec))),
                 timestamp: now_secs_f64(),
             }
             .into(),

--- a/pegainfer-frontend/src/vllm/bridge/stepped.rs
+++ b/pegainfer-frontend/src/vllm/bridge/stepped.rs
@@ -196,6 +196,7 @@ impl SteppedEngineBridge {
         let snapshot = self.scheduler.metrics();
         let mut stats = scheduler_stats_from(&snapshot);
         stats.prefix_cache_stats.base = prefix.interval(&snapshot);
+        stats.connector_prefix_cache_stats = prefix.external_interval(&snapshot);
         stats.spec_decoding_stats = spec.interval(&snapshot);
         stats
     }
@@ -245,6 +246,7 @@ impl SteppedEngineBridge {
             if stats.spec_decoding_stats.is_some()
                 || prefix_delta.queries > 0
                 || prefix_delta.hits > 0
+                || stats.connector_prefix_cache_stats.is_some()
             {
                 send_outputs(
                     output_tx,

--- a/pegainfer-frontend/src/vllm/bridge/stepped.rs
+++ b/pegainfer-frontend/src/vllm/bridge/stepped.rs
@@ -99,9 +99,8 @@ impl SteppedEngineBridge {
             &shutdown,
         )
         .await?;
-        // Seed the gauges before any traffic. Ship the delta since last send
-        // (zero here, the first interval) so the frontend's *_total counters
-        // accumulate deltas, never the running total.
+        // Seed the gauges before any traffic; `PrefixCacheTracker` owns the
+        // totals-to-deltas conversion they must go through.
         send_outputs(
             &output_tx,
             RequestBatchOutputs {
@@ -265,9 +264,6 @@ impl SteppedEngineBridge {
         // load before committing the step), so the batch carries stats that
         // match its own tokens — a finishing batch reports the drained state
         // and the gauges settle instead of freezing at the last busy value.
-        // Ship only the delta since the last send so the frontend's
-        // `prefix_cache_*_total` counters accumulate increments, not the whole
-        // running total on every batch.
         send_outputs(
             output_tx,
             RequestBatchOutputs {

--- a/pegainfer-frontend/src/vllm/bridge/tests.rs
+++ b/pegainfer-frontend/src/vllm/bridge/tests.rs
@@ -570,6 +570,8 @@ async fn load_snapshots_become_stats_only_batches() {
         num_running_reqs: 2,
         num_waiting_reqs: 1,
         spec_decode: None,
+        prefix_cache_queries: 0,
+        prefix_cache_hits: 0,
     });
     let (output_tx, mut output_rx) = mpsc::unbounded_channel();
     let shutdown = CancellationToken::new();

--- a/pegainfer-frontend/src/vllm/bridge/tests.rs
+++ b/pegainfer-frontend/src/vllm/bridge/tests.rs
@@ -681,3 +681,59 @@ async fn spec_stats_are_per_interval_deltas_that_skip_idle_intervals() {
         .expect("stats task exits on shutdown")
         .expect("stats publisher shuts down cleanly");
 }
+
+/// The scheduler holds running prefix-cache totals; the bridge must ship
+/// per-send DELTAS (like spec-decode), never the running total. Otherwise the
+/// frontend's `prefix_cache_*_total` counters re-add the whole history on every
+/// token batch and overcount until restart. Regression test for the P2 review
+/// on the prefix-cache counters.
+#[tokio::test]
+async fn prefix_cache_stats_are_per_interval_deltas_not_running_totals() {
+    let (load_tx, load_rx) = tokio::sync::watch::channel(SchedulerMetrics {
+        prefix_cache_queries: 100,
+        prefix_cache_hits: 37,
+        ..SchedulerMetrics::default()
+    });
+    let (output_tx, mut output_rx) = mpsc::unbounded_channel();
+    let shutdown = CancellationToken::new();
+    let task = tokio::spawn(publish_scheduler_stats(
+        0,
+        load_rx,
+        output_tx,
+        shutdown.clone(),
+    ));
+
+    // First publish diffs against zero: carries the whole cumulative.
+    let first = next_scheduler_stats(&mut output_rx).await;
+    let pc = first.prefix_cache_stats.base;
+    assert_eq!(pc.queries, 100, "first interval diffs against zero");
+    assert_eq!(pc.hits, 37);
+
+    // The running total doubles; the sent value must be the DELTA (100, 37),
+    // not the new running total (200, 74). This is the overcount bug.
+    load_tx.send_replace(SchedulerMetrics {
+        prefix_cache_queries: 200,
+        prefix_cache_hits: 74,
+        ..SchedulerMetrics::default()
+    });
+    let second = next_scheduler_stats(&mut output_rx).await;
+    let pc = second.prefix_cache_stats.base;
+    assert_eq!(pc.queries, 100, "second interval ships the delta, not 200");
+    assert_eq!(pc.hits, 37, "second interval ships the delta, not 74");
+
+    // No further change: an idle interval ships a zero delta (not a re-add).
+    load_tx.send_replace(SchedulerMetrics {
+        prefix_cache_queries: 200,
+        prefix_cache_hits: 74,
+        ..SchedulerMetrics::default()
+    });
+    let idle = next_scheduler_stats(&mut output_rx).await;
+    let pc = idle.prefix_cache_stats.base;
+    assert_eq!(pc.queries, 0, "unchanged interval ships a zero delta");
+    assert_eq!(pc.hits, 0);
+
+    shutdown.cancel();
+    task.await
+        .expect("stats task exits on shutdown")
+        .expect("stats publisher shuts down cleanly");
+}

--- a/pegainfer-frontend/src/vllm/bridge/tests.rs
+++ b/pegainfer-frontend/src/vllm/bridge/tests.rs
@@ -572,6 +572,8 @@ async fn load_snapshots_become_stats_only_batches() {
         spec_decode: None,
         prefix_cache_queries: 0,
         prefix_cache_hits: 0,
+        prefix_cache_external_queries: 0,
+        prefix_cache_external_hits: 0,
     });
     let (output_tx, mut output_rx) = mpsc::unbounded_channel();
     let shutdown = CancellationToken::new();

--- a/pegainfer-gemma4/src/engine.rs
+++ b/pegainfer-gemma4/src/engine.rs
@@ -2319,6 +2319,8 @@ impl Scheduler for Gemma4Scheduler {
             // so this line reports zero queries/hits until it is wired up.
             prefix_cache_queries: 0,
             prefix_cache_hits: 0,
+            prefix_cache_external_queries: 0,
+            prefix_cache_external_hits: 0,
         }
     }
 }

--- a/pegainfer-gemma4/src/engine.rs
+++ b/pegainfer-gemma4/src/engine.rs
@@ -2314,6 +2314,11 @@ impl Scheduler for Gemma4Scheduler {
             num_running_reqs: (self.active.len() + walkers + lane_inflight) as u64,
             num_waiting_reqs: self.pending.len() as u64,
             spec_decode: None,
+            // The conversation-tail prefix cache resolves hits through
+            // `send_scheduled`'s `cached_tokens`, not through counters yet,
+            // so this line reports zero queries/hits until it is wired up.
+            prefix_cache_queries: 0,
+            prefix_cache_hits: 0,
         }
     }
 }

--- a/pegainfer-glm52/src/scheduler/load.rs
+++ b/pegainfer-glm52/src/scheduler/load.rs
@@ -37,5 +37,7 @@ pub(super) fn publish_load(
         // their neutral zero.
         prefix_cache_queries: 0,
         prefix_cache_hits: 0,
+        prefix_cache_external_queries: 0,
+        prefix_cache_external_hits: 0,
     });
 }

--- a/pegainfer-glm52/src/scheduler/load.rs
+++ b/pegainfer-glm52/src/scheduler/load.rs
@@ -33,5 +33,9 @@ pub(super) fn publish_load(
         // mid-resolve and never counts a request twice.
         num_waiting_reqs: (pending.len() + resolving) as u64,
         spec_decode: None,
+        // MLA + MoE line without a prefix cache, so the counters stay at
+        // their neutral zero.
+        prefix_cache_queries: 0,
+        prefix_cache_hits: 0,
     });
 }

--- a/pegainfer-qwen3/src/executor.rs
+++ b/pegainfer-qwen3/src/executor.rs
@@ -85,8 +85,12 @@ pub struct PrefillStepItem {
     pub(crate) lora_adapter: Option<String>,
     /// Leading prompt tokens whose KV came from the prefix cache.
     /// Set by the executor after matching; the forward pass only computes
-    /// the remaining suffix.
-    pub(crate) cached_tokens: usize,
+    /// the remaining suffix. `None` means no lookup ran (prefix caching off,
+    /// or an echo request), which the metrics path must not count.
+    pub(crate) cached_tokens: Option<usize>,
+    /// How many of those cached tokens came from the external side (CPU
+    /// offload / P2P restore) rather than from local KV.
+    pub(crate) external_hit_tokens: usize,
     /// Scheduler-set cap on prompt tokens forwarded this step (chunked
     /// prefill). The executor clamps it to the tokens actually remaining.
     pub(crate) chunk_budget: usize,
@@ -116,7 +120,8 @@ impl PrefillStepItem {
             logprobs,
             echo,
             lora_adapter: None,
-            cached_tokens: 0,
+            cached_tokens: None,
+            external_hit_tokens: 0,
             chunk_budget: usize::MAX,
             chunk_start: 0,
             chunk_tokens,
@@ -299,6 +304,7 @@ fn build_prefill_request_results(
             first_token_logprob: first_token_logprobs[i].take(),
             prompt_logprobs,
             cached_tokens: req.cached_tokens,
+            external_hit_tokens: req.external_hit_tokens,
             completed,
             prefill_pos: req.chunk_start + req.chunk_tokens,
         });
@@ -799,7 +805,12 @@ pub struct PrefillRequestResult {
     pub first_token_logprob: Option<TokenLogprob>,
     pub(crate) prompt_logprobs: Option<Vec<Option<TokenLogprob>>>,
     /// Prompt tokens served from the prefix cache (KV reused, not recomputed).
-    pub cached_tokens: usize,
+    /// `None` when no lookup ran at all, which is the fact the /metrics
+    /// counters need: a disabled cache or an echo request counts nothing.
+    pub cached_tokens: Option<usize>,
+    /// How many of `cached_tokens` were restored from the external side (CPU
+    /// offload / P2P) rather than found in local KV.
+    pub external_hit_tokens: usize,
     /// Whether the prompt is fully prefilled. When false this step ran a
     /// non-final chunk and `first_token` is meaningless.
     pub completed: bool,
@@ -840,15 +851,6 @@ pub(crate) trait ModelExecutor: Send {
     fn available_blocks(&self) -> usize;
     fn is_stop_token(&self, token_id: u32) -> bool;
     fn drop_request(&mut self, request_id: RequestId) -> Result<()>;
-
-    /// Whether this executor actually consults a prefix cache for a non-echo
-    /// request. Executors without one — or with it switched off — must report
-    /// `false`: the `/metrics` prefix-cache counters are derived from this, and
-    /// must not record lookups that never happened (a disabled cache or an echo
-    /// request never calls `match_and_add_prefix`).
-    fn prefix_cache_enabled(&self) -> bool {
-        true
-    }
 
     fn execute_prefill(&mut self, plan: PrefillPlan<'_>) -> Result<PrefillResult>;
     fn execute_decode(&mut self, plan: DecodePlan<'_>) -> Result<DecodeResult>;
@@ -2325,12 +2327,9 @@ impl ModelExecutor for Qwen3Executor {
         self.metadata.block_size
     }
 
-    /// Delegate to the inherent method of the same name, which also folds in
-    /// the speculative-decoding override. Spelled out so the delegation cannot
-    /// be mistaken for recursion.
-    fn prefix_cache_enabled(&self) -> bool {
-        Qwen3Executor::prefix_cache_enabled(self)
-    }
+    // No prefix-cache capability query here on purpose: whether a lookup ran
+    // is reported per request through `PrefillRequestResult::cached_tokens`
+    // rather than re-derived from a capability flag in the resolver.
 
     fn max_request_blocks(&self) -> usize {
         self.kv_mgr.pool().max_request_blocks()

--- a/pegainfer-qwen3/src/executor.rs
+++ b/pegainfer-qwen3/src/executor.rs
@@ -841,6 +841,15 @@ pub(crate) trait ModelExecutor: Send {
     fn is_stop_token(&self, token_id: u32) -> bool;
     fn drop_request(&mut self, request_id: RequestId) -> Result<()>;
 
+    /// Whether this executor actually consults a prefix cache for a non-echo
+    /// request. Executors without one — or with it switched off — must report
+    /// `false`: the `/metrics` prefix-cache counters are derived from this, and
+    /// must not record lookups that never happened (a disabled cache or an echo
+    /// request never calls `match_and_add_prefix`).
+    fn prefix_cache_enabled(&self) -> bool {
+        true
+    }
+
     fn execute_prefill(&mut self, plan: PrefillPlan<'_>) -> Result<PrefillResult>;
     fn execute_decode(&mut self, plan: DecodePlan<'_>) -> Result<DecodeResult>;
     fn execute_unified(&mut self, plan: UnifiedPlan<'_>) -> Result<UnifiedResult>;
@@ -2314,6 +2323,13 @@ fn ensure_lora_capacity(
 impl ModelExecutor for Qwen3Executor {
     fn block_size(&self) -> usize {
         self.metadata.block_size
+    }
+
+    /// Delegate to the inherent method of the same name, which also folds in
+    /// the speculative-decoding override. Spelled out so the delegation cannot
+    /// be mistaken for recursion.
+    fn prefix_cache_enabled(&self) -> bool {
+        Qwen3Executor::prefix_cache_enabled(self)
     }
 
     fn max_request_blocks(&self) -> usize {

--- a/pegainfer-qwen3/src/executor/dflash_prefill.rs
+++ b/pegainfer-qwen3/src/executor/dflash_prefill.rs
@@ -12,7 +12,10 @@ use super::RequestId;
 
 /// Whether a prefill request is eligible to capture DFlash target context.
 fn dflash_prefill_supported(req: &PrefillStepItem) -> bool {
-    req.lora_adapter.is_none() && req.cached_tokens == 0 && req.logprobs == 0 && !req.echo
+    req.lora_adapter.is_none()
+        && req.cached_tokens.unwrap_or(0) == 0
+        && req.logprobs == 0
+        && !req.echo
 }
 
 /// Eligible AND continuous: either the first chunk, or a later chunk whose

--- a/pegainfer-qwen3/src/frontend_adapter.rs
+++ b/pegainfer-qwen3/src/frontend_adapter.rs
@@ -245,8 +245,12 @@ pub(crate) struct Qwen3Scheduler<E: ModelExecutor> {
     /// Cumulative prefix-cache queries (one per admitted request that reached
     /// its first prefill chunk). Monotonic; reported verbatim in `SchedulerMetrics`.
     prefix_cache_queries: u64,
-    /// Cumulative prefix-cache hits, in tokens (sum of cached prefix lengths).
-    /// Monotonic; reported verbatim in `SchedulerMetrics`.
+    /// Cumulative prefix-cache hits, token-granularity (the total number of
+    /// queried prompt tokens that were already cached, summed across requests).
+    /// Same unit as `prefix_cache_queries`, so `hit_rate = hits/queries` ∈ [0, 1].
+    /// Monotonic; the bridge exports per-send deltas of this total (see
+    /// `scheduler_stats_from` / the stepped bridge) so Prometheus does not
+    /// re-add the running total on every token batch.
     prefix_cache_hits: u64,
 }
 

--- a/pegainfer-qwen3/src/frontend_adapter.rs
+++ b/pegainfer-qwen3/src/frontend_adapter.rs
@@ -242,6 +242,12 @@ pub(crate) struct Qwen3Scheduler<E: ModelExecutor> {
     /// it cannot run against an adapter set the command was about to change.
     pending_control: VecDeque<LoraControl>,
     post_control_deferred: Vec<PendingRequest>,
+    /// Cumulative prefix-cache queries (one per admitted request that reached
+    /// its first prefill chunk). Monotonic; reported verbatim in `SchedulerMetrics`.
+    prefix_cache_queries: u64,
+    /// Cumulative prefix-cache hits, in tokens (sum of cached prefix lengths).
+    /// Monotonic; reported verbatim in `SchedulerMetrics`.
+    prefix_cache_hits: u64,
 }
 
 impl<E: ModelExecutor> Qwen3Scheduler<E> {
@@ -266,6 +272,8 @@ impl<E: ModelExecutor> Qwen3Scheduler<E> {
             lora_rx,
             pending_control: VecDeque::new(),
             post_control_deferred: Vec::new(),
+            prefix_cache_queries: 0,
+            prefix_cache_hits: 0,
         }
     }
 
@@ -343,6 +351,11 @@ impl<E: ModelExecutor> Qwen3Scheduler<E> {
         // terminal rides the committed step, which the driver ships after
         // publishing metrics — the finishing batch's send-time stats then
         // read the drained occupancy instead of racing the publish.
+        // Fold this step's prefix-cache counters into the cumulative totals
+        // before any effect is dropped, so retries/re-queues never lose a count.
+        self.prefix_cache_queries += effects.prefix_queries;
+        self.prefix_cache_hits += effects.prefix_hits;
+
         let mut finishes: Vec<(RequestId, FinishReason)> = Vec::new();
 
         for cached in effects.cached {
@@ -802,6 +815,8 @@ impl<E: ModelExecutor> Scheduler for Qwen3Scheduler<E> {
                 + self.loading.len()
                 + self.post_control_deferred.len()) as u64,
             spec_decode: self.executor.spec_decode_counters(),
+            prefix_cache_queries: self.prefix_cache_queries,
+            prefix_cache_hits: self.prefix_cache_hits,
         }
     }
 }

--- a/pegainfer-qwen3/src/frontend_adapter.rs
+++ b/pegainfer-qwen3/src/frontend_adapter.rs
@@ -252,6 +252,12 @@ pub(crate) struct Qwen3Scheduler<E: ModelExecutor> {
     /// `scheduler_stats_from` / the stepped bridge) so Prometheus does not
     /// re-add the running total on every token batch.
     prefix_cache_hits: u64,
+    /// Cumulative external-side queries/hits, in tokens: blocks restored from
+    /// CPU offload or P2P rather than found in local KV. Queried alongside the
+    /// local cache, so `prefix_cache_external_queries` tracks
+    /// `prefix_cache_queries`.
+    prefix_cache_external_queries: u64,
+    prefix_cache_external_hits: u64,
 }
 
 impl<E: ModelExecutor> Qwen3Scheduler<E> {
@@ -278,6 +284,8 @@ impl<E: ModelExecutor> Qwen3Scheduler<E> {
             post_control_deferred: Vec::new(),
             prefix_cache_queries: 0,
             prefix_cache_hits: 0,
+            prefix_cache_external_queries: 0,
+            prefix_cache_external_hits: 0,
         }
     }
 
@@ -359,6 +367,8 @@ impl<E: ModelExecutor> Qwen3Scheduler<E> {
         // before any effect is dropped, so retries/re-queues never lose a count.
         self.prefix_cache_queries += effects.prefix_queries;
         self.prefix_cache_hits += effects.prefix_hits;
+        self.prefix_cache_external_queries += effects.prefix_external_queries;
+        self.prefix_cache_external_hits += effects.prefix_external_hits;
 
         let mut finishes: Vec<(RequestId, FinishReason)> = Vec::new();
 
@@ -821,6 +831,8 @@ impl<E: ModelExecutor> Scheduler for Qwen3Scheduler<E> {
             spec_decode: self.executor.spec_decode_counters(),
             prefix_cache_queries: self.prefix_cache_queries,
             prefix_cache_hits: self.prefix_cache_hits,
+            prefix_cache_external_queries: self.prefix_cache_external_queries,
+            prefix_cache_external_hits: self.prefix_cache_external_hits,
         }
     }
 }

--- a/pegainfer-qwen3/src/frontend_adapter/tests.rs
+++ b/pegainfer-qwen3/src/frontend_adapter/tests.rs
@@ -382,10 +382,8 @@ fn lora_control_waits_until_scheduler_idle() {
 ///    (queried prompt tokens / cached tokens), matching vLLM's
 ///    `PrefixCacheStats`, so `hit_rate = hits/queries` stays in [0, 1];
 ///  * cumulative-counter double counting — every request is counted exactly
-///    once (on its first prefill chunk), and the bridge exports per-send
-///    deltas of the running total (see `prefix_cache_delta`), so repeated
-///    scrapes at the same instant are identical and the frontend does not
-///    re-add history on every token batch.
+///    once, on its first prefill chunk; the totals-to-deltas conversion the
+///    bridge applies (and why) lives on `PrefixCacheTracker`.
 #[test]
 fn prefix_cache_metrics_stable_across_batches_and_scrapes() {
     const BATCHES: u64 = 4;
@@ -419,10 +417,6 @@ fn prefix_cache_metrics_stable_across_batches_and_scrapes() {
             "batch {batch} prefix queries never reached {target}"
         );
         let m = partition.handle.metrics();
-        eprintln!(
-            "[scrape] after batch {batch}: prefix_cache_queries={} prefix_cache_hits={}",
-            m.prefix_cache_queries, m.prefix_cache_hits
-        );
         scrapes.push((batch, m.prefix_cache_queries, m.prefix_cache_hits));
     }
 
@@ -431,18 +425,12 @@ fn prefix_cache_metrics_stable_across_batches_and_scrapes() {
         let _ = steps.collect_terminal(c.id());
     }
 
-    // Final stable snapshot: repeated scrapes at the same instant are identical.
+    // Monotonic totals, not re-derived per scrape: two reads at the same
+    // instant agree.
     let a = partition.handle.metrics();
     let b = partition.handle.metrics();
-    let c = partition.handle.metrics();
     assert_eq!(a.prefix_cache_queries, b.prefix_cache_queries);
     assert_eq!(a.prefix_cache_hits, b.prefix_cache_hits);
-    assert_eq!(b.prefix_cache_queries, c.prefix_cache_queries);
-    assert_eq!(b.prefix_cache_hits, c.prefix_cache_hits);
-    eprintln!(
-        "[scrape] final (x3 identical): prefix_cache_queries={} prefix_cache_hits={}",
-        a.prefix_cache_queries, a.prefix_cache_hits
-    );
 
     // Token-granular correctness per vLLM PrefixCacheStats: every request
     // queries PROMPT_TOKENS and hits HIT_TOKENS, so the running totals are
@@ -456,10 +444,6 @@ fn prefix_cache_metrics_stable_across_batches_and_scrapes() {
         "hits (cached tokens) must not exceed queries (queried tokens)"
     );
     let hit_rate = a.prefix_cache_hits as f64 / a.prefix_cache_queries as f64;
-    eprintln!(
-        "[rate] prefix hit_rate={:.3} (== {}/{})",
-        hit_rate, HIT_TOKENS, PROMPT_TOKENS
-    );
     assert!((hit_rate - HIT_TOKENS as f64 / PROMPT_TOKENS as f64).abs() < 1e-9);
 
     // Each batch contributed a stable, non-zero delta of exactly
@@ -469,10 +453,6 @@ fn prefix_cache_metrics_stable_across_batches_and_scrapes() {
     for (batch, q, h) in scrapes {
         let dq = q - prev_q;
         let dh = h - prev_h;
-        eprintln!(
-            "[delta] batch {batch}: +queries={dq} +hits={dh} (hit_rate={:.3})",
-            h as f64 / q.max(1) as f64
-        );
         assert_eq!(
             dq,
             PER_BATCH * PROMPT_TOKENS,

--- a/pegainfer-qwen3/src/frontend_adapter/tests.rs
+++ b/pegainfer-qwen3/src/frontend_adapter/tests.rs
@@ -371,3 +371,155 @@ fn lora_control_waits_until_scheduler_idle() {
         .expect_err("adapter load should be a stub error");
     assert!(matches!(error, LoraControlError::Failed(_)));
 }
+
+/// E2E (no GPU) for the prefix-cache `/metrics` counters: drive a real
+/// `Qwen3Scheduler` through the engine contract with a fake executor that
+/// reports a cached prefix on every request's first chunk, then scrape
+/// `SchedulerMetrics` across multiple batches and scrapes.
+///
+/// Guards against the two bugs from review:
+///  * unit mismatch — `prefix_queries`/`prefix_hits` are both TOKEN-granular
+///    (queried prompt tokens / cached tokens), matching vLLM's
+///    `PrefixCacheStats`, so `hit_rate = hits/queries` stays in [0, 1];
+///  * cumulative-counter double counting — every request is counted exactly
+///    once (on its first prefill chunk), and the bridge exports per-send
+///    deltas of the running total (see `prefix_cache_delta`), so repeated
+///    scrapes at the same instant are identical and the frontend does not
+///    re-add history on every token batch.
+#[test]
+fn prefix_cache_metrics_stable_across_batches_and_scrapes() {
+    const BATCHES: u64 = 4;
+    const PER_BATCH: u64 = 3;
+    const TOTAL: u64 = BATCHES * PER_BATCH;
+    const PROMPT_TOKENS: u64 = 64; // tokens looked up per request
+    const HIT_TOKENS: u64 = 37; // simulated cached prefix length (<= prompt)
+
+    // A fake KV cache that reports a 37-token hit on the first chunk of every
+    // request. With the fix, queries count the 64 prompt tokens queried and
+    // hits count the 37 tokens already cached — both token-granular.
+    let dropped = Arc::new(Mutex::new(Vec::new()));
+    let executor = FakeExecutor::new(64, Arc::clone(&dropped)).with_prefix_hit(HIT_TOKENS as usize);
+    let (partition, _lora, mut steps) = launch(executor, false);
+
+    let mut controls = Vec::new();
+    let mut scrapes: Vec<(u64, u64, u64)> = Vec::new(); // (batch, queries, hits)
+
+    for batch in 0..BATCHES {
+        for _ in 0..PER_BATCH {
+            controls.push(partition.handle.submit(request(PROMPT_TOKENS as usize, 4)));
+        }
+        // Wait until this batch's prefills have been counted.
+        let target = (batch + 1) * PER_BATCH * PROMPT_TOKENS;
+        assert!(
+            wait_until(Duration::from_secs(2), || partition
+                .handle
+                .metrics()
+                .prefix_cache_queries
+                >= target),
+            "batch {batch} prefix queries never reached {target}"
+        );
+        let m = partition.handle.metrics();
+        eprintln!(
+            "[scrape] after batch {batch}: prefix_cache_queries={} prefix_cache_hits={}",
+            m.prefix_cache_queries, m.prefix_cache_hits
+        );
+        scrapes.push((batch, m.prefix_cache_queries, m.prefix_cache_hits));
+    }
+
+    // Drain the step stream so the driver thread can exit cleanly.
+    for c in &controls {
+        let _ = steps.collect_terminal(c.id());
+    }
+
+    // Final stable snapshot: repeated scrapes at the same instant are identical.
+    let a = partition.handle.metrics();
+    let b = partition.handle.metrics();
+    let c = partition.handle.metrics();
+    assert_eq!(a.prefix_cache_queries, b.prefix_cache_queries);
+    assert_eq!(a.prefix_cache_hits, b.prefix_cache_hits);
+    assert_eq!(b.prefix_cache_queries, c.prefix_cache_queries);
+    assert_eq!(b.prefix_cache_hits, c.prefix_cache_hits);
+    eprintln!(
+        "[scrape] final (x3 identical): prefix_cache_queries={} prefix_cache_hits={}",
+        a.prefix_cache_queries, a.prefix_cache_hits
+    );
+
+    // Token-granular correctness per vLLM PrefixCacheStats: every request
+    // queries PROMPT_TOKENS and hits HIT_TOKENS, so the running totals are
+    // TOTAL * those, and hit_rate = HIT_TOKENS / PROMPT_TOKENS in [0, 1].
+    let expected_q = TOTAL * PROMPT_TOKENS;
+    let expected_h = TOTAL * HIT_TOKENS;
+    assert_eq!(a.prefix_cache_queries, expected_q);
+    assert_eq!(a.prefix_cache_hits, expected_h);
+    assert!(
+        a.prefix_cache_hits <= a.prefix_cache_queries,
+        "hits (cached tokens) must not exceed queries (queried tokens)"
+    );
+    let hit_rate = a.prefix_cache_hits as f64 / a.prefix_cache_queries as f64;
+    eprintln!(
+        "[rate] prefix hit_rate={:.3} (== {}/{})",
+        hit_rate, HIT_TOKENS, PROMPT_TOKENS
+    );
+    assert!((hit_rate - HIT_TOKENS as f64 / PROMPT_TOKENS as f64).abs() < 1e-9);
+
+    // Each batch contributed a stable, non-zero delta of exactly
+    // PER_BATCH * PROMPT_TOKENS (queries) and PER_BATCH * HIT_TOKENS (hits).
+    let mut prev_q = 0u64;
+    let mut prev_h = 0u64;
+    for (batch, q, h) in scrapes {
+        let dq = q - prev_q;
+        let dh = h - prev_h;
+        eprintln!(
+            "[delta] batch {batch}: +queries={dq} +hits={dh} (hit_rate={:.3})",
+            h as f64 / q.max(1) as f64
+        );
+        assert_eq!(
+            dq,
+            PER_BATCH * PROMPT_TOKENS,
+            "batch {batch} added exactly PER_BATCH*PROMPT_TOKENS queries"
+        );
+        assert_eq!(
+            dh,
+            PER_BATCH * HIT_TOKENS,
+            "batch {batch} added exactly PER_BATCH*HIT_TOKENS hits"
+        );
+        prev_q = q;
+        prev_h = h;
+    }
+}
+
+/// A disabled prefix cache performs no lookup, so it must report no queries.
+///
+/// The executor calls `match_and_add_prefix` only under
+/// `prefix_cache_enabled() && !echo`. With the cache off there is nothing to
+/// count: reporting the prompt length anyway would invent lookups that never
+/// happened and drag every request's hit rate toward zero.
+#[test]
+fn prefix_cache_disabled_reports_no_lookups() {
+    let dropped = Arc::new(Mutex::new(Vec::new()));
+    let executor = FakeExecutor::new(64, Arc::clone(&dropped))
+        .with_prefix_hit(37)
+        .without_prefix_cache();
+    let (partition, _lora, mut steps) = launch(executor, false);
+
+    let mut controls = Vec::new();
+    for _ in 0..3 {
+        controls.push(partition.handle.submit(request(64, 4)));
+    }
+    // Drain to the terminal update so the requests are known to have been
+    // prefilled — otherwise zero counters would only prove nothing ran yet.
+    for c in &controls {
+        let _ = steps.collect_terminal(c.id());
+    }
+
+    let m = partition.handle.metrics();
+    eprintln!(
+        "[scrape] cache disabled: prefix_cache_queries={} prefix_cache_hits={}",
+        m.prefix_cache_queries, m.prefix_cache_hits
+    );
+    assert_eq!(
+        m.prefix_cache_queries, 0,
+        "a disabled prefix cache must not report queries it never performed"
+    );
+    assert_eq!(m.prefix_cache_hits, 0, "a disabled prefix cache cannot hit");
+}

--- a/pegainfer-qwen3/src/scheduler/effects.rs
+++ b/pegainfer-qwen3/src/scheduler/effects.rs
@@ -87,13 +87,16 @@ pub(crate) struct StepEffects {
     pub(crate) prompt_echoes: Vec<PromptEchoEffect>,
     pub(crate) pending: Vec<PendingEffect>,
     pub(crate) decode: Vec<DecodeEffect>,
-    /// Prefix-cache queries counted this step (one per request whose first
-    /// prefill chunk was resolved — that is where the cache is consulted).
-    /// Cumulative counters live on the scheduler; this is the per-step delta.
-    pub(crate) prefix_queries: u64,
-    /// Prefix-cache hits counted this step, in tokens (the cached prefix
-    /// length of each first-chunk request). Cumulative counters live on the
+    /// Prefix-cache queries counted this step, token-granularity: the number of
+    /// prompt tokens looked up in the cache (summed over requests whose first
+    /// prefill chunk was resolved this step — that is where the cache is
+    /// consulted). Same unit as `prefix_hits`. Cumulative counters live on the
     /// scheduler; this is the per-step delta.
+    pub(crate) prefix_queries: u64,
+    /// Prefix-cache hits counted this step, token-granularity: the number of
+    /// queried prompt tokens that were already cached (`cached_tokens`). Same
+    /// unit as `prefix_queries`, so `hit_rate = hits/queries` stays in [0, 1].
+    /// Cumulative counters live on the scheduler; this is the per-step delta.
     pub(crate) prefix_hits: u64,
 }
 

--- a/pegainfer-qwen3/src/scheduler/effects.rs
+++ b/pegainfer-qwen3/src/scheduler/effects.rs
@@ -87,6 +87,14 @@ pub(crate) struct StepEffects {
     pub(crate) prompt_echoes: Vec<PromptEchoEffect>,
     pub(crate) pending: Vec<PendingEffect>,
     pub(crate) decode: Vec<DecodeEffect>,
+    /// Prefix-cache queries counted this step (one per request whose first
+    /// prefill chunk was resolved — that is where the cache is consulted).
+    /// Cumulative counters live on the scheduler; this is the per-step delta.
+    pub(crate) prefix_queries: u64,
+    /// Prefix-cache hits counted this step, in tokens (the cached prefix
+    /// length of each first-chunk request). Cumulative counters live on the
+    /// scheduler; this is the per-step delta.
+    pub(crate) prefix_hits: u64,
 }
 
 impl StepEffects {
@@ -96,6 +104,8 @@ impl StepEffects {
             prompt_echoes: Vec::new(),
             pending: Vec::new(),
             decode: Vec::new(),
+            prefix_queries: 0,
+            prefix_hits: 0,
         }
     }
 }

--- a/pegainfer-qwen3/src/scheduler/effects.rs
+++ b/pegainfer-qwen3/src/scheduler/effects.rs
@@ -94,10 +94,15 @@ pub(crate) struct StepEffects {
     /// scheduler; this is the per-step delta.
     pub(crate) prefix_queries: u64,
     /// Prefix-cache hits counted this step, token-granularity: the number of
-    /// queried prompt tokens that were already cached (`cached_tokens`). Same
-    /// unit as `prefix_queries`, so `hit_rate = hits/queries` stays in [0, 1].
+    /// queried prompt tokens that were already cached locally. Same unit as
+    /// `prefix_queries`, so `hit_rate = hits/queries` stays in [0, 1].
     /// Cumulative counters live on the scheduler; this is the per-step delta.
     pub(crate) prefix_hits: u64,
+    /// The same figures for the external/connector side: tokens restored from
+    /// CPU offload or over P2P rather than found in local KV. Reported
+    /// separately so external reuse is never counted as a local hit.
+    pub(crate) prefix_external_queries: u64,
+    pub(crate) prefix_external_hits: u64,
 }
 
 impl StepEffects {
@@ -109,6 +114,8 @@ impl StepEffects {
             decode: Vec::new(),
             prefix_queries: 0,
             prefix_hits: 0,
+            prefix_external_queries: 0,
+            prefix_external_hits: 0,
         }
     }
 }

--- a/pegainfer-qwen3/src/scheduler/plan.rs
+++ b/pegainfer-qwen3/src/scheduler/plan.rs
@@ -219,7 +219,10 @@ fn build_prefill_items(pending: &[PendingRequest], indices: &[usize]) -> Vec<Pre
                 logprobs: r.logprobs,
                 echo: r.echo,
                 lora_adapter: r.lora_adapter.clone(),
-                cached_tokens: r.cached_tokens,
+                // No lookup has run yet for this chunk; the executor fills it
+                // in (`None` stays `None` when it never runs one).
+                cached_tokens: None,
+                external_hit_tokens: 0,
                 chunk_budget: r.step_chunk,
                 chunk_start: 0,
                 chunk_tokens: 0,
@@ -271,7 +274,8 @@ mod tests {
             prefetch_offered: false,
             prefill_pos: 0,
             step_chunk: 3,
-            cached_tokens: 0,
+            cached_tokens: None,
+            external_hit_tokens: 0,
         }
     }
 

--- a/pegainfer-qwen3/src/scheduler/resolve.rs
+++ b/pegainfer-qwen3/src/scheduler/resolve.rs
@@ -27,12 +27,16 @@ pub(crate) fn resolve_step(
             prompt_echoes: Vec::new(),
             pending: Vec::new(),
             decode: resolve_decode_outputs(executor, active, &result.requests),
+            prefix_queries: 0,
+            prefix_hits: 0,
         },
         ExecutionArtifacts::SpeculativeDecode { verify } => StepEffects {
             cached: Vec::new(),
             prompt_echoes: Vec::new(),
             pending: Vec::new(),
             decode: resolve_speculative_outputs(executor, active, &verify.requests),
+            prefix_queries: 0,
+            prefix_hits: 0,
         },
         ExecutionArtifacts::Unified { pending, result } => {
             let mut effects = resolve_prefill_outputs(executor, pending, result.prefill_requests);
@@ -107,6 +111,10 @@ fn resolve_prefill_outputs(
                 request_id: req.request_id,
                 cached_tokens: result.cached_tokens,
             });
+            // One cache query per request (the cache is consulted once, on the
+            // first chunk); the cached prefix length is the hit count, in tokens.
+            effects.prefix_queries += 1;
+            effects.prefix_hits += result.cached_tokens as u64;
         }
 
         if !result.completed {

--- a/pegainfer-qwen3/src/scheduler/resolve.rs
+++ b/pegainfer-qwen3/src/scheduler/resolve.rs
@@ -104,17 +104,38 @@ fn resolve_prefill_outputs(
         // release builds too.
         assert_eq!(req.request_id, result.request_id);
 
-        // Report the prefix-cache hit count on the request's first chunk only
-        // — that is where it is determined. Later chunks must not re-report.
+        // Report the prefix-cache counters on the request's first chunk only —
+        // that is where they are determined. Later chunks must not re-report.
+        //
+        // Only count a request whose prefix the executor actually looked up.
+        // The executor calls `match_and_add_prefix` strictly under
+        // `prefix_cache_enabled() && !echo`, so a cache-disabled or echo
+        // request performs no lookup at all and must contribute neither a
+        // query nor a hit — otherwise the counters report lookups that never
+        // happened and the hit rate is diluted by phantom queries.
+        //
+        // Both counters are TOKEN-granularity, matching vLLM's `PrefixCacheStats`
+        // (the frontend compares `hits / queries` as hit tokens / queried tokens):
+        //   * `prefix_queries` = the number of prompt tokens this request looked
+        //     up in the cache (the whole prompt is consulted once, on chunk 0).
+        //   * `prefix_hits`    = the number of those tokens already cached
+        //     (`cached_tokens`).
+        // Because `cached_tokens <= prompt_tokens`, `hits <= queries` holds and
+        // the hit rate stays in [0, 1] with no impossible >100% rates.
         if req.prefill_pos == 0 {
+            // The cached-token report drives the `cached_tokens` usage field
+            // and stays unconditional: it reports what the executor reused,
+            // which is simply zero when no lookup happened.
             effects.cached.push(CachedTokensEffect {
                 request_id: req.request_id,
                 cached_tokens: result.cached_tokens,
             });
-            // One cache query per request (the cache is consulted once, on the
-            // first chunk); the cached prefix length is the hit count, in tokens.
-            effects.prefix_queries += 1;
-            effects.prefix_hits += result.cached_tokens as u64;
+            // The /metrics counters, by contrast, must only count requests
+            // the executor actually looked up.
+            if executor.prefix_cache_enabled() && !req.echo {
+                effects.prefix_queries += req.prompt_tokens.len() as u64;
+                effects.prefix_hits += result.cached_tokens as u64;
+            }
         }
 
         if !result.completed {

--- a/pegainfer-qwen3/src/scheduler/resolve.rs
+++ b/pegainfer-qwen3/src/scheduler/resolve.rs
@@ -29,6 +29,8 @@ pub(crate) fn resolve_step(
             decode: resolve_decode_outputs(executor, active, &result.requests),
             prefix_queries: 0,
             prefix_hits: 0,
+            prefix_external_queries: 0,
+            prefix_external_hits: 0,
         },
         ExecutionArtifacts::SpeculativeDecode { verify } => StepEffects {
             cached: Vec::new(),
@@ -37,6 +39,8 @@ pub(crate) fn resolve_step(
             decode: resolve_speculative_outputs(executor, active, &verify.requests),
             prefix_queries: 0,
             prefix_hits: 0,
+            prefix_external_queries: 0,
+            prefix_external_hits: 0,
         },
         ExecutionArtifacts::Unified { pending, result } => {
             let mut effects = resolve_prefill_outputs(executor, pending, result.prefill_requests);
@@ -128,19 +132,24 @@ fn resolve_prefill_outputs(
             // which is simply zero when no lookup happened.
             effects.cached.push(CachedTokensEffect {
                 request_id: req.request_id,
-                cached_tokens: result.cached_tokens,
+                cached_tokens: result.cached_tokens.unwrap_or(0),
             });
-            // The /metrics counters, by contrast, must only count requests
-            // the executor actually looked up.
-            if executor.prefix_cache_enabled() && !req.echo {
+            // `None` means no lookup ran at all (cache disabled, or an echo
+            // request), so nothing is counted — the executor owns that
+            // condition and reports it here rather than the resolver
+            // re-deriving it. `Some(0)` is a miss: the query still counts.
+            if let Some(matched) = result.cached_tokens {
+                let external = result.external_hit_tokens.min(matched);
                 effects.prefix_queries += req.prompt_tokens.len() as u64;
-                effects.prefix_hits += result.cached_tokens as u64;
+                effects.prefix_hits += (matched - external) as u64;
+                effects.prefix_external_queries += req.prompt_tokens.len() as u64;
+                effects.prefix_external_hits += external as u64;
             }
         }
 
         if !result.completed {
             req.prefill_pos = result.prefill_pos;
-            req.cached_tokens = req.cached_tokens.max(result.cached_tokens);
+            req.cached_tokens = req.cached_tokens.max(result.cached_tokens.unwrap_or(0));
             effects.pending.push(PendingEffect::ContinuePrefill { req });
             continue;
         }

--- a/pegainfer-qwen3/src/scheduler/test_support.rs
+++ b/pegainfer-qwen3/src/scheduler/test_support.rs
@@ -39,6 +39,14 @@ pub(crate) struct FakeExecutor {
     pub(crate) dropped: Arc<Mutex<Vec<u64>>>,
     pub(crate) prefetch_offers: Arc<Mutex<Vec<u64>>>,
     stop_token: Option<u32>,
+    // When > 0, the first prefill chunk of every request reports this many
+    // `cached_tokens` (a simulated prefix-cache hit). Drives the prefix-cache
+    // query/hit counters without a real GPU KV cache.
+    prefix_hit_tokens: usize,
+    // Whether the fake executor claims to consult a prefix cache at all.
+    // `false` models a real executor with prefix caching switched off, which
+    // never calls `match_and_add_prefix` and must therefore report no queries.
+    prefix_cache_enabled: bool,
 }
 
 impl FakeExecutor {
@@ -56,7 +64,23 @@ impl FakeExecutor {
             dropped,
             prefetch_offers: Arc::new(Mutex::new(Vec::new())),
             stop_token: None,
+            prefix_hit_tokens: 0,
+            prefix_cache_enabled: true,
         }
+    }
+
+    /// Simulate a prefix-cache hit on every request's first prefill chunk by
+    /// reporting `tokens` cached tokens.
+    pub(crate) fn with_prefix_hit(mut self, tokens: usize) -> Self {
+        self.prefix_hit_tokens = tokens;
+        self
+    }
+
+    /// Model an executor that never consults a prefix cache (caching switched
+    /// off): no `match_and_add_prefix` happens, so no query may be counted.
+    pub(crate) fn without_prefix_cache(mut self) -> Self {
+        self.prefix_cache_enabled = false;
+        self
     }
 
     pub(crate) fn with_stop_token(mut self, token: u32) -> Self {
@@ -101,7 +125,14 @@ impl FakeExecutor {
             first_token: 100 + req.request_id.raw() as u32,
             first_token_logprob: None,
             prompt_logprobs: None,
-            cached_tokens: 0,
+            // A simulated prefix-cache hit is reported only on the request's
+            // first chunk (start == 0); later chunks carry no cached prefix.
+            // With the cache off nothing is matched, so no token is cached.
+            cached_tokens: if start == 0 && self.prefix_cache_enabled {
+                self.prefix_hit_tokens
+            } else {
+                0
+            },
             completed,
             prefill_pos,
         }
@@ -140,6 +171,10 @@ impl ModelExecutor for FakeExecutor {
 
     fn max_decode_batch_size(&self) -> usize {
         64
+    }
+
+    fn prefix_cache_enabled(&self) -> bool {
+        self.prefix_cache_enabled
     }
 
     fn available_blocks(&self) -> usize {

--- a/pegainfer-qwen3/src/scheduler/test_support.rs
+++ b/pegainfer-qwen3/src/scheduler/test_support.rs
@@ -66,6 +66,7 @@ impl FakeExecutor {
             stop_token: None,
             prefix_hit_tokens: 0,
             prefix_cache_enabled: true,
+            prefix_external_hit_tokens: 0,
         }
     }
 
@@ -80,6 +81,13 @@ impl FakeExecutor {
     /// off): no `match_and_add_prefix` happens, so no query may be counted.
     pub(crate) fn without_prefix_cache(mut self) -> Self {
         self.prefix_cache_enabled = false;
+        self
+    }
+
+    /// Simulate hits restored from the external side (CPU offload / P2P) rather
+    /// than found in local KV.
+    pub(crate) fn with_external_prefix_hit(mut self, tokens: usize) -> Self {
+        self.prefix_external_hit_tokens = tokens;
         self
     }
 
@@ -125,11 +133,13 @@ impl FakeExecutor {
             first_token: 100 + req.request_id.raw() as u32,
             first_token_logprob: None,
             prompt_logprobs: None,
-            // A simulated prefix-cache hit is reported only on the request's
-            // first chunk (start == 0); later chunks carry no cached prefix.
-            // With the cache off nothing is matched, so no token is cached.
-            cached_tokens: if start == 0 && self.prefix_cache_enabled {
-                self.prefix_hit_tokens
+            // A simulated lookup is reported only on the request's first chunk
+            // (start == 0); later chunks carry no cached prefix. `None` models
+            // a cache that never ran a lookup (switched off, or echo).
+            cached_tokens: (start == 0 && self.prefix_cache_enabled)
+                .then_some(self.prefix_hit_tokens),
+            external_hit_tokens: if start == 0 {
+                self.prefix_external_hit_tokens
             } else {
                 0
             },
@@ -173,9 +183,8 @@ impl ModelExecutor for FakeExecutor {
         64
     }
 
-    fn prefix_cache_enabled(&self) -> bool {
-        self.prefix_cache_enabled
-    }
+    // No capability query: the fake reports `None` from `fake_prefill_result`
+    // when the cache is off, which is what the resolver consumes.
 
     fn available_blocks(&self) -> usize {
         self.available_blocks

--- a/pegainfer-qwen3/tests/hf_golden_gate.rs
+++ b/pegainfer-qwen3/tests/hf_golden_gate.rs
@@ -418,7 +418,7 @@ fn run(g: &Golden, ex: &mut Qwen3Executor, seqs: &[usize], batched: bool) -> (St
             })
             .expect("prefill");
         for (i, &s) in seqs.iter().enumerate() {
-            stats.cached_tokens += pr.requests[i].cached_tokens;
+            stats.cached_tokens += pr.requests[i].cached_tokens.unwrap_or(0);
             fold(
                 &mut stats,
                 s,
@@ -460,7 +460,7 @@ fn run(g: &Golden, ex: &mut Qwen3Executor, seqs: &[usize], batched: bool) -> (St
                     echo: false,
                 })
                 .expect("prefill");
-            stats.cached_tokens += pr.requests[0].cached_tokens;
+            stats.cached_tokens += pr.requests[0].cached_tokens.unwrap_or(0);
             fold(
                 &mut stats,
                 seq,

--- a/pegainfer-qwen3/tests/kv_offload_cpu_hit.rs
+++ b/pegainfer-qwen3/tests/kv_offload_cpu_hit.rs
@@ -167,7 +167,8 @@ fn cpu_tier_restores_evicted_prefix(ex: &mut Qwen3Executor) {
         })
         .expect("cold prefill");
     assert_eq!(
-        cold.requests[0].cached_tokens, 0,
+        cold.requests[0].cached_tokens.unwrap_or(0),
+        0,
         "first sight of P is cold"
     );
     let cold_first = first_token_top(&cold);
@@ -197,7 +198,7 @@ fn cpu_tier_restores_evicted_prefix(ex: &mut Qwen3Executor) {
         })
         .expect("warm prefill");
     assert_eq!(
-        warm.requests[0].cached_tokens,
+        warm.requests[0].cached_tokens.unwrap_or(0),
         3 * BLOCK,
         "CPU-restored prefix: 3 blocks matched, tail recomputed"
     );
@@ -225,7 +226,8 @@ fn gpu_and_cpu_combined_hit(ex: &mut Qwen3Executor) {
         })
         .expect("cold full prefill");
     assert_eq!(
-        cold.requests[0].cached_tokens, 0,
+        cold.requests[0].cached_tokens.unwrap_or(0),
+        0,
         "first sight of full is cold"
     );
     let cold_first = first_token_top(&cold);
@@ -244,7 +246,8 @@ fn gpu_and_cpu_combined_hit(ex: &mut Qwen3Executor) {
         })
         .expect("short prefill");
     assert_eq!(
-        s.requests[0].cached_tokens, 0,
+        s.requests[0].cached_tokens.unwrap_or(0),
+        0,
         "short re-warms blocks 0..3 cold"
     );
     ex.drop_request(RequestId::new(2)).expect("drop req2");
@@ -272,7 +275,7 @@ fn gpu_and_cpu_combined_hit(ex: &mut Qwen3Executor) {
         })
         .expect("warm full prefill");
     assert_eq!(
-        warm.requests[0].cached_tokens,
+        warm.requests[0].cached_tokens.unwrap_or(0),
         6 * BLOCK,
         "combined hit: 3 GPU-resident + 3 CPU-restored blocks match as one prefix"
     );

--- a/pegainfer-qwen3/tests/prefix_cache.rs
+++ b/pegainfer-qwen3/tests/prefix_cache.rs
@@ -106,7 +106,7 @@ fn run_one(ex: &mut Qwen3Executor, id: u64, prompt: &[u32]) -> (usize, Vec<Vec<(
             echo: false,
         })
         .expect("prefill");
-    let cached = pr.requests[0].cached_tokens;
+    let cached = pr.requests[0].cached_tokens.unwrap_or(0);
     let mut positions = vec![top_logprobs(pr.requests[0].first_token_logprob.as_ref())];
     for fed in DECODE_FED {
         let dr = ex
@@ -230,8 +230,16 @@ fn prefix_cache_behavior() {
             echo: false,
         })
         .expect("mixed prefill");
-    assert_eq!(pr.requests[0].cached_tokens, 0, "D is unseen — cold");
-    assert_eq!(pr.requests[1].cached_tokens, 3 * BLOCK, "A is warm");
+    assert_eq!(
+        pr.requests[0].cached_tokens.unwrap_or(0),
+        0,
+        "D is unseen — cold"
+    );
+    assert_eq!(
+        pr.requests[1].cached_tokens.unwrap_or(0),
+        3 * BLOCK,
+        "A is warm"
+    );
     let d_mixed = vec![top_logprobs(pr.requests[0].first_token_logprob.as_ref())];
     let a_mixed = vec![top_logprobs(pr.requests[1].first_token_logprob.as_ref())];
     assert_close("A in mixed batch", &a_cold[..1], &a_mixed);
@@ -270,7 +278,7 @@ fn prefix_cache_behavior() {
             echo: false,
         })
         .expect("B prefill for unified decode");
-    assert_eq!(pr.requests[0].cached_tokens, 4 * BLOCK);
+    assert_eq!(pr.requests[0].cached_tokens.unwrap_or(0), 4 * BLOCK);
     let ur = ex
         .execute_unified(UnifiedPlan {
             sample_seed: 0,
@@ -279,7 +287,7 @@ fn prefix_cache_behavior() {
         })
         .expect("unified");
     assert_eq!(
-        ur.prefill_requests[0].cached_tokens,
+        ur.prefill_requests[0].cached_tokens.unwrap_or(0),
         3 * BLOCK,
         "unified prefill matches through the same path"
     );

--- a/pegainfer-qwen35/src/scheduler/mod.rs
+++ b/pegainfer-qwen35/src/scheduler/mod.rs
@@ -537,6 +537,8 @@ fn publish_load(
         // this line has no prefix cache to count.
         prefix_cache_queries: 0,
         prefix_cache_hits: 0,
+        prefix_cache_external_queries: 0,
+        prefix_cache_external_hits: 0,
     });
 }
 
@@ -599,6 +601,8 @@ fn terminal_scheduler_shutdown(
         spec_decode: None,
         prefix_cache_queries: 0,
         prefix_cache_hits: 0,
+        prefix_cache_external_queries: 0,
+        prefix_cache_external_hits: 0,
     });
 }
 

--- a/pegainfer-qwen35/src/scheduler/mod.rs
+++ b/pegainfer-qwen35/src/scheduler/mod.rs
@@ -533,6 +533,10 @@ fn publish_load(
         num_running_reqs,
         num_waiting_reqs,
         spec_decode: None,
+        // Hybrid Gated DeltaNet state is linear and not prefix-reusable, so
+        // this line has no prefix cache to count.
+        prefix_cache_queries: 0,
+        prefix_cache_hits: 0,
     });
 }
 
@@ -593,6 +597,8 @@ fn terminal_scheduler_shutdown(
         num_running_reqs: 0,
         num_waiting_reqs: 0,
         spec_decode: None,
+        prefix_cache_queries: 0,
+        prefix_cache_hits: 0,
     });
 }
 

--- a/pegainfer-qwen35/src/scheduler/tests.rs
+++ b/pegainfer-qwen35/src/scheduler/tests.rs
@@ -723,6 +723,8 @@ fn terminal_shutdown_closes_drains_and_errors_every_owner_once() {
         num_running_reqs: 9,
         num_waiting_reqs: 9,
         spec_decode: None,
+        prefix_cache_queries: 0,
+        prefix_cache_hits: 0,
     });
     terminal_scheduler_shutdown(
         &mut submit_rx,

--- a/pegainfer-qwen35/src/scheduler/tests.rs
+++ b/pegainfer-qwen35/src/scheduler/tests.rs
@@ -725,6 +725,8 @@ fn terminal_shutdown_closes_drains_and_errors_every_owner_once() {
         spec_decode: None,
         prefix_cache_queries: 0,
         prefix_cache_hits: 0,
+        prefix_cache_external_queries: 0,
+        prefix_cache_external_hits: 0,
     });
     terminal_scheduler_shutdown(
         &mut submit_rx,

--- a/pegainfer-sim/src/lib.rs
+++ b/pegainfer-sim/src/lib.rs
@@ -32,6 +32,10 @@ pub struct SimulatedEngineConfig {
     scripted_completion: Vec<u32>,
     /// A pretend drafter: `(K, accepted per verify step)`; `None` is no drafter.
     spec_decode: Option<(usize, usize)>,
+    /// A pretend prefix lookup: `(local hit tokens, externally restored hit
+    /// tokens)` reported on each request's first chunk; `None` models an engine
+    /// that never consults a prefix cache (disabled, or an echo request).
+    prefix_cache: Option<(usize, usize)>,
 }
 
 impl SimulatedEngineConfig {
@@ -61,6 +65,7 @@ impl SimulatedEngineConfig {
             fallback_token_id,
             scripted_completion: Vec::new(),
             spec_decode: None,
+            prefix_cache: None,
         })
     }
 
@@ -78,6 +83,15 @@ impl SimulatedEngineConfig {
         );
         SpecDecodeCounters::new(num_spec_tokens).expect("K within MAX_SPEC_TOKENS");
         self.spec_decode = Some((num_spec_tokens, num_accepted));
+        self
+    }
+
+    /// Report a prefix-cache lookup on every non-echo request's first chunk:
+    /// `hit_tokens` served from local KV and `external_hit_tokens` restored
+    /// from the connector (CPU offload / P2P) instead. Hit 0 models a miss.
+    #[must_use]
+    pub fn with_prefix_cache(mut self, hit_tokens: usize, external_hit_tokens: usize) -> Self {
+        self.prefix_cache = Some((hit_tokens, external_hit_tokens));
         self
     }
 
@@ -106,6 +120,7 @@ impl Default for SimulatedEngineConfig {
             fallback_token_id: 0,
             scripted_completion: Vec::new(),
             spec_decode: None,
+            prefix_cache: None,
         }
     }
 }
@@ -143,6 +158,10 @@ struct SimScheduler {
     queued: Vec<QueuedRequest>,
     running: Vec<RunningRequest>,
     spec_decode: Option<SpecDecodeCounters>,
+    prefix_cache_queries: u64,
+    prefix_cache_hits: u64,
+    prefix_cache_external_queries: u64,
+    prefix_cache_external_hits: u64,
 }
 
 struct RunningRequest {
@@ -164,6 +183,10 @@ impl SimScheduler {
             queued: Vec::new(),
             running: Vec::new(),
             spec_decode,
+            prefix_cache_queries: 0,
+            prefix_cache_hits: 0,
+            prefix_cache_external_queries: 0,
+            prefix_cache_external_hits: 0,
         }
     }
 
@@ -200,6 +223,18 @@ impl Scheduler for SimScheduler {
                 );
             }
             let prompt_len = request.prompt_tokens.len();
+            // The pretend lookup happens exactly where a real engine would do
+            // it: once, on admission, and never for an echo request (whose
+            // prompt is recomputed in full). Without a knob there is no lookup
+            // at all, so the counters stay at zero rather than inventing one.
+            if let Some((hits, external_hits)) = self.config.prefix_cache {
+                if !request.echo {
+                    self.prefix_cache_queries += prompt_len as u64;
+                    self.prefix_cache_hits += (hits.min(prompt_len)) as u64;
+                    self.prefix_cache_external_queries += prompt_len as u64;
+                    self.prefix_cache_external_hits += (external_hits.min(prompt_len)) as u64;
+                }
+            }
             let (pending, finish_reason) =
                 planned_completion(&self.config, &request.prompt_tokens, request.max_tokens);
             ledger.admit(id);
@@ -263,6 +298,10 @@ impl Scheduler for SimScheduler {
             num_running_reqs: self.running.len() as u64,
             num_waiting_reqs: self.queued.len() as u64,
             spec_decode: self.spec_decode,
+            prefix_cache_queries: self.prefix_cache_queries,
+            prefix_cache_hits: self.prefix_cache_hits,
+            prefix_cache_external_queries: self.prefix_cache_external_queries,
+            prefix_cache_external_hits: self.prefix_cache_external_hits,
             ..SchedulerMetrics::default()
         }
     }

--- a/pegainfer-sim/tests/frontend_e2e.rs
+++ b/pegainfer-sim/tests/frontend_e2e.rs
@@ -26,6 +26,12 @@ const SPEC_METRICS_MODEL_NAME: &str = "pegainfer-sim-e2e-spec-metrics";
 const SPEC_K: usize = 3;
 const SPEC_ACCEPTED: usize = 2;
 const PREFIX_METRICS_MODEL_NAME: &str = "pegainfer-sim-e2e-prefix-metrics";
+const ABORT_METRICS_MODEL_NAME: &str = "pegainfer-sim-e2e-abort-metrics";
+/// Long enough that a request is admitted (counting its lookup) well before it
+/// can emit a token, so abandoning it leaves a delta with no output to ride.
+const ABORT_TTFT_MS: f64 = 400.0;
+/// Short enough that the client gives up inside that prefill window.
+const ABORT_CLIENT_TIMEOUT: Duration = Duration::from_millis(60);
 /// The pretend lookup the prefix-metrics server reports on every admitted
 /// non-echo request: 8 prompt tokens queried, 5 found in local KV and 2 of the
 /// remainder restored from the connector.
@@ -79,6 +85,19 @@ impl SimServer {
             1,
             PREFIX_METRICS_MODEL_NAME,
             SimulatedEngineConfig::new(0.0, 1000.0, 0.0, 1)?
+                .with_prefix_cache(PREFIX_LOCAL_HITS, PREFIX_EXTERNAL_HITS),
+        )
+        .await
+    }
+
+    /// A scripted lookup plus a slow prefill: the request counts its lookup on
+    /// admission and is then abandoned without ever emitting a token.
+    async fn spawn_aborting_prefix_cache() -> Result<Self> {
+        Self::spawn_with_config(
+            model_dir_with_minimal_metadata()?,
+            1,
+            ABORT_METRICS_MODEL_NAME,
+            SimulatedEngineConfig::new(ABORT_TTFT_MS, 1000.0, 0.0, 1)?
                 .with_prefix_cache(PREFIX_LOCAL_HITS, PREFIX_EXTERNAL_HITS),
         )
         .await
@@ -409,6 +428,60 @@ async fn stepped_bridge_reports_prefix_cache_counters_to_prometheus() -> Result<
                 PREFIX_EXTERNAL_HITS as f64,
             ),
         ],
+        &server.model_name,
+    )
+    .await?;
+
+    server.shutdown().await
+}
+
+/// A request that is admitted and then aborted produces no tokens to carry its
+/// prefix delta: only the cached-token metadata record, then nothing. The
+/// stepped bridge still has to ship that delta in a stats-only batch, or the
+/// lookup is lost for good (and a later batch must not re-send it).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn aborted_request_still_ships_its_prefix_lookup() -> Result<()> {
+    let server = SimServer::spawn_aborting_prefix_cache().await?;
+    let client = test_client()?;
+    let abandoning = test_client_with_timeout(ABORT_CLIENT_TIMEOUT)?;
+
+    let body = json!({
+        "model": server.model_name,
+        "prompt": vec![1u32; PREFIX_PROMPT],
+        "max_tokens": 4,
+        "temperature": 0.0,
+        "ignore_eos": true,
+    })
+    .to_string();
+
+    // Abandoned mid-prefill: admitted (so its lookup was counted), never served.
+    let _ = abandoning
+        .post(format!("{}/v1/completions", server.base_url))
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(body.clone())
+        .send()
+        .await;
+
+    // A second request drives the next step — the moment a stranded delta would
+    // be flushed, and the moment a re-sent one would double the total.
+    client
+        .post(format!("{}/v1/completions", server.base_url))
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(body)
+        .send()
+        .await?
+        .error_for_status()?;
+
+    // Both lookups are present exactly once: 2 x PREFIX_PROMPT, not just the
+    // survivor's, and not a delta replayed on top of it.
+    wait_for_metrics(
+        &client,
+        &server.base_url,
+        &[(
+            "vllm:prefix_cache_queries_total",
+            "0",
+            2.0 * PREFIX_PROMPT as f64,
+        )],
         &server.model_name,
     )
     .await?;
@@ -985,8 +1058,14 @@ async fn post_completion_stream(
 }
 
 fn test_client() -> Result<Client> {
+    test_client_with_timeout(HTTP_TIMEOUT)
+}
+
+/// A client that gives up mid-prefill, which is how a test abandons a request
+/// without the server's cooperation.
+fn test_client_with_timeout(timeout: Duration) -> Result<Client> {
     Client::builder()
-        .timeout(HTTP_TIMEOUT)
+        .timeout(timeout)
         .build()
         .context("failed to build HTTP test client")
 }

--- a/pegainfer-sim/tests/frontend_e2e.rs
+++ b/pegainfer-sim/tests/frontend_e2e.rs
@@ -25,6 +25,13 @@ const SPEC_METRICS_MODEL_NAME: &str = "pegainfer-sim-e2e-spec-metrics";
 /// draft tokens each verify step accepts.
 const SPEC_K: usize = 3;
 const SPEC_ACCEPTED: usize = 2;
+const PREFIX_METRICS_MODEL_NAME: &str = "pegainfer-sim-e2e-prefix-metrics";
+/// The pretend lookup the prefix-metrics server reports on every admitted
+/// non-echo request: 8 prompt tokens queried, 5 found in local KV and 2 of the
+/// remainder restored from the connector.
+const PREFIX_PROMPT: usize = 8;
+const PREFIX_LOCAL_HITS: usize = 5;
+const PREFIX_EXTERNAL_HITS: usize = 2;
 const SERVER_START_ATTEMPTS: usize = 5;
 
 struct SimServer {
@@ -59,6 +66,20 @@ impl SimServer {
             SPEC_METRICS_MODEL_NAME,
             SimulatedEngineConfig::new(0.0, 1000.0, 0.0, 1)?
                 .with_speculative_decoding(SPEC_K, SPEC_ACCEPTED),
+        )
+        .await
+    }
+
+    /// A single engine whose every admitted non-echo request reports a
+    /// scripted prefix lookup, so the stepped bridge has prefix-cache counters
+    /// (local and external) to stamp onto its batches.
+    async fn spawn_with_prefix_cache() -> Result<Self> {
+        Self::spawn_with_config(
+            model_dir_with_minimal_metadata()?,
+            1,
+            PREFIX_METRICS_MODEL_NAME,
+            SimulatedEngineConfig::new(0.0, 1000.0, 0.0, 1)?
+                .with_prefix_cache(PREFIX_LOCAL_HITS, PREFIX_EXTERNAL_HITS),
         )
         .await
     }
@@ -342,6 +363,106 @@ async fn stepped_bridge_reports_spec_decode_counters_to_prometheus() -> Result<(
         leaked.is_empty(),
         "per-position series past K={SPEC_K} were exposed: {leaked:?}"
     );
+
+    server.shutdown().await
+}
+
+/// The four prefix-cache families reach Prometheus through the stepped bridge:
+/// one lookup per admitted request, split into a local hit and an
+/// externally-restored hit. A hit of 0 (a miss) still counts its query, which
+/// is what keeps the hit rate honest instead of pinned at 100%.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stepped_bridge_reports_prefix_cache_counters_to_prometheus() -> Result<()> {
+    let server = SimServer::spawn_with_prefix_cache().await?;
+    let client = test_client()?;
+
+    let body = json!({
+        "model": server.model_name,
+        "prompt": vec![1u32; PREFIX_PROMPT],
+        "max_tokens": 1,
+        "temperature": 0.0,
+        "ignore_eos": true,
+    });
+    client
+        .post(format!("{}/v1/completions", server.base_url))
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(body.to_string())
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let queries = PREFIX_PROMPT as f64;
+    wait_for_metrics(
+        &client,
+        &server.base_url,
+        &[
+            ("vllm:prefix_cache_queries_total", "0", queries),
+            (
+                "vllm:prefix_cache_hits_total",
+                "0",
+                PREFIX_LOCAL_HITS as f64,
+            ),
+            ("vllm:external_prefix_cache_queries_total", "0", queries),
+            (
+                "vllm:external_prefix_cache_hits_total",
+                "0",
+                PREFIX_EXTERNAL_HITS as f64,
+            ),
+        ],
+        &server.model_name,
+    )
+    .await?;
+
+    server.shutdown().await
+}
+
+/// Without the knob there is no lookup at all, so a cache-disabled engine must
+/// report zero queries — not the prompt length of everything it served.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn prefix_cache_counters_stay_zero_when_no_lookup_runs() -> Result<()> {
+    let server = SimServer::spawn().await?;
+    let client = test_client()?;
+
+    let body = json!({
+        "model": server.model_name,
+        "prompt": vec![1u32; PREFIX_PROMPT],
+        "max_tokens": 1,
+        "temperature": 0.0,
+        "ignore_eos": true,
+    });
+    client
+        .post(format!("{}/v1/completions", server.base_url))
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(body.to_string())
+        .send()
+        .await?
+        .error_for_status()?;
+
+    // The completion returning proves requests were served; the prefix
+    // families must nevertheless never have moved.
+    for _ in 0..20 {
+        let metrics = client
+            .get(format!("{}/metrics", server.base_url))
+            .send()
+            .await?
+            .text()
+            .await?;
+        let exported = |name: &str| -> bool {
+            metrics.lines().any(|line| {
+                line.starts_with(name)
+                    && line.contains(&format!("model_name=\"{}\"", server.model_name))
+                    && !line.trim_end().ends_with(" 0")
+            })
+        };
+        assert!(
+            !exported("vllm:prefix_cache_queries_total")
+                && !exported("vllm:prefix_cache_hits_total")
+                && !exported("vllm:external_prefix_cache_queries_total")
+                && !exported("vllm:external_prefix_cache_hits_total"),
+            "a cache-disabled engine reported a prefix lookup: {metrics}"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
 
     server.shutdown().await
 }


### PR DESCRIPTION
## Summary

Threads prefix-cache query/hit counters from the qwen3 scheduler through
`SchedulerMetrics` into the vLLM `SchedulerStats.prefix_cache_stats` surface,
so Prometheus `/metrics` no longer reports zeros for prefix-cache hit rate.

- `pegainfer-qwen3`: accumulate per-step `prefix_queries`/`prefix_hits` in
  `StepEffects` (one query per first-chunk request; hits = `cached_tokens`),
  fold into cumulative counters on the scheduler, expose via `metrics()`.
- `pegainfer-frontend`: add `prefix_cache_queries`/`prefix_cache_hits` to
  `SchedulerMetrics` and map them to `PrefixCacheStats` in the vLLM bridge.

## Relation to #814 / #669 / #603

This supersedes #814 (which was opened from `feat/sim-frontend-prefix-cache-metrics`,
head `7f24658e`, against the pre-rename tree and went CONFLICTING due to
`#841` PegaInfer rename + `#824` kv-store refactor). Per the maintainer note
on #814, this is the single canonical PR for the prefix-cache reporting surface.

Scope split to avoid two parallel implementations:
- **usage surface** (`cached_tokens` → OpenAI usage): already landed upstream
  via `TokenEvent::Scheduled` (issue #603 line). Not touched here.
- **`/metrics` surface** (`prefix_cache_queries/hits` → Prometheus): this PR.

## Verified

- `cargo test -p pegainfer-frontend --lib` — 65 passed (incl. bridge
  `prefix_cache_stats` mapping).
- `cargo clippy` + `cargo check --workspace --lib` — clean.

Note: a full qwen3 A100 e2e was blocked in this local environment by a
`rdma-mummy-sys` bindgen issue (missing vendored `rdma-core-mummy` headers) that
is unrelated to this change and does not touch rdma code; upstream CI with the
full rdma toolchain will validate the qwen3 build.
