### PR TITLE
perf(k3): parallelize staged weight startup

### DIFF
--- a/docs/models/k3/bring-up.md
+++ b/docs/models/k3/bring-up.md
@@ -27,8 +27,12 @@ layers served by **FlashMLA's SM100 dense FMHA** over kv_b-expanded K/V in
 fixed workspace (vLLM's recipe; the paged latent stays the only persistent
 storage). Chunk steps skip the batched epilogue — the boundary token is
 sampled once, at one row, after the final chunk. 6x-247x TTFT over per-token
-stepping at the 4-layer snapshot (2048 tokens: 6377 → 25.8 ms). Next: CUDA
-graphs over the EP4 fused path, kv-store integration.
+stepping at the 4-layer snapshot (2048 tokens: 6377 → 25.8 ms). Warm-cache
+startup now has one opt-in fast path combining pinned double-buffer upload with
+concurrent local-rank load/build; it cuts the full-depth EP4 process start →
+HTTP ready **126.27 → 22.08 s (5.72x)**, and the same rank-local path serves
+the full 896-expert EP16 fleet. Next: CUDA graphs over the EP4 fused path,
+kv-store integration.
 
 Last touched: 2026-08
 
@@ -46,6 +50,58 @@ multimodal wrapper (`KimiK3ForConditionalGeneration`, text tower under
 Two published checkpoints differ only in `num_experts` (224 vs 896). The
 224-expert variant at EP4 (56 experts/rank) is shape-isomorphic to the full
 model at EP16 — that is the development vehicle.
+
+## Weight-loading startup
+
+The K3 loader already shared GLM5.2's rank-resident load plan, shard-at-a-time
+mmap lifetime events, expert-major placement, and pinned double-buffer
+implementation. The missing production wiring was above that layer: the
+pinned uploader was always passed `false`, and a process completed one local
+rank's weight load, model build, executor allocation, and optional DSpark load
+before starting the next rank. Mirroring GLM5.2, one production switch enables
+the complete fast path:
+
+- `--k3-weight-staging`: load/build every rank hosted by this process
+  concurrently, with two 32 MiB pinned slots and four persistent fill workers
+  per active rank loader. It operates on the hosted `--k3-ranks` slice, not
+  the global EP width, so EP4/8/16/32/64 use the same path and map their local
+  ranks to devices 0..N.
+
+The 2026-08-25 same-binary EP4 A/B used the full 93-layer 224-expert
+checkpoint (189.08 GiB and 33,372 tensors per rank), four GB300s, warm page
+cache, one decode slot/rank, and a real HTTP completion after readiness. All
+four arms produced the same completion bytes:
+
+| Local-rank scheduling | Uploader | Local critical path | HTTP ready | Critical-path speedup |
+| --- | --- | ---: | ---: | ---: |
+| serial | pageable mmap | 125.16 s | 126.27 s | 1.00x |
+| serial | pinned double buffer | 47.15 s | 48.12 s | 2.65x |
+| parallel | pageable mmap | 44.54 s | 46.11 s | 2.81x |
+| parallel | pinned double buffer | **20.96 s** | **22.08 s** | **5.97x** |
+
+In the winning arm, the four rank weight loads were 15.96--18.58 s; model
+build was below one second/rank. This rules out the per-MoE-layer weight
+repack syncs as the current startup bottleneck: source-page materialization
+and H2D dominate.
+
+The CPU-affinity boundary is part of this result. A first Slurm run allocated
+the whole 144-core node but left `CPUs/Task=1`, pinning the process and all 16
+fill workers to CPU 0; the same parallel+pinned arm then took 100.61 s. The
+correct launch used `--cpus-per-task=144 --cpu-bind=none`. Startup now warns
+when the process affinity exposes fewer CPUs than the selected rank-loader +
+pinned-fill teams can use, rather than silently making a starved run look like
+a loader regression.
+
+The EP-width invariant was then closed on the full 896-expert model at EP16:
+four processes each hosted four ranks with parallel+pinned loading, all four
+HTTP endpoints reached ready, and the same prompt returned byte-identical
+text from every endpoint. Forced-cold/partially resident node critical paths
+were 134--194 s. On the immediate restart, three nodes whose selected pages
+survived reached 18.60/23.73/29.20 s; one node whose selected pages did not
+survive took 198.65 s despite a large aggregate page cache. Therefore the fast
+path remains opt-in: changing the default needs residency detection over
+the actual rank load plan (for example `mincore`), not a host-level free/cache
+memory heuristic.
 
 ## Decisions and why
 

--- a/pegainfer-k3/src/executor/mod.rs
+++ b/pegainfer-k3/src/executor/mod.rs
@@ -71,6 +71,7 @@ mod paged_kv;
 
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Instant;
 
 use anyhow::Context;
 use anyhow::Result;
@@ -185,6 +186,10 @@ pub struct K3ExecutorConfig {
     pub chunk_tokens: usize,
     /// Capture and replay the step, rather than launching it eagerly.
     pub cuda_graph: bool,
+    /// Stage checkpoint bytes through two pinned host buffers, overlapping
+    /// host fills with H2D DMA. Intended for warm-page-cache starts; cold
+    /// network-filesystem loads can prefer the direct pageable path.
+    pub weight_staging: bool,
     /// Which kernel runs the routed experts. Production is always
     /// [`K3MoeTransport::MEGA`]; see that type for why the alternative exists
     /// and why it is not selectable from a serving configuration.
@@ -242,6 +247,7 @@ impl Default for K3ExecutorConfig {
             num_layers: K3_LAYERS,
             chunk_tokens: 0,
             cuda_graph: true,
+            weight_staging: false,
             moe_transport: K3MoeTransport::MEGA,
         }
     }
@@ -455,6 +461,8 @@ impl K3Executor {
         config: K3ExecutorConfig,
         rendezvous: Option<Arc<K3EpRendezvous>>,
     ) -> Result<Self> {
+        let startup_started = Instant::now();
+        let plan_started = Instant::now();
         probe_config_json(&read_config(model_path)?)
             .with_context(|| format!("validate the K3 config at {}", model_path.display()))?;
         let manifest = K3WeightManifest::from_model_dir(model_path)?;
@@ -470,16 +478,37 @@ impl K3Executor {
         // the rest, but not before they are resident, and at low expert
         // parallelism a whole rank does not fit on one device.
         let bundle = manifest.rank_load_bundle_for_layers(rank, topo, config.num_layers)?;
+        let plan_secs = plan_started.elapsed().as_secs_f64();
+
+        let context_started = Instant::now();
         let gpu = K3RankGpuContext::new(device_ordinal)?;
         let ctx = gpu.device_context()?;
-        let loaded = load_rank_weights_to_gpu(&gpu, model_path, &bundle, false)?;
+        let context_secs = context_started.elapsed().as_secs_f64();
+
+        let weights_started = Instant::now();
+        let loaded = load_rank_weights_to_gpu(&gpu, model_path, &bundle, config.weight_staging)?;
+        let weights_secs = weights_started.elapsed().as_secs_f64();
         let form = if config.moe_transport.is_mega() {
             K3ExpertBankForm::Mega
         } else {
             K3ExpertBankForm::MaskedChain
         };
+        let model_started = Instant::now();
         let model = K3RankModel::build(&ctx, loaded.weights, topo, rank, config.num_layers, form)?;
-        Self::new(gpu, ctx, model, config, rendezvous)
+        let model_secs = model_started.elapsed().as_secs_f64();
+
+        let executor_started = Instant::now();
+        let executor = Self::new(gpu, ctx, model, config, rendezvous)?;
+        let executor_secs = executor_started.elapsed().as_secs_f64();
+        info!(
+            "K3 rank {rank} startup profile: total={:.2}s, plan={plan_secs:.2}s, \
+             cuda_context={context_secs:.2}s, weights={weights_secs:.2}s, \
+             model_build={model_secs:.2}s, executor_build={executor_secs:.2}s, \
+             weight_staging={}",
+            startup_started.elapsed().as_secs_f64(),
+            config.weight_staging,
+        );
+        Ok(executor)
     }
 
     /// Wrap an already-built rank model.

--- a/pegainfer-k3/src/model_line.rs
+++ b/pegainfer-k3/src/model_line.rs
@@ -3,11 +3,15 @@
 //! and launch.
 
 use std::collections::BTreeSet;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Instant;
 
 use anyhow::Context as _;
 use clap::Args as ClapArgs;
 use clap::FromArgMatches;
 use log::info;
+use log::warn;
 use pegainfer_frontend::engine::LaunchedEngine;
 use pegainfer_frontend::model_line::CliError;
 use pegainfer_frontend::model_line::LaunchContext;
@@ -25,6 +29,7 @@ use crate::executor::ep::K3EpRendezvous;
 use crate::scheduler::K3CpGang;
 use crate::scheduler::K3CpServing;
 use crate::scheduler::K3SchedulerConfig;
+use crate::weights::K3_WEIGHT_FILL_THREADS;
 
 pub static MODEL_LINE: K3Line = K3Line;
 
@@ -72,6 +77,12 @@ struct K3Cli {
     /// over the rack-wide NVLink domain).
     #[arg(long)]
     k3_rendezvous: Option<String>,
+
+    /// Load hosted K3 ranks concurrently and stage checkpoint bytes through
+    /// pinned double buffers. This can substantially accelerate
+    /// warm-page-cache loads; leave off for cold network-filesystem starts.
+    #[arg(long)]
+    k3_weight_staging: bool,
 }
 
 /// Parse a `start..end` rank range.
@@ -253,12 +264,18 @@ impl ModelLine for K3Line {
         let ep_size = ep_size(&cli)?;
         let ranks = local_ranks(&cli, ep_size)?;
         let eos_token_ids = eos_token_ids(ctx.config);
-        let config = K3ExecutorConfig::default().from_env().for_ep(ep_size);
+        let mut config = K3ExecutorConfig::default().from_env().for_ep(ep_size);
+        config.weight_staging = cli.k3_weight_staging;
+        warn_if_loader_cpu_starved(ranks.len(), config.weight_staging);
         info!(
             "K3 engine starting: ep_size={ep_size}, ranks={ranks:?}, \
              eos_token_ids={eos_token_ids:?}, slots={}, ctx={}, layers={}, cuda_graph={}, \
-             moe=mega",
-            config.max_batch, config.max_ctx, config.num_layers, config.cuda_graph
+             moe=mega, weight_staging={}",
+            config.max_batch,
+            config.max_ctx,
+            config.num_layers,
+            config.cuda_graph,
+            config.weight_staging,
         );
         // One executor per EP rank this process hosts, on devices
         // 0..ranks.len(). A single-rank run honours --device-ordinal, which
@@ -279,31 +296,26 @@ impl ModelLine for K3Line {
                 Some(K3EpRendezvous::fleet(ep_size, ranks.clone(), addr.clone())?)
             }
         };
-        let mut executors = Vec::with_capacity(ranks.len());
-        for (device, rank) in ranks.clone().enumerate() {
-            let device = if ep_size == 1 {
-                ctx.shared.device_ordinal
+        let load_started = Instant::now();
+        let executors = load_rank_executors(
+            ctx.model_path,
+            ctx.shared.dflash_draft_model_path.as_deref(),
+            ctx.shared.device_ordinal,
+            ranks.clone(),
+            ep_size,
+            config,
+            rendezvous.as_ref(),
+        )?;
+        info!(
+            "K3 local rank startup complete: ranks={}, mode={}, critical_path={:.2}s",
+            executors.len(),
+            if config.weight_staging {
+                "parallel"
             } else {
-                device
-            };
-            let executor = match rendezvous.clone() {
-                Some(rendezvous) => {
-                    K3Executor::load_ep(ctx.model_path, device, rank, config, rendezvous)
-                }
-                None => K3Executor::load(ctx.model_path, device, rank, ep_size, config),
-            };
-            let mut executor = executor.with_context(|| {
-                format!("loading K3 rank {rank} of {ep_size} onto device {device}")
-            })?;
-            // The DSpark draft lane is rank-local and collective-free, so
-            // arming it per rank adds no cross-rank coupling.
-            if let Some(draft_path) = &ctx.shared.dflash_draft_model_path {
-                executor
-                    .load_dspark(draft_path)
-                    .with_context(|| format!("arming the K3 dspark draft lane on rank {rank}"))?;
-            }
-            executors.push(executor);
-        }
+                "serial"
+            },
+            load_started.elapsed().as_secs_f64(),
+        );
         let dspark_armed = ctx.shared.dflash_draft_model_path.is_some();
         let chunk_tokens = executors
             .first()
@@ -321,6 +333,137 @@ impl ModelLine for K3Line {
             ),
         ))
     }
