### PR TITLE
feat(qwen3): multi-position hedged verification for the DSpark lane

### DIFF
--- a/docs/models/qwen3/dspark-integration.md
+++ b/docs/models/qwen3/dspark-integration.md
@@ -1,8 +1,8 @@
 # DSpark Integration (Qwen3-4B)
 
-**TL;DR:** DeepSeek's **DSpark** (paper + DeepSpec repo, Jun 2026) is **our DFlash drafter plus two bolt-ons**: (1) a *semi-autoregressive* **Markov head** — a rank-256 logit bias added in a short sequential loop over the block so each draft token conditions on the previously sampled one; this is the whole draft-quality win (+16–18% accepted length over DFlash in their offline table, paper Table 1), and (2) a **confidence head** (tiny linear → per-position survival probability) feeding a **hardware-aware prefix scheduler** that trims verify length under load — the production throughput/Pareto win. The released checkpoint `dspark_qwen3_4b_block7` has an **identical backbone to our `Qwen3-4B-DFlash-b16`** (same hidden 2560 / 5 layers / `target_layer_ids=[1,9,17,25,33]` / KV-injection) — it differs only by `block_size=7`, +4 tensors (`markov_w1 [V,256]`, `markov_w2 [V,256]`, `confidence_head.proj.weight [1,2816]`, `.bias [1]`), and an "anchor-is-the-first-prediction" block-layout tweak. **Our verify/accept/KV-transaction stack is reused unchanged** — DSpark only changes the *propose* step. On the 5090 greedy sweep, DSpark beats the matched block7 DFlash baseline by **+3.6% geomean output tok/s** overall, with the expected wins on text/code (+3.1% to +15.8%; random is the synthetic exception) and a better accepted-draft distribution (**2.52 vs 2.30** accepted draft tokens/round, full-7 accept **17.4% vs 13.9%**). Decisions settled: **block_size = 7**, **reuse the target head** (DSpark's `embed_tokens`/`lm_head` are byte-identical to target Qwen3-4B's — skip loading them). **Phase 1 delta over DFlash is small: config + 2 tensor loads + one sequential Markov loop in `execute_dflash_draft`; no new verify/KV/graph.**
+**TL;DR:** DeepSeek's **DSpark** (paper + DeepSpec repo, Jun 2026) is **our DFlash drafter plus two bolt-ons**: (1) a *semi-autoregressive* **Markov head** — a rank-256 logit bias added in a short sequential loop over the block so each draft token conditions on the previously sampled one; this is the whole draft-quality win (+16–18% accepted length over DFlash in their offline table, paper Table 1), and (2) a **confidence head** (tiny linear → per-position survival probability) feeding a **hardware-aware prefix scheduler** that trims verify length under load — the production throughput/Pareto win. The released checkpoint `dspark_qwen3_4b_block7` has an **identical backbone to our `Qwen3-4B-DFlash-b16`** (same hidden 2560 / 5 layers / `target_layer_ids=[1,9,17,25,33]` / KV-injection) — it differs only by `block_size=7`, +4 tensors (`markov_w1 [V,256]`, `markov_w2 [V,256]`, `confidence_head.proj.weight [1,2816]`, `.bias [1]`), and an "anchor-is-the-first-prediction" block-layout tweak. **Our verify/accept/KV-transaction stack is reused unchanged** — DSpark only changes the *propose* step (the later env-gated hedge, `PEGAINFER_SPEC_HEDGE*`, additionally expands verify with extra chain spans over scratch KV pages; off by default). On the 5090 greedy sweep, DSpark beats the matched block7 DFlash baseline by **+3.6% geomean output tok/s** overall, with the expected wins on text/code (+3.1% to +15.8%; random is the synthetic exception) and a better accepted-draft distribution (**2.52 vs 2.30** accepted draft tokens/round, full-7 accept **17.4% vs 13.9%**). Decisions settled: **block_size = 7**, **reuse the target head** (DSpark's `embed_tokens`/`lm_head` are byte-identical to target Qwen3-4B's — skip loading them). **Phase 1 delta over DFlash is small: config + 2 tensor loads + one sequential Markov loop in `execute_dflash_draft`; no new verify/KV/graph** *(true of Phase 1 as landed — the later opt-in hedge adds expanded verify spans, scratch KV pages, and per-shape Markov graphs, all behind `PEGAINFER_SPEC_HEDGE*`)*.
 
-Last touched: 2026-06
+Last touched: 2026-08
 
 ## Implementation status — Phase 1 built & lossless
 
@@ -11,9 +11,17 @@ Last touched: 2026-06
 ```
 PEGAINFER_TEST_MODEL_PATH=/data/models/Qwen3-4B \
 PEGAINFER_DFLASH_TEST_MODEL_PATH=/data/models/dspark_qwen3_4b_block7 \
+PEGAINFER_REQUIRE_HEDGE_GATE=1 \
 cargo test --release -p pegainfer-qwen3 --test dflash_speculative_gate
-# → 4 passed; all prompts 100% lossless. (The "kernel-gap flip … Not a spec bug"
-#   diagnostics are the pre-existing DFlash prefill/decode numeric gap, unrelated.)
+# → 5 passed. The fifth, hedged_ladder_passes_the_lossless_gates, re-runs the
+#   lossless suites with PEGAINFER_SPEC_HEDGE on and asserts that hedged rounds
+#   and chain spans actually executed, with at least one chain win and one
+#   loss. It needs a DSpark checkpoint; the REQUIRE flag above turns a missing
+#   one into a failure instead of a green skip, so always set it when the run
+#   is meant to be evidence. See the test's own doc for what it does and does
+#   not prove.
+#   The "kernel-gap flip … Not a spec bug" diagnostics are the pre-existing
+#   DFlash prefill/decode numeric gap, unrelated.
 ```
 
 What was actually built (the new DSpark code lives in its own module `pegainfer-qwen3/src/dspark.rs`):

