### PR TITLE
chore(k3): add checkpoint-gate runner script

### DIFF
--- a/docs/models/k3/bring-up.md
+++ b/docs/models/k3/bring-up.md
@@ -332,7 +332,10 @@ That is 27.6 KB/token against the 1.47 MB/token the expanded `[96×192 K |
 Gates (`pegainfer-k3/tests/paged_kv.rs`, plus the golden suite).
 `scripts/k3_gates.sh` runs the whole checkpoint-backed battery on a tray with
 the invocations below baked in (idle-tray check, prebuilt binaries, per-gate
-logs) — the commands here remain the reference for running one gate by hand:
+logs) — the commands here remain the reference for running one gate by hand.
+Either way the gates load weights through the pinned staged uploader by
+default (`PEGAINFER_K3_WEIGHT_STAGING=0` restores serial pageable mmap; same
+bytes, the whole battery drops to ~3 minutes on a warm page cache):
 
 ```bash
 # Paged gates: page-permutation bitwise, long-context (2048-ctx, 1100 steps,

--- a/docs/models/k3/bring-up.md
+++ b/docs/models/k3/bring-up.md
@@ -329,7 +329,10 @@ That is 27.6 KB/token against the 1.47 MB/token the expanded `[96×192 K |
   and an unmapped (`-1`) entry reads as zero latent, which is exactly the
   zeroed padding row of the old cache.
 
-Gates (`pegainfer-k3/tests/paged_kv.rs`, plus the golden suite):
+Gates (`pegainfer-k3/tests/paged_kv.rs`, plus the golden suite).
+`scripts/k3_gates.sh` runs the whole checkpoint-backed battery on a tray with
+the invocations below baked in (idle-tray check, prebuilt binaries, per-gate
+logs) — the commands here remain the reference for running one gate by hand:
 
 ```bash
 # Paged gates: page-permutation bitwise, long-context (2048-ctx, 1100 steps,

--- a/pegainfer-k3/tests/cp_prefill.rs
+++ b/pegainfer-k3/tests/cp_prefill.rs
@@ -61,6 +61,16 @@ fn rel_l2_bar() -> f64 {
     4e-2 * (layers as f64).sqrt()
 }
 
