### PR TITLE
perf(k3): raise the MegaMoE protocol max to 16896 tokens per rank

### DIFF
--- a/docs/models/k3/cp-lane-design.md
+++ b/docs/models/k3/cp-lane-design.md
@@ -20,7 +20,9 @@ HTTP e2e 同脚本 4 卡对 4 卡：16k CP4 1161 ms vs vLLM TP4 1181 ms 首次�
 §16 卡对局**；**gap anatomy 2026-08-25：2.86× 的缺口 40% 是 MoE 不吃 CP 的
 Amdahl 项，CP4 硬顶 3.49×，通信仅 0.6% 且纯 peer D2D 已快过 NCCL 地板，
 详见 §CP4 gap anatomy；event 门控交换 + M+D 融合 kernel 双双落地后
-CP4/CP1 = 2.95×，剩余缺口只剩 FMHA 三角与 Amdahl 项**）→ M1 full@EP16
+CP4/CP1 = 2.95×，剩余缺口只剩 FMHA 三角与 Amdahl 项；**mega 协议上限
+2026-08-25 直升 16896：CP4 单 superstep 盖 67.5k，64k 门禁绿 CP4 5.0s vs
+CP1 13.9s，CP8/CP16 只差 gang 侧**）→ M1 full@EP16
 交叉矩阵 + lane-vs-独占步系统 A/B
 → M2 agent cache 闭环 → M3 弹性调度。
 
@@ -217,7 +219,8 @@ strided-batched GEMM（96×128³，新增 `gemm_strided_batched_f32`）。conv h
 接收方把上游 3 行 normed 过 wbig band 投影（bucket 4 + 零 pad 行）。MLA 交换
 post-norm latent + rope，绕过 paged gather 直接拼 `mla_ctx`。进程内 barrier +
 peer D2D 读（MegaMoE mempool 已开 peer access）。M0 约束：单 superstep，每段
-≤ chunk_tokens（4224）。
+≤ chunk_tokens（当时 4224；2026-08-25 mega 协议上限升 16896 后 CP4 单
+superstep 盖到 67.5k，见 §Mega 协议上限）。
 
 实测（tray14，pruned 224-expert @EP4，`cp_prefill.rs`）：
 
@@ -274,7 +277,8 @@ peer D2D 读（MegaMoE mempool 已开 peer access）。M0 约束：单 superstep
   方案，可用 CP4 独占近似，不必真建 TP4），指标 = whale TTFT / decode TPOT
   p99 / goodput / EP barrier wait；
 - 单 gang、gang 内 BS=1、暂无 prefix hit 进 CP 路径；
-- 依赖：mega world >4224（roadmap 已挂账，whale chunk 12–16k 需要）。
+- 依赖：mega world >4224 —— **DONE 2026-08-25，直接 4 倍到 16896**（见
+  §Mega 协议上限）。
 
 ### M2 — Agent cache 闭环
 
@@ -384,8 +388,9 @@ gang——生产默认 2048 以下走本地）：
   的 2.62× 还好——全量 MoE 更重，CP 摊薄的 attention 份额相对更大）。
 - **对 vLLM 的横向账分两段**：1–2k CP4 赢 1.3–1.5×（他们的 TP16 中段
   掉进 ~400ms 平台）；4k 基本打平；8k+ 输 0.68–0.73×——vLLM prefill 是
-  16 路全切，我们 M0 的 CP 宽度被单 superstep 约束钉在 4（每段 ≤4224）。
-  **8k+ 的差距就是 M1 多 superstep + CP8/CP16 的立项理由**：CP4 已把
+  16 路全切，我们 M0 的 CP 宽度被单 superstep 约束钉在 4（每段 ≤4224；
+  2026-08-25 mega 升 16896 后该约束实际消失，CP8/CP16 只差 gang 侧）。
+  **8k+ 的差距就是 M1 CP8/CP16 的立项理由**：CP4 已把
   CP1 的 3061 压到 1072，宽度每翻倍理论上还有 ~1.6–1.8× 空间。
 - vLLM 两列的差距（16k 728 vs 8921，12×）是 fabric 的账不是引擎的账：
   任何一台 tray 的 nvidia-imex daemon 挂掉，整个 MNNVL 域的 fabric
