### PR TITLE
perf(k3): fuse the CP middle-rank M+D doctored FlashKDA calls

### DIFF
--- a/docs/models/k3/cp-lane-design.md
+++ b/docs/models/k3/cp-lane-design.md
@@ -19,7 +19,9 @@ HTTP e2e 同脚本 4 卡对 4 卡：16k CP4 1161 ms vs vLLM TP4 1181 ms 首次�
 1.3–1.5×，8k+ 输 0.68×（我们 CP 宽度钉在 4）——M1 加宽的立项数据，详表见
 §16 卡对局**；**gap anatomy 2026-08-25：2.86× 的缺口 40% 是 MoE 不吃 CP 的
 Amdahl 项，CP4 硬顶 3.49×，通信仅 0.6% 且纯 peer D2D 已快过 NCCL 地板，
-详见 §CP4 gap anatomy**）→ M1 full@EP16 交叉矩阵 + lane-vs-独占步系统 A/B
+详见 §CP4 gap anatomy；event 门控交换 + M+D 融合 kernel 双双落地后
+CP4/CP1 = 2.95×，剩余缺口只剩 FMHA 三角与 Amdahl 项**）→ M1 full@EP16
+交叉矩阵 + lane-vs-独占步系统 A/B
 → M2 agent cache 闭环 → M3 弹性调度。
 
 Last touched: 2026-08
@@ -427,12 +429,23 @@ superstep free-run，只有真依赖 stall stream。同门禁复测：logits 逐
 CP4 kernel 墙钟 1116.8→1071.9 ms（冷）/ 1054.9→1037.7（暖），
 **CP4/CP1 2.83→2.92×**；非临界 rank 空转 93/91→12/10 ms。剩余空转全部
 有名有姓：dev3 的 72.8 ms（×69 层）= 等 dev1/2 M/D doctored 调用的真依赖
-（下一刀 = M+D 融成单 kernel，~-35 ms）；dev0 的 53 ms 是 consume-wait
+（下一段：已被 M+D 融合 kernel 砍半）；dev0 的 53 ms 是 consume-wait
 挂在窗口尾的保守放置（不在临界路径，修了墙钟不动，暂不动）。
 
-杠杆排序（更新）：event 门控 DONE（2.92×）；M+D 单 kernel 融合（≈3.0×）
-→ FMHA 条带化配段（≈3.1–3.2×）→ **3.49× 是 EP 共享 MoE 的硬顶，再往上
-只有 M1 加宽**。
+**M+D 融合 kernel 已落地（2026-08-25）**：中间 rank 的两次 doctored 调用
+（M：v=0+单位态；D：真 v+零态）本就共享整个 kernel-1（prepare 与 v/state
+无关）且丢弃 token 输出，融成 `k3_flash_kda_fwd_md` —— 一次 K1 扫 + 双态
+K2（砍 q-GEMM/Phase4/Phase5/out-store，每 tile 6 发 GEMM 对 10 发）。保持
+上游 GEMM 形状与逐态累积顺序 → **与两次 doctored 调用逐位一致**
+（`k3_flash_kda_md_equiv` gate，T∈{14,224,1056,4223,4224} 全 0 diff）；
+微基准 pair 1.0165→0.5943 ms @4224（1.71×）。整机同门禁复测（tray13，
+argmax/token 一致）：暖跑 CP4 forward 墙钟 **1037.7→1001.6 ms，CP4/CP1
+2.92→2.95×**，−36 ms 正中 −28 ms×69 层预估区间。顺手删掉 `zero_v`/
+`zero_state`/`identity` scratch，每 rank 省 ~117 MB。
+
+杠杆排序（更新）：event 门控 DONE（2.92×）；M+D 单 kernel 融合 DONE
+（2.95×）→ FMHA 条带化配段（≈3.1–3.2×）→ **3.49× 是 EP 共享 MoE 的硬顶，
+再往上只有 M1 加宽**。
 
 ## Next action
 

--- a/pegainfer-k3/src/executor/cp.rs
+++ b/pegainfer-k3/src/executor/cp.rs
@@ -6,12 +6,13 @@
 //! * **KDA (KCP)**: the recurrence's per-token update is affine in the state
 //!   (`S' = A·S + b` with `A`, `b` functions of the inputs alone), so a whole
 //!   segment collapses to `S_out = M_seg·S_in + D_seg`. Each rank exports its
-//!   `(M, D)` package by running the vendored FlashKDA forward twice with
-//!   doctored operands — `v = 0` from an identity state yields `M`, real `v`
-//!   from a zero state yields `D` — then every rank folds its upstream
-//!   packages into its true input state with per-head fp32 GEMMs and runs the
-//!   real forward once. Rank 0's real forward *is* its package (`D`, with a
-//!   known zero input), and the last rank exports nothing.
+//!   `(M, D)` package in one fused FlashKDA pass (`k3_flash_kda_fwd_md` —
+//!   kernel 1 once, a dual-state kernel 2 carrying `M` from an in-kernel
+//!   identity seed with `v = 0` and `D` from a zero seed with real `v`) —
+//!   then every rank folds its upstream packages into its true input state
+//!   with per-head fp32 GEMMs and runs the real forward once. Rank 0's real
+//!   forward *is* its package (`D`, with a known zero input), and the last
+//!   rank exports nothing.
 //! * **conv halo**: a segment's first `K3_CONV_STATE` convolution windows
 //!   reach into the previous segment. The upstream rank publishes its last
 //!   `K3_CONV_STATE` *normed* rows; the receiver projects them through the