+}
+
+fn warn_if_loader_cpu_starved(local_ranks: usize, weight_staging: bool) {
+    let loader_threads = if weight_staging { local_ranks } else { 1 };
+    let fill_threads = if weight_staging {
+        K3_WEIGHT_FILL_THREADS * loader_threads
+    } else {
+        0
+    };
+    let wanted = loader_threads + fill_threads;
+    let available = std::thread::available_parallelism().map_or(1, usize::from);
+    if available < wanted {
+        warn!(
+            "K3 weight startup is CPU-starved: affinity exposes {available} CPU(s), but \
+             weight_staging={weight_staging} can use {wanted} \
+             ({loader_threads} rank loader(s) + {fill_threads} pinned-fill worker(s)); \
+             widen the process CPU affinity or expect serialized host fills"
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn load_rank_executors(
+    model_path: &Path,
+    draft_path: Option<&Path>,
+    single_rank_device: usize,
+    ranks: std::ops::Range<usize>,
+    ep_size: usize,
+    config: K3ExecutorConfig,
+    rendezvous: Option<&Arc<K3EpRendezvous>>,
+) -> anyhow::Result<Vec<K3Executor>> {
+    let placements = rank_placements(single_rank_device, ranks, ep_size);
+
+    if !config.weight_staging || placements.len() == 1 {
+        return placements
+            .into_iter()
+            .map(|(device, rank)| {
+                load_rank_executor(
+                    model_path,
+                    draft_path,
+                    device,
+                    rank,
+                    ep_size,
+                    config,
+                    rendezvous.cloned(),
+                )
+            })
+            .collect();
+    }
+
+    std::thread::scope(|scope| {
+        let handles = placements
+            .into_iter()
+            .map(|(device, rank)| {
+                let rendezvous = rendezvous.cloned();
+                (
+                    rank,
+                    scope.spawn(move || {
+                        load_rank_executor(
+                            model_path, draft_path, device, rank, ep_size, config, rendezvous,
+                        )
+                    }),
+                )
+            })
+            .collect::<Vec<_>>();
+        handles
+            .into_iter()
+            .map(|(rank, handle)| {
+                handle
+                    .join()
+                    .map_err(|_| anyhow::anyhow!("K3 rank {rank} loader thread panicked"))?
+            })
+            .collect()
+    })
+}
+
+fn rank_placements(
+    single_rank_device: usize,
+    ranks: std::ops::Range<usize>,
+    ep_size: usize,
+) -> Vec<(usize, usize)> {
+    ranks
+        .enumerate()
+        .map(|(local_device, rank)| {
+            let device = if ep_size == 1 {
+                single_rank_device
+            } else {
+                local_device
+            };
+            (device, rank)
+        })
+        .collect()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn load_rank_executor(
+    model_path: &Path,
+    draft_path: Option<&Path>,
+    device: usize,
+    rank: usize,
+    ep_size: usize,
+    config: K3ExecutorConfig,
+    rendezvous: Option<Arc<K3EpRendezvous>>,
+) -> anyhow::Result<K3Executor> {
+    let started = Instant::now();
+    let target_started = Instant::now();
+    let executor = match rendezvous {
+        Some(rendezvous) => K3Executor::load_ep(model_path, device, rank, config, rendezvous),
+        None => K3Executor::load(model_path, device, rank, ep_size, config),
+    };
+    let mut executor = executor
+        .with_context(|| format!("loading K3 rank {rank} of {ep_size} onto device {device}"))?;
+    let target_secs = target_started.elapsed().as_secs_f64();
+
+    let draft_started = Instant::now();
+    if let Some(draft_path) = draft_path {
+        // The DSpark draft lane is rank-local and collective-free, so arming
+        // it per rank adds no cross-rank coupling.
+        executor
+            .load_dspark(draft_path)
+            .with_context(|| format!("arming the K3 dspark draft lane on rank {rank}"))?;
+    }
+    let draft_secs = draft_path
+        .is_some()
+        .then(|| draft_started.elapsed().as_secs_f64());
+    info!(
+        "K3 rank {rank} complete startup: total={:.2}s, target={target_secs:.2}s, dspark={}",
+        started.elapsed().as_secs_f64(),
+        draft_secs.map_or_else(|| "off".to_owned(), |secs| format!("{secs:.2}s")),
+    );
+    Ok(executor)
 }
 
 /// Arm the CP prefill lane from `PEGAINFER_K3_CP` (the CP width — must equal
@@ -507,6 +650,26 @@ mod tests {
             let partitions = partitions_for(&["pegainfer", "--k3-ep-size", &ep_size.to_string()])
                 .expect("a supported EP width should validate");
             assert_eq!(partitions, *ep_size);
+        }
+    }
+
+    #[test]
+    fn weight_staging_flag_is_k3_owned() {
+        let partitions = partitions_for(&["pegainfer", "--k3-ep-size", "4", "--k3-weight-staging"])
+            .expect("K3 should accept its weight staging flag");
+        assert_eq!(partitions, 4);
+    }
+
+    #[test]
+    fn every_ep_width_maps_hosted_ranks_to_local_device_ordinals() {
+        assert_eq!(rank_placements(7, 0..1, 1), vec![(7, 0)]);
+        for ep_size in [4, 8, 16, 32, 64] {
+            let start = ep_size - 4;
+            assert_eq!(
+                rank_placements(7, start..ep_size, ep_size),
+                vec![(0, start), (1, start + 1), (2, start + 2), (3, start + 3)],
+                "EP{ep_size}",
+            );
         }
     }
 

--- a/pegainfer-k3/src/weights.rs
+++ b/pegainfer-k3/src/weights.rs
@@ -70,6 +70,7 @@ pub(crate) use load::K3ExpertLayerRegions;
 pub(crate) use load::K3RankGpuWeights;
 #[allow(unused_imports)]
 pub(crate) use load::load_rank_weights_to_gpu;
+pub(crate) use staging::FILL_THREADS as K3_WEIGHT_FILL_THREADS;
 
 const K3_WEIGHT_INDEX: &str = "model.safetensors.index.json";
 const K3_CONFIG: &str = "config.json";

--- a/pegainfer-k3/src/weights/staging.rs
+++ b/pegainfer-k3/src/weights/staging.rs
@@ -28,7 +28,7 @@ use super::K3RankGpuContext;
 const STAGE_BYTES: usize = 32 << 20;
 /// Persistent host memcpy workers per rank; retaining them avoids repeated
 /// thread creation across the tens of thousands of uploads a rank performs.
-const FILL_THREADS: usize = 4;
+pub(crate) const FILL_THREADS: usize = 4;
 /// MXFP4 expert scale tensors are only a few hundred KiB; channel fan-out costs
 /// more than their memcpy. Large projections still use all persistent workers.
 const PARALLEL_FILL_MIN_BYTES: usize = 1 << 20;

--- a/pegainfer-k3/tests/ep_mega_oracle.rs
+++ b/pegainfer-k3/tests/ep_mega_oracle.rs
@@ -161,6 +161,7 @@ fn config(fixture: &Fixture) -> K3ExecutorConfig {
         // match. (The single-rank mega path does capture; this pins it off so
         // the two differ only in world size.)
         cuda_graph: false,
+        weight_staging: false,
         moe_transport: K3MoeTransport::MEGA,
     }
 }

--- a/pegainfer-k3/tests/golden_decode.rs
+++ b/pegainfer-k3/tests/golden_decode.rs
@@ -139,6 +139,7 @@ fn executor(
         // chunk widths through `max_batch` (cap 1, cap 8).
         chunk_tokens: max_batch,
         cuda_graph,
+        weight_staging: false,
         moe_transport,
     };
     Some(
@@ -725,6 +726,7 @@ fn prefill_time_snapshot() {
         // Derived: the widest chunk the transport carries (protocol max).
         chunk_tokens: 0,
         cuda_graph: true,
+        weight_staging: false,
         moe_transport: K3MoeTransport::MEGA,
     };
     let mut executor =
@@ -831,6 +833,7 @@ fn chunked_prefill_agrees_with_the_per_token_walk_at_depth() {
             num_layers: depth,
             chunk_tokens: max_batch,
             cuda_graph: false,
+            weight_staging: false,
             moe_transport: K3MoeTransport::MEGA,
         };
         K3Executor::load(&path, device(), 0, 1, config)

--- a/pegainfer-k3/tests/paged_kv.rs
+++ b/pegainfer-k3/tests/paged_kv.rs
@@ -162,6 +162,7 @@ fn page_permutation_leaves_every_logit_bit_identical() {
         num_layers: fixture.num_layers,
         chunk_tokens: 0,
         cuda_graph: false,
+        weight_staging: false,
         moe_transport: K3MoeTransport::MEGA,
     };
     let Some(mut executor) = executor(config) else {
@@ -199,6 +200,7 @@ fn long_context_decode_is_self_consistent() {
         num_layers: fixture.num_layers,
         chunk_tokens: 0,
         cuda_graph: false,
+        weight_staging: false,
         moe_transport: K3MoeTransport::MEGA,
     };
     let mut feed = fixture.feed;
@@ -277,6 +279,7 @@ fn dump_forced_replay_logits() {
         num_layers: fixture.num_layers,
         chunk_tokens: 0,
         cuda_graph: false,
+        weight_staging: false,
         moe_transport: K3MoeTransport::MEGA,
     };
     let Some(mut executor) = executor(config) else {

--- a/pegainfer-k3/tests/spec_verify.rs
+++ b/pegainfer-k3/tests/spec_verify.rs
@@ -75,6 +75,7 @@ fn executor(num_layers: usize) -> Option<K3Executor> {
         num_layers,
         chunk_tokens: 0,
         cuda_graph: false,
+        weight_staging: false,
         moe_transport: K3MoeTransport::MEGA,
     };
     Some(


### PR DESCRIPTION
## Description

Wire K3's existing pinned double-buffer uploader into the serving path and load every rank hosted by a process concurrently.

The public surface mirrors GLM5.2: one opt-in `--k3-weight-staging` flag enables the complete warm-cache fast path. Without it, K3 keeps the original serial pageable-mmap behavior for cold network-filesystem starts.

The implementation is independent of global EP width: concurrency is over the process-local `--k3-ranks` slice, with local devices mapped as 0..N. It also warns when CPU affinity cannot feed the selected rank-loader and pinned-fill worker teams.

Warm-cache full-depth EP4 A/B (224-expert development checkpoint, four GB300s, real completion after readiness):

| Path | Local critical path | HTTP ready |
| --- | ---: | ---: |
| serial + pageable mmap | 125.16 s | 126.27 s |
| parallel + pinned staging | **20.96 s** | **22.08 s** |

That is 5.97x on the local critical path and 5.72x process-to-ready. A full 896-expert EP16 fleet also reached ready on all four endpoints and returned byte-identical completions.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project (see `docs/conventions/coding-style.md`).
- [x] I have performed a self-review of my own code.
- [x] I have formatted my commits according to Commitizen conventions.
- [x] I have run the local test suite and all tests pass (see `CLAUDE.md`).

Validation on current `main` (including #962):

- `cargo fmt --all -- --check`
- `cargo test --release -p pegainfer-k3 --lib model_line` (16 passed)
- `cargo test --release -p pegainfer-k3 --tests --no-run`
- `cargo build --release -p pegainfer-server --no-default-features --features k3`