@@ -447,8 +452,39 @@ argmax/token 一致）：暖跑 CP4 forward 墙钟 **1037.7→1001.6 ms，CP4/CP
 （2.95×）→ FMHA 条带化配段（≈3.1–3.2×）→ **3.49× 是 EP 共享 MoE 的硬顶，
 再往上只有 M1 加宽**。
 
+## Mega 协议上限 4224 → 16896（M1 的前半，2026-08-25）
+
+`kProtocolMaxTokensPerRank` 直接 4 倍到 16896（=44×384 对齐；ring 容量随
+之线性缩放，是 kernel 模板参数所以全 world 重实例化）。动机：**单
+superstep 的 CP 天花板从 16.9k 直升 67.5k @CP4**（CP16@EP16 理论 256k+，
+FlashKDA 264k 线性已证 kernel 侧免费），多 superstep 段游走在实用长度内
+基本失去必要性；CP1 本地 chunked prefill 同时受益（16k = 单 chunk，mega
+发射数 ÷4，GEMM 形状进高效区）。
+
+代价是 symm slab 随协议上限线性长（`k3_mega_symm_buffer_layout` 实测）：
+EP4/224 1.6→6.3 GiB，**EP16/896 5.1→19.6 GiB**——EP16 全量（权重 190.7
+GiB/rank）后 HBM 收紧 ~15 GiB，fleet 复测时要盯。TileLang prefill bucket
+梯子补 8448/16896 两档（AOT 全家 +24s 构建）。
+
+验证链（tray14/06，pruned@EP4）：
+- **16k 门禁与旧协议逐位同答案**（rel_l2 2.523e-1/4.511e-2 与 4224 时代
+  完全一致——GEMM 行独立 + FlashKDA 跨 call 状态 bf16↔fp32 无损 + FMHA
+  行内在线 softmax，chunking 对 CP1 逐位稳定）；CP4 墙钟不变（段仍 4096）。
+- **64k 单 superstep CP4 落地**：argmax/token 与 CP1 一致，rel_l2
+  9.4e-2/7.0e-2（bar 0.386）；暖跑墙钟 **CP1 13870 ms vs CP4 5006 ms =
+  2.77×**。
+- mega oracle 双绿且 **Gate 1 bitwise**（EP4 vs EP1 全 40 token +
+  163840 logits 逐位一致），Gate 2 流量不变性 bitwise 保持。
+- ttft sweep（tray06，min-of-4）：CP1 @16k 2980→2870 ms（单 chunk mega
+  赚 ~110 ms），CP4 @16k 1003.5 持平（段仍 4096），CP4/CP1 2.86×；
+  128–8k 档与旧表一致（128: 0.84× / 1k: 1.68× / 4k: 2.60× / 8k: 2.82×，
+  交叉点 ~400 tokens 不动）。
+- golden_decode 串行 13/13 绿（`--test-threads 1`，bring-up.md 的规定跑
+  法；默认并行会 13 实例同租一卡 OOM——mega slab EP1 涨到 3.2 GiB 后更
+  容易炸，跑法不对怪跑法）。
+
 ## Next action
 
-M1 立项：mega world >4224 + 多 superstep 段游走 → CP8/CP16，8k+ 追平
-vLLM TP16 的 16 路切分；full@EP16 交叉矩阵 + 系统 A/B。次优先：前端固定
-截距（132 vs 59 ms @122 tokens）。
+M1 后半：CP8/CP16 gang（full@EP16 交叉矩阵 + 系统 A/B），8k+ 追平 vLLM
+TP16 的 16 路切分；EP16 全量下 19.6 GiB slab 的 HBM 账实测。次优先：FMHA
+条带化配段、前端固定截距（132 vs 59 ms @122 tokens）。

--- a/pegainfer-k3/kernels/generate.py
+++ b/pegainfer-k3/kernels/generate.py
@@ -134,11 +134,11 @@ THREADS = 256
 B_BUCKETS = [1, 2, 4, 8, 16, 32, 48, 64, 96, 128]
 
 # Prefill chunk buckets: the chunked-prefill step runs the same batched
-# families at chunk width, up to the MegaMoE protocol maximum (4224 rows).
+# families at chunk width, up to the MegaMoE protocol maximum (16896 rows).
 # Every family gets the extended ladder except `kda_core` — chunks cross the
 # KDA recurrence through FlashKDA, so the fused core only ever sees decode
 # buckets. Mirrors `K3_PREFILL_BUCKETS` in `ops/k3_tilelang.rs`.