--- a/pegainfer-kernels/csrc/shared/argmax.cu
+++ b/pegainfer-kernels/csrc/shared/argmax.cu
@@ -249,6 +249,8 @@ __global__ void markov_step_partial_kernel(
     const __nv_bfloat16* __restrict__ bias,
     int block_size,
     int step,
+    int chains,
+    const int* __restrict__ req_map,
     float* __restrict__ partial_values,
     int* __restrict__ partial_indices,
     int rows,
@@ -267,7 +269,11 @@ __global__ void markov_step_partial_kernel(
   int end = start + MARKOV_STEP_TILE_ELEMS;
   if (end > n) end = n;
   const __nv_bfloat16* base_row =
-      base + static_cast<size_t>(row * block_size + step) * n;
+      base +
+      static_cast<size_t>(
+          (req_map ? req_map[row / chains] : (row / chains)) * block_size +
+          step) *
+          n;
   const __nv_bfloat16* bias_row = bias + static_cast<size_t>(row) * n;
   int tid = threadIdx.x;
 
@@ -356,6 +362,166 @@ __global__ void markov_step_finalize_kernel(
   }
 }
 
+// Top-2 over `base[(row*block_size + step)*n + v] + bias[row*n + v]` — exact
+// when a row has two or more finite candidates; a fully masked row emits
+// index 0 for both slots (callers deduplicate).
+// The single-best partial kernel above cannot back a top-2: when the winner
+// and runner-up land in the same tile, the tile's top-1 partial has already
+// discarded the runner-up. So the partial stage tracks a (top1, top2) pair per
+// tile and the finalize merges pairs. Used by the speculative hedge to open a
+// second draft chain at the runner-up token.
+__device__ __forceinline__ void top2_consider(float val, int idx, float& v1,
+                                              int& i1, float& v2, int& i2) {
+  if (argmax_better(val, idx, v1, i1)) {
+    v2 = v1;
+    i2 = i1;
+    v1 = val;
+    i1 = idx;
+  } else if (argmax_better(val, idx, v2, i2)) {
+    v2 = val;
+    i2 = idx;
+  }
+}
+
+__global__ void markov_step_top2_partial_kernel(
+    const __nv_bfloat16* __restrict__ base,
+    const __nv_bfloat16* __restrict__ bias,
+    int block_size,
+    int step,
+    int chains,
+    float* __restrict__ partial_v1,
+    int* __restrict__ partial_i1,
+    float* __restrict__ partial_v2,
+    int* __restrict__ partial_i2,
+    int rows,
+    int n,
+    int tiles_per_row) {
+  extern __shared__ char shared_mem[];
+  float* sv1 = reinterpret_cast<float*>(shared_mem);
+  float* sv2 = sv1 + blockDim.x;
+  int* si1 = reinterpret_cast<int*>(sv2 + blockDim.x);
+  int* si2 = si1 + blockDim.x;
+
+  int tile = blockIdx.x;
+  int row = blockIdx.y;
+  if (row >= rows || tile >= tiles_per_row) return;
+
+  int start = tile * MARKOV_STEP_TILE_ELEMS;
+  int end = start + MARKOV_STEP_TILE_ELEMS;
+  if (end > n) end = n;
+  const __nv_bfloat16* base_row =
+      base + static_cast<size_t>((row / chains) * block_size + step) * n;
+  const __nv_bfloat16* bias_row = bias + static_cast<size_t>(row) * n;
+  int tid = threadIdx.x;
+
+  float v1 = -INFINITY, v2 = -INFINITY;
+  int i1 = 0, i2 = 0;
+  for (int i = start + tid; i < end; i += blockDim.x) {
+    float val = __bfloat162float(base_row[i]) + __bfloat162float(bias_row[i]);
+    top2_consider(val, i, v1, i1, v2, i2);
+  }
+  sv1[tid] = v1;
+  si1[tid] = i1;
+  sv2[tid] = v2;
+  si2[tid] = i2;
+  __syncthreads();
+
+  for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+    if (tid < s) {
+      top2_consider(sv1[tid + s], si1[tid + s], sv1[tid], si1[tid], sv2[tid],
+                    si2[tid]);
+      top2_consider(sv2[tid + s], si2[tid + s], sv1[tid], si1[tid], sv2[tid],
+                    si2[tid]);
+    }
+    __syncthreads();
+  }
+
+  if (tid == 0) {
+    int out = row * tiles_per_row + tile;
+    partial_v1[out] = sv1[0];
+    partial_i1[out] = si1[0];
+    partial_v2[out] = sv2[0];
+    partial_i2[out] = si2[0];
+  }
+}
+
+__global__ void markov_step_top2_finalize_kernel(
+    const float* __restrict__ partial_v1,
+    const int* __restrict__ partial_i1,
+    const float* __restrict__ partial_v2,
+    const int* __restrict__ partial_i2,
+    unsigned int* __restrict__ out_tokens,
+    unsigned int* __restrict__ sampled_tokens,
+    unsigned int* __restrict__ out_top2,
+    int block_size,
+    int step,
+    int rows,
+    int tiles_per_row) {
+  extern __shared__ char shared_mem[];
+  float* sv1 = reinterpret_cast<float*>(shared_mem);
+  float* sv2 = sv1 + blockDim.x;
+  int* si1 = reinterpret_cast<int*>(sv2 + blockDim.x);
+  int* si2 = si1 + blockDim.x;
+
+  int row = blockIdx.x;
+  int tid = threadIdx.x;
+  int base = row * tiles_per_row;
+  float v1 = -INFINITY, v2 = -INFINITY;
+  int i1 = 0, i2 = 0;
+  for (int tile = tid; tile < tiles_per_row; tile += blockDim.x) {
+    top2_consider(partial_v1[base + tile], partial_i1[base + tile], v1, i1, v2,
+                  i2);
+    top2_consider(partial_v2[base + tile], partial_i2[base + tile], v1, i1, v2,
+                  i2);
+  }
+  sv1[tid] = v1;
+  si1[tid] = i1;
+  sv2[tid] = v2;
+  si2[tid] = i2;
+  __syncthreads();
+
+  for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+    if (tid < s) {
+      top2_consider(sv1[tid + s], si1[tid + s], sv1[tid], si1[tid], sv2[tid],
+                    si2[tid]);
+      top2_consider(sv2[tid + s], si2[tid + s], sv1[tid], si1[tid], sv2[tid],
+                    si2[tid]);
+    }
+    __syncthreads();
+  }
+
+  if (tid == 0) {
+    unsigned int token = static_cast<unsigned int>(si1[0]);
+    out_tokens[row] = token;
+    sampled_tokens[row * block_size + step] = token;
+    out_top2[row] = static_cast<unsigned int>(si2[0]);
+  }
+}
+
+
+// Hedge-ladder branch forcing: chain-row (i*c + j) takes its device-resident
+// runner-up token at `step` — written into both the ping-pong prev buffer
+// (so later steps condition on it) and the sampled block (so the single
+// final D2H carries it). Replaces per-branch-step D2H syncs.
+__global__ void hedge_ladder_force_kernel(unsigned int* __restrict__ prev,
+                                          unsigned int* __restrict__ sampled,
+                                          const unsigned int* __restrict__ runners,
+                                          const int* __restrict__ req_map,
+                                          int n,
+                                          int c,
+                                          int j,
+                                          int runner_stride,
+                                          int block_size,
+                                          int step) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i >= n) return;
+  int req = req_map[i];
+  unsigned int tok = runners[j * runner_stride + req];
+  int row = i * c + j;
+  prev[row] = tok;
+  sampled[row * block_size + step] = tok;
+}
+
 extern "C" {
 void argmax_cuda(const __nv_bfloat16* x, int* out, int n, cudaStream_t stream) {
   argmax_kernel<<<1, SAMPLE_BLOCK,
@@ -396,22 +562,28 @@ void argmax_batch_bf16_split_indexed_cuda(const __nv_bfloat16* x,
       partial_values, partial_indices, values, indices, rows, tiles_per_row);
 }
 
-void markov_step_argmax_cuda(const __nv_bfloat16* base,
-                             const __nv_bfloat16* bias, int block_size, int step,
-                             int rows, int n, float* partial_values,
-                             int* partial_indices, unsigned int* out_tokens,
-                             unsigned int* sampled_tokens,
-                             cudaStream_t stream) {
+// The three markov/hedge launchers below return `cudaGetLastError()` so the
+// safe wrappers fail closed on launch rejection (bad grid, shared-memory
+// exhaustion) instead of surfacing it at the next unrelated CUDA call.
+// Legal during stream capture: the error state is thread-local and querying
+// it does not touch the stream.
+cudaError_t markov_step_argmax_cuda(const __nv_bfloat16* base,
+                                    const __nv_bfloat16* bias, int block_size, int step,
+                                    int chains, const int* req_map, int rows, int n,
+                                    float* partial_values,
+                                    int* partial_indices, unsigned int* out_tokens,
+                                    unsigned int* sampled_tokens,
+                                    cudaStream_t stream) {
   int tiles_per_row = (n + MARKOV_STEP_TILE_ELEMS - 1) / MARKOV_STEP_TILE_ELEMS;
   size_t smem = SAMPLE_BLOCK * (sizeof(float) + sizeof(int));
   markov_step_partial_kernel<<<dim3(tiles_per_row, rows), SAMPLE_BLOCK, smem, stream>>>(
-      base, bias, block_size, step, partial_values, partial_indices, rows, n,
-      tiles_per_row);
+      base, bias, block_size, step, chains, req_map, partial_values,
+      partial_indices, rows, n, tiles_per_row);
   if (!markov_pdl_supported_on_current_device()) {
     markov_step_finalize_kernel<<<rows, SAMPLE_BLOCK, smem, stream>>>(
         partial_values, partial_indices, out_tokens, sampled_tokens, block_size,
         step, rows, tiles_per_row);
-    return;
+    return cudaGetLastError();
   }
 
   cudaLaunchAttribute attr[1] = {};
@@ -428,5 +600,35 @@ void markov_step_argmax_cuda(const __nv_bfloat16* base,
   cudaLaunchKernelEx(&config, markov_step_finalize_kernel, partial_values,
                      partial_indices, out_tokens, sampled_tokens, block_size,
                      step, rows, tiles_per_row);
+  return cudaGetLastError();
+}
+
+cudaError_t markov_step_top2_cuda(const __nv_bfloat16* base, const __nv_bfloat16* bias,
+                                  int block_size, int step, int chains, int rows, int n,
+                                  float* partial_v1, int* partial_i1, float* partial_v2,
+                                  int* partial_i2, unsigned int* out_tokens,
+                                  unsigned int* sampled_tokens, unsigned int* out_top2,
+                                  cudaStream_t stream) {
+  int tiles_per_row = (n + MARKOV_STEP_TILE_ELEMS - 1) / MARKOV_STEP_TILE_ELEMS;
+  size_t smem = SAMPLE_BLOCK * 2 * (sizeof(float) + sizeof(int));
+  markov_step_top2_partial_kernel<<<dim3(tiles_per_row, rows), SAMPLE_BLOCK, smem,
+                                    stream>>>(base, bias, block_size, step, chains,
+                                              partial_v1, partial_i1, partial_v2,
+                                              partial_i2, rows, n, tiles_per_row);
+  markov_step_top2_finalize_kernel<<<rows, SAMPLE_BLOCK, smem, stream>>>(
+      partial_v1, partial_i1, partial_v2, partial_i2, out_tokens, sampled_tokens,
+      out_top2, block_size, step, rows, tiles_per_row);
+  return cudaGetLastError();
+}
+
+cudaError_t hedge_ladder_force_cuda(unsigned int* prev, unsigned int* sampled,
+                                    const unsigned int* runners, const int* req_map,
+                                    int n, int c, int j, int runner_stride,
+                                    int block_size, int step, cudaStream_t stream) {
+  int threads = 128;
+  int blocks = (n + threads - 1) / threads;
+  hedge_ladder_force_kernel<<<blocks, threads, 0, stream>>>(
+      prev, sampled, runners, req_map, n, c, j, runner_stride, block_size, step);
+  return cudaGetLastError();
 }
 }

--- a/pegainfer-kernels/src/ffi/shared.rs
+++ b/pegainfer-kernels/src/ffi/shared.rs
@@ -849,6 +849,8 @@ unsafe extern "C" {
         bias: *const Half,
         block_size: i32,
         step: i32,
+        chains: i32,
+        req_map: *const i32,
         rows: i32,
         n: i32,
         partial_values: *mut f32,
@@ -856,7 +858,39 @@ unsafe extern "C" {
         out_tokens: *mut u32,
         sampled_tokens: *mut u32,
         stream: CUstream,
-    );
+    ) -> i32;
+
+    pub fn hedge_ladder_force_cuda(
+        prev: *mut u32,
+        sampled: *mut u32,
+        runners: *const u32,
+        req_map: *const i32,
+        n: i32,
+        c: i32,
+        j: i32,
+        runner_stride: i32,
+        block_size: i32,
+        step: i32,
+        stream: CUstream,
+    ) -> i32;
+
+    pub fn markov_step_top2_cuda(
+        base: *const Half,
+        bias: *const Half,
+        block_size: i32,
+        step: i32,
+        chains: i32,
+        rows: i32,
+        n: i32,
+        partial_v1: *mut f32,
+        partial_i1: *mut i32,
+        partial_v2: *mut f32,
+        partial_i2: *mut i32,
+        out_tokens: *mut u32,
+        sampled_tokens: *mut u32,
+        out_top2: *mut u32,
+        stream: CUstream,
+    ) -> i32;
 
     pub fn bf16_to_f32_cuda(
         input: *const Half,

--- a/pegainfer-kernels/src/ops.rs
+++ b/pegainfer-kernels/src/ops.rs
@@ -178,9 +178,12 @@ pub use sampling::argmax_bf16_split_into;
 pub use sampling::flashinfer_top1_batch_into;
 pub use sampling::flashinfer_top1_row_states_bytes;
 pub use sampling::gpu_sample_batch_into;
+pub use sampling::hedge_ladder_force_into;
 pub use sampling::logprob_topk_batch_bf16_into;
 pub use sampling::markov_step_argmax_into;
+pub use sampling::markov_step_argmax_mapped_into;
 pub use sampling::markov_step_argmax_partials_len;
+pub use sampling::markov_step_top2_into;
 
 pub(crate) fn checked_i32(value: usize, what: &str) -> anyhow::Result<i32> {
     i32::try_from(value).map_err(|_| anyhow::anyhow!("{what} {value} does not fit i32"))

--- a/pegainfer-kernels/src/ops/sampling.rs
+++ b/pegainfer-kernels/src/ops/sampling.rs
@@ -376,7 +376,9 @@ pub fn argmax_batch_bf16_split_partials_len(rows: usize, vocab: usize) -> usize 
 /// `MARKOV_STEP_TILE_ELEMS` in `argmax.cu`).
 pub fn markov_step_argmax_partials_len(rows: usize, vocab: usize) -> usize {
     const TILE_ELEMS: usize = 1024;
-    rows * vocab.div_ceil(TILE_ELEMS)
+    // Saturating: an overflowing request then fails every buffer-length check
+    // downstream instead of wrapping into a small (falsely satisfiable) need.
+    rows.saturating_mul(vocab.div_ceil(TILE_ELEMS))
 }
 
 /// Row-wise two-stage bf16 argmax over `rows` rows of `n`: tile-parallel
@@ -604,7 +606,8 @@ pub unsafe fn logprob_topk_batch_bf16_into(
 /// u32 (so it feeds straight back as the next step's prev-token lookup).
 /// `base` is the request-major block logits `[rows*block_size, vocab]`; `bias`
 /// is the per-request Markov logit bias `[rows, vocab]` for this step. `partial_*`
-/// must hold `argmax_batch_bf16_split_partials_len(rows, vocab)` elements.
+/// must hold [`markov_step_argmax_partials_len`] elements — this path tiles
+/// finer than the batched argmax, so its partials buffer is NOT the same size.
 /// `sampled_tokens` receives the request-major block token at
 /// `row * block_size + step`, allowing callers to D2H the finished block once.
 #[allow(clippy::too_many_arguments)]
@@ -620,8 +623,103 @@ pub fn markov_step_argmax_into(
     out_tokens: &mut CudaSlice<u32>,
     sampled_tokens: &mut CudaSlice<u32>,
 ) -> Result<()> {
+    markov_step_argmax_impl(
+        ctx,
+        base,
+        bias,
+        block_size,
+        step,
+        1,
+        None,
+        rows,
+        partial_values,
+        partial_indices,
+        out_tokens,
+        sampled_tokens,
+    )
+}
+
+/// [`markov_step_argmax_into`] over `rows = groups * chains` chain-rows with a
+/// per-chain-group request map: chain-row `r` belongs to group `r / chains`
+/// and reads base block `req_map[r / chains]`, so a hedged subset that is not
+/// a batch prefix still addresses its own requests' logits.
+///
+/// # Safety
+///
+/// The map lives on device, so its CONTENTS cannot be validated here. The
+/// caller must guarantee every `req_map[0..rows/chains]` value is in
+/// `0..base.seq_len / block_size` — the kernel uses them directly as base
+/// block indices, and an out-of-range or negative value reads out of bounds
+/// on the GPU. Validate on the host before uploading.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn markov_step_argmax_mapped_into(
+    ctx: &DeviceContext,
+    base: &HiddenStates,
+    bias: &HiddenStates,
+    block_size: usize,
+    step: usize,
+    chains: usize,
+    req_map: &CudaSlice<i32>,
+    rows: usize,
+    partial_values: &mut CudaSlice<f32>,
+    partial_indices: &mut CudaSlice<i32>,
+    out_tokens: &mut CudaSlice<u32>,
+    sampled_tokens: &mut CudaSlice<u32>,
+) -> Result<()> {
+    markov_step_argmax_impl(
+        ctx,
+        base,
+        bias,
+        block_size,
+        step,
+        chains,
+        Some(req_map),
+        rows,
+        partial_values,
+        partial_indices,
+        out_tokens,
+        sampled_tokens,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn markov_step_argmax_impl(
+    ctx: &DeviceContext,
+    base: &HiddenStates,
+    bias: &HiddenStates,
+    block_size: usize,
+    step: usize,
+    chains: usize,
+    req_map: Option<&CudaSlice<i32>>,
+    rows: usize,
+    partial_values: &mut CudaSlice<f32>,
+    partial_indices: &mut CudaSlice<i32>,
+    out_tokens: &mut CudaSlice<u32>,
+    sampled_tokens: &mut CudaSlice<u32>,
+) -> Result<()> {
     if rows == 0 {
         return Err(anyhow!("markov step argmax requires at least one row"));
+    }
+    if base.hidden_dim == 0 {
+        return Err(anyhow!(
+            "markov step argmax requires a non-zero vocab (zero tiles would launch an empty grid)"
+        ));
+    }
+    if step >= block_size {
+        return Err(anyhow!(
+            "markov step step {step} >= block_size {block_size}"
+        ));
+    }
+    base.checked_extent("markov step base")?;
+    bias.checked_extent("markov step bias")?;
+    // The kernels derive their indices in signed int, so the products need
+    // bounding, not just each factor.
+    super::checked_i32(base.seq_len, "markov step base rows")?;
+    if rows > 65_535 {
+        return Err(anyhow!("markov step rows {rows} exceeds grid-y limit"));
+    }
+    if base.hidden_dim > (i32::MAX as usize) - 1024 {
+        return Err(anyhow!("markov step vocab {} too large", base.hidden_dim));
     }
     let vocab = base.hidden_dim;
     if bias.hidden_dim != vocab {
@@ -631,12 +729,29 @@ pub fn markov_step_argmax_into(
             vocab
         ));
     }
-    if base.seq_len < rows * block_size {
+    if chains == 0 || !rows.is_multiple_of(chains) {
         return Err(anyhow!(
-            "markov step base rows {} < rows*block_size {}",
-            base.seq_len,
-            rows * block_size
+            "markov step rows {rows} not divisible by chains {chains}"
         ));
+    }
+    let base_needed = (rows / chains)
+        .checked_mul(block_size)
+        .ok_or_else(|| anyhow!("markov step (rows/chains)*block_size overflow"))?;
+    if req_map.is_none() && base.seq_len < base_needed {
+        return Err(anyhow!(
+            "markov step base rows {} < (rows/chains)*block_size {}",
+            base.seq_len,
+            base_needed
+        ));
+    }
+    if let Some(map) = req_map {
+        if map.len() < rows / chains {
+            return Err(anyhow!(
+                "markov step req_map {} < chain groups {}",
+                map.len(),
+                rows / chains
+            ));
+        }
     }
     if bias.seq_len < rows {
         return Err(anyhow!("markov step bias rows {} < {}", bias.seq_len, rows));
@@ -648,11 +763,14 @@ pub fn markov_step_argmax_into(
             rows
         ));
     }
-    if sampled_tokens.len() < rows * block_size {
+    let sampled_needed = rows
+        .checked_mul(block_size)
+        .ok_or_else(|| anyhow!("markov step rows*block_size overflow"))?;
+    if sampled_tokens.len() < sampled_needed {
         return Err(anyhow!(
             "markov sampled-token scratch too small: {} < {}",
             sampled_tokens.len(),
-            rows * block_size
+            sampled_needed
         ));
     }
     let needed = markov_step_argmax_partials_len(rows, vocab);
@@ -664,6 +782,11 @@ pub fn markov_step_argmax_into(
             needed
         ));
     }
+    if needed > i32::MAX as usize || sampled_needed > i32::MAX as usize {
+        return Err(anyhow!(
+            "markov step index space too large: partials {needed}, sampled {sampled_needed}"
+        ));
+    }
 
     let (base_ptr, _gb) = base.data.device_ptr(&ctx.stream);
     let (bias_ptr, _gbi) = bias.data.device_ptr(&ctx.stream);
@@ -671,23 +794,271 @@ pub fn markov_step_argmax_into(
     let (pi_ptr, _gpi) = partial_indices.device_ptr_mut(&ctx.stream);
     let (out_ptr, _go) = out_tokens.device_ptr_mut(&ctx.stream);
     let (sampled_ptr, _gs) = sampled_tokens.device_ptr_mut(&ctx.stream);
+    let map_guard = req_map.map(|map| map.device_ptr(&ctx.stream));
+    let map_ptr = map_guard
+        .as_ref()
+        .map_or(std::ptr::null(), |(ptr, _)| *ptr as *const i32);
 
-    unsafe {
+    let rc = unsafe {
         ffi::markov_step_argmax_cuda(
             base_ptr as *const ffi::Half,
             bias_ptr as *const ffi::Half,
-            block_size as i32,
-            step as i32,
-            rows as i32,
-            vocab as i32,
+            super::checked_i32(block_size, "markov step block_size")?,
+            super::checked_i32(step, "markov step step")?,
+            super::checked_i32(chains, "markov step chains")?,
+            map_ptr,
+            super::checked_i32(rows, "markov step rows")?,
+            super::checked_i32(vocab, "markov step vocab")?,
             pv_ptr as *mut f32,
             pi_ptr as *mut i32,
             out_ptr as *mut u32,
             sampled_ptr as *mut u32,
             crate::tensor::active_cu_stream(ctx),
-        );
+        )
+    };
+    if rc != 0 {
+        return Err(anyhow!("markov step argmax launch failed: cuda error {rc}"));
     }
 
+    Ok(())
+}
+
+/// Top-2 of `base[(row*block+step), v] + bias[row, v]` per row (exact for
+/// rows with two or more finite candidates; see the sentinel below). The
+/// top-1 is written exactly like [`markov_step_argmax_into`]'s output (the
+/// ping-pong `output` plus the `sampled_tokens` stamp), so a branch step needs
+/// no separate argmax pass; the runner-up lands in `out_top2` — the
+/// speculative hedge's branch source.
+/// A row with fewer than two finite logits returns index 0 as the runner-up
+/// sentinel (possibly duplicating top-1); callers must deduplicate — the
+/// hedge expansion drops chains identical to the greedy one.
+#[allow(clippy::too_many_arguments)]
+pub fn markov_step_top2_into(
+    ctx: &DeviceContext,
+    base: &HiddenStates,
+    bias: &HiddenStates,
+    block_size: usize,
+    step: usize,
+    rows: usize,
+    partial_v1: &mut CudaSlice<f32>,
+    partial_i1: &mut CudaSlice<i32>,
+    partial_v2: &mut CudaSlice<f32>,
+    partial_i2: &mut CudaSlice<i32>,
+    output: &mut CudaSlice<u32>,
+    sampled_tokens: &mut CudaSlice<u32>,
+    out_top2: &mut CudaSlice<u32>,
+) -> Result<()> {
+    if rows == 0 {
+        return Err(anyhow!("markov step top2 requires at least one row"));
+    }
+    if base.hidden_dim == 0 {
+        return Err(anyhow!(
+            "markov step top2 requires a non-zero vocab (zero tiles would launch an empty grid)"
+        ));
+    }
+    if step >= block_size {
+        return Err(anyhow!(
+            "markov top2 step {step} >= block_size {block_size}"
+        ));
+    }
+    base.checked_extent("markov top2 base")?;
+    bias.checked_extent("markov top2 bias")?;
+    super::checked_i32(base.seq_len, "markov top2 base rows")?;
+    if rows > 65_535 {
+        return Err(anyhow!("markov top2 rows {rows} exceeds grid-y limit"));
+    }
+    if base.hidden_dim > (i32::MAX as usize) - 1024 {
+        return Err(anyhow!("markov top2 vocab {} too large", base.hidden_dim));
+    }
+    let sampled_needed = rows
+        .checked_mul(block_size)
+        .ok_or_else(|| anyhow!("markov top2 rows*block_size overflow"))?;
+    if sampled_tokens.len() < sampled_needed {
+        return Err(anyhow!(
+            "markov top2 sampled buffer {} < rows*block_size {}",
+            sampled_tokens.len(),
+            sampled_needed
+        ));
+    }
+    let vocab = base.hidden_dim;
+    if bias.hidden_dim != vocab {
+        return Err(anyhow!(
+            "markov top2 bias vocab {} != base vocab {}",
+            bias.hidden_dim,
+            vocab
+        ));
+    }
+    let base_needed = rows
+        .checked_mul(block_size)
+        .ok_or_else(|| anyhow!("markov top2 rows*block_size overflow"))?;
+    if base.seq_len < base_needed {
+        return Err(anyhow!(
+            "markov top2 base rows {} < rows*block_size {}",
+            base.seq_len,
+            base_needed
+        ));
+    }
+    if bias.seq_len < rows {
+        return Err(anyhow!("markov top2 bias rows {} < {}", bias.seq_len, rows));
+    }
+    if output.len() < rows || out_top2.len() < rows {
+        return Err(anyhow!(
+            "markov top2 out too small: {}/{} < {}",
+            output.len(),
+            out_top2.len(),
+            rows
+        ));
+    }
+    let needed = markov_step_argmax_partials_len(rows, vocab);
+    if partial_v1.len() < needed
+        || partial_i1.len() < needed
+        || partial_v2.len() < needed
+        || partial_i2.len() < needed
+    {
+        return Err(anyhow!(
+            "markov top2 partials too small: need {needed} per pair"
+        ));
+    }
+    if needed > i32::MAX as usize || sampled_needed > i32::MAX as usize {
+        return Err(anyhow!(
+            "markov top2 index space too large: partials {needed}, sampled {sampled_needed}"
+        ));
+    }
+
+    let (base_ptr, _gb) = base.data.device_ptr(&ctx.stream);
+    let (bias_ptr, _gbi) = bias.data.device_ptr(&ctx.stream);
+    let (pv1_ptr, _g1) = partial_v1.device_ptr_mut(&ctx.stream);
+    let (pi1_ptr, _g2) = partial_i1.device_ptr_mut(&ctx.stream);
+    let (pv2_ptr, _g3) = partial_v2.device_ptr_mut(&ctx.stream);
+    let (pi2_ptr, _g4) = partial_i2.device_ptr_mut(&ctx.stream);
+    let (out_ptr, _g5) = output.device_ptr_mut(&ctx.stream);
+    let (samp_ptr, _g6) = sampled_tokens.device_ptr_mut(&ctx.stream);
+    let (o2_ptr, _g7) = out_top2.device_ptr_mut(&ctx.stream);
+
+    let block_i = super::checked_i32(block_size, "markov top2 block_size")?;
+    let step_i = super::checked_i32(step, "markov top2 step")?;
+    // One chain-row per request: the ladder's multi-chain rows go through the
+    // argmax path, which has the mapped variant.
+    let chains_i = 1i32;
+    let rows_i = super::checked_i32(rows, "markov top2 rows")?;
+    let vocab_i = super::checked_i32(vocab, "markov top2 vocab")?;
+    let rc = unsafe {
+        ffi::markov_step_top2_cuda(
+            base_ptr as *const ffi::Half,
+            bias_ptr as *const ffi::Half,
+            block_i,
+            step_i,
+            chains_i,
+            rows_i,
+            vocab_i,
+            pv1_ptr as *mut f32,
+            pi1_ptr as *mut i32,
+            pv2_ptr as *mut f32,
+            pi2_ptr as *mut i32,
+            out_ptr as *mut u32,
+            samp_ptr as *mut u32,
+            o2_ptr as *mut u32,
+            crate::tensor::active_cu_stream(ctx),
+        )
+    };
+    if rc != 0 {
+        return Err(anyhow!("markov top2 launch failed: cuda error {rc}"));
+    }
+
+    Ok(())
+}
+
+/// Hedge-ladder branch force (see `hedge_ladder_force_cuda`): stamps chain
+/// `(i, j)`'s device-resident runner token into the prev buffer and the
+/// sampled block at `step`, for all `n` requests.
+#[allow(clippy::too_many_arguments)]
+///
+/// # Safety
+///
+/// `req_map` lives on device and cannot be validated here: every
+/// `req_map[0..n]` value must be in `0..runner_stride`, or the runner gather
+/// reads out of bounds on the GPU. Validate on the host before uploading.
+pub unsafe fn hedge_ladder_force_into(
+    ctx: &DeviceContext,
+    prev_tokens: &mut CudaSlice<u32>,
+    sampled_tokens: &mut CudaSlice<u32>,
+    runner_tokens: &CudaSlice<u32>,
+    req_map: &CudaSlice<i32>,
+    n: usize,
+    c: usize,
+    j: usize,
+    runner_stride: usize,
+    block_size: usize,
+    step: usize,
+) -> Result<()> {
+    if n == 0 || c == 0 || j >= c {
+        return Err(anyhow!("hedge force bad shape: n={n} c={c} j={j}"));
+    }
+    let rows = n
+        .checked_mul(c)
+        .ok_or_else(|| anyhow!("hedge force n*c overflow"))?;
+    let sampled_needed = rows
+        .checked_mul(block_size)
+        .ok_or_else(|| anyhow!("hedge force n*c*block_size overflow"))?;
+    // Mapped indices may address anywhere in `0..runner_stride`, so the WHOLE
+    // stripe must be backed, not just its first `n` entries.
+    let runner_needed = j
+        .checked_add(1)
+        .and_then(|v| v.checked_mul(runner_stride))
+        .ok_or_else(|| anyhow!("hedge force runner stripe overflow"))?;
+    if prev_tokens.len() < rows
+        || sampled_tokens.len() < sampled_needed
+        || runner_tokens.len() < runner_needed
+    {
+        return Err(anyhow!("hedge force buffers too small"));
+    }
+    if step >= block_size {
+        return Err(anyhow!(
+            "hedge force step {step} >= block_size {block_size}"
+        ));
+    }
+    if runner_stride < n {
+        return Err(anyhow!("hedge force runner stride {runner_stride} < n {n}"));
+    }
+    if req_map.len() < n {
+        return Err(anyhow!("hedge force req_map {} < n {n}", req_map.len()));
+    }
+    if n > (i32::MAX as usize) - 128 {
+        return Err(anyhow!("hedge force n {n} too large"));
+    }
+    if sampled_needed > i32::MAX as usize || runner_needed > i32::MAX as usize {
+        return Err(anyhow!(
+            "hedge force index space too large: sampled {sampled_needed}, runner {runner_needed}"
+        ));
+    }
+    let n_i = super::checked_i32(n, "hedge force n")?;
+    let c_i = super::checked_i32(c, "hedge force c")?;
+    let j_i = super::checked_i32(j, "hedge force j")?;
+    let stride_i = super::checked_i32(runner_stride, "hedge force runner_stride")?;
+    let block_i = super::checked_i32(block_size, "hedge force block_size")?;
+    let step_i = super::checked_i32(step, "hedge force step")?;
+    let (prev_ptr, _g1) = prev_tokens.device_ptr_mut(&ctx.stream);
+    let (samp_ptr, _g2) = sampled_tokens.device_ptr_mut(&ctx.stream);
+    let (run_ptr, _g3) = runner_tokens.device_ptr(&ctx.stream);
+    let (map_ptr, _g4) = req_map.device_ptr(&ctx.stream);
+    let rc = unsafe {
+        ffi::hedge_ladder_force_cuda(
+            prev_ptr as *mut u32,
+            samp_ptr as *mut u32,
+            run_ptr as *const u32,
+            map_ptr as *const i32,
+            n_i,
+            c_i,
+            j_i,
+            stride_i,
+            block_i,
+            step_i,
+            crate::tensor::active_cu_stream(ctx),
+        )
+    };
+    if rc != 0 {
+        return Err(anyhow!("hedge ladder force launch failed: cuda error {rc}"));
+    }
     Ok(())
 }
 

--- a/pegainfer-kv-cache/src/buffer.rs
+++ b/pegainfer-kv-cache/src/buffer.rs
@@ -68,4 +68,33 @@ impl KvBuffer {
     pub fn num_blocks(&self) -> usize {
         self.inner.num_blocks
     }
+
+    /// Stream-ordered device-to-device copy of one whole page (every layer's
+    /// K/V for `page_size` tokens — one contiguous `page_stride` range in the
+    /// page-first layout). Both pages must lie inside the buffer; scratch
+    /// pages past the pool's block count are valid targets.
+    pub fn copy_page(
+        &self,
+        stream: &CudaStream,
+        src_page: usize,
+        dst_page: usize,
+    ) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            src_page < self.inner.num_blocks && dst_page < self.inner.num_blocks,
+            "KV page copy out of range: {src_page} -> {dst_page} of {}",
+            self.inner.num_blocks
+        );
+        if src_page == dst_page {
+            return Ok(());
+        }
+        let stride = self.inner.layout.page_stride;
+        let elem = std::mem::size_of::<bf16>();
+        let (base, _guard) = self.inner.buffer.device_ptr(stream);
+        let src = base + (src_page * stride * elem) as u64;
+        let dst = base + (dst_page * stride * elem) as u64;
+        unsafe {
+            cudarc::driver::result::memcpy_dtod_async(dst, src, stride * elem, stream.cu_stream())
+        }
+        .map_err(|e| anyhow::anyhow!("KV page copy failed: {e}"))
+    }
 }

--- a/pegainfer-kv-cache/src/manager.rs
+++ b/pegainfer-kv-cache/src/manager.rs
@@ -26,13 +26,40 @@ impl KvCacheManager {
         block_size: usize,
         num_blocks: usize,
     ) -> anyhow::Result<Self> {
-        let buffer = KvBuffer::new(
+        Self::new_with_scratch_pages(
             stream,
             num_layers,
             num_kv_heads,
             head_dim,
             block_size,
             num_blocks,
+            0,
+        )
+    }
+
+    /// Like [`new`](Self::new), plus `scratch_pages` extra pages in the GPU
+    /// buffer that the pool never hands out. Their page ids are
+    /// `num_blocks..num_blocks + scratch_pages`; ownership and content are the
+    /// caller's business (e.g. the speculative hedge's alternative-chain verify
+    /// KV). The transaction layer is unaware of them by construction.
+    pub fn new_with_scratch_pages(
+        stream: &Arc<CudaStream>,
+        num_layers: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+        block_size: usize,
+        num_blocks: usize,
+        scratch_pages: usize,
+    ) -> anyhow::Result<Self> {
+        let buffer = KvBuffer::new(
+            stream,
+            num_layers,
+            num_kv_heads,
+            head_dim,
+            block_size,
+            num_blocks.checked_add(scratch_pages).ok_or_else(|| {
+                anyhow::anyhow!("KV pages {num_blocks} + scratch {scratch_pages} overflow")
+            })?,
         )?;
         let pool = BlockPool::new(block_size, num_blocks)?;
         Ok(Self { pool, buffer })

--- a/pegainfer-qwen3/src/dflash.rs
+++ b/pegainfer-qwen3/src/dflash.rs
@@ -263,8 +263,16 @@ impl DFlashBatchScratch {
         })
     }
 
+    /// Markov scratch's max batch (chain-rows), `0` for a plain DFlash
+    /// drafter — the hedge ladder's capacity guard.
+    pub(crate) fn markov_max_batch(&self) -> usize {
+        self.markov
+            .as_ref()
+            .map_or(0, crate::dspark::MarkovScratch::max_batch)
+    }
+
     /// The batched backbone draft logits `[active_batch * block_size, vocab]`,
-    /// request-major, as produced by [`DFlashDraftModel::draft_logits_batched`].
+    /// request-major, as produced by `DFlashDraftModel::draft_logits_batched`.
     pub(crate) fn logits(&self) -> &HiddenStates {
         &self.logits
     }
@@ -794,6 +802,70 @@ impl DFlashDraftModel {
         )
     }
 
+    /// Chain-A markov proposal plus per-branch-position runner-up capture
+    /// (see [`crate::dspark::MarkovHead::sample_block_with_runners`]).
+    pub(crate) fn markov_draft_with_runners(
+        &self,
+        ctx: &DeviceContext,
+        current_tokens: &[u32],
+        branch_positions: &[usize],
+        scratch: &mut DFlashBatchScratch,
+    ) -> Result<Vec<u32>> {
+        let markov = self
+            .markov
+            .as_ref()
+            .context("markov_draft_with_runners called on a non-DSpark drafter")?;
+        let DFlashBatchScratch {
+            logits,
+            markov: markov_scratch,
+            ..
+        } = scratch;
+        let markov_scratch = markov_scratch
+            .as_mut()
+            .context("Markov scratch was not allocated for a DSpark drafter")?;
+        markov.sample_block_with_runners(
+            ctx,
+            logits,
+            current_tokens,
+            self.block_size(),
+            branch_positions,
+            markov_scratch,
+        )
+    }
+
+    /// Batched hedge-chain ladder (see
+    /// [`crate::dspark::MarkovHead::sample_chain_ladder`]).
+    pub(crate) fn markov_chain_ladder(
+        &self,
+        ctx: &DeviceContext,
+        chain_a: &[u32],
+        req_map: &[u32],
+        positions: &[usize],
+        scratch: &mut DFlashBatchScratch,
+    ) -> Result<Vec<u32>> {
+        let markov = self
+            .markov
+            .as_ref()
+            .context("markov_chain_ladder called on a non-DSpark drafter")?;
+        let DFlashBatchScratch {
+            logits,
+            markov: markov_scratch,
+            ..
+        } = scratch;
+        let markov_scratch = markov_scratch
+            .as_mut()
+            .context("Markov scratch was not allocated for a DSpark drafter")?;
+        markov.sample_chain_ladder(
+            ctx,
+            logits,
+            chain_a,
+            req_map,
+            positions,
+            self.block_size(),
+            markov_scratch,
+        )
+    }
+
     fn context_feature_dim(&self) -> usize {
         self.config.hidden_size * self.target_layer_ids().len()
     }
@@ -886,7 +958,8 @@ mod tests {
         // 2560*5*2) drives the ~12% block haircut; a layer-count or geometry
         // regression here would silently over/under-reserve and risk OOM.
         let reservation =
-            super::DFlashMemoryReservation::from_config(&dflash, /*max_decode_batch*/ 256);
+            super::DFlashMemoryReservation::from_config(&dflash, /*max_decode_batch*/ 256)
+                .expect("reservation sizing");
         assert_eq!(
             reservation.kv_bytes_per_token, 65_536,
             "draft KV(20480) + scratch-ctx(19456) + pending(25600) per token"
@@ -894,7 +967,9 @@ mod tests {
         // Weights (~1.1 GiB) dominate the fixed term at batch=1; the block-sized
         // per-request scratch (~6.5 MiB, logits-heavy) plus the one-block KV/tail
         // headroom (~0.5 MiB) add across the decode batch.
-        let fixed_batch1 = super::DFlashMemoryReservation::from_config(&dflash, 1).fixed_bytes;
+        let fixed_batch1 = super::DFlashMemoryReservation::from_config(&dflash, 1)
+            .expect("reservation sizing")
+            .fixed_bytes;
         assert!(
             (1_150_000_000..1_220_000_000).contains(&fixed_batch1),
             "draft weights ~1.1GiB, got {fixed_batch1}"

--- a/pegainfer-qwen3/src/dflash/reservation.rs
+++ b/pegainfer-qwen3/src/dflash/reservation.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 
 use crate::config::DFlashConfig;
 use crate::dspark::MarkovHead;
+use crate::sizing;
 
 /// GPU memory DFlash needs on top of the target KV pool, derived from the draft
 /// config so the KV budget can reserve it *before* the draft model loads (the
@@ -24,65 +25,102 @@ use crate::dspark::MarkovHead;
 pub(crate) struct DFlashMemoryReservation {
     pub(crate) kv_bytes_per_token: usize,
     pub(crate) fixed_bytes: usize,
+    /// Drafter block size, surfaced so startup budgets (hedge scratch pages,
+    /// verify-plan metadata) can share the config read.
+    pub(crate) block_size: usize,
+    /// Whether the drafter has a Markov head: a plain DFlash checkpoint can
+    /// never hedge, so startup must not reserve hedge scratch for it even
+    /// under a nonzero hedge env.
+    pub(crate) uses_markov_head: bool,
 }
 
 impl DFlashMemoryReservation {
     pub(crate) fn from_path(draft_path: &str, max_decode_batch_size: usize) -> Result<Self> {
         let config = DFlashConfig::from_file(draft_path)?;
-        Ok(Self::from_config(&config, max_decode_batch_size))
+        Self::from_config(&config, max_decode_batch_size)
     }
 
-    pub(crate) fn from_config(config: &DFlashConfig, max_decode_batch_size: usize) -> Self {
+    pub(crate) fn from_config(config: &DFlashConfig, max_decode_batch_size: usize) -> Result<Self> {
         const BF16: usize = 2;
         let hidden = config.hidden_size;
-        let kv_dim = config.num_key_value_heads * config.head_dim;
-        let q_dim = config.num_attention_heads * config.head_dim;
+        let kv_dim = sizing::product(&[config.num_key_value_heads, config.head_dim])?;
+        let q_dim = sizing::product(&[config.num_attention_heads, config.head_dim])?;
         let inter = config.intermediate_size;
         let capture_layers = config.target_layer_ids.len();
 
         // Per-sequence-token, pool-scaling buffers.
-        let draft_kv = config.num_hidden_layers * 2 * kv_dim * BF16; // DFlashLayerCache k+v
+        // DFlashLayerCache k+v
+        let draft_kv = sizing::product(&[config.num_hidden_layers, 2, kv_dim, BF16])?;
         // Scratch split by what it tracks: `context_*` grows with the committed
         // prefix; `tail_*` (tail_input + k_tail + v_tail) grows with the in-fill
         // tail, which is one block past the prefix.
-        let context_scratch = 2 * hidden * BF16; // context_projected + context_hidden
-        let tail_scratch = (hidden + 2 * kv_dim) * BF16; // tail_input + k_tail + v_tail
-        let pending = hidden * capture_layers * BF16; // context_feature_dim
-        let kv_bytes_per_token = draft_kv + context_scratch + tail_scratch + pending;
+        let context_scratch = sizing::product(&[2, hidden, BF16])?; // context_projected + context_hidden
+        // tail_input + k_tail + v_tail
+        let tail_scratch = sizing::product(&[
+            sizing::sum(&[hidden, sizing::product(&[2, kv_dim])?])?,
+            BF16,
+        ])?;
+        let pending = sizing::product(&[hidden, capture_layers, BF16])?; // context_feature_dim
+        let kv_bytes_per_token = sizing::sum(&[draft_kv, context_scratch, tail_scratch, pending])?;
 
         // Lane-level batched dense scratch: every dense buffer is sized for the
         // whole decode batch (`max_batch * block_size` rows), allocated once.
         // Same total magnitude as the old per-request scratch summed over the
         // batch, but now one contiguous allocation.
-        let dense_scratch_per_block_row =
-            BF16 * (config.vocab_size + 5 * hidden + 2 * q_dim + 3 * inter);
-        let scratch_total = dense_scratch_per_block_row * config.block_size * max_decode_batch_size;
+        let dense_scratch_per_block_row = sizing::product(&[
+            BF16,
+            sizing::sum(&[
+                config.vocab_size,
+                sizing::product(&[5, hidden])?,
+                sizing::product(&[2, q_dim])?,
+                sizing::product(&[3, inter])?,
+            ])?,
+        ])?;
+        let scratch_total = sizing::product(&[
+            dense_scratch_per_block_row,
+            config.block_size,
+            max_decode_batch_size,
+        ])?;
 
         // Draft weights (5 transformer layers + the context projection), +10% slack
         // for norms, rope caches, and allocator alignment.
-        let per_layer = BF16
-            * (hidden * (q_dim + 2 * kv_dim) // qkv_proj
-                + q_dim * hidden // o_proj
-                + hidden * 2 * inter // gate_up_proj
-                + inter * hidden); // down_proj
-        let fc = BF16 * hidden * (hidden * capture_layers); // context projection
-        let weights = per_layer * config.num_hidden_layers + fc;
-        let weights = weights + weights / 10;
+        let per_layer = sizing::product(&[
+            BF16,
+            sizing::sum(&[
+                sizing::product(&[
+                    hidden,
+                    sizing::sum(&[q_dim, sizing::product(&[2, kv_dim])?])?,
+                ])?, // qkv_proj
+                sizing::product(&[q_dim, hidden])?,    // o_proj
+                sizing::product(&[hidden, 2, inter])?, // gate_up_proj
+                sizing::product(&[inter, hidden])?,    // down_proj
+            ])?,
+        ])?;
+        // context projection
+        let fc = sizing::product(&[BF16, hidden, hidden, capture_layers])?;
+        let weights = sizing::sum(&[sizing::product(&[per_layer, config.num_hidden_layers])?, fc])?;
+        let weights = sizing::sum(&[weights, weights / 10])?;
 
         // The durable draft KV and the tail scratch are sized to `context +
         // block_size` — one in-fill block past the lifetime the KV pool reserves
         // for the request. The per-token term bills only the pool's tokens, so
         // reserve that one-block headroom per concurrently decoding request to
         // keep the reservation an upper bound.
-        let block_headroom = max_decode_batch_size * config.block_size * (draft_kv + tail_scratch);
+        let block_headroom = sizing::product(&[
+            max_decode_batch_size,
+            config.block_size,
+            sizing::sum(&[draft_kv, tail_scratch])?,
+        ])?;
 
         // DSpark Markov head: weights (2 × vocab × rank) + sample scratch (the
         // per-step bias is the dominant term). Zero for plain DFlash drafters.
-        let markov = MarkovHead::reservation_bytes(config, max_decode_batch_size);
+        let markov = MarkovHead::reservation_bytes(config, max_decode_batch_size)?;
 
-        Self {
+        Ok(Self {
             kv_bytes_per_token,
-            fixed_bytes: weights + scratch_total + block_headroom + markov,
-        }
+            fixed_bytes: sizing::sum(&[weights, scratch_total, block_headroom, markov])?,
+            block_size: config.block_size,
+            uses_markov_head: config.uses_markov_head(),
+        })
     }
 }

--- a/pegainfer-qwen3/src/dspark.rs
+++ b/pegainfer-qwen3/src/dspark.rs
@@ -3,8 +3,11 @@
 //!
 //! DSpark = DFlash backbone + a low-rank Markov head. The backbone forward, the
 //! verify span, and the optimistic KV transaction are reused verbatim from
-//! [`crate::dflash`]; the *only* change is how draft tokens are selected from the
-//! backbone's block logits. Where DFlash takes an independent argmax per block
+//! [`crate::dflash`]; the only change on the default path is how draft tokens
+//! are selected from the backbone's block logits. (With `PEGAINFER_SPEC_HEDGE`
+//! set, the verify pass additionally carries alternative chains over lane-owned
+//! scratch pages — opt-in, and still on the same transaction interface; see
+//! `try_execute_hedged_verify`.) Where DFlash takes an independent argmax per block
 //! position, DSpark adds a bigram-style logit bias `B(prev) = w2(w1[prev])` and
 //! samples the block left-to-right, so each draft conditions on the previous one
 //! (semi-autoregressive). In greedy decoding this is lossless — the bias only
@@ -23,14 +26,23 @@
 
 use anyhow::Result;
 use cudarc::driver::CudaSlice;
+use pegainfer_core::cuda_graph::CudaGraphState;
 use pegainfer_core::ops;
 use pegainfer_core::tensor::DeviceContext;
 use pegainfer_core::tensor::DeviceMatrix;
 use pegainfer_core::tensor::HiddenStates;
+use pegainfer_kernels::ops::hedge_ladder_force_into;
 use pegainfer_kernels::ops::markov_step_argmax_into;
+use pegainfer_kernels::ops::markov_step_argmax_mapped_into;
 use pegainfer_kernels::ops::markov_step_argmax_partials_len;
+use pegainfer_kernels::ops::markov_step_top2_into;
 
 use crate::config::DFlashConfig;
+use crate::sizing;
+
+fn markov_graph_enabled() -> bool {
+    std::env::var_os("DSPARK_NO_MARKOV_GRAPH").is_none()
+}
 
 pub(crate) const MARKOV_W1_TENSOR: &str = "markov_head.markov_w1.weight";
 pub(crate) const MARKOV_W2_TENSOR: &str = "markov_head.markov_w2.weight";
@@ -113,44 +125,534 @@ impl MarkovHead {
         }
 
         let mut sampled = vec![0u32; rows * block_size];
-        for step in 0..block_size {
-            // w1emb[rows, rank] = markov_w1[prev]
-            ops::embedding_batch(ctx, &self.w1, &scratch.prev_tokens, &mut scratch.w1emb)?;
-            // bias[rows, vocab] = w1emb @ w2^T
-            ops::gemm_into(ctx, &self.w2, &scratch.w1emb, &mut scratch.bias);
-            // next[i] = argmax_v ( base_logits[(i*B+step), v] + bias[i, v] )
-            markov_step_argmax_into(
-                ctx,
-                base_logits,
-                &scratch.bias,
-                block_size,
-                step,
-                rows,
-                &mut scratch.partial_values,
-                &mut scratch.partial_indices,
-                &mut scratch.next_tokens,
-                &mut scratch.sampled_tokens,
-            )?;
-            std::mem::swap(&mut scratch.prev_tokens, &mut scratch.next_tokens);
+        if markov_graph_enabled() && scratch.chain_warm[rows - 1] {
+            let MarkovScratch {
+                chain_graphs,
+                w1emb,
+                bias,
+                partial_values,
+                partial_indices,
+                prev_tokens,
+                next_tokens,
+                sampled_tokens,
+                ..
+            } = scratch;
+            chain_graphs[rows - 1].run_or_capture(ctx, || {
+                for step in 0..block_size {
+                    let (input, output): (&CudaSlice<u32>, &mut CudaSlice<u32>) = if step % 2 == 0 {
+                        (&*prev_tokens, &mut *next_tokens)
+                    } else {
+                        (&*next_tokens, &mut *prev_tokens)
+                    };
+                    ops::embedding_batch(ctx, &self.w1, input, w1emb)?;
+                    ops::gemm_into_checked(ctx, &self.w2, w1emb, bias)?;
+                    markov_step_argmax_into(
+                        ctx,
+                        base_logits,
+                        bias,
+                        block_size,
+                        step,
+                        rows,
+                        partial_values,
+                        partial_indices,
+                        output,
+                        sampled_tokens,
+                    )?;
+                }
+                Ok(())
+            })?;
+        } else {
+            for step in 0..block_size {
+                let input_is_prev = step % 2 == 0;
+                {
+                    let input = if input_is_prev {
+                        &scratch.prev_tokens
+                    } else {
+                        &scratch.next_tokens
+                    };
+                    ops::embedding_batch(ctx, &self.w1, input, &mut scratch.w1emb)?;
+                }
+                ops::gemm_into_checked(ctx, &self.w2, &scratch.w1emb, &mut scratch.bias)?;
+                let output = if input_is_prev {
+                    &mut scratch.next_tokens
+                } else {
+                    &mut scratch.prev_tokens
+                };
+                markov_step_argmax_into(
+                    ctx,
+                    base_logits,
+                    &scratch.bias,
+                    block_size,
+                    step,
+                    rows,
+                    &mut scratch.partial_values,
+                    &mut scratch.partial_indices,
+                    output,
+                    &mut scratch.sampled_tokens,
+                )?;
+            }
+            scratch.chain_warm[rows - 1] = true;
         }
         let sampled_view = scratch.sampled_tokens.slice(..rows * block_size);
         sampled.copy_from_slice(&ctx.stream.clone_dtoh(&sampled_view)?);
         Ok(sampled)
     }
 
+    /// Chain-A sample loop that also captures the exact Markov runner-up at
+    /// each `branch_positions` step (given the chain's true parent at that
+    /// step). Returns chain A's host tokens (request-major, needed for verify
+    /// span assembly); the runner-ups stay device-resident in
+    /// `MarkovScratch::runner_tokens` stripes (`[j * max_batch + i]` =
+    /// request `i`'s rank-2 alternative at `branch_positions[j]`) for the
+    /// ladder to consume. `branch_positions` must be sorted, deduped, and
+    /// `< block_size`.
+    pub(crate) fn sample_block_with_runners(
+        &self,
+        ctx: &DeviceContext,
+        base_logits: &HiddenStates,
+        current_tokens: &[u32],
+        block_size: usize,
+        branch_positions: &[usize],
+        scratch: &mut MarkovScratch,
+    ) -> Result<Vec<u32>> {
+        let rows = current_tokens.len();
+        anyhow::ensure!(rows > 0, "DSpark markov sample needs active requests");
+        let vocab = base_logits.hidden_dim;
+        anyhow::ensure!(
+            base_logits.seq_len == rows * block_size,
+            "DSpark markov base logits rows {} != rows*block_size {}",
+            base_logits.seq_len,
+            rows * block_size
+        );
+        // Checked, not just documented: an unsorted or out-of-block position
+        // walks the runner stripes out of range, which would panic inside the
+        // graph-capture closure below rather than return.
+        anyhow::ensure!(
+            branch_positions.windows(2).all(|w| w[0] < w[1])
+                && branch_positions.last().is_none_or(|&p| p < block_size),
+            "DSpark branch positions must be sorted, deduped and < block_size: {branch_positions:?}"
+        );
+        scratch.activate(rows, vocab)?;
+        {
+            let mut prev_dst = scratch.prev_tokens.slice_mut(..rows);
+            ctx.stream.memcpy_htod(current_tokens, &mut prev_dst)?;
+        }
+        let max_batch = scratch.max_batch;
+        if markov_graph_enabled() && scratch.runner_warm[rows - 1] {
+            let MarkovScratch {
+                runner_graphs,
+                w1emb,
+                bias,
+                partial_values,
+                partial_indices,
+                partial_values2,
+                partial_indices2,
+                top2_tokens,
+                runner_tokens,
+                prev_tokens,
+                next_tokens,
+                sampled_tokens,
+                ..
+            } = scratch;
+            runner_graphs[rows - 1].run_or_capture(ctx, || {
+                let mut snap = 0usize;
+                for step in 0..block_size {
+                    let input_is_prev = step % 2 == 0;
+                    {
+                        let input: &CudaSlice<u32> = if input_is_prev {
+                            prev_tokens
+                        } else {
+                            next_tokens
+                        };
+                        ops::embedding_batch(ctx, &self.w1, input, w1emb)?;
+                    }
+                    ops::gemm_into_checked(ctx, &self.w2, w1emb, bias)?;
+                    let output: &mut CudaSlice<u32> = if input_is_prev {
+                        next_tokens
+                    } else {
+                        prev_tokens
+                    };
+                    if branch_positions.contains(&step) {
+                        markov_step_top2_into(
+                            ctx,
+                            base_logits,
+                            bias,
+                            block_size,
+                            step,
+                            rows,
+                            partial_values2,
+                            partial_indices2,
+                            partial_values,
+                            partial_indices,
+                            output,
+                            sampled_tokens,
+                            top2_tokens,
+                        )?;
+                        let src = top2_tokens.slice(..rows);
+                        let mut dst =
+                            runner_tokens.slice_mut(snap * max_batch..snap * max_batch + rows);
+                        ctx.stream.memcpy_dtod(&src, &mut dst)?;
+                        snap += 1;
+                    } else {
+                        markov_step_argmax_into(
+                            ctx,
+                            base_logits,
+                            bias,
+                            block_size,
+                            step,
+                            rows,
+                            partial_values,
+                            partial_indices,
+                            output,
+                            sampled_tokens,
+                        )?;
+                    }
+                }
+                Ok(())
+            })?;
+        } else {
+            let mut snap = 0usize;
+            for step in 0..block_size {
+                let input_is_prev = step % 2 == 0;
+                {
+                    let input = if input_is_prev {
+                        &scratch.prev_tokens
+                    } else {
+                        &scratch.next_tokens
+                    };
+                    ops::embedding_batch(ctx, &self.w1, input, &mut scratch.w1emb)?;
+                }
+                ops::gemm_into_checked(ctx, &self.w2, &scratch.w1emb, &mut scratch.bias)?;
+                if branch_positions.contains(&step) {
+                    // One expression, three disjoint field borrows: splitting
+                    // it would re-borrow `scratch` a second time.
+                    let (output, top2, sampled) = if input_is_prev {
+                        (
+                            &mut scratch.next_tokens,
+                            &mut scratch.top2_tokens,
+                            &mut scratch.sampled_tokens,
+                        )
+                    } else {
+                        (
+                            &mut scratch.prev_tokens,
+                            &mut scratch.top2_tokens,
+                            &mut scratch.sampled_tokens,
+                        )
+                    };
+                    markov_step_top2_into(
+                        ctx,
+                        base_logits,
+                        &scratch.bias,
+                        block_size,
+                        step,
+                        rows,
+                        &mut scratch.partial_values2,
+                        &mut scratch.partial_indices2,
+                        &mut scratch.partial_values,
+                        &mut scratch.partial_indices,
+                        output,
+                        sampled,
+                        top2,
+                    )?;
+                    let src = scratch.top2_tokens.slice(..rows);
+                    let mut dst = scratch
+                        .runner_tokens
+                        .slice_mut(snap * max_batch..snap * max_batch + rows);
+                    ctx.stream.memcpy_dtod(&src, &mut dst)?;
+                    snap += 1;
+                } else {
+                    let output = if input_is_prev {
+                        &mut scratch.next_tokens
+                    } else {
+                        &mut scratch.prev_tokens
+                    };
+                    markov_step_argmax_into(
+                        ctx,
+                        base_logits,
+                        &scratch.bias,
+                        block_size,
+                        step,
+                        rows,
+                        &mut scratch.partial_values,
+                        &mut scratch.partial_indices,
+                        output,
+                        &mut scratch.sampled_tokens,
+                    )?;
+                }
+            }
+            scratch.runner_warm[rows - 1] = true;
+        }
+        let sampled_view = scratch.sampled_tokens.slice(..rows * block_size);
+        let sampled = ctx.stream.clone_dtoh(&sampled_view)?;
+        Ok(sampled)
+    }
+
+    /// Batched hedge-chain ladder: for every request, one chain per branch
+    /// position — chain `(i, j)` follows `chain_a[i]` up to `positions[j]`,
+    /// takes the rank-2 alternative there (`runners[j][i]`), and continues
+    /// greedily with the Markov loop over the same backbone logits. All
+    /// `rows = n_requests × n_chains` chain-rows run in one batched loop; the
+    /// kernels map chain-row `r` onto base block `r / n_chains` (`chains`
+    /// divisor). Returns request-major, chain-minor `[rows * block_size]`
+    /// tokens with the shared prefixes and branch tokens stamped in.
+    pub(crate) fn sample_chain_ladder(
+        &self,
+        ctx: &DeviceContext,
+        base_logits: &HiddenStates,
+        chain_a: &[u32],
+        req_map: &[u32],
+        positions: &[usize],
+        block_size: usize,
+        scratch: &mut MarkovScratch,
+    ) -> Result<Vec<u32>> {
+        let c = positions.len();
+        anyhow::ensure!(c > 0, "chain ladder needs positions");
+        // `req_map[i]` = the hedged slot's ORIGINAL request index: hedge
+        // eligibility can skip requests, so the hedged set is not a batch
+        // prefix. `chain_a` and `base_logits` stay full-batch; every kernel
+        // resolves its request through the map.
+        let n = req_map.len();
+        anyhow::ensure!(n > 0, "chain ladder needs hedged requests");
+        let total = chain_a.len() / block_size;
+        anyhow::ensure!(total * block_size == chain_a.len(), "chain_a shape");
+        // Both kernels index by `req_map[i]`: the argmax needs it below `total`
+        // (base blocks), the runner gather below the stripe width. Establish
+        // the tighter of the two — the unsafe calls below rely on it.
+        anyhow::ensure!(
+            total <= scratch.max_batch,
+            "chain ladder batch {total} exceeds runner stripe {}",
+            scratch.max_batch
+        );
+        anyhow::ensure!(
+            req_map.iter().all(|&r| (r as usize) < total),
+            "chain ladder req_map exceeds chain_a requests"
+        );
+        let rows = n * c;
+        let vocab = base_logits.hidden_dim;
+        anyhow::ensure!(
+            base_logits.seq_len == total * block_size,
+            "chain ladder base logits rows {} != total*block_size {}",
+            base_logits.seq_len,
+            total * block_size
+        );
+        scratch.activate(rows, vocab)?;
+        let max_batch = scratch.max_batch;
+        {
+            let map_i32: Vec<i32> = req_map.iter().map(|&r| r as i32).collect();
+            let mut map_dst = scratch.ladder_map.slice_mut(..n);
+            ctx.stream.memcpy_htod(&map_i32, &mut map_dst)?;
+        }
+        // Position-0 token per chain-row, seeded from chain A's host copy (it
+        // is already on the host for verify-span assembly; the re-upload is
+        // `rows` u32s). The force kernel then overwrites the position-0
+        // branch chains from the device-resident runner snapshot.
+        let prev0: Vec<u32> = (0..rows)
+            .map(|r| chain_a[req_map[r / c] as usize * block_size])
+            .collect();
+        {
+            let mut prev_dst = scratch.prev_tokens.slice_mut(..rows);
+            ctx.stream.memcpy_htod(&prev0, &mut prev_dst)?;
+        }
+        if let Some(j) = positions.iter().position(|&p| p == 0) {
+            // SAFETY: req_map indices are host-checked above.
+            unsafe {
+                hedge_ladder_force_into(
+                    ctx,
+                    &mut scratch.prev_tokens,
+                    &mut scratch.sampled_tokens,
+                    &scratch.runner_tokens,
+                    &scratch.ladder_map,
+                    n,
+                    c,
+                    j,
+                    max_batch,
+                    block_size,
+                    0,
+                )?;
+            }
+        }
+        // A captured ladder graph bakes the `chains` divisor into its kernels;
+        // `rows` alone is ambiguous at requests > 1 (2 req x 2 chains = 4 rows
+        // = 1 req x 4 chains). Replay only when the baked divisor matches;
+        // mismatched shapes run the eager loop forever (no recapture).
+        if markov_graph_enabled()
+            && scratch.ladder_warm[rows - 1]
+            && scratch.ladder_baked_chains[rows - 1] == c
+        {
+            let MarkovScratch {
+                ladder_graphs,
+                ladder_map,
+                w1emb,
+                bias,
+                partial_values,
+                partial_indices,
+                runner_tokens,
+                prev_tokens,
+                next_tokens,
+                sampled_tokens,
+                ..
+            } = scratch;
+            ladder_graphs[rows - 1].run_or_capture(ctx, || {
+                for step in 1..block_size {
+                    let input_is_prev = step % 2 == 1;
+                    {
+                        let input: &CudaSlice<u32> = if input_is_prev {
+                            prev_tokens
+                        } else {
+                            next_tokens
+                        };
+                        ops::embedding_batch(ctx, &self.w1, input, w1emb)?;
+                    }
+                    ops::gemm_into_checked(ctx, &self.w2, w1emb, bias)?;
+                    let output: &mut CudaSlice<u32> = if input_is_prev {
+                        next_tokens
+                    } else {
+                        prev_tokens
+                    };
+                    // SAFETY: req_map indices are host-checked above.
+                    unsafe {
+                        markov_step_argmax_mapped_into(
+                            ctx,
+                            base_logits,
+                            bias,
+                            block_size,
+                            step,
+                            c,
+                            ladder_map,
+                            rows,
+                            partial_values,
+                            partial_indices,
+                            output,
+                            sampled_tokens,
+                        )?;
+                    }
+                    // Chains branching AT this step take their runner-up in
+                    // place of the recomputed greedy token, written into the
+                    // step's output buffer and the sampled block.
+                    if let Some(j) = positions.iter().position(|&p| p == step) {
+                        let output: &mut CudaSlice<u32> = if input_is_prev {
+                            next_tokens
+                        } else {
+                            prev_tokens
+                        };
+                        // SAFETY: req_map indices are host-checked above.
+                        unsafe {
+                            hedge_ladder_force_into(
+                                ctx,
+                                output,
+                                sampled_tokens,
+                                runner_tokens,
+                                &*ladder_map,
+                                n,
+                                c,
+                                j,
+                                max_batch,
+                                block_size,
+                                step,
+                            )?;
+                        }
+                    }
+                }
+                Ok(())
+            })?;
+        } else {
+            for step in 1..block_size {
+                let input_is_prev = step % 2 == 1;
+                {
+                    let input = if input_is_prev {
+                        &scratch.prev_tokens
+                    } else {
+                        &scratch.next_tokens
+                    };
+                    ops::embedding_batch(ctx, &self.w1, input, &mut scratch.w1emb)?;
+                }
+                ops::gemm_into_checked(ctx, &self.w2, &scratch.w1emb, &mut scratch.bias)?;
+                {
+                    let output = if input_is_prev {
+                        &mut scratch.next_tokens
+                    } else {
+                        &mut scratch.prev_tokens
+                    };
+                    // SAFETY: req_map indices are host-checked above.
+                    unsafe {
+                        markov_step_argmax_mapped_into(
+                            ctx,
+                            base_logits,
+                            &scratch.bias,
+                            block_size,
+                            step,
+                            c,
+                            &scratch.ladder_map,
+                            rows,
+                            &mut scratch.partial_values,
+                            &mut scratch.partial_indices,
+                            output,
+                            &mut scratch.sampled_tokens,
+                        )?;
+                    }
+                }
+                if let Some(j) = positions.iter().position(|&p| p == step) {
+                    let output = if input_is_prev {
+                        &mut scratch.next_tokens
+                    } else {
+                        &mut scratch.prev_tokens
+                    };
+                    // SAFETY: req_map indices are host-checked above.
+                    unsafe {
+                        hedge_ladder_force_into(
+                            ctx,
+                            output,
+                            &mut scratch.sampled_tokens,
+                            &scratch.runner_tokens,
+                            &scratch.ladder_map,
+                            n,
+                            c,
+                            j,
+                            max_batch,
+                            block_size,
+                            step,
+                        )?;
+                    }
+                }
+            }
+            if !scratch.ladder_warm[rows - 1] {
+                scratch.ladder_warm[rows - 1] = true;
+                scratch.ladder_baked_chains[rows - 1] = c;
+            }
+        }
+        let sampled_view = scratch.sampled_tokens.slice(..rows * block_size);
+        let mut sampled = ctx.stream.clone_dtoh(&sampled_view)?;
+        // Stamp the shared prefixes from chain A (the loop recomputes them
+        // identically by determinism; stamping makes it exact by
+        // construction). Branch tokens were written on device by the force
+        // kernel and arrive in the same single D2H.
+        for (i, &orig) in req_map.iter().enumerate() {
+            let orig = orig as usize;
+            for (j, &p) in positions.iter().enumerate() {
+                let row = i * c + j;
+                sampled[row * block_size..row * block_size + p]
+                    .copy_from_slice(&chain_a[orig * block_size..orig * block_size + p]);
+            }
+        }
+        Ok(sampled)
+    }
+
     /// Bytes occupied by the Markov head weights + sample scratch, for the memory
     /// reservation. `0` when the head is disabled.
-    pub(crate) fn reservation_bytes(config: &DFlashConfig, max_decode_batch_size: usize) -> usize {
+    pub(crate) fn reservation_bytes(
+        config: &DFlashConfig,
+        max_decode_batch_size: usize,
+    ) -> Result<usize> {
         const BF16: usize = 2;
 
         if !config.uses_markov_head() {
-            return 0;
+            return Ok(0);
         }
         let vocab = config.vocab_size;
         let rank = config.markov_rank;
-        let weights = 2 * vocab * rank * BF16;
-        let scratch = MarkovScratch::bytes(vocab, rank, config.block_size, max_decode_batch_size);
-        weights + scratch
+        let weights = sizing::product(&[2, vocab, rank, BF16])?;
+        let scratch = MarkovScratch::bytes(vocab, rank, config.block_size, max_decode_batch_size)?;
+        sizing::sum(&[weights, scratch])
     }
 }
 
@@ -164,9 +666,40 @@ pub(crate) struct MarkovScratch {
     bias: HiddenStates,
     partial_values: CudaSlice<f32>,
     partial_indices: CudaSlice<i32>,
+    /// Second partials pair + runner-up output for the hedge's top-2 scan
+    /// (`markov_step_top2_into`); idle when the hedge is off. Allocated with
+    /// the head regardless: ~307 KiB at the bs-256 ceiling, bounded and
+    /// constant.
+    partial_values2: CudaSlice<f32>,
+    partial_indices2: CudaSlice<i32>,
+    top2_tokens: CudaSlice<u32>,
+    /// Device-resident runner-up snapshots for the hedge ladder, one
+    /// `max_batch` stripe per branch position (`[j * max_batch + i]`), copied
+    /// D2D from `top2_tokens` at each branch step. The runner tokens
+    /// themselves never visit the host; chain A does (verify spans are
+    /// assembled host-side), and the ladder re-uploads only its `rows`
+    /// position-0 parents.
+    runner_tokens: CudaSlice<u32>,
     prev_tokens: CudaSlice<u32>,
     next_tokens: CudaSlice<u32>,
     sampled_tokens: CudaSlice<u32>,
+    /// Per-`rows` CUDA graphs for the three markov loops (glm52 #591
+    /// pattern): warm flag = first call runs the plain loop so cuBLAS lazy
+    /// init happens outside capture; capture on the second, replay after.
+    /// `DSPARK_NO_MARKOV_GRAPH=1` restores the plain loops.
+    chain_graphs: Vec<CudaGraphState>,
+    chain_warm: Vec<bool>,
+    runner_graphs: Vec<CudaGraphState>,
+    runner_warm: Vec<bool>,
+    ladder_graphs: Vec<CudaGraphState>,
+    ladder_warm: Vec<bool>,
+    /// Hedged-slot -> original-request index map for the ladder kernels
+    /// (contents re-uploaded each round; the buffer pointer is stable so
+    /// captured graphs stay valid).
+    ladder_map: CudaSlice<i32>,
+    /// `chains` divisor baked into each captured ladder graph (0 = unset):
+    /// replay requires an exact match — see [`Self::sample_chain_ladder`].
+    ladder_baked_chains: Vec<usize>,
 }
 
 impl MarkovScratch {
@@ -182,17 +715,40 @@ impl MarkovScratch {
         let vocab = config.vocab_size;
         let rank = config.markov_rank;
         let partials = markov_step_argmax_partials_len(max_decode_batch_size, vocab);
-        let sampled = max_decode_batch_size * config.block_size;
+        let sampled = sizing::product(&[max_decode_batch_size, config.block_size])?;
         Ok(Self {
             max_batch: max_decode_batch_size,
             w1emb: HiddenStates::zeros(ctx, rank, max_decode_batch_size)?,
             bias: HiddenStates::zeros(ctx, vocab, max_decode_batch_size)?,
             partial_values: ctx.stream.alloc_zeros(partials)?,
             partial_indices: ctx.stream.alloc_zeros(partials)?,
+            partial_values2: ctx.stream.alloc_zeros(partials)?,
+            partial_indices2: ctx.stream.alloc_zeros(partials)?,
+            top2_tokens: ctx.stream.alloc_zeros(max_decode_batch_size)?,
+            runner_tokens: ctx.stream.alloc_zeros(sampled)?,
             prev_tokens: ctx.stream.alloc_zeros(max_decode_batch_size)?,
             next_tokens: ctx.stream.alloc_zeros(max_decode_batch_size)?,
             sampled_tokens: ctx.stream.alloc_zeros(sampled)?,
+            chain_graphs: (0..max_decode_batch_size)
+                .map(|_| CudaGraphState::new())
+                .collect(),
+            chain_warm: vec![false; max_decode_batch_size],
+            runner_graphs: (0..max_decode_batch_size)
+                .map(|_| CudaGraphState::new())
+                .collect(),
+            runner_warm: vec![false; max_decode_batch_size],
+            ladder_graphs: (0..max_decode_batch_size)
+                .map(|_| CudaGraphState::new())
+                .collect(),
+            ladder_warm: vec![false; max_decode_batch_size],
+            ladder_baked_chains: vec![0; max_decode_batch_size],
+            ladder_map: ctx.stream.alloc_zeros(max_decode_batch_size)?,
         })
+    }
+
+    /// Max chain-rows this scratch was allocated for.
+    pub(crate) fn max_batch(&self) -> usize {
+        self.max_batch
     }
 
     /// Point the dense scratch at the active `rows` prefix. Allocated for the max
@@ -215,14 +771,32 @@ impl MarkovScratch {
         Ok(())
     }
 
-    fn bytes(vocab: usize, rank: usize, block_size: usize, max_decode_batch_size: usize) -> usize {
+    fn bytes(
+        vocab: usize,
+        rank: usize,
+        block_size: usize,
+        max_decode_batch_size: usize,
+    ) -> Result<usize> {
         const BF16: usize = 2;
         let partials = markov_step_argmax_partials_len(max_decode_batch_size, vocab);
-        let w1emb = max_decode_batch_size * rank * BF16;
-        let bias = max_decode_batch_size * vocab * BF16;
-        let partial_bytes = partials * (std::mem::size_of::<f32>() + std::mem::size_of::<i32>());
-        let tokens = (2 * max_decode_batch_size + max_decode_batch_size * block_size)
-            * std::mem::size_of::<u32>();
-        w1emb + bias + partial_bytes + tokens
+        let w1emb = sizing::product(&[max_decode_batch_size, rank, BF16])?;
+        let bias = sizing::product(&[max_decode_batch_size, vocab, BF16])?;
+        // Two partials pairs: the argmax pair plus the hedge's top-2 pair.
+        let partial_bytes = sizing::product(&[
+            2,
+            partials,
+            std::mem::size_of::<f32>() + std::mem::size_of::<i32>(),
+        ])?;
+        let tokens = sizing::sum(&[
+            sizing::product(&[
+                sizing::sum(&[
+                    sizing::product(&[3, max_decode_batch_size])?,
+                    sizing::product(&[2, max_decode_batch_size, block_size])?,
+                ])?,
+                std::mem::size_of::<u32>(),
+            ])?,
+            sizing::product(&[max_decode_batch_size, std::mem::size_of::<i32>()])?,
+        ])?;
+        sizing::sum(&[w1emb, bias, partial_bytes, tokens])
     }
 }

--- a/pegainfer-qwen3/src/executor.rs
+++ b/pegainfer-qwen3/src/executor.rs
@@ -8,6 +8,7 @@ use anyhow::Context;
 use anyhow::Result;
 use anyhow::ensure;
 use crossbeam_channel as channel;
+use cudarc::driver::DevicePtr;
 use pegainfer_core::cuda_graph::CudaGraphDumpSummary;
 use pegainfer_core::kv_pool::KvLayout;
 use pegainfer_core::ops;
@@ -45,6 +46,7 @@ use crate::weights::ModelRuntimeConfig;
 use crate::weights::Qwen3MemoryOptions;
 use crate::weights::Qwen3Model;
 
+mod auto_hedge;
 mod dflash_lane;
 mod dflash_prefill;
 mod remote_fetch;
@@ -66,6 +68,7 @@ use crate::speculative::DraftPlan;
 use crate::speculative::DraftResult;
 use crate::speculative::DraftStepItem;
 use crate::speculative::VerifyPlan;
+use crate::speculative::VerifyRequestResult;
 use crate::speculative::VerifyResult;
 use crate::speculative::VerifyStepItem;
 use crate::speculative::build_verify_results;
@@ -989,7 +992,9 @@ pub struct Qwen3Executor {
     primary: RankWorker,
     workers: Vec<RankWorker>,
     loaded_lora_adapters: HashSet<String>,
-    prefix_cache_enabled: bool,
+    /// Requested prefix-cache state; read through `prefix_cache_enabled()`,
+    /// which also honours the drafter override.
+    prefix_cache_requested: bool,
     lora_options: Qwen3LoraOptions,
     /// pegaflow KV-offload bridge; `None` unless offload is opted in on the
     /// single-GPU path. Drives both the SAVE hook and the async LOAD prefetch.
@@ -1139,6 +1144,7 @@ impl Qwen3Executor {
         max_prefill_tokens: usize,
         dflash_kv_bytes_per_token: usize,
         memory_options: Qwen3MemoryOptions,
+        hedge_scratch_pages: usize,
     ) -> Result<Self> {
         let (model, budget) = profile_kv_budget_on_worker(
             model,
@@ -1146,13 +1152,14 @@ impl Qwen3Executor {
             dflash_kv_bytes_per_token,
             memory_options,
         )?;
-        let kv_mgr = KvCacheManager::new(
+        let kv_mgr = KvCacheManager::new_with_scratch_pages(
             &model.device_ctx().stream,
             budget.num_layers,
             budget.num_kv_heads,
             budget.head_dim,
             budget.block_size,
             budget.num_blocks,
+            hedge_scratch_pages,
         )?;
         let device_ordinal = model.device_ctx().device_ordinal;
         let metadata = Qwen3ExecutorMetadata {
@@ -1219,7 +1226,7 @@ impl Qwen3Executor {
             )?,
             workers: Vec::new(),
             loaded_lora_adapters: HashSet::new(),
-            prefix_cache_enabled: true,
+            prefix_cache_requested: true,
             lora_options: Qwen3LoraOptions::default(),
             offload,
             saved_cursor: HashMap::new(),
@@ -1352,23 +1359,56 @@ impl Qwen3Executor {
             // paged KV pool, so reserve its footprint up front from the draft
             // config: fixed bytes (weights + block scratch) via the margin, and
             // pool-scaling per-token bytes folded into the block budget.
-            let dflash_kv_bytes_per_token = match dflash_draft_path {
+            let max_verify_batch = *BATCH_BUCKETS.last().unwrap();
+            let (dflash_kv_bytes_per_token, hedge_scratch_pages) = match dflash_draft_path {
                 Some(path) => {
-                    let reservation = crate::dflash::DFlashMemoryReservation::from_path(
-                        path,
-                        *BATCH_BUCKETS.last().unwrap(),
-                    )?;
-                    memory_options.kv_cache_memory_margin_bytes += reservation.fixed_bytes;
-                    reservation.kv_bytes_per_token
+                    let reservation =
+                        crate::dflash::DFlashMemoryReservation::from_path(path, max_verify_batch)?;
+                    memory_options.kv_cache_memory_margin_bytes = crate::sizing::sum(&[
+                        memory_options.kv_cache_memory_margin_bytes,
+                        reservation.fixed_bytes,
+                    ])?;
+                    // Hedge-chain scratch KV pages (PEGAINFER_SPEC_HEDGE)
+                    // live in the KV buffer but outside the pool; bill them
+                    // via the margin so the profiled block budget shrinks to
+                    // fit instead of OOMing. Two bounds: the effective
+                    // geometry (worst-case span pages per chain) and the
+                    // expanded verify batch, which holds at most
+                    // `max_verify_batch - 1` hedge spans at once.
+                    let geometry = dflash_lane::spec_hedge_effective(reservation.block_size);
+                    let pages_per_chain = dflash_lane::hedge_pages_per_chain(
+                        reservation.block_size,
+                        memory_options.page_size,
+                    );
+                    let pages = if reservation.uses_markov_head {
+                        geometry
+                            .cap
+                            .saturating_mul(pages_per_chain)
+                            .saturating_mul(geometry.positions.len())
+                            .min(pages_per_chain.saturating_mul(max_verify_batch - 1))
+                    } else {
+                        // A plain DFlash drafter can never hedge; a nonzero
+                        // hedge env must not reserve scratch it cannot use.
+                        0
+                    };
+                    (reservation.kv_bytes_per_token, pages)
                 }
-                None => 0,
+                None => (0, 0),
             };
+            if hedge_scratch_pages > 0 {
+                let page_bytes = model.kv_page_bytes(memory_options.page_size)?;
+                memory_options.kv_cache_memory_margin_bytes = crate::sizing::sum(&[
+                    memory_options.kv_cache_memory_margin_bytes,
+                    crate::sizing::product(&[hedge_scratch_pages, page_bytes])?,
+                ])?;
+            }
             let mut executor = Self::single(
                 model,
                 &offload_options,
                 max_prefill_tokens,
                 dflash_kv_bytes_per_token,
                 memory_options,
+                hedge_scratch_pages,
             )?;
             executor.lora_options = lora_options;
             return Ok(executor);
@@ -1582,7 +1622,7 @@ impl Qwen3Executor {
             primary,
             workers,
             loaded_lora_adapters: HashSet::new(),
-            prefix_cache_enabled: true,
+            prefix_cache_requested: true,
             lora_options,
             // Offload is single-GPU only (asserted above); never built here.
             offload: None,
@@ -1627,14 +1667,23 @@ impl Qwen3Executor {
     /// creates duplicate primaries outside request-level capacity accounting.
     pub fn set_prefix_cache_enabled(&mut self, enabled: bool) {
         let retained_before = self.retains_completed_kv_blocks();
-        self.prefix_cache_enabled = enabled;
+        self.prefix_cache_requested = enabled;
         self.finish_retention_transition(retained_before);
+    }
+
+    /// Whether prefix reuse is actually in effect. A loaded drafter forces it
+    /// off: speculative capture needs uncached hidden states, and the KV budget
+    /// charges the draft's out-of-pool cache per POOL block, which only holds
+    /// while blocks are not shared between requests. `load_dflash_draft_model`
+    /// also clears the requested flag; this makes the override structural.
+    fn prefix_cache_enabled(&self) -> bool {
+        self.prefix_cache_requested && self.speculative.is_none()
     }
 
     /// Whether a completed request should leave its registered GPU blocks in
     /// the inactive L1 cache for a later prefix match.
     fn retains_completed_kv_blocks(&self) -> bool {
-        self.prefix_cache_enabled && !self.l1_retention_disabled
+        self.prefix_cache_enabled() && !self.l1_retention_disabled
     }
 
     /// Drain blocks retained under the old policy once when L1 retention is
@@ -1845,7 +1894,7 @@ impl Qwen3Executor {
             );
             // Echo needs logits for every prompt position; cached positions
             // are never forwarded, so echo requests prefill from scratch.
-            if self.prefix_cache_enabled && !req.echo {
+            if self.prefix_cache_enabled() && !req.echo {
                 req.cached_tokens = rkv.match_and_add_prefix(self.kv_mgr.pool())?;
             }
             self.request_kvs.insert(req.request_id, rkv);
@@ -2366,7 +2415,7 @@ impl ModelExecutor for Qwen3Executor {
         let Some(offload) = self.offload.as_ref() else {
             return false;
         };
-        if !self.prefix_cache_enabled {
+        if !self.prefix_cache_enabled() {
             return false;
         }
         if self.l1_retention_disabled {
@@ -3460,10 +3509,198 @@ impl LocalQwen3Lane {
         )
     }
 
+    /// Parallel multi-chain hedge (`PEGAINFER_SPEC_HEDGE`): verify each hedged
+    /// request's greedy chain (chain A) **and** its hedge-ladder alternative
+    /// chains in one expanded forward, then commit whichever chain the target
+    /// accepts further. Each hedge chain's span KV is written to lane-owned
+    /// scratch pages via a synthesized [`KvView`] (prefix pages shared
+    /// read-only, the partial committed page copied first); on a hedge win the
+    /// touched pages are copied back into the request's reservation before
+    /// `apply_speculative`, and the winning chain's captured hidden rows are
+    /// compacted onto chain A's offsets so
+    /// `record_verify_dflash_context` sees a plain N-request layout. The KV
+    /// transaction interface is untouched. Returns `Ok(None)` when nothing is
+    /// hedgeable this round (caller falls back to the plain pass).
+    fn try_execute_hedged_verify(
+        &mut self,
+        requests: &[VerifyStepItem],
+        kv_views: &[KvView],
+        capture_layer_ids: &[usize],
+        sample_seed: u64,
+        bufs: &mut VerifyGraphBuffers,
+    ) -> Result<Option<VerifyResult>> {
+        let page_size = self.layout.page_size;
+        let scratch_end = self.kv_buffer.num_blocks();
+        let max_batch = *BATCH_BUCKETS.last().unwrap();
+        let cap = self.dflash.as_ref().map_or(0, DFlashLaneState::hedge_cap);
+        if cap == 0 || scratch_end == self.total_blocks {
+            return Ok(None);
+        }
+
+        let ctx = self.model.device_ctx().clone();
+        // Single pass: expanded layout keeps the N chain-A spans first
+        // (offsets unchanged) and appends every accepted hedge span, walking a
+        // scratch-page cursor. `hedge_spans[slot]` = (request idx, replaced
+        // (original page, scratch page) pairs) for the winner copy-back.
+        let mut expanded: Vec<VerifyStepItem> = requests.to_vec();
+        let mut views: Vec<KvView> = kv_views.to_vec();
+        let mut hedge_spans: Vec<(usize, Vec<(usize, usize)>)> = Vec::new();
+        let mut next_scratch = self.total_blocks;
+        {
+            let Some(dflash) = self.dflash.as_ref() else {
+                return Ok(None);
+            };
+            if !dflash.model.uses_markov_head() {
+                return Ok(None);
+            }
+            let drafts_start = usize::from(!dflash.model.anchor_first());
+            let pages_per_chain =
+                dflash_lane::hedge_pages_per_chain(dflash.model.block_size(), page_size);
+            let mut hedged_requests = 0usize;
+            for (idx, req) in requests.iter().enumerate() {
+                if hedged_requests == cap {
+                    break;
+                }
+                if !req.params.is_greedy() || req.token_ids.len() < 2 {
+                    continue;
+                }
+                let Some(chains) = dflash.hedge_blocks.get(&req.request_id) else {
+                    continue;
+                };
+                let v = &kv_views[idx];
+                let committed = v.seq_len() - req.token_ids.len();
+                let first_span_page = committed / page_size;
+                let span_pages = v.page_indices().len() - first_span_page;
+                if span_pages > pages_per_chain {
+                    continue;
+                }
+                let keep = req.token_ids.len() - 1;
+                let mut added: Vec<Vec<u32>> = Vec::new();
+                for block in chains {
+                    if expanded.len() == max_batch || next_scratch + span_pages > scratch_end {
+                        break;
+                    }
+                    let mut ids = Vec::with_capacity(keep + 1);
+                    ids.push(req.token_ids[0]);
+                    ids.extend(block[drafts_start..].iter().take(keep).copied());
+                    if ids.len() != req.token_ids.len()
+                        || ids[1..] == req.token_ids[1..]
+                        || added.iter().any(|prev| prev[1..] == ids[1..])
+                    {
+                        continue;
+                    }
+                    let mut pages = v.page_indices().to_vec();
+                    let mut replaced = Vec::with_capacity(span_pages);
+                    for (k, page_slot) in (first_span_page..pages.len()).enumerate() {
+                        let orig = pages[page_slot] as usize;
+                        let scratch_page = next_scratch + k;
+                        if k == 0 && !committed.is_multiple_of(page_size) {
+                            // The hedge chain shares this page's committed
+                            // prefix rows: give it a full copy to write its
+                            // span into.
+                            self.kv_buffer.copy_page(&ctx.stream, orig, scratch_page)?;
+                        }
+                        pages[page_slot] = scratch_page as i32;
+                        replaced.push((orig, scratch_page));
+                    }
+                    next_scratch += span_pages;
+                    expanded.push(VerifyStepItem::new(req.request_id, ids.clone(), req.params));
+                    views.push(KvView::new(pages, v.seq_len(), page_size));
+                    hedge_spans.push((idx, replaced));
+                    added.push(ids);
+                }
+                if !added.is_empty() {
+                    hedged_requests += 1;
+                }
+            }
+        }
+        if hedge_spans.is_empty() {
+            return Ok(None);
+        }
+
+        let spans: Vec<&[u32]> = expanded.iter().map(VerifyStepItem::as_slice).collect();
+        self.model.batch_prefill_into(
+            &spans,
+            &views,
+            self.kv_buffer.buffer(),
+            &self.layout,
+            capture_layer_ids,
+            bufs,
+        )?;
+        let params: Vec<&SamplingParams> = expanded
+            .iter()
+            .flat_map(|req| std::iter::repeat_n(&req.params, req.as_slice().len()))
+            .collect();
+        let target_tokens = self.select_step_tokens(bufs.all_logits(), &params, sample_seed)?;
+        let all_results = build_verify_results(&expanded, &target_tokens)?;
+        let (results_a, results_b) = all_results.split_at(requests.len());
+
+        // Per request keep the best-accepting chain; ties keep chain A (no
+        // copies). A later chain of the same request only replaces the
+        // running winner when strictly better, so the final page/hidden
+        // copies always belong to the final winner.
+        let a_total_rows: usize = requests.iter().map(|r| r.token_ids.len()).sum();
+        let hidden_dim = bufs.captured_hidden().hidden_dim;
+        let elem = std::mem::size_of::<half::bf16>();
+        let mut final_requests: Vec<VerifyStepItem> = requests.to_vec();
+        let mut final_results: Vec<VerifyRequestResult> = results_a.to_vec();
+        let mut b_wins = 0usize;
+        let mut b_row_offset = a_total_rows;
+        for (slot, (idx, replaced)) in hedge_spans.iter().enumerate() {
+            let span_len = requests[*idx].token_ids.len();
+            let res_b = &results_b[slot];
+            if res_b.accepted_tokens.len() > final_results[*idx].accepted_tokens.len() {
+                // Winning chain: canonical pages take its span KV, and its
+                // captured hidden rows land on A's row offsets in place.
+                for &(orig, scratch_page) in replaced {
+                    self.kv_buffer.copy_page(&ctx.stream, scratch_page, orig)?;
+                }
+                let a_row_offset: usize = requests[..*idx].iter().map(|r| r.token_ids.len()).sum();
+                let (hid_ptr, _guard) = bufs.captured_hidden().data.device_ptr(&ctx.stream);
+                let src = hid_ptr + (b_row_offset * hidden_dim * elem) as u64;
+                let dst = hid_ptr + (a_row_offset * hidden_dim * elem) as u64;
+                unsafe {
+                    cudarc::driver::result::memcpy_dtod_async(
+                        dst,
+                        src,
+                        span_len * hidden_dim * elem,
+                        ctx.stream.cu_stream(),
+                    )
+                }
+                .map_err(|e| anyhow::anyhow!("hedge hidden compaction failed: {e}"))?;
+                b_wins += 1;
+                final_requests[*idx] = expanded[requests.len() + slot].clone();
+                final_results[*idx] = res_b.clone();
+            }
+            b_row_offset += span_len;
+        }
+        let b_extra: usize = final_results
+            .iter()
+            .zip(results_a)
+            .map(|(f, a)| f.accepted_tokens.len() - a.accepted_tokens.len())
+            .sum();
+        log::debug!(
+            "Qwen3 DFlash hedge: {} chain span(s), {b_wins} win event(s), +{b_extra} committed token(s)",
+            hedge_spans.len()
+        );
+
+        // The expanded forward left seq_len at A+B rows; the winner layout is
+        // exactly the N chain-A offsets.
+        bufs.captured_hidden_mut().seq_len = a_total_rows;
+        self.record_verify_dflash_context(
+            &final_requests,
+            &final_results,
+            Some(bufs.captured_hidden()),
+        )?;
+        Ok(Some(VerifyResult {
+            requests: final_results,
+        }))
+    }
+
     /// DFlash verify forward over each request's `block_size`-token span, using
-    /// the fixed pre-allocated [`VerifyGraphBuffers`] (no per-step allocation).
-    /// Numerically equivalent to the `batch_prefill(echo=true)` verify path it
-    /// replaces; the buffers are lazily built on first use.
+    /// the fixed pre-allocated [`VerifyGraphBuffers`] (no per-step allocation),
+    /// lazily built on first use. Numerically equivalent to the
+    /// `batch_prefill(echo=true)` verify path it replaces.
     fn execute_dflash_verify(
         &mut self,
         requests: &[VerifyStepItem],
@@ -3484,12 +3721,29 @@ impl LocalQwen3Lane {
 
         if self.verify_bufs.is_none() {
             let max_batch = *BATCH_BUCKETS.last().unwrap();
+            // Each hedged request repeats its full prefix page list once per
+            // chain, so the plan's page-index capacity must budget the
+            // duplicates on top of the pool-wide worst case.
+            // Base page lists are disjoint pool pages (sum <= total_blocks):
+            // loading a drafter force-disables the prefix cache (see
+            // `load_dflash_draft_model`), so no two active requests share
+            // pages on any path that can hedge. Each chain layer duplicates at
+            // most one pool-wide list, so the multiplier is the chain count
+            // alone, bounded by the expanded verify batch.
+            let hedge_dup = self.dflash.as_ref().map_or(0, |dflash| {
+                if dflash.hedge_cap() == 0 {
+                    0
+                } else {
+                    dflash.hedge_branch_count().min(max_batch - 1)
+                }
+            });
             self.verify_bufs = Some(VerifyGraphBuffers::new(
                 &self.model,
                 max_batch,
                 verify_span,
                 capture_layer_ids.len(),
-                self.total_blocks,
+                self.total_blocks
+                    .saturating_mul(hedge_dup.saturating_add(1)),
             )?);
         }
 
@@ -3498,6 +3752,23 @@ impl LocalQwen3Lane {
         // and context record (`&mut self.dflash`) don't alias a `self` borrow.
         let mut bufs = self.verify_bufs.take().expect("verify buffers just set");
         let result = (|| -> Result<VerifyResult> {
+            if self.dflash.as_ref().is_some_and(|d| d.hedge_cap() > 0) {
+                if let Some(result) = self.try_execute_hedged_verify(
+                    requests,
+                    kv_views,
+                    &capture_layer_ids,
+                    sample_seed,
+                    &mut bufs,
+                )? {
+                    return Ok(result);
+                }
+                // Fell back to the plain pass: whatever the draft prepared,
+                // this round executed unhedged — the controller must not book
+                // ladder cost to a chain count that never ran a verify span.
+                if let Some(dflash) = self.dflash.as_mut() {
+                    dflash.clear_round_chains();
+                }
+            }
             let spans: Vec<&[u32]> = requests.iter().map(VerifyStepItem::as_slice).collect();
             self.model.batch_prefill_into(
                 &spans,
@@ -3521,6 +3792,7 @@ impl LocalQwen3Lane {
                 .collect();
             let target_tokens = self.select_step_tokens(bufs.all_logits(), &params, sample_seed)?;
             let request_results = build_verify_results(requests, &target_tokens)?;
+
             self.record_verify_dflash_context(
                 requests,
                 &request_results,

--- a/pegainfer-qwen3/src/executor/auto_hedge.rs
+++ b/pegainfer-qwen3/src/executor/auto_hedge.rs
@@ -1,0 +1,286 @@
+//! Runtime self-pricing for the hedge ladder (`PEGAINFER_SPEC_HEDGE_AUTO`).
+//!
+//! Instead of a hand-picked chain count, the lane measures its own operating
+//! point: a windowed explore-then-commit controller cycles the chain count
+//! `C ∈ {0..=Cmax}` (prefixes of `PEGAINFER_SPEC_HEDGE_POSITIONS`), scores
+//! each window by delivered **committed tokens per second** — the objective
+//! itself, so bucket quantization, eager penalties, and host overhead are all
+//! priced in automatically — and commits to the argmax. A commit expires after
+//! [`COMMIT_ROUNDS`] and re-explores, so the choice follows workload drift
+//! (hard traffic converges to the ladder, easy traffic to `C = 0`). Per
+//! candidate the last [`MAX_WINDOWS`] windows are kept, unweighted: after a
+//! long commit the incumbent's windows are all recent while the challengers'
+//! are not, which biases re-exploration toward the incumbent. Round timing uses inter-round host timestamps; gaps above
+//! [`ROUND_GAP_CUTOFF`] (prefill, admission stalls) are treated as window
+//! boundaries and never attributed to a chain count.
+
+use std::time::Duration;
+use std::time::Instant;
+
+/// Rounds per exploration window. Each candidate C holds the lane for this
+/// many verify rounds before rotating; the first rounds of a fresh shape pay
+/// graph warm-up, which the window length amortizes.
+const WINDOW_ROUNDS: u32 = 64;
+/// Full rotations over all candidates before committing.
+const EXPLORE_CYCLES: u32 = 3;
+/// Rounds to hold a committed choice before re-exploring.
+const COMMIT_ROUNDS: u32 = 4096;
+/// Cheaper re-exploration after the first commit (per-candidate window).
+const REEXPLORE_WINDOW_ROUNDS: u32 = 32;
+/// Inter-round gaps above this are scheduling boundaries, not round cost.
+const ROUND_GAP_CUTOFF: Duration = Duration::from_millis(500);
+
+/// Extra throughput a larger chain count must show over the best smaller one
+/// (median window rate) before it is preferred. Below this the controller
+/// takes the cheaper configuration — on a flat landscape (easy traffic) the
+/// argmax is noise, and the noise of a 64-round window runs several percent.
+const ADD_CHAIN_MARGIN: f64 = 1.03;
+/// Completed windows kept per candidate (older ones age out).
+const MAX_WINDOWS: usize = 12;
+
+#[derive(Default, Clone)]
+struct CandidateStats {
+    /// Completed exploration windows, `(tokens, secs)` each. Scored by the
+    /// MEDIAN of per-window rates — one polluted window (graph warm-up, a
+    /// straggling request) cannot swing the commit the way pooled sums can.
+    windows: Vec<(f64, f64)>,
+}
+
+impl CandidateStats {
+    fn median_rate(&self) -> Option<f64> {
+        let mut rates: Vec<f64> = self
+            .windows
+            .iter()
+            .filter(|(_, secs)| *secs > 0.0)
+            .map(|(tokens, secs)| tokens / secs)
+            .collect();
+        if rates.is_empty() {
+            return None;
+        }
+        rates.sort_by(f64::total_cmp);
+        Some(rates[rates.len() / 2])
+    }
+}
+
+pub(super) struct AutoHedge {
+    stats: Vec<CandidateStats>,
+    cur_tokens: f64,
+    cur_secs: f64,
+    /// Executed chain count of the in-progress window. Capacity guards can
+    /// force a round to run below the candidate; a window only scores if
+    /// every round in it executed the same count, so those rounds are booked
+    /// to the configuration that actually ran.
+    window_c: usize,
+    cur_c: usize,
+    committed: Option<usize>,
+    rounds_in_window: u32,
+    window_rounds: u32,
+    cycles_done: u32,
+    commit_left: u32,
+    last_tick: Option<Instant>,
+}
+
+impl AutoHedge {
+    pub(super) fn new(max_chains: usize) -> Self {
+        Self {
+            stats: vec![CandidateStats::default(); max_chains + 1],
+            cur_tokens: 0.0,
+            cur_secs: 0.0,
+            window_c: 0,
+            cur_c: 0,
+            committed: None,
+            rounds_in_window: 0,
+            window_rounds: WINDOW_ROUNDS,
+            cycles_done: 0,
+            commit_left: 0,
+            last_tick: None,
+        }
+    }
+
+    /// Chain count for the next draft round (0 = no hedging this round).
+    pub(super) fn current_c(&self) -> usize {
+        self.committed.unwrap_or(self.cur_c)
+    }
+
+    /// Record one verify round's outcome. `executed_c` is the chain count
+    /// the round actually ran — 0 when a guard disabled hedging, whatever
+    /// [`Self::current_c`] requested.
+    pub(super) fn tick(&mut self, executed_c: usize, committed_tokens: usize) {
+        let now = Instant::now();
+        let Some(prev) = self.last_tick.replace(now) else {
+            return;
+        };
+        let elapsed = now - prev;
+        if elapsed > ROUND_GAP_CUTOFF {
+            // Documented boundary: a stall (prefill, admission) severs the
+            // window. Continuing it would mix measurements across whatever
+            // the traffic looked like on either side of the stall.
+            self.cur_tokens = 0.0;
+            self.cur_secs = 0.0;
+            self.rounds_in_window = 0;
+            return;
+        }
+        if executed_c >= self.stats.len() {
+            return;
+        }
+        if self.rounds_in_window == 0 {
+            self.window_c = executed_c;
+        } else if executed_c != self.window_c {
+            self.cur_tokens = 0.0;
+            self.cur_secs = 0.0;
+            self.rounds_in_window = 0;
+            self.window_c = executed_c;
+        }
+        self.cur_tokens += committed_tokens as f64;
+        self.cur_secs += elapsed.as_secs_f64();
+        self.rounds_in_window += 1;
+        let window_done = self.rounds_in_window >= self.window_rounds;
+        if window_done {
+            let c = self.window_c;
+            self.stats[c].windows.push((self.cur_tokens, self.cur_secs));
+            if self.stats[c].windows.len() > MAX_WINDOWS {
+                self.stats[c].windows.remove(0);
+            }
+            self.cur_tokens = 0.0;
+            self.cur_secs = 0.0;
+            self.rounds_in_window = 0;
+        }
+
+        if let Some(held) = self.committed {
+            self.commit_left = self.commit_left.saturating_sub(1);
+            if self.commit_left == 0 {
+                self.committed = None;
+                self.cur_c = 0;
+                self.cur_tokens = 0.0;
+                self.cur_secs = 0.0;
+                self.rounds_in_window = 0;
+                self.cycles_done = 0;
+                self.window_rounds = REEXPLORE_WINDOW_ROUNDS;
+                log::info!("spec hedge auto: re-exploring (held C={held})");
+            }
+            return;
+        }
+        if !window_done {
+            return;
+        }
+        if self.cur_c + 1 < self.stats.len() {
+            self.cur_c += 1;
+            return;
+        }
+        self.cur_c = 0;
+        self.cycles_done += 1;
+        if self.cycles_done < EXPLORE_CYCLES {
+            return;
+        }
+        // Commit. Walk candidates from cheapest up; a larger chain count must
+        // beat the running best's median window rate by ADD_CHAIN_MARGIN to
+        // be preferred — uncertainty resolves toward fewer chains, so a flat
+        // landscape (easy traffic) settles at the cheap end instead of the
+        // noise argmax.
+        let mut best = 0usize;
+        let mut best_rate = self.stats[0].median_rate().unwrap_or(0.0);
+        for (c, s) in self.stats.iter().enumerate().skip(1) {
+            let Some(rate) = s.median_rate() else {
+                continue;
+            };
+            if rate > best_rate * ADD_CHAIN_MARGIN {
+                best = c;
+                best_rate = rate;
+            }
+        }
+        let rates: Vec<String> = self
+            .stats
+            .iter()
+            .map(|s| {
+                s.median_rate()
+                    .map_or("-".to_string(), |r| format!("{r:.0}"))
+            })
+            .collect();
+        log::info!(
+            "spec hedge auto: committed C={best} (median window tok/s by C: [{}])",
+            rates.join(", ")
+        );
+        self.committed = Some(best);
+        self.commit_left = COMMIT_ROUNDS;
+        self.cycles_done = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn drive(auto: &mut AutoHedge, rounds: u32, tokens_for: impl Fn(usize) -> usize) {
+        for _ in 0..rounds {
+            auto.last_tick = Instant::now().checked_sub(Duration::from_millis(50));
+            let c = auto.current_c();
+            auto.tick(c, tokens_for(c));
+        }
+    }
+
+    #[test]
+    fn explores_all_candidates_then_commits_to_best() {
+        let mut auto = AutoHedge::new(3);
+        // C=2 yields the most tokens per (constant) round time.
+        drive(
+            &mut auto,
+            WINDOW_ROUNDS * 4 * EXPLORE_CYCLES + 1,
+            |c| match c {
+                2 => 30,
+                3 => 28,
+                _ => 20,
+            },
+        );
+        assert_eq!(auto.committed, Some(2));
+    }
+
+    #[test]
+    fn commit_expires_into_reexploration() {
+        let mut auto = AutoHedge::new(1);
+        drive(&mut auto, WINDOW_ROUNDS * 2 * EXPLORE_CYCLES + 1, |c| {
+            if c == 1 { 30 } else { 20 }
+        });
+        assert_eq!(auto.committed, Some(1));
+        drive(&mut auto, COMMIT_ROUNDS, |_| 30);
+        assert_eq!(auto.committed, None);
+        assert_eq!(auto.window_rounds, REEXPLORE_WINDOW_ROUNDS);
+    }
+
+    #[test]
+    fn long_gaps_sever_the_window() {
+        let mut auto = AutoHedge::new(1);
+        // Seed a half-built window, then stall: the gap round must not be
+        // attributed AND the pre-stall partial window must be discarded.
+        drive(&mut auto, 10, |_| 25);
+        assert!(auto.cur_tokens > 0.0);
+        auto.last_tick = Instant::now().checked_sub(Duration::from_secs(2));
+        auto.tick(0, 30);
+        assert!(auto.cur_tokens.abs() < f64::EPSILON);
+        assert_eq!(auto.rounds_in_window, 0);
+    }
+
+    #[test]
+    fn guard_disabled_rounds_are_booked_to_executed_config() {
+        let mut auto = AutoHedge::new(2);
+        // Every round runs C=0 regardless of the candidate (guard always
+        // trips): only stats[0] may accumulate windows.
+        drive_executed(&mut auto, WINDOW_ROUNDS * 3 * EXPLORE_CYCLES + 1, 0, 25);
+        assert!(auto.stats[1].windows.is_empty());
+        assert!(auto.stats[2].windows.is_empty());
+        assert_eq!(auto.committed, Some(0));
+    }
+
+    fn drive_executed(auto: &mut AutoHedge, rounds: u32, executed: usize, tokens: usize) {
+        for _ in 0..rounds {
+            auto.last_tick = Instant::now().checked_sub(Duration::from_millis(50));
+            auto.tick(executed, tokens);
+        }
+    }
+
+    #[test]
+    fn flat_landscape_settles_cheap() {
+        let mut auto = AutoHedge::new(3);
+        drive(&mut auto, WINDOW_ROUNDS * 4 * EXPLORE_CYCLES + 1, |_| 25);
+        assert_eq!(auto.committed, Some(0));
+    }
+}

--- a/pegainfer-qwen3/src/executor/dflash_lane.rs
+++ b/pegainfer-qwen3/src/executor/dflash_lane.rs
@@ -34,6 +34,27 @@ pub(super) struct DFlashLaneState {
     scratch: DFlashBatchScratch,
     verified_draft_tokens: usize,
     accepted_draft_tokens: usize,
+    /// Hedge chains proposed by the last draft round (`PEGAINFER_SPEC_HEDGE`):
+    /// per request, one full `block_size` chain per configured branch position
+    /// (`PEGAINFER_SPEC_HEDGE_POSITIONS`, default `0`) — chain `j` follows the
+    /// greedy chain to `positions[j]`, takes the exact Markov runner-up there,
+    /// and continues greedily. Consumed by the verify step's parallel hedge
+    /// expansion; refilled every draft round.
+    pub(super) hedge_blocks: HashMap<RequestId, Vec<Vec<u32>>>,
+    /// Runtime chain-count controller (`PEGAINFER_SPEC_HEDGE_AUTO`); `None`
+    /// = fixed chain count from `PEGAINFER_SPEC_HEDGE_POSITIONS`.
+    auto: Option<super::auto_hedge::AutoHedge>,
+    /// Chain count the LAST draft round actually ran (0 when the capacity
+    /// guard or cap disabled hedging) — the controller books rounds to the
+    /// executed configuration, not the requested one.
+    round_chains: usize,
+    /// Effective hedge geometry, resolved once against this drafter's block
+    /// size (`spec_hedge_effective`): the clamped request cap — zero when no
+    /// configured position can fire — and the in-block branch positions. The
+    /// draft path, the verify dispatch, and the controller all read THESE,
+    /// never the raw env values.
+    hedge_cap: usize,
+    hedge_branch_positions: Vec<usize>,
 }
 
 impl DFlashLaneState {
@@ -43,12 +64,39 @@ impl DFlashLaneState {
         max_decode_batch_size: usize,
     ) -> Result<Self> {
         let scratch = model.new_batch_scratch(ctx, max_decode_batch_size)?;
+        let geometry = spec_hedge_effective(model.block_size());
+        let hedge_branch_positions = geometry.positions;
+        let hedge_cap = if model.uses_markov_head() && !hedge_branch_positions.is_empty() {
+            geometry.cap
+        } else {
+            0
+        };
+        if hedge_cap > 0 {
+            // The parser drops unparsable entries and falls back to position
+            // 0, so a benchmark can otherwise measure a narrower ladder than
+            // it configured.
+            log::info!(
+                "spec hedge on: up to {hedge_cap} request(s)/round, branch positions {:?} (block size {})",
+                hedge_branch_positions,
+                model.block_size()
+            );
+        }
+        let auto = (spec_hedge_auto() && hedge_cap > 0).then(|| {
+            let max_chains = hedge_branch_positions.len();
+            log::info!("spec hedge auto: self-pricing controller on (C in 0..={max_chains})");
+            super::auto_hedge::AutoHedge::new(max_chains)
+        });
         Ok(Self {
             model,
             requests: HashMap::new(),
             scratch,
             verified_draft_tokens: 0,
             accepted_draft_tokens: 0,
+            hedge_blocks: HashMap::new(),
+            auto,
+            round_chains: 0,
+            hedge_cap,
+            hedge_branch_positions,
         })
     }
 }
@@ -211,6 +259,13 @@ impl LocalQwen3Lane {
             );
             token_offset += req.token_ids.len();
         }
+        if let Some(controller) = dflash.auto.as_mut() {
+            let committed: usize = results
+                .iter()
+                .map(|result| result.accepted_tokens.len())
+                .sum();
+            controller.tick(dflash.round_chains, committed);
+        }
         Ok(())
     }
 
@@ -248,6 +303,11 @@ impl LocalQwen3Lane {
                 model,
                 scratch,
                 requests: state_map,
+                hedge_blocks,
+                auto,
+                round_chains,
+                hedge_cap,
+                hedge_branch_positions,
                 ..
             } = &mut dflash;
             let mut state_refs: Vec<&mut DFlashRequestState> =
@@ -278,8 +338,83 @@ impl LocalQwen3Lane {
             // greedy argmax per position; DSpark adds the Markov bias and samples
             // the block left-to-right (anchor-first, all `block_size` positions).
             let markov = model.uses_markov_head();
+            let hedge_positions = if *hedge_cap > 0 {
+                hedge_branch_positions.as_slice()
+            } else {
+                &[]
+            };
+            // Parallel hedge (PEGAINFER_SPEC_HEDGE): the chain-A loop also
+            // captures the exact Markov runner-up at each configured branch
+            // position, and one batched ladder pass proposes a chain per
+            // (request, position) over the same backbone logits. Stashed
+            // lane-side; the draft/verify token-span seam is unchanged (the
+            // scheduler never sees hedge chains). Skipped when the ladder
+            // would exceed the Markov scratch's max batch.
+            hedge_blocks.clear();
+            // Auto mode: the controller picks how many of the configured
+            // positions to ladder this round. Always a PREFIX — runner
+            // stripes are indexed by position order, so prefixes keep the
+            // runner pass (always run over the full list, stable graph
+            // shape) aligned with the ladder's stripe reads.
+            let ladder_chains = match auto.as_ref() {
+                Some(controller) => controller.current_c().min(hedge_positions.len()),
+                None => hedge_positions.len(),
+            };
+            // Chains are built for the SAME requests the verify side will
+            // hedge: eligibility travels on the draft item, and selection is
+            // capped by the per-round hedge cap and the ladder's scratch
+            // budget at the chain count that actually runs this round.
+            let hedged = select_hedged_requests(
+                requests,
+                *hedge_cap,
+                match ladder_chains {
+                    0 => 0,
+                    // Slots are bounded by the ladder's Markov scratch AND by
+                    // the verify batch's remaining span capacity — chains the
+                    // expansion would drop at `max_batch` must not be built.
+                    c => (scratch.markov_max_batch() / c).min(
+                        (*crate::batch_decode_buffers::BATCH_BUCKETS.last().unwrap())
+                            .saturating_sub(requests.len())
+                            / c,
+                    ),
+                },
+                hedge_positions.first().copied().unwrap_or(usize::MAX),
+                model.block_size(),
+            );
+            let hedging = ladder_chains > 0 && !hedged.is_empty();
+            *round_chains = if hedging { ladder_chains } else { 0 };
             let sampled = if markov {
-                model.markov_draft_tokens(self.model.device_ctx(), &current_tokens, scratch)?
+                if hedging {
+                    let ctx = self.model.device_ctx();
+                    let chain_a = model.markov_draft_with_runners(
+                        ctx,
+                        &current_tokens,
+                        hedge_positions,
+                        scratch,
+                    )?;
+                    let bs = model.block_size();
+                    let req_map: Vec<u32> = hedged.iter().map(|&i| i as u32).collect();
+                    let ladder = model.markov_chain_ladder(
+                        ctx,
+                        &chain_a,
+                        &req_map,
+                        &hedge_positions[..ladder_chains],
+                        scratch,
+                    )?;
+                    let c = ladder_chains;
+                    for (slot, &i) in hedged.iter().enumerate() {
+                        let chains: Vec<Vec<u32>> = (0..c)
+                            .map(|j| {
+                                let row = slot * c + j;
+                                ladder[row * bs..(row + 1) * bs].to_vec()
+                            })
+                            .collect();
+                        hedge_blocks.insert(requests[i].request_id, chains);
+                    }
+                    chain_a
+                } else {
+                    model.markov_draft_tokens(self.model.device_ctx(), &current_tokens, scratch)?
+                }
             } else {
                 let greedy = SamplingParams::default();
                 let params: Vec<&SamplingParams> = vec![&greedy; draft_len];
@@ -336,5 +471,198 @@ impl LocalQwen3Lane {
         if let Some(dflash) = self.dflash.as_mut() {
             dflash.requests.remove(&request_id);
         }
+    }
+}
+
+/// `PEGAINFER_SPEC_HEDGE_AUTO=1` puts the hedge chain count under the
+/// runtime self-pricing controller ([`crate::executor::auto_hedge`]): the
+/// lane explores C ∈ {0..=len(positions)} (position-list prefixes) and
+/// commits to the measured tokens/sec argmax. Requires the hedge to be
+/// enabled (`PEGAINFER_SPEC_HEDGE` > 0). Read once.
+pub(super) fn spec_hedge_auto() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("PEGAINFER_SPEC_HEDGE_AUTO").is_ok_and(|v| v == "1"))
+}
+
+/// Effective hedge geometry for a drafter `block_size`: the clamped request
+/// cap and the configured branch positions that can actually fire
+/// (`p < block_size`). Startup scratch billing, verify-plan sizing, and the
+/// draft path all budget from this ONE shape — the sites drifting apart is
+/// how positions past the block ended up reserving pages no round could use.
+pub(super) struct HedgeGeometry {
+    pub(super) cap: usize,
+    pub(super) positions: Vec<usize>,
+}
+
+pub(super) fn spec_hedge_effective(block_size: usize) -> HedgeGeometry {
+    let positions = spec_hedge_positions()
+        .iter()
+        .copied()
+        .filter(|&p| p < block_size)
+        .collect();
+    HedgeGeometry {
+        cap: spec_hedge_cap(),
+        positions,
+    }
+}
+
+/// Worst-case scratch KV pages one hedge chain's verify span can touch: the
+/// span is at most the anchor plus `block_size` drafts, at an arbitrary page
+/// offset. Startup scratch billing and the verify-time span guard both
+/// budget from this ONE value; the two sites carrying independent literals
+/// is how a large-but-legal block would reserve pages the verify pass then
+/// silently refuses to use.
+pub(super) fn hedge_pages_per_chain(block_size: usize, page_size: usize) -> usize {
+    // Saturating: this bills against raw config dims, where over-estimating
+    // is safe but wrapping would under-reserve.
+    block_size.div_ceil(page_size.max(1)).saturating_add(1)
+}
+
+/// `PEGAINFER_SPEC_HEDGE=<H>` enables the parallel hedge and caps the number
+/// of hedged requests per verify round at `H`. Each hedged request costs one
+/// extra verify span and [`hedge_pages_per_chain`] lane scratch KV pages PER
+/// CHAIN, so a request branching at C positions costs C of each.
+/// `0`/unset/unparsable = off. Read once.
+pub(super) fn spec_hedge_cap() -> usize {
+    static CAP: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *CAP.get_or_init(|| {
+        std::env::var("PEGAINFER_SPEC_HEDGE")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(0)
+            // Scratch pages, plan metadata, and ladder rows all scale with
+            // the cap; clamp so a pathological value cannot blow any budget.
+            .min(64)
+    })
+}
+
+/// `PEGAINFER_SPEC_HEDGE_POSITIONS="0,1,2"` — draft positions at which hedge
+/// chains branch (each takes the exact Markov runner-up at that position,
+/// rank 2). Sorted/deduped; default `0` (the original single-chain hedge).
+/// Read once.
+pub(super) fn spec_hedge_positions() -> &'static [usize] {
+    static POSITIONS: std::sync::OnceLock<Vec<usize>> = std::sync::OnceLock::new();
+    POSITIONS.get_or_init(|| {
+        let mut positions: Vec<usize> = std::env::var("PEGAINFER_SPEC_HEDGE_POSITIONS")
+            .ok()
+            .map(|v| {
+                v.split(',')
+                    .filter_map(|t| t.trim().parse::<usize>().ok())
+                    .collect()
+            })
+            .unwrap_or_default();
+        positions.sort_unstable();
+        positions.dedup();
+        positions.truncate(16);
+        if positions.is_empty() {
+            positions.push(0);
+        }
+        positions
+    })
+}
+
+impl DFlashLaneState {
+    /// Verify-side correction for the controller's books: the round fell back
+    /// to the plain pass (no expanded spans), so it executed as C = 0
+    /// whatever the draft side prepared.
+    pub(super) fn clear_round_chains(&mut self) {
+        self.round_chains = 0;
+    }
+
+    /// Effective hedged-request cap (0 = hedging cannot run on this drafter
+    /// and the verify dispatch must not try).
+    pub(super) fn hedge_cap(&self) -> usize {
+        self.hedge_cap
+    }
+
+    /// Number of in-block branch positions (the maximum chain count).
+    pub(super) fn hedge_branch_count(&self) -> usize {
+        self.hedge_branch_positions.len()
+    }
+}
+
+/// First-come selection of hedge-eligible requests under the per-round cap
+/// and the ladder's scratch budget (both in requests). A request qualifies
+/// only when its chains can SURVIVE the verify-side span clamp: after the
+/// clamp it keeps `min(block_size, budget - 1)` drafts, and the earliest
+/// branch position must land inside them — otherwise every chain collapses
+/// onto chain A and is deduplicated away, wasting the slot. Draft and verify
+/// pick from this same list, so neither a sampled request nor a
+/// budget-starved greedy one ahead in the batch can burn a hedge slot the
+/// verify side then refuses.
+fn select_hedged_requests(
+    requests: &[DraftStepItem],
+    cap: usize,
+    slots: usize,
+    first_position: usize,
+    block_size: usize,
+) -> Vec<usize> {
+    requests
+        .iter()
+        .enumerate()
+        .filter(|(_, r)| r.hedge_budget >= 2 && first_position < block_size.min(r.hedge_budget - 1))
+        .map(|(i, _)| i)
+        .take(cap.min(slots))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(id: u64, budget: usize) -> DraftStepItem {
+        DraftStepItem::new(RequestId::new(id), 7, budget)
+    }
+
+    const BLOCK: usize = 7;
+
+    #[test]
+    fn hedge_selection_is_order_invariant_for_mixed_batches() {
+        // H=1: the single slot must land on the greedy request in BOTH
+        // orders — a sampled request (budget 0) must never consume it.
+        let sampled_first = [item(1, 0), item(2, 64)];
+        let greedy_first = [item(2, 64), item(1, 0)];
+        assert_eq!(
+            select_hedged_requests(&sampled_first, 1, usize::MAX, 0, BLOCK),
+            [1]
+        );
+        assert_eq!(
+            select_hedged_requests(&greedy_first, 1, usize::MAX, 0, BLOCK),
+            [0]
+        );
+    }
+
+    #[test]
+    fn hedge_selection_skips_spans_the_clamp_would_collapse() {
+        // Branch position 1 with remaining budget 2: the clamp keeps one
+        // draft, the branch cannot show, the chain would dedupe onto A. The
+        // slot must go to the request whose span can carry the branch — in
+        // BOTH orders.
+        let starved_first = [item(1, 2), item(2, 64)];
+        let healthy_first = [item(2, 64), item(1, 2)];
+        assert_eq!(
+            select_hedged_requests(&starved_first, 1, usize::MAX, 1, BLOCK),
+            [1]
+        );
+        assert_eq!(
+            select_hedged_requests(&healthy_first, 1, usize::MAX, 1, BLOCK),
+            [0]
+        );
+        // The same budget IS enough for a position-0 branch.
+        assert_eq!(
+            select_hedged_requests(&starved_first, 2, usize::MAX, 0, BLOCK),
+            [0, 1]
+        );
+    }
+
+    #[test]
+    fn hedge_selection_respects_cap_and_slots() {
+        let batch = [item(1, 64), item(2, 0), item(3, 64), item(4, 64)];
+        assert_eq!(
+            select_hedged_requests(&batch, 2, usize::MAX, 0, BLOCK),
+            [0, 2]
+        );
+        assert_eq!(select_hedged_requests(&batch, usize::MAX, 1, 0, BLOCK), [0]);
+        assert!(select_hedged_requests(&batch, 0, usize::MAX, 0, BLOCK).is_empty());
     }
 }

--- a/pegainfer-qwen3/src/executor/dflash_lane.rs
+++ b/pegainfer-qwen3/src/executor/dflash_lane.rs
@@ -356,17 +356,43 @@ impl LocalQwen3Lane {
             // stripes are indexed by position order, so prefixes keep the
             // runner pass (always run over the full list, stable graph
             // shape) aligned with the ladder's stripe reads.
-            let ladder_chains = match auto.as_ref() {
-                Some(controller) => controller.current_c().min(hedge_positions.len()),
-                None => hedge_positions.len(),
+            // Batch-adaptive policy (PEGAINFER_SPEC_HEDGE_KNEE) takes precedence
+            // over both the fixed count and the auto controller: it sets the
+            // chain count from the free zone at THIS round's batch size, so
+            // hedging fades to zero as concurrency fills the verify pass.
+            let knee = spec_hedge_knee();
+            let (ladder_chains, round_cap) = if knee > 0 {
+                // Batch-adaptive, bucket-aware: the chain count keeps the
+                // expanded verify batch on a CUDA-graph bucket inside the free
+                // zone, so it fades to the baseline as concurrency rises. The
+                // whole batch hedges at that count (the cap is not the knob).
+                let c = batch_adaptive_chains(
+                    requests.len(),
+                    model.block_size(),
+                    knee,
+                    hedge_positions.len(),
+                    crate::batch_decode_buffers::BATCH_BUCKETS,
+                );
+                log::debug!(
+                    "spec hedge plan: batch {} -> {c} chain(s) ({} verify spans)",
+                    requests.len(),
+                    requests.len() * (1 + c)
+                );
+                (c, requests.len())
+            } else {
+                let c = match auto.as_ref() {
+                    Some(controller) => controller.current_c().min(hedge_positions.len()),
+                    None => hedge_positions.len(),
+                };
+                (c, *hedge_cap)
             };
             // Chains are built for the SAME requests the verify side will
             // hedge: eligibility travels on the draft item, and selection is
-            // capped by the per-round hedge cap and the ladder's scratch
+            // capped by the per-round request cap and the ladder's scratch
             // budget at the chain count that actually runs this round.
             let hedged = select_hedged_requests(
                 requests,
-                *hedge_cap,
+                round_cap,
                 match ladder_chains {
                     0 => 0,
                     // Slots are bounded by the ladder's Markov scratch AND by
@@ -536,6 +562,62 @@ pub(super) fn spec_hedge_cap() -> usize {
     })
 }
 
+/// `PEGAINFER_SPEC_HEDGE_KNEE=<rows>` turns on the batch-adaptive policy: the
+/// per-round chain count is chosen so the expanded verify batch stays within
+/// the roofline free zone of `<rows>` rows — the compute knee for this model
+/// and GPU, below which the verify pass is weight-bandwidth-bound and extra
+/// rows are nearly free. `0`/unset = off, keeping the fixed or auto chain
+/// count. Read once.
+pub(super) fn spec_hedge_knee() -> usize {
+    static KNEE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *KNEE.get_or_init(|| {
+        std::env::var("PEGAINFER_SPEC_HEDGE_KNEE")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(0)
+    })
+}
+
+/// Uniform hedge chain count for this batch, chosen to keep the expanded
+/// verify batch BOTH inside the roofline free zone AND on a CUDA-graph bucket.
+///
+/// Every hedged request is verified over `1 + C` spans, so the batch spans
+/// `batch * (1 + C)`. Two constraints: the rows must stay under the compute
+/// knee (`batch * (1 + C) * span <= knee_rows`, below which extra rows are
+/// nearly free), and the span count must be a captured graph bucket — a count
+/// that falls between buckets runs eager and gives back the hedge gain. Return
+/// the largest `C <= max_chains` satisfying both, or `0` when no bucket-aligned
+/// count fits, which is how the policy fades to the baseline as concurrency
+/// fills the zone.
+///
+/// A fractional free-zone remainder (a batch that fits, say, four extra chain
+/// spans across eight requests) is deliberately NOT spent: the only span
+/// counts between one bucket and the next are off-bucket, so partial hedging
+/// runs eager and loses more than it gains.
+pub(super) fn batch_adaptive_chains(
+    batch: usize,
+    block_size: usize,
+    knee_rows: usize,
+    max_chains: usize,
+    buckets: &[usize],
+) -> usize {
+    if batch == 0 || knee_rows == 0 || max_chains == 0 {
+        return 0;
+    }
+    let span = block_size + 1;
+    let mut best = 0;
+    for c in 1..=max_chains {
+        let spans = batch * (1 + c);
+        if spans * span > knee_rows {
+            break; // past the free zone; larger C only goes further past
+        }
+        if buckets.contains(&spans) {
+            best = c;
+        }
+    }
+    best
+}
+
 /// `PEGAINFER_SPEC_HEDGE_POSITIONS="0,1,2"` — draft positions at which hedge
 /// chains branch (each takes the exact Markov runner-up at that position,
 /// rank 2). Sorted/deduped; default `0` (the original single-chain hedge).
@@ -615,6 +697,39 @@ mod tests {
     }
 
     const BLOCK: usize = 7;
+
+    #[test]
+    fn batch_adaptive_chains_picks_the_largest_bucket_aligned_count_under_the_knee() {
+        // block 7 -> span 8 rows; knee 96 rows = 12 spans.
+        let bk = crate::batch_decode_buffers::BATCH_BUCKETS;
+        let c = |b| batch_adaptive_chains(b, BLOCK, 96, 7, bk);
+        // B=1: 1*(1+C) must be a bucket <= 12 -> {2,4,8}; largest gives C=7 (8 spans).
+        assert_eq!(c(1), 7);
+        // B=2: 2*(1+C) in buckets <= 12 -> {2,4,8}; 8 -> C=3, NOT the free-zone C=5.
+        assert_eq!(c(2), 3);
+        // B=4: 4*(1+C) in buckets <= 12 -> 8 -> C=1 (12 would be off-bucket).
+        assert_eq!(c(4), 1);
+        // B=8: 8*(1+C): C=0 gives 8 (baseline), C=1 gives 16 = past the knee.
+        // 9..15 spans are all off-bucket -> no hedge fits, fade to baseline.
+        assert_eq!(c(8), 0);
+        assert_eq!(c(16), 0); // past the knee outright
+        // every chosen count lands on a bucket and inside the free zone
+        for b in 1..=32 {
+            let cc = c(b);
+            if cc > 0 {
+                let spans = b * (1 + cc);
+                assert!(
+                    bk.contains(&spans),
+                    "b={b} c={cc}: {spans} spans off-bucket"
+                );
+                assert!(spans * (BLOCK + 1) <= 96, "b={b} c={cc}: past the knee");
+            }
+        }
+        // off / degenerate inputs
+        assert_eq!(batch_adaptive_chains(1, BLOCK, 0, 7, bk), 0);
+        assert_eq!(batch_adaptive_chains(0, BLOCK, 96, 7, bk), 0);
+        assert_eq!(batch_adaptive_chains(1, BLOCK, 96, 0, bk), 0);
+    }
 
     #[test]
     fn hedge_selection_is_order_invariant_for_mixed_batches() {

--- a/pegainfer-qwen3/src/lib.rs
+++ b/pegainfer-qwen3/src/lib.rs
@@ -17,6 +17,7 @@ pub use lora::fixtures as lora_fixtures;
 mod prefill;
 mod projection_fusion;
 mod scheduler;
+mod sizing;
 mod speculative;
 mod split_kv;
 mod unified_forward;

--- a/pegainfer-qwen3/src/scheduler/plan.rs
+++ b/pegainfer-qwen3/src/scheduler/plan.rs
@@ -166,7 +166,17 @@ pub(crate) fn should_speculative_decode(
 fn build_speculative_draft_items(active: &[ActiveRequestState]) -> Vec<DraftStepItem> {
     active
         .iter()
-        .map(|r| DraftStepItem::new(r.request_id, r.last_token))
+        .map(|r| {
+            // Only greedy requests may hedge; the draft lane turns the
+            // remaining budget into eligibility against its effective branch
+            // positions (a chain must survive the verify-side span clamp).
+            let budget = if r.params.is_greedy() {
+                r.max_tokens.saturating_sub(r.generated_count)
+            } else {
+                0
+            };
+            DraftStepItem::new(r.request_id, r.last_token, budget)
+        })
         .collect()
 }
 
@@ -276,6 +286,18 @@ mod tests {
             params: SamplingParams::default(),
             logprobs: 0,
         }
+    }
+
+    #[test]
+    fn draft_items_carry_the_remaining_budget_for_greedy_requests_only() {
+        let exhausted = active(31, 32);
+        let fresh = active(0, 32);
+        let mut sampled = active(0, 32);
+        sampled.params.temperature = 0.7;
+        let items = build_speculative_draft_items(&[exhausted, fresh, sampled]);
+        assert_eq!(items[0].hedge_budget, 1);
+        assert_eq!(items[1].hedge_budget, 32);
+        assert_eq!(items[2].hedge_budget, 0);
     }
 
     #[test]

--- a/pegainfer-qwen3/src/sizing.rs
+++ b/pegainfer-qwen3/src/sizing.rs
@@ -1,0 +1,22 @@
+//! Checked sizing arithmetic for startup memory budgets.
+//!
+//! Budgets are computed from config-file dims before those dims are validated
+//! against the weight tensors, so a corrupt config must fail loudly here rather
+//! than wrap into an under-reservation.
+
+use anyhow::Result;
+use anyhow::anyhow;
+
+pub(crate) fn product(factors: &[usize]) -> Result<usize> {
+    factors
+        .iter()
+        .try_fold(1usize, |acc, &f| acc.checked_mul(f))
+        .ok_or_else(|| anyhow!("sizing overflow in product {factors:?}"))
+}
+
+pub(crate) fn sum(terms: &[usize]) -> Result<usize> {
+    terms
+        .iter()
+        .try_fold(0usize, |acc, &t| acc.checked_add(t))
+        .ok_or_else(|| anyhow!("sizing overflow in sum {terms:?}"))
+}

--- a/pegainfer-qwen3/src/speculative.rs
+++ b/pegainfer-qwen3/src/speculative.rs
@@ -86,13 +86,21 @@ pub(crate) struct VerifyResult {
 pub(crate) struct DraftStepItem {
     pub(crate) request_id: RequestId,
     pub(crate) current_token: u32,
+    /// Remaining output budget when the request may be hedged (greedy
+    /// sampler), `0` otherwise. Carried through the draft seam so the draft
+    /// lane — which owns the effective branch positions — makes the final
+    /// eligibility call: a chain only survives the verify-side span clamp
+    /// when some branch position fits inside `remaining - 1` kept drafts,
+    /// and a request that cannot show its chain must not burn a hedge slot.
+    pub(crate) hedge_budget: usize,
 }
 
 impl DraftStepItem {
-    pub(crate) fn new(request_id: RequestId, current_token: u32) -> Self {
+    pub(crate) fn new(request_id: RequestId, current_token: u32, hedge_budget: usize) -> Self {
         Self {
             request_id,
             current_token,
+            hedge_budget,
         }
     }
 }

--- a/pegainfer-qwen3/src/verify_graph.rs
+++ b/pegainfer-qwen3/src/verify_graph.rs
@@ -159,6 +159,13 @@ impl VerifyGraphBuffers {
         &self.all_logits
     }
 
+    /// Mutable view, for truncating `seq_len` back to the unexpanded row count
+    /// after the hedge's winner rows have been compacted onto chain A's
+    /// offsets.
+    pub(crate) fn captured_hidden_mut(&mut self) -> &mut HiddenStates {
+        &mut self.captured_hidden
+    }
+
     /// Captured target hidden states `[hidden_size * num_capture_layers, total_rows]`.
     pub(crate) fn captured_hidden(&self) -> &HiddenStates {
         &self.captured_hidden
@@ -279,6 +286,12 @@ impl Qwen3Model {
         let full_shape = total_tokens == batch_size * bufs.span;
         match BATCH_BUCKETS.iter().position(|&b| b == batch_size) {
             Some(bidx) if full_shape => {
+                if bufs.graphs[bidx].is_empty() || !bufs.graphs[bidx][0].is_captured() {
+                    log::info!(
+                        "verify graph capturing: bucket {batch_size} span {span}",
+                        span = bufs.span
+                    );
+                }
                 assert_eq!(
                     numeric_policy(),
                     bufs.policy_at_construction,

--- a/pegainfer-qwen3/src/weights.rs
+++ b/pegainfer-qwen3/src/weights.rs
@@ -46,7 +46,7 @@ pub struct Qwen3MemoryOptions {
     pub(crate) kv_cache_memory_margin_bytes: usize,
     /// KV cache page (block) size in tokens (`--kv-page-size`). FlashInfer
     /// constrains this to [`VALID_KV_PAGE_SIZES`]; 16 by default.
-    page_size: usize,
+    pub(crate) page_size: usize,
 }
 
 impl Qwen3MemoryOptions {
@@ -651,7 +651,7 @@ impl Qwen3Model {
     #[cfg(feature = "kernel-call-trace")]
     pub(crate) fn kv_budget(&self) -> KvBudget {
         let geometry = self.kv_budget_geometry(DEFAULT_KV_PAGE_SIZE);
-        let bytes_per_block = Self::kv_bytes_per_block(&geometry);
+        let bytes_per_block = Self::kv_bytes_per_block(&geometry).expect("KV bytes per block");
         let (free_bytes, _) = cudarc::driver::result::mem_get_info().expect("cuMemGetInfo failed");
         let kv_budget_bytes = (free_bytes as f64 * 0.85) as usize;
         Self::kv_budget_from_bytes(
@@ -662,6 +662,7 @@ impl Qwen3Model {
             free_bytes,
             "heuristic",
         )
+        .expect("KV budget")
     }
 
     pub(crate) fn profiled_kv_budget(
@@ -673,7 +674,7 @@ impl Qwen3Model {
     ) -> Result<KvBudget> {
         let memory_options = memory_options.validate()?;
         let geometry = self.kv_budget_geometry(memory_options.page_size);
-        let bytes_per_block = Self::kv_bytes_per_block(&geometry);
+        let bytes_per_block = Self::kv_bytes_per_block(&geometry)?;
         let (initial_free_bytes, total_bytes) = mem_info_bytes()?;
         let requested_bytes =
             (total_bytes as f64 * memory_options.gpu_memory_utilization).ceil() as usize;
@@ -700,7 +701,7 @@ impl Qwen3Model {
         let profile_rows = profile_prefill_rows + profile_decode_rows;
         let profile_blocks =
             profile_temp_blocks(max_prefill_tokens, profile_decode_rows, geometry.block_size);
-        let profile_kv_bytes = profile_blocks * bytes_per_block;
+        let profile_kv_bytes = crate::sizing::product(&[profile_blocks, bytes_per_block])?;
         let mut peak_used_bytes = initial_used_bytes;
         let mut record_peak = || -> Result<()> {
             let (free_bytes, total_bytes) = mem_info_bytes()?;
@@ -771,13 +772,6 @@ impl Qwen3Model {
             memory_options.kv_cache_memory_margin_bytes / (1024 * 1024)
         );
         let kv_budget_bytes = requested_bytes - non_kv_bytes;
-        let min_kv_bytes = 64 * bytes_per_block;
-        anyhow::ensure!(
-            kv_budget_bytes >= min_kv_bytes,
-            "Qwen3 memory profile leaves too little KV cache: available={} MiB, minimum={} MiB",
-            kv_budget_bytes / (1024 * 1024),
-            min_kv_bytes / (1024 * 1024)
-        );
         log::info!(
             "memory profile: total={} MiB requested={} MiB ({:.0}%) initial_used={} MiB \
              peak_non_kv_increase={} MiB margin={} MiB -> KV budget={} MiB",
@@ -789,14 +783,21 @@ impl Qwen3Model {
             memory_options.kv_cache_memory_margin_bytes / (1024 * 1024),
             kv_budget_bytes / (1024 * 1024),
         );
-        Ok(Self::kv_budget_from_bytes(
+        Self::kv_budget_from_bytes(
             geometry,
             bytes_per_block,
             dflash_kv_bytes_per_token,
             kv_budget_bytes,
             initial_free_bytes,
             "profiled",
-        ))
+        )
+    }
+
+    /// Bytes one KV page costs in the pool, for a given page size. The single
+    /// owner of this formula — callers that bill KV pages (hedge scratch,
+    /// budgets) must not re-derive it.
+    pub(crate) fn kv_page_bytes(&self, page_size: usize) -> Result<usize> {
+        Self::kv_bytes_per_block(&self.kv_budget_geometry(page_size))
     }
 
     fn kv_budget_geometry(&self, page_size: usize) -> KvBudget {
@@ -810,15 +811,33 @@ impl Qwen3Model {
         }
     }
 
-    fn kv_bytes_per_block(geometry: &KvBudget) -> usize {
+    fn kv_bytes_per_block(geometry: &KvBudget) -> Result<usize> {
+        // Checked BEFORE constructing the layout: `KvLayout::new` derives its
+        // strides with plain products, and this full product dominates every
+        // partial one, so clearing it clears them all.
+        let bytes = crate::sizing::product(&[
+            geometry.num_layers,
+            2,
+            geometry.num_kv_heads,
+            geometry.head_dim,
+            geometry.block_size,
+            std::mem::size_of::<half::bf16>(),
+        ])?;
         let layout = pegainfer_kv_cache::KvLayout::new(
             geometry.num_layers,
             geometry.num_kv_heads,
             geometry.head_dim,
             geometry.block_size,
         );
-        layout.page_stride * std::mem::size_of::<half::bf16>()
+        debug_assert_eq!(
+            bytes,
+            layout.page_stride * std::mem::size_of::<half::bf16>()
+        );
+        Ok(bytes)
     }
+
+    /// Smallest pool the scheduler can make progress with.
+    const MIN_KV_BLOCKS: usize = 64;
 
     fn kv_budget_from_bytes(
         mut geometry: KvBudget,
@@ -827,23 +846,57 @@ impl Qwen3Model {
         kv_budget_bytes: usize,
         free_bytes: usize,
         source: &'static str,
-    ) -> KvBudget {
+    ) -> Result<KvBudget> {
         // DFlash keeps its own per-request KV (plus prompt-scaling scratch) outside
         // the paged pool, scaling with the same token count. Charge it as extra
         // bytes per pool token so the target block count shrinks to leave room; the
         // pool itself is still allocated at the target-only `bytes_per_block`.
-        let effective_bytes_per_block =
-            bytes_per_block + dflash_kv_bytes_per_token * geometry.block_size;
-        let num_blocks = (kv_budget_bytes / effective_bytes_per_block).max(64);
-        let kv_mb = num_blocks * bytes_per_block / (1024 * 1024);
+        //
+        // Checked: the draft config is not shape-validated against the draft
+        // weights until the model loads, which is after this budget is fixed.
+        let effective_bytes_per_block = crate::sizing::sum(&[
+            bytes_per_block,
+            crate::sizing::product(&[dflash_kv_bytes_per_token, geometry.block_size])?,
+        ])?;
+        anyhow::ensure!(
+            effective_bytes_per_block > 0,
+            "KV budget ({source}): degenerate geometry gives zero bytes per block"
+        );
+        // Against `effective`, not `bytes_per_block`: a budget that affords 64
+        // target blocks can still be short once the draft's out-of-pool KV is
+        // charged, and forcing the floor anyway defers the shortfall into a
+        // draft-growth OOM at serving time.
+        let affordable = kv_budget_bytes / effective_bytes_per_block;
+        anyhow::ensure!(
+            affordable >= Self::MIN_KV_BLOCKS,
+            "KV cache ({source}) affords only {affordable} blocks, below the \
+             {}-block minimum: budget={} MiB, needed={} MiB \
+             ({} KiB per block = {} target + {} draft)",
+            Self::MIN_KV_BLOCKS,
+            kv_budget_bytes / (1024 * 1024),
+            crate::sizing::product(&[Self::MIN_KV_BLOCKS, effective_bytes_per_block])?
+                / (1024 * 1024),
+            effective_bytes_per_block / 1024,
+            bytes_per_block / 1024,
+            (effective_bytes_per_block - bytes_per_block) / 1024,
+        );
+        let num_blocks = affordable;
+        // Saturating, not checked: log-only figures must not abort startup.
+        // Reported on the same basis the blocks were derived from — pool and
+        // draft split out, since only the pool shows up in the KV allocation.
+        let pool_mb = num_blocks.saturating_mul(bytes_per_block) / (1024 * 1024);
+        let draft_mb =
+            num_blocks.saturating_mul(effective_bytes_per_block - bytes_per_block) / (1024 * 1024);
+        let spent = num_blocks.saturating_mul(effective_bytes_per_block);
         let page_size = geometry.block_size;
         log::info!(
-            "KV cache ({source}): {num_blocks} blocks ({kv_mb} MB, page size {page_size}, {:.0}% of {:.0} MB free)",
-            kv_budget_bytes as f64 / free_bytes as f64 * 100.0,
+            "KV cache ({source}): {num_blocks} blocks (pool {pool_mb} MB + draft {draft_mb} MB, \
+             page size {page_size}, {:.0}% of {:.0} MB free)",
+            spent as f64 / free_bytes as f64 * 100.0,
             free_bytes as f64 / 1024.0 / 1024.0
         );
         geometry.num_blocks = num_blocks;
-        geometry
+        Ok(geometry)
     }
 }
 
@@ -884,6 +937,94 @@ mod tests {
     use super::*;
     use crate::lora::DeviceLoraLayer;
     use crate::lora::LoraAdapterManifest;
+
+    /// The draft config drives `dflash_kv_bytes_per_token`, and it is not
+    /// shape-validated against the draft weights until the model loads — after
+    /// this budget is fixed. A malformed value must fail the budget instead of
+    /// wrapping into an under-reservation.
+    #[test]
+    fn a_malformed_draft_config_fails_the_kv_budget_instead_of_wrapping() {
+        let geometry = KvBudget {
+            num_layers: 36,
+            num_kv_heads: 8,
+            head_dim: 128,
+            block_size: 16,
+            num_blocks: 0,
+        };
+        let bytes_per_block = Qwen3Model::kv_bytes_per_block(&geometry).expect("sane geometry");
+        let sane = Qwen3Model::kv_budget_from_bytes(
+            geometry,
+            bytes_per_block,
+            65_536,
+            8 << 30,
+            16 << 30,
+            "test",
+        )
+        .expect("sane draft config budgets");
+        assert!(sane.num_blocks >= 64);
+
+        let err = Qwen3Model::kv_budget_from_bytes(
+            geometry,
+            bytes_per_block,
+            usize::MAX / 8,
+            8 << 30,
+            16 << 30,
+            "test",
+        )
+        .expect_err("overflowing draft bytes-per-token must fail closed");
+        assert!(
+            err.to_string().contains("overflow"),
+            "expected a sizing-overflow error, got: {err}"
+        );
+    }
+
+    /// The pool costs `bytes_per_block`, but each pool block also drags the
+    /// draft's out-of-pool KV along. A budget that affords the minimum in
+    /// target bytes alone must still be rejected when it cannot afford it in
+    /// effective bytes — otherwise the shortfall lands as a draft-growth OOM
+    /// once requests actually fill the pool.
+    #[test]
+    fn a_budget_that_affords_the_floor_only_without_the_draft_charge_is_rejected() {
+        let geometry = KvBudget {
+            num_layers: 36,
+            num_kv_heads: 8,
+            head_dim: 128,
+            block_size: 16,
+            num_blocks: 0,
+        };
+        let bytes_per_block = Qwen3Model::kv_bytes_per_block(&geometry).expect("sane geometry");
+        let per_token = 65_536;
+        let effective = bytes_per_block + per_token * geometry.block_size;
+        assert!(bytes_per_block < effective);
+
+        let between = (Qwen3Model::MIN_KV_BLOCKS * bytes_per_block + 1)
+            .max((Qwen3Model::MIN_KV_BLOCKS * effective) / 2);
+        let err = Qwen3Model::kv_budget_from_bytes(
+            geometry,
+            bytes_per_block,
+            per_token,
+            between,
+            16 << 30,
+            "test",
+        )
+        .expect_err("a budget short of the effective floor must be rejected");
+        assert!(
+            err.to_string().contains("below the"),
+            "expected a minimum-blocks error, got: {err}"
+        );
+
+        let exact = Qwen3Model::MIN_KV_BLOCKS * effective;
+        let budget = Qwen3Model::kv_budget_from_bytes(
+            geometry,
+            bytes_per_block,
+            per_token,
+            exact,
+            16 << 30,
+            "test",
+        )
+        .expect("the effective floor itself is affordable");
+        assert_eq!(budget.num_blocks, Qwen3Model::MIN_KV_BLOCKS);
+    }
 
     fn test_device_adapter(name: &str, path: &Path) -> DeviceLoraAdapter {
         DeviceLoraAdapter {

--- a/pegainfer-qwen3/tests/common/harness.rs
+++ b/pegainfer-qwen3/tests/common/harness.rs
@@ -249,3 +249,32 @@ pub(crate) struct Outcome {
     pub(crate) prompt_echo: Option<PromptEcho>,
     pub(crate) terminal: Terminal,
 }
+
+/// Minimal stderr logger for gate children (`PEGAINFER_TEST_LOG=1`): the
+/// hedged execution gate counts the executor's per-round hedge trace lines,
+/// and cargo test binaries install no logger of their own. Forwarding only
+/// this crate's records keeps child stderr parseable.
+struct TestLogger;
+
+impl log::Log for TestLogger {
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        metadata.target().starts_with("pegainfer_qwen3")
+    }
+
+    fn log(&self, record: &log::Record) {
+        if self.enabled(record.metadata()) {
+            eprintln!("[{}] {}", record.level(), record.args());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+static TEST_LOGGER: TestLogger = TestLogger;
+
+pub(crate) fn init_capture_logging() {
+    if std::env::var("PEGAINFER_TEST_LOG").is_ok() {
+        let _ = log::set_logger(&TEST_LOGGER);
+        log::set_max_level(log::LevelFilter::Debug);
+    }
+}

--- a/pegainfer-qwen3/tests/dflash_speculative_gate.rs
+++ b/pegainfer-qwen3/tests/dflash_speculative_gate.rs
@@ -41,6 +41,7 @@
 
 use std::path::Path;
 use std::path::PathBuf;
+use std::process::Command;
 use std::time::Duration;
 
 use pegainfer_frontend::engine::Terminal;
@@ -344,6 +345,7 @@ fn check_lossless(
 
 #[test]
 fn dflash_speculative_greedy_matches_plain_greedy() {
+    common::harness::init_capture_logging();
     let (Some(model_path), Some(draft_path)) = (target_path_or_skip(), draft_path_or_skip()) else {
         return;
     };
@@ -535,6 +537,7 @@ fn dflash_short_then_long_verify_capture_is_lossless() {
 /// (non-tie) divergence.
 #[test]
 fn dflash_concurrent_heterogeneous_is_lossless() {
+    common::harness::init_capture_logging();
     let (Some(model_path), Some(draft_path)) = (target_path_or_skip(), draft_path_or_skip()) else {
         return;
     };
@@ -624,8 +627,6 @@ fn dflash_concurrent_heterogeneous_is_lossless() {
 /// panicked mid-prefill when the draft allocated KV past its own max positions.
 #[test]
 fn dflash_request_in_draft_headroom_is_rejected_not_panicked() {
-    const BLOCK_SIZE: usize = 16; // DFlash drafter block size.
-
     let (Some(model_path), Some(draft_path)) = (target_path_or_skip(), draft_path_or_skip()) else {
         return;
     };
@@ -633,9 +634,10 @@ fn dflash_request_in_draft_headroom_is_rejected_not_panicked() {
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
 
-    // Read the real context window so the boundary is exact regardless of the
-    // checkpoint, then size the request to sit inside the draft's final in-fill
-    // block — it fits the target window but not the DFlash-effective one.
+    // Read both context windows so the boundary is exact for ANY checkpoint
+    // pairing: the request must clear the target's own limit but land inside
+    // the draft's final in-fill block `(draft_max - block_size, draft_max]`,
+    // where the DFlash admission cap (`draft_max - block_size`) rejects it.
     let config: serde_json::Value = serde_json::from_str(
         &std::fs::read_to_string(Path::new(&model_path).join("config.json")).expect("read config"),
     )
@@ -643,10 +645,26 @@ fn dflash_request_in_draft_headroom_is_rejected_not_panicked() {
     let max_pos = config["max_position_embeddings"]
         .as_u64()
         .expect("max_position_embeddings") as usize;
+    let draft_config: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(Path::new(&draft_path).join("config.json"))
+            .expect("read draft config"),
+    )
+    .expect("parse draft config");
+    let block_size = draft_config["block_size"]
+        .as_u64()
+        .expect("draft block_size") as usize;
+    let draft_max = draft_config["max_position_embeddings"]
+        .as_u64()
+        .map_or(max_pos, |v| v as usize);
     let prompt_len = 16usize;
-    // total in (max_pos - BLOCK_SIZE, max_pos]: clears the target check, trips
-    // the DFlash admission cap (max_pos - BLOCK_SIZE).
-    let max_tokens = max_pos - BLOCK_SIZE / 2 - prompt_len;
+    let total = (draft_max - block_size / 2).min(max_pos);
+    if total <= draft_max - block_size {
+        eprintln!(
+            "skipping draft-headroom case: target max {max_pos} cannot reach the draft in-fill window (draft max {draft_max}, block {block_size})"
+        );
+        return;
+    }
+    let max_tokens = total - prompt_len;
 
     let engine = EngineHarness::new(
         pegainfer_qwen3::launch(
@@ -680,4 +698,112 @@ fn dflash_request_in_draft_headroom_is_rejected_not_panicked() {
             )
         }
     }
+}
+
+/// Execution gate for the hedge ladder: re-runs the two losslessness tests
+/// above in child processes, since the hedge config is read once per process
+/// and cannot be toggled in-process.
+///
+/// Scope: this proves the copy-back and discard branches were ENTERED, not
+/// that a later round consumes the winner's state correctly — `check_lossless`
+/// returns at the first benign tie flip, so the suffix past it is never
+/// compared. A tie is also a non-win (the win test is strictly-greater), so
+/// the counters cannot separate a tie from a shorter chain.
+///
+/// Strict token equality against an unhedged run is NOT a valid contract:
+/// hedged rounds change the verify batch shape, which legally flips bf16 ties,
+/// and `--batch-invariant` rejects DFlash.
+#[test]
+fn hedged_ladder_passes_the_lossless_gates() {
+    // Strict mode (CI / validation boxes): every skip below is a failure —
+    // the gate must not go green without actually executing the hedge.
+    let strict = std::env::var("PEGAINFER_REQUIRE_HEDGE_GATE").is_ok_and(|v| v == "1");
+    let (target, draft) = (target_path_or_skip(), draft_path_or_skip());
+    let (Some(_), Some(draft_path)) = (target, draft) else {
+        assert!(
+            !strict,
+            "hedged gate requires model fixtures when PEGAINFER_REQUIRE_HEDGE_GATE is set"
+        );
+        return;
+    };
+    // A plain DFlash drafter (markov_rank == 0) never hedges; a green run
+    // against it would be vacuous.
+    let draft_config: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(Path::new(&draft_path).join("config.json"))
+            .expect("read draft config"),
+    )
+    .expect("parse draft config");
+    if draft_config["markov_rank"].as_u64().unwrap_or(0) == 0 {
+        assert!(
+            !strict,
+            "hedged gate requires a DSpark drafter but {draft_path} has markov_rank 0"
+        );
+        eprintln!(
+            "skipping hedged gate: {draft_path} is a plain DFlash drafter (markov_rank 0); \
+             point PEGAINFER_DFLASH_TEST_MODEL_PATH at a DSpark checkpoint"
+        );
+        return;
+    }
+    // Hold this process's GPU slot for the whole child run: the children own
+    // the card, and sibling tests here must not load an engine beside them.
+    let _gpu = GPU
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let exe = std::env::current_exe().expect("test binary path");
+    // One child per lossless suite, each with a single exact filter, so the
+    // invocation shape is beyond dispute on any libtest version.
+    // A hedge-free child would make its lossless pass vacuous, so each child
+    // must show expanded spans in the executor's per-round trace.
+    let mut total_spans = 0usize;
+    let mut total_wins = 0usize;
+    let mut total_rounds = 0usize;
+    for child_test in [
+        "dflash_speculative_greedy_matches_plain_greedy",
+        "dflash_concurrent_heterogeneous_is_lossless",
+    ] {
+        let output = Command::new(&exe)
+            .args(["--exact", child_test, "--test-threads=1", "--nocapture"])
+            .env("PEGAINFER_SPEC_HEDGE", "8")
+            .env("PEGAINFER_SPEC_HEDGE_POSITIONS", "0,1,2")
+            .env("PEGAINFER_TEST_LOG", "1")
+            .env_remove("PEGAINFER_SPEC_HEDGE_AUTO")
+            .output()
+            .expect("spawn hedged child gate");
+        let child_stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        assert!(
+            output.status.success(),
+            "hedged lossless gate '{child_test}' failed:\n{}\n{child_stderr}",
+            String::from_utf8_lossy(&output.stdout),
+        );
+        let mut rounds = 0usize;
+        let mut spans = 0usize;
+        let mut wins = 0usize;
+        for line in child_stderr.lines() {
+            let Some(rest) = line.split("DFlash hedge: ").nth(1) else {
+                continue;
+            };
+            let mut nums = rest
+                .split(|ch: char| !ch.is_ascii_digit())
+                .filter(|tok| !tok.is_empty())
+                .map(|tok| tok.parse::<usize>().expect("hedge trace number"));
+            spans += nums.next().expect("span count");
+            wins += nums.next().expect("win count");
+            rounds += 1;
+        }
+        assert!(
+            rounds > 0 && spans > 0,
+            "child '{child_test}' executed no hedged verify round:\n{child_stderr}"
+        );
+        total_rounds += rounds;
+        total_spans += spans;
+        total_wins += wins;
+    }
+    assert!(
+        total_wins > 0,
+        "no hedge chain ever won across {total_rounds} hedged rounds"
+    );
+    assert!(
+        total_spans > total_wins,
+        "every hedge span won ({total_wins}/{total_spans}) — the discard path never executed"
+    );
 }


### PR DESCRIPTION

## Description

A third of DSpark's speculative rounds accept zero draft tokens on agentic traffic — a full target forward buys one token — yet at the exact position where the chain breaks, the Markov head's runner-up is the committed token 29.6% of the time. Single-chain decoding throws that capacity away. This change verifies it instead: each draft round also proposes one alternative chain per configured branch position (`PEGAINFER_SPEC_HEDGE=<H>`, `PEGAINFER_SPEC_HEDGE_POSITIONS=0,1,2`) — the exact Markov top-2 at the branch, taken from a device-side snapshot, with greedy continuation over the same backbone logits — and all chains ride the existing verify pass as extra spans on the bucket-aligned CUDA graphs. The longest-matching chain wins and its scratch KV pages copy back; greedy output stays byte-identical, and the KV transaction interface and the draft/verify token-span seam are unchanged. Branch positions come from an offline counterfactual study over 10,801 logged break events: branching at the next position outprices deeper candidates at the same position.

Hedge eligibility travels the draft seam as a remaining-output budget: only a greedy request whose earliest branch position survives the verify-side span clamp can consume a hedge slot, and draft and verify select from the same list, so batch order never changes whether hedging runs. An opt-in controller (`PEGAINFER_SPEC_HEDGE_AUTO=1`) picks the chain count at runtime by measured tokens/sec — median window rate with an ascending margin, so flat traffic settles at zero chains. Kernel surface: a two-stage strided `markov_step_top2`, `hedge_ladder_force`, and a `chains` divisor plus an optional request map on the markov step kernels (the mapped variants are `unsafe` with documented device-index preconditions). KV surface: scratch pages outside the allocatable pool (`new_with_scratch_pages`) and a raw `copy_page` primitive.

### Test Env

- Single GPU (48 GB, sm_89, x86_64), CUDA 12.9.
- Qwen3-4B target + DSpark block7 drafter checkpoint; agentic coding traces (12.4-12.7k-token prompts), greedy, bs=1.

### Verification

- fmt and the crate unit suite green (97 tests, including order-invariance and span-clamp regressions for hedge selection and the controller's executed-configuration bookkeeping); `cargo check -p pegainfer-k3` green on the shared-kernel signature change. glm52's two identical call-site updates do not compile on this host (its kernels require sm_100+) — please re-verify in a cu132 environment.
- `dflash_speculative_gate` 5/5 on the exact base `bdbce8f4`, with `PEGAINFER_REQUIRE_HEDGE_GATE=1`: the hedged execution gate re-runs the sequential and concurrent-heterogeneous lossless suites in a child process with the hedge enabled, and its pass requires parsed per-round counters — hedged rounds > 0, at least one chain win (exercising winner copy-back and hidden-row compaction), and at least one loss round. The draft-headroom case is fixed in this PR (constants read from both checkpoint configs; unconstructable pairings skip explicitly).
- Wall-clock A/B, five arms x five interleaved 40-prompt chunks on the same 200 prompts, quiet host, output byte-identical across arms: baseline 572s; +1 chain 565s (-1.2%); +2 chains 555s (-3.0%); +3 chains 549s (-4.0%); +4 chains 553s (-3.3%). Within-arm chunk spread is <=2s and C=3 beats C=4 in all five paired chunks — the knee is systemic (five verify spans fall off the CUDA-graph batch buckets into eager execution), not yield saturation.
- Accept-length probes on the same prompts (9.2k-11k rounds per arm): committed tokens per verify round 2.302 -> 2.744 at three chains (+19.2%), verify rounds -16.1%; the fourth chain's marginal yield lands exactly where the offline study priced it (+0.027 measured vs +0.028 predicted). Easy traffic (HumanEval) is neutral and the auto controller settles at C=0 there.