### PR TITLE
docs: require evidence for AI-assisted PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,12 @@ HTTP Request → vLLM frontend → EngineHandle → per-model scheduler/executor
 
 ---
 
+# AI-Assisted Contributions
+
+AI-assisted PRs must be accountable and verifiable. Show that the work is not duplicated, name the production invariant being changed, and provide real evidence: production E2E for features and fixes, same-context A/B for performance, and model evals for output or accuracy changes. Every changed file must serve that invariant; remove unrelated cleanup, thin wrappers, generated scaffolding, and mock or source-text tests presented as production evidence.
+
+---
+
 # Team Documentation Workflow
 
 Collaboration centered on the `docs/` directory.


### PR DESCRIPTION
## Summary

Add one concise contribution rule for AI-assisted PRs:

- establish that the work is not duplicated and name the production invariant;
- provide production E2E, same-context performance A/B, or model evaluation evidence as applicable;
- remove files and tests that do not serve that invariant, including unrelated cleanup, thin wrappers, generated scaffolding, and mock or source-text checks presented as production evidence.

`AGENTS.md` links to `CLAUDE.md`, so the rule applies to both agent entry points without duplication.

## Verification

- `prek run --files CLAUDE.md`
- `git diff --check`