-B_PREFILL_BUCKETS = [256, 512, 1024, 2048, 4224]
+B_PREFILL_BUCKETS = [256, 512, 1024, 2048, 4224, 8448, 16896]
 B_CHUNK_BUCKETS = B_BUCKETS + B_PREFILL_BUCKETS
 
 

--- a/pegainfer-k3/src/executor/mod.rs
+++ b/pegainfer-k3/src/executor/mod.rs
@@ -22,7 +22,7 @@
 //!
 //! Prefill runs the batched step over **chunks of one sequence**: the bucket's
 //! rows carry up to `chunk_tokens` consecutive prompt tokens (default: the
-//! 4224-row MegaMoE protocol maximum, clamped to `max_ctx`), so every
+//! 16896-row MegaMoE protocol maximum, clamped to `max_ctx`), so every
 //! row-independent stage (norms, projections, MoE) digests the whole chunk
 //! in one launch, the MLA layers attend `[context | chunk]` through one
 //! dense FlashMLA FMHA call per layer over kv_b-expanded scratch, and the
@@ -152,7 +152,7 @@ const K3_MEGA_SMS: usize = 152;
 
 /// Slots per rank an expert-parallel launch takes when nothing says otherwise.
 ///
-/// The fused kernel's protocol maximum is 4224 rows per rank (sized for
+/// The fused kernel's protocol maximum is 16896 rows per rank (sized for
 /// chunked prefill), so the compiled
 /// bucket ceiling (128) is the target once the backbone goes FP8. Today the
 /// binding constraint is the KDA state slab: ~929 MB per slot (f32 recurrent