+/// The gates load through the pinned double-buffer uploader by default —
+/// the same bytes, much faster on a warm page cache.
+/// `PEGAINFER_K3_WEIGHT_STAGING=0` falls back to the serial pageable-mmap
+/// path (e.g. a cold network-filesystem first run). This gate
+/// pays two full-depth loads (the gang world and the CP1 baseline), the
+/// heaviest loads in the battery.
+fn weight_staging() -> bool {
+    std::env::var("PEGAINFER_K3_WEIGHT_STAGING").as_deref() != Ok("0")
+}
+
 /// The prompt length the logits gate runs at (`PEGAINFER_K3_CP_PROMPT`,
 /// default [`MAX_CTX`]).
 fn gate_prompt_ceiling() -> usize {
@@ -85,6 +95,7 @@ fn config() -> K3ExecutorConfig {
     // One decode slot: the gate never decodes, and a slot's KDA state slab is
     // ~1 GiB across the full depth.
     config.max_batch = 1;
+    config.weight_staging = weight_staging();
     config
 }
 

--- a/pegainfer-k3/tests/ep_mega_oracle.rs
+++ b/pegainfer-k3/tests/ep_mega_oracle.rs
@@ -148,6 +148,15 @@ fn checkpoint() -> Option<PathBuf> {
     path.join("config.json").exists().then_some(path)
 }
 
+/// The gates load through the pinned double-buffer uploader by default —
+/// the same bytes, much faster on a warm page cache.
+/// `PEGAINFER_K3_WEIGHT_STAGING=0` falls back to the serial pageable-mmap
+/// path (e.g. a cold network-filesystem first run). Both worlds
+/// see the same setting, so the oracle still differs only in world size.
+fn weight_staging() -> bool {
+    std::env::var("PEGAINFER_K3_WEIGHT_STAGING").as_deref() != Ok("0")
+}
+
 /// Every rank — and the single-rank reference — runs the same geometry, so the
 /// only thing under test is the expert parallelism.
 fn config(fixture: &Fixture) -> K3ExecutorConfig {
@@ -161,7 +170,7 @@ fn config(fixture: &Fixture) -> K3ExecutorConfig {
         // match. (The single-rank mega path does capture; this pins it off so
         // the two differ only in world size.)
         cuda_graph: false,
-        weight_staging: false,
+        weight_staging: weight_staging(),
         moe_transport: K3MoeTransport::MEGA,
     }
 }

--- a/pegainfer-k3/tests/golden_decode.rs
+++ b/pegainfer-k3/tests/golden_decode.rs
@@ -115,6 +115,15 @@ fn device() -> usize {
         .unwrap_or(0)
 }
 
+/// The gates load through the pinned double-buffer uploader by default —
+/// the same bytes, much faster on a warm page cache.
+/// `PEGAINFER_K3_WEIGHT_STAGING=0` falls back to the serial pageable-mmap
+/// path (e.g. a cold network-filesystem first run). The gates'
+/// answers are load-path independent.
+fn weight_staging() -> bool {
+    std::env::var("PEGAINFER_K3_WEIGHT_STAGING").as_deref() != Ok("0")
+}
+
 /// The two routed-expert transports, named for the gate reports.
 const TRANSPORTS: [(&str, K3MoeTransport); 2] = [
     ("mega", K3MoeTransport::MEGA),
@@ -139,7 +148,7 @@ fn executor(
         // chunk widths through `max_batch` (cap 1, cap 8).
         chunk_tokens: max_batch,
         cuda_graph,
-        weight_staging: false,
+        weight_staging: weight_staging(),
         moe_transport,
     };
     Some(
@@ -726,7 +735,7 @@ fn prefill_time_snapshot() {
         // Derived: the widest chunk the transport carries (protocol max).
         chunk_tokens: 0,
         cuda_graph: true,
-        weight_staging: false,
+        weight_staging: weight_staging(),
         moe_transport: K3MoeTransport::MEGA,
     };
     let mut executor =
@@ -833,7 +842,7 @@ fn chunked_prefill_agrees_with_the_per_token_walk_at_depth() {
             num_layers: depth,
             chunk_tokens: max_batch,
             cuda_graph: false,
-            weight_staging: false,
+            weight_staging: weight_staging(),
             moe_transport: K3MoeTransport::MEGA,
         };
         K3Executor::load(&path, device(), 0, 1, config)

--- a/pegainfer-k3/tests/paged_kv.rs
+++ b/pegainfer-k3/tests/paged_kv.rs
@@ -82,6 +82,15 @@ fn device() -> usize {
         .unwrap_or(0)
 }
 
+/// The gates load through the pinned double-buffer uploader by default —
+/// the same bytes, much faster on a warm page cache.
+/// `PEGAINFER_K3_WEIGHT_STAGING=0` falls back to the serial pageable-mmap
+/// path (e.g. a cold network-filesystem first run). The gates'
+/// answers are load-path independent.
+fn weight_staging() -> bool {
+    std::env::var("PEGAINFER_K3_WEIGHT_STAGING").as_deref() != Ok("0")
+}
+
 fn executor(config: K3ExecutorConfig) -> Option<K3Executor> {
     let path = checkpoint()?;
     Some(
@@ -162,7 +171,7 @@ fn page_permutation_leaves_every_logit_bit_identical() {
         num_layers: fixture.num_layers,
         chunk_tokens: 0,
         cuda_graph: false,
-        weight_staging: false,
+        weight_staging: weight_staging(),
         moe_transport: K3MoeTransport::MEGA,
     };
     let Some(mut executor) = executor(config) else {
@@ -200,7 +209,7 @@ fn long_context_decode_is_self_consistent() {
         num_layers: fixture.num_layers,
         chunk_tokens: 0,
         cuda_graph: false,
-        weight_staging: false,
+        weight_staging: weight_staging(),
         moe_transport: K3MoeTransport::MEGA,
     };
     let mut feed = fixture.feed;
@@ -279,7 +288,7 @@ fn dump_forced_replay_logits() {
         num_layers: fixture.num_layers,
         chunk_tokens: 0,
         cuda_graph: false,
-        weight_staging: false,
+        weight_staging: weight_staging(),
         moe_transport: K3MoeTransport::MEGA,
     };
     let Some(mut executor) = executor(config) else {

--- a/pegainfer-k3/tests/spec_verify.rs
+++ b/pegainfer-k3/tests/spec_verify.rs
@@ -66,6 +66,15 @@ fn device() -> usize {
         .unwrap_or(0)
 }
 
+/// The gates load through the pinned double-buffer uploader by default —
+/// the same bytes, much faster on a warm page cache.
+/// `PEGAINFER_K3_WEIGHT_STAGING=0` falls back to the serial pageable-mmap
+/// path (e.g. a cold network-filesystem first run). The gates'
+/// answers are load-path independent.
+fn weight_staging() -> bool {
+    std::env::var("PEGAINFER_K3_WEIGHT_STAGING").as_deref() != Ok("0")
+}
+
 fn executor(num_layers: usize) -> Option<K3Executor> {
     let path = checkpoint()?;
     let config = K3ExecutorConfig {
@@ -75,7 +84,7 @@ fn executor(num_layers: usize) -> Option<K3Executor> {
         num_layers,
         chunk_tokens: 0,
         cuda_graph: false,
-        weight_staging: false,
+        weight_staging: weight_staging(),
         moe_transport: K3MoeTransport::MEGA,
     };
     Some(

--- a/scripts/k3_gates.sh
+++ b/scripts/k3_gates.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Maintainer runner for the Kimi-K3 checkpoint-backed gates.
+#
+# The K3 gates need a real checkpoint and one-to-four otherwise-free GB300s,
+# so CI only compiles them. This script owns their execution on a tray: it
+# refuses a busy tray (shared machines — someone else's job landing mid-suite
+# reads as OOM, not as contention), runs each gate with its documented
+# invocation (golden_decode is serial-only: its parallel default oversubscribes
+# one device with 13 model loads), and archives every log.
+#
+# The host has no cargo: gates run as prebuilt test binaries out of
+# target/release/deps (build in the kernel-lab container first). The newest
+# binary per target is selected; a binary older than HEAD gets a warning, not
+# a refusal, because the tree may be dirty in ways that do not touch K3.
+#
+#   PEGAINFER_K3_TEST_224=<224-expert checkpoint> scripts/k3_gates.sh [filter]
+#
+# Optional environment:
+#   PEGAINFER_K3_NCCL_LIB    directory prepended to LD_LIBRARY_PATH (the
+#                            bare-host NCCL 2.30.7; must contain the
+#                            unversioned libnccl.so symlink — see #810)
+#   PEGAINFER_K3_CP_PROMPT   cp_prefill gate prompt length (default 16384;
+#                            65536 exercises the 64k single superstep)
+#   PEGAINFER_K3_TEST_DSPARK RadixArk drafter dir for the spec_verify draft
+#                            lane gates
+#   K3_GATES_ALLOW_BUSY=1    skip the idle-tray refusal (you own the overlap)
+#   K3_GATES_LOG_DIR         log directory (default /tmp/k3-gates-<timestamp>)
+#
+# A filter runs the subset of manifest entries whose "<target> <gate>" line
+# contains it, e.g. `scripts/k3_gates.sh cp_prefill` or `... oracle`.
+set -uo pipefail
+
+die() { echo "k3 gates: $*" >&2; exit 1; }
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$root" || die "cannot enter the repository root"
+
+# --- the suite ------------------------------------------------------------
+# "<gpus> <target> <gate-or-ALL> [env NAME=VALUE ...]"
+# ALL runs the target's whole --ignored set in one process. Everything runs
+# --test-threads=1: each K3 gate loads a multi-GiB model, and the harness
+# default of one thread per CPU oversubscribes a device (the golden_decode
+# suite is 13 loads).
+MANIFEST=(
+  "1 golden_decode ALL"
+  "1 paged_kv ALL"
+  "1 spec_verify ALL"
+  "4 ep_mega_oracle ep4_mega_matches_ep1_mega env PEGAINFER_K3_LAYERS=4 PEGAINFER_K3_MAX_BATCH=16"
+  "4 ep_mega_oracle ep4_mega_is_invariant_to_peer_traffic env PEGAINFER_K3_LAYERS=4 PEGAINFER_K3_MAX_BATCH=16"
+  "4 cp_prefill cp4_prefill_matches_cp1"
+)
+
+# --- prerequisites --------------------------------------------------------
+[ -n "${PEGAINFER_K3_TEST_224:-}" ] || die "PEGAINFER_K3_TEST_224 is unset"
+[ -d "$PEGAINFER_K3_TEST_224" ] || die "checkpoint $PEGAINFER_K3_TEST_224 does not exist"
+command -v nvidia-smi >/dev/null 2>&1 || die "nvidia-smi is unavailable — run this on the tray"
+
+if [ -n "${PEGAINFER_K3_NCCL_LIB:-}" ]; then
+  [ -e "$PEGAINFER_K3_NCCL_LIB/libnccl.so" ] || die \
+    "$PEGAINFER_K3_NCCL_LIB has no unversioned libnccl.so symlink — cudarc \
+dlopens that name, and falling back to the system NCCL mixes two libraries (#810)"
+  export LD_LIBRARY_PATH="$PEGAINFER_K3_NCCL_LIB${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+
+# Shared trays: Slurm's ledger and the GPUs' actual occupancy are separate
+# books, so the only trustworthy check is nvidia-smi on the spot. Residual
+# memory means a parked job that can wake mid-suite.
+busy=$(nvidia-smi --query-gpu=index,memory.used --format=csv,noheader,nounits |
+  awk -F', *' '$2 > 1024 { printf "  GPU %s: %s MiB\n", $1, $2 }')
+if [ -n "$busy" ] && [ "${K3_GATES_ALLOW_BUSY:-0}" != 1 ]; then
+  die "the tray is not idle (K3_GATES_ALLOW_BUSY=1 to override):"$'\n'"$busy"
+fi
+
+# --- binary discovery -----------------------------------------------------
+# Newest executable per target. The hash suffix changes with every rebuild
+# and stale siblings accumulate, so "the" binary is a moving name.
+find_binary() {
+  local target=$1 found
+  found=$(find target/release/deps -maxdepth 1 -name "$target-*" ! -name '*.d' \
+    -type f -perm -u+x -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2)
+  [ -n "$found" ] || die \
+    "no $target binary under target/release/deps — build it in kernel-lab: \
+PEGAINFER_CUDA_SM=103 cargo test --release -p pegainfer-k3 --no-run"
+  echo "$found"
+}
+
+head_epoch=$(git log -1 --format=%ct 2>/dev/null || echo 0)
+
+# --- selection ------------------------------------------------------------
+filter=${1:-}
+selected=()
+for entry in "${MANIFEST[@]}"; do
+  [ -z "$filter" ] || [[ $entry == *"$filter"* ]] || continue
+  selected+=("$entry")
+done
+[ ${#selected[@]} -gt 0 ] || die "filter ${filter:-<none>} selected no gate"
+
+log_dir=${K3_GATES_LOG_DIR:-/tmp/k3-gates-$(date +%Y%m%d-%H%M%S)}
+mkdir -p "$log_dir" || die "cannot create log directory $log_dir"
+
+echo "k3 gates: source $(git rev-parse HEAD)$([ -n "$(git status --porcelain)" ] && echo ' (dirty)')"
+echo "k3 gates: checkpoint $PEGAINFER_K3_TEST_224"
+echo "k3 gates: logs in $log_dir"
+echo "k3 gates: ${#selected[@]} selected of ${#MANIFEST[@]} in the manifest"
+
+# --- execution: one gate per process, serialized --------------------------
+completed=0
+failed=()
+for entry in "${selected[@]}"; do
+  read -r gpus target gate rest <<<"$entry"
+  binary=$(find_binary "$target") || exit 1
+  if [ "$(stat -c %Y "$binary")" -lt "$head_epoch" ]; then
+    echo "k3 gates: WARNING $binary is older than HEAD — rebuild if K3 changed"
+  fi
+  gate_env=()
+  [ "${rest:-}" = "" ] || { read -r _env_kw envs <<<"$rest"; read -ra gate_env <<<"$envs"; }
+  args=(--ignored --test-threads=1 --nocapture)
+  [ "$gate" = ALL ] || args=("$gate" --exact "${args[@]}")
+  label="$target/${gate/ALL/all}"
+  log="$log_dir/${label//\//-}.log"
+  echo "--- $label (${gpus} GPU)"
+  if env "${gate_env[@]}" "$binary" "${args[@]}" >"$log" 2>&1; then
+    tail -3 "$log" | sed 's/^/    /'
+    completed=$((completed + 1))
+  else
+    echo "k3 gates: FAILED $label — full log: $log"
+    tail -15 "$log" | sed 's/^/    /'
+    failed+=("$label")
+  fi
+done
+
+echo "k3 gates: selected ${#selected[@]}, completed $completed, failed ${#failed[@]}"
+if [ ${#failed[@]} -gt 0 ]; then
+  printf 'k3 gates: FAILED %s\n' "${failed[@]}"
+  exit 1
+fi
+echo "k3 gates: all selected gates completed"

--- a/scripts/k3_gates.sh
+++ b/scripts/k3_gates.sh
@@ -16,6 +16,11 @@
 #   PEGAINFER_K3_TEST_224=<224-expert checkpoint> scripts/k3_gates.sh [filter]
 #
 # Optional environment:
+#   PEGAINFER_K3_WEIGHT_STAGING  the gates load weights through the pinned
+#                            double-buffer uploader by default (#964) — same
+#                            bytes, ~6x faster full-depth loads on a warm page
+#                            cache. Set 0 for the serial pageable-mmap path,
+#                            e.g. on a cold network-filesystem first run.
 #   PEGAINFER_K3_NCCL_LIB    directory prepended to LD_LIBRARY_PATH (the
 #                            bare-host NCCL 2.30.7; must contain the
 #                            unversioned libnccl.so symlink — see #810)


### PR DESCRIPTION
## What

`scripts/k3_gates.sh` — a maintainer runner for the K3 checkpoint-backed gate battery (golden_decode / paged_kv / spec_verify on 1 GPU, the two EP4 mega oracle gates and the CP4 prefill gate on 4 GPUs) — plus, on top of #964, the gate tests now load weights through the pinned staged uploader by default.

CI only compiles these gates; running them means reassembling five documented invocations by hand on a shared tray, and that hand assembly is where the mistakes live.

## Why a script

- **Busy tray reads as OOM.** Shared GB300 trays get jobs landing mid-suite; the Slurm ledger and actual GPU occupancy are separate books. The runner refuses a non-idle tray (`nvidia-smi` on the spot, >1 GiB used on any device; `K3_GATES_ALLOW_BUSY=1` overrides).
- **Parallel harness default oversubscribes the device.** golden_decode is 13 model loads; the Rust harness default of one thread per CPU runs them concurrently on one GPU and tips over. Every invocation is forced `--test-threads=1`.
- **NCCL double-load (#810).** `PEGAINFER_K3_NCCL_LIB` is validated to contain the unversioned `libnccl.so` symlink before it is prepended to `LD_LIBRARY_PATH`.
- **The host has no cargo.** Gates run as prebuilt binaries out of `target/release/deps`; the runner picks the newest per target and warns (not refuses) when it predates HEAD.

A filter argument runs a subset (`k3_gates.sh oracle`, `k3_gates.sh cp_prefill`); logs are archived one file per gate.

## Staged gate loads (on top of #964)

The battery's wall clock is dominated by model loads. Every gate test now reads `PEGAINFER_K3_WEIGHT_STAGING` and defaults to the pinned double-buffer uploader; `0` restores serial pageable mmap (cold network-filesystem first runs). Same bytes either way — the bitwise gates hold unchanged.

Same-tray A/B (GB300, warm page cache):

| Gate | serial mmap | staged | speedup |
| --- | ---: | ---: | ---: |
| golden_decode (13 tests) | 111.3 s | 54.7 s | 2.03× |
| cp_prefill 16k gate | 56.2 s | 29.3 s | 1.92× |

Staged ran *before* serial in both pairs, so the serial arm had the warmer cache — the ratios are conservative.

## Evidence

- Full battery green end-to-end through the runner in ~186 s: golden 13/13, paged_kv 3/3, spec_verify 6/6, both EP oracle gates (bitwise), CP4 16k gate.
- Busy-tray refusal path exercised live.
- `bash -n` clean.

`docs/models/k3/bring-up.md` gains a pointer to the runner and the staging default; the hand-run commands there remain the reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)