@@ -371,12 +372,6 @@ pub(crate) struct K3CpScratch {
     pub(crate) halo_partial: CudaSlice<f32>,
     /// Landed halo inputs, `[4, inner]` bf16.
     pub(crate) halo_xs: CudaSlice<bf16>,
-    /// All-zero `v` operand for the transition (`M`) forward.
-    pub(crate) zero_v: CudaSlice<bf16>,
-    /// All-zero input state for the `D` forward.
-    pub(crate) zero_state: CudaSlice<f32>,
-    /// Per-head identity input state for the `M` forward.
-    pub(crate) identity: CudaSlice<f32>,
     /// Received packages, `[cp_size, K3_KDA_STATE]` each.
     pub(crate) recv_m: CudaSlice<f32>,
     pub(crate) recv_d: CudaSlice<f32>,
@@ -398,13 +393,6 @@ impl K3CpScratch {
     pub(crate) fn new(ctx: &DeviceContext, group: Arc<K3CpGroup>, seg_cap: usize) -> Result<Self> {
         let cp_size = group.cp_size();
         let stream = &ctx.stream;
-        let d = K3_KDA_HEAD_DIM;
-        let mut identity_host = vec![0f32; K3_KDA_STATE];
-        for head in 0..K3_KDA_HEADS {
-            for i in 0..d {
-                identity_host[head * d * d + i * d + i] = 1.0;
-            }
-        }
         Ok(Self {
             // Meaningful only between an `arm` and the superstep it opened.
             cp_rank: 0,
@@ -423,11 +411,6 @@ impl K3CpScratch {
             halo_normed: stream.alloc_zeros((K3_CONV_STATE + 1) * K3_HIDDEN)?,
             halo_partial: stream.alloc_zeros((K3_CONV_STATE + 1) * K3_ATTN_INNER)?,
             halo_xs: stream.alloc_zeros((K3_CONV_STATE + 1) * K3_ATTN_INNER)?,
-            zero_v: stream
-                .alloc_zeros(seg_cap * K3_ATTN_INNER)
-                .context("alloc K3 CP zero-v operand")?,
-            zero_state: stream.alloc_zeros(K3_KDA_STATE)?,
-            identity: stream.clone_htod(&identity_host)?,
             recv_m: stream
                 .alloc_zeros(cp_size * K3_KDA_STATE)
                 .context("alloc K3 CP package arena")?,
@@ -443,10 +426,6 @@ impl K3CpScratch {
             consume_event: new_event(ctx).context("create K3 CP consume event")?,
             group,
         })
-    }
-
-    pub(crate) fn seg_cap(&self) -> usize {
-        self.seg_cap
     }
 
     /// Arm the upstream persist: `indices` are the owner's pool write indices

--- a/pegainfer-k3/src/executor/forward/prefill.rs
+++ b/pegainfer-k3/src/executor/forward/prefill.rs
@@ -495,11 +495,13 @@ pub(super) fn kda_attention_chunk(
         }
         Some(cp) => {
             // KCP: the recurrence is affine in the state, so the segment is
-            // `S_out = M·S_in + D`. Export `(M, D)` by running the same
-            // forward with doctored operands (`v = 0` from identity gives
-            // `M`; real `v` from zero gives `D`), exchange, fold the
+            // `S_out = S_in·M + D`. Export `(M, D)`, exchange, fold the
             // upstream packages, and run the real forward from the true
-            // input state. Rank 0's real forward doubles as its package.
+            // input state. Rank 0's real forward doubles as its package; a
+            // middle rank derives both package halves in one fused pass
+            // (`k3_flash_kda_fwd_md_launch` — one kernel-1 sweep, dual-state
+            // kernel 2, bit-identical to the two doctored forwards it
+            // replaced, pinned by the `k3_flash_kda_md_equiv` gate).
             let group = groups[0];
             let rows = shape.live_rows;
             let scale = (K3_HEAD_DIM as f32).powf(-0.5);
@@ -515,6 +517,26 @@ pub(super) fn kda_attention_chunk(
                 flash_kda_ws,
                 ..
             } = s;
+            if cp.cp_rank != 0 && cp.cp_rank + 1 < cp.cp_size {
+                pegainfer_kernels::ops::k3_flash_kda_fwd_md_launch(
+                    ctx,
+                    rows,
+                    K3_HEADS,
+                    conv_q,
+                    conv_k,
+                    conv_v,
+                    kda_g,
+                    beta,
+                    kda_beta_t,
+                    &w.a_log,
+                    &w.dt_bias,
+                    &mut cp.kda_d,
+                    &mut cp.kda_m,
+                    flash_kda_ws,
+                    scale,
+                    lower_bound,
+                )?;
+            }
             let mut forward = |v: &CudaSlice<bf16>,
                                state_in: &CudaSlice<f32>,
                                state_out: &mut CudaSlice<f32>|
@@ -556,9 +578,6 @@ pub(super) fn kda_attention_chunk(
                     1,
                     K3_KDA_STATE,
                 )?;
-            } else if cp.cp_rank + 1 < cp.cp_size {
-                forward(&cp.zero_v, &cp.identity, &mut cp.kda_m)?;
-                forward(&*conv_v, &cp.zero_state, &mut cp.kda_d)?;
             }
             let cp_group = cp.group.clone();
             let cp_sync = cp.window_sync(K3CpWindowKind::Upstream);

--- a/pegainfer-kernels/csrc/k3/k3_flash_kda.cu
+++ b/pegainfer-kernels/csrc/k3/k3_flash_kda.cu
@@ -30,6 +30,7 @@
 
 #ifdef K3_FLASH_KDA_SM90A
 #include "fwd_launch.cu"
+#include "k3_flash_kda_md.cuh"
 #endif
 
 // Not in an anonymous namespace: nvcc's device-stub generation trips over an
@@ -139,6 +140,59 @@ CUresult k3_flash_kda_fwd(
         h,
         /*N=*/1,
         /*cu_seqlens=*/nullptr,
+        a_log,
+        dt_bias,
+        gate_scale,
+        stream
+    );
+    return k3_flash_kda_map_cuda_error(cudaGetLastError());
+#endif
+}
+
+// Fused KCP package forward: one kernel-1 pass plus the dual-state kernel 2
+// (k3_flash_kda_md.cuh), producing the segment's affine package in one sweep:
+// `state_out_d` = D (real v from zero state) and `state_out_m` = M (v = 0
+// from identity state). No token output — a CP middle rank discards it.
+// Same operand contract and workspace as k3_flash_kda_fwd.
+CUresult k3_flash_kda_fwd_md(
+    const void* q,          // [T, H, 128] bf16
+    const void* k,          // [T, H, 128] bf16
+    const void* v,          // [T, H, 128] bf16
+    const void* g,          // [T, H, 128] bf16, pre-activation gate
+    const void* beta_ht,    // [H, T] bf16, beta logits
+    const float* a_log,     // [H]
+    const float* dt_bias,   // [H, 128]
+    void* state_out_d,      // [H, 128, 128] f32
+    void* state_out_m,      // [H, 128, 128] f32
+    void* workspace,        // k3_flash_kda_workspace_bytes(t_total, h)
+    int t_total,
+    int h,
+    float scale,
+    float lower_bound,
+    cudaStream_t stream
+) {
+#ifndef K3_FLASH_KDA_SM90A
+    (void)q; (void)k; (void)v; (void)g; (void)beta_ht; (void)a_log;
+    (void)dt_bias; (void)state_out_d; (void)state_out_m; (void)workspace;
+    (void)t_total; (void)h; (void)scale; (void)lower_bound; (void)stream;
+    return CUDA_ERROR_NOT_SUPPORTED;
+#else
+    constexpr int kChunk = 16;
+    int total_tiles = (t_total + kChunk - 1) / kChunk;
+    float gate_scale = lower_bound * 1.4426950408889634f;
+    launch_fwd_md<128>(
+        static_cast<cutlass::bfloat16_t const*>(q),
+        static_cast<cutlass::bfloat16_t const*>(k),
+        static_cast<cutlass::bfloat16_t const*>(v),
+        static_cast<cutlass::bfloat16_t const*>(g),
+        static_cast<cutlass::bfloat16_t const*>(beta_ht),
+        scale,
+        static_cast<float*>(state_out_d),
+        static_cast<float*>(state_out_m),
+        workspace,
+        total_tiles,
+        t_total,
+        h,
         a_log,
         dt_bias,
         gate_scale,

--- a/pegainfer-kernels/csrc/k3/k3_flash_kda_md.cuh
+++ b/pegainfer-kernels/csrc/k3/k3_flash_kda_md.cuh
@@ -1,0 +1,706 @@
+// Fused KCP package forward: one FlashKDA recurrence pass producing both the
+// segment transition M and offset D.
+//
+// A CP middle rank exports its KDA package `(M, D)` — `S_out = S_in·M + D` —
+// which the plain path derives with two full doctored forwards: `M` from
+// (v = 0, state = I) and `D` from (real v, state = 0). Both discard the token
+// output (the rank's real forward runs later from the merged state), and both
+// consume the *same* kernel-1 workspace: k_decayed/k_restored/g_total/INV
+// depend only on q/k/g/beta, never on v or the state. So the fused pass runs
+// kernel 1 once and a derived kernel 2 that walks the chunk tiles carrying
+// TWO state accumulators:
+//
+//   u_d = INV @ ((v − k_decayed @ S_D)·β)     S_D ← S_D·g + k_restored^T @ u_d
+//   u_m = INV @ ((    − k_decayed @ S_M)·β)   S_M ← S_M·g + k_restored^T @ u_m
+//
+// with S_D seeded 0 and S_M seeded I in smem (no state TMA loads), and the
+// q_decayed/Mqk loads, the q@S and Mqk@U GEMMs, and the entire output store
+// path removed. Per tile that is 6 GEMMs against the two calls' 10, one
+// workspace read instead of two, and zero output traffic.
+//
+// Derived from third_party/flash-kda csrc/smxx/fwd_kernel2.cuh +
+// fwd_launch.cu (MIT, MoonshotAI — see PROVENANCE.md); the per-state tile
+// math keeps the upstream GEMM shapes and accumulation order exactly, so
+// each state is bit-identical to its standalone doctored call. Included by
+// k3_flash_kda.cu inside the K3_FLASH_KDA_SM90A guard — one TU, implicit
+// instantiation, D = 128 / fp32 states / non-varlen (N = 1) only.
+
+#pragma once
+
+template <class Layouts, int InputStages>
+struct SharedStorageK2MD {
+    using BF16 = cutlass::bfloat16_t;
+    using VOLayout = typename Layouts::VOLayout;
+    using BetaSmemLayout = typename Layouts::BetaSmemLayout;
+    using StateSmemLayout = typename Layouts::StateSmemLayout;
+    using GTotalLayout = typename Layouts::GTotalLayout;
+    using LMLayout = typename Layouts::LMLayout;
+    using MMALayout = typename Layouts::MMALayout;
+
+    alignas(128) cute::ArrayEngine<BF16, cute::cosize_v<StateSmemLayout>> state_d;
+    alignas(128) cute::ArrayEngine<BF16, cute::cosize_v<StateSmemLayout>> state_m;
+
+    struct InputStorage {
+        alignas(128) cute::ArrayEngine<BF16, cute::cosize_v<VOLayout>> v;
+        alignas(128) cute::ArrayEngine<BF16, cute::cosize_v<BetaSmemLayout>> beta;
+        alignas(128) cute::ArrayEngine<BF16, cute::cosize_v<MMALayout>> k_decayed;
+        alignas(128) cute::ArrayEngine<BF16, cute::cosize_v<MMALayout>> k_restored;
+        alignas(128) cute::ArrayEngine<float, cute::cosize_v<GTotalLayout>> g_total;
+        alignas(128) cute::ArrayEngine<BF16, cute::cosize_v<LMLayout>> INV;
+    };
+
+    // The fp32 conversion buffer overlays the pipeline stages: state stores
+    // happen strictly after the tile loop, one state at a time.
+    union {
+        InputStorage input[InputStages];
+        alignas(128) char state_fp32_buf[cute::cosize_v<StateSmemLayout> * sizeof(float)];
+    };
+
+    typename cutlass::PipelineTmaAsync<InputStages>::SharedStorage load_pipeline;
+};
+
+// ==================== Kernel 2-MD: dual-state recurrence ====================
+template <
+    class TmaLoadV,
+    class TmaLoadBeta,
+    class TmaLoadWsKD, class TmaLoadWsKR,
+    class TmaLoadWsGT, class TmaLoadWsINV,
+    class TmaStoreStateD,
+    class TmaStoreStateM,
+    int CHUNK,
+    int D,
+    int InputStages,
+    int NumThreads
+>
+__global__ void __launch_bounds__(NumThreads) _k3_flash_kda_fwd_md_recurrence(
+    CUTE_GRID_CONSTANT TmaLoadV const tma_load_v,
+    CUTE_GRID_CONSTANT TmaLoadBeta const tma_load_beta,
+    CUTE_GRID_CONSTANT TmaLoadWsKD const tma_load_ws_kd,
+    CUTE_GRID_CONSTANT TmaLoadWsKR const tma_load_ws_kr,
+    CUTE_GRID_CONSTANT TmaLoadWsGT const tma_load_ws_gt,
+    CUTE_GRID_CONSTANT TmaLoadWsINV const tma_load_ws_inv,
+    CUTE_GRID_CONSTANT TmaStoreStateD const tma_store_state_d,
+    CUTE_GRID_CONSTANT TmaStoreStateM const tma_store_state_m,
+    int T_total,
+    int H,
+    int total_tiles
+) {
+    using BF16 = cutlass::bfloat16_t;
+    using Layouts = K2Layouts<D, CHUNK>;
+    using MMALayout = typename Layouts::MMALayout;
+    using TransposedMMALayout = typename Layouts::TransposedMMALayout;
+    using VOLayout = typename Layouts::VOLayout;
+    using BetaSmemLayout = typename Layouts::BetaSmemLayout;
+    using StateSmemLayout = typename Layouts::StateSmemLayout;
+    using TransposedStateSmemLayout = typename Layouts::TransposedStateSmemLayout;
+    using GTotalLayout = typename Layouts::GTotalLayout;
+    using LMLayout = typename Layouts::LMLayout;
+    using TMAVOLayout = typename Layouts::TMAVOLayout;
+    using TMABetaSmemLayout = typename Layouts::TMABetaSmemLayout;
+    using TMALMLayout = typename Layouts::TMALMLayout;
+    using TMAGTotalSmemLayout = typename Layouts::TMAGTotalSmemLayout;
+    using FP32StateSmemLayout = typename Layouts::FP32StateSmemLayout;
+    using TMAFP32StateSmemLayout = typename Layouts::TMAFP32StateSmemLayout;
+    constexpr int kWarpSize = 32;
+    constexpr int kComputeThreads = 128;
+
+    // Transaction bytes: v + beta + k_decayed + k_restored + g_total + INV
+    constexpr uint32_t kTmaTransactionBytes =
+        uint32_t(cute::cosize_v<VOLayout>) * uint32_t(sizeof(BF16)) +
+        uint32_t(32) * uint32_t(sizeof(BF16)) +
+        uint32_t(cute::cosize_v<MMALayout>) * uint32_t(sizeof(BF16)) * 2 +
+        uint32_t(cute::cosize_v<GTotalLayout>) * uint32_t(sizeof(float)) +
+        uint32_t(cute::cosize_v<LMLayout>) * uint32_t(sizeof(BF16));
+
+    extern __shared__ __align__(128) unsigned char shared_mem[];
+    using SharedStorageT = SharedStorageK2MD<Layouts, InputStages>;
+    SharedStorageT& shared_storage = *reinterpret_cast<SharedStorageT*>(shared_mem);
+
+    int warp_id = threadIdx.x / kWarpSize;
+    WarpRole warp_role = WarpRole::NonParticipant;
+    if (warp_id < kComputeThreads / kWarpSize) {
+        warp_role = WarpRole::MMA;
+    } else if (warp_id < kComputeThreads / kWarpSize + 1) {
+        warp_role = WarpRole::LOAD_QKG;
+    }
+
+    using LoadPipelineState = cutlass::PipelineState<InputStages>;
+    using LoadPipeline = cutlass::PipelineTmaAsync<InputStages>;
+    LoadPipeline load_pipeline = make_load_pipeline<InputStages>(
+        shared_storage.load_pipeline,
+        kTmaTransactionBytes,
+        warp_role, 1, kComputeThreads
+    );
+
+    // Non-varlen N = 1: one sequence, whole chunk.
+    int head_idx = blockIdx.y;
+    int seq_len = T_total;
+    int t_tiles = (seq_len + CHUNK - 1) / CHUNK;
+    bool lane_predicate = cute::elect_one_sync();
+
+    // --- Seed the states: S_D = 0, S_M = I (no state TMA loads).
+    {
+        BF16* buf_d = shared_storage.state_d.begin();
+        BF16* buf_m = shared_storage.state_m.begin();
+        constexpr int kTotal = cute::cosize_v<StateSmemLayout>;
+        for (int i = threadIdx.x; i < kTotal; i += NumThreads) {
+            buf_d[i] = BF16(0);
+            buf_m[i] = BF16(0);
+        }
+    }
+    __syncthreads();
+    {
+        Tensor s_m = make_tensor(
+            make_smem_ptr(shared_storage.state_m.begin()), StateSmemLayout{});
+        for (int i = threadIdx.x; i < D; i += NumThreads) {
+            s_m(i, i) = BF16(1);
+        }
+    }
+    // generic writes -> visible to async proxy (TMA state store covers t_tiles==0)
+    cutlass::arch::fence_view_async_shared();
+    __syncthreads();
+
+    // --- LOAD warp: TMA loads for v, beta, and the v/state-independent
+    // workspace subset (k_decayed, k_restored, g_total, INV).
+    if (warp_role == WarpRole::LOAD_QKG && lane_predicate) {
+        Tensor g_v = tma_load_v.get_tma_tensor(make_shape(H, T_total, D));
+        Tensor g_beta = tma_load_beta.get_tma_tensor(make_shape(H * T_total));
+        auto g_ws_kd = tma_load_ws_kd.get_tma_tensor(make_shape(H * total_tiles, CHUNK, D));
+        auto g_ws_kr = tma_load_ws_kr.get_tma_tensor(make_shape(H * total_tiles, CHUNK, D));
+        auto g_ws_gt = tma_load_ws_gt.get_tma_tensor(make_shape(H * total_tiles, D));
+        auto g_ws_inv = tma_load_ws_inv.get_tma_tensor(make_shape(H * total_tiles, CHUNK, CHUNK));
+
+        LoadPipelineState load_write = cutlass::make_producer_start_state<LoadPipeline>();
+        auto cta_tma_load_v = tma_load_v.get_slice(Int<0>{});
+        auto cta_tma_load_beta = tma_load_beta.get_slice(Int<0>{});
+        auto cta_ws_kd = tma_load_ws_kd.get_slice(Int<0>{});
+        auto cta_ws_kr = tma_load_ws_kr.get_slice(Int<0>{});
+        auto cta_ws_gt = tma_load_ws_gt.get_slice(Int<0>{});
+        auto cta_ws_inv = tma_load_ws_inv.get_slice(Int<0>{});
+
+        for (int t = 0; t < t_tiles; ++t) {
+            load_pipeline.producer_acquire(load_write);
+            using LoadBarrierType = typename LoadPipeline::ProducerBarrierType;
+            LoadBarrierType* tma_barrier = load_pipeline.producer_get_barrier(load_write);
+            int stage = load_write.index();
+            int ws_idx = head_idx * total_tiles + t;
+
+            {
+                auto v_off = g_v.layout()(head_idx, t * CHUNK, 0);
+                Tensor g_v_tile = make_tensor(g_v.data() + v_off,
+                    make_layout(make_shape(Int<1>{}, Int<CHUNK>{}, Int<D>{}), stride(g_v.layout())));
+                Tensor s_v_tile = make_tensor(make_smem_ptr(shared_storage.input[stage].v.begin()), TMAVOLayout{});
+                cute::copy(tma_load_v.with(*tma_barrier),
+                    cta_tma_load_v.partition_S(g_v_tile), cta_tma_load_v.partition_D(s_v_tile));
+            }
+            {
+                int beta_linear = head_idx * T_total + t * CHUNK;
+                int beta_aligned = beta_linear & ~7;
+                auto beta_off = g_beta.layout()(beta_aligned);
+                Tensor g_beta_tile = make_tensor(g_beta.data() + beta_off, BetaSmemLayout{});
+                Tensor s_beta_tile = make_tensor(make_smem_ptr(shared_storage.input[stage].beta.begin()), TMABetaSmemLayout{});
+                cute::copy(tma_load_beta.with(*tma_barrier),
+                    cta_tma_load_beta.partition_S(g_beta_tile), cta_tma_load_beta.partition_D(s_beta_tile));
+            }
+            {
+                auto off = g_ws_kd.layout()(ws_idx, 0, 0);
+                Tensor g_tile = make_tensor(g_ws_kd.data() + off,
+                    make_layout(make_shape(Int<1>{}, Int<CHUNK>{}, Int<D>{}), stride(g_ws_kd.layout())));
+                Tensor s_tile = make_tensor(make_smem_ptr(shared_storage.input[stage].k_decayed.begin()), TMAVOLayout{});
+                cute::copy(tma_load_ws_kd.with(*tma_barrier), cta_ws_kd.partition_S(g_tile), cta_ws_kd.partition_D(s_tile));
+            }
+            {
+                auto off = g_ws_kr.layout()(ws_idx, 0, 0);
+                Tensor g_tile = make_tensor(g_ws_kr.data() + off,
+                    make_layout(make_shape(Int<1>{}, Int<CHUNK>{}, Int<D>{}), stride(g_ws_kr.layout())));
+                Tensor s_tile = make_tensor(make_smem_ptr(shared_storage.input[stage].k_restored.begin()), TMAVOLayout{});
+                cute::copy(tma_load_ws_kr.with(*tma_barrier), cta_ws_kr.partition_S(g_tile), cta_ws_kr.partition_D(s_tile));
+            }
+            {
+                auto off = g_ws_gt.layout()(ws_idx, 0);
+                Tensor g_tile = make_tensor(g_ws_gt.data() + off,
+                    make_layout(make_shape(Int<1>{}, Int<D>{}), stride(g_ws_gt.layout())));
+                Tensor s_tile = make_tensor(make_smem_ptr(shared_storage.input[stage].g_total.begin()), TMAGTotalSmemLayout{});
+                cute::copy(tma_load_ws_gt.with(*tma_barrier), cta_ws_gt.partition_S(g_tile), cta_ws_gt.partition_D(s_tile));
+            }
+            {
+                auto off = g_ws_inv.layout()(ws_idx, 0, 0);
+                Tensor g_tile = make_tensor(g_ws_inv.data() + off,
+                    make_layout(make_shape(Int<1>{}, Int<CHUNK>{}, Int<CHUNK>{}), stride(g_ws_inv.layout())));
+                Tensor s_tile = make_tensor(make_smem_ptr(shared_storage.input[stage].INV.begin()), TMALMLayout{});
+                cute::copy(tma_load_ws_inv.with(*tma_barrier), cta_ws_inv.partition_S(g_tile), cta_ws_inv.partition_D(s_tile));
+            }
+
+            ++load_write;
+        }
+        load_pipeline.producer_tail(load_write);
+    }
+
+    // --- MMA warps
+    if (warp_role == WarpRole::MMA) {
+        cutlass::arch::NamedBarrier compute_barrier(kComputeThreads, 0);
+        LoadPipelineState load_read;
+        int compute_tid = threadIdx.x;
+
+        for (int t = 0; t < t_tiles; ++t) {
+            load_pipeline.consumer_wait(load_read);
+            int load_stage = load_read.index();
+
+            Tensor v_tile = make_tensor(make_smem_ptr(shared_storage.input[load_stage].v.begin()), VOLayout{});
+            Tensor beta_tile = make_tensor(make_smem_ptr(shared_storage.input[load_stage].beta.begin()), BetaSmemLayout{});
+            int beta_smem_offset = (head_idx * T_total + t * CHUNK) & 7;
+
+            Tensor k_decayed = make_tensor(make_smem_ptr(shared_storage.input[load_stage].k_decayed.begin()), MMALayout{});
+            Tensor k_restored_t = make_tensor(make_smem_ptr(shared_storage.input[load_stage].k_restored.begin()), TransposedMMALayout{});
+            Tensor g_total = make_tensor(make_smem_ptr(shared_storage.input[load_stage].g_total.begin()), GTotalLayout{});
+            Tensor INV = make_tensor(make_smem_ptr(shared_storage.input[load_stage].INV.begin()), LMLayout{});
+
+            Tensor s_d = make_tensor(make_smem_ptr(shared_storage.state_d.begin()), StateSmemLayout{});
+            Tensor s_d_T = make_tensor(make_smem_ptr(shared_storage.state_d.begin()), TransposedStateSmemLayout{});
+            Tensor s_m = make_tensor(make_smem_ptr(shared_storage.state_m.begin()), StateSmemLayout{});
+            Tensor s_m_T = make_tensor(make_smem_ptr(shared_storage.state_m.begin()), TransposedStateSmemLayout{});
+
+            {
+            constexpr int PREFETCH = 1;
+
+            auto mma = make_tiled_mma(
+                MMA_Atom<SM80_16x8x16_F32BF16BF16F32_TN>{},
+                Layout<Shape<_1,_1>>{},
+                Tile<_16,_16,_16>{}
+            );
+
+            const int warp_id_c = compute_tid / 32;
+            const int lane_id = compute_tid % 32;
+            const int group_id = (lane_id / 4) % 8;
+
+            ThrMMA thr_mma = mma.get_slice(lane_id);
+
+            auto smem_tiled_copy_A = make_tiled_copy_A(Copy_Atom<SM75_U32x4_LDSM_N, BF16>{}, mma);
+            auto smem_thr_copy_A   = smem_tiled_copy_A.get_thread_slice(lane_id);
+
+            auto smem_tiled_copy_A_T = make_tiled_copy_A(Copy_Atom<SM75_U16x8_LDSM_T, BF16>{}, mma);
+            auto smem_thr_copy_A_T   = smem_tiled_copy_A_T.get_thread_slice(lane_id);
+
+            auto smem_tiled_copy_B = make_tiled_copy_B(Copy_Atom<SM75_U32x4_LDSM_N, BF16>{}, mma);
+            auto smem_thr_copy_B   = smem_tiled_copy_B.get_thread_slice(lane_id);
+
+            auto smem_tiled_load_C  = make_tiled_copy_C(Copy_Atom<SM75_U32x4_LDSM_N, BF16>{}, mma);
+            auto smem_thr_load_C    = smem_tiled_load_C.get_slice(lane_id);
+
+            auto smem_tiled_load_C_T  = make_tiled_copy_C(Copy_Atom<SM75_U16x8_LDSM_T, BF16>{}, mma);
+            auto smem_thr_load_C_T    = smem_tiled_load_C_T.get_slice(lane_id);
+            auto smem_tiled_store_C_T = make_tiled_copy_C(Copy_Atom<SM90_U16x8_STSM_T, BF16>{}, mma);
+            auto smem_thr_store_C_T   = smem_tiled_store_C_T.get_slice(lane_id);
+
+            Tensor A_ref = local_tile(k_decayed, make_shape(Int<16>{}, Int<16>{}), make_coord(0, 0));
+            Tensor B_ref = local_tile(s_d, make_shape(Int<16>{}, Int<16>{}), make_coord(0, 0));
+            Tensor C_ref = local_tile(v_tile, make_shape(Int<16>{}, Int<16>{}), make_coord(0, 0));
+
+            Tensor tCrAi_k = make_fragment_like<BF16>(thr_mma.partition_fragment_A(A_ref));
+            auto tCrAi_k_view = smem_thr_copy_A.retile_D(tCrAi_k);
+            auto tCrA_k = thr_mma.partition_fragment_A(A_ref);
+
+            Tensor tCrBi = make_fragment_like<BF16>(thr_mma.partition_fragment_B(B_ref));
+            auto tCrBi_view = smem_thr_copy_B.retile_D(tCrBi);
+            auto tCrB = thr_mma.partition_fragment_B(B_ref);
+
+            auto tCrC_ref = thr_mma.partition_C(C_ref);
+
+            using AccFragT = decltype(thr_mma.make_fragment_C(tCrC_ref));
+            using SFragT = decltype(make_fragment_like<BF16>(thr_mma.make_fragment_C(tCrC_ref)));
+            using AFragT = decltype(thr_mma.partition_fragment_A(A_ref));
+            using BFragT_u = decltype(thr_mma.partition_fragment_B(B_ref));
+
+            // Accumulators: [state 0 = D, state 1 = M][column block]
+            AccFragT u_acc[2][2];
+            #pragma unroll
+            for (int st = 0; st < 2; ++st)
+                #pragma unroll
+                for (int i = 0; i < 2; ++i) { u_acc[st][i] = thr_mma.make_fragment_C(tCrC_ref); clear(u_acc[st][i]); }
+
+            // ======== Phase 1: k@S for BOTH states (k-loop, 2 blocks per warp) ========
+            constexpr int K_BLOCKS = decltype(cute::size<1>(k_decayed))::value / 16;
+
+            copy(smem_tiled_copy_A, smem_thr_copy_A.partition_S(
+                local_tile(k_decayed, make_shape(Int<16>{}, Int<16>{}), make_coord(0, 0))), tCrAi_k_view);
+
+            #pragma unroll
+            for (int k = 0; k < K_BLOCKS; ++k) {
+                cute::transform(tCrAi_k, tCrA_k, cute::identity{});
+
+                if (k + 1 < K_BLOCKS) {
+                    // A(k) is consumed into registers; prefetch A(k+1) after use.
+                }
+
+                #pragma unroll
+                for (int st = 0; st < 2; ++st) {
+                    auto& s_state = (st == 0) ? s_d : s_m;
+                    #pragma unroll
+                    for (int bi = 0; bi < 2; ++bi) {
+                        copy(smem_tiled_copy_B, smem_thr_copy_B.partition_S(
+                            local_tile(s_state, make_shape(Int<16>{}, Int<16>{}), make_coord(warp_id_c * 2 + bi, k))), tCrBi_view);
+                        cute::transform(tCrBi, tCrB, cute::identity{});
+                        gemm(thr_mma, tCrA_k(_,_,Int<0>{}), tCrB(_,_,Int<0>{}), u_acc[st][bi]);
+                    }
+                }
+
+                if (k + 1 < K_BLOCKS) {
+                    copy(smem_tiled_copy_A, smem_thr_copy_A.partition_S(
+                        local_tile(k_decayed, make_shape(Int<16>{}, Int<16>{}), make_coord(0, k + 1))), tCrAi_k_view);
+                }
+            }
+
+            // ======== Phase 2: load v (D path only) and INV, beta ========
+            SFragT v_bf16[2];
+            #pragma unroll
+            for (int i = 0; i < 2; ++i) {
+                Tensor v_block = local_tile(v_tile, make_shape(Int<16>{}, Int<16>{}), make_coord(0, warp_id_c * 2 + i));
+                copy(smem_tiled_load_C, smem_thr_load_C.partition_S(v_block), smem_thr_load_C.retile_D(v_bf16[i]));
+            }
+
+            copy(smem_tiled_copy_A, smem_thr_copy_A.partition_S(INV), tCrAi_k_view);
+            cute::transform(tCrAi_k, tCrA_k, cute::identity{});
+
+            BF16 beta0 = BF16(sigmoid_tanh_approx_f32(float(beta_tile(beta_smem_offset + group_id))));
+            BF16 beta1 = BF16(sigmoid_tanh_approx_f32(float(beta_tile(beta_smem_offset + group_id + 8))));
+
+            // ======== Phase 3: u = INV @ ((v − u)·β) per state (v ≡ 0 for M),
+            // then MOVM_T into B fragments for Phase 6 ========
+            BFragT_u tCrB_u_arr[2][2];
+            uint32_t u_b_regs[4];
+
+            #pragma unroll
+            for (int st = 0; st < 2; ++st) {
+                #pragma unroll
+                for (int i = 0; i < 2; ++i) {
+                    SFragT u_bf16;
+                    cute::transform(u_acc[st][i], u_bf16, [] __device__ (float x) { return BF16(x); });
+
+                    #pragma unroll
+                    for (int a = 0; a < 2; ++a) {
+                        #pragma unroll
+                        for (int d = 0; d < 2; ++d) {
+                            auto c0 = make_coord(make_coord(a, 0), 0, d);
+                            auto c1 = make_coord(make_coord(a, 1), 0, d);
+                            BF16 v0 = (st == 0) ? v_bf16[i](c0) : BF16(0);
+                            BF16 v1 = (st == 0) ? v_bf16[i](c1) : BF16(0);
+                            u_bf16(c0) = (v0 - u_bf16(c0)) * beta0;
+                            u_bf16(c1) = (v1 - u_bf16(c1)) * beta1;
+                        }
+                    }
+
+                    uint32_t* u_c = reinterpret_cast<uint32_t*>(&u_bf16(0));
+                    SM75_U32x1_MOVM_T::copy(u_c[0], u_b_regs[0]);
+                    SM75_U32x1_MOVM_T::copy(u_c[1], u_b_regs[1]);
+                    SM75_U32x1_MOVM_T::copy(u_c[2], u_b_regs[2]);
+                    SM75_U32x1_MOVM_T::copy(u_c[3], u_b_regs[3]);
+
+                    auto tCrB_u_tmp = thr_mma.partition_fragment_B(B_ref);
+                    uint32_t* b_dst = reinterpret_cast<uint32_t*>(&tCrB_u_tmp(0));
+                    b_dst[0] = u_b_regs[0]; b_dst[1] = u_b_regs[1];
+                    b_dst[2] = u_b_regs[2]; b_dst[3] = u_b_regs[3];
+
+                    clear(u_acc[st][i]);
+                    gemm(thr_mma, tCrA_k(_,_,Int<0>{}), tCrB_u_tmp(_,_,Int<0>{}), u_acc[st][i]);
+
+                    cute::transform(u_acc[st][i], u_bf16, [] __device__ (float x) { return BF16(x); });
+
+                    u_c = reinterpret_cast<uint32_t*>(&u_bf16(0));
+                    SM75_U32x1_MOVM_T::copy(u_c[0], u_b_regs[0]);
+                    SM75_U32x1_MOVM_T::copy(u_c[1], u_b_regs[1]);
+                    SM75_U32x1_MOVM_T::copy(u_c[2], u_b_regs[2]);
+                    SM75_U32x1_MOVM_T::copy(u_c[3], u_b_regs[3]);
+
+                    tCrB_u_arr[st][i] = thr_mma.partition_fragment_B(B_ref);
+                    b_dst = reinterpret_cast<uint32_t*>(&tCrB_u_arr[st][i](0));
+                    b_dst[0] = u_b_regs[0]; b_dst[1] = u_b_regs[1];
+                    b_dst[2] = u_b_regs[2]; b_dst[3] = u_b_regs[3];
+                }
+            }
+
+            // ======== Phase 6: S ← S·g + k_restored^T @ U for BOTH states ========
+            constexpr int S_M_BLOCKS = decltype(cute::size<0>(k_restored_t))::value / 16;
+
+            Tensor tCrAi_kr = make_fragment_like<BF16>(thr_mma.partition_fragment_A(A_ref));
+            auto tCrAi_kr_view = smem_thr_copy_A_T.retile_D(tCrAi_kr);
+
+            AFragT ring_A_kr[PREFETCH];
+            SFragT ring_S_acc[2][2][PREFETCH];
+            float ring_g0[PREFETCH], ring_g1[PREFETCH];
+
+            #pragma unroll
+            for (int i = 0; i < PREFETCH; ++i) {
+                Tensor kr_block = local_tile(k_restored_t, make_shape(Int<16>{}, Int<16>{}), make_coord(i, 0));
+                copy(smem_tiled_copy_A_T, smem_thr_copy_A_T.partition_S(kr_block), tCrAi_kr_view);
+                cute::transform(tCrAi_kr, ring_A_kr[i], cute::identity{});
+
+                #pragma unroll
+                for (int st = 0; st < 2; ++st) {
+                    auto& s_state_T = (st == 0) ? s_d_T : s_m_T;
+                    #pragma unroll
+                    for (int bi = 0; bi < 2; ++bi) {
+                        Tensor s_block = local_tile(s_state_T, make_shape(Int<16>{}, Int<16>{}), make_coord(i, warp_id_c * 2 + bi));
+                        copy(smem_tiled_load_C_T, smem_thr_load_C_T.partition_S(s_block), smem_thr_load_C_T.retile_D(ring_S_acc[st][bi][i]));
+                    }
+                }
+
+                ring_g0[i] = g_total(i * 16 + group_id);
+                ring_g1[i] = g_total(i * 16 + group_id + 8);
+            }
+
+            #pragma unroll
+            for (int m = 0; m < S_M_BLOCKS; ++m) {
+                const int slot = m % PREFETCH;
+
+                float g0 = ring_g0[slot];
+                float g1 = ring_g1[slot];
+
+                AccFragT s_upd[2][2];
+                #pragma unroll
+                for (int st = 0; st < 2; ++st)
+                    #pragma unroll
+                    for (int bi = 0; bi < 2; ++bi) {
+                        s_upd[st][bi] = thr_mma.make_fragment_C(tCrC_ref);
+                        clear(s_upd[st][bi]);
+                        gemm(thr_mma, ring_A_kr[slot](_,_,Int<0>{}), tCrB_u_arr[st][bi](_,_,Int<0>{}), s_upd[st][bi]);
+                    }
+
+                if (m + PREFETCH < S_M_BLOCKS) {
+                    Tensor kr_next = local_tile(k_restored_t, make_shape(Int<16>{}, Int<16>{}), make_coord(m + PREFETCH, 0));
+                    copy(smem_tiled_copy_A_T, smem_thr_copy_A_T.partition_S(kr_next), tCrAi_kr_view);
+                    cute::transform(tCrAi_kr, ring_A_kr[slot], cute::identity{});
+
+                    ring_g0[slot] = g_total((m + PREFETCH) * 16 + group_id);
+                    ring_g1[slot] = g_total((m + PREFETCH) * 16 + group_id + 8);
+                }
+
+                #pragma unroll
+                for (int st = 0; st < 2; ++st) {
+                    auto& s_state_T = (st == 0) ? s_d_T : s_m_T;
+                    #pragma unroll
+                    for (int bi = 0; bi < 2; ++bi) {
+                        #pragma unroll
+                        for (int a = 0; a < 2; ++a) {
+                            #pragma unroll
+                            for (int d = 0; d < 2; ++d) {
+                                auto c0 = make_coord(make_coord(a, 0), 0, d);
+                                auto c1 = make_coord(make_coord(a, 1), 0, d);
+                                ring_S_acc[st][bi][slot](c0) = BF16(bf16_to_f32(ring_S_acc[st][bi][slot](c0)) * g0 + s_upd[st][bi](c0));
+                                ring_S_acc[st][bi][slot](c1) = BF16(bf16_to_f32(ring_S_acc[st][bi][slot](c1)) * g1 + s_upd[st][bi](c1));
+                            }
+                        }
+
+                        Tensor s_block = local_tile(s_state_T, make_shape(Int<16>{}, Int<16>{}), make_coord(m, warp_id_c * 2 + bi));
+                        copy(smem_tiled_store_C_T, smem_thr_store_C_T.retile_S(ring_S_acc[st][bi][slot]), smem_thr_store_C_T.partition_D(s_block));
+
+                        if (m + PREFETCH < S_M_BLOCKS) {
+                            Tensor s_next = local_tile(s_state_T, make_shape(Int<16>{}, Int<16>{}), make_coord(m + PREFETCH, warp_id_c * 2 + bi));
+                            copy(smem_tiled_load_C_T, smem_thr_load_C_T.partition_S(s_next), smem_thr_load_C_T.retile_D(ring_S_acc[st][bi][slot]));
+                        }
+                    }
+                }
+            }
+            }
+            compute_barrier.arrive_and_wait();
+
+            cutlass::arch::fence_view_async_shared();
+            load_pipeline.consumer_release(load_read);
+            ++load_read;
+        }
+    }
+
+    // --- Epilogue: fp32-convert and TMA-store both states, sequentially
+    // through the shared conversion buffer (pipeline smem is dead now).
+    __syncthreads();
+
+    auto store_state = [&](BF16 const* state_smem, auto const& tma_store) {
+        smem_cvt_bf16_to_fp32<StateSmemLayout, FP32StateSmemLayout, D, NumThreads>(
+            const_cast<BF16*>(state_smem),
+            reinterpret_cast<float*>(shared_storage.state_fp32_buf),
+            threadIdx.x);
+        cutlass::arch::fence_view_async_shared();
+        __syncthreads();
+
+        if (warp_role == WarpRole::LOAD_QKG && lane_predicate) {
+            Tensor g_final = tma_store.get_tma_tensor(make_shape(H, D, D));
+            auto state_off = g_final.layout()(head_idx, 0, 0);
+            Tensor g_final_tile = make_tensor(g_final.data() + state_off,
+                make_layout(make_shape(Int<1>{}, Int<D>{}, Int<D>{}), stride(g_final.layout())));
+            Tensor s_fp32 = make_tensor(
+                make_smem_ptr(reinterpret_cast<float*>(shared_storage.state_fp32_buf)),
+                TMAFP32StateSmemLayout{});
+
+            auto cta_tma_store_state = tma_store.get_slice(Int<0>{});
+            cute::copy(
+                tma_store,
+                cta_tma_store_state.partition_S(s_fp32),
+                cta_tma_store_state.partition_D(g_final_tile)
+            );
+            tma_store_arrive();
+            tma_store_wait<0>();
+        }
+        __syncthreads();
+    };
+
+    store_state(shared_storage.state_d.begin(), tma_store_state_d);
+    store_state(shared_storage.state_m.begin(), tma_store_state_m);
+}
+
+// ==================== launch_fwd_md ====================
+// Kernel 1 verbatim from fwd_launch.cu, then the dual-state kernel 2.
+template <int D>
+void launch_fwd_md(
+    cutlass::bfloat16_t const* q_ptr,
+    cutlass::bfloat16_t const* k_ptr,
+    cutlass::bfloat16_t const* v_ptr,
+    cutlass::bfloat16_t const* g_bf16_ptr,
+    cutlass::bfloat16_t const* beta_ptr,
+    float scale,
+    float* state_d_ptr,
+    float* state_m_ptr,
+    void* workspace_ptr,
+    int total_tiles,
+    int T_total,
+    int H,
+    float const* A_log_ptr,
+    float const* dt_bias_ptr,
+    float gate_scale,
+    cudaStream_t stream
+) {
+    using BF16 = cutlass::bfloat16_t;
+    constexpr int kInputStages = 3;
+    constexpr int CHUNK = 16;
+
+    using K1L = K1Layouts<D, CHUNK>;
+    using K2L = K2Layouts<D, CHUNK>;
+    using WS = WorkspaceSizes<CHUNK, D>;
+
+    using TMAQKLayout = typename K1L::TMAQKLayout;
+    using TMABetaSmemLayout = typename K1L::TMABetaSmemLayout;
+    using TMAVOLayout = typename K1L::TMAVOLayout;
+    using TMALMLayout = typename K1L::TMALMLayout;
+    using TMAGTotalSmemLayout = typename K1L::TMAGTotalSmemLayout;
+    using TMAFP32StateSmemLayout = typename K2L::TMAFP32StateSmemLayout;
+
+    auto gmem_layout = make_layout(make_shape(H, T_total, D), make_stride(D, D * H, 1));
+    auto beta_gmem_layout = make_layout(make_shape(H * T_total));
+    auto state_gmem_layout = make_layout(make_shape(H, D, D), LayoutRight{});
+
+    Tensor m_q = make_tensor(make_gmem_ptr(q_ptr), gmem_layout);
+    Tensor m_k = make_tensor(make_gmem_ptr(k_ptr), gmem_layout);
+    Tensor m_v = make_tensor(make_gmem_ptr(v_ptr), gmem_layout);
+    Tensor m_beta = make_tensor(make_gmem_ptr<BF16>(beta_ptr), beta_gmem_layout);
+
+    int64_t n_ht = int64_t(H) * total_tiles;
+    char* ws = reinterpret_cast<char*>(workspace_ptr);
+    BF16*  ws_kd  = reinterpret_cast<BF16*>(ws);
+    BF16*  ws_qd  = reinterpret_cast<BF16*>(ws + n_ht * WS::kKDecayed);
+    BF16*  ws_kr  = reinterpret_cast<BF16*>(ws + n_ht * (WS::kKDecayed + WS::kQDecayed));
+    float* ws_gt  = reinterpret_cast<float*>(ws + n_ht * (WS::kKDecayed + WS::kQDecayed + WS::kKRestored));
+    BF16*  ws_inv = reinterpret_cast<BF16*>(ws + n_ht * (WS::kKDecayed + WS::kQDecayed + WS::kKRestored + WS::kGTotal));
+    BF16*  ws_mqk = reinterpret_cast<BF16*>(ws + n_ht * (WS::kKDecayed + WS::kQDecayed + WS::kKRestored + WS::kGTotal + WS::kINV));
+
+    auto ws_kd_gmem_layout = make_layout(make_shape(int(n_ht), CHUNK, D), LayoutRight{});
+    auto ws_qd_gmem_layout = ws_kd_gmem_layout;
+    auto ws_kr_gmem_layout = ws_kd_gmem_layout;
+    auto ws_gt_gmem_layout = make_layout(make_shape(int(n_ht), D), LayoutRight{});
+    auto ws_lm_gmem_layout = make_layout(make_shape(int(n_ht), CHUNK, CHUNK), LayoutRight{});
+
+    Tensor m_ws_kd  = make_tensor(make_gmem_ptr(ws_kd), ws_kd_gmem_layout);
+    Tensor m_ws_qd  = make_tensor(make_gmem_ptr(ws_qd), ws_qd_gmem_layout);
+    Tensor m_ws_kr  = make_tensor(make_gmem_ptr(ws_kr), ws_kr_gmem_layout);
+    Tensor m_ws_gt  = make_tensor(make_gmem_ptr(ws_gt), ws_gt_gmem_layout);
+    Tensor m_ws_inv = make_tensor(make_gmem_ptr(ws_inv), ws_lm_gmem_layout);
+    Tensor m_ws_mqk = make_tensor(make_gmem_ptr(ws_mqk), ws_lm_gmem_layout);
+
+    // Kernel 1 TMA descriptors (loads: q,k,beta,g,dt_bias; stores: workspace).
+    auto tma_load_q    = make_tma_copy(SM90_TMA_LOAD{}, m_q, TMAQKLayout{});
+    auto tma_load_k    = make_tma_copy(SM90_TMA_LOAD{}, m_k, TMAQKLayout{});
+    auto tma_load_beta = make_tma_copy(SM90_TMA_LOAD{}, m_beta, TMABetaSmemLayout{});
+
+    Tensor m_g = make_tensor(make_gmem_ptr(g_bf16_ptr), gmem_layout);
+    auto tma_load_g = make_tma_copy(SM90_TMA_LOAD{}, m_g, TMAQKLayout{});
+
+    auto dt_bias_gmem_layout = make_layout(make_shape(H, D), LayoutRight{});
+    Tensor m_dt_bias = make_tensor(make_gmem_ptr(dt_bias_ptr), dt_bias_gmem_layout);
+    auto tma_load_dt_bias = make_tma_copy(SM90_TMA_LOAD{}, m_dt_bias, TMAGTotalSmemLayout{});
+
+    auto tma_store_ws_kd  = make_tma_copy(SM90_TMA_STORE{}, m_ws_kd, TMAVOLayout{});
+    auto tma_store_ws_qd  = make_tma_copy(SM90_TMA_STORE{}, m_ws_qd, TMAVOLayout{});
+    auto tma_store_ws_kr  = make_tma_copy(SM90_TMA_STORE{}, m_ws_kr, TMAVOLayout{});
+    auto tma_store_ws_gt  = make_tma_copy(SM90_TMA_STORE{}, m_ws_gt, TMAGTotalSmemLayout{});
+    auto tma_store_ws_inv = make_tma_copy(SM90_TMA_STORE{}, m_ws_inv, TMALMLayout{});
+    auto tma_store_ws_mqk = make_tma_copy(SM90_TMA_STORE{}, m_ws_mqk, TMALMLayout{});
+
+    // Kernel 2-MD TMA descriptors.
+    auto tma_load_v     = make_tma_copy(SM90_TMA_LOAD{}, m_v, typename K2L::TMAVOLayout{});
+    auto tma_load_beta2 = make_tma_copy(SM90_TMA_LOAD{}, m_beta, typename K2L::TMABetaSmemLayout{});
+    auto tma_load_ws_kd  = make_tma_copy(SM90_TMA_LOAD{}, m_ws_kd, typename K2L::TMAVOLayout{});
+    auto tma_load_ws_kr  = make_tma_copy(SM90_TMA_LOAD{}, m_ws_kr, typename K2L::TMAVOLayout{});
+    auto tma_load_ws_gt  = make_tma_copy(SM90_TMA_LOAD{}, m_ws_gt, typename K2L::TMAGTotalSmemLayout{});
+    auto tma_load_ws_inv = make_tma_copy(SM90_TMA_LOAD{}, m_ws_inv, typename K2L::TMALMLayout{});
+
+    auto m_state_d = make_tensor(make_gmem_ptr(state_d_ptr), state_gmem_layout);
+    auto m_state_m = make_tensor(make_gmem_ptr(state_m_ptr), state_gmem_layout);
+    auto tma_store_state_d = make_tma_copy(SM90_TMA_STORE{}, m_state_d, TMAFP32StateSmemLayout{});
+    auto tma_store_state_m = make_tma_copy(SM90_TMA_STORE{}, m_state_m, TMAFP32StateSmemLayout{});
+
+    // ===== Kernel 1 (prepare), verbatim =====
+    {
+        constexpr int kK1Threads = 256;
+        using SharedStorageK1T = SharedStorageK1<K1L>;
+        int smem_size_k1 = sizeof(SharedStorageK1T);
+
+        auto kernel1 = _flash_kda_fwd_prepare<
+            decltype(tma_load_q), decltype(tma_load_k),
+            decltype(tma_load_beta),
+            decltype(tma_load_g), decltype(tma_load_dt_bias),
+            decltype(tma_store_ws_kd), decltype(tma_store_ws_qd), decltype(tma_store_ws_kr),
+            decltype(tma_store_ws_gt), decltype(tma_store_ws_inv), decltype(tma_store_ws_mqk),
+            CHUNK, D, kK1Threads, /*IsVarlen=*/false
+        >;
+
+        cudaFuncSetAttribute(kernel1, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size_k1);
+
+        dim3 grid_k1(total_tiles, H);
+        dim3 block_k1(kK1Threads);
+
+        kernel1<<<grid_k1, block_k1, smem_size_k1, stream>>>(
+            tma_load_q, tma_load_k, tma_load_beta,
+            tma_load_g, tma_load_dt_bias,
+            tma_store_ws_kd, tma_store_ws_qd, tma_store_ws_kr,
+            tma_store_ws_gt, tma_store_ws_inv, tma_store_ws_mqk,
+            scale, T_total, H, /*N=*/1, /*cu_seqlens=*/nullptr, total_tiles,
+            A_log_ptr, gate_scale, /*ws_tile_prefix=*/nullptr
+        );
+    }
+
+    // ===== Kernel 2-MD (dual-state recurrence) =====
+    {
+        constexpr int kK2Threads = 128 + 32;
+        using SharedStorageK2T = SharedStorageK2MD<K2L, kInputStages>;
+        int smem_size_k2 = sizeof(SharedStorageK2T);
+
+        auto kernel2 = _k3_flash_kda_fwd_md_recurrence<
+            decltype(tma_load_v), decltype(tma_load_beta2),
+            decltype(tma_load_ws_kd), decltype(tma_load_ws_kr),
+            decltype(tma_load_ws_gt), decltype(tma_load_ws_inv),
+            decltype(tma_store_state_d),
+            decltype(tma_store_state_m),
+            CHUNK, D, kInputStages, kK2Threads
+        >;
+
+        cudaFuncSetAttribute(kernel2, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size_k2);
+
+        dim3 grid_k2(1, H);
+        dim3 block_k2(kK2Threads);
+
+        kernel2<<<grid_k2, block_k2, smem_size_k2, stream>>>(
+            tma_load_v, tma_load_beta2,
+            tma_load_ws_kd, tma_load_ws_kr,
+            tma_load_ws_gt, tma_load_ws_inv,
+            tma_store_state_d, tma_store_state_m,
+            T_total, H, total_tiles
+        );
+    }
+}

--- a/pegainfer-kernels/src/ffi/k3.rs
+++ b/pegainfer-kernels/src/ffi/k3.rs
@@ -356,6 +356,29 @@ unsafe extern "C" {
         stream: CUstream,
     ) -> CUresult;
 
+    /// Fused KCP package forward: one kernel-1 pass plus a dual-state
+    /// kernel 2 producing the segment's affine package in one sweep —
+    /// `state_out_d` = D (real v from zero state), `state_out_m` = M (v = 0
+    /// from identity state), both `[H, 128, 128]` f32. No token output.
+    /// Same operand contract and workspace as [`k3_flash_kda_fwd`].
+    pub fn k3_flash_kda_fwd_md(
+        q: *const Half,
+        k: *const Half,
+        v: *const Half,
+        g: *const Half,
+        beta_ht: *const Half,
+        a_log: *const f32,
+        dt_bias: *const f32,
+        state_out_d: *mut f32,
+        state_out_m: *mut f32,
+        workspace: *mut core::ffi::c_void,
+        t_total: i32,
+        h: i32,
+        scale: f32,
+        lower_bound: f32,
+        stream: CUstream,
+    ) -> CUresult;
+
     /// Chunked-prefill MLA context gather: walk one block-table row and split
     /// `t_total` cached 576-wide latent rows into dense `[t, 512]` latent and
     /// `[t, 64]` rope halves. Strides/offsets are in elements.

--- a/pegainfer-kernels/src/ops/k3/flash_kda.rs
+++ b/pegainfer-kernels/src/ops/k3/flash_kda.rs
@@ -177,3 +177,112 @@ pub fn k3_flash_kda_fwd_launch(
         anyhow!("K3 FlashKDA forward (T={t_total}, H={heads}) failed: {error} (NOT_SUPPORTED = built without an accelerated SM90+ target)")
     })
 }
+
+/// Fused KCP package forward: one segment through kernel 1 plus a dual-state
+/// kernel 2, producing the segment's affine package `S_out = S_in·M + D` in
+/// one sweep — `state_out_d` = D (real `v` from zero state) and
+/// `state_out_m` = M (`v = 0` from identity state), each one `[heads, 128,
+/// 128]` f32 row. The doctored initial states are seeded in-kernel and the
+/// token output is not computed (a CP middle rank discards it). Operand
+/// contract otherwise matches [`k3_flash_kda_fwd_launch`] at span zero;
+/// `state_out_d` and `state_out_m` may not alias.
+#[allow(clippy::too_many_arguments)]
+pub fn k3_flash_kda_fwd_md_launch(
+    ctx: &DeviceContext,
+    t_total: usize,
+    heads: usize,
+    q: &CudaSlice<bf16>,
+    k: &CudaSlice<bf16>,
+    v: &CudaSlice<bf16>,
+    g: &CudaSlice<bf16>,
+    beta: &CudaSlice<bf16>,
+    beta_scratch: &mut CudaSlice<bf16>,
+    a_log: &CudaSlice<f32>,
+    dt_bias: &CudaSlice<f32>,
+    state_out_d: &mut CudaSlice<f32>,
+    state_out_m: &mut CudaSlice<f32>,
+    workspace: &mut CudaSlice<u8>,
+    scale: f32,
+    lower_bound: f32,
+) -> Result<()> {
+    let d = K3_FLASH_KDA_HEAD_DIM;
+    let width = heads * d;
+    ensure!(t_total > 0, "K3 FlashKDA MD got an empty segment");
+    ensure!(
+        q.len() >= t_total * width
+            && k.len() >= t_total * width
+            && v.len() >= t_total * width
+            && g.len() >= t_total * width,
+        "K3 FlashKDA MD q/k/v/g buffers too small for t={t_total}, heads={heads}"
+    );
+    ensure!(
+        beta.len() >= t_total * heads && beta_scratch.len() >= t_total * heads,
+        "K3 FlashKDA MD beta buffers too small for t={t_total}, heads={heads}: beta {}, scratch {}",
+        beta.len(),
+        beta_scratch.len()
+    );
+    ensure!(
+        a_log.len() >= heads && dt_bias.len() >= width,
+        "K3 FlashKDA MD a_log/dt_bias too small for heads={heads}"
+    );
+    let state = heads * d * d;
+    ensure!(
+        state_out_d.len() >= state && state_out_m.len() >= state,
+        "K3 FlashKDA MD state slabs too small for heads={heads}: d {}, m {}",
+        state_out_d.len(),
+        state_out_m.len()
+    );
+    let needed = k3_flash_kda_workspace_bytes(t_total, heads);
+    ensure!(
+        workspace.len() >= needed,
+        "K3 FlashKDA MD workspace of {} bytes is under the {needed} the segment needs",
+        workspace.len()
+    );
+
+    let (beta_ptr, _beta_guard) = beta.device_ptr(&ctx.stream);
+    let (beta_t_ptr, _beta_t_guard) = beta_scratch.device_ptr_mut(&ctx.stream);
+    let rc = unsafe {
+        ffi::k3_flash_kda_beta_transpose(
+            beta_ptr as *const Half,
+            beta_t_ptr as *mut Half,
+            t_total as i32,
+            heads as i32,
+            ctx.stream.cu_stream(),
+        )
+    };
+    rc.result().map_err(|error| {
+        anyhow!("K3 FlashKDA MD beta transpose (T={t_total}, H={heads}): {error}")
+    })?;
+
+    let (q_ptr, _q_guard) = q.device_ptr(&ctx.stream);
+    let (k_ptr, _k_guard) = k.device_ptr(&ctx.stream);
+    let (v_ptr, _v_guard) = v.device_ptr(&ctx.stream);
+    let (g_ptr, _g_guard) = g.device_ptr(&ctx.stream);
+    let (a_log_ptr, _a_log_guard) = a_log.device_ptr(&ctx.stream);
+    let (dt_bias_ptr, _dt_bias_guard) = dt_bias.device_ptr(&ctx.stream);
+    let (state_d_ptr, _state_d_guard) = state_out_d.device_ptr_mut(&ctx.stream);
+    let (state_m_ptr, _state_m_guard) = state_out_m.device_ptr_mut(&ctx.stream);
+    let (ws_ptr, _ws_guard) = workspace.device_ptr_mut(&ctx.stream);
+    let rc = unsafe {
+        ffi::k3_flash_kda_fwd_md(
+            q_ptr as *const Half,
+            k_ptr as *const Half,
+            v_ptr as *const Half,
+            g_ptr as *const Half,
+            beta_t_ptr as *const Half,
+            a_log_ptr as *const f32,
+            dt_bias_ptr as *const f32,
+            state_d_ptr as *mut f32,
+            state_m_ptr as *mut f32,
+            ws_ptr as *mut core::ffi::c_void,
+            t_total as i32,
+            heads as i32,
+            scale,
+            lower_bound,
+            ctx.stream.cu_stream(),
+        )
+    };
+    rc.result().map_err(|error| {
+        anyhow!("K3 FlashKDA MD forward (T={t_total}, H={heads}) failed: {error} (NOT_SUPPORTED = built without an accelerated SM90+ target)")
+    })
+}

--- a/pegainfer-kernels/tests/k3_flash_kda_md_equiv.rs
+++ b/pegainfer-kernels/tests/k3_flash_kda_md_equiv.rs
@@ -1,0 +1,347 @@
+//! Fused KCP package forward equivalence gate.
+//!
+//! The fused `k3_flash_kda_fwd_md_launch` must reproduce the two standalone
+//! doctored calls it replaces — `M` from (v = 0, state = I) and `D` from
+//! (real v, state = 0) — bit-for-bit: the derived kernel keeps the upstream
+//! GEMM shapes and accumulation order per state, so any drift is a bug, not
+//! rounding.
+//!
+//! Needs one GPU with the accelerated FlashKDA build (SM90+):
+//! `cargo test --release -p pegainfer-kernels --features k3 \
+//!    --test k3_flash_kda_md_equiv -- --ignored --nocapture`
+
+#![cfg(feature = "k3")]
+
+mod common;
+
+use cudarc::driver::CudaSlice;
+use half::bf16;
+use pegainfer_kernels::ops::K3FlashKdaSpan;
+use pegainfer_kernels::ops::k3_flash_kda_fwd_launch;
+use pegainfer_kernels::ops::k3_flash_kda_fwd_md_launch;
+use pegainfer_kernels::ops::k3_flash_kda_workspace_bytes;
+use pegainfer_kernels::tensor::DeviceContext;
+
+const HEADS: usize = 96;
+const D: usize = 128;
+const SCALE: f32 = 0.088_388_35; // 128^-0.5
+const LOWER_BOUND: f32 = -5.0;
+
+fn xorshift_fill(seed: &mut u64, len: usize, amp: f32) -> Vec<bf16> {
+    (0..len)
+        .map(|_| {
+            *seed ^= *seed << 13;
+            *seed ^= *seed >> 7;
+            *seed ^= *seed << 17;
+            let unit = (*seed >> 40) as f32 / (1u64 << 24) as f32; // [0,1)
+            bf16::from_f32((unit - 0.5) * 2.0 * amp)
+        })
+        .collect()
+}
+
+fn identity_state(heads: usize) -> Vec<f32> {
+    let mut state = vec![0f32; heads * D * D];
+    for h in 0..heads {
+        for i in 0..D {
+            state[(h * D + i) * D + i] = 1.0;
+        }
+    }
+    state
+}
+
+fn dtoh(ctx: &DeviceContext, slice: &CudaSlice<f32>) -> Vec<f32> {
+    let host = ctx.stream.clone_dtoh(slice).expect("dtoh");
+    ctx.stream.synchronize().expect("dtoh sync");
+    host
+}
+
+fn max_abs_diff(a: &[f32], b: &[f32]) -> (f32, usize) {
+    let mut worst = 0f32;
+    let mut mismatches = 0usize;
+    for (x, y) in a.iter().zip(b) {
+        let diff = (x - y).abs();
+        if diff > 0.0 {
+            mismatches += 1;
+        }
+        if diff > worst {
+            worst = diff;
+        }
+    }
+    (worst, mismatches)
+}
+
+#[test]
+#[ignore = "needs one GPU with the accelerated FlashKDA build"]
+fn fused_md_vs_two_calls_timing() {
+    let Some(ctx) = common::device_or_skip() else {
+        return;
+    };
+    let mut seed = 0x7137_0f_u64;
+    let width = HEADS * D;
+    let state = HEADS * D * D;
+
+    for t in [2112usize, 4224] {
+        const SETS: usize = 8;
+        let mut ops = Vec::new();
+        for _ in 0..SETS {
+            ops.push((
+                ctx.stream
+                    .clone_htod(&xorshift_fill(&mut seed, t * width, 0.5))
+                    .expect("q"),
+                ctx.stream
+                    .clone_htod(&xorshift_fill(&mut seed, t * width, 0.5))
+                    .expect("k"),
+                ctx.stream
+                    .clone_htod(&xorshift_fill(&mut seed, t * width, 0.5))
+                    .expect("v"),
+                ctx.stream
+                    .clone_htod(&xorshift_fill(&mut seed, t * width, 1.0))
+                    .expect("g"),
+                ctx.stream
+                    .clone_htod(&xorshift_fill(&mut seed, t * HEADS, 1.0))
+                    .expect("beta"),
+            ));
+        }
+        let zero_v = ctx.stream.alloc_zeros::<bf16>(t * width).expect("zero v");
+        let mut beta_scratch = ctx
+            .stream
+            .alloc_zeros::<bf16>(t * HEADS)
+            .expect("beta scratch");
+        let a_log = ctx.stream.clone_htod(&vec![0.5f32; HEADS]).expect("a_log");
+        let dt_bias = ctx.stream.alloc_zeros::<f32>(width).expect("dt_bias");
+        let identity = ctx
+            .stream
+            .clone_htod(&identity_state(HEADS))
+            .expect("identity");
+        let zero_state = ctx.stream.alloc_zeros::<f32>(state).expect("zero state");
+        let mut out = ctx.stream.alloc_zeros::<bf16>(t * width).expect("out");
+        let mut workspace = ctx
+            .stream
+            .alloc_zeros::<u8>(k3_flash_kda_workspace_bytes(t, HEADS).max(16))
+            .expect("workspace");
+        let mut m_slab = ctx.stream.alloc_zeros::<f32>(state).expect("m slab");
+        let mut d_slab = ctx.stream.alloc_zeros::<f32>(state).expect("d slab");
+
+        let iters = 200usize;
+        let mut two_call = |ctx: &DeviceContext| {
+            for i in 0..iters {
+                let (q, k, v, g, beta) = &ops[i % SETS];
+                k3_flash_kda_fwd_launch(
+                    ctx,
+                    t,
+                    HEADS,
+                    K3FlashKdaSpan::default(),
+                    q,
+                    k,
+                    &zero_v,
+                    g,
+                    beta,
+                    &mut beta_scratch,
+                    &a_log,
+                    &dt_bias,
+                    &identity,
+                    &mut m_slab,
+                    &mut out,
+                    &mut workspace,
+                    SCALE,
+                    LOWER_BOUND,
+                )
+                .expect("M forward");
+                k3_flash_kda_fwd_launch(
+                    ctx,
+                    t,
+                    HEADS,
+                    K3FlashKdaSpan::default(),
+                    q,
+                    k,
+                    v,
+                    g,
+                    beta,
+                    &mut beta_scratch,
+                    &a_log,
+                    &dt_bias,
+                    &zero_state,
+                    &mut d_slab,
+                    &mut out,
+                    &mut workspace,
+                    SCALE,
+                    LOWER_BOUND,
+                )
+                .expect("D forward");
+            }
+            ctx.stream.synchronize().expect("sync");
+        };
+        two_call(&ctx); // warmup
+        let start = std::time::Instant::now();
+        two_call(&ctx);
+        let two_ms = start.elapsed().as_secs_f64() * 1e3 / iters as f64;
+
+        let mut fused = |ctx: &DeviceContext| {
+            for i in 0..iters {
+                let (q, k, v, g, beta) = &ops[i % SETS];
+                k3_flash_kda_fwd_md_launch(
+                    ctx,
+                    t,
+                    HEADS,
+                    q,
+                    k,
+                    v,
+                    g,
+                    beta,
+                    &mut beta_scratch,
+                    &a_log,
+                    &dt_bias,
+                    &mut d_slab,
+                    &mut m_slab,
+                    &mut workspace,
+                    SCALE,
+                    LOWER_BOUND,
+                )
+                .expect("fused forward");
+            }
+            ctx.stream.synchronize().expect("sync");
+        };
+        fused(&ctx); // warmup
+        let start = std::time::Instant::now();
+        fused(&ctx);
+        let fused_ms = start.elapsed().as_secs_f64() * 1e3 / iters as f64;
+
+        eprintln!(
+            "T={t:>5}: two calls {two_ms:.4} ms, fused {fused_ms:.4} ms ({:.2}x)",
+            two_ms / fused_ms
+        );
+    }
+}
+
+#[test]
+#[ignore = "needs one GPU with the accelerated FlashKDA build"]
+fn fused_md_matches_the_two_doctored_calls() {
+    let Some(ctx) = common::device_or_skip() else {
+        return;
+    };
+    let mut seed = 0x0dd5_eed5_0f_u64;
+    let width = HEADS * D;
+    let state = HEADS * D * D;
+
+    // Tail (14), verify pack (224), chunk divisions (1056, 4224), and an
+    // uneven segment (4223) — the shape every real uneven CP split has.
+    for t in [14usize, 224, 1056, 4223, 4224] {
+        let q = ctx
+            .stream
+            .clone_htod(&xorshift_fill(&mut seed, t * width, 0.5))
+            .expect("q");
+        let k = ctx
+            .stream
+            .clone_htod(&xorshift_fill(&mut seed, t * width, 0.5))
+            .expect("k");
+        let v = ctx
+            .stream
+            .clone_htod(&xorshift_fill(&mut seed, t * width, 0.5))
+            .expect("v");
+        let g = ctx
+            .stream
+            .clone_htod(&xorshift_fill(&mut seed, t * width, 1.0))
+            .expect("g");
+        let beta = ctx
+            .stream
+            .clone_htod(&xorshift_fill(&mut seed, t * HEADS, 1.0))
+            .expect("beta");
+        let zero_v = ctx.stream.alloc_zeros::<bf16>(t * width).expect("zero v");
+        let mut beta_scratch = ctx
+            .stream
+            .alloc_zeros::<bf16>(t * HEADS)
+            .expect("beta scratch");
+        let a_log = ctx.stream.clone_htod(&vec![0.5f32; HEADS]).expect("a_log");
+        let dt_bias = ctx.stream.alloc_zeros::<f32>(width).expect("dt_bias");
+        let identity = ctx
+            .stream
+            .clone_htod(&identity_state(HEADS))
+            .expect("identity");
+        let zero_state = ctx.stream.alloc_zeros::<f32>(state).expect("zero state");
+        let mut out = ctx.stream.alloc_zeros::<bf16>(t * width).expect("out");
+        let mut workspace = ctx
+            .stream
+            .alloc_zeros::<u8>(k3_flash_kda_workspace_bytes(t, HEADS).max(16))
+            .expect("workspace");
+
+        // Reference: the two standalone doctored calls.
+        let mut ref_m = ctx.stream.alloc_zeros::<f32>(state).expect("ref m");
+        let mut ref_d = ctx.stream.alloc_zeros::<f32>(state).expect("ref d");
+        k3_flash_kda_fwd_launch(
+            &ctx,
+            t,
+            HEADS,
+            K3FlashKdaSpan::default(),
+            &q,
+            &k,
+            &zero_v,
+            &g,
+            &beta,
+            &mut beta_scratch,
+            &a_log,
+            &dt_bias,
+            &identity,
+            &mut ref_m,
+            &mut out,
+            &mut workspace,
+            SCALE,
+            LOWER_BOUND,
+        )
+        .expect("reference M forward");
+        k3_flash_kda_fwd_launch(
+            &ctx,
+            t,
+            HEADS,
+            K3FlashKdaSpan::default(),
+            &q,
+            &k,
+            &v,
+            &g,
+            &beta,
+            &mut beta_scratch,
+            &a_log,
+            &dt_bias,
+            &zero_state,
+            &mut ref_d,
+            &mut out,
+            &mut workspace,
+            SCALE,
+            LOWER_BOUND,
+        )
+        .expect("reference D forward");
+
+        // Fused pass.
+        let mut fused_d = ctx.stream.alloc_zeros::<f32>(state).expect("fused d");
+        let mut fused_m = ctx.stream.alloc_zeros::<f32>(state).expect("fused m");
+        k3_flash_kda_fwd_md_launch(
+            &ctx,
+            t,
+            HEADS,
+            &q,
+            &k,
+            &v,
+            &g,
+            &beta,
+            &mut beta_scratch,
+            &a_log,
+            &dt_bias,
+            &mut fused_d,
+            &mut fused_m,
+            &mut workspace,
+            SCALE,
+            LOWER_BOUND,
+        )
+        .expect("fused MD forward");
+
+        let (m_diff, m_bad) = max_abs_diff(&dtoh(&ctx, &ref_m), &dtoh(&ctx, &fused_m));
+        let (d_diff, d_bad) = max_abs_diff(&dtoh(&ctx, &ref_d), &dtoh(&ctx, &fused_d));
+        eprintln!(
+            "T={t:>5}: M max|diff| {m_diff:.3e} ({m_bad} cells), D max|diff| {d_diff:.3e} ({d_bad} cells)"
+        );
+        assert_eq!(
+            (m_diff, d_diff),
+            (0.0, 0.0),
+            "fused MD diverged from the doctored calls at T={t}"
+        );
+    }
+}


### PR DESCRIPTION
## What

A CP middle rank derived its KCP affine package `(M, D)` with two doctored FlashKDA forwards — `M` from `(v = 0, state = I)`, `D` from `(real v, state = 0)`. Both calls share kernel 1 byte-for-byte (prepare is v- and state-independent) and discard the token output. This PR fuses the pair into one pass: `k3_flash_kda_fwd_md` = a single K1 sweep + a dual-state K2 that drops the q GEMM, the two output phases, and the out-store (6 GEMM issues per tile vs the 10 the standalone pair paid). The `zero_v`/`zero_state`/`identity` scratch slabs die with the second call (~117 MB back per middle rank).

## Production invariant

CP prefill correctness is untouched by construction: the derived kernel keeps the upstream GEMM shapes and per-state accumulation order, so the fused pass is **bit-identical** to the two calls it replaces — any drift is a bug, not rounding.

## Evidence

- **New equivalence gate** `k3_flash_kda_md_equiv` (1 GPU): zero diff on both output states at T ∈ {14, 224, 1056, 4223, 4224} — tail, verify pack, chunk divisions, and an uneven CP segment. Timing test: pair 1.0165 → fused 0.5943 ms @4224 (**1.71×**).
- **Production 4-GPU gate** `cp_prefill` (pruned 224-expert @EP4, tray13, GB300): argmax + sampled token unchanged, rel_l2 at the established depth noise floor (2.52e-1 @93 layers, same as pre-fusion). Warm CP4 forward wall **1037.7 → 1001.6 ms, CP4/CP1 2.92 → 2.95×** — the −36 ms lands the projection from the CP4 gap anatomy (dev1/2's M/D production was dev3's largest remaining true dependency, docs/models/k3/cp-lane-design.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)