@@ -179,7 +179,7 @@ pub struct K3ExecutorConfig {
     /// Layers to build; `K3_LAYERS` for the whole model.
     pub num_layers: usize,
     /// Prefill chunk cap in tokens. `0` derives the widest the transport
-    /// carries: the MegaMoE protocol maximum (4224, clamped to `max_ctx`)
+    /// carries: the MegaMoE protocol maximum (16896, clamped to `max_ctx`)
     /// under the fused kernel, `max_batch` under the masked chain (whose
     /// layout reserves at most [`K3_MASKED_CAP`] rows per expert).
     pub chunk_tokens: usize,

--- a/pegainfer-k3/tests/cp_prefill.rs
+++ b/pegainfer-k3/tests/cp_prefill.rs
@@ -61,6 +61,15 @@ fn rel_l2_bar() -> f64 {
     4e-2 * (layers as f64).sqrt()
 }
 
+/// The prompt length the logits gate runs at (`PEGAINFER_K3_CP_PROMPT`,
+/// default [`MAX_CTX`]).
+fn gate_prompt_ceiling() -> usize {
+    std::env::var("PEGAINFER_K3_CP_PROMPT")
+        .ok()
+        .and_then(|raw| raw.parse::<usize>().ok())
+        .unwrap_or(MAX_CTX)
+}
+
 fn checkpoint() -> PathBuf {
     let path = std::env::var(CHECKPOINT_ENV)
         .unwrap_or_else(|_| panic!("set {CHECKPOINT_ENV} to the 224-expert checkpoint directory"));
@@ -69,7 +78,10 @@ fn checkpoint() -> PathBuf {
 
 fn config() -> K3ExecutorConfig {
     let mut config = K3ExecutorConfig::default().from_env();
-    config.max_ctx = MAX_CTX;
+    // `PEGAINFER_K3_CP_PROMPT` raises the serving ceiling with the prompt:
+    // the 16896-token MegaMoE protocol maximum makes CP4 span 64k prompts in
+    // one superstep, and the gate must be able to follow it up.
+    config.max_ctx = MAX_CTX.max(gate_prompt_ceiling());
     // One decode slot: the gate never decodes, and a slot's KDA state slab is
     // ~1 GiB across the full depth.
     config.max_batch = 1;
@@ -185,10 +197,7 @@ fn run_gang(lengths: &[usize], runs: usize) -> (RankReport, RankReport) {
 #[test]
 #[ignore = "needs 4 GPUs and the 224-expert checkpoint"]
 fn cp4_prefill_matches_cp1() {
-    let ceiling = std::env::var("PEGAINFER_K3_CP_PROMPT")
-        .ok()
-        .and_then(|raw| raw.parse::<usize>().ok())
-        .unwrap_or(MAX_CTX);
+    let ceiling = gate_prompt_ceiling();
     let lengths = [ceiling, ceiling - 1];
     let (first, last) = run_gang(&lengths, 1);
     for (index, &len) in lengths.iter().enumerate() {

--- a/pegainfer-kernels/csrc/k3/k3_mega_moe_sm100.cu
+++ b/pegainfer-kernels/csrc/k3/k3_mega_moe_sm100.cu
@@ -68,7 +68,7 @@
 // Instantiation matrix
 // ---------------------------------------------------------------------------
 // hidden 3584 (K3 latent), intermediate 3072, topk 16, num_max_tokens_per_rank
-// 4224 (the chunked-prefill ceiling; 11x `kLCMCandidateBlockM`, the token
+// 16896 (the chunked-prefill ceiling; 44x `kLCMCandidateBlockM`, the token
 // alignment the upstream API enforces), 152 SMs (GB300). The GLOBAL expert
 // count and the rank count together name a world, and the worlds are split
 // across translation units so nvcc compiles them in parallel:
@@ -85,8 +85,8 @@
 //
 // At ranks 1 the launch picks among the block configs by live token count
 // under `get_block_config_for_mega_moe`, so a single-rank launch stays
-// bit-identical to what upstream's Python wrapper would run; at 4224 max
-// tokens the whole six-entry ladder is reachable and instantiated.
+// bit-identical to what upstream's Python wrapper would run; at the protocol
+// maximum the whole six-entry ladder is reachable and instantiated.
 // Every multi-rank world has exactly ONE config, taken at the protocol maximum
 // rather than from the live token count — see `k3_mega::pinned_config`.
 //
@@ -298,8 +298,8 @@ __global__ void mega_write_routing_kernel(const int* __restrict__ topk_idx,
 
 constexpr int kPrunedExperts = 224;
 
-// Single rank: at num_max_tokens_per_rank == 4224 with 224 experts and topk 16
-// every ladder entry is reachable (the thresholds land at 119/231/455/903/1351
+// Single rank: with 224 experts and topk 16 every ladder entry is reachable
+// below the protocol maximum (the thresholds land at 119/231/455/903/1351
 // tokens), so the whole ladder is instantiated, and the launch picks among the
 // entries by the upstream heuristic so a single-rank launch stays bit-identical
 // to what DeepGEMM's own Python wrapper would have run.
@@ -375,7 +375,7 @@ int k3_mega_token_alignment(void) { return 384; }
 // (`num_max_tokens_per_rank`). The launch accepts exactly this value — the
 // ring capacities derived from it are kernel template parameters — so slabs
 // are allocated at exactly this size, whatever the executor's live batch is.
-int k3_mega_max_tokens_per_rank(void) { return 4224; }
+int k3_mega_max_tokens_per_rank(void) { return 16896; }
 
 // Whether the AOT matrix carries a kernel for this world (GLOBAL expert count
 // x rank count, situ activation). One definition of the supported set — the

--- a/pegainfer-kernels/csrc/k3/k3_mega_moe_sm100_common.cuh
+++ b/pegainfer-kernels/csrc/k3/k3_mega_moe_sm100_common.cuh
@@ -58,12 +58,18 @@ constexpr int kIntermediate = 3072;
 constexpr int kNumTopk = 16;
 
 // Token capacity one rank's slab and kernel instantiation carry
-// (`num_max_tokens_per_rank`): the chunked-prefill ceiling, 11x the upstream
+// (`num_max_tokens_per_rank`): the chunked-prefill ceiling, 44x the upstream
 // token alignment (`layout::kLCMCandidateBlockM`, 384). This is the ONLY value
 // any launch accepts: the ring capacities derived from it are kernel template
 // parameters, so a slab allocated for any other value addresses the rings
 // wrong. Exported to the Rust side through `k3_mega_max_tokens_per_rank`.
-constexpr int kProtocolMaxTokensPerRank = 4224;
+//
+// 16896 = 4 x the historical 4224 ceiling: a 16k-class chunk lands the MoE
+// GEMMs in their efficient shape range and lets a CP gang swallow a 64k
+// prompt in one superstep at CP4 (16 x 16896 at CP16). The bill is the slab —
+// the rings scale linearly with the protocol max (~6.3 GiB at EP4/224,
+// ~19.6 GiB at EP16/896, measured via `k3_mega_symm_buffer_layout`).
+constexpr int kProtocolMaxTokensPerRank = 16896;
 
 // MXFP4 / activation scale-factor group size along K, and how many such groups
 // pack into one i32 word.

--- a/pegainfer-kernels/src/ops/k3_tilelang.rs
+++ b/pegainfer-kernels/src/ops/k3_tilelang.rs
@@ -46,14 +46,14 @@ pub const K3_BATCH_BUCKETS: [usize; 10] = [1, 2, 4, 8, 16, 32, 48, 64, 96, 128];
 
 /// Prefill chunk buckets: the chunked-prefill step runs the same batched
 /// families at chunk width, whose ceiling is the MegaMoE protocol maximum
-/// (4224 rows). Compiled for every family except `kda_core` — chunks cross
+/// (16896 rows). Compiled for every family except `kda_core` — chunks cross
 /// the KDA recurrence through FlashKDA, so the fused core never sees a
 /// chunk-sized bucket.
-pub const K3_PREFILL_BUCKETS: [usize; 5] = [256, 512, 1024, 2048, 4224];
+pub const K3_PREFILL_BUCKETS: [usize; 7] = [256, 512, 1024, 2048, 4224, 8448, 16896];
 
 /// The largest prefill chunk any configuration can run — the MegaMoE
 /// protocol maximum (`k3_mega_max_tokens_per_rank`).
-pub const K3_MAX_CHUNK: usize = 4224;
+pub const K3_MAX_CHUNK: usize = 16896;
 /// Largest bucket, i.e. the row capacity every reusable buffer should have.
 pub const K3_MAX_BATCH: usize = 128;
 


### PR DESCRIPTION
## What

`kProtocolMaxTokensPerRank` 4224 → 16896 (44× the 384-token alignment; ring capacities are kernel template parameters, so every AOT world re-instantiates). The M1 "mega world >4224" prerequisite, done by going straight to 4×.

- **Single-superstep CP ceiling: 16.9k → 67.5k @CP4** (256k+ @CP16 — the FlashKDA 264k sweep already showed the kernel side is free there). The multi-superstep walk loses most of its motivation at practical lengths.
- **CP1 chunked prefill**: 16k = one mega launch per layer instead of four; the shape sweep's "chunks <8k eat half the MoE GEMM efficiency" region is left behind.
- TileLang prefill bucket ladder gains 8448/16896 (+24s AOT build).

## Cost

The symmetric slab is linear in the protocol max (measured via `k3_mega_symm_buffer_layout`): EP4/224 1.6 → 6.3 GiB, **EP16/896 5.1 → 19.6 GiB per rank**. The full-model EP16 fleet loses ~15 GiB HBM headroom — flagged in `docs/models/k3/cp-lane-design.md` for a re-audit before the next fleet run.

## Production invariant & evidence (pruned 224-expert @EP4, GB300)

- **16k `cp_prefill` gate: bit-for-bit the same answers as the 4224 build** (rel_l2 vs CP1 2.523e-1/4.511e-2, argmax/token unchanged). Chunking is answer-neutral by construction — row-independent GEMMs, lossless bf16↔fp32 FlashKDA state carry across calls, row-local FMHA softmax — and the gate confirms it.
- **64k single-superstep CP4** (impossible under 4224): argmax/token match CP1, rel_l2 9.4e-2/7.0e-2 (bar 0.386); warm wall CP1 13870 ms vs CP4 5006 ms (2.77×).
- **`ep_mega_oracle`**: gate 1 EP4-vs-EP1 **BITWISE** (all 40 tokens, all 163840 logits); gate 2 traffic invariance bitwise.
- **`golden_decode`**: 13/13 serial (`--test-threads 1` per bring-up.md).
- **ttft sweep** (min-of-4): CP1 @16k 2980 → 2870 ms (the single-chunk mega win), CP4 @16k 1003.5 ms unchanged (segments still 4096); 128–8k rungs within noise of the old table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)