### PR TITLE
docs: delegate DCO validation to CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,4 +187,4 @@ When a session wraps up:
 
 Commit messages use Commitizen format: `<type>(<scope>): <subject>`. Never commit directly to `main` — create a `feat/`/`fix/`/`chore/`/… branch first.
 
-Every commit must carry a DCO `Signed-off-by:` trailer (`git commit -s`, or `git rebase --signoff` to fix up a branch) — CI enforces it and rejects PRs without it. CI also runs `cargo fmt --check`; run `cargo fmt` before committing.
+CI runs `cargo fmt --check`; run `cargo fmt` before committing.


### PR DESCRIPTION
## Summary

Remove DCO trailer checking from the agent instructions so automated reviews do not duplicate the repository's deterministic DCO CI check.

This is a focused follow-up to #954. The remaining Git convention still tells agents to run `cargo fmt`, while DCO enforcement stays unchanged in CI.

## Verification

- `prek run --files CLAUDE.md`
- `git diff --check`
