### PR TITLE
feat(k3): cross-process CP whale gang — fleet-wide long-prompt prefill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,15 @@ HTTP Request → vLLM frontend → EngineHandle → per-model scheduler/executor
 1. Compiles `pegainfer-kernels/csrc/*.cu` with nvcc (auto-detects GPU SM targets)
 2. Feature-gated codegen: `qwen35` runs Triton AOT via `pegainfer-kernels/tools/triton/gen_triton_aot.py`; `kimi-k2` adds MLA/MoE/Marlin CUDA; `glm52` adds MLA/MoE/FP8 CUDA plus TileLang sparse-MLA codegen on sm_90a
 
+## EP Free-Running Discipline
+
+Canonical doc: `docs/models/glm52/free-running-dp.md` (K3's gang lane follows it). Invariants — violating any of these is a deadlock design:
+
+- **No rank ever stops or waits.** Every engine loop runs unconditionally at full speed; idle ranks step with padding rows. Any quiet wait (condvar, sleep-poll) inside EP coordination is a bug, and the fleet is never asleep, so never design "wake up" or "pump until X" steps.
+- **The per-step collective chain is fixed** — no conditional collectives. Skipping work happens inside kernels via zero-load padding entry, never by host negotiation.
+- **The launch count is the global clock** (pairing pins all ranks within ±1 launch). Coordination means agreeing ahead of time on *what step N contains*, never "wait until everyone is ready".
+- **Padding rows are protocol surface**: their bytes reach peers, so every dummy-row input must be constructively deterministic.
+
 ---
 
 # AI-Assisted Contributions

--- a/docs/models/k3/cp-lane-design.md
+++ b/docs/models/k3/cp-lane-design.md
@@ -527,16 +527,36 @@ admits 的最大 2 的幂：粗梯子 ≈ CP4 @ 8k–16k / CP8 @ 16k–32k / CP1
 (M,D)∘(M',D') = (MM', DM'+D') 可结合 → Blelloch 并行前缀扫描 log₂CP 轮是
 现成后手；按拍板**先 naive 实现，profile 后再决定**。
 
-数据面（GPU 阶段）：CUDA event 是进程局部的，跨机 four-beat 协议换成
-doorbell（`cuStreamWriteValue32/WaitValue32` 打在 fabric 映射的 flag 上，
-mega kernel 内已用同一技术）；CP scratch 一次性分配指针稳定，fabric handle
-在 gang 形成时一次交换。
+**Scheduler 接线（`a474f7f6`）**：每步 `serve_whale` 在 launch boundary 干三
+件事——drain 收件箱回 Gather、恰在 committed L 进 `prefill_whale`、给本步一个
+`may_prefill` 判决（armed/committed 期间只许 decode，count 恰好每步 +1，正是
+arming 契约的 scheduler 半边）。poster 一次只挂一头（cancel 配对因此平凡；
+slot 在 post 时刻就预留，commit 到达永远有座）；宽度拒绝/超时 Cancel →
+下一个非受限 launch 本地 prefill 兜底。Mock 舰队测试（真 scheduler ×
+LocalWhaleHub × 假 executor 计 launch 配对）钉住：全 gang 同一 count 入场、
+poster 恰为 CP 末位持 slot、gang 外 rank 全程不知情、双 whale（跨 rank 与
+同 rank 排队）串到两个不同 superstep、短 prompt 走本地。
+
+**数据面（`b2091501`）**：CUDA event 与 pool 指针都活不过进程边界，换成
+MegaMoE 同款基底。每 rank 的 CP 发布面（halo tail、KDA (M,D)、MLA
+latent/rope）整体挪进一块 fabric slab；whale hub 启动时加一轮 slab
+allgather（64 字节 handle × world，兼作 fleet 启动 barrier，对齐 ep.rs
+bootstrap 语义），每进程 import 一次全表。four-beat 协议原样翻译成
+doorbell：远端 `cuStreamWriteValue64` 宣布、本地 `cuStreamWaitValue64/GEQ`
+等待——等待永远在本 rank 自己的内存上，远端只有 NVLink store，superstep 内
+host 零同步。doorbell 值全由 rendezvous 推导（`(seq+1)*4096 + window`）：
+seq 严格递增 + 每 superstep 窗口数固定 ⇒ 值跨 whale 单调，gang 轮换不需要
+任何 host 协商（flag 槽按 global rank 索引）。forward 路径零改动：
+`K3CpScratch` 换 `K3CpSyncHandle`（Local/Fleet 枚举）分发三个交换窗口，
+`prefill_whale` 与 `prefill_cp` 共享同一 superstep 主体（whale 用 leveled
+分段）。`PEGAINFER_K3_WHALE=<addr>` 一个变量拉起全部（rank0 进程 host
+sequencer；端口选 <32768 避 ephemeral 坑）；`PEGAINFER_K3_WHALE_MIN` 准入
+下限默认 4096。与 `PEGAINFER_K3_CP`、dspark 互斥。
 
 ## Next action
 
-M1 后半剩余：whale 接入 scheduler（每个 launch boundary 询 `at_launch`，含
-chunk 边界；clearance 约束多 launch 操作）→ CP scratch fabric 化 + doorbell
-交换 → CP8@2-tray / CP16@4-tray pruned 门禁 → 256k 单 superstep 门禁 →
-**验收：full 896@EP16 对 vLLM TP16-MNNVL 重赛 8k/16k/64k/256k**。EP16 全量下
-19.6 GiB slab 的 HBM 账实测。次优先：FMHA 条带化配段、前端固定截距
-（132 vs 59 ms @122 tokens）。
+M1 后半剩余（代码全落地，进入真机阶段）：CP8@2-tray pruned EP8 门禁（首个
+真 doorbell/fabric 冒烟）→ CP16@4-tray pruned EP16 → 256k 单 superstep 门禁
+→ **验收：full 896@EP16 对 vLLM TP16-MNNVL 重赛 8k/16k/64k/256k**。EP16
+全量下 19.6 GiB slab 的 HBM 账实测。次优先：FMHA 条带化配段、前端固定截距
+（132 vs 59 ms @122 tokens）、KDA 包 prefix-scan（profile 后决定）。

--- a/docs/models/k3/cp-lane-design.md
+++ b/docs/models/k3/cp-lane-design.md
@@ -595,12 +595,26 @@ cap 到均值所在 bucket（attention 是 varlen，cap 内仍按深度配平）
 期议题）。剩余对理想 8× 的缺口 = 850ms 截距 + bucket 内 padding + causal
 残余不均衡，留 profile 期。
 
+⑥ **whale CP8@128k 首次 nsys 剖析**（2026-08-25，全账
+`~/code/bench_results/2026-08-25-k3-whale-cp16-smoke/` README 末节）：tray09
+上 BIN wrapper `nsys --delay 150 --duration 90 --kill=none`，窗口内探针命中。
+128k superstep wall 6,233ms（锁步全程）：**FMHA 35.8%**（深位 rank 2,230ms）
+> mega MoE 19.8%（1,237ms，含双侧配对等待）> dense GEMM 15.5% > elementwise
+10.4% > KDA 4.2%，kernel 间隙 6.7%。深/中位 rank 的 fmha+mega 之和相等
+（~3,470ms）——mega 等待吸收了 attention 深度不均衡，真 MoE 算量 ≲1.2s。
+Amdahl 账：CP1 的 MoE 墙钟与 CP8 同额（mega dispatch 本就全 EP 宽，与 CP 无
+关）≈1.26s → 128k 理论顶 = 32/8+1.26 ≈ 5.3s = **6.4×**；实测扣截距 6.0× =
+顶的 93%。剩余 7% 有了名字：**128k 均值 16k 正好顶 16896 bucket cap，
+leveling 被钳成等长切分，深位 attention ≈ 均摊 1.6×** → 下一刀 = FMHA
+条带化配段。扣除 MoE 的极限即 CP 宽度本身（非 MoE 家族完美缩放，CP4 已证、
+本次未推翻）；CP16@EP16 验收配置推演顶 ≈ 12–13×@128k。
+
 ## Next action
 
 256k 单 superstep 门禁只差机器：需 CP16（16×16896=270k 盖 256k，CP8 上限
 135k），而 tray14 在重启窗口被第三方 NeMo LoRA 抢走，2026-08-25 时点全集群无
 第 4 台空 tray（监视器在轮询）。拿到机器即跑 256k 门禁（ctx=262144 batch=1，
 已验证 armed 无 OOM）→ **验收：full 896@EP16 对 vLLM TP16-MNNVL 重赛
-8k/16k/64k/256k**。EP16 全量下 19.6 GiB slab 的 HBM 账实测。次优先：whale
-固定截距 ~850ms 剖析（slack/armed decode-only/前端合账）、FMHA 条带化配段、
-KDA 包 prefix-scan（profile 后决定）。
+8k/16k/64k/256k**。EP16 全量下 19.6 GiB slab 的 HBM 账实测。次优先（whale
+剖析 ⑥ 定序）：FMHA 条带化配段（剩余 7% 缺口的主项）、固定截距 ~850ms
+剖析（slack/armed decode-only/前端合账）、KDA 包 prefix-scan。

--- a/docs/models/k3/cp-lane-design.md
+++ b/docs/models/k3/cp-lane-design.md
@@ -647,7 +647,7 @@ Amdahl 账：CP1 的 MoE 墙钟与 CP8 同额（mega dispatch 本就全 EP 宽�
 | 16,725 | **794** | 1,020 | 0.78× |
 | 66,677 | 3,251 | **1,734** | **1.88×** |
 | 130,232 | 6,199 | **3,615** | **1.71×** |
-| 254,811 | 13,155 | （full 挂 W-chunk）pruned 9,316 | ~1.41×* |
+| 254,808 | 13,155 | **8,850**（W-chunk 后 @262144 实测） | **1.49×** |
 
 交叉点 16k–64k 之间；短档输 = bucket 阶梯（16.7k/16=1,045 行 → 4224 桶
 padding 4×）+ ~270ms 截距，与 ⑥ 的杠杆排序一致。full CP16@128k 比 pruned
@@ -676,10 +676,15 @@ gather 仍按 max_ctx 长。**full-256k 的结构性 blocker 解除**（账面 ~
 k3 门禁 6/6、`PEGAINFER_K3_CP_PROMPT=65536` 的 cp_prefill 门禁（CP1/CP4 双双
 压出窗口循环）全过。这套 merge 原语同时就是 FMHA 条带化和 DIST_CTX 的底座。
 
+**同日实测（full 1.5T @ctx=262144，tray03/04/06/07，账在 bench 档案追加节）**：
+16 卡整齐 268.3 GiB used / 余量 ~9.3 GiB；254,808 tok TTFT **8,850 ms**（对
+vLLM 13,155 = **1.49×**，快过 pruned CP16 的 9,316）；64k/128k 与 W-chunk 前
+逐 ms 持平（1,717/3,618 vs 1,734/3,615，零回归）；249,891 tok + 48 greedy
+生成连贯。验收表 256k 行补齐——**64k 及以上全档反超 vLLM TP16-MNNVL**。
+
 ## Next action
 
-PR #970 已带三修（`07be170e`）+ W-chunk（`91c23211`）push，track CI 到全绿。
-待 4 tray 空档复跑 full 1.5T @ctx=262144 的 256k 档补上验收表的 `*` 行。
+PR #970 CI 17/17 全绿（`05da7961`），待 susun review。
 性能杠杆按 ⑥ 实测定序不变：FMHA 条带化（merge 原语已在）→ superstep
 图化/融合 → **bucket 细化（8k/16k 档翻盘的主杠杆，验收表的 0.39×/0.78× 就是
 它）** → 协调压缩。KDA 包 prefix-scan 排后。

--- a/docs/models/k3/cp-lane-design.md
+++ b/docs/models/k3/cp-lane-design.md
@@ -542,16 +542,20 @@ MegaMoE 同款基底。每 rank 的 CP 发布面（halo tail、KDA (M,D)、MLA
 latent/rope）整体挪进一块 fabric slab；whale hub 启动时加一轮 slab
 allgather（64 字节 handle × world，兼作 fleet 启动 barrier，对齐 ep.rs
 bootstrap 语义），每进程 import 一次全表。four-beat 协议原样翻译成
-doorbell：远端 `cuStreamWriteValue64` 宣布、本地 `cuStreamWaitValue64/GEQ`
-等待——等待永远在本 rank 自己的内存上，远端只有 NVLink store，superstep 内
-host 零同步。doorbell 值全由 rendezvous 推导（`(seq+1)*4096 + window`）：
+doorbell：宣布 = 单线程 SM kernel 批量 store 进各 peer 的 flag 槽（GB300
+memops 引擎拒绝 fabric-imported VA，见下方 CP8 门禁 bug ②）、本地
+`cuStreamWaitValue64/GEQ` 等待——等待永远在本 rank 自己的内存上，远端只有
+NVLink store，superstep 内 host 零同步。doorbell 值全由 rendezvous 推导（`(seq+1)*4096 + window`）：
 seq 严格递增 + 每 superstep 窗口数固定 ⇒ 值跨 whale 单调，gang 轮换不需要
 任何 host 协商（flag 槽按 global rank 索引）。forward 路径零改动：
 `K3CpScratch` 换 `K3CpSyncHandle`（Local/Fleet 枚举）分发三个交换窗口，
 `prefill_whale` 与 `prefill_cp` 共享同一 superstep 主体（whale 用 leveled
 分段）。`PEGAINFER_K3_WHALE=<addr>` 一个变量拉起全部（rank0 进程 host
 sequencer；端口选 <32768 避 ephemeral 坑）；`PEGAINFER_K3_WHALE_MIN` 准入
-下限默认 4096。与 `PEGAINFER_K3_CP`、dspark 互斥。
+下限默认 4096。与 `PEGAINFER_K3_CP`、dspark 互斥。隐含约定：分段是
+descriptor 的确定性函数、不上 wire，各进程按自己的 prefill chunk 上限
+（`chunk_tokens`）本地重算——全 fleet 必须跑同一 binary/配置，chunk 上限
+不一致会算出不同分段而各自入场。
 
 **CP8@2-tray 真机门禁 PASS（2026-08-25，tray08+tray09 pruned EP8，全账
 `~/code/bench_results/2026-08-25-k3-whale-cp8-smoke/`）**：8-wide 跨机 whale

--- a/docs/models/k3/cp-lane-design.md
+++ b/docs/models/k3/cp-lane-design.md
@@ -632,12 +632,42 @@ Amdahl 账：CP1 的 MoE 墙钟与 CP8 同额（mega dispatch 本就全 EP 宽�
   ③ bucket 阶梯细化（2048–4224、8448–16896 之间加档；16k 档 1,042→~700 的
   主杠杆）；④ 协调 270→~150ms（降级，不再是主要矛盾）。
 
+## 256k 门禁 + full 16 卡验收（2026-08-26，账在
+`~/bench_results/2026-08-26-k3-cp16-256k-gate/`）
+
+**256k 门禁 PASS**（pruned CP16@tray09/11/12/14, ctx=262144 batch=1）：
+254,808-token TTFT min **9,316 ms** 三跑稳定，CP1 local 基线 90,459 →
+**9.71×**；249,891-token 生成 tray09/tray14 逐字节一致。
+
+**Full 1.5T 16v16 验收**（tray03/04/06/07 前后脚跑双方，同脚本 min-of-3）：
+
+| tokens | vLLM TP16-MNNVL | full CP16 whale | 比 |
+|---:|---:|---:|---|
+| 8,251 | **404** | 1,044 | 0.39× |
+| 16,725 | **794** | 1,020 | 0.78× |
+| 66,677 | 3,251 | **1,734** | **1.88×** |
+| 130,232 | 6,199 | **3,615** | **1.71×** |
+| 254,811 | 13,155 | （full 挂 W-chunk）pruned 9,316 | ~1.41×* |
+
+交叉点 16k–64k 之间；短档输 = bucket 阶梯（16.7k/16=1,045 行 → 4224 桶
+padding 4×）+ ~270ms 截距，与 ⑥ 的杠杆排序一致。full CP16@128k 比 pruned
+CP8@2-tray 快近 2×（宽度 + EP16 每 rank expert 减半）。vLLM TP16 深档还慢于
+其 8 卡 TP8×EP8（08-18: 64k 1,959 / 128k 4,477）——16 路 TP prefill 深上下文
+反噬，我方 64k 已压过它 8 卡最优布局。
+
+**HBM 账实测（都在 `07be170e` 修）**：mega slab 19.65 GiB 分配失败的元凶是
+pool release threshold=MAX 让加载 churn 后 used 达 255.75 GiB（权重 190 之外
+~66 GiB 活分配：max_ctx-scaled MLA 物化 buffer 21.3 + KV ~7 + rows-scaled
+scratch ~37.5）→ slab allocator OOM 时 trim-then-retry。**full@262144 结构性
+放不下**（需 ~283 > 276.6 GiB）：`mla_ctx_nope_v` 12 GiB + `mla_ctx_k` 9 GiB
+是 `mla_chunk_attend` 一发整 ctx 物化——**W-chunked ctx loop + scratch trim
+升格为 full-256k 的硬前置**。验收跑在 ctx=135168（~270 GiB，实测过）。
+另修 whale arming × staged 加载的 INVALID_CONTEXT（launch 线程无 context，
+`arm_whale_slab` 补 `bind_thread`；此前 whale 门禁从未开过 staging）。
+
 ## Next action
 
-256k 单 superstep 门禁只差机器：需 CP16（16×16896=270k 盖 256k，CP8 上限
-135k），而 tray14 在重启窗口被第三方 NeMo LoRA 抢走，2026-08-25 时点全集群无
-第 4 台空 tray（监视器在轮询）。拿到机器即跑 256k 门禁（ctx=262144 batch=1，
-已验证 armed 无 OOM）→ **验收：full 896@EP16 对 vLLM TP16-MNNVL 重赛
-8k/16k/64k/256k**。EP16 全量下 19.6 GiB slab 的 HBM 账实测。次优先按 ⑥ 的
-实测定序：FMHA 条带化 → superstep 图化/融合 → bucket 细化 → 协调压缩；
-KDA 包 prefix-scan 排后。
+PR #970 已带三修 push（`07be170e`），track CI 到全绿。性能杠杆按 ⑥ 实测定序
+不变：FMHA 条带化 → superstep 图化/融合 → **bucket 细化（8k/16k 档翻盘的
+主杠杆，验收表的 0.39×/0.78× 就是它）** → 协调压缩；**W-chunked ctx loop +
+scratch trim 新增为 full-256k 前置**。KDA 包 prefix-scan 排后。

--- a/docs/models/k3/cp-lane-design.md
+++ b/docs/models/k3/cp-lane-design.md
@@ -483,8 +483,60 @@ GiB/rank）后 HBM 收紧 ~15 GiB，fleet 复测时要盯。TileLang prefill buc
   法；默认并行会 13 实例同租一卡 OOM——mega slab EP1 涨到 3.2 GiB 后更
   容易炸，跑法不对怪跑法）。
 
+## Whale rendezvous：跨机 gang 的共识层（M1 后半，2026-08-25 无 GPU 部分落地）
+
+CP8/CP16 的 gang 成员跨进程跨机器，M0.5 的 in-process board（一个 Mutex）不再
+可用，而 free-running 纪律禁止任何"等"。协议内容退化到一条：**whale w 在绝对
+launch L 跑**——launch count 本身是全局时钟（mega 双边配对把全 world 钉在 ±1
+以内），所以约定 L 就是约定一个全局时刻，谁都不用被叫醒。实现是 host 侧两阶段
+广播（`scheduler/whale.rs` 纯状态机 + `whale_hub.rs` 传输；rank0 进程当唯一
+sequencer，复用 ep.rs bootstrap 风格的常驻 TCP）：
+
+1. **Gather**：poster 把 prompt 发给 sequencer；sequencer 选宽度（能宽就宽：
+   superstep 挡的是全 fleet，最宽的 gang = 最短的全局 stall）、tray 对齐选
+   gang（poster 转到 CP 末位，KDA 终态和全量 MLA ctx 落在 decode 它的 rank），
+   广播 descriptor。成员回自己当前 launch count 并 **arm**：从此到 commit 不再
+   发起多 launch 操作（每步恰好 +1），但一步不停。
+2. **Commit**：`L = max(replies) + slack(4)`，且严格大于上一头 whale 的 L。
+   armed 成员每 period +1，所以 commit 在 slack 个 period 内送达就一定还没越过
+   L——host TCP 亚毫秒 vs launch period 数十毫秒起，裕量 ~2 个数量级；真迟到
+   在成员侧响亮报错，不会错配 collective。gang 外的 rank 全程不知情：它们的
+   launch L 是普通步，mega 照常配对异构步。Cancel 只作用于 armed（gather 超时
+   /宽度拒绝）；committed 不可撤销——unanimity 就是全部意义，不要的结果跑完丢弃。
+
+**正确性靠仿真而非机器**：状态机纯函数化（transition 进事件出消息），单测覆盖
+happy path、mid-op 迟回、双 whale 串行化（L 严格递增）、超时取消 + 迟到 Ready
+静默丢弃、hash 篡改/非成员/重复 Ready/漏询 boundary/slack 击穿全部响亮死；外加
+48 seed xorshift 舰队 fuzz（8 rank 逐轮 ±1 pinning、消息 0–1 轮延迟 per-dest
+FIFO、随机多 launch 操作跳询 boundary），不变量 = 每头可入场 whale 全 gang 同一
+L 入场、CP rank 恰为 0..width 排列、commit 顺序=seq 顺序、fleet 必静默。
+
+**分段理论模型**（`k3_whale_segments`）：per-rank superstep 时间
+`t_i ∝ len_i + Q·(start_i + len_i/2)·len_i`，线性项是全深度逐 token 走
+（MoE/KDA/dense GEMM），二次项是 MLA ctx 三角；Q = 2.7e-6（CP4 16k profile
+标定：12k 深 prefix 对 ~1000ms superstep 贵 ~32ms）。256k 下末 rank 三角 ≈ 走
+的 2/3，均匀切会把全 fleet 挂在它尾巴上——按预算二分 + 贪心填充做 leveling
+（前 rank 长后 rank 短，封顶 16896）。段下限 `K3_CP_SEGMENT_FLOOR = 2048`
+（FlashKDA 段长扫描：4224 段 96% 饱和、1056 段 87%、264 段 58%），宽度取
+admits 的最大 2 的幂：粗梯子 ≈ CP4 @ 8k–16k / CP8 @ 16k–32k / CP16 @ 32k+，
+16×16896 恰盖 262144（#962 抬协议的动机闭环）。
+
+**KDA 包流量账**（naive 右乘链 vs prefix-scan 的立项数据）：(M,D) 每层
+~12.6 MB，upstream fan-out 全量 O(CP²)、末 rank O(CP)——CP16 末 rank 每层收
+15 对 ≈ 189 MB，全 93 层 ≈ 12.6 GiB/whale，占 256k superstep ~4%、64k ~15%。
+(M,D)∘(M',D') = (MM', DM'+D') 可结合 → Blelloch 并行前缀扫描 log₂CP 轮是
+现成后手；按拍板**先 naive 实现，profile 后再决定**。
+
+数据面（GPU 阶段）：CUDA event 是进程局部的，跨机 four-beat 协议换成
+doorbell（`cuStreamWriteValue32/WaitValue32` 打在 fabric 映射的 flag 上，
+mega kernel 内已用同一技术）；CP scratch 一次性分配指针稳定，fabric handle
+在 gang 形成时一次交换。
+
 ## Next action
 
-M1 后半：CP8/CP16 gang（full@EP16 交叉矩阵 + 系统 A/B），8k+ 追平 vLLM
-TP16 的 16 路切分；EP16 全量下 19.6 GiB slab 的 HBM 账实测。次优先：FMHA
-条带化配段、前端固定截距（132 vs 59 ms @122 tokens）。
+M1 后半剩余：whale 接入 scheduler（每个 launch boundary 询 `at_launch`，含
+chunk 边界；clearance 约束多 launch 操作）→ CP scratch fabric 化 + doorbell
+交换 → CP8@2-tray / CP16@4-tray pruned 门禁 → 256k 单 superstep 门禁 →
+**验收：full 896@EP16 对 vLLM TP16-MNNVL 重赛 8k/16k/64k/256k**。EP16 全量下
+19.6 GiB slab 的 HBM 账实测。次优先：FMHA 条带化配段、前端固定截距
+（132 vs 59 ms @122 tokens）。

--- a/docs/models/k3/cp-lane-design.md
+++ b/docs/models/k3/cp-lane-design.md
@@ -553,10 +553,29 @@ seq 严格递增 + 每 superstep 窗口数固定 ⇒ 值跨 whale 单调，gang 
 sequencer；端口选 <32768 避 ephemeral 坑）；`PEGAINFER_K3_WHALE_MIN` 准入
 下限默认 4096。与 `PEGAINFER_K3_CP`、dspark 互斥。
 
+**CP8@2-tray 真机门禁 PASS（2026-08-25，tray08+tray09 pruned EP8，全账
+`~/code/bench_results/2026-08-25-k3-whale-cp8-smoke/`）**：8-wide 跨机 whale
+单 superstep prefill 打通，16k prompt + 48 greedy 两端点逐字节一致。同 fleet
+同配置 A/B（min TTFT ms，CP1 local vs CP8 whale）：4.2k 1246→893（1.40×）、
+8.25k 1502→1042（1.44×）、16.7k 3005→1042（**2.88×**）、28.5k 5881→1286
+（**4.57×**）。固定截距 ~850ms（4k 与 16k 同 TTFT）= rendezvous slack + armed
+期 decode-only + 前端截距合账，profile 阶段第一杠杆。真机修掉两个 bug：
+① sequencer bind 字面 addr 踩 127.0.1.1 回环（`da7c6dc9`，EP bootstrap 同款）；
+② **GB300 stream memops 引擎拒绝 fabric-imported 映射**——
+`cuStreamWriteValue64` 对 import 进来的 VA 报 `CUDA_ERROR_INVALID_VALUE`，同
+映射 DtoD copy / SM store 正常（两进程 C probe 定案，
+`~/.fabric-test/memops_import.c`）。doorbell 写改单线程 SM kernel
+（`k3_whale_doorbell_ring`，一个 beat 的全部 flag 批一次 launch）；wait 不动
+——等的全是本地 slab，本地 fabric 分配 memops 接受（`6b7ae0e4`）。运维注意：
+fleet OOM 后重启前必须逐 tray 杀干净旧进程（`nvidia-smi
+--query-compute-apps`，pgrep 会匹配自己的 ssh shell）；EP8@32k ctx 要
+`PEGAINFER_K3_MAX_BATCH=8`（默认 64 slots 的 KV 预算超 288 GiB HBM）。
+
 ## Next action
 
-M1 后半剩余（代码全落地，进入真机阶段）：CP8@2-tray pruned EP8 门禁（首个
-真 doorbell/fabric 冒烟）→ CP16@4-tray pruned EP16 → 256k 单 superstep 门禁
-→ **验收：full 896@EP16 对 vLLM TP16-MNNVL 重赛 8k/16k/64k/256k**。EP16
-全量下 19.6 GiB slab 的 HBM 账实测。次优先：FMHA 条带化配段、前端固定截距
-（132 vs 59 ms @122 tokens）、KDA 包 prefix-scan（profile 后决定）。
+M1 后半（CP8@2-tray 门禁已过）：CP16@4-tray pruned EP16（等第 4 台空 tray，
+2026-08-25 时点只有 tray08/09/17 空）→ 256k 单 superstep 门禁（需 CP16：
+16×16896=270k 盖 256k，CP8 只到 135k）→ **验收：full 896@EP16 对 vLLM
+TP16-MNNVL 重赛 8k/16k/64k/256k**。EP16 全量下 19.6 GiB slab 的 HBM 账实测。
+次优先：whale 固定截距 ~850ms 剖析（slack/armed decode-only/前端合账）、FMHA
+条带化配段、KDA 包 prefix-scan（profile 后决定）。

--- a/docs/models/k3/cp-lane-design.md
+++ b/docs/models/k3/cp-lane-design.md
@@ -660,14 +660,26 @@ pool release threshold=MAX 让加载 churn 后 used 达 255.75 GiB（权重 190 
 ~66 GiB 活分配：max_ctx-scaled MLA 物化 buffer 21.3 + KV ~7 + rows-scaled
 scratch ~37.5）→ slab allocator OOM 时 trim-then-retry。**full@262144 结构性
 放不下**（需 ~283 > 276.6 GiB）：`mla_ctx_nope_v` 12 GiB + `mla_ctx_k` 9 GiB
-是 `mla_chunk_attend` 一发整 ctx 物化——**W-chunked ctx loop + scratch trim
-升格为 full-256k 的硬前置**。验收跑在 ctx=135168（~270 GiB，实测过）。
+是 `mla_chunk_attend` 一发整 ctx 物化。验收跑在 ctx=135168（~270 GiB，实测过）。
 另修 whale arming × staged 加载的 INVALID_CONTEXT（launch 线程无 context，
 `arm_whale_slab` 补 `bind_thread`；此前 whale 门禁从未开过 staging）。
 
+**W-chunked ctx loop 已落地（`91c23211`，2026-08-26）**：物化 scratch 从
+max_ctx 行缩到 `min(max_ctx, 16896)` 行（W = 4×4224 chunk cap）。`t_kv ≤ W`
+仍是原单发 causal FMHA（bitwise 不变，既有门禁不动）；更深的 ctx 用 dense
+窗口（ResidualMask + individual scheduler 新入口，t_q/t_kv 无约束，ragged 尾
+可以比 chunk 窄）扫过去，每窗输出连 LSE 一起 `lse_merge` 进 f32 累加器，最后
+一发 t_q×t_q causal 收 chunk 自身的键，`o_finalize` 回 bf16。262144 档物化
+buffer 21 GiB → 1.4 GiB，新增累加器 ~210 MB；只剩 576 B/token 的 latent/rope
+gather 仍按 max_ctx 长。**full-256k 的结构性 blocker 解除**（账面 ~283 →
+~263 GiB < 276.6）。验证：windowed-vs-single 等价 GPU 测试（含 ragged 尾）、
+k3 门禁 6/6、`PEGAINFER_K3_CP_PROMPT=65536` 的 cp_prefill 门禁（CP1/CP4 双双
+压出窗口循环）全过。这套 merge 原语同时就是 FMHA 条带化和 DIST_CTX 的底座。
+
 ## Next action
 
-PR #970 已带三修 push（`07be170e`），track CI 到全绿。性能杠杆按 ⑥ 实测定序
-不变：FMHA 条带化 → superstep 图化/融合 → **bucket 细化（8k/16k 档翻盘的
-主杠杆，验收表的 0.39×/0.78× 就是它）** → 协调压缩；**W-chunked ctx loop +
-scratch trim 新增为 full-256k 前置**。KDA 包 prefix-scan 排后。
+PR #970 已带三修（`07be170e`）+ W-chunk（`91c23211`）push，track CI 到全绿。
+待 4 tray 空档复跑 full 1.5T @ctx=262144 的 256k 档补上验收表的 `*` 行。
+性能杠杆按 ⑥ 实测定序不变：FMHA 条带化（merge 原语已在）→ superstep
+图化/融合 → **bucket 细化（8k/16k 档翻盘的主杠杆，验收表的 0.39×/0.78× 就是
+它）** → 协调压缩。KDA 包 prefix-scan 排后。

--- a/docs/models/k3/cp-lane-design.md
+++ b/docs/models/k3/cp-lane-design.md
@@ -649,8 +649,12 @@ Amdahl 账：CP1 的 MoE 墙钟与 CP8 同额（mega dispatch 本就全 EP 宽�
 | 130,232 | 6,199 | **3,615** | **1.71×** |
 | 254,808 | 13,155 | **8,850**（W-chunk 后 @262144 实测） | **1.49×** |
 
-交叉点 16k–64k 之间；短档输 = bucket 阶梯（16.7k/16=1,045 行 → 4224 桶
-padding 4×）+ ~270ms 截距，与 ⑥ 的杠杆排序一致。full CP16@128k 比 pruned
+交叉点 16k–64k 之间。短档账（08-26 复核修正）：桶阶梯是几何级
+（`K3_PREFILL_BUCKETS` 256..16896），1,045 行落 2048 桶 ≤2×，且只作用于按
+`shape.bucket` 整跑的本地 dense 批处理族——mega dispatch 在 EP>1 只发 live 行
+（`step.rs`，padding 不上线），MoE 免疫。短档主因是 ~270ms 协调截距 + 固定
+开销；杠杆 = 本地 dense 族 de-bucket（cuBLAS 按 live_rows 发射，纯 host 改动）
++ 截距剖析，"加桶档"收益很小。full CP16@128k 比 pruned
 CP8@2-tray 快近 2×（宽度 + EP16 每 rank expert 减半）。vLLM TP16 深档还慢于
 其 8 卡 TP8×EP8（08-18: 64k 1,959 / 128k 4,477）——16 路 TP prefill 深上下文
 反噬，我方 64k 已压过它 8 卡最优布局。

--- a/docs/models/k3/cp-lane-design.md
+++ b/docs/models/k3/cp-lane-design.md
@@ -604,10 +604,29 @@ cap 到均值所在 bucket（attention 是 varlen，cap 内仍按深度配平）
 （~3,470ms）——mega 等待吸收了 attention 深度不均衡，真 MoE 算量 ≲1.2s。
 Amdahl 账：CP1 的 MoE 墙钟与 CP8 同额（mega dispatch 本就全 EP 宽，与 CP 无
 关）≈1.26s → 128k 理论顶 = 32/8+1.26 ≈ 5.3s = **6.4×**；实测扣截距 6.0× =
-顶的 93%。剩余 7% 有了名字：**128k 均值 16k 正好顶 16896 bucket cap，
-leveling 被钳成等长切分，深位 attention ≈ 均摊 1.6×** → 下一刀 = FMHA
-条带化配段。扣除 MoE 的极限即 CP 宽度本身（非 MoE 家族完美缩放，CP4 已证、
-本次未推翻）；CP16@EP16 验收配置推演顶 ≈ 12–13×@128k。
+顶的 93%。剩余缺口：**128k 均值 16k 正好顶 16896 bucket cap，leveling 被钳
+成等长切分，深位 attention ≈ 均摊 1.6×**。扣除 MoE 的极限即 CP 宽度本身
+（非 MoE 家族完美缩放，CP4 已证、本次未推翻）；CP16@EP16 验收配置推演顶
+≈ 12–13×@128k。
+
+同一 profile 的 65k superstep（cluster #3，深位 rank，wall 2,524ms）修正了
+两笔旧账，并给 vLLM 对标定了性（`2026-08-18-k3-vllm-layout-e2e`，full 模型
+8 卡最优布局 TP8×EP8：64k 1,959ms / 128k 4,477ms，截距 ~75ms）：
+
+- **"~850ms 固定截距"是高估**：65k e2e 2,790 − superstep 2,520 = 协调+前端
+  实际 ~270ms。850 来自 4k–16k 平台，但那个平台的大头是 bucket 翻倍
+  （16k/8=2,090 行 → 4224 桶，全行族 padding 2×）——短中档输 TP8×EP8
+  （1,042 vs 442）的主因是桶，不是协调。
+- **65k 纯算力慢 vLLM 34%（2,520 vs ~1,884）**，拆账：FMHA 579ms（深位超额
+  ~270，均衡应 ~310；TP8 按头切无此项）、mega 566（同款+等待）、dense GEMM
+  503（1,455 launch，M≈8.4k 在"chunk<8k contiguous padding 吃一半算力"临界
+  区）、elementwise 325（2,076 launch；CP 行数只有 TP 的 1/8，本应优势项）、
+  间隙 176（单 superstep ~5,000 launch）。可回收 ≈0.5s（不均衡+间隙+padding）
+  → 修完**追平** TP8×EP8；反超还差 ~120ms 的 GEMM 形状/融合效率债。
+- **杠杆重排（实测定序）**：① FMHA 条带化配段（65k −270ms / 128k −800ms，
+  唯一救两档）；② superstep 层遍历图化/融合（5,000 launch → 间隙+尾巴）；
+  ③ bucket 阶梯细化（2048–4224、8448–16896 之间加档；16k 档 1,042→~700 的
+  主杠杆）；④ 协调 270→~150ms（降级，不再是主要矛盾）。
 
 ## Next action
 
@@ -615,6 +634,6 @@ leveling 被钳成等长切分，深位 attention ≈ 均摊 1.6×** → 下一�
 135k），而 tray14 在重启窗口被第三方 NeMo LoRA 抢走，2026-08-25 时点全集群无
 第 4 台空 tray（监视器在轮询）。拿到机器即跑 256k 门禁（ctx=262144 batch=1，
 已验证 armed 无 OOM）→ **验收：full 896@EP16 对 vLLM TP16-MNNVL 重赛
-8k/16k/64k/256k**。EP16 全量下 19.6 GiB slab 的 HBM 账实测。次优先（whale
-剖析 ⑥ 定序）：FMHA 条带化配段（剩余 7% 缺口的主项）、固定截距 ~850ms
-剖析（slack/armed decode-only/前端合账）、KDA 包 prefix-scan。
+8k/16k/64k/256k**。EP16 全量下 19.6 GiB slab 的 HBM 账实测。次优先按 ⑥ 的
+实测定序：FMHA 条带化 → superstep 图化/融合 → bucket 细化 → 协调压缩；
+KDA 包 prefix-scan 排后。

--- a/docs/models/k3/cp-lane-design.md
+++ b/docs/models/k3/cp-lane-design.md
@@ -571,11 +571,36 @@ fleet OOM 后重启前必须逐 tray 杀干净旧进程（`nvidia-smi
 --query-compute-apps`，pgrep 会匹配自己的 ssh shell）；EP8@32k ctx 要
 `PEGAINFER_K3_MAX_BATCH=8`（默认 64 slots 的 KV 预算超 288 GiB HBM）。
 
+**CP16@4-tray 真机门禁 PASS（2026-08-25，tray08/09/14/17 pruned EP16，全账
+`~/code/bench_results/2026-08-25-k3-whale-cp16-smoke/`）**：4/4 armed ~120s，
+512/16k 四端点逐字节一致；TTFT 与 CP8 持平（28.5k 1228ms = 对 CP1 4.79×；
+这些长度全被 ~850ms 截距压着，CP16 收益在更长 prompt 与 256k 容量）。又修掉
+两个真 bug：③ **whale hub acceptor 串行死锁**（`c2e4ba99`）——acceptor 内联跑
+slab 交换，`wait_complete` 等全世界；2 进程恰好能过（CP8 掩盖），4 进程第一个
+peer 锁死 accept 循环。修：每连接独立线程，writer 注册仍在 table 帧后；附 3
+进程回归测试 + whale arming 分阶段计时日志（顺带证明旧"4.5 分钟 arming 谜团"
+就是这个死锁的轻症形态，修后 slab_exchange barrier = 权重加载 skew 0–24s）。
+④ **FlashMLA prefill 116k 上下文天花板**（`6650ef91`）——wrapper 把
+`t_kv×heads×192 > INT_MAX`（heads=96 时 ~116k token）当 batch stride 溢出拒绝，
+256k 请求 fail-stop 全 fleet；但 b=1 的 batch stride 恒不参与寻址（TMA 描述符
+内 64 位算术），传 0 删守卫即可。附 260k×96 头 ignored GPU 深度测试（均匀 K +
+按头 V，输出须精确等每头 V 值）。修复后 CP8@ctx131072 e2e：**128,459 token
+连贯且两端一致**；同配置 A/B：65k 13,922ms local、128k 33,609ms local。
+⑤ **leveling 跨 bucket 台阶**（`7c6dcd96`）——细阶梯（40k–128k）暴露 57k→65k
+间 ~+900ms 台阶：leveled 分段在均值贴近 bucket 边界时把头段推过 8448，头
+rank 落进 16896 bucket，padded 行翻倍、lockstep 全员等它。修：leveling 段长
+cap 到均值所在 bucket（attention 是 varlen，cap 内仍按深度配平）。实测
+65,116 tok 3,638→**2,747ms（5.07×）**、128k 6,382ms（**5.27×**），邻档不动。
+73k 起均值 >8448 的 16896-bucket 台阶是 AOT 阶梯固有（加 12672 档 = profile
+期议题）。剩余对理想 8× 的缺口 = 850ms 截距 + bucket 内 padding + causal
+残余不均衡，留 profile 期。
+
 ## Next action
 
-M1 后半（CP8@2-tray 门禁已过）：CP16@4-tray pruned EP16（等第 4 台空 tray，
-2026-08-25 时点只有 tray08/09/17 空）→ 256k 单 superstep 门禁（需 CP16：
-16×16896=270k 盖 256k，CP8 只到 135k）→ **验收：full 896@EP16 对 vLLM
-TP16-MNNVL 重赛 8k/16k/64k/256k**。EP16 全量下 19.6 GiB slab 的 HBM 账实测。
-次优先：whale 固定截距 ~850ms 剖析（slack/armed decode-only/前端合账）、FMHA
-条带化配段、KDA 包 prefix-scan（profile 后决定）。
+256k 单 superstep 门禁只差机器：需 CP16（16×16896=270k 盖 256k，CP8 上限
+135k），而 tray14 在重启窗口被第三方 NeMo LoRA 抢走，2026-08-25 时点全集群无
+第 4 台空 tray（监视器在轮询）。拿到机器即跑 256k 门禁（ctx=262144 batch=1，
+已验证 armed 无 OOM）→ **验收：full 896@EP16 对 vLLM TP16-MNNVL 重赛
+8k/16k/64k/256k**。EP16 全量下 19.6 GiB slab 的 HBM 账实测。次优先：whale
+固定截距 ~850ms 剖析（slack/armed decode-only/前端合账）、FMHA 条带化配段、
+KDA 包 prefix-scan（profile 后决定）。

--- a/pegainfer-k3/src/config.rs
+++ b/pegainfer-k3/src/config.rs
@@ -52,6 +52,13 @@ pub(crate) const K3_Q_B_OUT: usize = K3_HEADS * K3_QK_HEAD_DIM;
 pub(crate) const K3_KV_A_OUT: usize = K3_KV_LORA_RANK + K3_QK_ROPE_HEAD_DIM;
 pub(crate) const K3_KV_B_OUT: usize = K3_HEADS * (K3_QK_NOPE_HEAD_DIM + K3_V_HEAD_DIM);
 pub(crate) const K3_O_PROJ_IN: usize = K3_HEADS * K3_V_HEAD_DIM;
+/// Chunked-prefill MLA context window: the expanded K/V workspace covers this
+/// many rows, and deeper contexts walk in windows merged through the FMHA's
+/// log-sum-exp. The expansion is the 74x-inflation side of MLA prefill
+/// (576 B/token latent -> 42 KiB/token K+V), so the window is what keeps the
+/// scratch off the `max_ctx` scale; 4x the 4224 chunk cap keeps the per-window
+/// FMHA long enough to stay compute-bound.
+pub(crate) const K3_MLA_CTX_WINDOW: usize = 16_896;
 
 // ---- KDA (linear-attention) layers ---------------------------------------
 /// Short depthwise conv window in front of the KDA q/k/v streams.

--- a/pegainfer-k3/src/executor/buffers.rs
+++ b/pegainfer-k3/src/executor/buffers.rs
@@ -795,11 +795,21 @@ pub(crate) struct K3Scratch {
     pub(crate) mla_ctx_latent: HiddenStates,
     /// Chunked prefill: the gathered shared rope halves, `[max_ctx, 64]`.
     pub(crate) mla_ctx_rope: CudaSlice<bf16>,
-    /// Chunked prefill: the kv_b expansion, `[max_ctx, heads, 256]` per-head
+    /// Chunked prefill: the kv_b expansion, `[win, heads, 256]` per-head
     /// `nope | value` rows — the FMHA reads V as a strided view into this.
+    /// `win = min(max_ctx, K3_MLA_CTX_WINDOW)`: deeper contexts re-expand
+    /// window by window and merge through the LSE, so only the latent/rope
+    /// gather above scales with `max_ctx`.
     pub(crate) mla_ctx_nope_v: HiddenStates,
-    /// Chunked prefill: the assembled K rows, `[max_ctx, heads, 192]`.
+    /// Chunked prefill: the assembled K rows, `[win, heads, 192]`.
     pub(crate) mla_ctx_k: CudaSlice<bf16>,
+    /// Chunked prefill: the windowed walk's f32 output accumulator,
+    /// `[rows, heads, 128]`.
+    pub(crate) mla_o_acc: CudaSlice<f32>,
+    /// Chunked prefill: the running log-sum-exp, `[heads, rows]`.
+    pub(crate) mla_lse_acc: CudaSlice<f32>,
+    /// Chunked prefill: one window's LSE from the FMHA, `[heads, rows]`.
+    pub(crate) mla_lse_win: CudaSlice<f32>,
     // MLP / MoE.
     pub(crate) hidden_partial: CudaSlice<f32>,
     pub(crate) router_partial: CudaSlice<f32>,
@@ -908,11 +918,16 @@ impl K3Scratch {
             },
             mla_ctx_rope: stream.alloc_zeros(max_ctx * K3_QK_ROPE_HEAD_DIM)?,
             mla_ctx_nope_v: HiddenStates {
-                data: stream.alloc_zeros(max_ctx * K3_KV_B_OUT)?,
+                data: stream
+                    .alloc_zeros(max_ctx.min(crate::config::K3_MLA_CTX_WINDOW) * K3_KV_B_OUT)?,
                 hidden_dim: K3_KV_B_OUT,
                 seq_len: 0,
             },
-            mla_ctx_k: stream.alloc_zeros(max_ctx * K3_Q_B_OUT)?,
+            mla_ctx_k: stream
+                .alloc_zeros(max_ctx.min(crate::config::K3_MLA_CTX_WINDOW) * K3_Q_B_OUT)?,
+            mla_o_acc: stream.alloc_zeros(rows * K3_MLA_V_ROW)?,
+            mla_lse_acc: stream.alloc_zeros(K3_MLA_HEADS * rows)?,
+            mla_lse_win: stream.alloc_zeros(K3_MLA_HEADS * rows)?,
             hidden_partial: partial(K3_HIDDEN)?,
             router_partial: partial(routed_experts)?,
             topk_idx: stream.alloc_zeros(rows * K3_ROUTER_TOPK)?,

--- a/pegainfer-k3/src/executor/cp.rs
+++ b/pegainfer-k3/src/executor/cp.rs
@@ -313,6 +313,14 @@ fn wait_event(ctx: &DeviceContext, event: u64) -> Result<()> {
     .map_err(|error| anyhow::anyhow!("{error}"))
 }
 
+/// The per-rank segment floor for a *fleet* whale gang, in tokens: below
+/// ~2k-token segments FlashKDA falls off its throughput plateau (the 2026-08
+/// segment sweep: 4224-token segments run at 96% of peak, 1056 at 87%, 264 at
+/// 58%), so a wider gang stops paying for itself. The in-process lane's floor
+/// stays [`K3_CONV_STATE`]-based ([`k3_cp_admits`]) — its width is fixed at
+/// arm time, not chosen per prompt.
+pub const K3_CP_SEGMENT_FLOOR: usize = 2048;
+
 /// Whether a prompt of `total` tokens is CP-eligible: every segment must
 /// outspan the conv window (the halo exchange publishes exactly
 /// [`K3_CONV_STATE`] rows) and fit one chunk step (M0: one superstep). This

--- a/pegainfer-k3/src/executor/cp.rs
+++ b/pegainfer-k3/src/executor/cp.rs
@@ -481,9 +481,6 @@ const K3_CP_QUAD_PER_LINEAR: f64 = 2.7e-6;
 /// impossible, which admission rejects too.
 pub fn k3_whale_segments(total: usize, width: usize, chunk_tokens: usize) -> Vec<(usize, usize)> {
     debug_assert!(width >= 2);
-    if total == 0 {
-        return vec![(0, 0)];
-    }
     // The padded per-row families (KDA, norms, projections, MoE entry) run at
     // the covering chunk *bucket*, a step function of segment length — only
     // attention is varlen. Pure leveling stretches the earliest segment past

--- a/pegainfer-k3/src/executor/cp.rs
+++ b/pegainfer-k3/src/executor/cp.rs
@@ -76,6 +76,7 @@ use pegainfer_kernels::tensor::active_cu_stream;
 use super::buffers::K3_CONV_STATE;
 use super::buffers::K3_KDA_STATE;
 use super::buffers::copy_rows;
+use super::whale_gang::K3WhaleGang;
 use crate::config::K3_ATTN_INNER;
 use crate::config::K3_HIDDEN;
 use crate::config::K3_KV_LORA_RANK;
@@ -108,8 +109,9 @@ pub(crate) enum K3CpWindowKind {
 }
 
 impl K3CpWindowKind {
-    /// Ranks whose publications `me` reads this window.
-    fn reads_from(self, me: usize) -> Range<usize> {
+    /// Ranks whose publications `me` reads this window. CP ranks — the fleet
+    /// gang maps them through its member table.
+    pub(crate) fn reads_from(self, me: usize) -> Range<usize> {
         match self {
             Self::Halo => me.saturating_sub(1)..me,
             Self::Upstream => 0..me,
@@ -117,7 +119,7 @@ impl K3CpWindowKind {
     }
 
     /// Ranks that read `me`'s publications this window.
-    fn read_by(self, me: usize, cp_size: usize) -> Range<usize> {
+    pub(crate) fn read_by(self, me: usize, cp_size: usize) -> Range<usize> {
         match self {
             Self::Halo => (me + 1).min(cp_size)..(me + 2).min(cp_size),
             Self::Upstream => me + 1..cp_size,
@@ -125,13 +127,59 @@ impl K3CpWindowKind {
     }
 }
 
+/// The coordination substrate one CP scratch runs its exchange windows over:
+/// the in-process gang (peer access + CUDA events) or the fleet whale gang
+/// (fabric slabs + doorbells). The forward path is agnostic — it snapshots a
+/// [`K3CpWindowSync`] and calls [`K3CpSyncHandle::exchange`], and the window
+/// protocol semantics are identical either way.
+#[derive(Clone)]
+pub(crate) enum K3CpSyncHandle {
+    Local(Arc<K3CpGroup>),
+    Fleet(Arc<K3WhaleGang>),
+}
+
+impl K3CpSyncHandle {
+    pub(crate) fn exchange(
+        &self,
+        ctx: &DeviceContext,
+        sync: &K3CpWindowSync,
+        consume: impl FnOnce() -> Result<()>,
+    ) -> Result<()> {
+        match (self, sync) {
+            (Self::Local(group), K3CpWindowSync::Local { .. }) => {
+                group.exchange(ctx, sync, consume)
+            }
+            (
+                Self::Fleet(gang),
+                K3CpWindowSync::Fleet {
+                    cp_rank,
+                    kind,
+                    gang: members,
+                    value,
+                },
+            ) => gang.exchange(ctx, *cp_rank, *kind, members, *value, consume),
+            _ => anyhow::bail!("K3 CP window sync does not match its coordination substrate"),
+        }
+    }
+}
+
 /// The borrow-free snapshot one exchange window needs: taken from the
 /// scratch *before* the `consume` closure mutably captures it.
-pub(crate) struct K3CpWindowSync {
-    cp_rank: usize,
-    kind: K3CpWindowKind,
-    /// `(publish_event, consume_event)` raw handles per CP rank.
-    events: Vec<(u64, u64)>,
+pub(crate) enum K3CpWindowSync {
+    Local {
+        cp_rank: usize,
+        kind: K3CpWindowKind,
+        /// `(publish_event, consume_event)` raw handles per CP rank.
+        events: Vec<(u64, u64)>,
+    },
+    Fleet {
+        cp_rank: usize,
+        kind: K3CpWindowKind,
+        /// The whale's global ranks in CP order.
+        gang: Vec<usize>,
+        /// This window's doorbell value.
+        value: u64,
+    },
 }
 
 /// The in-process CP gang: a barrier and a published pointer table shared by
@@ -224,27 +272,35 @@ impl K3CpGroup {
         sync: &K3CpWindowSync,
         consume: impl FnOnce() -> Result<()>,
     ) -> Result<()> {
-        let me = sync.cp_rank;
+        let K3CpWindowSync::Local {
+            cp_rank: me,
+            kind,
+            events,
+        } = sync
+        else {
+            anyhow::bail!("an in-process K3 CP group was handed a fleet window sync");
+        };
+        let me = *me;
         ensure!(
-            sync.events.len() == self.cp_size,
+            events.len() == self.cp_size,
             "K3 CP window sync of {} ranks in a {}-rank gang",
-            sync.events.len(),
+            events.len(),
             self.cp_size
         );
         // Only this thread advances its own slot, so Relaxed reads it back.
         let window = self.published[me].load(Ordering::Relaxed) + 1;
-        record_event(ctx, sync.events[me].0).context("K3 CP publish event record failed")?;
+        record_event(ctx, events[me].0).context("K3 CP publish event record failed")?;
         self.published[me].store(window, Ordering::Release);
-        for rank in sync.kind.reads_from(me) {
+        for rank in kind.reads_from(me) {
             self.await_announce(&self.published[rank], window, rank, "publish")?;
-            wait_event(ctx, sync.events[rank].0).context("K3 CP publish event wait failed")?;
+            wait_event(ctx, events[rank].0).context("K3 CP publish event wait failed")?;
         }
         consume()?;
-        record_event(ctx, sync.events[me].1).context("K3 CP consume event record failed")?;
+        record_event(ctx, events[me].1).context("K3 CP consume event record failed")?;
         self.consumed[me].store(window, Ordering::Release);
-        for rank in sync.kind.read_by(me, self.cp_size) {
+        for rank in kind.read_by(me, self.cp_size) {
             self.await_announce(&self.consumed[rank], window, rank, "consume")?;
-            wait_event(ctx, sync.events[rank].1).context("K3 CP consume event wait failed")?;
+            wait_event(ctx, events[rank].1).context("K3 CP consume event wait failed")?;
         }
         Ok(())
     }
@@ -355,7 +411,7 @@ pub(crate) fn k3_cp_segments(total: usize, cp_size: usize) -> Vec<(usize, usize)
 /// that superstep's split and CP rank (the rank is a function of the job's
 /// poster, so it rotates job to job while the buffers stay put).
 pub(crate) struct K3CpScratch {
-    pub(crate) group: Arc<K3CpGroup>,
+    pub(crate) sync: K3CpSyncHandle,
     pub(crate) cp_rank: usize,
     pub(crate) cp_size: usize,
     /// `(start, len)` of every rank's segment, re-derived per superstep.
@@ -392,9 +448,17 @@ pub(crate) struct K3CpScratch {
     pub(crate) upstream_len: usize,
     seg_cap: usize,
     /// This rank's exchange events; peers wait on their raw handles via the
-    /// gang table, so they must live exactly as long as the scratch.
-    publish_event: CudaEvent,
-    consume_event: CudaEvent,
+    /// gang table, so they must live exactly as long as the scratch. Present
+    /// exactly on the in-process substrate — the fleet orders with doorbells.
+    publish_event: Option<CudaEvent>,
+    consume_event: Option<CudaEvent>,
+    /// The committed whale sequence the current fleet superstep serves —
+    /// the doorbell value base. Meaningless on the in-process substrate.
+    whale_seq: u64,
+    /// Exchange windows this fleet superstep has opened so far.
+    whale_window: u64,
+    /// The current whale's global ranks in CP order (fleet only).
+    whale_gang: Vec<usize>,
 }
 
 impl K3CpScratch {
@@ -430,9 +494,67 @@ impl K3CpScratch {
                 .context("alloc K3 CP upstream index buffer")?,
             upstream_len: 0,
             seg_cap,
-            publish_event: new_event(ctx).context("create K3 CP publish event")?,
-            consume_event: new_event(ctx).context("create K3 CP consume event")?,
-            group,
+            publish_event: Some(new_event(ctx).context("create K3 CP publish event")?),
+            consume_event: Some(new_event(ctx).context("create K3 CP consume event")?),
+            whale_seq: 0,
+            whale_window: 0,
+            whale_gang: Vec::new(),
+            sync: K3CpSyncHandle::Local(group),
+        })
+    }
+
+    /// The fleet variant: publish buffers are carved out of this rank's
+    /// fabric slab (so peers across processes can read them), local working
+    /// buffers stay pool allocations, and the recv arenas are sized for the
+    /// widest gang the world can seat. The slab arrives zeroed from its
+    /// allocation, matching the local constructor's `alloc_zeros`.
+    pub(crate) fn new_fleet(
+        ctx: &DeviceContext,
+        gang: Arc<K3WhaleGang>,
+        seg_cap: usize,
+    ) -> Result<Self> {
+        let world = gang.world();
+        let mine = gang.peer_ptrs(gang.rank())?;
+        // SAFETY: each pointer addresses a live region of this rank's own
+        // fabric slab, disjoint by layout, sized exactly as claimed, and the
+        // slab is never freed (fleet slabs are process-lifetime). The
+        // wrapper's drop will try a pool free on a VMM pointer, which the
+        // context records and ignores — same story as the mega slab.
+        let carve_bf16 =
+            |base: u64, len: usize| unsafe { ctx.stream.upgrade_device_ptr::<bf16>(base, len) };
+        let carve_f32 =
+            |base: u64, len: usize| unsafe { ctx.stream.upgrade_device_ptr::<f32>(base, len) };
+        let stream = &ctx.stream;
+        Ok(Self {
+            cp_rank: 0,
+            cp_size: world,
+            segments: Vec::new(),
+            peers: Vec::new(),
+            normed_tail: carve_bf16(mine.normed_tail, K3_CONV_STATE * K3_HIDDEN),
+            kda_m: carve_f32(mine.kda_m, K3_KDA_STATE),
+            kda_d: carve_f32(mine.kda_d, K3_KDA_STATE),
+            mla_latent_pub: carve_bf16(mine.mla_latent, seg_cap * K3_KV_LORA_RANK),
+            mla_rope_pub: carve_bf16(mine.mla_rope, seg_cap * K3_QK_ROPE_HEAD_DIM),
+            halo_normed: stream.alloc_zeros((K3_CONV_STATE + 1) * K3_HIDDEN)?,
+            halo_partial: stream.alloc_zeros((K3_CONV_STATE + 1) * K3_ATTN_INNER)?,
+            halo_xs: stream.alloc_zeros((K3_CONV_STATE + 1) * K3_ATTN_INNER)?,
+            recv_m: stream
+                .alloc_zeros(world * K3_KDA_STATE)
+                .context("alloc K3 whale package arena")?,
+            recv_d: stream.alloc_zeros(world * K3_KDA_STATE)?,
+            merge_a: stream.alloc_zeros(K3_KDA_STATE)?,
+            merge_b: stream.alloc_zeros(K3_KDA_STATE)?,
+            upstream_kv_rows: stream
+                .alloc_zeros(seg_cap.saturating_mul(world.saturating_sub(1)).max(1))
+                .context("alloc K3 whale upstream index buffer")?,
+            upstream_len: 0,
+            seg_cap,
+            publish_event: None,
+            consume_event: None,
+            whale_seq: 0,
+            whale_window: 0,
+            whale_gang: Vec::new(),
+            sync: K3CpSyncHandle::Fleet(gang),
         })
     }
 
@@ -460,13 +582,17 @@ impl K3CpScratch {
     }
 
     /// Enter one superstep: take this superstep's CP rank, adopt the split,
-    /// and swap pointer tables with the gang. Collective.
+    /// and swap pointer tables with the gang. Collective. In-process only —
+    /// a fleet scratch arms with [`K3CpScratch::arm_fleet`].
     pub(crate) fn arm(
         &mut self,
         ctx: &DeviceContext,
         cp_rank: usize,
         segments: Vec<(usize, usize)>,
     ) -> Result<()> {
+        let K3CpSyncHandle::Local(group) = self.sync.clone() else {
+            anyhow::bail!("a fleet K3 CP scratch cannot arm an in-process superstep");
+        };
         ensure!(
             cp_rank < self.cp_size,
             "K3 CP rank {cp_rank} of {}",
@@ -500,25 +626,99 @@ impl K3CpScratch {
             kda_d: ptr(&self.kda_d),
             mla_latent: ptr_bf(&self.mla_latent_pub),
             mla_rope: ptr_bf(&self.mla_rope_pub),
-            publish_event: self.publish_event.cu_event() as u64,
-            consume_event: self.consume_event.cu_event() as u64,
+            publish_event: self
+                .publish_event
+                .as_ref()
+                .expect("a local scratch owns its events")
+                .cu_event() as u64,
+            consume_event: self
+                .consume_event
+                .as_ref()
+                .expect("a local scratch owns its events")
+                .cu_event() as u64,
         };
-        self.peers = self.group.publish_and_snapshot(self.cp_rank, mine)?;
+        self.peers = group.publish_and_snapshot(self.cp_rank, mine)?;
         Ok(())
     }
 
-    /// Snapshot the event handles one exchange window needs — plain copied
-    /// data, so the `consume` closure is free to capture the scratch.
-    pub(crate) fn window_sync(&self, kind: K3CpWindowKind) -> K3CpWindowSync {
-        K3CpWindowSync {
-            cp_rank: self.cp_rank,
-            kind,
-            events: self
-                .peers
-                .iter()
-                .map(|peer| (peer.publish_event, peer.consume_event))
-                .collect(),
-        }
+    /// Enter one whale superstep: adopt the committed descriptor's gang, CP
+    /// rank and split, and point the peer table at the pre-imported fabric
+    /// slabs. Not collective on the host — the whale rendezvous already
+    /// committed every member to this exact superstep, and the pointer table
+    /// is static after the import — so there is nothing to wait for.
+    pub(crate) fn arm_fleet(
+        &mut self,
+        seq: u64,
+        cp_rank: usize,
+        gang_ranks: &[usize],
+        segments: Vec<(usize, usize)>,
+    ) -> Result<()> {
+        let K3CpSyncHandle::Fleet(gang) = self.sync.clone() else {
+            anyhow::bail!("an in-process K3 CP scratch cannot arm a whale superstep");
+        };
+        let width = gang_ranks.len();
+        ensure!(
+            (2..=gang.world()).contains(&width),
+            "K3 whale gang of {width} ranks in a {}-rank world",
+            gang.world()
+        );
+        ensure!(cp_rank < width, "K3 whale CP rank {cp_rank} of {width}");
+        ensure!(
+            gang_ranks[cp_rank] == gang.rank(),
+            "K3 whale gang seats rank {} at CP position {cp_rank}, but this executor is rank {}",
+            gang_ranks[cp_rank],
+            gang.rank()
+        );
+        ensure!(
+            segments.len() == width,
+            "K3 whale split of {} segments for a {width}-rank gang",
+            segments.len()
+        );
+        ensure!(
+            segments[cp_rank].1 <= self.seg_cap,
+            "K3 whale segment of {} tokens exceeds the {}-row publish buffers",
+            segments[cp_rank].1,
+            self.seg_cap
+        );
+        self.cp_rank = cp_rank;
+        self.cp_size = width;
+        self.segments = segments;
+        self.peers = gang_ranks
+            .iter()
+            .map(|&member| gang.peer_ptrs(member))
+            .collect::<Result<_>>()?;
+        self.whale_seq = seq;
+        self.whale_window = 0;
+        self.whale_gang = gang_ranks.to_vec();
+        Ok(())
+    }
+
+    /// Snapshot what one exchange window needs — plain copied data, so the
+    /// `consume` closure is free to capture the scratch. On the fleet
+    /// substrate this also claims the window's doorbell value, so every
+    /// snapshot must be spent on exactly one exchange.
+    pub(crate) fn window_sync(&mut self, kind: K3CpWindowKind) -> Result<K3CpWindowSync> {
+        Ok(match &self.sync {
+            K3CpSyncHandle::Local(_) => K3CpWindowSync::Local {
+                cp_rank: self.cp_rank,
+                kind,
+                events: self
+                    .peers
+                    .iter()
+                    .map(|peer| (peer.publish_event, peer.consume_event))
+                    .collect(),
+            },
+            K3CpSyncHandle::Fleet(_) => {
+                let value = K3WhaleGang::window_value(self.whale_seq, self.whale_window)?;
+                self.whale_window += 1;
+                K3CpWindowSync::Fleet {
+                    cp_rank: self.cp_rank,
+                    kind,
+                    gang: self.whale_gang.clone(),
+                    value,
+                }
+            }
+        })
     }
 
     /// Fold the received upstream packages into this rank's true KDA input

--- a/pegainfer-k3/src/executor/cp.rs
+++ b/pegainfer-k3/src/executor/cp.rs
@@ -404,6 +404,148 @@ pub(crate) fn k3_cp_segments(total: usize, cp_size: usize) -> Vec<(usize, usize)
     segments
 }
 
+/// The widest gang the prompt admits, or `None` when no width in
+/// `1 < w <= world` (powers of two, tray-aligned) does. Wider is better: the
+/// whale superstep stalls the *whole* fleet on the gang's finish line (the
+/// mega collective is global), so the gang that spreads the prompt thinnest —
+/// subject to every leveled segment staying above the floor and below one
+/// chunk — minimizes everyone's stall, not just the whale's latency.
+pub fn k3_whale_width(total: usize, world: usize, chunk_tokens: usize) -> Option<usize> {
+    let mut width = 1usize;
+    while width * 2 <= world {
+        width *= 2;
+    }
+    while width >= 2 {
+        if k3_whale_admits(total, width, chunk_tokens) {
+            return Some(width);
+        }
+        width /= 2;
+    }
+    None
+}
+
+/// Whether `total` tokens split over `width` ranks keeps every leveled
+/// segment above the floor and within one chunk step (one superstep per rank
+/// — the multi-superstep walk is out of scope until profiles demand it).
+pub fn k3_whale_admits(total: usize, width: usize, chunk_tokens: usize) -> bool {
+    if width < 2 || total < width * K3_WHALE_SEGMENT_FLOOR {
+        return false;
+    }
+    let segments = k3_whale_segments(total, width, chunk_tokens);
+    segments
+        .last()
+        .is_some_and(|&(start, len)| start + len == total)
+        && segments
+            .iter()
+            .all(|&(_, len)| len >= K3_WHALE_SEGMENT_FLOOR && len <= chunk_tokens)
+}
+
+/// The gang for a `width`-wide whale posted by `poster`: the tray-aligned
+/// contiguous block of ranks containing the poster (trays are 4 ranks; a
+/// contiguous block keeps the halo hop and most upstream traffic inside a
+/// tray or between adjacent trays), with the poster rotated to the end — the
+/// owner is the last CP rank, so the final KDA state and the whole MLA
+/// context land on the rank that will decode.
+pub fn k3_whale_gang(poster: usize, width: usize, world: usize) -> Vec<usize> {
+    debug_assert!(poster < world && width <= world);
+    const TRAY: usize = 4;
+    let start = if width >= TRAY {
+        (poster / TRAY * TRAY).min(world.saturating_sub(width))
+    } else {
+        poster.min(world.saturating_sub(width))
+    };
+    let mut gang: Vec<usize> = (start..start + width).filter(|&r| r != poster).collect();
+    gang.push(poster);
+    gang
+}
+
+/// How much one context token costs relative to one segment token, in the
+/// per-rank superstep time model `t_i ∝ len_i + Q·(start_i + len_i/2)·len_i`:
+/// the linear term is the full-depth per-token walk (MoE, KDA, dense GEMMs),
+/// the quadratic term is the MLA context triangle (each of the segment's rows
+/// attends its whole prefix). Calibrated from the CP4 16k profile
+/// (2026-08-25: a 12k-deeper prefix cost the last rank ~32ms against a
+/// ~1000ms/4k-row superstep); refit when the fleet profile lands. Leveling
+/// only needs the ratio, not the absolute times.
+const K3_CP_QUAD_PER_LINEAR: f64 = 2.7e-6;
+
+/// Split `total` tokens into `width` contiguous leveled segments: earlier
+/// ranks get longer segments, so every rank's modeled superstep time — walk
+/// plus its MLA triangle — comes out even.
+///
+/// Bisected on the per-rank time budget; coverage is monotone in the budget,
+/// so the smallest covering budget is the leveled split. The floor is *not*
+/// enforced here — [`k3_whale_admits`] rejects splits that level below it.
+/// The returned segments always number `width` and start at 0; they
+/// under-cover `total` when the chunk cap makes an exact partition
+/// impossible, which admission rejects too.
+pub fn k3_whale_segments(total: usize, width: usize, chunk_tokens: usize) -> Vec<(usize, usize)> {
+    debug_assert!(width >= 2);
+    if total == 0 {
+        return vec![(0, 0)];
+    }
+    // The padded per-row families (KDA, norms, projections, MoE entry) run at
+    // the covering chunk *bucket*, a step function of segment length — only
+    // attention is varlen. Pure leveling stretches the earliest segment past
+    // the bucket the mean sits in whenever the mean runs close to a boundary
+    // (65k over 8 ranks: mean 8,140, leveled head 8.6k → the 16,896 bucket,
+    // doubling its padded rows while the lockstep superstep waits — a
+    // measured ~900ms step). Cap segments at the mean's bucket: everyone
+    // stays in the same bucket, and leveling still balances the attention
+    // triangle inside it.
+    let cap = pegainfer_kernels::ops::k3_chunk_bucket(total.div_ceil(width))
+        .map_or(chunk_tokens, |bucket| bucket.min(chunk_tokens));
+    let affordable = |start: usize, budget: f64| -> usize {
+        // Largest len with len + Q·(start + len/2)·len <= budget:
+        // (Q/2)·len² + (1 + Q·start)·len − budget = 0.
+        let a = K3_CP_QUAD_PER_LINEAR / 2.0;
+        let b = 1.0 + K3_CP_QUAD_PER_LINEAR * start as f64;
+        let len = (2.0 * budget) / (b + (b * b + 4.0 * a * budget).sqrt());
+        (len.floor() as usize).min(cap)
+    };
+    let coverage = |budget: f64| -> usize {
+        let mut start = 0usize;
+        for _ in 0..width {
+            start += affordable(start, budget);
+        }
+        start
+    };
+    // Bisect the smallest budget that covers the prompt. The even split's
+    // per-rank cost bounds it above (leveling can only lower the maximum).
+    let per = total.div_ceil(width) as f64;
+    let mut hi = per * (1.0 + K3_CP_QUAD_PER_LINEAR * total as f64);
+    let mut lo = 0.0f64;
+    for _ in 0..64 {
+        let mid = (lo + hi) / 2.0;
+        if coverage(mid) >= total {
+            hi = mid;
+        } else {
+            lo = mid;
+        }
+    }
+    let mut segments = Vec::with_capacity(width);
+    let mut start = 0usize;
+    for rank in 0..width {
+        let remaining = total - start;
+        let ranks_left = width - rank;
+        // The bisected budget's segment, clamped to leave every later rank at
+        // least one token; the last rank takes whatever is left. Leveling is
+        // a preference, the exact partition is the contract — when the chunk
+        // cap makes exactness impossible the result under-covers and
+        // [`k3_whale_admits`] rejects it.
+        let len = if ranks_left == 1 {
+            remaining.min(chunk_tokens)
+        } else {
+            affordable(start, hi)
+                .max(1)
+                .min(remaining.saturating_sub(ranks_left - 1))
+        };
+        segments.push((start, len));
+        start += len;
+    }
+    segments
+}
+
 /// One rank's CP working set: the buffers it publishes to its peers, the
 /// receive arenas it folds their packages in, and the gang handle. Allocated
 /// exactly once per executor — the pool grants to the gang's devices must
@@ -837,4 +979,130 @@ pub(crate) fn k3_cp_copy_in<T: cudarc::driver::DeviceRepr>(
     }
     .result()
     .map_err(|error| anyhow::anyhow!("K3 CP peer copy failed: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The mega row ceiling (#962): CP16 x one chunk covers 256k in a single
+    /// superstep, which is exactly why the protocol was raised to 16896.
+    const CHUNK: usize = 16896;
+
+    #[test]
+    fn width_covers_256k_at_ep16() {
+        assert_eq!(k3_whale_width(262144, 16, CHUNK), Some(16));
+    }
+
+    #[test]
+    fn width_refuses_hopeless_prompts() {
+        // Below two floors no gang splits legally...
+        assert_eq!(
+            k3_whale_width(2 * K3_WHALE_SEGMENT_FLOOR - 1, 16, CHUNK),
+            None
+        );
+        assert_eq!(k3_whale_width(1024, 16, CHUNK), None);
+        // ...and past world x chunk the M0 one-superstep-per-rank walk ends.
+        assert_eq!(k3_whale_width(16 * CHUNK + 1, 16, CHUNK), None);
+    }
+
+    #[test]
+    fn width_is_the_widest_admitting_power_of_two() {
+        for total in [8192usize, 12288, 16384, 32768, 65536, 131072, 262144] {
+            let width = k3_whale_width(total, 16, CHUNK)
+                .unwrap_or_else(|| panic!("{total} tokens should admit some width"));
+            assert!(k3_whale_admits(total, width, CHUNK), "{total} @ {width}");
+            let mut wider = width * 2;
+            while wider <= 16 {
+                assert!(!k3_whale_admits(total, wider, CHUNK), "{total} @ {wider}");
+                wider *= 2;
+            }
+        }
+    }
+
+    #[test]
+    fn segments_partition_exactly_and_level_downward() {
+        for (total, width) in [(262144usize, 16usize), (65536, 8), (12288, 4), (8192, 2)] {
+            let segments = k3_whale_segments(total, width, CHUNK);
+            assert_eq!(segments.len(), width, "{total} @ {width}");
+            let mut expected_start = 0;
+            for &(start, len) in &segments {
+                assert_eq!(start, expected_start, "{total} @ {width}: {segments:?}");
+                assert!(len <= CHUNK);
+                expected_start += len;
+            }
+            assert_eq!(expected_start, total, "{total} @ {width}: {segments:?}");
+            // Later ranks sit on deeper prefixes: leveling only shortens them.
+            for pair in segments.windows(2) {
+                assert!(pair[0].1 >= pair[1].1, "{total} @ {width}: {segments:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn segments_stay_inside_the_mean_chunk_bucket() {
+        // The padded per-row families run at the covering chunk bucket, so a
+        // leveled head stretching past the bucket the mean sits in doubles
+        // that rank's padded rows and stalls the lockstep superstep on it
+        // (the measured ~900ms TTFT step at 65k over 8 ranks, where pure
+        // leveling pushed the head from a mean of 8,140 past 8,448). Every
+        // segment must sit in the mean's bucket.
+        for (total, width) in [(65116usize, 8usize), (66000, 8), (33000, 8), (131072, 16)] {
+            let cap = pegainfer_kernels::ops::k3_chunk_bucket(total.div_ceil(width)).unwrap();
+            let segments = k3_whale_segments(total, width, CHUNK);
+            assert_eq!(segments.iter().map(|&(_, len)| len).sum::<usize>(), total);
+            for &(_, len) in &segments {
+                assert!(
+                    len <= cap,
+                    "{total} @ {width}: segment of {len} rows leaves the {cap} bucket: \
+                     {segments:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn segments_leveling_bites_at_depth() {
+        // At 256k the last rank's MLA triangle is ~2/3 of its walk; an even
+        // split would park the whole fleet on its tail.
+        let segments = k3_whale_segments(262144, 16, CHUNK);
+        let first = segments.first().unwrap().1;
+        let last = segments.last().unwrap().1;
+        assert!(
+            first > last + 1000,
+            "leveling too timid at 256k: first {first}, last {last}"
+        );
+    }
+
+    #[test]
+    fn gang_is_tray_aligned_with_the_poster_last() {
+        assert_eq!(k3_whale_gang(5, 8, 16), vec![4, 6, 7, 8, 9, 10, 11, 5]);
+        assert_eq!(k3_whale_gang(14, 8, 16), vec![8, 9, 10, 11, 12, 13, 15, 14]);
+        let full = k3_whale_gang(0, 16, 16);
+        assert_eq!(full.len(), 16);
+        assert_eq!(full.last(), Some(&0));
+    }
+
+    #[test]
+    fn gang_is_always_a_contiguous_in_world_block_containing_the_poster() {
+        for world in [4usize, 8, 16] {
+            for width in [2usize, 4, 8, 16].into_iter().filter(|&w| w <= world) {
+                for poster in 0..world {
+                    let gang = k3_whale_gang(poster, width, world);
+                    assert_eq!(gang.len(), width);
+                    assert_eq!(gang.last(), Some(&poster));
+                    let mut sorted = gang.clone();
+                    sorted.sort_unstable();
+                    sorted.dedup();
+                    assert_eq!(sorted.len(), width, "duplicates in {gang:?}");
+                    assert!(sorted.iter().all(|&rank| rank < world));
+                    assert_eq!(
+                        sorted.last().unwrap() - sorted.first().unwrap(),
+                        width - 1,
+                        "gang {gang:?} is not contiguous"
+                    );
+                }
+            }
+        }
+    }
 }

--- a/pegainfer-k3/src/executor/cp.rs
+++ b/pegainfer-k3/src/executor/cp.rs
@@ -155,9 +155,9 @@ impl K3CpSyncHandle {
                     cp_rank,
                     kind,
                     gang: members,
-                    value,
+                    doorbell,
                 },
-            ) => gang.exchange(ctx, *cp_rank, *kind, members, *value, consume),
+            ) => gang.exchange(ctx, *cp_rank, *kind, members, *doorbell, consume),
             _ => anyhow::bail!("K3 CP window sync does not match its coordination substrate"),
         }
     }
@@ -178,7 +178,7 @@ pub(crate) enum K3CpWindowSync {
         /// The whale's global ranks in CP order.
         gang: Vec<usize>,
         /// This window's doorbell value.
-        value: u64,
+        doorbell: u64,
     },
 }
 
@@ -375,7 +375,7 @@ fn wait_event(ctx: &DeviceContext, event: u64) -> Result<()> {
 /// 58%), so a wider gang stops paying for itself. The in-process lane's floor
 /// stays [`K3_CONV_STATE`]-based ([`k3_cp_admits`]) — its width is fixed at
 /// arm time, not chosen per prompt.
-pub const K3_CP_SEGMENT_FLOOR: usize = 2048;
+pub const K3_WHALE_SEGMENT_FLOOR: usize = 2048;
 
 /// Whether a prompt of `total` tokens is CP-eligible: every segment must
 /// outspan the conv window (the halo exchange publishes exactly
@@ -452,62 +452,62 @@ pub(crate) struct K3CpScratch {
     /// exactly on the in-process substrate — the fleet orders with doorbells.
     publish_event: Option<CudaEvent>,
     consume_event: Option<CudaEvent>,
-    /// The committed whale sequence the current fleet superstep serves —
-    /// the doorbell value base. Meaningless on the in-process substrate.
-    whale_seq: u64,
+    /// The committed whale sequence the current fleet superstep serves — the
+    /// doorbell value base. `None` until the first [`K3CpScratch::arm_fleet`];
+    /// re-arms must strictly increase it or doorbell values would alias a
+    /// previous superstep's.
+    whale_seq: Option<u64>,
     /// Exchange windows this fleet superstep has opened so far.
     whale_window: u64,
     /// The current whale's global ranks in CP order (fleet only).
-    whale_gang: Vec<usize>,
+    gang_ranks: Vec<usize>,
+}
+
+/// The five buffers a CP rank publishes to its peers: pool allocations
+/// in-process, fabric-slab carvings on the fleet.
+struct K3CpPublish {
+    normed_tail: CudaSlice<bf16>,
+    kda_m: CudaSlice<f32>,
+    kda_d: CudaSlice<f32>,
+    mla_latent: CudaSlice<bf16>,
+    mla_rope: CudaSlice<bf16>,
 }
 
 impl K3CpScratch {
     pub(crate) fn new(ctx: &DeviceContext, group: Arc<K3CpGroup>, seg_cap: usize) -> Result<Self> {
         let cp_size = group.cp_size();
         let stream = &ctx.stream;
-        Ok(Self {
-            // Meaningful only between an `arm` and the superstep it opened.
-            cp_rank: 0,
-            cp_size,
-            segments: Vec::new(),
-            peers: Vec::new(),
+        let publish = K3CpPublish {
             normed_tail: stream.alloc_zeros(K3_CONV_STATE * K3_HIDDEN)?,
             kda_m: stream
                 .alloc_zeros(K3_KDA_STATE)
                 .context("alloc K3 CP transition package")?,
             kda_d: stream.alloc_zeros(K3_KDA_STATE)?,
-            mla_latent_pub: stream
+            mla_latent: stream
                 .alloc_zeros(seg_cap * K3_KV_LORA_RANK)
                 .context("alloc K3 CP latent publish buffer")?,
-            mla_rope_pub: stream.alloc_zeros(seg_cap * K3_QK_ROPE_HEAD_DIM)?,
-            halo_normed: stream.alloc_zeros((K3_CONV_STATE + 1) * K3_HIDDEN)?,
-            halo_partial: stream.alloc_zeros((K3_CONV_STATE + 1) * K3_ATTN_INNER)?,
-            halo_xs: stream.alloc_zeros((K3_CONV_STATE + 1) * K3_ATTN_INNER)?,
-            recv_m: stream
-                .alloc_zeros(cp_size * K3_KDA_STATE)
-                .context("alloc K3 CP package arena")?,
-            recv_d: stream.alloc_zeros(cp_size * K3_KDA_STATE)?,
-            merge_a: stream.alloc_zeros(K3_KDA_STATE)?,
-            merge_b: stream.alloc_zeros(K3_KDA_STATE)?,
-            upstream_kv_rows: stream
-                .alloc_zeros(seg_cap.saturating_mul(cp_size.saturating_sub(1)).max(1))
-                .context("alloc K3 CP upstream index buffer")?,
-            upstream_len: 0,
+            mla_rope: stream.alloc_zeros(seg_cap * K3_QK_ROPE_HEAD_DIM)?,
+        };
+        let events = Some((
+            new_event(ctx).context("create K3 CP publish event")?,
+            new_event(ctx).context("create K3 CP consume event")?,
+        ));
+        Self::new_inner(
+            ctx,
+            K3CpSyncHandle::Local(group),
+            cp_size,
             seg_cap,
-            publish_event: Some(new_event(ctx).context("create K3 CP publish event")?),
-            consume_event: Some(new_event(ctx).context("create K3 CP consume event")?),
-            whale_seq: 0,
-            whale_window: 0,
-            whale_gang: Vec::new(),
-            sync: K3CpSyncHandle::Local(group),
-        })
+            publish,
+            events,
+        )
     }
 
     /// The fleet variant: publish buffers are carved out of this rank's
     /// fabric slab (so peers across processes can read them), local working
     /// buffers stay pool allocations, and the recv arenas are sized for the
     /// widest gang the world can seat. The slab arrives zeroed from its
-    /// allocation, matching the local constructor's `alloc_zeros`.
+    /// allocation, matching the local constructor's `alloc_zeros`; doorbells
+    /// replace events.
     pub(crate) fn new_fleet(
         ctx: &DeviceContext,
         gang: Arc<K3WhaleGang>,
@@ -524,37 +524,69 @@ impl K3CpScratch {
             |base: u64, len: usize| unsafe { ctx.stream.upgrade_device_ptr::<bf16>(base, len) };
         let carve_f32 =
             |base: u64, len: usize| unsafe { ctx.stream.upgrade_device_ptr::<f32>(base, len) };
-        let stream = &ctx.stream;
-        Ok(Self {
-            cp_rank: 0,
-            cp_size: world,
-            segments: Vec::new(),
-            peers: Vec::new(),
+        let publish = K3CpPublish {
             normed_tail: carve_bf16(mine.normed_tail, K3_CONV_STATE * K3_HIDDEN),
             kda_m: carve_f32(mine.kda_m, K3_KDA_STATE),
             kda_d: carve_f32(mine.kda_d, K3_KDA_STATE),
-            mla_latent_pub: carve_bf16(mine.mla_latent, seg_cap * K3_KV_LORA_RANK),
-            mla_rope_pub: carve_bf16(mine.mla_rope, seg_cap * K3_QK_ROPE_HEAD_DIM),
+            mla_latent: carve_bf16(mine.mla_latent, seg_cap * K3_KV_LORA_RANK),
+            mla_rope: carve_bf16(mine.mla_rope, seg_cap * K3_QK_ROPE_HEAD_DIM),
+        };
+        Self::new_inner(
+            ctx,
+            K3CpSyncHandle::Fleet(gang),
+            world,
+            seg_cap,
+            publish,
+            None,
+        )
+    }
+
+    /// The substrate-independent remainder of both constructors: local
+    /// working buffers plus the not-yet-armed bookkeeping.
+    fn new_inner(
+        ctx: &DeviceContext,
+        sync: K3CpSyncHandle,
+        cp_size: usize,
+        seg_cap: usize,
+        publish: K3CpPublish,
+        events: Option<(CudaEvent, CudaEvent)>,
+    ) -> Result<Self> {
+        let stream = &ctx.stream;
+        let (publish_event, consume_event) = match events {
+            Some((publish, consume)) => (Some(publish), Some(consume)),
+            None => (None, None),
+        };
+        Ok(Self {
+            // Meaningful only between an `arm` and the superstep it opened.
+            cp_rank: 0,
+            cp_size,
+            segments: Vec::new(),
+            peers: Vec::new(),
+            normed_tail: publish.normed_tail,
+            kda_m: publish.kda_m,
+            kda_d: publish.kda_d,
+            mla_latent_pub: publish.mla_latent,
+            mla_rope_pub: publish.mla_rope,
             halo_normed: stream.alloc_zeros((K3_CONV_STATE + 1) * K3_HIDDEN)?,
             halo_partial: stream.alloc_zeros((K3_CONV_STATE + 1) * K3_ATTN_INNER)?,
             halo_xs: stream.alloc_zeros((K3_CONV_STATE + 1) * K3_ATTN_INNER)?,
             recv_m: stream
-                .alloc_zeros(world * K3_KDA_STATE)
-                .context("alloc K3 whale package arena")?,
-            recv_d: stream.alloc_zeros(world * K3_KDA_STATE)?,
+                .alloc_zeros(cp_size * K3_KDA_STATE)
+                .context("alloc K3 CP package arena")?,
+            recv_d: stream.alloc_zeros(cp_size * K3_KDA_STATE)?,
             merge_a: stream.alloc_zeros(K3_KDA_STATE)?,
             merge_b: stream.alloc_zeros(K3_KDA_STATE)?,
             upstream_kv_rows: stream
-                .alloc_zeros(seg_cap.saturating_mul(world.saturating_sub(1)).max(1))
-                .context("alloc K3 whale upstream index buffer")?,
+                .alloc_zeros(seg_cap.saturating_mul(cp_size.saturating_sub(1)).max(1))
+                .context("alloc K3 CP upstream index buffer")?,
             upstream_len: 0,
             seg_cap,
-            publish_event: None,
-            consume_event: None,
-            whale_seq: 0,
+            publish_event,
+            consume_event,
+            whale_seq: None,
             whale_window: 0,
-            whale_gang: Vec::new(),
-            sync: K3CpSyncHandle::Fleet(gang),
+            gang_ranks: Vec::new(),
+            sync,
         })
     }
 
@@ -680,6 +712,12 @@ impl K3CpScratch {
             segments[cp_rank].1,
             self.seg_cap
         );
+        ensure!(
+            self.whale_seq.is_none_or(|previous| seq > previous),
+            "K3 whale superstep re-armed at seq {seq}, not after {:?} — its doorbell values \
+             would alias an earlier superstep's",
+            self.whale_seq
+        );
         self.cp_rank = cp_rank;
         self.cp_size = width;
         self.segments = segments;
@@ -687,9 +725,9 @@ impl K3CpScratch {
             .iter()
             .map(|&member| gang.peer_ptrs(member))
             .collect::<Result<_>>()?;
-        self.whale_seq = seq;
+        self.whale_seq = Some(seq);
         self.whale_window = 0;
-        self.whale_gang = gang_ranks.to_vec();
+        self.gang_ranks = gang_ranks.to_vec();
         Ok(())
     }
 
@@ -709,13 +747,16 @@ impl K3CpScratch {
                     .collect(),
             },
             K3CpSyncHandle::Fleet(_) => {
-                let value = K3WhaleGang::window_value(self.whale_seq, self.whale_window)?;
+                let seq = self
+                    .whale_seq
+                    .context("K3 fleet exchange window before any arm_fleet")?;
+                let doorbell = K3WhaleGang::window_value(seq, self.whale_window)?;
                 self.whale_window += 1;
                 K3CpWindowSync::Fleet {
                     cp_rank: self.cp_rank,
                     kind,
-                    gang: self.whale_gang.clone(),
-                    value,
+                    gang: self.gang_ranks.clone(),
+                    doorbell,
                 }
             }
         })

--- a/pegainfer-k3/src/executor/forward/prefill.rs
+++ b/pegainfer-k3/src/executor/forward/prefill.rs
@@ -321,8 +321,8 @@ pub(super) fn kda_attention_chunk(
                 K3_HIDDEN,
             )?;
         }
-        let group = cp.group.clone();
-        let sync = cp.window_sync(K3CpWindowKind::Halo);
+        let group = cp.sync.clone();
+        let sync = cp.window_sync(K3CpWindowKind::Halo)?;
         group.exchange(ctx, &sync, || {
             if cp.cp_rank > 0 {
                 let source = cp.peers[cp.cp_rank - 1].normed_tail;
@@ -579,8 +579,8 @@ pub(super) fn kda_attention_chunk(
                     K3_KDA_STATE,
                 )?;
             }
-            let cp_group = cp.group.clone();
-            let cp_sync = cp.window_sync(K3CpWindowKind::Upstream);
+            let cp_group = cp.sync.clone();
+            let cp_sync = cp.window_sync(K3CpWindowKind::Upstream)?;
             cp_group.exchange(ctx, &cp_sync, || {
                 for j in 0..cp.cp_rank {
                     k3_cp_copy_in(
@@ -835,8 +835,8 @@ pub(super) fn mla_attention_chunk_cp(
         t_q,
         crate::config::K3_QK_ROPE_HEAD_DIM,
     )?;
-    let group = cp.group.clone();
-    let sync = cp.window_sync(K3CpWindowKind::Upstream);
+    let group = cp.sync.clone();
+    let sync = cp.window_sync(K3CpWindowKind::Upstream)?;
     group.exchange(ctx, &sync, || {
         for j in 0..cp.cp_rank {
             let (peer_start, peer_len) = cp.segments[j];

--- a/pegainfer-k3/src/executor/forward/prefill.rs
+++ b/pegainfer-k3/src/executor/forward/prefill.rs
@@ -9,13 +9,16 @@ use half::bf16;
 use pegainfer_kernels::ops::K3_CONV_WIDTH;
 use pegainfer_kernels::ops::K3_MLA_HEADS;
 use pegainfer_kernels::ops::argmax_bf16_split_into;
-use pegainfer_kernels::ops::gemm_rows_into_checked;
+use pegainfer_kernels::ops::gemm_rows_span_into_checked;
 use pegainfer_kernels::ops::k3_conv_silu_batched_launch;
 use pegainfer_kernels::ops::k3_flash_kda_fwd_launch;
+use pegainfer_kernels::ops::k3_flash_mla_prefill_fwd_dense_launch;
 use pegainfer_kernels::ops::k3_flash_mla_prefill_fwd_launch;
 use pegainfer_kernels::ops::k3_land_batched_launch;
 use pegainfer_kernels::ops::k3_mla_prefill_expand_k_launch;
 use pegainfer_kernels::ops::k3_mla_prefill_gather_launch;
+use pegainfer_kernels::ops::k3_mla_prefill_lse_merge_launch;
+use pegainfer_kernels::ops::k3_mla_prefill_o_finalize_launch;
 use pegainfer_kernels::ops::k3_o_norm_gate_batched_launch;
 use pegainfer_kernels::ops::k3_rms_norm_rbs_batched_launch;
 use pegainfer_kernels::tensor::DeviceContext;
@@ -895,7 +898,14 @@ pub(super) fn mla_attention_chunk_cp(
 }
 
 /// The shared tail of a chunk's MLA attention: kv_b expansion of the
-/// assembled `[t_kv]` context latents and one causal Q-at-the-end FMHA.
+/// assembled `[t_kv]` context latents and the Q-at-the-end FMHA.
+///
+/// The expansion scratch holds `min(max_ctx, K3_MLA_CTX_WINDOW)` rows. A
+/// context that fits takes today's single causal call, bitwise unchanged. A
+/// deeper one walks the past in dense windows — expand a window, attend all
+/// `t_q` queries over it unmasked, fold output and log-sum-exp into the f32
+/// accumulator — and closes with the causal `t_q x t_q` call over the chunk's
+/// own keys; the finalize converts the merged accumulator into `s.attn`.
 fn mla_chunk_attend(
     ctx: &DeviceContext,
     t_q: usize,
@@ -908,36 +918,113 @@ fn mla_chunk_attend(
         "K3 MLA prefill workspace of {} tokens cannot span the {t_kv}-token context",
         s.mla_ctx_latent.data.len() / K3_KV_LORA_RANK
     );
-    s.mla_ctx_latent.seq_len = t_kv;
-    s.mla_ctx_nope_v.seq_len = t_kv;
-    gemm_rows_into_checked(
-        ctx,
-        &w.w_kv_b,
-        0,
-        K3_KV_B_OUT,
-        &s.mla_ctx_latent,
-        &mut s.mla_ctx_nope_v,
-    )?;
-    k3_mla_prefill_expand_k_launch(
-        ctx,
-        t_kv,
-        K3_MLA_HEADS,
-        &s.mla_ctx_nope_v.data,
-        &s.mla_ctx_rope,
-        &mut s.mla_ctx_k,
-    )?;
     // The decode kernel reads the softmax scale as a bf16 device scalar; feed
     // the FMHA the same rounded constant so the two paths agree on it.
     let scale = bf16::from_f64(crate::model::k3_mla_scale()).to_f32();
+    s.mla_ctx_latent.seq_len = t_kv;
+    let win = s.mla_ctx_k.len() / crate::config::K3_Q_B_OUT;
+    if t_kv <= win {
+        mla_expand_window(ctx, w, s, 0, t_kv)?;
+        return k3_flash_mla_prefill_fwd_launch(
+            ctx,
+            t_q,
+            t_kv,
+            K3_MLA_HEADS,
+            &s.query,
+            &s.mla_ctx_k,
+            &s.mla_ctx_nope_v.data,
+            &mut s.attn,
+            None,
+            scale,
+        );
+    }
+    // Dense windows over the past context, then the chunk's own causal window.
+    let ctx_len = t_kv - t_q;
+    ensure!(
+        t_q <= win,
+        "K3 MLA prefill chunk of {t_q} queries exceeds the {win}-row expansion window"
+    );
+    let mut row = 0;
+    while row < ctx_len {
+        let len = win.min(ctx_len - row);
+        mla_expand_window(ctx, w, s, row, len)?;
+        k3_flash_mla_prefill_fwd_dense_launch(
+            ctx,
+            t_q,
+            len,
+            K3_MLA_HEADS,
+            &s.query,
+            &s.mla_ctx_k,
+            &s.mla_ctx_nope_v.data,
+            &mut s.attn,
+            Some(&mut s.mla_lse_win),
+            scale,
+        )?;
+        k3_mla_prefill_lse_merge_launch(
+            ctx,
+            t_q,
+            K3_MLA_HEADS,
+            &s.attn,
+            &s.mla_lse_win,
+            &mut s.mla_o_acc,
+            &mut s.mla_lse_acc,
+            row == 0,
+        )?;
+        row += len;
+    }
+    mla_expand_window(ctx, w, s, ctx_len, t_q)?;
     k3_flash_mla_prefill_fwd_launch(
         ctx,
         t_q,
-        t_kv,
+        t_q,
         K3_MLA_HEADS,
         &s.query,
         &s.mla_ctx_k,
         &s.mla_ctx_nope_v.data,
         &mut s.attn,
+        Some(&mut s.mla_lse_win),
         scale,
+    )?;
+    k3_mla_prefill_lse_merge_launch(
+        ctx,
+        t_q,
+        K3_MLA_HEADS,
+        &s.attn,
+        &s.mla_lse_win,
+        &mut s.mla_o_acc,
+        &mut s.mla_lse_acc,
+        false,
+    )?;
+    k3_mla_prefill_o_finalize_launch(ctx, t_q, K3_MLA_HEADS, &s.mla_o_acc, &mut s.attn)
+}
+
+/// Expand context rows `[row, row + len)` through `kv_b` into the window
+/// scratch: the nope|value expansion lands in `mla_ctx_nope_v` and the
+/// assembled per-head K rows in `mla_ctx_k`, both window-relative.
+fn mla_expand_window(
+    ctx: &DeviceContext,
+    w: &K3MlaWeights,
+    s: &mut K3Scratch,
+    row: usize,
+    len: usize,
+) -> Result<()> {
+    s.mla_ctx_nope_v.seq_len = len;
+    gemm_rows_span_into_checked(
+        ctx,
+        &w.w_kv_b,
+        0,
+        K3_KV_B_OUT,
+        &s.mla_ctx_latent,
+        row,
+        &mut s.mla_ctx_nope_v,
+    )?;
+    k3_mla_prefill_expand_k_launch(
+        ctx,
+        len,
+        K3_MLA_HEADS,
+        &s.mla_ctx_nope_v.data,
+        &s.mla_ctx_rope,
+        row,
+        &mut s.mla_ctx_k,
     )
 }

--- a/pegainfer-k3/src/executor/mod.rs
+++ b/pegainfer-k3/src/executor/mod.rs
@@ -99,6 +99,8 @@ use self::buffers::K3Scratch;
 use self::buffers::K3StatePool;
 use self::cp::K3CpGroup;
 use self::cp::K3CpScratch;
+use self::cp::k3_whale_admits;
+use self::cp::k3_whale_segments;
 use self::dspark::K3_DSPARK_AUX_LAYERS;
 use self::dspark::K3_DSPARK_BLOCK;
 use self::dspark::K3_DSPARK_CONTEXT_DIM;
@@ -115,10 +117,6 @@ use self::forward::k3_decode_step;
 use self::forward::k3_prefill_boundary_sample;
 use self::forward::k3_prefill_chunk_step;
 use self::forward::k3_verify_step;
-use self::whale_gang::K3WhaleGang;
-use self::whale_gang::K3WhaleSlabLayout;
-use self::whale_gang::K3WhaleSlabWire;
-use self::whale_gang::k3_whale_slab_alloc;
 use crate::config::K3_DENSE_LAYERS;
 use crate::config::K3_LAYERS;
 use crate::config::K3MoeTopo;
@@ -129,8 +127,6 @@ use crate::scheduler::DecodeSlot;
 use crate::scheduler::SlotId;
 use crate::scheduler::StepExecutor;
 use crate::scheduler::whale::CommittedWhale;
-use crate::scheduler::whale::k3_whale_admits;
-use crate::scheduler::whale::k3_whale_segments;
 use crate::weights::K3RankGpuContext;
 use crate::weights::K3WeightManifest;
 use crate::weights::load_rank_weights_to_gpu;
@@ -1512,52 +1508,6 @@ impl K3Executor {
             .arm(&self.ctx, cp_rank, segments)
     }
 
-    /// Allocate this rank's whale slab — its fleet CP publish surface plus
-    /// doorbells — before the fleet's handle exchange. `world` is the whale
-    /// world size; every rank must derive the identical layout, which the
-    /// import checks byte-for-byte. Once per executor. Returns the local base
-    /// (for the process-wide import table) and the wire identity peers import.
-    pub fn arm_whale_slab(&mut self, world: usize) -> Result<(u64, K3WhaleSlabWire)> {
-        ensure!(
-            self.whale_slab.is_none(),
-            "K3 rank {} armed its whale slab twice",
-            self.model.rank
-        );
-        let layout = K3WhaleSlabLayout::new(world, k3_chunk_bucket(self.chunk_tokens)?);
-        let (base, wire) = k3_whale_slab_alloc(self.ctx.device_ordinal, &layout)?;
-        self.whale_slab = Some((base, layout));
-        Ok((base, wire))
-    }
-
-    /// Map the exchanged world table into this process — once, on any one
-    /// local executor; every local rank then installs one clone of the
-    /// result. `local` maps this process's ranks to their slab bases.
-    pub fn import_whale_world(
-        &self,
-        table: &[K3WhaleSlabWire],
-        local: &[(usize, u64)],
-    ) -> Result<Vec<u64>> {
-        let (_, layout) = self
-            .whale_slab
-            .context("K3 whale import before arm_whale_slab")?;
-        whale_gang::k3_whale_import_world(table, local, &layout, self.ctx.device_ordinal)
-    }
-
-    /// Install the imported world table ([`k3_whale_import_world`]'s result)
-    /// and stand the whale data plane up for this rank.
-    pub fn install_whale_gang(&mut self, bases: Vec<u64>) -> Result<()> {
-        let (base, layout) = self
-            .whale_slab
-            .context("K3 whale gang install before arm_whale_slab")?;
-        let rank = self.model.rank;
-        ensure!(
-            bases.get(rank).copied() == Some(base),
-            "K3 whale slab table does not carry rank {rank}'s own base"
-        );
-        self.whale_gang = Some(Arc::new(K3WhaleGang::new(bases, rank, layout)?));
-        Ok(())
-    }
-
     fn prefill_whale_inner(
         &mut self,
         whale: &CommittedWhale,
@@ -1594,40 +1544,6 @@ impl K3Executor {
         self.prefill_state.reset_row(&self.ctx, 0)?;
         self.ensure_whale_scratch(descriptor.seq, cp_rank, &descriptor.gang, segments)?;
         self.cp_superstep(slot, prompt, cp_rank, width)
-    }
-
-    /// Build (or re-arm) the fleet CP working set for this whale superstep.
-    /// Unlike the in-process path this opens no peer access — the fabric
-    /// mappings carry their own grants — and arms without any collective.
-    fn ensure_whale_scratch(
-        &mut self,
-        seq: u64,
-        cp_rank: usize,
-        gang_ranks: &[usize],
-        segments: Vec<(usize, usize)>,
-    ) -> Result<()> {
-        let gang = self
-            .whale_gang
-            .clone()
-            .context("K3 whale prefill before the gang was installed")?;
-        if let Some(scratch) = self.cp_scratch.as_ref() {
-            ensure!(
-                matches!(&scratch.sync, cp::K3CpSyncHandle::Fleet(mine) if Arc::ptr_eq(mine, &gang)),
-                "K3 CP scratch was built for a different substrate than the whale gang"
-            );
-        } else {
-            self.cp_scratch = Some(Box::new(K3CpScratch::new_fleet(
-                &self.ctx,
-                gang,
-                k3_chunk_bucket(self.chunk_tokens)?,
-            )?));
-            // Local arenas live and zeroed before the superstep touches them.
-            self.gpu.sync()?;
-        }
-        self.cp_scratch
-            .as_mut()
-            .expect("built above")
-            .arm_fleet(seq, cp_rank, gang_ranks, segments)
     }
 
     /// One decode step.

--- a/pegainfer-k3/src/executor/mod.rs
+++ b/pegainfer-k3/src/executor/mod.rs
@@ -68,6 +68,7 @@ mod dspark;
 pub mod ep;
 mod forward;
 mod paged_kv;
+pub(crate) mod whale_gang;
 
 use std::path::Path;
 use std::sync::Arc;
@@ -114,6 +115,10 @@ use self::forward::k3_decode_step;
 use self::forward::k3_prefill_boundary_sample;
 use self::forward::k3_prefill_chunk_step;
 use self::forward::k3_verify_step;
+use self::whale_gang::K3WhaleGang;
+use self::whale_gang::K3WhaleSlabLayout;
+use self::whale_gang::K3WhaleSlabWire;
+use self::whale_gang::k3_whale_slab_alloc;
 use crate::config::K3_DENSE_LAYERS;
 use crate::config::K3_LAYERS;
 use crate::config::K3MoeTopo;
@@ -123,6 +128,8 @@ use crate::model::K3RankModel;
 use crate::scheduler::DecodeSlot;
 use crate::scheduler::SlotId;
 use crate::scheduler::StepExecutor;
+use crate::scheduler::whale::CommittedWhale;
+use crate::scheduler::whale::k3_whale_segments;
 use crate::weights::K3RankGpuContext;
 use crate::weights::K3WeightManifest;
 use crate::weights::load_rank_weights_to_gpu;
@@ -395,8 +402,14 @@ pub struct K3Executor {
     /// Present exactly when `ep_size > 1`: this rank's slab handshake with its
     /// peers. It issues nothing per step.
     ep: Option<K3EpRuntime>,
-    /// Context-parallel working set, allocated at the first [`Self::prefill_cp`].
+    /// Context-parallel working set, allocated at the first
+    /// [`Self::prefill_cp`] (in-process) or [`Self::prefill_whale`] (fleet).
     cp_scratch: Option<Box<K3CpScratch>>,
+    /// This rank's whale slab, allocated by [`Self::arm_whale_slab`] before
+    /// the fleet's handle exchange: local base plus the world-agreed layout.
+    whale_slab: Option<(u64, whale_gang::K3WhaleSlabLayout)>,
+    /// The imported whale data plane, installed after the exchange.
+    whale_gang: Option<Arc<whale_gang::K3WhaleGang>>,
 }
 
 // SAFETY: the executor owns one rank's context, stream and device buffers, and
@@ -714,6 +727,8 @@ impl K3Executor {
             bound_thread: None,
             ep,
             cp_scratch: None,
+            whale_slab: None,
+            whale_gang: None,
         })
     }
 
@@ -1091,6 +1106,24 @@ impl StepExecutor for K3Executor {
         }
     }
 
+    /// Enter a committed whale's superstep as the gang member the descriptor
+    /// seats at `whale.cp_rank` — the fleet counterpart of
+    /// [`Self::prefill_cp`], with the same segment walk over the same chunk
+    /// step; only the exchange substrate differs (fabric slabs and doorbells
+    /// for peer copies and events). The owner (the poster, always the last
+    /// CP rank) passes its decode `slot` and gets the boundary token back.
+    fn prefill_whale(
+        &mut self,
+        whale: &CommittedWhale,
+        slot: Option<SlotId>,
+    ) -> Result<Option<u32>> {
+        let rank = self.model.rank;
+        match self.prefill_whale_inner(whale, slot) {
+            Err(error) if self.is_expert_parallel() => ep_fatal(rank, "prefill-whale", &error),
+            other => other,
+        }
+    }
+
     /// One padding step, waited to completion.
     ///
     /// A scheduler thread leveling up at a CP-gang board must keep feeding
@@ -1293,7 +1326,6 @@ impl K3Executor {
             self.chunk_tokens
         );
         let segments = cp::k3_cp_segments(prompt.len(), cp_size);
-        let (seg_start, seg_len) = segments[cp_rank];
         let owner = cp_rank + 1 == cp_size;
         ensure!(
             !owner || slot < self.max_batch,
@@ -1306,6 +1338,30 @@ impl K3Executor {
         self.enter_step()?;
         self.prefill_state.reset_row(&self.ctx, 0)?;
         self.ensure_cp_scratch(group, cp_rank, segments)?;
+        self.cp_superstep(owner.then_some(slot), prompt, cp_rank, cp_size)
+    }
+
+    /// The shared body of one CP superstep, run after the scratch is armed
+    /// with this superstep's split — the in-process gang and the fleet whale
+    /// gang differ only in how they got here. `slot` is set exactly on the
+    /// owner (the last CP rank).
+    fn cp_superstep(
+        &mut self,
+        slot: Option<SlotId>,
+        prompt: &[u32],
+        cp_rank: usize,
+        cp_size: usize,
+    ) -> Result<Option<u32>> {
+        let owner = cp_rank + 1 == cp_size;
+        ensure!(
+            owner == slot.is_some(),
+            "K3 CP superstep: the owner and only the owner adopts a decode slot"
+        );
+        let (seg_start, seg_len) = self
+            .cp_scratch
+            .as_ref()
+            .context("K3 CP superstep needs an armed scratch")?
+            .segments[cp_rank];
 
         // Stage the segment at global positions for causality. Only the OWNER
         // stages the paged pool (at global positions): the step's normal
@@ -1372,7 +1428,7 @@ impl K3Executor {
         if let Some(mega) = self.scratch.mega.as_ref() {
             mega.end_step()?;
         }
-        if owner {
+        if let Some(slot) = slot {
             // The owner's post-chunk state IS the whole prompt's: the merged
             // upstream KDA state fed its chunk, its conv window is the prompt
             // tail, and its pool covers positions 0..len. Sample the boundary
@@ -1428,7 +1484,7 @@ impl K3Executor {
             // One gang per process, one seg_cap per executor — the scratch
             // built once serves every superstep.
             ensure!(
-                Arc::ptr_eq(&scratch.group, group),
+                matches!(&scratch.sync, cp::K3CpSyncHandle::Local(mine) if Arc::ptr_eq(mine, group)),
                 "K3 CP scratch was built for a different gang"
             );
         } else {
@@ -1453,6 +1509,130 @@ impl K3Executor {
             .as_mut()
             .expect("built above")
             .arm(&self.ctx, cp_rank, segments)
+    }
+
+    /// Allocate this rank's whale slab — its fleet CP publish surface plus
+    /// doorbells — before the fleet's handle exchange. `world` is the whale
+    /// world size; every rank must derive the identical layout, which the
+    /// import checks byte-for-byte. Once per executor.
+    pub fn arm_whale_slab(&mut self, world: usize) -> Result<K3WhaleSlabWire> {
+        ensure!(
+            self.whale_slab.is_none(),
+            "K3 rank {} armed its whale slab twice",
+            self.model.rank
+        );
+        let layout = K3WhaleSlabLayout::new(world, k3_chunk_bucket(self.chunk_tokens)?);
+        let (base, wire) = k3_whale_slab_alloc(self.ctx.device_ordinal, &layout)?;
+        self.whale_slab = Some((base, layout));
+        Ok(wire)
+    }
+
+    /// This rank's local slab base, for the process-wide import table.
+    pub fn whale_slab_base(&self) -> Option<u64> {
+        self.whale_slab.map(|(base, _)| base)
+    }
+
+    /// Map the exchanged world table into this process — once, on any one
+    /// local executor; every local rank then installs one clone of the
+    /// result. `local` maps this process's ranks to their slab bases.
+    pub fn import_whale_world(
+        &self,
+        table: &[K3WhaleSlabWire],
+        local: &[(usize, u64)],
+    ) -> Result<Vec<u64>> {
+        let (_, layout) = self
+            .whale_slab
+            .context("K3 whale import before arm_whale_slab")?;
+        whale_gang::k3_whale_import_world(table, local, &layout, self.ctx.device_ordinal)
+    }
+
+    /// Install the imported world table ([`k3_whale_import_world`]'s result)
+    /// and stand the whale data plane up for this rank.
+    pub fn install_whale_gang(&mut self, bases: Vec<u64>) -> Result<()> {
+        let (base, layout) = self
+            .whale_slab
+            .context("K3 whale gang install before arm_whale_slab")?;
+        let rank = self.model.rank;
+        ensure!(
+            bases.get(rank).copied() == Some(base),
+            "K3 whale slab table does not carry rank {rank}'s own base"
+        );
+        self.whale_gang = Some(Arc::new(K3WhaleGang::new(bases, rank, layout)?));
+        Ok(())
+    }
+
+    fn prefill_whale_inner(
+        &mut self,
+        whale: &CommittedWhale,
+        slot: Option<SlotId>,
+    ) -> Result<Option<u32>> {
+        let descriptor = &whale.descriptor;
+        let width = descriptor.gang.len();
+        let cp_rank = whale.cp_rank;
+        let prompt: &[u32] = &descriptor.prompt;
+        ensure!(
+            prompt.len() <= self.max_ctx,
+            "K3 whale prompt of {} tokens exceeds the {} context",
+            prompt.len(),
+            self.max_ctx
+        );
+        // The poster is always the gang's last CP rank, and only the poster
+        // adopts a decode slot.
+        let owner = cp_rank + 1 == width;
+        ensure!(
+            owner == slot.is_some(),
+            "K3 whale {}: the owner and only the owner passes a slot",
+            descriptor.seq
+        );
+        if let Some(slot) = slot {
+            ensure!(
+                slot < self.max_batch,
+                "K3 whale slot {slot} is out of range"
+            );
+        }
+        ensure!(
+            self.dspark.is_none(),
+            "K3 whale prefill does not feed the dspark draft lane; disarm it"
+        );
+        let segments = k3_whale_segments(prompt.len(), width, self.chunk_tokens);
+        self.enter_step()?;
+        self.prefill_state.reset_row(&self.ctx, 0)?;
+        self.ensure_whale_scratch(descriptor.seq, cp_rank, &descriptor.gang, segments)?;
+        self.cp_superstep(slot, prompt, cp_rank, width)
+    }
+
+    /// Build (or re-arm) the fleet CP working set for this whale superstep.
+    /// Unlike the in-process path this opens no peer access — the fabric
+    /// mappings carry their own grants — and arms without any collective.
+    fn ensure_whale_scratch(
+        &mut self,
+        seq: u64,
+        cp_rank: usize,
+        gang_ranks: &[usize],
+        segments: Vec<(usize, usize)>,
+    ) -> Result<()> {
+        let gang = self
+            .whale_gang
+            .clone()
+            .context("K3 whale prefill before the gang was installed")?;
+        if let Some(scratch) = self.cp_scratch.as_ref() {
+            ensure!(
+                matches!(&scratch.sync, cp::K3CpSyncHandle::Fleet(mine) if Arc::ptr_eq(mine, &gang)),
+                "K3 CP scratch was built for a different substrate than the whale gang"
+            );
+        } else {
+            self.cp_scratch = Some(Box::new(K3CpScratch::new_fleet(
+                &self.ctx,
+                gang,
+                k3_chunk_bucket(self.chunk_tokens)?,
+            )?));
+            // Local arenas live and zeroed before the superstep touches them.
+            self.gpu.sync()?;
+        }
+        self.cp_scratch
+            .as_mut()
+            .expect("built above")
+            .arm_fleet(seq, cp_rank, gang_ranks, segments)
     }
 
     /// One decode step.

--- a/pegainfer-k3/src/executor/mod.rs
+++ b/pegainfer-k3/src/executor/mod.rs
@@ -129,6 +129,7 @@ use crate::scheduler::DecodeSlot;
 use crate::scheduler::SlotId;
 use crate::scheduler::StepExecutor;
 use crate::scheduler::whale::CommittedWhale;
+use crate::scheduler::whale::k3_whale_admits;
 use crate::scheduler::whale::k3_whale_segments;
 use crate::weights::K3RankGpuContext;
 use crate::weights::K3WeightManifest;
@@ -1514,8 +1515,9 @@ impl K3Executor {
     /// Allocate this rank's whale slab — its fleet CP publish surface plus
     /// doorbells — before the fleet's handle exchange. `world` is the whale
     /// world size; every rank must derive the identical layout, which the
-    /// import checks byte-for-byte. Once per executor.
-    pub fn arm_whale_slab(&mut self, world: usize) -> Result<K3WhaleSlabWire> {
+    /// import checks byte-for-byte. Once per executor. Returns the local base
+    /// (for the process-wide import table) and the wire identity peers import.
+    pub fn arm_whale_slab(&mut self, world: usize) -> Result<(u64, K3WhaleSlabWire)> {
         ensure!(
             self.whale_slab.is_none(),
             "K3 rank {} armed its whale slab twice",
@@ -1524,12 +1526,7 @@ impl K3Executor {
         let layout = K3WhaleSlabLayout::new(world, k3_chunk_bucket(self.chunk_tokens)?);
         let (base, wire) = k3_whale_slab_alloc(self.ctx.device_ordinal, &layout)?;
         self.whale_slab = Some((base, layout));
-        Ok(wire)
-    }
-
-    /// This rank's local slab base, for the process-wide import table.
-    pub fn whale_slab_base(&self) -> Option<u64> {
-        self.whale_slab.map(|(base, _)| base)
+        Ok((base, wire))
     }
 
     /// Map the exchanged world table into this process — once, on any one
@@ -1576,13 +1573,15 @@ impl K3Executor {
             prompt.len(),
             self.max_ctx
         );
-        // The poster is always the gang's last CP rank, and only the poster
-        // adopts a decode slot.
-        let owner = cp_rank + 1 == width;
+        // The descriptor crossed a process boundary: re-check the admission
+        // predicate its segments are derived from before trusting it.
         ensure!(
-            owner == slot.is_some(),
-            "K3 whale {}: the owner and only the owner passes a slot",
-            descriptor.seq
+            k3_whale_admits(prompt.len(), width, self.chunk_tokens),
+            "K3 whale {}: {} tokens across a width-{width} gang does not fit the {}-token chunk \
+             cap",
+            descriptor.seq,
+            prompt.len(),
+            self.chunk_tokens
         );
         if let Some(slot) = slot {
             ensure!(
@@ -1590,10 +1589,6 @@ impl K3Executor {
                 "K3 whale slot {slot} is out of range"
             );
         }
-        ensure!(
-            self.dspark.is_none(),
-            "K3 whale prefill does not feed the dspark draft lane; disarm it"
-        );
         let segments = k3_whale_segments(prompt.len(), width, self.chunk_tokens);
         self.enter_step()?;
         self.prefill_state.reset_row(&self.ctx, 0)?;

--- a/pegainfer-k3/src/executor/whale_gang.rs
+++ b/pegainfer-k3/src/executor/whale_gang.rs
@@ -41,6 +41,7 @@ use anyhow::Context as _;
 use anyhow::Result;
 use anyhow::ensure;
 use cudarc::driver::sys as cu_sys;
+use half::bf16;
 use pegainfer_kernels::ops::K3_MEGA_FABRIC_HANDLE_BYTES;
 use pegainfer_kernels::ops::k3_mega_fabric_slab_alloc;
 use pegainfer_kernels::ops::k3_mega_fabric_slab_import;
@@ -100,11 +101,11 @@ impl K3WhaleSlabLayout {
         };
         let publish_inbox = region(world * K3_WHALE_ALIGN);
         let consume_inbox = region(world * K3_WHALE_ALIGN);
-        let normed_tail = region(K3_CONV_STATE * K3_HIDDEN * 2);
-        let kda_m = region(K3_KDA_STATE * 4);
-        let kda_d = region(K3_KDA_STATE * 4);
-        let mla_latent = region(seg_cap * K3_KV_LORA_RANK * 2);
-        let mla_rope = region(seg_cap * K3_QK_ROPE_HEAD_DIM * 2);
+        let normed_tail = region(K3_CONV_STATE * K3_HIDDEN * size_of::<bf16>());
+        let kda_m = region(K3_KDA_STATE * size_of::<f32>());
+        let kda_d = region(K3_KDA_STATE * size_of::<f32>());
+        let mla_latent = region(seg_cap * K3_KV_LORA_RANK * size_of::<bf16>());
+        let mla_rope = region(seg_cap * K3_QK_ROPE_HEAD_DIM * size_of::<bf16>());
         Self {
             publish_inbox,
             consume_inbox,
@@ -162,7 +163,6 @@ pub(crate) fn k3_whale_slab_alloc(
 /// hub's slab exchange; process-lifetime, like the mega slabs (a whale fleet
 /// dies together).
 pub(crate) struct K3WhaleGang {
-    world: usize,
     /// This executor's global rank — where peers ring my doorbells.
     rank: usize,
     layout: K3WhaleSlabLayout,
@@ -226,7 +226,6 @@ impl K3WhaleGang {
             "K3 whale slab table has an unmapped rank"
         );
         Ok(Self {
-            world: bases.len(),
             rank,
             layout,
             bases,
@@ -234,7 +233,7 @@ impl K3WhaleGang {
     }
 
     pub(crate) fn world(&self) -> usize {
-        self.world
+        self.bases.len()
     }
 
     pub(crate) fn rank(&self) -> usize {
@@ -242,7 +241,7 @@ impl K3WhaleGang {
     }
 
     /// This rank's own slab base — where its publish buffers are carved.
-    pub(crate) fn my_base(&self) -> u64 {
+    fn my_base(&self) -> u64 {
         self.bases[self.rank]
     }
 
@@ -251,9 +250,9 @@ impl K3WhaleGang {
     /// doorbells, never on events.
     pub(crate) fn peer_ptrs(&self, rank: usize) -> Result<K3CpPeerPtrs> {
         ensure!(
-            rank < self.world,
+            rank < self.bases.len(),
             "K3 whale peer rank {rank} outside the {} world",
-            self.world
+            self.bases.len()
         );
         let base = self.bases[rank];
         Ok(K3CpPeerPtrs {
@@ -280,27 +279,20 @@ impl K3WhaleGang {
     /// One exchange window over the fabric — the four-beat protocol of
     /// [`super::cp::K3CpGroup::exchange`] with doorbells for events. `gang`
     /// is the whale's global ranks in CP order and `cp_rank` this rank's
-    /// position in it; `consume` issues this rank's reads of peer buffers on
-    /// its own stream. Entirely stream-ordered: the host enqueues and
-    /// returns, and every wait is a `cuStreamWaitValue64` on this rank's own
-    /// slab.
+    /// position in it (both validated when the superstep armed); `consume`
+    /// issues this rank's reads of peer buffers on its own stream. Entirely
+    /// stream-ordered: the host enqueues and returns, and every wait is a
+    /// `cuStreamWaitValue64` on this rank's own slab.
     pub(crate) fn exchange(
         &self,
         ctx: &DeviceContext,
         cp_rank: usize,
         kind: K3CpWindowKind,
         gang: &[usize],
-        value: u64,
+        doorbell: u64,
         consume: impl FnOnce() -> Result<()>,
     ) -> Result<()> {
         let cp_size = gang.len();
-        ensure!(cp_rank < cp_size, "K3 whale CP rank {cp_rank} of {cp_size}");
-        ensure!(
-            gang[cp_rank] == self.rank,
-            "K3 whale gang seats rank {} at CP position {cp_rank}, but this executor is rank {}",
-            gang[cp_rank],
-            self.rank
-        );
         let my_base = self.my_base();
         // Beat 1: announce my publication to every rank that reads it, in one
         // ring. The kernel's system fence releases my preceding stream work,
@@ -313,13 +305,13 @@ impl K3WhaleGang {
             })
             .collect();
         if !publish_flags.is_empty() {
-            k3_whale_doorbell_ring(&publish_flags, value, active_cu_stream(ctx))
+            k3_whale_doorbell_ring(&publish_flags, doorbell, active_cu_stream(ctx))
                 .context("K3 whale publish doorbell ring")?;
         }
         // Beat 2: wait for every publication I read this window.
         for source in kind.reads_from(cp_rank) {
             let flag = self.layout.publish_flag(my_base, gang[source]);
-            stream_wait_value(ctx, flag, value).context("K3 whale publish doorbell wait")?;
+            stream_wait_value(ctx, flag, doorbell).context("K3 whale publish doorbell wait")?;
         }
         // Beat 3: enqueue my reads, then acknowledge them to their owners.
         consume()?;
@@ -331,14 +323,14 @@ impl K3WhaleGang {
             })
             .collect();
         if !consume_flags.is_empty() {
-            k3_whale_doorbell_ring(&consume_flags, value, active_cu_stream(ctx))
+            k3_whale_doorbell_ring(&consume_flags, doorbell, active_cu_stream(ctx))
                 .context("K3 whale consume doorbell ring")?;
         }
         // Beat 4: wait for my readers, so my next window's publish writes
         // cannot overwrite what a peer is still reading.
         for reader in kind.read_by(cp_rank, cp_size) {
             let flag = self.layout.consume_flag(my_base, gang[reader]);
-            stream_wait_value(ctx, flag, value).context("K3 whale consume doorbell wait")?;
+            stream_wait_value(ctx, flag, doorbell).context("K3 whale consume doorbell wait")?;
         }
         Ok(())
     }
@@ -374,11 +366,20 @@ mod tests {
         let regions = [
             (layout.publish_inbox, world * K3_WHALE_ALIGN),
             (layout.consume_inbox, world * K3_WHALE_ALIGN),
-            (layout.normed_tail, K3_CONV_STATE * K3_HIDDEN * 2),
-            (layout.kda_m, K3_KDA_STATE * 4),
-            (layout.kda_d, K3_KDA_STATE * 4),
-            (layout.mla_latent, seg_cap * K3_KV_LORA_RANK * 2),
-            (layout.mla_rope, seg_cap * K3_QK_ROPE_HEAD_DIM * 2),
+            (
+                layout.normed_tail,
+                K3_CONV_STATE * K3_HIDDEN * size_of::<bf16>(),
+            ),
+            (layout.kda_m, K3_KDA_STATE * size_of::<f32>()),
+            (layout.kda_d, K3_KDA_STATE * size_of::<f32>()),
+            (
+                layout.mla_latent,
+                seg_cap * K3_KV_LORA_RANK * size_of::<bf16>(),
+            ),
+            (
+                layout.mla_rope,
+                seg_cap * K3_QK_ROPE_HEAD_DIM * size_of::<bf16>(),
+            ),
         ];
         for (offset, _) in regions {
             assert_eq!(offset % K3_WHALE_ALIGN, 0, "unaligned region at {offset}");
@@ -431,19 +432,27 @@ mod tests {
     }
 
     #[test]
-    fn flag_slots_are_one_line_apart_per_source_rank() {
+    fn flag_slots_are_aligned_and_one_line_apart() {
         let layout = K3WhaleSlabLayout::new(4, 4224);
         let base = 1 << 20;
-        for from in 0..4 {
-            let publish = layout.publish_flag(base, from);
-            let consume = layout.consume_flag(base, from);
-            assert_eq!(publish % 8, 0);
-            assert_eq!(consume % 8, 0);
-            assert_eq!(
-                publish,
-                base + layout.publish_inbox as u64 + (from * K3_WHALE_ALIGN) as u64
+        let flags: Vec<u64> = (0..4)
+            .flat_map(|from| {
+                [
+                    layout.publish_flag(base, from),
+                    layout.consume_flag(base, from),
+                ]
+            })
+            .collect();
+        for &flag in &flags {
+            assert_eq!(flag % 8, 0, "a doorbell store at {flag:#x} would tear");
+        }
+        let mut sorted = flags;
+        sorted.sort_unstable();
+        for pair in sorted.windows(2) {
+            assert!(
+                pair[1] - pair[0] >= K3_WHALE_ALIGN as u64,
+                "flag slots share a cache line: {pair:x?}"
             );
-            assert!(consume >= base + layout.consume_inbox as u64);
         }
     }
 }

--- a/pegainfer-k3/src/executor/whale_gang.rs
+++ b/pegainfer-k3/src/executor/whale_gang.rs
@@ -357,6 +357,10 @@ impl super::K3Executor {
             "K3 rank {} armed its whale slab twice",
             self.model.rank
         );
+        // Arming runs on the engine-launch thread, which under parallel
+        // (staged) loading has never held a CUDA context — the VMM calls
+        // behind the slab alloc need one current.
+        self.bind_thread()?;
         let layout = K3WhaleSlabLayout::new(world, k3_chunk_bucket(self.chunk_tokens)?);
         let (base, wire) = k3_whale_slab_alloc(self.ctx.device_ordinal, &layout)?;
         self.whale_slab = Some((base, layout));

--- a/pegainfer-k3/src/executor/whale_gang.rs
+++ b/pegainfer-k3/src/executor/whale_gang.rs
@@ -1,0 +1,426 @@
+//! The fleet whale gang's data plane: the cross-process counterpart of the
+//! in-process CP gang in [`super::cp`].
+//!
+//! An in-process gang exchanges segment publications through peer-access
+//! device copies ordered by CUDA events. Neither survives a process boundary:
+//! peers in another process cannot dereference a pool pointer, and a CUDA
+//! event handle is meaningless outside the context that created it. The fleet
+//! replaces both with the same substrate the MegaMoE kernel already runs on —
+//! NVLink-fabric memory (NVL72 + IMEX):
+//!
+//! * **Buffers**: every rank's whole CP publish surface (conv halo tail, KDA
+//!   `(M, D)` packages, MLA latent/rope rows) lives in one
+//!   `CU_MEM_HANDLE_TYPE_FABRIC` slab, allocated at startup and imported once
+//!   by every process in the world. After that import, a peer's publication
+//!   is an ordinary device pointer — [`super::cp::k3_cp_copy_in`] works
+//!   unchanged.
+//! * **Ordering**: CUDA events give way to **doorbells** — `u64` flag arrays
+//!   in the same slabs, written with `cuStreamWriteValue64` and waited on
+//!   with `cuStreamWaitValue64`. Writes go to the *remote* rank's slab and
+//!   waits watch the rank's *own* slab, so every wait is on local memory and
+//!   every remote touch is a plain NVLink store — the direction the fabric
+//!   is built for. The four-beat window protocol is the in-process one
+//!   verbatim (publish, await publications, consume, await consumers); only
+//!   the primitive changed.
+//!
+//! Doorbell values must be agreed without any host negotiation, across gangs
+//! that rotate membership whale to whale. They are derived entirely from the
+//! whale rendezvous ([`crate::scheduler::whale`]): window `w` of whale `seq`
+//! carries the value `(seq + 1) * K3_WHALE_WINDOW_STRIDE + w + 1`. The
+//! sequencer hands out `seq` strictly increasing and every superstep runs the
+//! same fixed window schedule, so the values a rank writes are strictly
+//! monotonic even across whales it sits out — which is exactly what the
+//! `GEQ` wait condition needs. Flag arrays are indexed by *global* rank, so
+//! rotation never aliases a slot.
+
+use anyhow::Context as _;
+use anyhow::Result;
+use anyhow::ensure;
+use cudarc::driver::sys as cu_sys;
+use pegainfer_kernels::ops::K3_MEGA_FABRIC_HANDLE_BYTES;
+use pegainfer_kernels::ops::k3_mega_fabric_slab_alloc;
+use pegainfer_kernels::ops::k3_mega_fabric_slab_import;
+use pegainfer_kernels::ops::k3_mega_fabric_supported;
+use pegainfer_kernels::tensor::DeviceContext;
+use pegainfer_kernels::tensor::active_cu_stream;
+
+use super::buffers::K3_CONV_STATE;
+use super::buffers::K3_KDA_STATE;
+use super::cp::K3CpPeerPtrs;
+use super::cp::K3CpWindowKind;
+use crate::config::K3_HIDDEN;
+use crate::config::K3_KV_LORA_RANK;
+use crate::config::K3_QK_ROPE_HEAD_DIM;
+
+/// Doorbell values per whale: window `w` of whale `seq` rings
+/// `(seq + 1) * STRIDE + w + 1`. The stride bounds the windows one superstep
+/// may run (the real schedule is ~`2 x layers + mix layers`, far below it),
+/// and `window_value` asserts the bound instead of silently aliasing the
+/// next whale's values.
+pub(crate) const K3_WHALE_WINDOW_STRIDE: u64 = 4096;
+
+/// Byte offsets of one rank's regions inside its whale slab. Every rank in
+/// the world derives the identical layout from the same `(world, seg_cap)`,
+/// which is what lets a peer address a remote region with nothing but the
+/// imported base.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct K3WhaleSlabLayout {
+    /// `[world] u64` — inbox: rank `r` announces its window publication here.
+    publish_inbox: usize,
+    /// `[world] u64` — inbox: rank `r` acknowledges consuming my publication.
+    consume_inbox: usize,
+    normed_tail: usize,
+    kda_m: usize,
+    kda_d: usize,
+    mla_latent: usize,
+    mla_rope: usize,
+    pub(crate) num_bytes: usize,
+}
+
+/// Every region starts on a fresh cache line; the doorbell flags get one
+/// line per slot so a remote store never false-shares with a neighbour.
+const K3_WHALE_ALIGN: usize = 128;
+
+fn aligned(offset: usize) -> usize {
+    offset.next_multiple_of(K3_WHALE_ALIGN)
+}
+
+impl K3WhaleSlabLayout {
+    pub(crate) fn new(world: usize, seg_cap: usize) -> Self {
+        let mut offset = 0usize;
+        let mut region = |bytes: usize| -> usize {
+            let base = aligned(offset);
+            offset = base + bytes;
+            base
+        };
+        let publish_inbox = region(world * K3_WHALE_ALIGN);
+        let consume_inbox = region(world * K3_WHALE_ALIGN);
+        let normed_tail = region(K3_CONV_STATE * K3_HIDDEN * 2);
+        let kda_m = region(K3_KDA_STATE * 4);
+        let kda_d = region(K3_KDA_STATE * 4);
+        let mla_latent = region(seg_cap * K3_KV_LORA_RANK * 2);
+        let mla_rope = region(seg_cap * K3_QK_ROPE_HEAD_DIM * 2);
+        Self {
+            publish_inbox,
+            consume_inbox,
+            normed_tail,
+            kda_m,
+            kda_d,
+            mla_latent,
+            mla_rope,
+            num_bytes: aligned(offset),
+        }
+    }
+
+    fn publish_flag(&self, base: u64, from: usize) -> u64 {
+        base + (self.publish_inbox + from * K3_WHALE_ALIGN) as u64
+    }
+
+    fn consume_flag(&self, base: u64, from: usize) -> u64 {
+        base + (self.consume_inbox + from * K3_WHALE_ALIGN) as u64
+    }
+}
+
+/// One rank's slab identity on the wire: what the whale hub's startup
+/// exchange moves between processes.
+#[derive(Clone, Copy, Debug)]
+pub struct K3WhaleSlabWire {
+    pub handle: [u8; K3_MEGA_FABRIC_HANDLE_BYTES],
+    pub num_bytes: usize,
+}
+
+/// Allocate this rank's whale slab on `device_ordinal`: zeroed, mapped for
+/// every local device, fabric-exportable. Returns the local base pointer and
+/// the wire identity peers import.
+pub(crate) fn k3_whale_slab_alloc(
+    device_ordinal: usize,
+    layout: &K3WhaleSlabLayout,
+) -> Result<(u64, K3WhaleSlabWire)> {
+    ensure!(
+        k3_mega_fabric_supported(device_ordinal).unwrap_or(false),
+        "K3 whale rank on device {device_ordinal} cannot allocate NVLink-fabric memory; a \
+         cross-machine whale gang needs the IMEX daemon and a fabric-capable driver"
+    );
+    let (ptr, handle) = k3_mega_fabric_slab_alloc(device_ordinal, layout.num_bytes)
+        .context("alloc K3 whale CP fabric slab")?;
+    Ok((
+        u64::try_from(ptr).context("K3 whale slab base pointer")?,
+        K3WhaleSlabWire {
+            handle,
+            num_bytes: layout.num_bytes,
+        },
+    ))
+}
+
+/// The world's whale data plane as seen from one rank: every rank's slab
+/// mapped into this process, plus the shared layout. Built once after the
+/// hub's slab exchange; process-lifetime, like the mega slabs (a whale fleet
+/// dies together).
+pub(crate) struct K3WhaleGang {
+    world: usize,
+    /// This executor's global rank — where peers ring my doorbells.
+    rank: usize,
+    layout: K3WhaleSlabLayout,
+    /// Per world rank: the slab base as addressed from this process (my own
+    /// entry is the local allocation).
+    bases: Vec<u64>,
+}
+
+/// Map the whole world's whale slabs into this process, once: `local` maps
+/// the ranks this process hosts to their locally allocated bases (already
+/// mapped for every local device by their allocation); every other rank's
+/// handle is imported through `device_ordinal`, which likewise maps it for
+/// all local devices. Every local executor then builds its own
+/// [`K3WhaleGang`] over one clone of the returned table.
+pub(crate) fn k3_whale_import_world(
+    world_slabs: &[K3WhaleSlabWire],
+    local: &[(usize, u64)],
+    layout: &K3WhaleSlabLayout,
+    device_ordinal: usize,
+) -> Result<Vec<u64>> {
+    let world = world_slabs.len();
+    let mut bases = vec![0u64; world];
+    let mut have = vec![false; world];
+    for &(local_rank, base) in local {
+        ensure!(
+            local_rank < world,
+            "K3 whale local rank {local_rank} outside the {world} world"
+        );
+        bases[local_rank] = base;
+        have[local_rank] = true;
+    }
+    for (peer, wire) in world_slabs.iter().enumerate() {
+        if have[peer] {
+            continue;
+        }
+        ensure!(
+            wire.num_bytes == layout.num_bytes,
+            "K3 whale rank {peer} published a {}-byte slab, expected {} — the fleet disagrees on \
+             the slab layout",
+            wire.num_bytes,
+            layout.num_bytes
+        );
+        let ptr = k3_mega_fabric_slab_import(&wire.handle, wire.num_bytes, device_ordinal)
+            .with_context(|| format!("import K3 whale rank {peer}'s slab"))?;
+        bases[peer] = u64::try_from(ptr).context("K3 whale imported base")?;
+    }
+    Ok(bases)
+}
+
+impl K3WhaleGang {
+    /// One rank's view over the process-wide base table from
+    /// [`k3_whale_import_world`].
+    pub(crate) fn new(bases: Vec<u64>, rank: usize, layout: K3WhaleSlabLayout) -> Result<Self> {
+        ensure!(
+            rank < bases.len(),
+            "K3 whale rank {rank} outside the {}-slab table",
+            bases.len()
+        );
+        ensure!(
+            bases.iter().all(|&base| base != 0),
+            "K3 whale slab table has an unmapped rank"
+        );
+        Ok(Self {
+            world: bases.len(),
+            rank,
+            layout,
+            bases,
+        })
+    }
+
+    pub(crate) fn world(&self) -> usize {
+        self.world
+    }
+
+    pub(crate) fn rank(&self) -> usize {
+        self.rank
+    }
+
+    /// This rank's own slab base — where its publish buffers are carved.
+    pub(crate) fn my_base(&self) -> u64 {
+        self.bases[self.rank]
+    }
+
+    /// The publish-surface pointers of `rank`'s slab, as addressed from this
+    /// process. The event fields stay zero: fleet ordering runs on
+    /// doorbells, never on events.
+    pub(crate) fn peer_ptrs(&self, rank: usize) -> Result<K3CpPeerPtrs> {
+        ensure!(
+            rank < self.world,
+            "K3 whale peer rank {rank} outside the {} world",
+            self.world
+        );
+        let base = self.bases[rank];
+        Ok(K3CpPeerPtrs {
+            normed_tail: base + self.layout.normed_tail as u64,
+            kda_m: base + self.layout.kda_m as u64,
+            kda_d: base + self.layout.kda_d as u64,
+            mla_latent: base + self.layout.mla_latent as u64,
+            mla_rope: base + self.layout.mla_rope as u64,
+            publish_event: 0,
+            consume_event: 0,
+        })
+    }
+
+    /// The doorbell value window `window` of whale `seq` rings.
+    pub(crate) fn window_value(seq: u64, window: u64) -> Result<u64> {
+        ensure!(
+            window + 1 < K3_WHALE_WINDOW_STRIDE,
+            "K3 whale superstep ran {window} exchange windows, past the {K3_WHALE_WINDOW_STRIDE} \
+             doorbell stride"
+        );
+        Ok((seq + 1) * K3_WHALE_WINDOW_STRIDE + window + 1)
+    }
+
+    /// One exchange window over the fabric — the four-beat protocol of
+    /// [`super::cp::K3CpGroup::exchange`] with doorbells for events. `gang`
+    /// is the whale's global ranks in CP order and `cp_rank` this rank's
+    /// position in it; `consume` issues this rank's reads of peer buffers on
+    /// its own stream. Entirely stream-ordered: the host enqueues and
+    /// returns, and every wait is a `cuStreamWaitValue64` on this rank's own
+    /// slab.
+    pub(crate) fn exchange(
+        &self,
+        ctx: &DeviceContext,
+        cp_rank: usize,
+        kind: K3CpWindowKind,
+        gang: &[usize],
+        value: u64,
+        consume: impl FnOnce() -> Result<()>,
+    ) -> Result<()> {
+        let cp_size = gang.len();
+        ensure!(cp_rank < cp_size, "K3 whale CP rank {cp_rank} of {cp_size}");
+        ensure!(
+            gang[cp_rank] == self.rank,
+            "K3 whale gang seats rank {} at CP position {cp_rank}, but this executor is rank {}",
+            gang[cp_rank],
+            self.rank
+        );
+        let my_base = self.my_base();
+        // Beat 1: announce my publication to every rank that reads it. The
+        // default write flag fences my preceding stream work first, so the
+        // publication bytes are visible before the doorbell rings.
+        for reader in kind.read_by(cp_rank, cp_size) {
+            let flag = self
+                .layout
+                .publish_flag(self.bases[gang[reader]], self.rank);
+            stream_write_value(ctx, flag, value).context("K3 whale publish doorbell write")?;
+        }
+        // Beat 2: wait for every publication I read this window.
+        for source in kind.reads_from(cp_rank) {
+            let flag = self.layout.publish_flag(my_base, gang[source]);
+            stream_wait_value(ctx, flag, value).context("K3 whale publish doorbell wait")?;
+        }
+        // Beat 3: enqueue my reads, then acknowledge them to their owners.
+        consume()?;
+        for source in kind.reads_from(cp_rank) {
+            let flag = self
+                .layout
+                .consume_flag(self.bases[gang[source]], self.rank);
+            stream_write_value(ctx, flag, value).context("K3 whale consume doorbell write")?;
+        }
+        // Beat 4: wait for my readers, so my next window's publish writes
+        // cannot overwrite what a peer is still reading.
+        for reader in kind.read_by(cp_rank, cp_size) {
+            let flag = self.layout.consume_flag(my_base, gang[reader]);
+            stream_wait_value(ctx, flag, value).context("K3 whale consume doorbell wait")?;
+        }
+        Ok(())
+    }
+}
+
+fn stream_write_value(ctx: &DeviceContext, addr: u64, value: u64) -> Result<()> {
+    // SAFETY: `addr` is inside a live fabric mapping (local or imported) that
+    // is never freed; the default flag performs the system-scope fence the
+    // publish ordering needs.
+    unsafe {
+        cu_sys::cuStreamWriteValue64_v2(
+            active_cu_stream(ctx),
+            addr,
+            value,
+            cu_sys::CUstreamWriteValue_flags::CU_STREAM_WRITE_VALUE_DEFAULT as u32,
+        )
+    }
+    .result()
+    .map_err(|error| anyhow::anyhow!("cuStreamWriteValue64 failed: {error}"))
+}
+
+fn stream_wait_value(ctx: &DeviceContext, addr: u64, value: u64) -> Result<()> {
+    // SAFETY: as above; GEQ is what monotonic doorbell values need — a rank
+    // that sat out intermediate whales left its flags behind, and any later
+    // ring satisfies every earlier wait.
+    unsafe {
+        cu_sys::cuStreamWaitValue64_v2(
+            active_cu_stream(ctx),
+            addr,
+            value,
+            cu_sys::CUstreamWaitValue_flags::CU_STREAM_WAIT_VALUE_GEQ as u32,
+        )
+    }
+    .result()
+    .map_err(|error| anyhow::anyhow!("cuStreamWaitValue64 failed: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn layout_regions_are_disjoint_aligned_and_world_scaled() {
+        let world = 16;
+        let seg_cap = 16896;
+        let layout = K3WhaleSlabLayout::new(world, seg_cap);
+        let regions = [
+            (layout.publish_inbox, world * K3_WHALE_ALIGN),
+            (layout.consume_inbox, world * K3_WHALE_ALIGN),
+            (layout.normed_tail, K3_CONV_STATE * K3_HIDDEN * 2),
+            (layout.kda_m, K3_KDA_STATE * 4),
+            (layout.kda_d, K3_KDA_STATE * 4),
+            (layout.mla_latent, seg_cap * K3_KV_LORA_RANK * 2),
+            (layout.mla_rope, seg_cap * K3_QK_ROPE_HEAD_DIM * 2),
+        ];
+        for (offset, _) in regions {
+            assert_eq!(offset % K3_WHALE_ALIGN, 0, "unaligned region at {offset}");
+        }
+        let mut sorted = regions;
+        sorted.sort_by_key(|&(offset, _)| offset);
+        for pair in sorted.windows(2) {
+            assert!(
+                pair[0].0 + pair[0].1 <= pair[1].0,
+                "regions overlap: {pair:?}"
+            );
+        }
+        let (last_offset, last_bytes) = sorted[sorted.len() - 1];
+        assert!(last_offset + last_bytes <= layout.num_bytes);
+    }
+
+    #[test]
+    fn doorbell_values_are_strictly_monotonic_across_whales_and_windows() {
+        let mut previous = 0u64;
+        for seq in [0u64, 1, 2, 7, 8] {
+            for window in 0..4u64 {
+                let value = K3WhaleGang::window_value(seq, window).unwrap();
+                assert!(value > previous, "seq {seq} window {window}");
+                previous = value;
+            }
+        }
+        assert!(K3WhaleGang::window_value(0, K3_WHALE_WINDOW_STRIDE).is_err());
+    }
+
+    #[test]
+    fn flag_slots_are_one_line_apart_per_source_rank() {
+        let layout = K3WhaleSlabLayout::new(4, 4224);
+        let base = 1 << 20;
+        for from in 0..4 {
+            let publish = layout.publish_flag(base, from);
+            let consume = layout.consume_flag(base, from);
+            assert_eq!(publish % 8, 0);
+            assert_eq!(consume % 8, 0);
+            assert_eq!(
+                publish,
+                base + layout.publish_inbox as u64 + (from * K3_WHALE_ALIGN) as u64
+            );
+            assert!(consume >= base + layout.consume_inbox as u64);
+        }
+    }
+}

--- a/pegainfer-k3/src/executor/whale_gang.rs
+++ b/pegainfer-k3/src/executor/whale_gang.rs
@@ -37,12 +37,15 @@
 //! `GEQ` wait condition needs. Flag arrays are indexed by *global* rank, so
 //! rotation never aliases a slot.
 
+use std::sync::Arc;
+
 use anyhow::Context as _;
 use anyhow::Result;
 use anyhow::ensure;
 use cudarc::driver::sys as cu_sys;
 use half::bf16;
 use pegainfer_kernels::ops::K3_MEGA_FABRIC_HANDLE_BYTES;
+use pegainfer_kernels::ops::k3_chunk_bucket;
 use pegainfer_kernels::ops::k3_mega_fabric_slab_alloc;
 use pegainfer_kernels::ops::k3_mega_fabric_slab_import;
 use pegainfer_kernels::ops::k3_mega_fabric_supported;
@@ -53,6 +56,8 @@ use pegainfer_kernels::tensor::active_cu_stream;
 use super::buffers::K3_CONV_STATE;
 use super::buffers::K3_KDA_STATE;
 use super::cp::K3CpPeerPtrs;
+use super::cp::K3CpScratch;
+use super::cp::K3CpSyncHandle;
 use super::cp::K3CpWindowKind;
 use crate::config::K3_HIDDEN;
 use crate::config::K3_KV_LORA_RANK;
@@ -333,6 +338,92 @@ impl K3WhaleGang {
             stream_wait_value(ctx, flag, doorbell).context("K3 whale consume doorbell wait")?;
         }
         Ok(())
+    }
+}
+
+/// The whale lane's startup dance on one executor, in call order: allocate
+/// the slab, exchange handles through the hub (the caller's job), import the
+/// world, install the gang. Serving needs nothing further — a committed
+/// whale re-arms the scratch per superstep.
+impl super::K3Executor {
+    /// Allocate this rank's whale slab — its fleet CP publish surface plus
+    /// doorbells — before the fleet's handle exchange. `world` is the whale
+    /// world size; every rank must derive the identical layout, which the
+    /// import checks byte-for-byte. Once per executor. Returns the local base
+    /// (for the process-wide import table) and the wire identity peers import.
+    pub fn arm_whale_slab(&mut self, world: usize) -> Result<(u64, K3WhaleSlabWire)> {
+        ensure!(
+            self.whale_slab.is_none(),
+            "K3 rank {} armed its whale slab twice",
+            self.model.rank
+        );
+        let layout = K3WhaleSlabLayout::new(world, k3_chunk_bucket(self.chunk_tokens)?);
+        let (base, wire) = k3_whale_slab_alloc(self.ctx.device_ordinal, &layout)?;
+        self.whale_slab = Some((base, layout));
+        Ok((base, wire))
+    }
+
+    /// Map the exchanged world table into this process — once, on any one
+    /// local executor; every local rank then installs one clone of the
+    /// result. `local` maps this process's ranks to their slab bases.
+    pub fn import_whale_world(
+        &self,
+        table: &[K3WhaleSlabWire],
+        local: &[(usize, u64)],
+    ) -> Result<Vec<u64>> {
+        let (_, layout) = self
+            .whale_slab
+            .context("K3 whale import before arm_whale_slab")?;
+        k3_whale_import_world(table, local, &layout, self.ctx.device_ordinal)
+    }
+
+    /// Install the imported world table ([`k3_whale_import_world`]'s result)
+    /// and stand the whale data plane up for this rank.
+    pub fn install_whale_gang(&mut self, bases: Vec<u64>) -> Result<()> {
+        let (base, layout) = self
+            .whale_slab
+            .context("K3 whale gang install before arm_whale_slab")?;
+        let rank = self.model.rank;
+        ensure!(
+            bases.get(rank).copied() == Some(base),
+            "K3 whale slab table does not carry rank {rank}'s own base"
+        );
+        self.whale_gang = Some(Arc::new(K3WhaleGang::new(bases, rank, layout)?));
+        Ok(())
+    }
+
+    /// Build (or re-arm) the fleet CP working set for this whale superstep.
+    /// Unlike the in-process path this opens no peer access — the fabric
+    /// mappings carry their own grants — and arms without any collective.
+    pub(crate) fn ensure_whale_scratch(
+        &mut self,
+        seq: u64,
+        cp_rank: usize,
+        gang_ranks: &[usize],
+        segments: Vec<(usize, usize)>,
+    ) -> Result<()> {
+        let gang = self
+            .whale_gang
+            .clone()
+            .context("K3 whale prefill before the gang was installed")?;
+        if let Some(scratch) = self.cp_scratch.as_ref() {
+            ensure!(
+                matches!(&scratch.sync, K3CpSyncHandle::Fleet(mine) if Arc::ptr_eq(mine, &gang)),
+                "K3 CP scratch was built for a different substrate than the whale gang"
+            );
+        } else {
+            self.cp_scratch = Some(Box::new(K3CpScratch::new_fleet(
+                &self.ctx,
+                gang,
+                k3_chunk_bucket(self.chunk_tokens)?,
+            )?));
+            // Local arenas live and zeroed before the superstep touches them.
+            self.gpu.sync()?;
+        }
+        self.cp_scratch
+            .as_mut()
+            .expect("built above")
+            .arm_fleet(seq, cp_rank, gang_ranks, segments)
     }
 }
 

--- a/pegainfer-k3/src/executor/whale_gang.rs
+++ b/pegainfer-k3/src/executor/whale_gang.rs
@@ -15,13 +15,17 @@
 //!   is an ordinary device pointer — [`super::cp::k3_cp_copy_in`] works
 //!   unchanged.
 //! * **Ordering**: CUDA events give way to **doorbells** — `u64` flag arrays
-//!   in the same slabs, written with `cuStreamWriteValue64` and waited on
-//!   with `cuStreamWaitValue64`. Writes go to the *remote* rank's slab and
-//!   waits watch the rank's *own* slab, so every wait is on local memory and
-//!   every remote touch is a plain NVLink store — the direction the fabric
-//!   is built for. The four-beat window protocol is the in-process one
-//!   verbatim (publish, await publications, consume, await consumers); only
-//!   the primitive changed.
+//!   in the same slabs, rung by a one-thread SM kernel
+//!   (`k3_whale_doorbell_ring`) and waited on with `cuStreamWaitValue64`.
+//!   Writes go to the *remote* rank's slab and waits watch the rank's *own*
+//!   slab, so every wait is stream-memops on local memory and every remote
+//!   touch is a plain NVLink store — the direction the fabric is built for.
+//!   The split is forced, not stylistic: the stream memops engine rejects
+//!   fabric-imported mappings outright (`CUDA_ERROR_INVALID_VALUE` on GB300,
+//!   two-process probe), while SM stores go through them on every MegaMoE
+//!   step. The four-beat window protocol is the in-process one verbatim
+//!   (publish, await publications, consume, await consumers); only the
+//!   primitive changed.
 //!
 //! Doorbell values must be agreed without any host negotiation, across gangs
 //! that rotate membership whale to whale. They are derived entirely from the
@@ -41,6 +45,7 @@ use pegainfer_kernels::ops::K3_MEGA_FABRIC_HANDLE_BYTES;
 use pegainfer_kernels::ops::k3_mega_fabric_slab_alloc;
 use pegainfer_kernels::ops::k3_mega_fabric_slab_import;
 use pegainfer_kernels::ops::k3_mega_fabric_supported;
+use pegainfer_kernels::ops::k3_whale_doorbell_ring;
 use pegainfer_kernels::tensor::DeviceContext;
 use pegainfer_kernels::tensor::active_cu_stream;
 
@@ -297,14 +302,19 @@ impl K3WhaleGang {
             self.rank
         );
         let my_base = self.my_base();
-        // Beat 1: announce my publication to every rank that reads it. The
-        // default write flag fences my preceding stream work first, so the
-        // publication bytes are visible before the doorbell rings.
-        for reader in kind.read_by(cp_rank, cp_size) {
-            let flag = self
-                .layout
-                .publish_flag(self.bases[gang[reader]], self.rank);
-            stream_write_value(ctx, flag, value).context("K3 whale publish doorbell write")?;
+        // Beat 1: announce my publication to every rank that reads it, in one
+        // ring. The kernel's system fence releases my preceding stream work,
+        // so the publication bytes are visible before the doorbell rings.
+        let publish_flags: Vec<u64> = kind
+            .read_by(cp_rank, cp_size)
+            .map(|reader| {
+                self.layout
+                    .publish_flag(self.bases[gang[reader]], self.rank)
+            })
+            .collect();
+        if !publish_flags.is_empty() {
+            k3_whale_doorbell_ring(&publish_flags, value, active_cu_stream(ctx))
+                .context("K3 whale publish doorbell ring")?;
         }
         // Beat 2: wait for every publication I read this window.
         for source in kind.reads_from(cp_rank) {
@@ -313,11 +323,16 @@ impl K3WhaleGang {
         }
         // Beat 3: enqueue my reads, then acknowledge them to their owners.
         consume()?;
-        for source in kind.reads_from(cp_rank) {
-            let flag = self
-                .layout
-                .consume_flag(self.bases[gang[source]], self.rank);
-            stream_write_value(ctx, flag, value).context("K3 whale consume doorbell write")?;
+        let consume_flags: Vec<u64> = kind
+            .reads_from(cp_rank)
+            .map(|source| {
+                self.layout
+                    .consume_flag(self.bases[gang[source]], self.rank)
+            })
+            .collect();
+        if !consume_flags.is_empty() {
+            k3_whale_doorbell_ring(&consume_flags, value, active_cu_stream(ctx))
+                .context("K3 whale consume doorbell ring")?;
         }
         // Beat 4: wait for my readers, so my next window's publish writes
         // cannot overwrite what a peer is still reading.
@@ -329,24 +344,10 @@ impl K3WhaleGang {
     }
 }
 
-fn stream_write_value(ctx: &DeviceContext, addr: u64, value: u64) -> Result<()> {
-    // SAFETY: `addr` is inside a live fabric mapping (local or imported) that
-    // is never freed; the default flag performs the system-scope fence the
-    // publish ordering needs.
-    unsafe {
-        cu_sys::cuStreamWriteValue64_v2(
-            active_cu_stream(ctx),
-            addr,
-            value,
-            cu_sys::CUstreamWriteValue_flags::CU_STREAM_WRITE_VALUE_DEFAULT as u32,
-        )
-    }
-    .result()
-    .map_err(|error| anyhow::anyhow!("cuStreamWriteValue64 failed: {error}"))
-}
-
 fn stream_wait_value(ctx: &DeviceContext, addr: u64, value: u64) -> Result<()> {
-    // SAFETY: as above; GEQ is what monotonic doorbell values need — a rank
+    // SAFETY: `addr` is inside this rank's own live fabric slab (locally
+    // allocated — the memops engine accepts local fabric memory, unlike
+    // imported mappings); GEQ is what monotonic doorbell values need — a rank
     // that sat out intermediate whales left its flags behind, and any later
     // ring satisfies every earlier wait.
     unsafe {
@@ -405,6 +406,28 @@ mod tests {
             }
         }
         assert!(K3WhaleGang::window_value(0, K3_WHALE_WINDOW_STRIDE).is_err());
+    }
+
+    /// GPU: ring a doorbell on a freshly allocated whale slab through the
+    /// exact production call chain (fabric alloc -> `k3_whale_doorbell_ring`
+    /// -> `stream_wait_value`). Needs one fabric-capable GPU. Cross-process
+    /// import coverage is the fleet smoke's job — a single process cannot
+    /// import its own handle.
+    #[test]
+    #[ignore = "needs a fabric-capable GPU"]
+    fn doorbell_rings_on_a_real_fabric_slab() {
+        use pegainfer_kernels::tensor::DeviceContext;
+        let ctx = DeviceContext::new_with_device(0).expect("device 0");
+        let layout = K3WhaleSlabLayout::new(8, 16896);
+        let (base, _wire) = k3_whale_slab_alloc(0, &layout).expect("fabric slab");
+        let value = K3WhaleGang::window_value(0, 0).unwrap();
+        let flags: Vec<u64> = (0..8).map(|from| layout.publish_flag(base, from)).collect();
+        k3_whale_doorbell_ring(&flags, value, active_cu_stream(&ctx)).expect("doorbell ring");
+        for (from, &flag) in flags.iter().enumerate() {
+            stream_wait_value(&ctx, flag, value)
+                .unwrap_or_else(|e| panic!("publish wait from={from}: {e:#}"));
+        }
+        ctx.stream.synchronize().expect("stream sync");
     }
 
     #[test]

--- a/pegainfer-k3/src/executor/whale_gang.rs
+++ b/pegainfer-k3/src/executor/whale_gang.rs
@@ -300,8 +300,8 @@ impl K3WhaleGang {
         let cp_size = gang.len();
         let my_base = self.my_base();
         // Beat 1: announce my publication to every rank that reads it, in one
-        // ring. The kernel's system fence releases my preceding stream work,
-        // so the publication bytes are visible before the doorbell rings.
+        // ring. Stream order puts those bytes complete before the ring kernel
+        // launches.
         let publish_flags: Vec<u64> = kind
             .read_by(cp_rank, cp_size)
             .map(|reader| {

--- a/pegainfer-k3/src/model_line.rs
+++ b/pegainfer-k3/src/model_line.rs
@@ -393,10 +393,12 @@ fn whale_serving(
                 .with_context(|| format!("PEGAINFER_K3_WHALE_MIN={raw} is not a token count"))?
         }
     };
+    let arm_started = Instant::now();
     let slabs = executors
         .iter_mut()
         .map(|executor| executor.arm_whale_slab(world))
         .collect::<anyhow::Result<Vec<_>>>()?;
+    let slabs_armed = Instant::now();
     let (hub, table) = if ranks.start == 0 {
         TcpWhaleHub::host(&addr, world, chunk_tokens, 0, ranks.len(), slabs)
             .context("host the K3 whale hub")?
@@ -404,6 +406,7 @@ fn whale_serving(
         TcpWhaleHub::connect(&addr, ranks.start, ranks.len(), slabs)
             .context("join the K3 whale hub")?
     };
+    let world_exchanged = Instant::now();
     let local: Vec<(usize, u64)> = executors
         .iter()
         .enumerate()
@@ -420,7 +423,11 @@ fn whale_serving(
     }
     info!(
         "K3 whale lane armed: world={world}, local_ranks={ranks:?}, min_tokens={min_tokens}, \
-         chunk_tokens={chunk_tokens}, rendezvous={addr}"
+         chunk_tokens={chunk_tokens}, rendezvous={addr}, slab_alloc={:.2}s, \
+         slab_exchange={:.2}s (fleet startup barrier), import_install={:.2}s",
+        (slabs_armed - arm_started).as_secs_f64(),
+        (world_exchanged - slabs_armed).as_secs_f64(),
+        world_exchanged.elapsed().as_secs_f64(),
     );
     Ok(Some(K3WhaleServing {
         hub: K3WhaleHub::Tcp(hub),

--- a/pegainfer-k3/src/model_line.rs
+++ b/pegainfer-k3/src/model_line.rs
@@ -24,6 +24,7 @@ use crate::config::K3_LAYERS;
 use crate::config::K3_SUPPORTED_ROUTED_EXPERTS;
 use crate::executor::K3Executor;
 use crate::executor::K3ExecutorConfig;
+use crate::executor::cp::K3_WHALE_SEGMENT_FLOOR;
 use crate::executor::cp::K3CpGroup;
 use crate::executor::ep::K3EpRendezvous;
 use crate::scheduler::K3CpGang;
@@ -330,13 +331,9 @@ impl ModelLine for K3Line {
             ep_size,
             ranks.clone(),
             dspark_armed,
+            cp.is_some(),
             chunk_tokens,
         )?;
-        anyhow::ensure!(
-            cp.is_none() || whale.is_none(),
-            "PEGAINFER_K3_CP and PEGAINFER_K3_WHALE are exclusive: the in-process gang and the \
-             fleet whale lane coordinate the same superstep"
-        );
         Ok(LaunchedEngine::Stepped(
             crate::scheduler::start_with_executors(
                 executors,
@@ -354,8 +351,8 @@ impl ModelLine for K3Line {
 /// Arm the fleet whale lane from `PEGAINFER_K3_WHALE` (the rendezvous
 /// address — the process hosting global rank 0 binds it and runs the
 /// sequencer, everyone else connects) and `PEGAINFER_K3_WHALE_MIN` (admission
-/// floor in prompt tokens, default 4096 — twice the fleet segment floor, the
-/// narrowest prompt a width-2 gang can serve).
+/// floor in prompt tokens, at least twice [`K3_WHALE_SEGMENT_FLOOR`] — the
+/// narrowest prompt a width-2 gang can serve — which is also the default).
 ///
 /// Arming stands the whole data plane up before any engine steps: every
 /// local rank allocates its fabric slab, the hub's startup exchange moves the
@@ -368,6 +365,7 @@ fn whale_serving(
     world: usize,
     ranks: std::ops::Range<usize>,
     dspark_armed: bool,
+    cp_armed: bool,
     chunk_tokens: usize,
 ) -> anyhow::Result<Option<K3WhaleServing>> {
     let Some(raw) = std::env::var_os("PEGAINFER_K3_WHALE") else {
@@ -379,25 +377,42 @@ fn whale_serving(
         "PEGAINFER_K3_WHALE does not compose with the dspark draft lane yet; disarm one of them"
     );
     anyhow::ensure!(
+        !cp_armed,
+        "PEGAINFER_K3_CP and PEGAINFER_K3_WHALE are exclusive: the in-process gang and the fleet \
+         whale lane coordinate the same superstep"
+    );
+    anyhow::ensure!(
         world >= 2,
         "PEGAINFER_K3_WHALE needs an EP world of at least two ranks; a whale gang is never \
          narrower than two"
     );
+    let narrowest = 2 * K3_WHALE_SEGMENT_FLOOR;
     let min_tokens = match std::env::var_os("PEGAINFER_K3_WHALE_MIN") {
-        None => 4096,
+        None => narrowest,
         Some(raw) => {
             let raw = raw.to_string_lossy();
             raw.parse()
                 .ok()
-                .filter(|&min| min > 0)
-                .with_context(|| format!("PEGAINFER_K3_WHALE_MIN={raw} is not a token count"))?
+                .filter(|&min| min >= narrowest)
+                .with_context(|| {
+                    format!(
+                        "PEGAINFER_K3_WHALE_MIN={raw} must be a token count of at least \
+                         {narrowest} — no gang serves a shorter prompt"
+                    )
+                })?
         }
     };
     let arm_started = Instant::now();
-    let slabs = executors
+    let armed = executors
         .iter_mut()
         .map(|executor| executor.arm_whale_slab(world))
         .collect::<anyhow::Result<Vec<_>>>()?;
+    let slabs: Vec<_> = armed.iter().map(|&(_, wire)| wire).collect();
+    let local: Vec<(usize, u64)> = armed
+        .iter()
+        .enumerate()
+        .map(|(offset, &(base, _))| (ranks.start + offset, base))
+        .collect();
     let slabs_armed = Instant::now();
     let (hub, table) = if ranks.start == 0 {
         TcpWhaleHub::host(&addr, world, chunk_tokens, 0, ranks.len(), slabs)
@@ -407,16 +422,6 @@ fn whale_serving(
             .context("join the K3 whale hub")?
     };
     let world_exchanged = Instant::now();
-    let local: Vec<(usize, u64)> = executors
-        .iter()
-        .enumerate()
-        .map(|(offset, executor)| {
-            (
-                ranks.start + offset,
-                executor.whale_slab_base().expect("armed above"),
-            )
-        })
-        .collect();
     let bases = executors[0].import_whale_world(&table, &local)?;
     for executor in executors.iter_mut() {
         executor.install_whale_gang(bases.clone())?;

--- a/pegainfer-k3/src/model_line.rs
+++ b/pegainfer-k3/src/model_line.rs
@@ -329,6 +329,9 @@ impl ModelLine for K3Line {
                     eos_token_ids,
                     kv_capacity: None,
                     cp,
+                    // The whale lane arms with the fleet data plane (fabric
+                    // scratch + doorbells), not from a single-process launch.
+                    whale: None,
                 },
             ),
         ))

--- a/pegainfer-k3/src/model_line.rs
+++ b/pegainfer-k3/src/model_line.rs
@@ -29,6 +29,9 @@ use crate::executor::ep::K3EpRendezvous;
 use crate::scheduler::K3CpGang;
 use crate::scheduler::K3CpServing;
 use crate::scheduler::K3SchedulerConfig;
+use crate::scheduler::K3WhaleHub;
+use crate::scheduler::K3WhaleServing;
+use crate::scheduler::whale_hub::TcpWhaleHub;
 use crate::weights::K3_WEIGHT_FILL_THREADS;
 
 pub static MODEL_LINE: K3Line = K3Line;
@@ -297,7 +300,7 @@ impl ModelLine for K3Line {
             }
         };
         let load_started = Instant::now();
-        let executors = load_rank_executors(
+        let mut executors = load_rank_executors(
             ctx.model_path,
             ctx.shared.dflash_draft_model_path.as_deref(),
             ctx.shared.device_ordinal,
@@ -322,6 +325,18 @@ impl ModelLine for K3Line {
             .context("K3 EP serving needs at least one local rank")?
             .chunk_tokens();
         let cp = cp_serving(ranks.len(), dspark_armed, chunk_tokens)?;
+        let whale = whale_serving(
+            &mut executors,
+            ep_size,
+            ranks.clone(),
+            dspark_armed,
+            chunk_tokens,
+        )?;
+        anyhow::ensure!(
+            cp.is_none() || whale.is_none(),
+            "PEGAINFER_K3_CP and PEGAINFER_K3_WHALE are exclusive: the in-process gang and the \
+             fleet whale lane coordinate the same superstep"
+        );
         Ok(LaunchedEngine::Stepped(
             crate::scheduler::start_with_executors(
                 executors,
@@ -329,13 +344,91 @@ impl ModelLine for K3Line {
                     eos_token_ids,
                     kv_capacity: None,
                     cp,
-                    // The whale lane arms with the fleet data plane (fabric
-                    // scratch + doorbells), not from a single-process launch.
-                    whale: None,
+                    whale,
                 },
             ),
         ))
     }
+}
+
+/// Arm the fleet whale lane from `PEGAINFER_K3_WHALE` (the rendezvous
+/// address — the process hosting global rank 0 binds it and runs the
+/// sequencer, everyone else connects) and `PEGAINFER_K3_WHALE_MIN` (admission
+/// floor in prompt tokens, default 4096 — twice the fleet segment floor, the
+/// narrowest prompt a width-2 gang can serve).
+///
+/// Arming stands the whole data plane up before any engine steps: every
+/// local rank allocates its fabric slab, the hub's startup exchange moves the
+/// world's handles (doubling as the fleet's startup barrier), and each
+/// executor imports the table. From then on a committed whale needs no
+/// further setup — the scheduler consults the rendezvous at every launch
+/// boundary and enters supersteps at the committed launch.
+fn whale_serving(
+    executors: &mut [K3Executor],
+    world: usize,
+    ranks: std::ops::Range<usize>,
+    dspark_armed: bool,
+    chunk_tokens: usize,
+) -> anyhow::Result<Option<K3WhaleServing>> {
+    let Some(raw) = std::env::var_os("PEGAINFER_K3_WHALE") else {
+        return Ok(None);
+    };
+    let addr = raw.to_string_lossy().into_owned();
+    anyhow::ensure!(
+        !dspark_armed,
+        "PEGAINFER_K3_WHALE does not compose with the dspark draft lane yet; disarm one of them"
+    );
+    anyhow::ensure!(
+        world >= 2,
+        "PEGAINFER_K3_WHALE needs an EP world of at least two ranks; a whale gang is never \
+         narrower than two"
+    );
+    let min_tokens = match std::env::var_os("PEGAINFER_K3_WHALE_MIN") {
+        None => 4096,
+        Some(raw) => {
+            let raw = raw.to_string_lossy();
+            raw.parse()
+                .ok()
+                .filter(|&min| min > 0)
+                .with_context(|| format!("PEGAINFER_K3_WHALE_MIN={raw} is not a token count"))?
+        }
+    };
+    let slabs = executors
+        .iter_mut()
+        .map(|executor| executor.arm_whale_slab(world))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let (hub, table) = if ranks.start == 0 {
+        TcpWhaleHub::host(&addr, world, chunk_tokens, 0, ranks.len(), slabs)
+            .context("host the K3 whale hub")?
+    } else {
+        TcpWhaleHub::connect(&addr, ranks.start, ranks.len(), slabs)
+            .context("join the K3 whale hub")?
+    };
+    let local: Vec<(usize, u64)> = executors
+        .iter()
+        .enumerate()
+        .map(|(offset, executor)| {
+            (
+                ranks.start + offset,
+                executor.whale_slab_base().expect("armed above"),
+            )
+        })
+        .collect();
+    let bases = executors[0].import_whale_world(&table, &local)?;
+    for executor in executors.iter_mut() {
+        executor.install_whale_gang(bases.clone())?;
+    }
+    info!(
+        "K3 whale lane armed: world={world}, local_ranks={ranks:?}, min_tokens={min_tokens}, \
+         chunk_tokens={chunk_tokens}, rendezvous={addr}"
+    );
+    Ok(Some(K3WhaleServing {
+        hub: K3WhaleHub::Tcp(hub),
+        world,
+        first_local: ranks.start,
+        min_tokens,
+        chunk_tokens,
+    }))
 }
 
 fn warn_if_loader_cpu_starved(local_ranks: usize, weight_staging: bool) {

--- a/pegainfer-k3/src/scheduler/executor.rs
+++ b/pegainfer-k3/src/scheduler/executor.rs
@@ -19,6 +19,7 @@ use anyhow::Result;
 use anyhow::bail;
 use pegainfer_frontend::sampler::SamplingParams;
 
+use super::whale::CommittedWhale;
 use crate::executor::cp::K3CpGroup;
 
 /// Index of one execution slot, in `0..max_batch`.
@@ -93,6 +94,23 @@ pub trait StepExecutor: Send {
     ) -> Result<Option<u32>> {
         let _ = (slot, prompt, group, cp_rank);
         bail!("this executor does not serve context-parallel prefill")
+    }
+
+    /// Enter a committed whale's CP superstep — the fleet-wide counterpart of
+    /// [`StepExecutor::prefill_cp`]. Called exactly at the whale's committed
+    /// launch, on every gang member, by the whale serving lane
+    /// ([`super::whale`]); the descriptor names the gang and the segments are
+    /// a deterministic function of it. `slot` is set on the owner (the
+    /// poster, always the last CP rank), which ingests the result and returns
+    /// the boundary token; helpers pass `None` and return `None`. One
+    /// superstep is one launch. Default: this executor serves no whale lane.
+    fn prefill_whale(
+        &mut self,
+        whale: &CommittedWhale,
+        slot: Option<SlotId>,
+    ) -> Result<Option<u32>> {
+        let _ = (whale, slot);
+        bail!("this executor does not serve whale prefill")
     }
 
     /// Run one padding step and wait for it. A scheduler thread waiting at a

--- a/pegainfer-k3/src/scheduler/mod.rs
+++ b/pegainfer-k3/src/scheduler/mod.rs
@@ -51,9 +51,9 @@ use self::whale::WhaleMember;
 use self::whale::WhaleSeq;
 use self::whale::WhaleToMember;
 use self::whale::WhaleToSequencer;
-use self::whale::k3_whale_width;
 pub use self::whale_hub::K3WhaleHub;
 use crate::executor::cp::k3_cp_admits;
+use crate::executor::cp::k3_whale_width;
 
 // ── Engine assembly ─────────────────────────────────────────────────────
 

--- a/pegainfer-k3/src/scheduler/mod.rs
+++ b/pegainfer-k3/src/scheduler/mod.rs
@@ -19,6 +19,8 @@ mod executor;
 mod gang;
 #[cfg(test)]
 mod tests;
+pub mod whale;
+pub mod whale_hub;
 
 use std::collections::VecDeque;
 use std::sync::Arc;

--- a/pegainfer-k3/src/scheduler/mod.rs
+++ b/pegainfer-k3/src/scheduler/mod.rs
@@ -112,7 +112,7 @@ pub struct K3WhaleServing {
 /// A whale request this poster sent to the sequencer and is waiting to hear
 /// back about. Its slot is reserved the whole time, so the commit can never
 /// arrive to a full batch. `id.raw()` rides the descriptor's `request` field,
-/// pairing gathers, commits, and cancels with this admission.
+/// pairing gathers and commits with this admission.
 struct PostedWhale {
     id: RequestId,
     slot: SlotId,

--- a/pegainfer-k3/src/scheduler/mod.rs
+++ b/pegainfer-k3/src/scheduler/mod.rs
@@ -111,13 +111,11 @@ pub struct K3WhaleServing {
 
 /// A whale request this poster sent to the sequencer and is waiting to hear
 /// back about. Its slot is reserved the whole time, so the commit can never
-/// arrive to a full batch.
-struct PendingWhale {
+/// arrive to a full batch. `id.raw()` rides the descriptor's `request` field,
+/// pairing gathers, commits, and cancels with this admission.
+struct PostedWhale {
     id: RequestId,
     slot: SlotId,
-    /// The request key echoed through the descriptor — how the poster pairs
-    /// gathers, commits, and cancels with this admission.
-    key: u64,
     /// The sequence this whale got, learned from our own gather broadcast.
     /// `None` until the gather arrives; a cancel for an unknown sequence can
     /// only be the width refusal of this one outstanding post.
@@ -125,7 +123,6 @@ struct PendingWhale {
     prompt: Arc<[u32]>,
     params: SamplingParams,
     max_tokens: usize,
-    ignore_eos: bool,
 }
 
 /// One partition's live whale state: the protocol member plus the poster-side
@@ -135,12 +132,11 @@ struct WhaleLane {
     serving: K3WhaleServing,
     member: WhaleMember,
     rank: GlobalRank,
-    next_key: u64,
     /// The outstanding post, if any (awaiting commit or cancel).
-    pending: Option<PendingWhale>,
+    posted: Option<PostedWhale>,
     /// A cancelled post falling back to a local prefill, run at the next
     /// unrestricted launch.
-    fallback: Option<PendingWhale>,
+    fallback: Option<PostedWhale>,
 }
 
 /// Wrap ready executors in schedulers and hand the whole thing to the
@@ -241,8 +237,7 @@ impl<E: StepExecutor> K3Scheduler<E> {
             WhaleLane {
                 member: WhaleMember::new(rank),
                 rank,
-                next_key: 0,
-                pending: None,
+                posted: None,
                 fallback: None,
                 serving,
             }
@@ -305,7 +300,7 @@ impl<E: StepExecutor> K3Scheduler<E> {
     ) -> Result<bool> {
         loop {
             for message in lane.serving.hub.drain(lane.rank) {
-                Self::note_poster_pairing(lane, &message);
+                Self::track_own_post(lane, &message);
                 let count = self.executor.step_count();
                 if let Some(reply) = lane.member.on_message(message, count)? {
                     lane.serving.hub.send(reply)?;
@@ -315,8 +310,8 @@ impl<E: StepExecutor> K3Scheduler<E> {
                 // The superstep advanced the count; consult the next boundary
                 // before leaving — a second whale may sit right behind it.
                 WhaleDuty::Enter(whale) => self.enter_whale(lane, *whale, ledger)?,
-                WhaleDuty::Free { clearance } => {
-                    if clearance.is_some() {
+                WhaleDuty::Free => {
+                    if !lane.member.is_quiet() {
                         return Ok(false);
                     }
                     self.run_whale_fallback(lane, ledger);
@@ -326,27 +321,27 @@ impl<E: StepExecutor> K3Scheduler<E> {
         }
     }
 
-    /// Pair an inbound rendezvous message with the poster's outstanding post,
+    /// Pair an inbound rendezvous message with this rank's outstanding post,
     /// before the member consumes it. A gather for our own request records
     /// its sequence; a cancel routes the post to the local-prefill fallback —
     /// either by its recorded sequence, or, for a post that never gathered
     /// (unknown sequence, not armed here), as the sequencer's width refusal.
-    fn note_poster_pairing(lane: &mut WhaleLane, message: &WhaleToMember) {
+    fn track_own_post(lane: &mut WhaleLane, message: &WhaleToMember) {
         match message {
             WhaleToMember::Gather { descriptor } if descriptor.poster == lane.rank => {
-                if let Some(pending) = lane.pending.as_mut()
-                    && pending.key == descriptor.request
+                if let Some(posted) = lane.posted.as_mut()
+                    && posted.id.raw() == descriptor.request
                 {
-                    pending.seq = Some(descriptor.seq);
+                    posted.seq = Some(descriptor.seq);
                 }
             }
             WhaleToMember::Cancel { seq } => {
-                let refused = lane.pending.as_ref().is_some_and(|pending| {
-                    pending.seq == Some(*seq)
-                        || (pending.seq.is_none() && !lane.member.is_armed(*seq))
+                let refused = lane.posted.as_ref().is_some_and(|posted| {
+                    posted.seq == Some(*seq)
+                        || (posted.seq.is_none() && !lane.member.is_armed(*seq))
                 });
                 if refused {
-                    lane.fallback = lane.pending.take();
+                    lane.fallback = lane.posted.take();
                 }
             }
             _ => {}
@@ -364,28 +359,28 @@ impl<E: StepExecutor> K3Scheduler<E> {
         whale: CommittedWhale,
         ledger: &mut RequestLedger,
     ) -> Result<()> {
-        let pending = if whale.descriptor.poster == lane.rank {
-            let pending = lane.pending.take().ok_or_else(|| {
+        let posted = if whale.descriptor.poster == lane.rank {
+            let posted = lane.posted.take().ok_or_else(|| {
                 anyhow::anyhow!(
                     "whale {} committed for this poster, but no post is outstanding",
                     whale.descriptor.seq
                 )
             })?;
             anyhow::ensure!(
-                pending.key == whale.descriptor.request,
-                "whale {} answers request key {}, but the outstanding post is {}",
+                posted.id.raw() == whale.descriptor.request,
+                "whale {} answers request {}, but the outstanding post is {}",
                 whale.descriptor.seq,
                 whale.descriptor.request,
-                pending.key
+                posted.id.raw()
             );
-            Some(pending)
+            Some(posted)
         } else {
             None
         };
         let first = self
             .executor
-            .prefill_whale(&whale, pending.as_ref().map(|pending| pending.slot))?;
-        let Some(pending) = pending else {
+            .prefill_whale(&whale, posted.as_ref().map(|posted| posted.slot))?;
+        let Some(posted) = posted else {
             return Ok(());
         };
         let first = first.ok_or_else(|| {
@@ -394,19 +389,19 @@ impl<E: StepExecutor> K3Scheduler<E> {
                 whale.descriptor.seq
             )
         })?;
-        if ledger.is_aborted(pending.id) {
+        if ledger.is_aborted(posted.id) {
             // The whale ran regardless (unanimity is the contract); only the
             // answer is dropped.
-            ledger.retire(pending.id);
-            self.release_slot(pending.slot);
+            ledger.retire(posted.id);
+            self.release_slot(posted.slot);
             return Ok(());
         }
         self.commit_first_token(
-            pending.id,
-            pending.slot,
+            posted.id,
+            posted.slot,
             first,
-            pending.max_tokens,
-            pending.ignore_eos,
+            posted.max_tokens,
+            posted.params.ignore_eos,
             ledger,
         );
         Ok(())
@@ -415,31 +410,31 @@ impl<E: StepExecutor> K3Scheduler<E> {
     /// A cancelled whale post answers its request with a plain local prefill,
     /// run at the first unrestricted launch after the cancel.
     fn run_whale_fallback(&mut self, lane: &mut WhaleLane, ledger: &mut RequestLedger) {
-        let Some(pending) = lane.fallback.take() else {
+        let Some(posted) = lane.fallback.take() else {
             return;
         };
-        if ledger.is_aborted(pending.id) {
-            ledger.retire(pending.id);
-            self.release_slot(pending.slot);
+        if ledger.is_aborted(posted.id) {
+            ledger.retire(posted.id);
+            self.release_slot(posted.slot);
             return;
         }
         match self
             .executor
-            .prefill(pending.slot, &pending.prompt, &pending.params)
+            .prefill(posted.slot, &posted.prompt, &posted.params)
         {
             Ok(first) => self.commit_first_token(
-                pending.id,
-                pending.slot,
+                posted.id,
+                posted.slot,
                 first,
-                pending.max_tokens,
-                pending.ignore_eos,
+                posted.max_tokens,
+                posted.params.ignore_eos,
                 ledger,
             ),
             Err(error) => {
                 // A local prefill failure is this request's problem, exactly
                 // as on the ordinary admission path.
-                self.release_slot(pending.slot);
-                ledger.fail(pending.id, format!("{error:#}"));
+                self.release_slot(posted.slot);
+                ledger.fail(posted.id, format!("{error:#}"));
             }
         }
     }
@@ -554,27 +549,22 @@ impl<E: StepExecutor> K3Scheduler<E> {
             }
             if self.whale_eligible(prompt_len) {
                 let lane = self.whale.as_ref().expect("eligibility implies the lane");
-                if lane.pending.is_some() || lane.fallback.is_some() {
+                if lane.posted.is_some() || lane.fallback.is_some() {
                     // One outstanding whale per rank keeps the cancel pairing
                     // trivial; whales are sparse and the rendezvous is a few
                     // launches, so the head of the queue waits.
                     break;
                 }
-                let pending = self.queued.pop_front().expect("front just observed");
+                let (poster, hub) = (lane.rank, lane.serving.hub.clone());
+                let queued = self.queued.pop_front().expect("front just observed");
                 ledger.admit(id);
                 let slot = self
                     .free_slots
                     .pop()
                     .expect("loop runs only while a slot is free");
-                let prompt: Arc<[u32]> = Arc::from(pending.request.prompt_tokens.as_slice());
-                let (key, poster, hub) = {
-                    let lane = self.whale.as_mut().expect("eligibility implies the lane");
-                    let key = lane.next_key;
-                    lane.next_key += 1;
-                    (key, lane.rank, lane.serving.hub.clone())
-                };
+                let prompt: Arc<[u32]> = Arc::from(queued.request.prompt_tokens.as_slice());
                 if let Err(error) = hub.send(WhaleToSequencer::Request {
-                    request: key,
+                    request: id.raw(),
                     poster,
                     prompt: prompt.clone(),
                 }) {
@@ -584,17 +574,14 @@ impl<E: StepExecutor> K3Scheduler<E> {
                     ledger.fail(id, format!("{error:#}"));
                     return Err(error);
                 }
-                let ignore_eos = pending.request.params.ignore_eos;
                 let lane = self.whale.as_mut().expect("eligibility implies the lane");
-                lane.pending = Some(PendingWhale {
+                lane.posted = Some(PostedWhale {
                     id,
                     slot,
-                    key,
                     seq: None,
                     prompt,
-                    params: pending.request.params,
-                    max_tokens: pending.request.max_tokens,
-                    ignore_eos,
+                    params: queued.request.params,
+                    max_tokens: queued.request.max_tokens,
                 });
                 continue;
             }

--- a/pegainfer-k3/src/scheduler/mod.rs
+++ b/pegainfer-k3/src/scheduler/mod.rs
@@ -38,11 +38,21 @@ use pegainfer_frontend::engine::RequestLedger;
 use pegainfer_frontend::engine::Scheduler;
 use pegainfer_frontend::engine::SchedulerMetrics;
 use pegainfer_frontend::engine::spawn_scheduler;
+use pegainfer_frontend::sampler::SamplingParams;
 
 pub use self::executor::DecodeSlot;
 pub use self::executor::SlotId;
 pub use self::executor::StepExecutor;
 pub use self::gang::K3CpGang;
+use self::whale::CommittedWhale;
+use self::whale::GlobalRank;
+use self::whale::WhaleDuty;
+use self::whale::WhaleMember;
+use self::whale::WhaleSeq;
+use self::whale::WhaleToMember;
+use self::whale::WhaleToSequencer;
+use self::whale::k3_whale_width;
+pub use self::whale_hub::K3WhaleHub;
 use crate::executor::cp::k3_cp_admits;
 
 // ── Engine assembly ─────────────────────────────────────────────────────
@@ -60,6 +70,10 @@ pub struct K3SchedulerConfig {
     /// Context-parallel prefill serving, when armed. `None` = every prompt
     /// prefills on its own partition.
     pub cp: Option<K3CpServing>,
+    /// The fleet whale lane, when armed. Mutually exclusive with `cp`: the
+    /// in-process gang and the fleet rendezvous are two coordination layers
+    /// for the same superstep, and a deployment runs exactly one.
+    pub whale: Option<K3WhaleServing>,
 }
 
 /// The armed CP prefill lane: the gang handle plus the admission window that
@@ -73,6 +87,60 @@ pub struct K3CpServing {
     /// The executors' prefill chunk cap. A CP segment must fit one chunk
     /// (M0: one chunk step per rank), so this bounds eligibility from above.
     pub chunk_tokens: usize,
+}
+
+/// The armed whale lane: fleet-wide CP prefill through the whale rendezvous
+/// ([`whale`]). One hub per process; each scheduler partition is one global
+/// rank in the fleet's world.
+#[derive(Clone, Debug)]
+pub struct K3WhaleServing {
+    /// The rendezvous transport. The process hosting global rank 0 also
+    /// hosts the sequencer inside its hub.
+    pub hub: K3WhaleHub,
+    /// Total ranks in the fleet.
+    pub world: usize,
+    /// The global rank of this process's partition 0; partition `p` serves
+    /// global rank `first_local + p`.
+    pub first_local: GlobalRank,
+    /// Prompts shorter than this prefill locally.
+    pub min_tokens: usize,
+    /// The executors' prefill chunk cap — bounds a whale segment from above
+    /// (one superstep per rank).
+    pub chunk_tokens: usize,
+}
+
+/// A whale request this poster sent to the sequencer and is waiting to hear
+/// back about. Its slot is reserved the whole time, so the commit can never
+/// arrive to a full batch.
+struct PendingWhale {
+    id: RequestId,
+    slot: SlotId,
+    /// The request key echoed through the descriptor — how the poster pairs
+    /// gathers, commits, and cancels with this admission.
+    key: u64,
+    /// The sequence this whale got, learned from our own gather broadcast.
+    /// `None` until the gather arrives; a cancel for an unknown sequence can
+    /// only be the width refusal of this one outstanding post.
+    seq: Option<WhaleSeq>,
+    prompt: Arc<[u32]>,
+    params: SamplingParams,
+    max_tokens: usize,
+    ignore_eos: bool,
+}
+
+/// One partition's live whale state: the protocol member plus the poster-side
+/// bookkeeping. At most one whale post is outstanding per rank at a time —
+/// whales are sparse, and one-at-a-time keeps the cancel pairing trivial.
+struct WhaleLane {
+    serving: K3WhaleServing,
+    member: WhaleMember,
+    rank: GlobalRank,
+    next_key: u64,
+    /// The outstanding post, if any (awaiting commit or cancel).
+    pending: Option<PendingWhale>,
+    /// A cancelled post falling back to a local prefill, run at the next
+    /// unrestricted launch.
+    fallback: Option<PendingWhale>,
 }
 
 /// Wrap ready executors in schedulers and hand the whole thing to the
@@ -139,6 +207,8 @@ pub struct K3Scheduler<E: StepExecutor> {
     kv_capacity: Option<KvCapacity>,
     /// The CP prefill lane, when the engine armed one.
     cp: Option<K3CpServing>,
+    /// The whale lane, when the engine armed one.
+    whale: Option<WhaleLane>,
     /// Requests waiting for a slot, in submit order. A full batch is a
     /// wait, not a verdict — only permanently unservable requests are refused
     /// (see [`K3Scheduler::admission_refusal`]).
@@ -157,6 +227,26 @@ impl<E: StepExecutor> K3Scheduler<E> {
                 cp.gang.size()
             );
         }
+        assert!(
+            config.cp.is_none() || config.whale.is_none(),
+            "the in-process CP gang and the fleet whale lane are exclusive"
+        );
+        let whale = config.whale.map(|serving| {
+            let rank = serving.first_local + partition;
+            assert!(
+                rank < serving.world,
+                "partition {partition} maps to global rank {rank}, outside the {}-rank world",
+                serving.world
+            );
+            WhaleLane {
+                member: WhaleMember::new(rank),
+                rank,
+                next_key: 0,
+                pending: None,
+                fallback: None,
+                serving,
+            }
+        });
         let free_slots = (0..executor.max_batch()).rev().collect();
         Self {
             executor,
@@ -164,6 +254,7 @@ impl<E: StepExecutor> K3Scheduler<E> {
             eos_token_ids: config.eos_token_ids,
             kv_capacity: config.kv_capacity,
             cp: config.cp,
+            whale,
             queued: VecDeque::new(),
             running: Vec::new(),
             free_slots,
@@ -186,6 +277,214 @@ impl<E: StepExecutor> K3Scheduler<E> {
             return Ok(());
         };
         gang.serve(self.partition, &mut self.executor)
+    }
+
+    /// Serve the whale lane at this launch boundary: drain the rendezvous,
+    /// answer gathers, enter any whale committed for this exact launch, and
+    /// say whether multi-launch admissions are allowed this step.
+    ///
+    /// `false` (an armed or committed whale is pending) restricts the step to
+    /// single-launch work: the scheduler then only decodes, the launch count
+    /// advances exactly one per step, and this member hits the committed
+    /// launch dead on. That is the scheduler's half of the arming contract in
+    /// [`whale`] — the member's replies stay exact floors on reachable
+    /// launches because nothing multi-launch starts while one is pending.
+    fn serve_whale(&mut self, ledger: &mut RequestLedger) -> Result<bool> {
+        let Some(mut lane) = self.whale.take() else {
+            return Ok(true);
+        };
+        let verdict = self.serve_whale_lane(&mut lane, ledger);
+        self.whale = Some(lane);
+        verdict
+    }
+
+    fn serve_whale_lane(
+        &mut self,
+        lane: &mut WhaleLane,
+        ledger: &mut RequestLedger,
+    ) -> Result<bool> {
+        loop {
+            for message in lane.serving.hub.drain(lane.rank) {
+                Self::note_poster_pairing(lane, &message);
+                let count = self.executor.step_count();
+                if let Some(reply) = lane.member.on_message(message, count)? {
+                    lane.serving.hub.send(reply)?;
+                }
+            }
+            match lane.member.at_launch(self.executor.step_count())? {
+                // The superstep advanced the count; consult the next boundary
+                // before leaving — a second whale may sit right behind it.
+                WhaleDuty::Enter(whale) => self.enter_whale(lane, *whale, ledger)?,
+                WhaleDuty::Free { clearance } => {
+                    if clearance.is_some() {
+                        return Ok(false);
+                    }
+                    self.run_whale_fallback(lane, ledger);
+                    return Ok(true);
+                }
+            }
+        }
+    }
+
+    /// Pair an inbound rendezvous message with the poster's outstanding post,
+    /// before the member consumes it. A gather for our own request records
+    /// its sequence; a cancel routes the post to the local-prefill fallback —
+    /// either by its recorded sequence, or, for a post that never gathered
+    /// (unknown sequence, not armed here), as the sequencer's width refusal.
+    fn note_poster_pairing(lane: &mut WhaleLane, message: &WhaleToMember) {
+        match message {
+            WhaleToMember::Gather { descriptor } if descriptor.poster == lane.rank => {
+                if let Some(pending) = lane.pending.as_mut()
+                    && pending.key == descriptor.request
+                {
+                    pending.seq = Some(descriptor.seq);
+                }
+            }
+            WhaleToMember::Cancel { seq } => {
+                let refused = lane.pending.as_ref().is_some_and(|pending| {
+                    pending.seq == Some(*seq)
+                        || (pending.seq.is_none() && !lane.member.is_armed(*seq))
+                });
+                if refused {
+                    lane.fallback = lane.pending.take();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Enter a committed whale's superstep. Every gang member calls the
+    /// executor at this exact launch, unconditionally — a committed whale
+    /// cannot be cancelled, and an unwanted result is dropped, not prevented.
+    /// An executor error here is engine-fatal: this rank just left its gang
+    /// mid-superstep.
+    fn enter_whale(
+        &mut self,
+        lane: &mut WhaleLane,
+        whale: CommittedWhale,
+        ledger: &mut RequestLedger,
+    ) -> Result<()> {
+        let pending = if whale.descriptor.poster == lane.rank {
+            let pending = lane.pending.take().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "whale {} committed for this poster, but no post is outstanding",
+                    whale.descriptor.seq
+                )
+            })?;
+            anyhow::ensure!(
+                pending.key == whale.descriptor.request,
+                "whale {} answers request key {}, but the outstanding post is {}",
+                whale.descriptor.seq,
+                whale.descriptor.request,
+                pending.key
+            );
+            Some(pending)
+        } else {
+            None
+        };
+        let first = self
+            .executor
+            .prefill_whale(&whale, pending.as_ref().map(|pending| pending.slot))?;
+        let Some(pending) = pending else {
+            return Ok(());
+        };
+        let first = first.ok_or_else(|| {
+            anyhow::anyhow!(
+                "whale {} owner sampled no boundary token",
+                whale.descriptor.seq
+            )
+        })?;
+        if ledger.is_aborted(pending.id) {
+            // The whale ran regardless (unanimity is the contract); only the
+            // answer is dropped.
+            ledger.retire(pending.id);
+            self.release_slot(pending.slot);
+            return Ok(());
+        }
+        self.commit_first_token(
+            pending.id,
+            pending.slot,
+            first,
+            pending.max_tokens,
+            pending.ignore_eos,
+            ledger,
+        );
+        Ok(())
+    }
+
+    /// A cancelled whale post answers its request with a plain local prefill,
+    /// run at the first unrestricted launch after the cancel.
+    fn run_whale_fallback(&mut self, lane: &mut WhaleLane, ledger: &mut RequestLedger) {
+        let Some(pending) = lane.fallback.take() else {
+            return;
+        };
+        if ledger.is_aborted(pending.id) {
+            ledger.retire(pending.id);
+            self.release_slot(pending.slot);
+            return;
+        }
+        match self
+            .executor
+            .prefill(pending.slot, &pending.prompt, &pending.params)
+        {
+            Ok(first) => self.commit_first_token(
+                pending.id,
+                pending.slot,
+                first,
+                pending.max_tokens,
+                pending.ignore_eos,
+                ledger,
+            ),
+            Err(error) => {
+                // A local prefill failure is this request's problem, exactly
+                // as on the ordinary admission path.
+                self.release_slot(pending.slot);
+                ledger.fail(pending.id, format!("{error:#}"));
+            }
+        }
+    }
+
+    /// Record a freshly prefilled request's first token: finish it on the
+    /// spot when the token is terminal, seat it in the running batch
+    /// otherwise.
+    fn commit_first_token(
+        &mut self,
+        id: RequestId,
+        slot: SlotId,
+        first: u32,
+        max_tokens: usize,
+        ignore_eos: bool,
+        ledger: &mut RequestLedger,
+    ) {
+        if self.is_stop_token(first, ignore_eos) {
+            // The stop token itself is not part of the completion.
+            self.release_slot(slot);
+            finish_or_retire(id, FinishReason::Stop, ledger);
+            return;
+        }
+        ledger.push_tokens(id, &[first], &[]);
+        if ledger.completion_tokens(id) >= max_tokens {
+            self.release_slot(slot);
+            finish_or_retire(id, FinishReason::Length, ledger);
+            return;
+        }
+        self.running.push(RunningRequest {
+            id,
+            slot,
+            last_token: first,
+            max_tokens,
+            ignore_eos,
+        });
+    }
+
+    /// Whether the whale lane should carry this prompt: lane armed, prompt in
+    /// its window, and some gang width admits it.
+    fn whale_eligible(&self, prompt_len: usize) -> bool {
+        self.whale.as_ref().is_some_and(|lane| {
+            prompt_len >= lane.serving.min_tokens
+                && k3_whale_width(prompt_len, lane.serving.world, lane.serving.chunk_tokens)
+                    .is_some()
+        })
     }
 
     /// Hand a slot back: the executor drops its state, the scheduler its
@@ -215,33 +514,100 @@ impl<E: StepExecutor> K3Scheduler<E> {
     }
 
     /// Fill free slots from the queue: retire what the frontend abandoned,
-    /// refuse what can never fit, prefill the rest. `Err` means a gang
-    /// prefill failed — never a local one, which is the request's problem.
-    fn admit_queued(&mut self, ledger: &mut RequestLedger) -> Result<()> {
+    /// refuse what can never fit, post whale-window prompts to the
+    /// rendezvous, prefill the rest. `Err` means a gang prefill or the
+    /// rendezvous transport failed — never a local prefill, which is the
+    /// request's problem.
+    ///
+    /// `may_prefill = false` (an armed or committed whale pins this rank's
+    /// launch count) defers admissions that would launch — a multi-launch
+    /// local prefill would overshoot the committed superstep. Verdicts that
+    /// never touch the device (aborts, rejections, empty completions) flow
+    /// regardless.
+    fn admit_queued(&mut self, ledger: &mut RequestLedger, may_prefill: bool) -> Result<()> {
         while !self.free_slots.is_empty() {
-            let Some(pending) = self.queued.pop_front() else {
+            // Peek: a wait verdict must leave the request untouched (no
+            // ledger writes) for a later step.
+            let Some(next) = self.queued.front() else {
                 break;
             };
-            let id = pending.id;
+            let id = next.id;
+            let prompt_len = next.request.prompt_tokens.len();
+            let refusal = self.admission_refusal(&next.request);
+            let empty_completion = next.request.max_tokens == 0;
             if ledger.is_aborted(id) {
+                self.queued.pop_front();
                 ledger.retire(id);
                 continue;
             }
-            if let Some(reason) = self.admission_refusal(&pending.request) {
+            if let Some(reason) = refusal {
+                self.queued.pop_front();
                 ledger.reject(id, reason);
                 continue;
             }
-            ledger.admit(id);
-            if pending.request.max_tokens == 0 {
+            if empty_completion {
                 // Nothing to generate: answer without occupying a slot.
+                self.queued.pop_front();
+                ledger.admit(id);
                 finish_or_retire(id, FinishReason::Length, ledger);
                 continue;
             }
+            if self.whale_eligible(prompt_len) {
+                let lane = self.whale.as_ref().expect("eligibility implies the lane");
+                if lane.pending.is_some() || lane.fallback.is_some() {
+                    // One outstanding whale per rank keeps the cancel pairing
+                    // trivial; whales are sparse and the rendezvous is a few
+                    // launches, so the head of the queue waits.
+                    break;
+                }
+                let pending = self.queued.pop_front().expect("front just observed");
+                ledger.admit(id);
+                let slot = self
+                    .free_slots
+                    .pop()
+                    .expect("loop runs only while a slot is free");
+                let prompt: Arc<[u32]> = Arc::from(pending.request.prompt_tokens.as_slice());
+                let (key, poster, hub) = {
+                    let lane = self.whale.as_mut().expect("eligibility implies the lane");
+                    let key = lane.next_key;
+                    lane.next_key += 1;
+                    (key, lane.rank, lane.serving.hub.clone())
+                };
+                if let Err(error) = hub.send(WhaleToSequencer::Request {
+                    request: key,
+                    poster,
+                    prompt: prompt.clone(),
+                }) {
+                    // The rendezvous transport is fleet infrastructure; its
+                    // loss is the engine's, not the request's.
+                    self.release_slot(slot);
+                    ledger.fail(id, format!("{error:#}"));
+                    return Err(error);
+                }
+                let ignore_eos = pending.request.params.ignore_eos;
+                let lane = self.whale.as_mut().expect("eligibility implies the lane");
+                lane.pending = Some(PendingWhale {
+                    id,
+                    slot,
+                    key,
+                    seq: None,
+                    prompt,
+                    params: pending.request.params,
+                    max_tokens: pending.request.max_tokens,
+                    ignore_eos,
+                });
+                continue;
+            }
+            if !may_prefill {
+                break;
+            }
+            let pending = self.queued.pop_front().expect("front just observed");
+            ledger.admit(id);
             let slot = self
                 .free_slots
                 .pop()
                 .expect("loop runs only while a slot is free");
-            let first = match self.cp_gang_for(pending.request.prompt_tokens.len()) {
+            let first = match self.cp_gang_for(prompt_len) {
                 Some(gang) => {
                     match gang.post_and_run(
                         self.partition,
@@ -278,26 +644,14 @@ impl<E: StepExecutor> K3Scheduler<E> {
                     }
                 }
             };
-            let state = RunningRequest {
+            self.commit_first_token(
                 id,
                 slot,
-                last_token: first,
-                max_tokens: pending.request.max_tokens,
-                ignore_eos: pending.request.params.ignore_eos,
-            };
-            if self.is_stop_token(first, state.ignore_eos) {
-                // The stop token itself is not part of the completion.
-                self.release_slot(slot);
-                finish_or_retire(id, FinishReason::Stop, ledger);
-                continue;
-            }
-            ledger.push_tokens(id, &[first], &[]);
-            if ledger.completion_tokens(id) >= state.max_tokens {
-                self.release_slot(slot);
-                finish_or_retire(id, FinishReason::Length, ledger);
-                continue;
-            }
-            self.running.push(state);
+                first,
+                pending.request.max_tokens,
+                pending.request.params.ignore_eos,
+                ledger,
+            );
         }
         Ok(())
     }
@@ -417,10 +771,16 @@ impl<E: StepExecutor> Scheduler for K3Scheduler<E> {
         // whole extra step time. A serve error propagates: this partition can
         // no longer hold up its end of the gang, so the engine is beyond use.
         self.serve_gang()?;
-        self.admit_queued(ledger)?;
+        // Then the whale lane, at what is a launch boundary by construction:
+        // it drains the rendezvous, enters a committed superstep when this is
+        // its launch, and its verdict caps this step's admissions at
+        // single-launch work while a whale is pending.
+        let may_prefill = self.serve_whale(ledger)?;
+        self.admit_queued(ledger, may_prefill)?;
         self.decode_running(ledger);
         // Local prefill and decode failures are per-request and absorbed
-        // above; gang failures propagate the same way a serve error does.
+        // above; gang, whale, and transport failures propagate the same way a
+        // serve error does.
         Ok(())
     }
 

--- a/pegainfer-k3/src/scheduler/tests.rs
+++ b/pegainfer-k3/src/scheduler/tests.rs
@@ -30,9 +30,13 @@ use super::DecodeSlot;
 use super::K3CpGang;
 use super::K3CpServing;
 use super::K3SchedulerConfig;
+use super::K3WhaleHub;
+use super::K3WhaleServing;
 use super::SlotId;
 use super::StepExecutor;
 use super::start_with_executors;
+use super::whale::CommittedWhale;
+use super::whale_hub::LocalWhaleHub;
 use crate::executor::cp::K3CpGroup;
 
 const EOS_TOKEN: u32 = 99;
@@ -186,6 +190,7 @@ fn launch(executor: FakeExecutor) -> (LiveScheduler, StepCollector) {
         eos_token_ids: vec![EOS_TOKEN],
         kv_capacity: None,
         cp: None,
+        whale: None,
     };
     partition(start_with_executors(vec![executor], &config))
 }
@@ -692,6 +697,7 @@ fn launch_cp(size: usize) -> (Arc<CpWorld>, Vec<(LiveScheduler, StepCollector)>)
             min_tokens: 32,
             chunk_tokens: 4096,
         }),
+        whale: None,
     };
     let mut engine = start_with_executors(executors, &config);
     let partitions = engine
@@ -817,6 +823,329 @@ fn a_local_prefill_burst_does_not_unlevel_the_gang() {
         drop(partition.handle);
         partition.join.join().expect("scheduler thread exits");
     }
+}
+
+// ── The whale lane ──────────────────────────────────────────────────────
+//
+// Same fake world as the CP gang — the launch counts and their pairing are
+// the physics under test — but coordination runs through the whale
+// rendezvous ([`super::whale`]) over a [`LocalWhaleHub`], the in-process
+// degenerate fleet. What these pin: a committed whale enters `prefill_whale`
+// on every gang member at one launch count, non-members never hear of it,
+// and concurrent whales serialize. The cancel → local-fallback path has no
+// in-process trigger (the poster's eligibility check and the sequencer's
+// admission are the same deterministic predicate, and gather timeouts live
+// in the TCP hub), so it is pinned at the state-machine level in
+// [`super::whale`]'s tests instead.
+
+const WHALE_CHUNK: usize = 4096;
+const WHALE_MIN: usize = 2048;
+
+/// Per whale (keyed by the prompt's first token): each member's view on
+/// entry — partition, CP rank, and whether it owns the result slot.
+type WhaleRoles = Arc<Mutex<HashMap<u32, Vec<(usize, usize, bool)>>>>;
+
+/// One partition of the fake fleet. Pacing (launch counts, pairing, the
+/// entry/order logs) reuses [`CpWorld`]; `roles` records what only the whale
+/// lane decides.
+struct FakeWhaleExecutor {
+    world: Arc<CpWorld>,
+    roles: WhaleRoles,
+    partition: usize,
+}
+
+impl Drop for FakeWhaleExecutor {
+    fn drop(&mut self) {
+        self.world.finished[self.partition].store(true, Ordering::SeqCst);
+    }
+}
+
+impl StepExecutor for FakeWhaleExecutor {
+    fn max_batch(&self) -> usize {
+        2
+    }
+
+    fn max_context_tokens(&self) -> usize {
+        65536
+    }
+
+    fn prefill(&mut self, _slot: SlotId, prompt: &[u32], _params: &SamplingParams) -> Result<u32> {
+        anyhow::ensure!(
+            prompt.len() < WHALE_MIN,
+            "a whale-eligible prompt of {} tokens took the local prefill path",
+            prompt.len()
+        );
+        self.world.burst(self.partition, 4);
+        Ok(500)
+    }
+
+    fn decode(&mut self, batch: &[DecodeSlot]) -> Result<Vec<u32>> {
+        self.world.step(self.partition);
+        Ok(vec![7; batch.len()])
+    }
+
+    fn prefill_whale(
+        &mut self,
+        whale: &CommittedWhale,
+        slot: Option<SlotId>,
+    ) -> Result<Option<u32>> {
+        let key = whale.descriptor.prompt[0];
+        {
+            let mut entries = self.world.entries.lock().expect("entry log");
+            entries.entry(key).or_default().push((
+                self.partition,
+                self.world.counts[self.partition].load(Ordering::SeqCst),
+            ));
+            self.world.orders.lock().expect("order log")[self.partition].push(key);
+            self.roles
+                .lock()
+                .expect("role log")
+                .entry(key)
+                .or_default()
+                .push((self.partition, whale.cp_rank, slot.is_some()));
+        }
+        self.world.await_gang(key, whale.descriptor.gang.len());
+        self.world.step(self.partition);
+        Ok(slot.map(|_| 2000 + key))
+    }
+
+    fn step_count(&self) -> u64 {
+        self.world.counts[self.partition].load(Ordering::SeqCst)
+    }
+
+    fn release(&mut self, _slot: SlotId) {}
+}
+
+/// A `size`-partition engine over one fake world, whale lane armed through a
+/// local hub (`world == size`, global rank == partition).
+fn launch_whale(
+    size: usize,
+) -> (
+    Arc<CpWorld>,
+    WhaleRoles,
+    Vec<(LiveScheduler, StepCollector)>,
+) {
+    let world = CpWorld::new(size);
+    let roles: WhaleRoles = Arc::default();
+    let executors = (0..size)
+        .map(|partition| FakeWhaleExecutor {
+            world: Arc::clone(&world),
+            roles: Arc::clone(&roles),
+            partition,
+        })
+        .collect();
+    let config = K3SchedulerConfig {
+        eos_token_ids: vec![EOS_TOKEN],
+        kv_capacity: None,
+        cp: None,
+        whale: Some(K3WhaleServing {
+            hub: K3WhaleHub::Local(LocalWhaleHub::new(size, WHALE_CHUNK)),
+            world: size,
+            first_local: 0,
+            min_tokens: WHALE_MIN,
+            chunk_tokens: WHALE_CHUNK,
+        }),
+    };
+    let mut engine = start_with_executors(executors, &config);
+    let partitions = engine
+        .schedulers
+        .drain(..)
+        .map(|mut scheduler| {
+            let steps = scheduler
+                .handle
+                .take_steps()
+                .expect("a fresh scheduler yields its step stream once");
+            (scheduler, StepCollector::new(steps))
+        })
+        .collect();
+    (world, roles, partitions)
+}
+
+/// A whale-window request whose prompt is keyed by its first token.
+fn whale_request(key: u32, prompt_len: usize, max_tokens: usize) -> Request {
+    Request {
+        prompt_tokens: vec![key; prompt_len],
+        ..request(0, max_tokens)
+    }
+}
+
+fn drain_partitions(mut partitions: Vec<(LiveScheduler, StepCollector)>) {
+    for (partition, _) in partitions.drain(..) {
+        drop(partition.handle);
+        partition.join.join().expect("scheduler thread exits");
+    }
+}
+
+#[test]
+fn a_committed_whale_enters_every_rank_at_one_launch_count() {
+    let (world, roles, mut partitions) = launch_whale(4);
+
+    // 12288 tokens over chunk 4096: only width 4 admits, so the whole world
+    // is the gang.
+    let control = partitions[2].0.handle.submit(whale_request(5, 12288, 2));
+    let (tokens, terminal) = partitions[2].1.collect_terminal(control.id());
+    assert_eq!(
+        tokens,
+        vec![2005, 7],
+        "the poster streams the boundary token, then decodes"
+    );
+    assert!(
+        matches!(
+            terminal,
+            Terminal::Finished {
+                reason: FinishReason::Length,
+                completion_tokens: 2,
+                ..
+            }
+        ),
+        "{terminal:?}"
+    );
+
+    let entries = world.entries.lock().expect("entry log");
+    let job = &entries[&5];
+    assert_eq!(job.len(), 4, "every rank ran the whale exactly once");
+    assert!(
+        job.iter().all(|&(_, count)| count == job[0].1),
+        "the gang must enter prefill_whale at one launch count: {job:?}"
+    );
+    let roles = roles.lock().expect("role log");
+    let job = &roles[&5];
+    let cp_ranks: HashSet<usize> = job.iter().map(|&(_, cp_rank, _)| cp_rank).collect();
+    assert_eq!(cp_ranks, (0..4).collect(), "CP ranks must be a permutation");
+    for &(partition, cp_rank, owns_slot) in job {
+        assert_eq!(
+            owns_slot,
+            partition == 2,
+            "only the poster owns the result slot: {job:?}"
+        );
+        if partition == 2 {
+            assert_eq!(cp_rank, 3, "the poster serves the last CP rank");
+        }
+    }
+    drop((entries, roles));
+
+    drain_partitions(partitions);
+}
+
+#[test]
+fn ranks_outside_the_gang_never_hear_of_the_whale() {
+    let (world, roles, mut partitions) = launch_whale(4);
+
+    // 6144 tokens: width 4 makes 1536-token segments (under the floor), so
+    // the whale runs on a width-2 gang and two ranks stay out entirely.
+    let control = partitions[0].0.handle.submit(whale_request(6, 6144, 1));
+    let (tokens, _) = partitions[0].1.collect_terminal(control.id());
+    assert_eq!(tokens, vec![2006]);
+
+    let entries = world.entries.lock().expect("entry log");
+    let job = &entries[&6];
+    assert_eq!(
+        job.len(),
+        2,
+        "exactly the gang enters; the other ranks only ever pad: {job:?}"
+    );
+    assert!(
+        job.iter().all(|&(_, count)| count == job[0].1),
+        "the gang must enter at one launch count: {job:?}"
+    );
+    let roles = roles.lock().expect("role log");
+    let job = &roles[&6];
+    let poster = job
+        .iter()
+        .find(|&&(partition, _, _)| partition == 0)
+        .expect("the poster is in its own gang");
+    assert_eq!(
+        (poster.1, poster.2),
+        (1, true),
+        "the poster serves the last CP rank and owns the slot"
+    );
+    let helper = job
+        .iter()
+        .find(|&&(partition, _, _)| partition != 0)
+        .expect("a width-2 gang has one helper");
+    assert_eq!((helper.1, helper.2), (0, false), "{job:?}");
+    drop((entries, roles));
+
+    drain_partitions(partitions);
+}
+
+#[test]
+fn concurrent_whales_serialize_in_one_order_on_every_rank() {
+    let (world, _roles, mut partitions) = launch_whale(4);
+
+    // Two posters race. The sequencer gathers one whale at a time and every
+    // committed launch is strictly later than the previous, so all ranks run
+    // the two supersteps in the same order at two distinct counts.
+    let first = partitions[0].0.handle.submit(whale_request(5, 12288, 1));
+    let second = partitions[3].0.handle.submit(whale_request(6, 12288, 1));
+    let (tokens, _) = partitions[0].1.collect_terminal(first.id());
+    assert_eq!(tokens, vec![2005]);
+    let (tokens, _) = partitions[3].1.collect_terminal(second.id());
+    assert_eq!(tokens, vec![2006]);
+
+    let entries = world.entries.lock().expect("entry log");
+    for key in [5, 6] {
+        let job = &entries[&key];
+        assert_eq!(job.len(), 4);
+        assert!(
+            job.iter().all(|&(_, count)| count == job[0].1),
+            "whale {key} entered unlevel: {job:?}"
+        );
+    }
+    assert_ne!(
+        entries[&5][0].1, entries[&6][0].1,
+        "two whales cannot share a superstep"
+    );
+    let orders = world.orders.lock().expect("order log");
+    assert!(
+        orders.iter().all(|order| *order == orders[0]),
+        "ranks disagree on the whale order: {orders:?}"
+    );
+    drop((entries, orders));
+
+    drain_partitions(partitions);
+}
+
+#[test]
+fn a_second_whale_on_one_rank_waits_for_the_outstanding_post() {
+    let (world, _roles, mut partitions) = launch_whale(4);
+
+    // One rank posts two whales back-to-back. The lane keeps one post
+    // outstanding, so the second waits at the head of the queue and both
+    // still complete, on distinct supersteps.
+    let first = partitions[1].0.handle.submit(whale_request(5, 12288, 1));
+    let second = partitions[1].0.handle.submit(whale_request(6, 12288, 1));
+    let (tokens, _) = partitions[1].1.collect_terminal(first.id());
+    assert_eq!(tokens, vec![2005]);
+    let (tokens, _) = partitions[1].1.collect_terminal(second.id());
+    assert_eq!(tokens, vec![2006]);
+
+    let entries = world.entries.lock().expect("entry log");
+    assert_eq!(entries[&5].len(), 4);
+    assert_eq!(entries[&6].len(), 4);
+    assert!(
+        entries[&5][0].1 < entries[&6][0].1,
+        "the queued whale must run strictly after the outstanding one: {entries:?}"
+    );
+    drop(entries);
+
+    drain_partitions(partitions);
+}
+
+#[test]
+fn short_prompts_prefill_locally_under_the_whale_lane() {
+    let (world, roles, mut partitions) = launch_whale(4);
+
+    let control = partitions[0].0.handle.submit(request(60, 1));
+    let (tokens, _) = partitions[0].1.collect_terminal(control.id());
+    assert_eq!(tokens, vec![500], "a short prompt takes the local prefill");
+    assert!(
+        world.entries.lock().expect("entry log").is_empty(),
+        "no whale ran"
+    );
+    assert!(roles.lock().expect("role log").is_empty());
+
+    drain_partitions(partitions);
 }
 
 #[test]

--- a/pegainfer-k3/src/scheduler/tests.rs
+++ b/pegainfer-k3/src/scheduler/tests.rs
@@ -609,12 +609,18 @@ impl CpWorld {
     }
 }
 
-/// One partition of the fake world. Every stepping method launches through
+/// One partition of the fake world, serving whichever lane the test armed
+/// (CP gang or whale). Every stepping method launches through
 /// [`CpWorld::step`], so the scheduler's own cadence (decode padding, gang
 /// pumps, the chunk step) is what drives the pairing.
 struct FakeCpExecutor {
     world: Arc<CpWorld>,
+    /// Per-whale role log; stays empty when only the CP lane is armed.
+    roles: WhaleRoles,
     partition: usize,
+    /// The armed lane's admission floor: a prompt at or past it taking the
+    /// plain local prefill path is the failure under test.
+    local_floor: usize,
 }
 
 impl Drop for FakeCpExecutor {
@@ -629,13 +635,13 @@ impl StepExecutor for FakeCpExecutor {
     }
 
     fn max_context_tokens(&self) -> usize {
-        4096
+        65536
     }
 
     fn prefill(&mut self, _slot: SlotId, prompt: &[u32], _params: &SamplingParams) -> Result<u32> {
         anyhow::ensure!(
-            prompt.len() < 32,
-            "a CP-eligible prompt of {} tokens took the local prefill path",
+            prompt.len() < self.local_floor,
+            "a gang-eligible prompt of {} tokens took the local prefill path",
             prompt.len()
         );
         self.world.burst(self.partition, 4);
@@ -668,6 +674,31 @@ impl StepExecutor for FakeCpExecutor {
         Ok((cp_rank == group.cp_size() - 1).then_some(1000 + key))
     }
 
+    fn prefill_whale(
+        &mut self,
+        whale: &CommittedWhale,
+        slot: Option<SlotId>,
+    ) -> Result<Option<u32>> {
+        let key = whale.descriptor.prompt[0];
+        {
+            let mut entries = self.world.entries.lock().expect("entry log");
+            entries.entry(key).or_default().push((
+                self.partition,
+                self.world.counts[self.partition].load(Ordering::SeqCst),
+            ));
+            self.world.orders.lock().expect("order log")[self.partition].push(key);
+            self.roles
+                .lock()
+                .expect("role log")
+                .entry(key)
+                .or_default()
+                .push((self.partition, whale.cp_rank, slot.is_some()));
+        }
+        self.world.await_gang(key, whale.descriptor.gang.len());
+        self.world.step(self.partition);
+        Ok(slot.map(|_| 2000 + key))
+    }
+
     fn pump_step(&mut self) -> Result<()> {
         self.world.step(self.partition);
         Ok(())
@@ -686,7 +717,9 @@ fn launch_cp(size: usize) -> (Arc<CpWorld>, Vec<(LiveScheduler, StepCollector)>)
     let executors = (0..size)
         .map(|partition| FakeCpExecutor {
             world: Arc::clone(&world),
+            roles: Arc::default(),
             partition,
+            local_floor: 32,
         })
         .collect();
     let config = K3SchedulerConfig {
@@ -753,10 +786,7 @@ fn cp_gang_enters_prefill_cp_at_one_launch_count() {
         "the gang must enter prefill_cp at one launch count: {job:?}"
     );
 
-    for (partition, _) in partitions.drain(..) {
-        drop(partition.handle);
-        partition.join.join().expect("scheduler thread exits");
-    }
+    drain_partitions(partitions);
 }
 
 #[test]
@@ -790,10 +820,7 @@ fn concurrent_cp_posters_run_in_one_order_on_every_partition() {
         );
     }
 
-    for (partition, _) in partitions.drain(..) {
-        drop(partition.handle);
-        partition.join.join().expect("scheduler thread exits");
-    }
+    drain_partitions(partitions);
 }
 
 #[test]
@@ -819,20 +846,15 @@ fn a_local_prefill_burst_does_not_unlevel_the_gang() {
     );
     drop(entries);
 
-    for (partition, _) in partitions.drain(..) {
-        drop(partition.handle);
-        partition.join.join().expect("scheduler thread exits");
-    }
+    drain_partitions(partitions);
 }
 
 // ── The whale lane ──────────────────────────────────────────────────────
 //
-// Same fake world as the CP gang — the launch counts and their pairing are
-// the physics under test — but coordination runs through the whale
-// rendezvous ([`super::whale`]) over a [`LocalWhaleHub`], the in-process
-// degenerate fleet. What these pin: a committed whale enters `prefill_whale`
-// on every gang member at one launch count, non-members never hear of it,
-// and concurrent whales serialize. The cancel → local-fallback path has no
+// Same fake world and executor as the CP gang — the launch counts and their
+// pairing are the physics under test — but coordination runs through the
+// whale rendezvous ([`super::whale`]) over a [`LocalWhaleHub`], the
+// in-process degenerate fleet. The cancel → local-fallback path has no
 // in-process trigger (the poster's eligibility check and the sequencer's
 // admission are the same deterministic predicate, and gather timeouts live
 // in the TCP hub), so it is pinned at the state-machine level in
@@ -844,77 +866,6 @@ const WHALE_MIN: usize = 2048;
 /// Per whale (keyed by the prompt's first token): each member's view on
 /// entry — partition, CP rank, and whether it owns the result slot.
 type WhaleRoles = Arc<Mutex<HashMap<u32, Vec<(usize, usize, bool)>>>>;
-
-/// One partition of the fake fleet. Pacing (launch counts, pairing, the
-/// entry/order logs) reuses [`CpWorld`]; `roles` records what only the whale
-/// lane decides.
-struct FakeWhaleExecutor {
-    world: Arc<CpWorld>,
-    roles: WhaleRoles,
-    partition: usize,
-}
-
-impl Drop for FakeWhaleExecutor {
-    fn drop(&mut self) {
-        self.world.finished[self.partition].store(true, Ordering::SeqCst);
-    }
-}
-
-impl StepExecutor for FakeWhaleExecutor {
-    fn max_batch(&self) -> usize {
-        2
-    }
-
-    fn max_context_tokens(&self) -> usize {
-        65536
-    }
-
-    fn prefill(&mut self, _slot: SlotId, prompt: &[u32], _params: &SamplingParams) -> Result<u32> {
-        anyhow::ensure!(
-            prompt.len() < WHALE_MIN,
-            "a whale-eligible prompt of {} tokens took the local prefill path",
-            prompt.len()
-        );
-        self.world.burst(self.partition, 4);
-        Ok(500)
-    }
-
-    fn decode(&mut self, batch: &[DecodeSlot]) -> Result<Vec<u32>> {
-        self.world.step(self.partition);
-        Ok(vec![7; batch.len()])
-    }
-
-    fn prefill_whale(
-        &mut self,
-        whale: &CommittedWhale,
-        slot: Option<SlotId>,
-    ) -> Result<Option<u32>> {
-        let key = whale.descriptor.prompt[0];
-        {
-            let mut entries = self.world.entries.lock().expect("entry log");
-            entries.entry(key).or_default().push((
-                self.partition,
-                self.world.counts[self.partition].load(Ordering::SeqCst),
-            ));
-            self.world.orders.lock().expect("order log")[self.partition].push(key);
-            self.roles
-                .lock()
-                .expect("role log")
-                .entry(key)
-                .or_default()
-                .push((self.partition, whale.cp_rank, slot.is_some()));
-        }
-        self.world.await_gang(key, whale.descriptor.gang.len());
-        self.world.step(self.partition);
-        Ok(slot.map(|_| 2000 + key))
-    }
-
-    fn step_count(&self) -> u64 {
-        self.world.counts[self.partition].load(Ordering::SeqCst)
-    }
-
-    fn release(&mut self, _slot: SlotId) {}
-}
 
 /// A `size`-partition engine over one fake world, whale lane armed through a
 /// local hub (`world == size`, global rank == partition).
@@ -928,10 +879,11 @@ fn launch_whale(
     let world = CpWorld::new(size);
     let roles: WhaleRoles = Arc::default();
     let executors = (0..size)
-        .map(|partition| FakeWhaleExecutor {
+        .map(|partition| FakeCpExecutor {
             world: Arc::clone(&world),
             roles: Arc::clone(&roles),
             partition,
+            local_floor: WHALE_MIN,
         })
         .collect();
     let config = K3SchedulerConfig {
@@ -969,8 +921,9 @@ fn whale_request(key: u32, prompt_len: usize, max_tokens: usize) -> Request {
     }
 }
 
-fn drain_partitions(mut partitions: Vec<(LiveScheduler, StepCollector)>) {
-    for (partition, _) in partitions.drain(..) {
+/// Tear the engine down: drop every handle and join the scheduler threads.
+fn drain_partitions(partitions: Vec<(LiveScheduler, StepCollector)>) {
+    for (partition, _) in partitions {
         drop(partition.handle);
         partition.join.join().expect("scheduler thread exits");
     }

--- a/pegainfer-k3/src/scheduler/whale.rs
+++ b/pegainfer-k3/src/scheduler/whale.rs
@@ -56,7 +56,8 @@ use anyhow::Result;
 use anyhow::bail;
 use anyhow::ensure;
 
-use crate::executor::cp::K3_WHALE_SEGMENT_FLOOR;
+use crate::executor::cp::k3_whale_gang;
+use crate::executor::cp::k3_whale_width;
 
 /// A rank's identity across the whole EP world (not its process-local index).
 pub type GlobalRank = usize;
@@ -508,152 +509,6 @@ impl WhaleMember {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Policy: width, gang membership, segment leveling
-// ---------------------------------------------------------------------------
-
-/// The widest gang the prompt admits, or `None` when no width in
-/// `1 < w <= world` (powers of two, tray-aligned) does. Wider is better: the
-/// whale superstep stalls the *whole* fleet on the gang's finish line (the
-/// mega collective is global), so the gang that spreads the prompt thinnest —
-/// subject to every leveled segment staying above the floor and below one
-/// chunk — minimizes everyone's stall, not just the whale's latency.
-pub fn k3_whale_width(total: usize, world: usize, chunk_tokens: usize) -> Option<usize> {
-    let mut width = 1usize;
-    while width * 2 <= world {
-        width *= 2;
-    }
-    while width >= 2 {
-        if k3_whale_admits(total, width, chunk_tokens) {
-            return Some(width);
-        }
-        width /= 2;
-    }
-    None
-}
-
-/// Whether `total` tokens split over `width` ranks keeps every leveled
-/// segment above the floor and within one chunk step (one superstep per rank
-/// — the multi-superstep walk is out of scope until profiles demand it).
-pub fn k3_whale_admits(total: usize, width: usize, chunk_tokens: usize) -> bool {
-    if width < 2 || total < width * K3_WHALE_SEGMENT_FLOOR {
-        return false;
-    }
-    let segments = k3_whale_segments(total, width, chunk_tokens);
-    segments
-        .last()
-        .is_some_and(|&(start, len)| start + len == total)
-        && segments
-            .iter()
-            .all(|&(_, len)| len >= K3_WHALE_SEGMENT_FLOOR && len <= chunk_tokens)
-}
-
-/// The gang for a `width`-wide whale posted by `poster`: the tray-aligned
-/// contiguous block of ranks containing the poster (trays are 4 ranks; a
-/// contiguous block keeps the halo hop and most upstream traffic inside a
-/// tray or between adjacent trays), with the poster rotated to the end — the
-/// owner is the last CP rank, so the final KDA state and the whole MLA
-/// context land on the rank that will decode.
-pub fn k3_whale_gang(poster: GlobalRank, width: usize, world: usize) -> Vec<GlobalRank> {
-    debug_assert!(poster < world && width <= world);
-    const TRAY: usize = 4;
-    let start = if width >= TRAY {
-        (poster / TRAY * TRAY).min(world.saturating_sub(width))
-    } else {
-        poster.min(world.saturating_sub(width))
-    };
-    let mut gang: Vec<GlobalRank> = (start..start + width).filter(|&r| r != poster).collect();
-    gang.push(poster);
-    gang
-}
-
-/// How much one context token costs relative to one segment token, in the
-/// per-rank superstep time model `t_i ∝ len_i + Q·(start_i + len_i/2)·len_i`:
-/// the linear term is the full-depth per-token walk (MoE, KDA, dense GEMMs),
-/// the quadratic term is the MLA context triangle (each of the segment's rows
-/// attends its whole prefix). Calibrated from the CP4 16k profile
-/// (2026-08-25: a 12k-deeper prefix cost the last rank ~32ms against a
-/// ~1000ms/4k-row superstep); refit when the fleet profile lands. Leveling
-/// only needs the ratio, not the absolute times.
-const K3_CP_QUAD_PER_LINEAR: f64 = 2.7e-6;
-
-/// Split `total` tokens into `width` contiguous leveled segments: earlier
-/// ranks get longer segments, so every rank's modeled superstep time — walk
-/// plus its MLA triangle — comes out even.
-///
-/// Bisected on the per-rank time budget; coverage is monotone in the budget,
-/// so the smallest covering budget is the leveled split. The floor is *not*
-/// enforced here — [`k3_whale_admits`] rejects splits that level below it.
-/// The returned segments always number `width` and start at 0; they
-/// under-cover `total` when the chunk cap makes an exact partition
-/// impossible, which admission rejects too.
-pub fn k3_whale_segments(total: usize, width: usize, chunk_tokens: usize) -> Vec<(usize, usize)> {
-    debug_assert!(width >= 2);
-    if total == 0 {
-        return vec![(0, 0)];
-    }
-    // The padded per-row families (KDA, norms, projections, MoE entry) run at
-    // the covering chunk *bucket*, a step function of segment length — only
-    // attention is varlen. Pure leveling stretches the earliest segment past
-    // the bucket the mean sits in whenever the mean runs close to a boundary
-    // (65k over 8 ranks: mean 8,140, leveled head 8.6k → the 16,896 bucket,
-    // doubling its padded rows while the lockstep superstep waits — a
-    // measured ~900ms step). Cap segments at the mean's bucket: everyone
-    // stays in the same bucket, and leveling still balances the attention
-    // triangle inside it.
-    let cap = pegainfer_kernels::ops::k3_chunk_bucket(total.div_ceil(width))
-        .map_or(chunk_tokens, |bucket| bucket.min(chunk_tokens));
-    let affordable = |start: usize, budget: f64| -> usize {
-        // Largest len with len + Q·(start + len/2)·len <= budget:
-        // (Q/2)·len² + (1 + Q·start)·len − budget = 0.
-        let a = K3_CP_QUAD_PER_LINEAR / 2.0;
-        let b = 1.0 + K3_CP_QUAD_PER_LINEAR * start as f64;
-        let len = (2.0 * budget) / (b + (b * b + 4.0 * a * budget).sqrt());
-        (len.floor() as usize).min(cap)
-    };
-    let coverage = |budget: f64| -> usize {
-        let mut start = 0usize;
-        for _ in 0..width {
-            start += affordable(start, budget);
-        }
-        start
-    };
-    // Bisect the smallest budget that covers the prompt. The even split's
-    // per-rank cost bounds it above (leveling can only lower the maximum).
-    let per = total.div_ceil(width) as f64;
-    let mut hi = per * (1.0 + K3_CP_QUAD_PER_LINEAR * total as f64);
-    let mut lo = 0.0f64;
-    for _ in 0..64 {
-        let mid = (lo + hi) / 2.0;
-        if coverage(mid) >= total {
-            hi = mid;
-        } else {
-            lo = mid;
-        }
-    }
-    let mut segments = Vec::with_capacity(width);
-    let mut start = 0usize;
-    for rank in 0..width {
-        let remaining = total - start;
-        let ranks_left = width - rank;
-        // The bisected budget's segment, clamped to leave every later rank at
-        // least one token; the last rank takes whatever is left. Leveling is
-        // a preference, the exact partition is the contract — when the chunk
-        // cap makes exactness impossible the result under-covers and
-        // [`k3_whale_admits`] rejects it.
-        let len = if ranks_left == 1 {
-            remaining.min(chunk_tokens)
-        } else {
-            affordable(start, hi)
-                .max(1)
-                .min(remaining.saturating_sub(ranks_left - 1))
-        };
-        segments.push((start, len));
-        start += len;
-    }
-    segments
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -664,129 +519,6 @@ mod tests {
 
     fn prompt_of(total: usize) -> Arc<[u32]> {
         (0..total as u32).collect()
-    }
-
-    // ---- policy: width -----------------------------------------------------
-
-    #[test]
-    fn width_covers_256k_at_ep16() {
-        assert_eq!(k3_whale_width(262144, 16, CHUNK), Some(16));
-    }
-
-    #[test]
-    fn width_refuses_hopeless_prompts() {
-        // Below two floors no gang splits legally...
-        assert_eq!(
-            k3_whale_width(2 * K3_WHALE_SEGMENT_FLOOR - 1, 16, CHUNK),
-            None
-        );
-        assert_eq!(k3_whale_width(1024, 16, CHUNK), None);
-        // ...and past world x chunk the M0 one-superstep-per-rank walk ends.
-        assert_eq!(k3_whale_width(16 * CHUNK + 1, 16, CHUNK), None);
-    }
-
-    #[test]
-    fn width_is_the_widest_admitting_power_of_two() {
-        for total in [8192usize, 12288, 16384, 32768, 65536, 131072, 262144] {
-            let width = k3_whale_width(total, 16, CHUNK)
-                .unwrap_or_else(|| panic!("{total} tokens should admit some width"));
-            assert!(k3_whale_admits(total, width, CHUNK), "{total} @ {width}");
-            let mut wider = width * 2;
-            while wider <= 16 {
-                assert!(!k3_whale_admits(total, wider, CHUNK), "{total} @ {wider}");
-                wider *= 2;
-            }
-        }
-    }
-
-    // ---- policy: segments --------------------------------------------------
-
-    #[test]
-    fn segments_partition_exactly_and_level_downward() {
-        for (total, width) in [(262144usize, 16usize), (65536, 8), (12288, 4), (8192, 2)] {
-            let segments = k3_whale_segments(total, width, CHUNK);
-            assert_eq!(segments.len(), width, "{total} @ {width}");
-            let mut expected_start = 0;
-            for &(start, len) in &segments {
-                assert_eq!(start, expected_start, "{total} @ {width}: {segments:?}");
-                assert!(len <= CHUNK);
-                expected_start += len;
-            }
-            assert_eq!(expected_start, total, "{total} @ {width}: {segments:?}");
-            // Later ranks sit on deeper prefixes: leveling only shortens them.
-            for pair in segments.windows(2) {
-                assert!(pair[0].1 >= pair[1].1, "{total} @ {width}: {segments:?}");
-            }
-        }
-    }
-
-    #[test]
-    fn segments_stay_inside_the_mean_chunk_bucket() {
-        // The padded per-row families run at the covering chunk bucket, so a
-        // leveled head stretching past the bucket the mean sits in doubles
-        // that rank's padded rows and stalls the lockstep superstep on it
-        // (the measured ~900ms TTFT step at 65k over 8 ranks, where pure
-        // leveling pushed the head from a mean of 8,140 past 8,448). Every
-        // segment must sit in the mean's bucket.
-        for (total, width) in [(65116usize, 8usize), (66000, 8), (33000, 8), (131072, 16)] {
-            let cap = pegainfer_kernels::ops::k3_chunk_bucket(total.div_ceil(width)).unwrap();
-            let segments = k3_whale_segments(total, width, CHUNK);
-            assert_eq!(segments.iter().map(|&(_, len)| len).sum::<usize>(), total);
-            for &(_, len) in &segments {
-                assert!(
-                    len <= cap,
-                    "{total} @ {width}: segment of {len} rows leaves the {cap} bucket: \
-                     {segments:?}"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn segments_leveling_bites_at_depth() {
-        // At 256k the last rank's MLA triangle is ~2/3 of its walk; an even
-        // split would park the whole fleet on its tail.
-        let segments = k3_whale_segments(262144, 16, CHUNK);
-        let first = segments.first().unwrap().1;
-        let last = segments.last().unwrap().1;
-        assert!(
-            first > last + 1000,
-            "leveling too timid at 256k: first {first}, last {last}"
-        );
-    }
-
-    // ---- policy: gang ------------------------------------------------------
-
-    #[test]
-    fn gang_is_tray_aligned_with_the_poster_last() {
-        assert_eq!(k3_whale_gang(5, 8, 16), vec![4, 6, 7, 8, 9, 10, 11, 5]);
-        assert_eq!(k3_whale_gang(14, 8, 16), vec![8, 9, 10, 11, 12, 13, 15, 14]);
-        let full = k3_whale_gang(0, 16, 16);
-        assert_eq!(full.len(), 16);
-        assert_eq!(full.last(), Some(&0));
-    }
-
-    #[test]
-    fn gang_is_always_a_contiguous_in_world_block_containing_the_poster() {
-        for world in [4usize, 8, 16] {
-            for width in [2usize, 4, 8, 16].into_iter().filter(|&w| w <= world) {
-                for poster in 0..world {
-                    let gang = k3_whale_gang(poster, width, world);
-                    assert_eq!(gang.len(), width);
-                    assert_eq!(gang.last(), Some(&poster));
-                    let mut sorted = gang.clone();
-                    sorted.sort_unstable();
-                    sorted.dedup();
-                    assert_eq!(sorted.len(), width, "duplicates in {gang:?}");
-                    assert!(sorted.iter().all(|&rank| rank < world));
-                    assert_eq!(
-                        sorted.last().unwrap() - sorted.first().unwrap(),
-                        width - 1,
-                        "gang {gang:?} is not contiguous"
-                    );
-                }
-            }
-        }
     }
 
     #[test]
@@ -1240,6 +972,7 @@ mod fuzz {
     use std::collections::HashMap;
 
     use super::*;
+    use crate::executor::cp::K3_WHALE_SEGMENT_FLOOR;
 
     struct Rng(u64);
 

--- a/pegainfer-k3/src/scheduler/whale.rs
+++ b/pegainfer-k3/src/scheduler/whale.rs
@@ -45,7 +45,9 @@
 //!
 //! The state machines below are pure — one event in, the messages to send
 //! out — so the transports ([`LocalWhaleHub`],
-//! [`super::whale_hub::TcpWhaleHub`]) stay I/O-only.
+//! [`super::whale_hub::TcpWhaleHub`]) stay I/O-only. Width and gang policy
+//! live with the data plane ([`crate::executor::cp`]); this module only
+//! applies them.
 //!
 //! [`LocalWhaleHub`]: super::whale_hub::LocalWhaleHub
 
@@ -120,7 +122,7 @@ impl WhaleDescriptor {
 /// FNV-1a, the token stream fed as little-endian bytes. Not cryptographic —
 /// the threat is corruption and framing bugs, not an adversary on the fabric
 /// management network.
-pub fn k3_whale_prompt_hash(prompt: &[u32]) -> u64 {
+fn k3_whale_prompt_hash(prompt: &[u32]) -> u64 {
     let mut hash = 0xcbf2_9ce4_8422_2325u64;
     for &token in prompt {
         for byte in token.to_le_bytes() {

--- a/pegainfer-k3/src/scheduler/whale.rs
+++ b/pegainfer-k3/src/scheduler/whale.rs
@@ -613,13 +613,24 @@ pub fn k3_whale_segments(total: usize, width: usize, chunk_tokens: usize) -> Vec
     if width == 1 || total == 0 {
         return vec![(0, total)];
     }
+    // The padded per-row families (KDA, norms, projections, MoE entry) run at
+    // the covering chunk *bucket*, a step function of segment length — only
+    // attention is varlen. Pure leveling stretches the earliest segment past
+    // the bucket the mean sits in whenever the mean runs close to a boundary
+    // (65k over 8 ranks: mean 8,140, leveled head 8.6k → the 16,896 bucket,
+    // doubling its padded rows while the lockstep superstep waits — a
+    // measured ~900ms step). Cap segments at the mean's bucket: everyone
+    // stays in the same bucket, and leveling still balances the attention
+    // triangle inside it.
+    let cap = pegainfer_kernels::ops::k3_chunk_bucket(total.div_ceil(width))
+        .map_or(chunk_tokens, |bucket| bucket.min(chunk_tokens));
     let affordable = |start: usize, budget: f64| -> usize {
         // Largest len with len + Q·(start + len/2)·len <= budget:
         // (Q/2)·len² + (1 + Q·start)·len − budget = 0.
         let a = K3_CP_QUAD_PER_LINEAR / 2.0;
         let b = 1.0 + K3_CP_QUAD_PER_LINEAR * start as f64;
         let len = (2.0 * budget) / (b + (b * b + 4.0 * a * budget).sqrt());
-        (len.floor() as usize).min(chunk_tokens)
+        (len.floor() as usize).min(cap)
     };
     let coverage = |budget: f64| -> usize {
         let mut start = 0usize;
@@ -727,6 +738,28 @@ mod tests {
             // Later ranks sit on deeper prefixes: leveling only shortens them.
             for pair in segments.windows(2) {
                 assert!(pair[0].1 >= pair[1].1, "{total} @ {width}: {segments:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn segments_stay_inside_the_mean_chunk_bucket() {
+        // The padded per-row families run at the covering chunk bucket, so a
+        // leveled head stretching past the bucket the mean sits in doubles
+        // that rank's padded rows and stalls the lockstep superstep on it
+        // (the measured ~900ms TTFT step at 65k over 8 ranks, where pure
+        // leveling pushed the head from a mean of 8,140 past 8,448). Every
+        // segment must sit in the mean's bucket.
+        for (total, width) in [(65116usize, 8usize), (66000, 8), (33000, 8), (131072, 16)] {
+            let cap = pegainfer_kernels::ops::k3_chunk_bucket(total.div_ceil(width)).unwrap();
+            let segments = k3_whale_segments(total, width, CHUNK);
+            assert_eq!(segments.iter().map(|&(_, len)| len).sum::<usize>(), total);
+            for &(_, len) in &segments {
+                assert!(
+                    len <= cap,
+                    "{total} @ {width}: segment of {len} rows leaves the {cap} bucket: \
+                     {segments:?}"
+                );
             }
         }
     }

--- a/pegainfer-k3/src/scheduler/whale.rs
+++ b/pegainfer-k3/src/scheduler/whale.rs
@@ -36,20 +36,18 @@
 //!    advanced at most one per launch period while the commit was in flight,
 //!    and the slack covers that), so each one steps normally until its count
 //!    reaches `L` and enters the CP superstep there. All members enter at the
-//!    same absolute launch or none do — the failure mode of a member entering
-//!    a superstep its peers never join cannot arise from ordering, only from
-//!    a death, which the exchange deadline already turns into a fleet-fatal
-//!    error.
+//!    same absolute launch or none do; a member that dies instead of entering
+//!    is caught by the exchange deadline (fleet-fatal), not here.
 //!
 //! Ranks outside the gang never hear about the whale: their launch `L` is an
 //! ordinary step, and the mega collective pairs it against the gang's
 //! superstep exactly as it pairs any other heterogeneous step.
 //!
-//! The state machines below are pure — every transition consumes one event
-//! and returns the messages to send — so the whole protocol is exercised by
-//! the deterministic fleet simulation and the seeded fuzzer in the tests, and
-//! the transports ([`LocalWhaleHub`], [`super::whale_hub::TcpWhaleHub`]) stay
-//! I/O-only.
+//! The state machines below are pure — one event in, the messages to send
+//! out — so the transports ([`LocalWhaleHub`],
+//! [`super::whale_hub::TcpWhaleHub`]) stay I/O-only.
+//!
+//! [`LocalWhaleHub`]: super::whale_hub::LocalWhaleHub
 
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -58,7 +56,7 @@ use anyhow::Result;
 use anyhow::bail;
 use anyhow::ensure;
 
-use crate::executor::cp::K3_CP_SEGMENT_FLOOR;
+use crate::executor::cp::K3_WHALE_SEGMENT_FLOOR;
 
 /// A rank's identity across the whole EP world (not its process-local index).
 pub type GlobalRank = usize;
@@ -236,7 +234,7 @@ impl WhaleSequencer {
                 prompt,
             } => {
                 self.queue.push_back((request, poster, prompt));
-                self.pump()
+                self.start_next_gather()
             }
             WhaleToSequencer::Ready { seq, rank, count } => {
                 let Some(gathering) = self.gathering.as_mut() else {
@@ -280,16 +278,14 @@ impl WhaleSequencer {
         let seq = gathering.descriptor.seq;
         log::warn!("K3 whale {seq}: gather timed out; cancelling");
         let mut outbound = broadcast(&gathering.descriptor.gang, &WhaleToMember::Cancel { seq });
-        outbound.extend(self.pump()?);
+        outbound.extend(self.start_next_gather()?);
         Ok(outbound)
     }
 
     /// Start the next gatherable queued whale, if none is gathering. A
     /// refused whale must not strand the ones queued behind it: no later
-    /// message is guaranteed to ever arrive and pump again, so a quiet
-    /// early-return after a refusal is a wedged queue (the fuzzer found
-    /// exactly that).
-    fn pump(&mut self) -> Result<Vec<WhaleOutbound>> {
+    /// message is guaranteed to ever arrive.
+    fn start_next_gather(&mut self) -> Result<Vec<WhaleOutbound>> {
         let mut outbound = Vec::new();
         while self.gathering.is_none() {
             let Some((request, poster, prompt)) = self.queue.pop_front() else {
@@ -324,7 +320,6 @@ impl WhaleSequencer {
                 prompt,
                 prompt_hash,
             };
-            descriptor.verify()?;
             outbound.extend(broadcast(
                 &descriptor.gang,
                 &WhaleToMember::Gather {
@@ -365,7 +360,7 @@ impl WhaleSequencer {
             &gathering.descriptor.gang,
             &WhaleToMember::Commit { seq, launch },
         );
-        outbound.extend(self.pump()?);
+        outbound.extend(self.start_next_gather()?);
         Ok(outbound)
     }
 }
@@ -385,11 +380,9 @@ pub struct CommittedWhale {
 /// What the scheduler must do at a launch boundary.
 #[derive(Debug)]
 pub enum WhaleDuty {
-    /// Nothing scheduled at this count: run a normal step. `clearance` is how
-    /// many launches a multi-launch operation may span from here without
-    /// straddling a scheduled (or still-gathering) whale — `None` means
-    /// unbounded.
-    Free { clearance: Option<u64> },
+    /// Nothing scheduled here: run a normal step. While the member is not
+    /// [`WhaleMember::is_quiet`] that step must stay single-launch.
+    Free,
     /// This launch is a committed whale's superstep: enter `prefill_cp` now.
     Enter(Box<CommittedWhale>),
 }
@@ -497,22 +490,12 @@ impl WhaleMember {
                 return Ok(WhaleDuty::Enter(Box::new(whale)));
             }
         }
-        // A committed whale bounds operations to the launches before its
-        // superstep; a gathered-but-uncommitted whale bounds them to one —
-        // its commit may name any launch above the reply. Both can hold at
-        // once (a second whale gathering behind a committed first): take the
-        // tighter bound.
-        let committed_cap = self.committed.front().map(|front| front.launch - count);
-        let armed_cap = if self.armed.is_empty() { None } else { Some(1) };
-        let clearance = match (committed_cap, armed_cap) {
-            (Some(commit), Some(arm)) => Some(commit.min(arm)),
-            (committed, armed) => committed.or(armed),
-        };
-        Ok(WhaleDuty::Free { clearance })
+        Ok(WhaleDuty::Free)
     }
 
-    /// Whether this member currently constrains the scheduler at all — used
-    /// by tests and by the scheduler's idle accounting.
+    /// Whether nothing is gathered or committed here. A member that is not
+    /// quiet must step one launch at a time: an armed reply is an exact floor
+    /// on reachable launches, and a committed superstep must be hit exactly.
     pub fn is_quiet(&self) -> bool {
         self.armed.is_empty() && self.committed.is_empty()
     }
@@ -553,17 +536,16 @@ pub fn k3_whale_width(total: usize, world: usize, chunk_tokens: usize) -> Option
 /// segment above the floor and within one chunk step (one superstep per rank
 /// — the multi-superstep walk is out of scope until profiles demand it).
 pub fn k3_whale_admits(total: usize, width: usize, chunk_tokens: usize) -> bool {
-    if width < 2 || total < width * K3_CP_SEGMENT_FLOOR {
+    if width < 2 || total < width * K3_WHALE_SEGMENT_FLOOR {
         return false;
     }
     let segments = k3_whale_segments(total, width, chunk_tokens);
-    segments.len() == width
-        && segments
-            .last()
-            .is_some_and(|&(start, len)| start + len == total)
+    segments
+        .last()
+        .is_some_and(|&(start, len)| start + len == total)
         && segments
             .iter()
-            .all(|&(_, len)| len >= K3_CP_SEGMENT_FLOOR && len <= chunk_tokens)
+            .all(|&(_, len)| len >= K3_WHALE_SEGMENT_FLOOR && len <= chunk_tokens)
 }
 
 /// The gang for a `width`-wide whale posted by `poster`: the tray-aligned
@@ -575,12 +557,11 @@ pub fn k3_whale_admits(total: usize, width: usize, chunk_tokens: usize) -> bool 
 pub fn k3_whale_gang(poster: GlobalRank, width: usize, world: usize) -> Vec<GlobalRank> {
     debug_assert!(poster < world && width <= world);
     const TRAY: usize = 4;
-    let aligned = if width >= TRAY {
+    let start = if width >= TRAY {
         (poster / TRAY * TRAY).min(world.saturating_sub(width))
     } else {
         poster.min(world.saturating_sub(width))
     };
-    let start = aligned.min(poster);
     let mut gang: Vec<GlobalRank> = (start..start + width).filter(|&r| r != poster).collect();
     gang.push(poster);
     gang
@@ -598,20 +579,18 @@ const K3_CP_QUAD_PER_LINEAR: f64 = 2.7e-6;
 
 /// Split `total` tokens into `width` contiguous leveled segments: earlier
 /// ranks get longer segments, so every rank's modeled superstep time — walk
-/// plus its MLA triangle — comes out even. At 16k the difference from an even
-/// split is small; at 256k the last rank's triangle is two thirds of its
-/// walk, and an even split would put the whole fleet on its tail.
+/// plus its MLA triangle — comes out even.
 ///
-/// Segments are found by bisecting the per-rank time budget: given a budget,
-/// each rank greedily takes the longest affordable segment (capped at
-/// `chunk_tokens`), which is monotone in the budget. The floor is *not*
-/// enforced here — [`k3_whale_admits`] rejects splits that level below it —
-/// but coverage is: the returned segments always partition `total` exactly,
-/// or the result is shorter than `width` (inadmissible).
+/// Bisected on the per-rank time budget; coverage is monotone in the budget,
+/// so the smallest covering budget is the leveled split. The floor is *not*
+/// enforced here — [`k3_whale_admits`] rejects splits that level below it.
+/// The returned segments always number `width` and start at 0; they
+/// under-cover `total` when the chunk cap makes an exact partition
+/// impossible, which admission rejects too.
 pub fn k3_whale_segments(total: usize, width: usize, chunk_tokens: usize) -> Vec<(usize, usize)> {
-    debug_assert!(width >= 1);
-    if width == 1 || total == 0 {
-        return vec![(0, total)];
+    debug_assert!(width >= 2);
+    if total == 0 {
+        return vec![(0, 0)];
     }
     // The padded per-row families (KDA, norms, projections, MoE entry) run at
     // the covering chunk *bucket*, a step function of segment length — only
@@ -666,7 +645,7 @@ pub fn k3_whale_segments(total: usize, width: usize, chunk_tokens: usize) -> Vec
             remaining.min(chunk_tokens)
         } else {
             affordable(start, hi)
-                .clamp(1, chunk_tokens)
+                .max(1)
                 .min(remaining.saturating_sub(ranks_left - 1))
         };
         segments.push((start, len));
@@ -674,10 +653,6 @@ pub fn k3_whale_segments(total: usize, width: usize, chunk_tokens: usize) -> Vec
     }
     segments
 }
-
-// ---------------------------------------------------------------------------
-// Tests: the protocol never runs its first fleet — it runs here first
-// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
@@ -701,7 +676,10 @@ mod tests {
     #[test]
     fn width_refuses_hopeless_prompts() {
         // Below two floors no gang splits legally...
-        assert_eq!(k3_whale_width(2 * K3_CP_SEGMENT_FLOOR - 1, 16, CHUNK), None);
+        assert_eq!(
+            k3_whale_width(2 * K3_WHALE_SEGMENT_FLOOR - 1, 16, CHUNK),
+            None
+        );
         assert_eq!(k3_whale_width(1024, 16, CHUNK), None);
         // ...and past world x chunk the M0 one-superstep-per-rank walk ends.
         assert_eq!(k3_whale_width(16 * CHUNK + 1, 16, CHUNK), None);
@@ -864,9 +842,7 @@ mod tests {
             for count in 12..=launch {
                 match member.at_launch(count).unwrap() {
                     WhaleDuty::Enter(whale) => entered = Some((count, whale)),
-                    WhaleDuty::Free { clearance } => {
-                        assert_eq!(clearance, Some(launch - count));
-                    }
+                    WhaleDuty::Free => assert!(!member.is_quiet()),
                 }
             }
             let (count, whale) = entered.expect("member never entered");
@@ -1010,10 +986,7 @@ mod tests {
             .on_message(WhaleToMember::Cancel { seq: 0 }, 6)
             .unwrap();
         assert!(member.is_quiet());
-        assert!(matches!(
-            member.at_launch(7).unwrap(),
-            WhaleDuty::Free { clearance: None }
-        ));
+        assert!(matches!(member.at_launch(7).unwrap(), WhaleDuty::Free));
         // And the sequencer lives on: the next whale gathers normally.
         let next = sequencer
             .on_message(WhaleToSequencer::Request {
@@ -1228,55 +1201,28 @@ mod tests {
     }
 
     #[test]
-    fn clearance_shrinks_to_one_while_a_second_whale_is_gathering() {
+    fn a_pending_whale_pins_the_member_until_its_superstep() {
+        // Committed but before the launch: free steps, not quiet — the
+        // scheduler keeps a non-quiet member single-launch.
         let (mut member, launch) = committed_member();
-        // Behind the committed whale alone, the clearance is the distance.
-        let count = launch - 3;
-        match member.at_launch(count).unwrap() {
-            WhaleDuty::Free { clearance } => assert_eq!(clearance, Some(3)),
-            duty => panic!("expected free, got {duty:?}"),
-        }
-        // A second whale gathering on the same member caps it at one: the
-        // pending commit may name any launch above the reply, and a
-        // multi-launch operation would overshoot it.
-        let mut second = WhaleSequencer::new(4, CHUNK);
-        let mut gathers = one_gather(&mut second, 0);
-        // committed_member's rank is gathers[0].to of an identical whale, so
-        // the same gang covers it; re-seq the descriptor so the member sees a
-        // distinct, later whale.
-        let Some(WhaleOutbound {
-            message: WhaleToMember::Gather { mut descriptor },
-            ..
-        }) = gathers.drain(..1).next()
-        else {
-            panic!("expected gather");
-        };
-        descriptor.seq = 7;
-        member
-            .on_message(WhaleToMember::Gather { descriptor }, count)
-            .unwrap()
-            .expect("a gather demands a ready");
-        match member.at_launch(count).unwrap() {
-            WhaleDuty::Free { clearance } => assert_eq!(clearance, Some(1)),
-            duty => panic!("expected free, got {duty:?}"),
-        }
-        // Armed alone (no commit yet) also caps at one.
-        let rank = member_rank(&member);
-        let mut fresh = WhaleMember::new(rank);
+        assert!(matches!(
+            member.at_launch(launch - 3).unwrap(),
+            WhaleDuty::Free
+        ));
+        assert!(!member.is_quiet());
+        assert!(matches!(
+            member.at_launch(launch).unwrap(),
+            WhaleDuty::Enter(_)
+        ));
+        assert!(member.is_quiet());
+        // Gathered alone (no commit yet) pins too: the pending commit may
+        // name any launch above the reply.
+        let mut fresh = WhaleMember::new(2);
         let gathers = one_gather(&mut WhaleSequencer::new(4, CHUNK), 0);
-        let mine = gathers
-            .into_iter()
-            .find(|gather| gather.to == rank)
-            .unwrap();
+        let mine = gathers.into_iter().find(|gather| gather.to == 2).unwrap();
         fresh.on_message(mine.message, 0).unwrap();
-        match fresh.at_launch(1).unwrap() {
-            WhaleDuty::Free { clearance } => assert_eq!(clearance, Some(1)),
-            duty => panic!("expected free, got {duty:?}"),
-        }
-    }
-
-    fn member_rank(member: &WhaleMember) -> GlobalRank {
-        member.rank
+        assert!(matches!(fresh.at_launch(1).unwrap(), WhaleDuty::Free));
+        assert!(!fresh.is_quiet());
     }
 }
 
@@ -1360,11 +1306,11 @@ mod fuzz {
             // a runt the sequencer must refuse without wedging the queue.
             if posted < whales && rng.below(3) == 0 {
                 let poster = rng.below(WORLD as u64) as usize;
-                let span = (WORLD * CHUNK - 2 * K3_CP_SEGMENT_FLOOR) as u64;
+                let span = (WORLD * CHUNK - 2 * K3_WHALE_SEGMENT_FLOOR) as u64;
                 let total = if rng.below(4) != 0 {
-                    2 * K3_CP_SEGMENT_FLOOR + rng.below(span) as usize
+                    2 * K3_WHALE_SEGMENT_FLOOR + rng.below(span) as usize
                 } else {
-                    1 + rng.below(K3_CP_SEGMENT_FLOOR as u64) as usize
+                    1 + rng.below(K3_WHALE_SEGMENT_FLOOR as u64) as usize
                 };
                 if k3_whale_width(total, WORLD, CHUNK).is_some() {
                     admissible += 1;
@@ -1413,10 +1359,12 @@ mod fuzz {
                         ));
                         rank.count += 1;
                     }
-                    WhaleDuty::Free { clearance } => {
+                    WhaleDuty::Free => {
                         // Start an operation spanning 1..=cap launches; the
-                        // boundaries inside it go unconsulted.
-                        let cap = clearance.unwrap_or(3).min(3);
+                        // boundaries inside it go unconsulted. A non-quiet
+                        // member must stay single-launch — that pin is the
+                        // production contract this fuzz drives.
+                        let cap = if rank.member.is_quiet() { 3 } else { 1 };
                         rank.busy = rng.below(cap);
                         rank.count += 1;
                     }

--- a/pegainfer-k3/src/scheduler/whale.rs
+++ b/pegainfer-k3/src/scheduler/whale.rs
@@ -1,0 +1,1441 @@
+//! Whale rendezvous: how a fleet of free-running EP ranks agrees to run one
+//! long prompt's context-parallel prefill together — across processes.
+//!
+//! The in-process gang ([`super::gang`]) levels its members through a shared
+//! board: every member re-posts its launch count until the whole gang sits at
+//! the board's maximum. That works because the board is one `Mutex` away from
+//! every member. A fleet gang spans processes on different machines, and the
+//! free-running discipline (`docs/models/glm52/free-running-dp.md`) forbids
+//! replacing the board with anything that waits: no rank ever stops, so the
+//! agreement must ride on facts that are already true while everyone keeps
+//! stepping.
+//!
+//! Two such facts carry the whole protocol:
+//!
+//! * **The launch count is a global clock.** Every launch is a two-sided
+//!   paired collective, so the whole world's counts stay within one launch of
+//!   each other. "Launch `L`" therefore names one global moment, and it
+//!   arrives on its own — nobody has to be woken up for it.
+//! * **Whales are sparse.** A 32k+ prompt is an event, not the steady state,
+//!   so the coordination state may exist only around one whale and cost one
+//!   host round-trip; there is no standing cross-process protocol.
+//!
+//! The rendezvous is a two-phase broadcast over a host side-channel (the
+//! fleet's bootstrap TCP link, kept alive), sequenced by one rank so that
+//! concurrent whales get one global order:
+//!
+//! 1. **Gather.** The poster sends the prompt to the sequencer, which picks
+//!    the gang (widest width the segment floor admits — the wider the gang,
+//!    the shorter the whole fleet's stall) and broadcasts the descriptor to
+//!    the members. A member replies with its current launch count and *arms*:
+//!    from here until the commit it starts no multi-launch operation, so its
+//!    count advances by exactly one per step and any launch after its reply
+//!    is one it can hit exactly. It keeps stepping the whole time.
+//! 2. **Commit.** When every member has replied, the sequencer broadcasts
+//!    `L = max(replies) + slack`. Every member's count is below `L` (counts
+//!    advanced at most one per launch period while the commit was in flight,
+//!    and the slack covers that), so each one steps normally until its count
+//!    reaches `L` and enters the CP superstep there. All members enter at the
+//!    same absolute launch or none do — the failure mode of a member entering
+//!    a superstep its peers never join cannot arise from ordering, only from
+//!    a death, which the exchange deadline already turns into a fleet-fatal
+//!    error.
+//!
+//! Ranks outside the gang never hear about the whale: their launch `L` is an
+//! ordinary step, and the mega collective pairs it against the gang's
+//! superstep exactly as it pairs any other heterogeneous step.
+//!
+//! The state machines below are pure — every transition consumes one event
+//! and returns the messages to send — so the whole protocol is exercised by
+//! the deterministic fleet simulation and the seeded fuzzer in the tests, and
+//! the transports ([`LocalWhaleHub`], [`super::whale_hub::TcpWhaleHub`]) stay
+//! I/O-only.
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+use anyhow::Result;
+use anyhow::bail;
+use anyhow::ensure;
+
+use crate::executor::cp::K3_CP_SEGMENT_FLOOR;
+
+/// A rank's identity across the whole EP world (not its process-local index).
+pub type GlobalRank = usize;
+/// The absolute launch count — the fleet's global clock.
+pub type LaunchCount = u64;
+/// A whale's position in the sequencer's global order.
+pub type WhaleSeq = u64;
+
+/// Launches of slack the commit adds over the highest gathered count. An
+/// armed member cannot stop launching (free-running), so the commit must name
+/// a launch it has not yet passed: the slack is the number of launch periods
+/// the reply-to-commit host round trip may take. Launch periods are tens of
+/// milliseconds and up, the management-TCP round trip is sub-millisecond, so
+/// four is a wide margin — and a commit that still arrives late dies loudly
+/// at the member instead of mispairing a collective.
+const K3_WHALE_COMMIT_SLACK: LaunchCount = 4;
+
+/// One whale's identity and shape. Everything a member needs to run its
+/// segment is a deterministic function of this descriptor, so agreeing on the
+/// descriptor and the launch is agreeing on everything.
+#[derive(Clone, Debug)]
+pub struct WhaleDescriptor {
+    pub seq: WhaleSeq,
+    /// The scheduler-side request this whale answers, echoed back so the
+    /// poster can pair the commit with its pending admission.
+    pub request: u64,
+    /// The gang's owner: the rank whose slot the prompt lands in. Always the
+    /// last CP rank, so the final KDA state and the full MLA context end up
+    /// on the rank that decodes the sequence.
+    pub poster: GlobalRank,
+    /// Gang members in CP order (`gang.last() == poster`).
+    pub gang: Arc<[GlobalRank]>,
+    pub prompt: Arc<[u32]>,
+    /// FNV-1a over the prompt tokens: a descriptor that crossed the wire and
+    /// disagrees with its own hash must die loudly, not compute garbage.
+    pub prompt_hash: u64,
+}
+
+impl WhaleDescriptor {
+    /// This rank's CP rank in the gang, if it is a member.
+    pub fn cp_rank_of(&self, rank: GlobalRank) -> Option<usize> {
+        self.gang.iter().position(|&member| member == rank)
+    }
+
+    pub fn verify(&self) -> Result<()> {
+        ensure!(
+            k3_whale_prompt_hash(&self.prompt) == self.prompt_hash,
+            "whale {} prompt hash mismatch — the descriptor was corrupted in transit",
+            self.seq
+        );
+        ensure!(
+            self.gang.last() == Some(&self.poster),
+            "whale {} gang does not end at its poster",
+            self.seq
+        );
+        Ok(())
+    }
+}
+
+/// FNV-1a, the token stream fed as little-endian bytes. Not cryptographic —
+/// the threat is corruption and framing bugs, not an adversary on the fabric
+/// management network.
+pub fn k3_whale_prompt_hash(prompt: &[u32]) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325u64;
+    for &token in prompt {
+        for byte in token.to_le_bytes() {
+            hash ^= u64::from(byte);
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+    hash
+}
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+/// Member -> sequencer.
+#[derive(Clone, Debug)]
+pub enum WhaleToSequencer {
+    /// A rank asks for a whale prefill of `prompt` (it becomes the poster).
+    Request {
+        request: u64,
+        poster: GlobalRank,
+        prompt: Arc<[u32]>,
+    },
+    /// A member's gather reply: its launch count at the reply, from which on
+    /// it is armed (stepping one launch at a time until the commit lands).
+    Ready {
+        seq: WhaleSeq,
+        rank: GlobalRank,
+        count: LaunchCount,
+    },
+}
+
+/// Sequencer -> one member (the transport routes by rank).
+#[derive(Clone, Debug)]
+pub enum WhaleToMember {
+    Gather {
+        descriptor: WhaleDescriptor,
+    },
+    Commit {
+        seq: WhaleSeq,
+        launch: LaunchCount,
+    },
+    /// The whale will not run (a member never replied, or admission failed
+    /// after sequencing). Members disarm; the poster answers the request by
+    /// falling back to a local prefill.
+    Cancel {
+        seq: WhaleSeq,
+    },
+}
+
+/// One outbound message with its destination.
+#[derive(Clone, Debug)]
+pub struct WhaleOutbound {
+    pub to: GlobalRank,
+    pub message: WhaleToMember,
+}
+
+fn broadcast(gang: &[GlobalRank], message: &WhaleToMember) -> Vec<WhaleOutbound> {
+    gang.iter()
+        .map(|&to| WhaleOutbound {
+            to,
+            message: message.clone(),
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Sequencer
+// ---------------------------------------------------------------------------
+
+/// One whale mid-gather.
+struct Gathering {
+    descriptor: WhaleDescriptor,
+    /// Reply per gang member, in gang order.
+    replies: Vec<Option<LaunchCount>>,
+}
+
+/// The fleet's single whale sequencer, hosted next to global rank 0. Pure
+/// state machine: transitions return the messages to deliver. One gather runs
+/// at a time — a second request queues behind it — so commits leave here in
+/// one global order with strictly increasing launches, which is what keeps
+/// two whales from interleaving their exchange windows.
+pub struct WhaleSequencer {
+    world: usize,
+    chunk_tokens: usize,
+    next_seq: WhaleSeq,
+    /// The launch the last committed whale runs at. The next commit must land
+    /// strictly after it: the superstep at `L` is the whale's, whole.
+    committed_floor: Option<LaunchCount>,
+    gathering: Option<Gathering>,
+    queue: VecDeque<(u64, GlobalRank, Arc<[u32]>)>,
+}
+
+impl WhaleSequencer {
+    pub fn new(world: usize, chunk_tokens: usize) -> Self {
+        Self {
+            world,
+            chunk_tokens,
+            next_seq: 0,
+            committed_floor: None,
+            gathering: None,
+            queue: VecDeque::new(),
+        }
+    }
+
+    /// Feed one inbound message; returns what to send.
+    pub fn on_message(&mut self, message: WhaleToSequencer) -> Result<Vec<WhaleOutbound>> {
+        match message {
+            WhaleToSequencer::Request {
+                request,
+                poster,
+                prompt,
+            } => {
+                self.queue.push_back((request, poster, prompt));
+                self.pump()
+            }
+            WhaleToSequencer::Ready { seq, rank, count } => {
+                let Some(gathering) = self.gathering.as_mut() else {
+                    // A reply to a whale that was cancelled under it: stale,
+                    // not an error — the member already got the cancel.
+                    return Ok(Vec::new());
+                };
+                if gathering.descriptor.seq != seq {
+                    return Ok(Vec::new());
+                }
+                let Some(cp_rank) = gathering.descriptor.cp_rank_of(rank) else {
+                    bail!("whale {seq}: ready from rank {rank}, which is not in the gang");
+                };
+                ensure!(
+                    gathering.replies[cp_rank].is_none(),
+                    "whale {seq}: rank {rank} replied ready twice"
+                );
+                gathering.replies[cp_rank] = Some(count);
+                self.try_commit()
+            }
+        }
+    }
+
+    /// The whale currently gathering, if any. The transport owns the clock:
+    /// it tracks how long one seq has been gathering and drives
+    /// [`WhaleSequencer::on_gather_timeout`].
+    pub fn gathering_seq(&self) -> Option<WhaleSeq> {
+        self.gathering
+            .as_ref()
+            .map(|gathering| gathering.descriptor.seq)
+    }
+
+    /// The sequencer's gather deadline fired (transport-driven): cancel the
+    /// gathering whale, if any, and move on. The poster falls back to a local
+    /// prefill; a member that is genuinely dead kills the fleet through the
+    /// collective's own deadline, not through this one.
+    pub fn on_gather_timeout(&mut self) -> Result<Vec<WhaleOutbound>> {
+        let Some(gathering) = self.gathering.take() else {
+            return Ok(Vec::new());
+        };
+        let seq = gathering.descriptor.seq;
+        log::warn!("K3 whale {seq}: gather timed out; cancelling");
+        let mut outbound = broadcast(&gathering.descriptor.gang, &WhaleToMember::Cancel { seq });
+        outbound.extend(self.pump()?);
+        Ok(outbound)
+    }
+
+    /// Start the next gatherable queued whale, if none is gathering. A
+    /// refused whale must not strand the ones queued behind it: no later
+    /// message is guaranteed to ever arrive and pump again, so a quiet
+    /// early-return after a refusal is a wedged queue (the fuzzer found
+    /// exactly that).
+    fn pump(&mut self) -> Result<Vec<WhaleOutbound>> {
+        let mut outbound = Vec::new();
+        while self.gathering.is_none() {
+            let Some((request, poster, prompt)) = self.queue.pop_front() else {
+                break;
+            };
+            let seq = self.next_seq;
+            self.next_seq += 1;
+            let Some(width) = k3_whale_width(prompt.len(), self.world, self.chunk_tokens) else {
+                // Too short for even the narrowest gang, or too long for the
+                // widest: the poster prefills locally. Sequenced requests are
+                // pre-screened by the poster, so this is a race (config
+                // changed) or a bug — either way, refuse rather than wedge.
+                log::warn!(
+                    "K3 whale {seq}: {} tokens admit no gang width in a {}-rank world; \
+                     cancelling",
+                    prompt.len(),
+                    self.world
+                );
+                outbound.push(WhaleOutbound {
+                    to: poster,
+                    message: WhaleToMember::Cancel { seq },
+                });
+                continue;
+            };
+            let gang = k3_whale_gang(poster, width, self.world);
+            let prompt_hash = k3_whale_prompt_hash(&prompt);
+            let descriptor = WhaleDescriptor {
+                seq,
+                request,
+                poster,
+                gang: gang.into(),
+                prompt,
+                prompt_hash,
+            };
+            descriptor.verify()?;
+            outbound.extend(broadcast(
+                &descriptor.gang,
+                &WhaleToMember::Gather {
+                    descriptor: descriptor.clone(),
+                },
+            ));
+            self.gathering = Some(Gathering {
+                replies: vec![None; descriptor.gang.len()],
+                descriptor,
+            });
+        }
+        Ok(outbound)
+    }
+
+    fn try_commit(&mut self) -> Result<Vec<WhaleOutbound>> {
+        let Some(gathering) = self.gathering.as_ref() else {
+            return Ok(Vec::new());
+        };
+        let Some(highest) = gathering
+            .replies
+            .iter()
+            .copied()
+            .try_fold(0, |max: LaunchCount, reply| {
+                reply.map(|count| max.max(count))
+            })
+        else {
+            return Ok(Vec::new());
+        };
+        let gathering = self.gathering.take().expect("checked above");
+        // Strictly after both every member's armed count and the previous
+        // whale's superstep. Armed members advance one launch per step, so
+        // any launch above their replies is reachable exactly.
+        let launch = (highest + K3_WHALE_COMMIT_SLACK)
+            .max(self.committed_floor.map_or(0, |floor| floor + 1));
+        self.committed_floor = Some(launch);
+        let seq = gathering.descriptor.seq;
+        let mut outbound = broadcast(
+            &gathering.descriptor.gang,
+            &WhaleToMember::Commit { seq, launch },
+        );
+        outbound.extend(self.pump()?);
+        Ok(outbound)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Member
+// ---------------------------------------------------------------------------
+
+/// A committed whale this member will enter.
+#[derive(Clone, Debug)]
+pub struct CommittedWhale {
+    pub descriptor: WhaleDescriptor,
+    pub launch: LaunchCount,
+    pub cp_rank: usize,
+}
+
+/// What the scheduler must do at a launch boundary.
+#[derive(Debug)]
+pub enum WhaleDuty {
+    /// Nothing scheduled at this count: run a normal step. `clearance` is how
+    /// many launches a multi-launch operation may span from here without
+    /// straddling a scheduled (or still-gathering) whale — `None` means
+    /// unbounded.
+    Free { clearance: Option<u64> },
+    /// This launch is a committed whale's superstep: enter `prefill_cp` now.
+    Enter(Box<CommittedWhale>),
+}
+
+/// One rank's side of the rendezvous. Pure: the scheduler feeds it inbound
+/// messages and its own launch count, and acts on what comes back. The
+/// scheduler must consult [`WhaleMember::at_launch`] at *every* launch
+/// boundary — the protocol's soundness is exactly that an armed member's
+/// count advances one launch at a time.
+pub struct WhaleMember {
+    rank: GlobalRank,
+    /// Gathered, replied-to whales awaiting their commit. While any is
+    /// pending the member is armed: no multi-launch operations, so the
+    /// gathered reply stays an exact floor on reachable launches.
+    armed: VecDeque<WhaleDescriptor>,
+    /// Committed whales in launch order.
+    committed: VecDeque<CommittedWhale>,
+}
+
+impl WhaleMember {
+    pub fn new(rank: GlobalRank) -> Self {
+        Self {
+            rank,
+            armed: VecDeque::new(),
+            committed: VecDeque::new(),
+        }
+    }
+
+    /// Feed one message from the sequencer; optionally returns the reply.
+    pub fn on_message(
+        &mut self,
+        message: WhaleToMember,
+        count: LaunchCount,
+    ) -> Result<Option<WhaleToSequencer>> {
+        match message {
+            WhaleToMember::Gather { descriptor } => {
+                descriptor.verify()?;
+                ensure!(
+                    descriptor.cp_rank_of(self.rank).is_some(),
+                    "whale {} gathered rank {}, which is not in its gang",
+                    descriptor.seq,
+                    self.rank
+                );
+                let seq = descriptor.seq;
+                self.armed.push_back(descriptor);
+                Ok(Some(WhaleToSequencer::Ready {
+                    seq,
+                    rank: self.rank,
+                    count,
+                }))
+            }
+            WhaleToMember::Commit { seq, launch } => {
+                let Some(position) = self.armed.iter().position(|armed| armed.seq == seq) else {
+                    bail!("whale {seq}: commit for a whale this member never gathered");
+                };
+                let descriptor = self.armed.remove(position).expect("position just found");
+                ensure!(
+                    launch > count,
+                    "whale {seq}: committed to launch {launch}, but rank {} is already at \
+                     {count} — the commit slack failed to cover the arming window",
+                    self.rank
+                );
+                if let Some(last) = self.committed.back() {
+                    ensure!(
+                        launch > last.launch,
+                        "whale {seq}: commit at {launch} does not follow whale {} at {}",
+                        last.descriptor.seq,
+                        last.launch
+                    );
+                }
+                let cp_rank = descriptor
+                    .cp_rank_of(self.rank)
+                    .expect("membership checked at gather");
+                self.committed.push_back(CommittedWhale {
+                    descriptor,
+                    launch,
+                    cp_rank,
+                });
+                Ok(None)
+            }
+            WhaleToMember::Cancel { seq } => {
+                self.armed.retain(|armed| armed.seq != seq);
+                // A committed whale cannot be cancelled: members enter at its
+                // launch unconditionally (unanimity is the whole point), and
+                // an unwanted result is dropped, not prevented.
+                Ok(None)
+            }
+        }
+    }
+
+    /// What to do at launch boundary `count`. Must be consulted at every
+    /// boundary, including between the chunks of a local chunked prefill.
+    pub fn at_launch(&mut self, count: LaunchCount) -> Result<WhaleDuty> {
+        if let Some(front) = self.committed.front() {
+            ensure!(
+                front.launch >= count,
+                "rank {} is at launch {count}, past whale {}'s superstep at {} — a launch \
+                 boundary went unconsulted",
+                self.rank,
+                front.descriptor.seq,
+                front.launch
+            );
+            if front.launch == count {
+                let whale = self.committed.pop_front().expect("front just observed");
+                return Ok(WhaleDuty::Enter(Box::new(whale)));
+            }
+        }
+        // A committed whale bounds operations to the launches before its
+        // superstep; a gathered-but-uncommitted whale bounds them to one —
+        // its commit may name any launch above the reply. Both can hold at
+        // once (a second whale gathering behind a committed first): take the
+        // tighter bound.
+        let committed_cap = self.committed.front().map(|front| front.launch - count);
+        let armed_cap = if self.armed.is_empty() { None } else { Some(1) };
+        let clearance = match (committed_cap, armed_cap) {
+            (Some(commit), Some(arm)) => Some(commit.min(arm)),
+            (committed, armed) => committed.or(armed),
+        };
+        Ok(WhaleDuty::Free { clearance })
+    }
+
+    /// Whether this member currently constrains the scheduler at all — used
+    /// by tests and by the scheduler's idle accounting.
+    pub fn is_quiet(&self) -> bool {
+        self.armed.is_empty() && self.committed.is_empty()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Policy: width, gang membership, segment leveling
+// ---------------------------------------------------------------------------
+
+/// The widest gang the prompt admits, or `None` when no width in
+/// `1 < w <= world` (powers of two, tray-aligned) does. Wider is better: the
+/// whale superstep stalls the *whole* fleet on the gang's finish line (the
+/// mega collective is global), so the gang that spreads the prompt thinnest —
+/// subject to every leveled segment staying above the floor and below one
+/// chunk — minimizes everyone's stall, not just the whale's latency.
+pub fn k3_whale_width(total: usize, world: usize, chunk_tokens: usize) -> Option<usize> {
+    let mut width = 1usize;
+    while width * 2 <= world {
+        width *= 2;
+    }
+    while width >= 2 {
+        if k3_whale_admits(total, width, chunk_tokens) {
+            return Some(width);
+        }
+        width /= 2;
+    }
+    None
+}
+
+/// Whether `total` tokens split over `width` ranks keeps every leveled
+/// segment above the floor and within one chunk step (one superstep per rank
+/// — the multi-superstep walk is out of scope until profiles demand it).
+pub fn k3_whale_admits(total: usize, width: usize, chunk_tokens: usize) -> bool {
+    if width < 2 || total < width * K3_CP_SEGMENT_FLOOR {
+        return false;
+    }
+    let segments = k3_whale_segments(total, width, chunk_tokens);
+    segments.len() == width
+        && segments
+            .last()
+            .is_some_and(|&(start, len)| start + len == total)
+        && segments
+            .iter()
+            .all(|&(_, len)| len >= K3_CP_SEGMENT_FLOOR && len <= chunk_tokens)
+}
+
+/// The gang for a `width`-wide whale posted by `poster`: the tray-aligned
+/// contiguous block of ranks containing the poster (trays are 4 ranks; a
+/// contiguous block keeps the halo hop and most upstream traffic inside a
+/// tray or between adjacent trays), with the poster rotated to the end — the
+/// owner is the last CP rank, so the final KDA state and the whole MLA
+/// context land on the rank that will decode.
+pub fn k3_whale_gang(poster: GlobalRank, width: usize, world: usize) -> Vec<GlobalRank> {
+    debug_assert!(poster < world && width <= world);
+    const TRAY: usize = 4;
+    let aligned = if width >= TRAY {
+        (poster / TRAY * TRAY).min(world.saturating_sub(width))
+    } else {
+        poster.min(world.saturating_sub(width))
+    };
+    let start = aligned.min(poster);
+    let mut gang: Vec<GlobalRank> = (start..start + width).filter(|&r| r != poster).collect();
+    gang.push(poster);
+    gang
+}
+
+/// How much one context token costs relative to one segment token, in the
+/// per-rank superstep time model `t_i ∝ len_i + Q·(start_i + len_i/2)·len_i`:
+/// the linear term is the full-depth per-token walk (MoE, KDA, dense GEMMs),
+/// the quadratic term is the MLA context triangle (each of the segment's rows
+/// attends its whole prefix). Calibrated from the CP4 16k profile
+/// (2026-08-25: a 12k-deeper prefix cost the last rank ~32ms against a
+/// ~1000ms/4k-row superstep); refit when the fleet profile lands. Leveling
+/// only needs the ratio, not the absolute times.
+const K3_CP_QUAD_PER_LINEAR: f64 = 2.7e-6;
+
+/// Split `total` tokens into `width` contiguous leveled segments: earlier
+/// ranks get longer segments, so every rank's modeled superstep time — walk
+/// plus its MLA triangle — comes out even. At 16k the difference from an even
+/// split is small; at 256k the last rank's triangle is two thirds of its
+/// walk, and an even split would put the whole fleet on its tail.
+///
+/// Segments are found by bisecting the per-rank time budget: given a budget,
+/// each rank greedily takes the longest affordable segment (capped at
+/// `chunk_tokens`), which is monotone in the budget. The floor is *not*
+/// enforced here — [`k3_whale_admits`] rejects splits that level below it —
+/// but coverage is: the returned segments always partition `total` exactly,
+/// or the result is shorter than `width` (inadmissible).
+pub fn k3_whale_segments(total: usize, width: usize, chunk_tokens: usize) -> Vec<(usize, usize)> {
+    debug_assert!(width >= 1);
+    if width == 1 || total == 0 {
+        return vec![(0, total)];
+    }
+    let affordable = |start: usize, budget: f64| -> usize {
+        // Largest len with len + Q·(start + len/2)·len <= budget:
+        // (Q/2)·len² + (1 + Q·start)·len − budget = 0.
+        let a = K3_CP_QUAD_PER_LINEAR / 2.0;
+        let b = 1.0 + K3_CP_QUAD_PER_LINEAR * start as f64;
+        let len = (2.0 * budget) / (b + (b * b + 4.0 * a * budget).sqrt());
+        (len.floor() as usize).min(chunk_tokens)
+    };
+    let coverage = |budget: f64| -> usize {
+        let mut start = 0usize;
+        for _ in 0..width {
+            start += affordable(start, budget);
+        }
+        start
+    };
+    // Bisect the smallest budget that covers the prompt. The even split's
+    // per-rank cost bounds it above (leveling can only lower the maximum).
+    let per = total.div_ceil(width) as f64;
+    let mut hi = per * (1.0 + K3_CP_QUAD_PER_LINEAR * total as f64);
+    let mut lo = 0.0f64;
+    for _ in 0..64 {
+        let mid = (lo + hi) / 2.0;
+        if coverage(mid) >= total {
+            hi = mid;
+        } else {
+            lo = mid;
+        }
+    }
+    let mut segments = Vec::with_capacity(width);
+    let mut start = 0usize;
+    for rank in 0..width {
+        let remaining = total - start;
+        let ranks_left = width - rank;
+        // The bisected budget's segment, clamped to leave every later rank at
+        // least one token; the last rank takes whatever is left. Leveling is
+        // a preference, the exact partition is the contract — when the chunk
+        // cap makes exactness impossible the result under-covers and
+        // [`k3_whale_admits`] rejects it.
+        let len = if ranks_left == 1 {
+            remaining.min(chunk_tokens)
+        } else {
+            affordable(start, hi)
+                .clamp(1, chunk_tokens)
+                .min(remaining.saturating_sub(ranks_left - 1))
+        };
+        segments.push((start, len));
+        start += len;
+    }
+    segments
+}
+
+// ---------------------------------------------------------------------------
+// Tests: the protocol never runs its first fleet — it runs here first
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The mega row ceiling (#962): CP16 x one chunk covers 256k in a single
+    /// superstep, which is exactly why the protocol was raised to 16896.
+    const CHUNK: usize = 16896;
+
+    fn prompt_of(total: usize) -> Arc<[u32]> {
+        (0..total as u32).collect()
+    }
+
+    // ---- policy: width -----------------------------------------------------
+
+    #[test]
+    fn width_covers_256k_at_ep16() {
+        assert_eq!(k3_whale_width(262144, 16, CHUNK), Some(16));
+    }
+
+    #[test]
+    fn width_refuses_hopeless_prompts() {
+        // Below two floors no gang splits legally...
+        assert_eq!(k3_whale_width(2 * K3_CP_SEGMENT_FLOOR - 1, 16, CHUNK), None);
+        assert_eq!(k3_whale_width(1024, 16, CHUNK), None);
+        // ...and past world x chunk the M0 one-superstep-per-rank walk ends.
+        assert_eq!(k3_whale_width(16 * CHUNK + 1, 16, CHUNK), None);
+    }
+
+    #[test]
+    fn width_is_the_widest_admitting_power_of_two() {
+        for total in [8192usize, 12288, 16384, 32768, 65536, 131072, 262144] {
+            let width = k3_whale_width(total, 16, CHUNK)
+                .unwrap_or_else(|| panic!("{total} tokens should admit some width"));
+            assert!(k3_whale_admits(total, width, CHUNK), "{total} @ {width}");
+            let mut wider = width * 2;
+            while wider <= 16 {
+                assert!(!k3_whale_admits(total, wider, CHUNK), "{total} @ {wider}");
+                wider *= 2;
+            }
+        }
+    }
+
+    // ---- policy: segments --------------------------------------------------
+
+    #[test]
+    fn segments_partition_exactly_and_level_downward() {
+        for (total, width) in [(262144usize, 16usize), (65536, 8), (12288, 4), (8192, 2)] {
+            let segments = k3_whale_segments(total, width, CHUNK);
+            assert_eq!(segments.len(), width, "{total} @ {width}");
+            let mut expected_start = 0;
+            for &(start, len) in &segments {
+                assert_eq!(start, expected_start, "{total} @ {width}: {segments:?}");
+                assert!(len <= CHUNK);
+                expected_start += len;
+            }
+            assert_eq!(expected_start, total, "{total} @ {width}: {segments:?}");
+            // Later ranks sit on deeper prefixes: leveling only shortens them.
+            for pair in segments.windows(2) {
+                assert!(pair[0].1 >= pair[1].1, "{total} @ {width}: {segments:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn segments_leveling_bites_at_depth() {
+        // At 256k the last rank's MLA triangle is ~2/3 of its walk; an even
+        // split would park the whole fleet on its tail.
+        let segments = k3_whale_segments(262144, 16, CHUNK);
+        let first = segments.first().unwrap().1;
+        let last = segments.last().unwrap().1;
+        assert!(
+            first > last + 1000,
+            "leveling too timid at 256k: first {first}, last {last}"
+        );
+    }
+
+    // ---- policy: gang ------------------------------------------------------
+
+    #[test]
+    fn gang_is_tray_aligned_with_the_poster_last() {
+        assert_eq!(k3_whale_gang(5, 8, 16), vec![4, 6, 7, 8, 9, 10, 11, 5]);
+        assert_eq!(k3_whale_gang(14, 8, 16), vec![8, 9, 10, 11, 12, 13, 15, 14]);
+        let full = k3_whale_gang(0, 16, 16);
+        assert_eq!(full.len(), 16);
+        assert_eq!(full.last(), Some(&0));
+    }
+
+    #[test]
+    fn gang_is_always_a_contiguous_in_world_block_containing_the_poster() {
+        for world in [4usize, 8, 16] {
+            for width in [2usize, 4, 8, 16].into_iter().filter(|&w| w <= world) {
+                for poster in 0..world {
+                    let gang = k3_whale_gang(poster, width, world);
+                    assert_eq!(gang.len(), width);
+                    assert_eq!(gang.last(), Some(&poster));
+                    let mut sorted = gang.clone();
+                    sorted.sort_unstable();
+                    sorted.dedup();
+                    assert_eq!(sorted.len(), width, "duplicates in {gang:?}");
+                    assert!(sorted.iter().all(|&rank| rank < world));
+                    assert_eq!(
+                        sorted.last().unwrap() - sorted.first().unwrap(),
+                        width - 1,
+                        "gang {gang:?} is not contiguous"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn prompt_hash_sees_order_and_length() {
+        assert_ne!(
+            k3_whale_prompt_hash(&[1, 2, 3]),
+            k3_whale_prompt_hash(&[3, 2, 1])
+        );
+        assert_ne!(k3_whale_prompt_hash(&[]), k3_whale_prompt_hash(&[0]));
+    }
+
+    // ---- protocol: deterministic exchanges ---------------------------------
+
+    fn commit_of(outbound: &WhaleOutbound) -> Option<(WhaleSeq, LaunchCount)> {
+        match outbound.message {
+            WhaleToMember::Commit { seq, launch } => Some((seq, launch)),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn happy_path_commits_every_member_to_one_launch() {
+        let mut sequencer = WhaleSequencer::new(4, CHUNK);
+        let gathers = sequencer
+            .on_message(WhaleToSequencer::Request {
+                request: 9,
+                poster: 2,
+                prompt: prompt_of(12288),
+            })
+            .unwrap();
+        assert_eq!(gathers.len(), 4);
+        let mut members: Vec<WhaleMember> = (0..4).map(WhaleMember::new).collect();
+        let mut commits = Vec::new();
+        for gather in gathers {
+            // Counts 10/11: the fleet's real ±1 launch skew.
+            let count = 10 + gather.to as LaunchCount % 2;
+            let reply = members[gather.to]
+                .on_message(gather.message, count)
+                .unwrap()
+                .expect("a gather demands a ready");
+            commits.extend(sequencer.on_message(reply).unwrap());
+        }
+        assert_eq!(commits.len(), 4);
+        let (seq, launch) = commit_of(&commits[0]).expect("commit");
+        assert_eq!(seq, 0);
+        assert!(launch >= 11 + K3_WHALE_COMMIT_SLACK);
+        for commit in commits {
+            members[commit.to].on_message(commit.message, 12).unwrap();
+        }
+        // Every member free-runs to the launch and enters exactly there.
+        for (rank, member) in members.iter_mut().enumerate() {
+            let mut entered = None;
+            for count in 12..=launch {
+                match member.at_launch(count).unwrap() {
+                    WhaleDuty::Enter(whale) => entered = Some((count, whale)),
+                    WhaleDuty::Free { clearance } => {
+                        assert_eq!(clearance, Some(launch - count));
+                    }
+                }
+            }
+            let (count, whale) = entered.expect("member never entered");
+            assert_eq!(count, launch);
+            assert_eq!(whale.descriptor.cp_rank_of(rank), Some(whale.cp_rank));
+            assert!(member.is_quiet());
+        }
+    }
+
+    #[test]
+    fn late_reply_from_a_mid_operation_member_still_clears_its_count() {
+        let mut sequencer = WhaleSequencer::new(4, CHUNK);
+        let gathers = sequencer
+            .on_message(WhaleToSequencer::Request {
+                request: 1,
+                poster: 0,
+                prompt: prompt_of(12288),
+            })
+            .unwrap();
+        let mut members: Vec<WhaleMember> = (0..4).map(WhaleMember::new).collect();
+        // Rank 0 is three launches deep in a chunked local prefill and only
+        // drains its inbox at 23; everyone else replies at 20.
+        let mut commits = Vec::new();
+        for gather in gathers {
+            let count = if gather.to == 0 { 23 } else { 20 };
+            let reply = members[gather.to]
+                .on_message(gather.message, count)
+                .unwrap()
+                .unwrap();
+            commits.extend(sequencer.on_message(reply).unwrap());
+        }
+        let (_, launch) = commit_of(&commits[0]).expect("commit");
+        assert!(launch >= 23 + K3_WHALE_COMMIT_SLACK);
+        // The straggler receives the commit one launch later still.
+        let to_zero = commits.iter().find(|commit| commit.to == 0).unwrap();
+        members[0].on_message(to_zero.message.clone(), 24).unwrap();
+    }
+
+    #[test]
+    fn concurrent_whales_serialize_with_strictly_increasing_launches() {
+        let mut sequencer = WhaleSequencer::new(8, CHUNK);
+        let first_gathers = sequencer
+            .on_message(WhaleToSequencer::Request {
+                request: 1,
+                poster: 1,
+                prompt: prompt_of(20480),
+            })
+            .unwrap();
+        assert_eq!(first_gathers.len(), 8);
+        // The second request queues behind the first gather: silence.
+        let queued = sequencer
+            .on_message(WhaleToSequencer::Request {
+                request: 2,
+                poster: 5,
+                prompt: prompt_of(20480),
+            })
+            .unwrap();
+        assert!(queued.is_empty());
+        let mut members: Vec<WhaleMember> = (0..8).map(WhaleMember::new).collect();
+        let mut second_wave = Vec::new();
+        for gather in first_gathers {
+            let reply = members[gather.to]
+                .on_message(gather.message, 5)
+                .unwrap()
+                .unwrap();
+            second_wave.extend(sequencer.on_message(reply).unwrap());
+        }
+        // The last ready commits whale 0 and pumps whale 1's gather in one
+        // transition; per-destination FIFO delivers them in that order.
+        let launch_a = second_wave
+            .iter()
+            .find_map(commit_of)
+            .expect("first commit")
+            .1;
+        let mut commits_b = Vec::new();
+        for outbound in second_wave {
+            match outbound.message {
+                WhaleToMember::Commit { .. } => {
+                    members[outbound.to]
+                        .on_message(outbound.message, 6)
+                        .unwrap();
+                }
+                WhaleToMember::Gather { .. } => {
+                    let reply = members[outbound.to]
+                        .on_message(outbound.message, 7)
+                        .unwrap()
+                        .unwrap();
+                    commits_b.extend(sequencer.on_message(reply).unwrap());
+                }
+                WhaleToMember::Cancel { .. } => panic!("unexpected cancel"),
+            }
+        }
+        let (seq_b, launch_b) = commits_b.iter().find_map(commit_of).expect("second commit");
+        assert_eq!(seq_b, 1);
+        assert!(
+            launch_b > launch_a,
+            "whale 1 at {launch_b} must follow whale 0 at {launch_a}"
+        );
+        // A member in both gangs accepts the commits in order.
+        for commit in commits_b {
+            members[commit.to].on_message(commit.message, 8).unwrap();
+        }
+    }
+
+    #[test]
+    fn gather_timeout_cancels_and_the_stale_ready_is_ignored() {
+        let mut sequencer = WhaleSequencer::new(4, CHUNK);
+        let gathers = sequencer
+            .on_message(WhaleToSequencer::Request {
+                request: 3,
+                poster: 1,
+                prompt: prompt_of(12288),
+            })
+            .unwrap();
+        let straggler = gathers[3].to;
+        let mut member = WhaleMember::new(straggler);
+        let reply = member
+            .on_message(gathers[3].message.clone(), 4)
+            .unwrap()
+            .unwrap();
+        for gather in &gathers[..2] {
+            sequencer
+                .on_message(WhaleToSequencer::Ready {
+                    seq: 0,
+                    rank: gather.to,
+                    count: 4,
+                })
+                .unwrap();
+        }
+        let cancels = sequencer.on_gather_timeout().unwrap();
+        assert_eq!(cancels.len(), 4);
+        assert!(
+            cancels
+                .iter()
+                .all(|c| matches!(c.message, WhaleToMember::Cancel { seq: 0 }))
+        );
+        // The straggler's ready limps in afterward: stale, silently dropped.
+        assert!(sequencer.on_message(reply).unwrap().is_empty());
+        // The cancel disarms the member entirely.
+        member
+            .on_message(WhaleToMember::Cancel { seq: 0 }, 6)
+            .unwrap();
+        assert!(member.is_quiet());
+        assert!(matches!(
+            member.at_launch(7).unwrap(),
+            WhaleDuty::Free { clearance: None }
+        ));
+        // And the sequencer lives on: the next whale gathers normally.
+        let next = sequencer
+            .on_message(WhaleToSequencer::Request {
+                request: 4,
+                poster: 0,
+                prompt: prompt_of(12288),
+            })
+            .unwrap();
+        assert_eq!(next.len(), 4);
+    }
+
+    #[test]
+    fn inadmissible_request_is_refused_to_the_poster_alone() {
+        let mut sequencer = WhaleSequencer::new(4, CHUNK);
+        let out = sequencer
+            .on_message(WhaleToSequencer::Request {
+                request: 8,
+                poster: 2,
+                prompt: prompt_of(1024),
+            })
+            .unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].to, 2);
+        assert!(matches!(out[0].message, WhaleToMember::Cancel { .. }));
+    }
+
+    #[test]
+    fn a_refused_whale_does_not_strand_the_queue_behind_it() {
+        // Regression (found by the fuzzer): a runt queued ahead of a real
+        // whale used to be refused without pumping further, and no later
+        // message was guaranteed to arrive — the real whale sat in the
+        // sequencer queue forever.
+        let mut sequencer = WhaleSequencer::new(4, CHUNK);
+        let gathers = sequencer
+            .on_message(WhaleToSequencer::Request {
+                request: 1,
+                poster: 0,
+                prompt: prompt_of(12288),
+            })
+            .unwrap();
+        for runt_poster in [1, 2] {
+            let queued = sequencer
+                .on_message(WhaleToSequencer::Request {
+                    request: 2,
+                    poster: runt_poster,
+                    prompt: prompt_of(64),
+                })
+                .unwrap();
+            assert!(queued.is_empty(), "queued behind the gather");
+        }
+        let queued = sequencer
+            .on_message(WhaleToSequencer::Request {
+                request: 4,
+                poster: 3,
+                prompt: prompt_of(12288),
+            })
+            .unwrap();
+        assert!(queued.is_empty());
+        // The last ready commits whale 0, refuses both runts, and gathers the
+        // real whale queued behind them — all in one transition.
+        let mut tail = Vec::new();
+        for gather in &gathers {
+            tail = sequencer
+                .on_message(WhaleToSequencer::Ready {
+                    seq: 0,
+                    rank: gather.to,
+                    count: 3,
+                })
+                .unwrap();
+        }
+        let commits = tail
+            .iter()
+            .filter(|out| matches!(out.message, WhaleToMember::Commit { .. }))
+            .count();
+        let cancels: Vec<GlobalRank> = tail
+            .iter()
+            .filter(|out| matches!(out.message, WhaleToMember::Cancel { .. }))
+            .map(|out| out.to)
+            .collect();
+        let gathers_after = tail
+            .iter()
+            .filter(|out| matches!(out.message, WhaleToMember::Gather { .. }))
+            .count();
+        assert_eq!(commits, 4);
+        assert_eq!(cancels, vec![1, 2]);
+        assert_eq!(gathers_after, 4, "the whale behind the runts must gather");
+        assert_eq!(sequencer.gathering_seq(), Some(3));
+    }
+
+    // ---- protocol: things that must die loudly -----------------------------
+
+    fn one_gather(sequencer: &mut WhaleSequencer, poster: GlobalRank) -> Vec<WhaleOutbound> {
+        sequencer
+            .on_message(WhaleToSequencer::Request {
+                request: 1,
+                poster,
+                prompt: prompt_of(12288),
+            })
+            .unwrap()
+    }
+
+    #[test]
+    fn corrupted_descriptor_dies_loudly() {
+        let mut sequencer = WhaleSequencer::new(4, CHUNK);
+        let gathers = one_gather(&mut sequencer, 0);
+        let WhaleToMember::Gather { mut descriptor } = gathers[0].message.clone() else {
+            panic!("expected gather");
+        };
+        descriptor.prompt_hash ^= 1;
+        let to = gathers[0].to;
+        let error = WhaleMember::new(to)
+            .on_message(WhaleToMember::Gather { descriptor }, 0)
+            .unwrap_err();
+        assert!(error.to_string().contains("hash"), "{error}");
+    }
+
+    #[test]
+    fn gather_addressed_to_a_non_member_dies_loudly() {
+        let mut sequencer = WhaleSequencer::new(8, CHUNK);
+        // Width-4 whale gangs ranks 0..4; rank 7 must refuse its descriptor.
+        let gathers = sequencer
+            .on_message(WhaleToSequencer::Request {
+                request: 1,
+                poster: 0,
+                prompt: prompt_of(9000),
+            })
+            .unwrap();
+        assert!(gathers.iter().all(|gather| gather.to != 7));
+        let error = WhaleMember::new(7)
+            .on_message(gathers[0].message.clone(), 0)
+            .unwrap_err();
+        assert!(error.to_string().contains("not in its gang"), "{error}");
+    }
+
+    #[test]
+    fn duplicate_ready_dies_loudly() {
+        let mut sequencer = WhaleSequencer::new(4, CHUNK);
+        let gathers = one_gather(&mut sequencer, 0);
+        let rank = gathers[0].to;
+        sequencer
+            .on_message(WhaleToSequencer::Ready {
+                seq: 0,
+                rank,
+                count: 3,
+            })
+            .unwrap();
+        let error = sequencer
+            .on_message(WhaleToSequencer::Ready {
+                seq: 0,
+                rank,
+                count: 4,
+            })
+            .unwrap_err();
+        assert!(error.to_string().contains("twice"), "{error}");
+    }
+
+    #[test]
+    fn an_unconsulted_launch_boundary_is_detected() {
+        let (mut member, launch) = committed_member();
+        let error = member.at_launch(launch + 1).unwrap_err();
+        assert!(error.to_string().contains("unconsulted"), "{error}");
+    }
+
+    #[test]
+    fn a_commit_arriving_past_its_launch_is_detected() {
+        let mut sequencer = WhaleSequencer::new(4, CHUNK);
+        let gathers = one_gather(&mut sequencer, 0);
+        let rank = gathers[0].to;
+        let mut member = WhaleMember::new(rank);
+        member.on_message(gathers[0].message.clone(), 10).unwrap();
+        // The member somehow launched past the committed slot before the
+        // commit arrived: the slack failed, and silence would mispair a
+        // collective — this must be the loud path.
+        let error = member
+            .on_message(
+                WhaleToMember::Commit {
+                    seq: 0,
+                    launch: 10 + K3_WHALE_COMMIT_SLACK,
+                },
+                10 + K3_WHALE_COMMIT_SLACK,
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("slack"), "{error}");
+    }
+
+    /// A member with a whale committed a few launches out.
+    fn committed_member() -> (WhaleMember, LaunchCount) {
+        let mut sequencer = WhaleSequencer::new(4, CHUNK);
+        let gathers = one_gather(&mut sequencer, 0);
+        let rank = gathers[0].to;
+        let mut member = WhaleMember::new(rank);
+        let reply = member
+            .on_message(gathers[0].message.clone(), 10)
+            .unwrap()
+            .unwrap();
+        let mut commits = sequencer.on_message(reply).unwrap();
+        for gather in &gathers[1..] {
+            commits.extend(
+                sequencer
+                    .on_message(WhaleToSequencer::Ready {
+                        seq: 0,
+                        rank: gather.to,
+                        count: 10,
+                    })
+                    .unwrap(),
+            );
+        }
+        let (_, launch) = commits.iter().find_map(commit_of).expect("commit");
+        let mine = commits.iter().find(|commit| commit.to == rank).unwrap();
+        member.on_message(mine.message.clone(), 11).unwrap();
+        (member, launch)
+    }
+
+    #[test]
+    fn clearance_shrinks_to_one_while_a_second_whale_is_gathering() {
+        let (mut member, launch) = committed_member();
+        // Behind the committed whale alone, the clearance is the distance.
+        let count = launch - 3;
+        match member.at_launch(count).unwrap() {
+            WhaleDuty::Free { clearance } => assert_eq!(clearance, Some(3)),
+            duty => panic!("expected free, got {duty:?}"),
+        }
+        // A second whale gathering on the same member caps it at one: the
+        // pending commit may name any launch above the reply, and a
+        // multi-launch operation would overshoot it.
+        let mut second = WhaleSequencer::new(4, CHUNK);
+        let mut gathers = one_gather(&mut second, 0);
+        // committed_member's rank is gathers[0].to of an identical whale, so
+        // the same gang covers it; re-seq the descriptor so the member sees a
+        // distinct, later whale.
+        let Some(WhaleOutbound {
+            message: WhaleToMember::Gather { mut descriptor },
+            ..
+        }) = gathers.drain(..1).next()
+        else {
+            panic!("expected gather");
+        };
+        descriptor.seq = 7;
+        member
+            .on_message(WhaleToMember::Gather { descriptor }, count)
+            .unwrap()
+            .expect("a gather demands a ready");
+        match member.at_launch(count).unwrap() {
+            WhaleDuty::Free { clearance } => assert_eq!(clearance, Some(1)),
+            duty => panic!("expected free, got {duty:?}"),
+        }
+        // Armed alone (no commit yet) also caps at one.
+        let rank = member_rank(&member);
+        let mut fresh = WhaleMember::new(rank);
+        let gathers = one_gather(&mut WhaleSequencer::new(4, CHUNK), 0);
+        let mine = gathers
+            .into_iter()
+            .find(|gather| gather.to == rank)
+            .unwrap();
+        fresh.on_message(mine.message, 0).unwrap();
+        match fresh.at_launch(1).unwrap() {
+            WhaleDuty::Free { clearance } => assert_eq!(clearance, Some(1)),
+            duty => panic!("expected free, got {duty:?}"),
+        }
+    }
+
+    fn member_rank(member: &WhaleMember) -> GlobalRank {
+        member.rank
+    }
+}
+
+/// Seeded fleet fuzz: a simulated free-running world where every rank
+/// launches once per round (the mega pairing's ±1 pinning), messages ride
+/// per-destination FIFO queues with 0–1 rounds of latency (TCP ordering,
+/// latency below one launch period — the slack's stated assumption), and
+/// unconstrained ranks start multi-launch operations that skip boundary
+/// consultation exactly as a local chunked prefill does. The invariants are
+/// the protocol's whole contract: every admissible whale enters unanimously —
+/// full gang, one launch, distinct CP ranks — launches follow sequence order,
+/// no transition errors, and the fleet quiesces.
+#[cfg(test)]
+mod fuzz {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    struct Rng(u64);
+
+    impl Rng {
+        fn new(seed: u64) -> Self {
+            Self(seed | 1)
+        }
+
+        fn next(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            self.0 = x;
+            x
+        }
+
+        fn below(&mut self, bound: u64) -> u64 {
+            self.next() % bound
+        }
+    }
+
+    struct SimRank {
+        member: WhaleMember,
+        count: LaunchCount,
+        inbox: VecDeque<(u64, WhaleToMember)>,
+        /// Launches left in the multi-launch operation in flight; boundaries
+        /// inside it go unconsulted and the inbox stays undrained.
+        busy: u64,
+    }
+
+    #[test]
+    fn fuzzed_fleets_reach_unanimous_entries() {
+        for seed in 1..=48u64 {
+            fuzz_one(&mut Rng::new(seed.wrapping_mul(0x9e37_79b9_7f4a_7c15)));
+        }
+    }
+
+    fn fuzz_one(rng: &mut Rng) {
+        const WORLD: usize = 8;
+        const CHUNK: usize = 4224;
+        let mut sequencer = WhaleSequencer::new(WORLD, CHUNK);
+        let mut ranks: Vec<SimRank> = (0..WORLD)
+            .map(|rank| SimRank {
+                member: WhaleMember::new(rank),
+                count: 0,
+                inbox: VecDeque::new(),
+                busy: 0,
+            })
+            .collect();
+        let mut to_sequencer: VecDeque<(u64, WhaleToSequencer)> = VecDeque::new();
+        let mut entered: Vec<(WhaleSeq, LaunchCount, usize, usize)> = Vec::new();
+        let mut cancels = 0usize;
+        let whales = 4 + rng.below(8) as usize;
+        let mut posted = 0usize;
+        let mut admissible = 0usize;
+        let mut round = 0u64;
+
+        loop {
+            round += 1;
+            assert!(round < 4000, "the fleet failed to quiesce");
+
+            // Sometimes a rank posts a whale — usually a real one, sometimes
+            // a runt the sequencer must refuse without wedging the queue.
+            if posted < whales && rng.below(3) == 0 {
+                let poster = rng.below(WORLD as u64) as usize;
+                let span = (WORLD * CHUNK - 2 * K3_CP_SEGMENT_FLOOR) as u64;
+                let total = if rng.below(4) != 0 {
+                    2 * K3_CP_SEGMENT_FLOOR + rng.below(span) as usize
+                } else {
+                    1 + rng.below(K3_CP_SEGMENT_FLOOR as u64) as usize
+                };
+                if k3_whale_width(total, WORLD, CHUNK).is_some() {
+                    admissible += 1;
+                }
+                posted += 1;
+                to_sequencer.push_back((
+                    round + rng.below(2),
+                    WhaleToSequencer::Request {
+                        request: posted as u64,
+                        poster,
+                        prompt: (0..total as u32).collect(),
+                    },
+                ));
+            }
+
+            // Rank phase: everyone launches exactly once, in a rotated order.
+            let offset = rng.below(WORLD as u64) as usize;
+            for i in 0..WORLD {
+                let rank_id = (i + offset) % WORLD;
+                let rank = &mut ranks[rank_id];
+                if rank.busy > 0 {
+                    rank.busy -= 1;
+                    rank.count += 1;
+                    continue;
+                }
+                while rank.inbox.front().is_some_and(|&(at, _)| at <= round) {
+                    let (_, message) = rank.inbox.pop_front().expect("front just observed");
+                    if matches!(message, WhaleToMember::Cancel { .. }) {
+                        cancels += 1;
+                    }
+                    if let Some(reply) = rank
+                        .member
+                        .on_message(message, rank.count)
+                        .expect("member transition")
+                    {
+                        to_sequencer.push_back((round + rng.below(2), reply));
+                    }
+                }
+                match rank.member.at_launch(rank.count).expect("launch boundary") {
+                    WhaleDuty::Enter(whale) => {
+                        entered.push((
+                            whale.descriptor.seq,
+                            rank.count,
+                            whale.cp_rank,
+                            whale.descriptor.gang.len(),
+                        ));
+                        rank.count += 1;
+                    }
+                    WhaleDuty::Free { clearance } => {
+                        // Start an operation spanning 1..=cap launches; the
+                        // boundaries inside it go unconsulted.
+                        let cap = clearance.unwrap_or(3).min(3);
+                        rank.busy = rng.below(cap);
+                        rank.count += 1;
+                    }
+                }
+            }
+
+            // Sequencer phase: drain what has arrived, route the outbound.
+            while to_sequencer.front().is_some_and(|&(at, _)| at <= round) {
+                let (_, message) = to_sequencer.pop_front().expect("front just observed");
+                for out in sequencer.on_message(message).expect("sequencer transition") {
+                    ranks[out.to]
+                        .inbox
+                        .push_back((round + rng.below(2), out.message));
+                }
+            }
+
+            let quiet = posted == whales
+                && to_sequencer.is_empty()
+                && ranks
+                    .iter()
+                    .all(|rank| rank.inbox.is_empty() && rank.member.is_quiet());
+            if quiet {
+                break;
+            }
+        }
+
+        // Unanimity: every admissible whale entered with its full gang at one
+        // launch, CP ranks a permutation of 0..width.
+        let mut by_seq: HashMap<WhaleSeq, Vec<(LaunchCount, usize, usize)>> = HashMap::new();
+        for (seq, launch, cp_rank, width) in entered {
+            by_seq
+                .entry(seq)
+                .or_default()
+                .push((launch, cp_rank, width));
+        }
+        assert_eq!(by_seq.len(), admissible, "every admissible whale must run");
+        assert_eq!(
+            cancels,
+            posted - admissible,
+            "every runt must be refused once"
+        );
+        let mut launches: Vec<(WhaleSeq, LaunchCount)> = Vec::new();
+        for (seq, entries) in &by_seq {
+            let width = entries[0].2;
+            assert_eq!(entries.len(), width, "whale {seq}: partial entry");
+            let launch = entries[0].0;
+            assert!(
+                entries.iter().all(|&(at, _, _)| at == launch),
+                "whale {seq}: split entry {entries:?}"
+            );
+            let mut cp_ranks: Vec<usize> = entries.iter().map(|&(_, cp_rank, _)| cp_rank).collect();
+            cp_ranks.sort_unstable();
+            assert_eq!(cp_ranks, (0..width).collect::<Vec<_>>(), "whale {seq}");
+            launches.push((*seq, launch));
+        }
+        launches.sort_unstable();
+        assert!(
+            launches.windows(2).all(|pair| pair[0].1 < pair[1].1),
+            "commit order must follow sequence order: {launches:?}"
+        );
+    }
+}

--- a/pegainfer-k3/src/scheduler/whale.rs
+++ b/pegainfer-k3/src/scheduler/whale.rs
@@ -516,6 +516,13 @@ impl WhaleMember {
     pub fn is_quiet(&self) -> bool {
         self.armed.is_empty() && self.committed.is_empty()
     }
+
+    /// Whether `seq` is armed here (gathered, commit pending). The poster
+    /// uses this to tell a helper-side cancel from the width refusal of its
+    /// own not-yet-gathered post.
+    pub fn is_armed(&self, seq: WhaleSeq) -> bool {
+        self.armed.iter().any(|armed| armed.seq == seq)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/pegainfer-k3/src/scheduler/whale_hub.rs
+++ b/pegainfer-k3/src/scheduler/whale_hub.rs
@@ -25,6 +25,7 @@ use std::io::Write;
 use std::net::TcpListener;
 use std::net::TcpStream;
 use std::sync::Arc;
+use std::sync::Condvar;
 use std::sync::Mutex;
 use std::sync::mpsc;
 use std::time::Duration;
@@ -33,6 +34,7 @@ use anyhow::Context as _;
 use anyhow::Result;
 use anyhow::bail;
 use anyhow::ensure;
+use pegainfer_kernels::ops::K3_MEGA_FABRIC_HANDLE_BYTES;
 
 use super::whale::GlobalRank;
 use super::whale::WhaleDescriptor;
@@ -41,6 +43,7 @@ use super::whale::WhaleSeq;
 use super::whale::WhaleSequencer;
 use super::whale::WhaleToMember;
 use super::whale::WhaleToSequencer;
+use crate::executor::whale_gang::K3WhaleSlabWire;
 
 /// `"K3WH"`: a stray connection to the wrong port dies loudly.
 const WHALE_MAGIC: u32 = u32::from_le_bytes(*b"K3WH");
@@ -219,6 +222,10 @@ const KIND_READY: u32 = 2;
 const KIND_GATHER: u32 = 3;
 const KIND_COMMIT: u32 = 4;
 const KIND_CANCEL: u32 = 5;
+/// Startup only, peer → host: one local rank's whale-slab fabric identity.
+const KIND_SLAB: u32 = 6;
+/// Startup only, host → peer: the world's completed slab table.
+const KIND_TABLE: u32 = 7;
 
 fn write_header(writer: &mut impl Write, kind: u32) -> Result<()> {
     let mut frame = FrameWriter(writer);
@@ -360,10 +367,13 @@ fn read_to_member(reader: &mut impl Read, kind: u32) -> Result<(GlobalRank, Whal
 // TCP hub
 // ---------------------------------------------------------------------------
 
-/// What one peer process announces on connect: the global ranks it hosts.
+/// What one peer process announces on connect: the global ranks it hosts,
+/// and how many slab frames follow (0 = no data-plane exchange, or exactly
+/// `count` — one per hosted rank).
 struct Hello {
     first: GlobalRank,
     count: usize,
+    slabs: usize,
 }
 
 fn write_hello(writer: &mut impl Write, hello: &Hello) -> Result<()> {
@@ -371,7 +381,102 @@ fn write_hello(writer: &mut impl Write, hello: &Hello) -> Result<()> {
     let mut frame = FrameWriter(writer);
     frame.u32(u32::try_from(hello.first).context("whale hello rank")?)?;
     frame.u32(u32::try_from(hello.count).context("whale hello count")?)?;
+    frame.u32(u32::try_from(hello.slabs).context("whale hello slabs")?)?;
     writer.flush().context("whale link flush")
+}
+
+fn write_slab(writer: &mut impl Write, rank: GlobalRank, slab: &K3WhaleSlabWire) -> Result<()> {
+    write_header(writer, KIND_SLAB)?;
+    let mut frame = FrameWriter(writer);
+    frame.u32(u32::try_from(rank).context("whale slab rank")?)?;
+    frame.u64(u64::try_from(slab.num_bytes).context("whale slab size")?)?;
+    writer
+        .write_all(&slab.handle)
+        .context("whale slab handle write")?;
+    writer.flush().context("whale link flush")
+}
+
+fn read_slab(reader: &mut impl Read) -> Result<(GlobalRank, K3WhaleSlabWire)> {
+    let mut frame = FrameReader(reader);
+    let rank = frame.u32()? as GlobalRank;
+    let num_bytes = usize::try_from(frame.u64()?).context("whale slab size")?;
+    let mut handle = [0u8; K3_MEGA_FABRIC_HANDLE_BYTES];
+    reader
+        .read_exact(&mut handle)
+        .context("whale slab handle read")?;
+    Ok((rank, K3WhaleSlabWire { handle, num_bytes }))
+}
+
+fn write_table(writer: &mut impl Write, table: &[K3WhaleSlabWire]) -> Result<()> {
+    write_header(writer, KIND_TABLE)?;
+    let mut frame = FrameWriter(writer);
+    frame.u32(u32::try_from(table.len()).context("whale table size")?)?;
+    for slab in table {
+        let mut frame = FrameWriter(writer);
+        frame.u64(u64::try_from(slab.num_bytes).context("whale slab size")?)?;
+        writer
+            .write_all(&slab.handle)
+            .context("whale table handle write")?;
+    }
+    writer.flush().context("whale link flush")
+}
+
+fn read_table(reader: &mut impl Read) -> Result<Vec<K3WhaleSlabWire>> {
+    let world = FrameReader(reader).u32()?;
+    ensure!(world <= 1024, "whale link: table of {world} ranks");
+    (0..world)
+        .map(|_| {
+            let num_bytes = usize::try_from(FrameReader(reader).u64()?)?;
+            let mut handle = [0u8; K3_MEGA_FABRIC_HANDLE_BYTES];
+            reader
+                .read_exact(&mut handle)
+                .context("whale table handle read")?;
+            Ok(K3WhaleSlabWire { handle, num_bytes })
+        })
+        .collect()
+}
+
+/// The startup slab allgather's shared state on the host: one slot per world
+/// rank, completed when every process has checked its slabs in.
+struct SlabBoard {
+    table: Mutex<Vec<Option<K3WhaleSlabWire>>>,
+    done: Condvar,
+}
+
+impl SlabBoard {
+    fn insert(&self, rank: GlobalRank, slab: K3WhaleSlabWire) -> Result<()> {
+        let mut table = self.table.lock().expect("whale slab board poisoned");
+        let slot = table
+            .get_mut(rank)
+            .with_context(|| format!("whale slab for rank {rank}, outside the world"))?;
+        ensure!(slot.is_none(), "whale slab for rank {rank} arrived twice");
+        *slot = Some(slab);
+        self.done.notify_all();
+        Ok(())
+    }
+
+    /// Block until every rank's slab is in, then return the completed table.
+    fn wait_complete(&self, timeout: Duration) -> Result<Vec<K3WhaleSlabWire>> {
+        let deadline = std::time::Instant::now() + timeout;
+        let mut table = self.table.lock().expect("whale slab board poisoned");
+        loop {
+            if table.iter().all(Option::is_some) {
+                return Ok(table.iter().map(|slot| slot.expect("checked")).collect());
+            }
+            let now = std::time::Instant::now();
+            ensure!(
+                now < deadline,
+                "whale slab exchange timed out: {} of {} ranks checked in",
+                table.iter().filter(|slot| slot.is_some()).count(),
+                table.len()
+            );
+            let (next, _) = self
+                .done
+                .wait_timeout(table, deadline - now)
+                .expect("whale slab board poisoned");
+            table = next;
+        }
+    }
 }
 
 /// The fleet transport. Construct with [`TcpWhaleHub::host`] on the process
@@ -406,13 +511,38 @@ impl TcpWhaleHub {
     /// Host the sequencer for a `world`-rank fleet, serving `local` ranks
     /// `first_local..first_local + local` from this process. Binds `addr` and
     /// accepts peer processes for the hub's whole lifetime.
+    ///
+    /// `local_slabs` arms the startup data-plane exchange: this process's
+    /// slab identities, one per local rank in rank order. When non-empty,
+    /// every peer must check in its own (`connect` with slabs), the call
+    /// blocks until the world's table is complete — the fleet's startup
+    /// barrier, like the EP bootstrap — and the table comes back alongside
+    /// the hub. Empty runs the pure rendezvous with no exchange.
     pub fn host(
         addr: &str,
         world: usize,
         chunk_tokens: usize,
         first_local: GlobalRank,
         local: usize,
-    ) -> Result<Arc<Self>> {
+        local_slabs: Vec<K3WhaleSlabWire>,
+    ) -> Result<(Arc<Self>, Vec<K3WhaleSlabWire>)> {
+        ensure!(
+            local_slabs.is_empty() || local_slabs.len() == local,
+            "whale hub: {} slabs for {local} local ranks",
+            local_slabs.len()
+        );
+        let board = if local_slabs.is_empty() {
+            None
+        } else {
+            let mut table = vec![None; world];
+            for (offset, slab) in local_slabs.into_iter().enumerate() {
+                table[first_local + offset] = Some(slab);
+            }
+            Some(Arc::new(SlabBoard {
+                table: Mutex::new(table),
+                done: Condvar::new(),
+            }))
+        };
         let listener =
             TcpListener::bind(addr).with_context(|| format!("whale hub: bind {addr}"))?;
         let bound = listener.local_addr().ok();
@@ -435,10 +565,15 @@ impl TcpWhaleHub {
         });
 
         // Acceptor: one reader thread per peer process, forwarding its
-        // sequencer-bound frames into the channel.
+        // sequencer-bound frames into the channel. When the data-plane
+        // exchange is armed it runs first on each connection: the peer's slab
+        // frames check in, and the completed world table goes back before the
+        // steady-state protocol starts — so the sequencer can never
+        // interleave a write with the table.
         {
             let peers = peers.clone();
             let failed = failed.clone();
+            let board = board.clone();
             std::thread::Builder::new()
                 .name("k3-whale-accept".into())
                 .spawn(move || {
@@ -450,8 +585,13 @@ impl TcpWhaleHub {
                             let mut frame = FrameReader(&mut socket);
                             let first = frame.u32()? as GlobalRank;
                             let count = frame.u32()? as usize;
+                            let slabs = frame.u32()? as usize;
                             ensure!(count <= 1024, "whale hub: hello claims {count} ranks");
-                            Ok(Hello { first, count })
+                            Ok(Hello {
+                                first,
+                                count,
+                                slabs,
+                            })
                         }) {
                             Ok(hello) => hello,
                             Err(error) => {
@@ -459,6 +599,15 @@ impl TcpWhaleHub {
                                 continue;
                             }
                         };
+                        if let Err(error) = serve_slab_exchange(&mut socket, &hello, board.as_ref())
+                        {
+                            log::warn!(
+                                "K3 whale hub: slab exchange with ranks {}..{} failed: {error:#}",
+                                hello.first,
+                                hello.first + hello.count
+                            );
+                            continue;
+                        }
                         let Ok(writer) = socket.try_clone() else {
                             continue;
                         };
@@ -562,13 +711,34 @@ impl TcpWhaleHub {
                 })
                 .expect("spawn whale sequencer");
         }
-        Ok(hub)
+        let table = match board {
+            None => Vec::new(),
+            // The wait doubles as the fleet's startup barrier: every process
+            // has connected and published its data plane before any engine
+            // serves — mirroring the EP bootstrap's semantics.
+            Some(board) => board
+                .wait_complete(WHALE_CONNECT_TIMEOUT)
+                .context("whale hub: the world never completed its slab exchange")?,
+        };
+        Ok((hub, table))
     }
 
     /// Join the fleet's whale hub as the process serving `local` ranks
     /// `first_local..`, connecting to the sequencer at `addr` (retrying
-    /// through its weight load, like the EP bootstrap).
-    pub fn connect(addr: &str, first_local: GlobalRank, local: usize) -> Result<Arc<Self>> {
+    /// through its weight load, like the EP bootstrap). Non-empty
+    /// `local_slabs` join the startup data-plane exchange and block until
+    /// the host serves the world's completed table back.
+    pub fn connect(
+        addr: &str,
+        first_local: GlobalRank,
+        local: usize,
+        local_slabs: Vec<K3WhaleSlabWire>,
+    ) -> Result<(Arc<Self>, Vec<K3WhaleSlabWire>)> {
+        ensure!(
+            local_slabs.is_empty() || local_slabs.len() == local,
+            "whale hub: {} slabs for {local} local ranks",
+            local_slabs.len()
+        );
         let deadline = std::time::Instant::now() + WHALE_CONNECT_TIMEOUT;
         let mut socket = loop {
             match TcpStream::connect(addr) {
@@ -591,8 +761,31 @@ impl TcpWhaleHub {
             &Hello {
                 first: first_local,
                 count: local,
+                slabs: local_slabs.len(),
             },
         )?;
+        let table = if local_slabs.is_empty() {
+            Vec::new()
+        } else {
+            for (offset, slab) in local_slabs.iter().enumerate() {
+                write_slab(&mut socket, first_local + offset, slab)?;
+            }
+            // The table lands only when the SLOWEST process has loaded and
+            // checked in, so this read is a fleet-load bound, not an IO one.
+            socket
+                .set_read_timeout(Some(WHALE_CONNECT_TIMEOUT))
+                .context("whale hub: set table read timeout")?;
+            let kind = read_header(&mut socket)?;
+            ensure!(
+                kind == KIND_TABLE,
+                "whale hub: expected the slab table, got frame kind {kind}"
+            );
+            let table = read_table(&mut socket)?;
+            socket
+                .set_read_timeout(None)
+                .context("whale hub: clear table read timeout")?;
+            table
+        };
         let mailboxes: Mailboxes = Arc::new(Mutex::new(vec![VecDeque::new(); local]));
         let failed: Arc<Mutex<Option<String>>> = Arc::default();
         let reader_boxes = mailboxes.clone();
@@ -623,15 +816,18 @@ impl TcpWhaleHub {
                 }
             })
             .expect("spawn whale reader");
-        Ok(Arc::new(Self {
-            first_local,
-            addr: None,
-            mailboxes,
-            outbound: HubRole::Peer {
-                link: Mutex::new(socket),
-            },
-            failed,
-        }))
+        Ok((
+            Arc::new(Self {
+                first_local,
+                addr: None,
+                mailboxes,
+                outbound: HubRole::Peer {
+                    link: Mutex::new(socket),
+                },
+                failed,
+            }),
+            table,
+        ))
     }
 
     /// The listener address (host side only; `None` on a peer). A host bound
@@ -667,6 +863,44 @@ impl TcpWhaleHub {
             .map(|inbox| inbox.drain(..).collect())
             .unwrap_or_default()
     }
+}
+
+/// The host side of one connection's startup slab exchange: read the peer's
+/// slab frames onto the board, wait for the world to complete, and serve the
+/// table back. A no-op when neither side armed the exchange; an error when
+/// they disagree.
+fn serve_slab_exchange(
+    socket: &mut TcpStream,
+    hello: &Hello,
+    board: Option<&Arc<SlabBoard>>,
+) -> Result<()> {
+    match (board, hello.slabs) {
+        (None, 0) => return Ok(()),
+        (None, _) => bail!("the peer sent slabs, but this host has no data-plane exchange armed"),
+        (Some(_), 0) => bail!("this host runs a data-plane exchange, but the peer sent no slabs"),
+        (Some(_), slabs) if slabs != hello.count => {
+            bail!(
+                "the peer hosts {} ranks but sent {slabs} slabs",
+                hello.count
+            )
+        }
+        (Some(_), _) => {}
+    }
+    let board = board.expect("matched above");
+    for _ in 0..hello.slabs {
+        let kind = read_header(socket)?;
+        ensure!(kind == KIND_SLAB, "expected a slab frame, got kind {kind}");
+        let (rank, slab) = read_slab(socket)?;
+        ensure!(
+            (hello.first..hello.first + hello.count).contains(&rank),
+            "a slab for rank {rank} from the process hosting {}..{}",
+            hello.first,
+            hello.first + hello.count
+        );
+        board.insert(rank, slab)?;
+    }
+    let table = board.wait_complete(WHALE_CONNECT_TIMEOUT)?;
+    write_table(socket, &table)
 }
 
 fn fail(failed: &Arc<Mutex<Option<String>>>, reason: String) {
@@ -730,9 +964,9 @@ mod tests {
         // serves ranks 2..4 and posts the whale. One simulated launch period
         // per loop pass keeps the loopback latency far below it, which is the
         // commit slack's stated assumption.
-        let host = TcpWhaleHub::host("127.0.0.1:0", 4, CHUNK, 0, 2).unwrap();
+        let (host, _) = TcpWhaleHub::host("127.0.0.1:0", 4, CHUNK, 0, 2, Vec::new()).unwrap();
         let addr = host.local_addr().expect("host knows its port").to_string();
-        let peer = TcpWhaleHub::connect(&addr, 2, 2).unwrap();
+        let (peer, _) = TcpWhaleHub::connect(&addr, 2, 2, Vec::new()).unwrap();
         peer.send(WhaleToSequencer::Request {
             request: 5,
             poster: 2,
@@ -767,5 +1001,34 @@ mod tests {
             launches.iter().all(|&launch| launch == launches[0]),
             "{launches:?}"
         );
+    }
+
+    #[test]
+    fn slab_exchange_serves_every_process_the_same_world_table() {
+        fn slab(seed: u8) -> K3WhaleSlabWire {
+            K3WhaleSlabWire {
+                handle: [seed; K3_MEGA_FABRIC_HANDLE_BYTES],
+                num_bytes: 4096 + seed as usize,
+            }
+        }
+        // The host serves ranks 0..2 and blocks until the world checks in, so
+        // the peer joins from another thread.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        drop(listener);
+        let peer_addr = addr.clone();
+        let peer = std::thread::spawn(move || {
+            TcpWhaleHub::connect(&peer_addr, 2, 2, vec![slab(2), slab(3)]).unwrap()
+        });
+        let (_host, host_table) =
+            TcpWhaleHub::host(&addr, 4, CHUNK, 0, 2, vec![slab(0), slab(1)]).unwrap();
+        let (_peer, peer_table) = peer.join().expect("peer joins the exchange");
+        assert_eq!(host_table.len(), 4);
+        assert_eq!(peer_table.len(), 4);
+        for (rank, (host_slab, peer_slab)) in host_table.iter().zip(&peer_table).enumerate() {
+            assert_eq!(host_slab.handle, [rank as u8; K3_MEGA_FABRIC_HANDLE_BYTES]);
+            assert_eq!(host_slab.handle, peer_slab.handle);
+            assert_eq!(host_slab.num_bytes, peer_slab.num_bytes);
+        }
     }
 }

--- a/pegainfer-k3/src/scheduler/whale_hub.rs
+++ b/pegainfer-k3/src/scheduler/whale_hub.rs
@@ -74,6 +74,40 @@ fn deliver_local(mailboxes: &Mailboxes, first_local: GlobalRank, outbound: &Whal
     true
 }
 
+/// The transport a whale serving lane holds, whichever process shape the
+/// deployment has: one process hosting the whole world ([`LocalWhaleHub`]) or
+/// a fleet peer/host ([`TcpWhaleHub`]).
+#[derive(Clone)]
+pub enum K3WhaleHub {
+    Local(Arc<LocalWhaleHub>),
+    Tcp(Arc<TcpWhaleHub>),
+}
+
+impl K3WhaleHub {
+    pub fn send(&self, message: WhaleToSequencer) -> Result<()> {
+        match self {
+            Self::Local(hub) => hub.send(message),
+            Self::Tcp(hub) => hub.send(message),
+        }
+    }
+
+    pub fn drain(&self, rank: GlobalRank) -> Vec<WhaleToMember> {
+        match self {
+            Self::Local(hub) => hub.drain(rank),
+            Self::Tcp(hub) => hub.drain(rank),
+        }
+    }
+}
+
+impl std::fmt::Debug for K3WhaleHub {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Local(_) => "K3WhaleHub::Local",
+            Self::Tcp(_) => "K3WhaleHub::Tcp",
+        })
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Local hub
 // ---------------------------------------------------------------------------

--- a/pegainfer-k3/src/scheduler/whale_hub.rs
+++ b/pegainfer-k3/src/scheduler/whale_hub.rs
@@ -543,8 +543,17 @@ impl TcpWhaleHub {
                 done: Condvar::new(),
             }))
         };
-        let listener =
-            TcpListener::bind(addr).with_context(|| format!("whale hub: bind {addr}"))?;
+        // Bind the port on every interface rather than whatever the hostname
+        // in `addr` resolves to locally: /etc/hosts commonly maps a machine's
+        // own name to 127.0.1.1, which would put the listener on loopback
+        // while the peers dial the fabric address — connection refused with
+        // nothing in the sequencer's log (the EP bootstrap hit exactly this).
+        let port = addr
+            .rsplit_once(':')
+            .map(|(_, port)| port)
+            .with_context(|| format!("whale hub: address {addr} carries no port"))?;
+        let listener = TcpListener::bind(("0.0.0.0", port.parse::<u16>()?))
+            .with_context(|| format!("whale hub: bind 0.0.0.0:{port} ({addr})"))?;
         let bound = listener.local_addr().ok();
         let mailboxes: Mailboxes = Arc::new(Mutex::new(vec![VecDeque::new(); local]));
         let failed: Arc<Mutex<Option<String>>> = Arc::default();
@@ -965,7 +974,9 @@ mod tests {
         // per loop pass keeps the loopback latency far below it, which is the
         // commit slack's stated assumption.
         let (host, _) = TcpWhaleHub::host("127.0.0.1:0", 4, CHUNK, 0, 2, Vec::new()).unwrap();
-        let addr = host.local_addr().expect("host knows its port").to_string();
+        // The listener binds every interface, so dial loopback explicitly.
+        let port = host.local_addr().expect("host knows its port").port();
+        let addr = format!("127.0.0.1:{port}");
         let (peer, _) = TcpWhaleHub::connect(&addr, 2, 2, Vec::new()).unwrap();
         peer.send(WhaleToSequencer::Request {
             request: 5,

--- a/pegainfer-k3/src/scheduler/whale_hub.rs
+++ b/pegainfer-k3/src/scheduler/whale_hub.rs
@@ -573,12 +573,15 @@ impl TcpWhaleHub {
             failed: failed.clone(),
         });
 
-        // Acceptor: one reader thread per peer process, forwarding its
-        // sequencer-bound frames into the channel. When the data-plane
-        // exchange is armed it runs first on each connection: the peer's slab
-        // frames check in, and the completed world table goes back before the
-        // steady-state protocol starts — so the sequencer can never
-        // interleave a write with the table.
+        // Acceptor: one connection thread per peer process. Each thread runs
+        // the hello, then — when the data-plane exchange is armed — the slab
+        // exchange, then registers its writer and settles into the reader
+        // loop. The exchange must run OFF the accept loop: `wait_complete`
+        // blocks until every peer's slabs are in, and a serial acceptor
+        // holding it would leave the remaining peers unaccepted in the
+        // backlog — a startup deadlock for any world with more than one peer
+        // process. Registration stays after the exchange so the sequencer
+        // can never interleave a commit with the table frame on one socket.
         {
             let peers = peers.clone();
             let failed = failed.clone();
@@ -589,51 +592,59 @@ impl TcpWhaleHub {
                     for connection in listener.incoming() {
                         let Ok(mut socket) = connection else { continue };
                         let _ = socket.set_nodelay(true);
-                        let hello = match read_header(&mut socket).and_then(|kind| {
-                            ensure!(kind == KIND_HELLO, "whale hub: first frame kind {kind}");
-                            let mut frame = FrameReader(&mut socket);
-                            let first = frame.u32()? as GlobalRank;
-                            let count = frame.u32()? as usize;
-                            let slabs = frame.u32()? as usize;
-                            ensure!(count <= 1024, "whale hub: hello claims {count} ranks");
-                            Ok(Hello {
-                                first,
-                                count,
-                                slabs,
-                            })
-                        }) {
-                            Ok(hello) => hello,
-                            Err(error) => {
-                                log::warn!("K3 whale hub: rejected connection: {error:#}");
-                                continue;
-                            }
-                        };
-                        if let Err(error) = serve_slab_exchange(&mut socket, &hello, board.as_ref())
-                        {
-                            log::warn!(
-                                "K3 whale hub: slab exchange with ranks {}..{} failed: {error:#}",
-                                hello.first,
-                                hello.first + hello.count
-                            );
-                            continue;
-                        }
-                        let Ok(writer) = socket.try_clone() else {
-                            continue;
-                        };
-                        // The sequencer thread writes commits through this
-                        // handle while holding the peer table; a wedged peer
-                        // must fail the hub, not park the sequencer forever.
-                        let _ = writer.set_write_timeout(Some(WHALE_IO_TIMEOUT));
-                        peers.lock().expect("whale peers poisoned").push((
-                            hello.first,
-                            hello.count,
-                            writer,
-                        ));
+                        let peers = peers.clone();
+                        let board = board.clone();
                         let inbound = inbound_tx.clone();
                         let failed = failed.clone();
                         std::thread::Builder::new()
-                            .name("k3-whale-read".into())
+                            .name("k3-whale-conn".into())
                             .spawn(move || {
+                                let hello = match read_header(&mut socket).and_then(|kind| {
+                                    ensure!(
+                                        kind == KIND_HELLO,
+                                        "whale hub: first frame kind {kind}"
+                                    );
+                                    let mut frame = FrameReader(&mut socket);
+                                    let first = frame.u32()? as GlobalRank;
+                                    let count = frame.u32()? as usize;
+                                    let slabs = frame.u32()? as usize;
+                                    ensure!(count <= 1024, "whale hub: hello claims {count} ranks");
+                                    Ok(Hello {
+                                        first,
+                                        count,
+                                        slabs,
+                                    })
+                                }) {
+                                    Ok(hello) => hello,
+                                    Err(error) => {
+                                        log::warn!("K3 whale hub: rejected connection: {error:#}");
+                                        return;
+                                    }
+                                };
+                                if let Err(error) =
+                                    serve_slab_exchange(&mut socket, &hello, board.as_ref())
+                                {
+                                    log::warn!(
+                                        "K3 whale hub: slab exchange with ranks {}..{} failed: \
+                                         {error:#}",
+                                        hello.first,
+                                        hello.first + hello.count
+                                    );
+                                    return;
+                                }
+                                let Ok(writer) = socket.try_clone() else {
+                                    return;
+                                };
+                                // The sequencer thread writes commits through
+                                // this handle while holding the peer table; a
+                                // wedged peer must fail the hub, not park the
+                                // sequencer forever.
+                                let _ = writer.set_write_timeout(Some(WHALE_IO_TIMEOUT));
+                                peers.lock().expect("whale peers poisoned").push((
+                                    hello.first,
+                                    hello.count,
+                                    writer,
+                                ));
                                 loop {
                                     let message = read_header(&mut socket)
                                         .and_then(|kind| read_to_sequencer(&mut socket, kind));
@@ -650,7 +661,7 @@ impl TcpWhaleHub {
                                     }
                                 }
                             })
-                            .expect("spawn whale reader");
+                            .expect("spawn whale connection");
                     }
                 })
                 .expect("spawn whale acceptor");
@@ -1040,6 +1051,49 @@ mod tests {
             assert_eq!(host_slab.handle, [rank as u8; K3_MEGA_FABRIC_HANDLE_BYTES]);
             assert_eq!(host_slab.handle, peer_slab.handle);
             assert_eq!(host_slab.num_bytes, peer_slab.num_bytes);
+        }
+    }
+
+    #[test]
+    fn slab_exchange_completes_with_more_than_one_peer_process() {
+        fn slab(seed: u8) -> K3WhaleSlabWire {
+            K3WhaleSlabWire {
+                handle: [seed; K3_MEGA_FABRIC_HANDLE_BYTES],
+                num_bytes: 4096 + seed as usize,
+            }
+        }
+        // Regression: with a serial acceptor the first accepted peer's
+        // exchange blocked in `wait_complete` until the whole world checked
+        // in, so the second peer was never accepted — a startup deadlock at
+        // any world with more than one peer process (worked at two processes,
+        // wedged the CP16 4-tray fleet). Three processes here: host ranks
+        // 0..2, peers 2..4 and 4..6.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        drop(listener);
+        let peers: Vec<_> = [2usize, 4]
+            .into_iter()
+            .map(|first| {
+                let addr = addr.clone();
+                std::thread::spawn(move || {
+                    let slabs = vec![slab(first as u8), slab(first as u8 + 1)];
+                    TcpWhaleHub::connect(&addr, first, 2, slabs).unwrap()
+                })
+            })
+            .collect();
+        let (_host, host_table) =
+            TcpWhaleHub::host(&addr, 6, CHUNK, 0, 2, vec![slab(0), slab(1)]).unwrap();
+        let mut tables = vec![host_table];
+        for peer in peers {
+            let (_peer, table) = peer.join().expect("peer joins the exchange");
+            tables.push(table);
+        }
+        for table in &tables {
+            assert_eq!(table.len(), 6);
+            for (rank, entry) in table.iter().enumerate() {
+                assert_eq!(entry.handle, [rank as u8; K3_MEGA_FABRIC_HANDLE_BYTES]);
+                assert_eq!(entry.num_bytes, 4096 + rank);
+            }
         }
     }
 }

--- a/pegainfer-k3/src/scheduler/whale_hub.rs
+++ b/pegainfer-k3/src/scheduler/whale_hub.rs
@@ -1,0 +1,737 @@
+//! Transports for the whale rendezvous ([`super::whale`]): the pure state
+//! machines exchange [`WhaleToSequencer`]/[`WhaleToMember`] values; a hub
+//! moves them between processes and holds the sequencer.
+//!
+//! * [`LocalWhaleHub`] — one process hosts the whole world: the sequencer
+//!   lives behind a mutex and outbound messages land straight in per-rank
+//!   mailboxes. This is the in-process degenerate case of the fleet protocol,
+//!   and what the protocol tests and the fuzzer drive.
+//! * [`TcpWhaleHub`] — the fleet: the process hosting global rank 0 runs the
+//!   sequencer and listens; every other process keeps one connection open
+//!   (the same lifetime as the EP bootstrap link, `executor/ep.rs`) and
+//!   routes its local ranks' traffic over it. Messages are hand-framed
+//!   little-endian, magic-tagged, and versioned, like the EP bootstrap —
+//!   whales are sparse and small (a 256k-token prompt is 1 MiB), so there is
+//!   nothing here worth a serialization dependency.
+//!
+//! Either hub presents the same two calls to the scheduler: `send` a message
+//! toward the sequencer, `drain` this rank's pending messages at a launch
+//! boundary. Both are non-blocking — the free-running loop never waits on
+//! the rendezvous, it only checks in as it passes.
+
+use std::collections::VecDeque;
+use std::io::Read;
+use std::io::Write;
+use std::net::TcpListener;
+use std::net::TcpStream;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::mpsc;
+use std::time::Duration;
+
+use anyhow::Context as _;
+use anyhow::Result;
+use anyhow::bail;
+use anyhow::ensure;
+
+use super::whale::GlobalRank;
+use super::whale::WhaleDescriptor;
+use super::whale::WhaleOutbound;
+use super::whale::WhaleSeq;
+use super::whale::WhaleSequencer;
+use super::whale::WhaleToMember;
+use super::whale::WhaleToSequencer;
+
+/// `"K3WH"`: a stray connection to the wrong port dies loudly.
+const WHALE_MAGIC: u32 = u32::from_le_bytes(*b"K3WH");
+const WHALE_VERSION: u32 = 1;
+/// A gathering whale whose member never replies is cancelled after this and
+/// the poster falls back to a local prefill. A genuinely dead member kills
+/// the fleet through the collective's own deadline; this bound only keeps
+/// the whale queue from wedging behind a slow joiner.
+const WHALE_GATHER_DEADLINE: Duration = Duration::from_secs(30);
+const WHALE_IO_TIMEOUT: Duration = Duration::from_secs(30);
+const WHALE_CONNECT_RETRY: Duration = Duration::from_secs(2);
+/// The sequencer process binds after its (possibly enormous) weight load;
+/// peers retry for a window that survives it, exactly like the EP bootstrap.
+const WHALE_CONNECT_TIMEOUT: Duration = Duration::from_secs(3600);
+/// A prompt is at most the serving ceiling; anything claiming more than this
+/// many tokens is a framing bug, not a request.
+const WHALE_MAX_PROMPT_TOKENS: u32 = 1 << 22;
+
+/// Per-rank inbox of sequencer messages, drained at launch boundaries.
+type Mailboxes = Arc<Mutex<Vec<VecDeque<WhaleToMember>>>>;
+
+fn deliver_local(mailboxes: &Mailboxes, first_local: GlobalRank, outbound: &WhaleOutbound) -> bool {
+    let mut boxes = mailboxes.lock().expect("whale mailboxes poisoned");
+    let Some(slot) = outbound.to.checked_sub(first_local) else {
+        return false;
+    };
+    let Some(inbox) = boxes.get_mut(slot) else {
+        return false;
+    };
+    inbox.push_back(outbound.message.clone());
+    true
+}
+
+// ---------------------------------------------------------------------------
+// Local hub
+// ---------------------------------------------------------------------------
+
+/// The whole world in one process: `send` feeds the sequencer directly and
+/// its outbound lands in the mailboxes before the call returns.
+pub struct LocalWhaleHub {
+    sequencer: Mutex<WhaleSequencer>,
+    mailboxes: Mailboxes,
+}
+
+impl LocalWhaleHub {
+    pub fn new(world: usize, chunk_tokens: usize) -> Arc<Self> {
+        Arc::new(Self {
+            sequencer: Mutex::new(WhaleSequencer::new(world, chunk_tokens)),
+            mailboxes: Arc::new(Mutex::new(vec![VecDeque::new(); world])),
+        })
+    }
+
+    pub fn send(&self, message: WhaleToSequencer) -> Result<()> {
+        let outbound = self
+            .sequencer
+            .lock()
+            .expect("whale sequencer poisoned")
+            .on_message(message)?;
+        for out in outbound {
+            ensure!(
+                deliver_local(&self.mailboxes, 0, &out),
+                "whale sequencer addressed rank {} outside the local world",
+                out.to
+            );
+        }
+        Ok(())
+    }
+
+    pub fn drain(&self, rank: GlobalRank) -> Vec<WhaleToMember> {
+        let mut boxes = self.mailboxes.lock().expect("whale mailboxes poisoned");
+        boxes
+            .get_mut(rank)
+            .map(|inbox| inbox.drain(..).collect())
+            .unwrap_or_default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wire format
+// ---------------------------------------------------------------------------
+
+struct FrameWriter<'a, W: Write>(&'a mut W);
+
+impl<W: Write> FrameWriter<'_, W> {
+    fn u32(&mut self, value: u32) -> Result<()> {
+        self.0
+            .write_all(&value.to_le_bytes())
+            .context("whale frame write")
+    }
+
+    fn u64(&mut self, value: u64) -> Result<()> {
+        self.0
+            .write_all(&value.to_le_bytes())
+            .context("whale frame write")
+    }
+
+    fn tokens(&mut self, tokens: &[u32]) -> Result<()> {
+        self.u32(u32::try_from(tokens.len()).context("whale prompt length")?)?;
+        // One pass over a re-encoded buffer beats one syscall per token for
+        // megabyte prompts.
+        let mut bytes = Vec::with_capacity(tokens.len() * 4);
+        for &token in tokens {
+            bytes.extend_from_slice(&token.to_le_bytes());
+        }
+        self.0.write_all(&bytes).context("whale frame write")
+    }
+}
+
+struct FrameReader<'a, R: Read>(&'a mut R);
+
+impl<R: Read> FrameReader<'_, R> {
+    fn u32(&mut self) -> Result<u32> {
+        let mut buf = [0u8; 4];
+        self.0.read_exact(&mut buf).context("whale frame read")?;
+        Ok(u32::from_le_bytes(buf))
+    }
+
+    fn u64(&mut self) -> Result<u64> {
+        let mut buf = [0u8; 8];
+        self.0.read_exact(&mut buf).context("whale frame read")?;
+        Ok(u64::from_le_bytes(buf))
+    }
+
+    fn tokens(&mut self) -> Result<Arc<[u32]>> {
+        let len = self.u32()?;
+        ensure!(
+            len <= WHALE_MAX_PROMPT_TOKENS,
+            "whale frame claims {len} prompt tokens — framing bug"
+        );
+        let mut bytes = vec![0u8; len as usize * 4];
+        self.0.read_exact(&mut bytes).context("whale frame read")?;
+        Ok(bytes
+            .chunks_exact(4)
+            .map(|chunk| u32::from_le_bytes(chunk.try_into().expect("chunks_exact(4)")))
+            .collect())
+    }
+}
+
+const KIND_HELLO: u32 = 0;
+const KIND_REQUEST: u32 = 1;
+const KIND_READY: u32 = 2;
+const KIND_GATHER: u32 = 3;
+const KIND_COMMIT: u32 = 4;
+const KIND_CANCEL: u32 = 5;
+
+fn write_header(writer: &mut impl Write, kind: u32) -> Result<()> {
+    let mut frame = FrameWriter(writer);
+    frame.u32(WHALE_MAGIC)?;
+    frame.u32(WHALE_VERSION)?;
+    frame.u32(kind)
+}
+
+fn read_header(reader: &mut impl Read) -> Result<u32> {
+    let mut frame = FrameReader(reader);
+    let magic = frame.u32()?;
+    ensure!(magic == WHALE_MAGIC, "whale link: bad magic {magic:#x}");
+    let version = frame.u32()?;
+    ensure!(
+        version == WHALE_VERSION,
+        "whale link: version {version}, expected {WHALE_VERSION}"
+    );
+    frame.u32()
+}
+
+fn write_to_sequencer(writer: &mut impl Write, message: &WhaleToSequencer) -> Result<()> {
+    match message {
+        WhaleToSequencer::Request {
+            request,
+            poster,
+            prompt,
+        } => {
+            write_header(writer, KIND_REQUEST)?;
+            let mut frame = FrameWriter(writer);
+            frame.u64(*request)?;
+            frame.u32(u32::try_from(*poster).context("whale poster rank")?)?;
+            frame.tokens(prompt)?;
+        }
+        WhaleToSequencer::Ready { seq, rank, count } => {
+            write_header(writer, KIND_READY)?;
+            let mut frame = FrameWriter(writer);
+            frame.u64(*seq)?;
+            frame.u32(u32::try_from(*rank).context("whale ready rank")?)?;
+            frame.u64(*count)?;
+        }
+    }
+    writer.flush().context("whale link flush")
+}
+
+fn read_to_sequencer(reader: &mut impl Read, kind: u32) -> Result<WhaleToSequencer> {
+    let mut frame = FrameReader(reader);
+    match kind {
+        KIND_REQUEST => {
+            let request = frame.u64()?;
+            let poster = frame.u32()? as GlobalRank;
+            let prompt = frame.tokens()?;
+            Ok(WhaleToSequencer::Request {
+                request,
+                poster,
+                prompt,
+            })
+        }
+        KIND_READY => {
+            let seq = frame.u64()?;
+            let rank = frame.u32()? as GlobalRank;
+            let count = frame.u64()?;
+            Ok(WhaleToSequencer::Ready { seq, rank, count })
+        }
+        other => bail!("whale link: kind {other} is not a sequencer-bound message"),
+    }
+}
+
+fn write_to_member(writer: &mut impl Write, to: GlobalRank, message: &WhaleToMember) -> Result<()> {
+    match message {
+        WhaleToMember::Gather { descriptor } => {
+            write_header(writer, KIND_GATHER)?;
+            let mut frame = FrameWriter(writer);
+            frame.u32(u32::try_from(to).context("whale member rank")?)?;
+            frame.u64(descriptor.seq)?;
+            frame.u64(descriptor.request)?;
+            frame.u32(u32::try_from(descriptor.poster).context("whale poster rank")?)?;
+            frame.u32(u32::try_from(descriptor.gang.len()).context("whale gang size")?)?;
+            for &member in descriptor.gang.iter() {
+                frame.u32(u32::try_from(member).context("whale gang rank")?)?;
+            }
+            frame.u64(descriptor.prompt_hash)?;
+            frame.tokens(&descriptor.prompt)?;
+        }
+        WhaleToMember::Commit { seq, launch } => {
+            write_header(writer, KIND_COMMIT)?;
+            let mut frame = FrameWriter(writer);
+            frame.u32(u32::try_from(to).context("whale member rank")?)?;
+            frame.u64(*seq)?;
+            frame.u64(*launch)?;
+        }
+        WhaleToMember::Cancel { seq } => {
+            write_header(writer, KIND_CANCEL)?;
+            let mut frame = FrameWriter(writer);
+            frame.u32(u32::try_from(to).context("whale member rank")?)?;
+            frame.u64(*seq)?;
+        }
+    }
+    writer.flush().context("whale link flush")
+}
+
+fn read_to_member(reader: &mut impl Read, kind: u32) -> Result<(GlobalRank, WhaleToMember)> {
+    let mut frame = FrameReader(reader);
+    let to = frame.u32()? as GlobalRank;
+    let message = match kind {
+        KIND_GATHER => {
+            let seq = frame.u64()?;
+            let request = frame.u64()?;
+            let poster = frame.u32()? as GlobalRank;
+            let gang_len = frame.u32()?;
+            ensure!(gang_len <= 1024, "whale link: gang of {gang_len} ranks");
+            let gang: Arc<[GlobalRank]> = (0..gang_len)
+                .map(|_| frame.u32().map(|rank| rank as GlobalRank))
+                .collect::<Result<_>>()?;
+            let prompt_hash = frame.u64()?;
+            let prompt = frame.tokens()?;
+            let descriptor = WhaleDescriptor {
+                seq,
+                request,
+                poster,
+                gang,
+                prompt,
+                prompt_hash,
+            };
+            descriptor.verify()?;
+            WhaleToMember::Gather { descriptor }
+        }
+        KIND_COMMIT => {
+            let seq = frame.u64()?;
+            let launch = frame.u64()?;
+            WhaleToMember::Commit { seq, launch }
+        }
+        KIND_CANCEL => WhaleToMember::Cancel { seq: frame.u64()? },
+        other => bail!("whale link: kind {other} is not a member-bound message"),
+    };
+    Ok((to, message))
+}
+
+// ---------------------------------------------------------------------------
+// TCP hub
+// ---------------------------------------------------------------------------
+
+/// What one peer process announces on connect: the global ranks it hosts.
+struct Hello {
+    first: GlobalRank,
+    count: usize,
+}
+
+fn write_hello(writer: &mut impl Write, hello: &Hello) -> Result<()> {
+    write_header(writer, KIND_HELLO)?;
+    let mut frame = FrameWriter(writer);
+    frame.u32(u32::try_from(hello.first).context("whale hello rank")?)?;
+    frame.u32(u32::try_from(hello.count).context("whale hello count")?)?;
+    writer.flush().context("whale link flush")
+}
+
+/// The fleet transport. Construct with [`TcpWhaleHub::host`] on the process
+/// hosting global rank 0 (it runs the sequencer) or [`TcpWhaleHub::connect`]
+/// everywhere else. Both sides serve `send`/`drain` for their local ranks;
+/// the reader/sequencer threads live for the hub's lifetime, like the engine
+/// threads they serve — a dead link is engine-fatal, reported at the next
+/// `send`.
+pub struct TcpWhaleHub {
+    first_local: GlobalRank,
+    /// The bound listener address (host side only) — lets a hub bound to
+    /// port 0 tell its peers where to connect.
+    addr: Option<std::net::SocketAddr>,
+    mailboxes: Mailboxes,
+    /// Where this process's `send` goes: straight into the sequencer channel
+    /// (host) or up the socket (peer).
+    outbound: HubRole,
+    /// The first error any background thread hit; `send` reports it.
+    failed: Arc<Mutex<Option<String>>>,
+}
+
+enum HubRole {
+    Host {
+        inbound: mpsc::Sender<WhaleToSequencer>,
+    },
+    Peer {
+        link: Mutex<TcpStream>,
+    },
+}
+
+impl TcpWhaleHub {
+    /// Host the sequencer for a `world`-rank fleet, serving `local` ranks
+    /// `first_local..first_local + local` from this process. Binds `addr` and
+    /// accepts peer processes for the hub's whole lifetime.
+    pub fn host(
+        addr: &str,
+        world: usize,
+        chunk_tokens: usize,
+        first_local: GlobalRank,
+        local: usize,
+    ) -> Result<Arc<Self>> {
+        let listener =
+            TcpListener::bind(addr).with_context(|| format!("whale hub: bind {addr}"))?;
+        let bound = listener.local_addr().ok();
+        let mailboxes: Mailboxes = Arc::new(Mutex::new(vec![VecDeque::new(); local]));
+        let failed: Arc<Mutex<Option<String>>> = Arc::default();
+        let (inbound_tx, inbound_rx) = mpsc::channel::<WhaleToSequencer>();
+        // Peer connections register their writer half here, keyed by the rank
+        // range from their hello.
+        type PeerLinks = Arc<Mutex<Vec<(GlobalRank, usize, TcpStream)>>>;
+        let peers: PeerLinks = Arc::default();
+
+        let hub = Arc::new(Self {
+            first_local,
+            addr: bound,
+            mailboxes: mailboxes.clone(),
+            outbound: HubRole::Host {
+                inbound: inbound_tx.clone(),
+            },
+            failed: failed.clone(),
+        });
+
+        // Acceptor: one reader thread per peer process, forwarding its
+        // sequencer-bound frames into the channel.
+        {
+            let peers = peers.clone();
+            let failed = failed.clone();
+            std::thread::Builder::new()
+                .name("k3-whale-accept".into())
+                .spawn(move || {
+                    for connection in listener.incoming() {
+                        let Ok(mut socket) = connection else { continue };
+                        let _ = socket.set_nodelay(true);
+                        let hello = match read_header(&mut socket).and_then(|kind| {
+                            ensure!(kind == KIND_HELLO, "whale hub: first frame kind {kind}");
+                            let mut frame = FrameReader(&mut socket);
+                            let first = frame.u32()? as GlobalRank;
+                            let count = frame.u32()? as usize;
+                            ensure!(count <= 1024, "whale hub: hello claims {count} ranks");
+                            Ok(Hello { first, count })
+                        }) {
+                            Ok(hello) => hello,
+                            Err(error) => {
+                                log::warn!("K3 whale hub: rejected connection: {error:#}");
+                                continue;
+                            }
+                        };
+                        let Ok(writer) = socket.try_clone() else {
+                            continue;
+                        };
+                        // The sequencer thread writes commits through this
+                        // handle while holding the peer table; a wedged peer
+                        // must fail the hub, not park the sequencer forever.
+                        let _ = writer.set_write_timeout(Some(WHALE_IO_TIMEOUT));
+                        peers.lock().expect("whale peers poisoned").push((
+                            hello.first,
+                            hello.count,
+                            writer,
+                        ));
+                        let inbound = inbound_tx.clone();
+                        let failed = failed.clone();
+                        std::thread::Builder::new()
+                            .name("k3-whale-read".into())
+                            .spawn(move || {
+                                loop {
+                                    let message = read_header(&mut socket)
+                                        .and_then(|kind| read_to_sequencer(&mut socket, kind));
+                                    match message {
+                                        Ok(message) => {
+                                            if inbound.send(message).is_err() {
+                                                return;
+                                            }
+                                        }
+                                        Err(error) => {
+                                            fail(&failed, format!("peer link died: {error:#}"));
+                                            return;
+                                        }
+                                    }
+                                }
+                            })
+                            .expect("spawn whale reader");
+                    }
+                })
+                .expect("spawn whale acceptor");
+        }
+
+        // Sequencer: consumes the inbound channel, routes outbound locally or
+        // to the owning peer link. The recv timeout doubles as the gather
+        // deadline tick.
+        {
+            let mailboxes = mailboxes.clone();
+            let failed = failed.clone();
+            std::thread::Builder::new()
+                .name("k3-whale-seq".into())
+                .spawn(move || {
+                    let mut sequencer = WhaleSequencer::new(world, chunk_tokens);
+                    let mut gathering: Option<(WhaleSeq, std::time::Instant)> = None;
+                    loop {
+                        let step = match inbound_rx.recv_timeout(WHALE_GATHER_DEADLINE / 4) {
+                            Ok(message) => sequencer.on_message(message),
+                            Err(mpsc::RecvTimeoutError::Timeout) => {
+                                if gathering.is_some_and(|(_, start)| {
+                                    start.elapsed() > WHALE_GATHER_DEADLINE
+                                }) {
+                                    sequencer.on_gather_timeout()
+                                } else {
+                                    continue;
+                                }
+                            }
+                            Err(mpsc::RecvTimeoutError::Disconnected) => return,
+                        };
+                        let outbound = match step {
+                            Ok(outbound) => outbound,
+                            Err(error) => {
+                                fail(&failed, format!("sequencer refused a message: {error:#}"));
+                                return;
+                            }
+                        };
+                        // The deadline clock belongs to one seq: a commit can
+                        // pump the next gather within the same transition, and
+                        // the new whale deserves a fresh window.
+                        gathering = sequencer.gathering_seq().map(|seq| match gathering {
+                            Some((previous, start)) if previous == seq => (seq, start),
+                            _ => (seq, std::time::Instant::now()),
+                        });
+                        for out in outbound {
+                            if deliver_local(&mailboxes, first_local, &out) {
+                                continue;
+                            }
+                            let mut links = peers.lock().expect("whale peers poisoned");
+                            let Some((_, _, writer)) =
+                                links.iter_mut().find(|(first, count, _)| {
+                                    (*first..*first + *count).contains(&out.to)
+                                })
+                            else {
+                                fail(
+                                    &failed,
+                                    format!("no link hosts whale member rank {}", out.to),
+                                );
+                                return;
+                            };
+                            if let Err(error) = write_to_member(writer, out.to, &out.message) {
+                                fail(&failed, format!("peer write failed: {error:#}"));
+                                return;
+                            }
+                        }
+                    }
+                })
+                .expect("spawn whale sequencer");
+        }
+        Ok(hub)
+    }
+
+    /// Join the fleet's whale hub as the process serving `local` ranks
+    /// `first_local..`, connecting to the sequencer at `addr` (retrying
+    /// through its weight load, like the EP bootstrap).
+    pub fn connect(addr: &str, first_local: GlobalRank, local: usize) -> Result<Arc<Self>> {
+        let deadline = std::time::Instant::now() + WHALE_CONNECT_TIMEOUT;
+        let mut socket = loop {
+            match TcpStream::connect(addr) {
+                Ok(socket) => break socket,
+                Err(error) => {
+                    ensure!(
+                        std::time::Instant::now() < deadline,
+                        "whale hub: could not reach the sequencer at {addr}: {error}"
+                    );
+                    std::thread::sleep(WHALE_CONNECT_RETRY);
+                }
+            }
+        };
+        socket.set_nodelay(true).ok();
+        socket
+            .set_write_timeout(Some(WHALE_IO_TIMEOUT))
+            .context("whale hub: set write timeout")?;
+        write_hello(
+            &mut socket,
+            &Hello {
+                first: first_local,
+                count: local,
+            },
+        )?;
+        let mailboxes: Mailboxes = Arc::new(Mutex::new(vec![VecDeque::new(); local]));
+        let failed: Arc<Mutex<Option<String>>> = Arc::default();
+        let reader_boxes = mailboxes.clone();
+        let reader_failed = failed.clone();
+        let mut reader = socket.try_clone().context("whale hub: clone socket")?;
+        std::thread::Builder::new()
+            .name("k3-whale-read".into())
+            .spawn(move || {
+                loop {
+                    let message =
+                        read_header(&mut reader).and_then(|kind| read_to_member(&mut reader, kind));
+                    match message {
+                        Ok((to, message)) => {
+                            let out = WhaleOutbound { to, message };
+                            if !deliver_local(&reader_boxes, first_local, &out) {
+                                fail(
+                                    &reader_failed,
+                                    format!("sequencer addressed rank {to}, not hosted here"),
+                                );
+                                return;
+                            }
+                        }
+                        Err(error) => {
+                            fail(&reader_failed, format!("sequencer link died: {error:#}"));
+                            return;
+                        }
+                    }
+                }
+            })
+            .expect("spawn whale reader");
+        Ok(Arc::new(Self {
+            first_local,
+            addr: None,
+            mailboxes,
+            outbound: HubRole::Peer {
+                link: Mutex::new(socket),
+            },
+            failed,
+        }))
+    }
+
+    /// The listener address (host side only; `None` on a peer). A host bound
+    /// to port 0 reads its actual port here.
+    pub fn local_addr(&self) -> Option<std::net::SocketAddr> {
+        self.addr
+    }
+
+    pub fn send(&self, message: WhaleToSequencer) -> Result<()> {
+        if let Some(reason) = self
+            .failed
+            .lock()
+            .expect("whale hub failure poisoned")
+            .clone()
+        {
+            bail!("whale hub failed: {reason}");
+        }
+        match &self.outbound {
+            HubRole::Host { inbound } => inbound
+                .send(message)
+                .map_err(|_| anyhow::anyhow!("whale sequencer thread is gone")),
+            HubRole::Peer { link } => {
+                let mut socket = link.lock().expect("whale link poisoned");
+                write_to_sequencer(&mut *socket, &message)
+            }
+        }
+    }
+
+    pub fn drain(&self, rank: GlobalRank) -> Vec<WhaleToMember> {
+        let mut boxes = self.mailboxes.lock().expect("whale mailboxes poisoned");
+        rank.checked_sub(self.first_local)
+            .and_then(|slot| boxes.get_mut(slot))
+            .map(|inbox| inbox.drain(..).collect())
+            .unwrap_or_default()
+    }
+}
+
+fn fail(failed: &Arc<Mutex<Option<String>>>, reason: String) {
+    let mut slot = failed.lock().expect("whale hub failure poisoned");
+    if slot.is_none() {
+        log::error!("K3 whale hub: {reason}");
+        *slot = Some(reason);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::whale::WhaleDuty;
+    use super::super::whale::WhaleMember;
+    use super::*;
+
+    const CHUNK: usize = 16896;
+
+    fn prompt_of(total: usize) -> Arc<[u32]> {
+        (0..total as u32).collect()
+    }
+
+    #[test]
+    fn local_hub_runs_a_whale_end_to_end() {
+        let hub = LocalWhaleHub::new(4, CHUNK);
+        hub.send(WhaleToSequencer::Request {
+            request: 1,
+            poster: 3,
+            prompt: prompt_of(12288),
+        })
+        .unwrap();
+        let mut members: Vec<WhaleMember> = (0..4).map(WhaleMember::new).collect();
+        // The local hub is synchronous: gathers already sit in the mailboxes.
+        for rank in 0..4 {
+            for message in hub.drain(rank) {
+                if let Some(reply) = members[rank].on_message(message, 7).unwrap() {
+                    hub.send(reply).unwrap();
+                }
+            }
+        }
+        // ...and so do the commits after the last ready.
+        let mut launches = Vec::new();
+        for (rank, member) in members.iter_mut().enumerate() {
+            for message in hub.drain(rank) {
+                member.on_message(message, 8).unwrap();
+            }
+            let launch = (8..64)
+                .find(|&count| matches!(member.at_launch(count).unwrap(), WhaleDuty::Enter(_)))
+                .expect("member never entered");
+            launches.push(launch);
+        }
+        assert!(
+            launches.iter().all(|&launch| launch == launches[0]),
+            "{launches:?}"
+        );
+    }
+
+    #[test]
+    fn tcp_hub_commits_across_a_loopback_peer() {
+        // Host process serves ranks 0..2 and the sequencer; the peer process
+        // serves ranks 2..4 and posts the whale. One simulated launch period
+        // per loop pass keeps the loopback latency far below it, which is the
+        // commit slack's stated assumption.
+        let host = TcpWhaleHub::host("127.0.0.1:0", 4, CHUNK, 0, 2).unwrap();
+        let addr = host.local_addr().expect("host knows its port").to_string();
+        let peer = TcpWhaleHub::connect(&addr, 2, 2).unwrap();
+        peer.send(WhaleToSequencer::Request {
+            request: 5,
+            poster: 2,
+            prompt: prompt_of(12288),
+        })
+        .unwrap();
+        let hubs: [&Arc<TcpWhaleHub>; 4] = [&host, &host, &peer, &peer];
+        let mut members: Vec<WhaleMember> = (0..4).map(WhaleMember::new).collect();
+        let mut launches: [Option<u64>; 4] = [None; 4];
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        let mut count = 0u64;
+        while launches.iter().any(Option::is_none) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the whale never committed over the loopback: {launches:?}"
+            );
+            for rank in 0..4 {
+                for message in hubs[rank].drain(rank) {
+                    if let Some(reply) = members[rank].on_message(message, count).unwrap() {
+                        hubs[rank].send(reply).unwrap();
+                    }
+                }
+                if let WhaleDuty::Enter(whale) = members[rank].at_launch(count).unwrap() {
+                    assert_eq!(whale.descriptor.cp_rank_of(rank), Some(whale.cp_rank));
+                    launches[rank] = Some(count);
+                }
+            }
+            count += 1;
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        assert!(
+            launches.iter().all(|&launch| launch == launches[0]),
+            "{launches:?}"
+        );
+    }
+}

--- a/pegainfer-k3/src/scheduler/whale_hub.rs
+++ b/pegainfer-k3/src/scheduler/whale_hub.rs
@@ -5,7 +5,7 @@
 //! * [`LocalWhaleHub`] — one process hosts the whole world: the sequencer
 //!   lives behind a mutex and outbound messages land straight in per-rank
 //!   mailboxes. This is the in-process degenerate case of the fleet protocol,
-//!   and what the protocol tests and the fuzzer drive.
+//!   and what the scheduler's mock-fleet tests drive.
 //! * [`TcpWhaleHub`] — the fleet: the process hosting global rank 0 runs the
 //!   sequencer and listens; every other process keeps one connection open
 //!   (the same lifetime as the EP bootstrap link, `executor/ep.rs`) and
@@ -16,8 +16,9 @@
 //!
 //! Either hub presents the same two calls to the scheduler: `send` a message
 //! toward the sequencer, `drain` this rank's pending messages at a launch
-//! boundary. Both are non-blocking — the free-running loop never waits on
-//! the rendezvous, it only checks in as it passes.
+//! boundary. Neither waits on another rank's progress: `drain` empties a
+//! local mailbox and a host's `send` is a channel put; a peer's `send`
+//! writes the frame inline, bounded by the write timeout, not by a peer.
 
 use std::collections::VecDeque;
 use std::io::Read;
@@ -53,7 +54,9 @@ const WHALE_VERSION: u32 = 1;
 /// the fleet through the collective's own deadline; this bound only keeps
 /// the whale queue from wedging behind a slow joiner.
 const WHALE_GATHER_DEADLINE: Duration = Duration::from_secs(30);
-const WHALE_IO_TIMEOUT: Duration = Duration::from_secs(30);
+/// Socket writes only; reads are unbounded (a link is engine-lifetime) except
+/// the one startup table read, which waits on the whole fleet's load.
+const WHALE_WRITE_TIMEOUT: Duration = Duration::from_secs(30);
 const WHALE_CONNECT_RETRY: Duration = Duration::from_secs(2);
 /// The sequencer process binds after its (possibly enormous) weight load;
 /// peers retry for a window that survives it, exactly like the EP bootstrap.
@@ -61,6 +64,8 @@ const WHALE_CONNECT_TIMEOUT: Duration = Duration::from_secs(3600);
 /// A prompt is at most the serving ceiling; anything claiming more than this
 /// many tokens is a framing bug, not a request.
 const WHALE_MAX_PROMPT_TOKENS: u32 = 1 << 22;
+/// No fleet is bigger than this; larger counts in a frame are framing bugs.
+const WHALE_MAX_WORLD: usize = 1024;
 
 /// Per-rank inbox of sequencer messages, drained at launch boundaries.
 type Mailboxes = Arc<Mutex<Vec<VecDeque<WhaleToMember>>>>;
@@ -75,6 +80,18 @@ fn deliver_local(mailboxes: &Mailboxes, first_local: GlobalRank, outbound: &Whal
     };
     inbox.push_back(outbound.message.clone());
     true
+}
+
+fn drain_mailbox(
+    mailboxes: &Mailboxes,
+    first_local: GlobalRank,
+    rank: GlobalRank,
+) -> Vec<WhaleToMember> {
+    let mut boxes = mailboxes.lock().expect("whale mailboxes poisoned");
+    rank.checked_sub(first_local)
+        .and_then(|slot| boxes.get_mut(slot))
+        .map(|inbox| inbox.drain(..).collect())
+        .unwrap_or_default()
 }
 
 /// The transport a whale serving lane holds, whichever process shape the
@@ -137,21 +154,13 @@ impl LocalWhaleHub {
             .expect("whale sequencer poisoned")
             .on_message(message)?;
         for out in outbound {
-            ensure!(
-                deliver_local(&self.mailboxes, 0, &out),
-                "whale sequencer addressed rank {} outside the local world",
-                out.to
-            );
+            deliver_local(&self.mailboxes, 0, &out);
         }
         Ok(())
     }
 
     pub fn drain(&self, rank: GlobalRank) -> Vec<WhaleToMember> {
-        let mut boxes = self.mailboxes.lock().expect("whale mailboxes poisoned");
-        boxes
-            .get_mut(rank)
-            .map(|inbox| inbox.drain(..).collect())
-            .unwrap_or_default()
+        drain_mailbox(&self.mailboxes, 0, rank)
     }
 }
 
@@ -159,61 +168,62 @@ impl LocalWhaleHub {
 // Wire format
 // ---------------------------------------------------------------------------
 
-struct FrameWriter<'a, W: Write>(&'a mut W);
-
-impl<W: Write> FrameWriter<'_, W> {
-    fn u32(&mut self, value: u32) -> Result<()> {
-        self.0
-            .write_all(&value.to_le_bytes())
-            .context("whale frame write")
-    }
-
-    fn u64(&mut self, value: u64) -> Result<()> {
-        self.0
-            .write_all(&value.to_le_bytes())
-            .context("whale frame write")
-    }
-
-    fn tokens(&mut self, tokens: &[u32]) -> Result<()> {
-        self.u32(u32::try_from(tokens.len()).context("whale prompt length")?)?;
-        // One pass over a re-encoded buffer beats one syscall per token for
-        // megabyte prompts.
-        let mut bytes = Vec::with_capacity(tokens.len() * 4);
-        for &token in tokens {
-            bytes.extend_from_slice(&token.to_le_bytes());
-        }
-        self.0.write_all(&bytes).context("whale frame write")
-    }
+fn put_u32(writer: &mut impl Write, value: u32) -> Result<()> {
+    writer
+        .write_all(&value.to_le_bytes())
+        .context("whale frame write")
 }
 
-struct FrameReader<'a, R: Read>(&'a mut R);
+fn put_u64(writer: &mut impl Write, value: u64) -> Result<()> {
+    writer
+        .write_all(&value.to_le_bytes())
+        .context("whale frame write")
+}
 
-impl<R: Read> FrameReader<'_, R> {
-    fn u32(&mut self) -> Result<u32> {
-        let mut buf = [0u8; 4];
-        self.0.read_exact(&mut buf).context("whale frame read")?;
-        Ok(u32::from_le_bytes(buf))
-    }
+fn put_rank(writer: &mut impl Write, rank: GlobalRank) -> Result<()> {
+    put_u32(writer, u32::try_from(rank).context("whale rank")?)
+}
 
-    fn u64(&mut self) -> Result<u64> {
-        let mut buf = [0u8; 8];
-        self.0.read_exact(&mut buf).context("whale frame read")?;
-        Ok(u64::from_le_bytes(buf))
+fn put_tokens(writer: &mut impl Write, tokens: &[u32]) -> Result<()> {
+    put_u32(
+        writer,
+        u32::try_from(tokens.len()).context("whale prompt length")?,
+    )?;
+    let mut bytes = Vec::with_capacity(tokens.len() * 4);
+    for &token in tokens {
+        bytes.extend_from_slice(&token.to_le_bytes());
     }
+    writer.write_all(&bytes).context("whale frame write")
+}
 
-    fn tokens(&mut self) -> Result<Arc<[u32]>> {
-        let len = self.u32()?;
-        ensure!(
-            len <= WHALE_MAX_PROMPT_TOKENS,
-            "whale frame claims {len} prompt tokens — framing bug"
-        );
-        let mut bytes = vec![0u8; len as usize * 4];
-        self.0.read_exact(&mut bytes).context("whale frame read")?;
-        Ok(bytes
-            .chunks_exact(4)
-            .map(|chunk| u32::from_le_bytes(chunk.try_into().expect("chunks_exact(4)")))
-            .collect())
-    }
+fn get_u32(reader: &mut impl Read) -> Result<u32> {
+    let mut buf = [0u8; 4];
+    reader.read_exact(&mut buf).context("whale frame read")?;
+    Ok(u32::from_le_bytes(buf))
+}
+
+fn get_u64(reader: &mut impl Read) -> Result<u64> {
+    let mut buf = [0u8; 8];
+    reader.read_exact(&mut buf).context("whale frame read")?;
+    Ok(u64::from_le_bytes(buf))
+}
+
+fn get_rank(reader: &mut impl Read) -> Result<GlobalRank> {
+    Ok(get_u32(reader)? as GlobalRank)
+}
+
+fn get_tokens(reader: &mut impl Read) -> Result<Arc<[u32]>> {
+    let len = get_u32(reader)?;
+    ensure!(
+        len <= WHALE_MAX_PROMPT_TOKENS,
+        "whale frame claims {len} prompt tokens — framing bug"
+    );
+    let mut bytes = vec![0u8; len as usize * 4];
+    reader.read_exact(&mut bytes).context("whale frame read")?;
+    Ok(bytes
+        .chunks_exact(4)
+        .map(|chunk| u32::from_le_bytes(chunk.try_into().expect("chunks_exact(4)")))
+        .collect())
 }
 
 const KIND_HELLO: u32 = 0;
@@ -228,22 +238,20 @@ const KIND_SLAB: u32 = 6;
 const KIND_TABLE: u32 = 7;
 
 fn write_header(writer: &mut impl Write, kind: u32) -> Result<()> {
-    let mut frame = FrameWriter(writer);
-    frame.u32(WHALE_MAGIC)?;
-    frame.u32(WHALE_VERSION)?;
-    frame.u32(kind)
+    put_u32(writer, WHALE_MAGIC)?;
+    put_u32(writer, WHALE_VERSION)?;
+    put_u32(writer, kind)
 }
 
 fn read_header(reader: &mut impl Read) -> Result<u32> {
-    let mut frame = FrameReader(reader);
-    let magic = frame.u32()?;
+    let magic = get_u32(reader)?;
     ensure!(magic == WHALE_MAGIC, "whale link: bad magic {magic:#x}");
-    let version = frame.u32()?;
+    let version = get_u32(reader)?;
     ensure!(
         version == WHALE_VERSION,
         "whale link: version {version}, expected {WHALE_VERSION}"
     );
-    frame.u32()
+    get_u32(reader)
 }
 
 fn write_to_sequencer(writer: &mut impl Write, message: &WhaleToSequencer) -> Result<()> {
@@ -254,29 +262,26 @@ fn write_to_sequencer(writer: &mut impl Write, message: &WhaleToSequencer) -> Re
             prompt,
         } => {
             write_header(writer, KIND_REQUEST)?;
-            let mut frame = FrameWriter(writer);
-            frame.u64(*request)?;
-            frame.u32(u32::try_from(*poster).context("whale poster rank")?)?;
-            frame.tokens(prompt)?;
+            put_u64(writer, *request)?;
+            put_rank(writer, *poster)?;
+            put_tokens(writer, prompt)?;
         }
         WhaleToSequencer::Ready { seq, rank, count } => {
             write_header(writer, KIND_READY)?;
-            let mut frame = FrameWriter(writer);
-            frame.u64(*seq)?;
-            frame.u32(u32::try_from(*rank).context("whale ready rank")?)?;
-            frame.u64(*count)?;
+            put_u64(writer, *seq)?;
+            put_rank(writer, *rank)?;
+            put_u64(writer, *count)?;
         }
     }
     writer.flush().context("whale link flush")
 }
 
 fn read_to_sequencer(reader: &mut impl Read, kind: u32) -> Result<WhaleToSequencer> {
-    let mut frame = FrameReader(reader);
     match kind {
         KIND_REQUEST => {
-            let request = frame.u64()?;
-            let poster = frame.u32()? as GlobalRank;
-            let prompt = frame.tokens()?;
+            let request = get_u64(reader)?;
+            let poster = get_rank(reader)?;
+            let prompt = get_tokens(reader)?;
             Ok(WhaleToSequencer::Request {
                 request,
                 poster,
@@ -284,9 +289,9 @@ fn read_to_sequencer(reader: &mut impl Read, kind: u32) -> Result<WhaleToSequenc
             })
         }
         KIND_READY => {
-            let seq = frame.u64()?;
-            let rank = frame.u32()? as GlobalRank;
-            let count = frame.u64()?;
+            let seq = get_u64(reader)?;
+            let rank = get_rank(reader)?;
+            let count = get_u64(reader)?;
             Ok(WhaleToSequencer::Ready { seq, rank, count })
         }
         other => bail!("whale link: kind {other} is not a sequencer-bound message"),
@@ -294,53 +299,54 @@ fn read_to_sequencer(reader: &mut impl Read, kind: u32) -> Result<WhaleToSequenc
 }
 
 fn write_to_member(writer: &mut impl Write, to: GlobalRank, message: &WhaleToMember) -> Result<()> {
+    let kind = match message {
+        WhaleToMember::Gather { .. } => KIND_GATHER,
+        WhaleToMember::Commit { .. } => KIND_COMMIT,
+        WhaleToMember::Cancel { .. } => KIND_CANCEL,
+    };
+    write_header(writer, kind)?;
+    put_rank(writer, to)?;
     match message {
         WhaleToMember::Gather { descriptor } => {
-            write_header(writer, KIND_GATHER)?;
-            let mut frame = FrameWriter(writer);
-            frame.u32(u32::try_from(to).context("whale member rank")?)?;
-            frame.u64(descriptor.seq)?;
-            frame.u64(descriptor.request)?;
-            frame.u32(u32::try_from(descriptor.poster).context("whale poster rank")?)?;
-            frame.u32(u32::try_from(descriptor.gang.len()).context("whale gang size")?)?;
+            put_u64(writer, descriptor.seq)?;
+            put_u64(writer, descriptor.request)?;
+            put_rank(writer, descriptor.poster)?;
+            put_u32(
+                writer,
+                u32::try_from(descriptor.gang.len()).context("whale gang size")?,
+            )?;
             for &member in descriptor.gang.iter() {
-                frame.u32(u32::try_from(member).context("whale gang rank")?)?;
+                put_rank(writer, member)?;
             }
-            frame.u64(descriptor.prompt_hash)?;
-            frame.tokens(&descriptor.prompt)?;
+            put_u64(writer, descriptor.prompt_hash)?;
+            put_tokens(writer, &descriptor.prompt)?;
         }
         WhaleToMember::Commit { seq, launch } => {
-            write_header(writer, KIND_COMMIT)?;
-            let mut frame = FrameWriter(writer);
-            frame.u32(u32::try_from(to).context("whale member rank")?)?;
-            frame.u64(*seq)?;
-            frame.u64(*launch)?;
+            put_u64(writer, *seq)?;
+            put_u64(writer, *launch)?;
         }
-        WhaleToMember::Cancel { seq } => {
-            write_header(writer, KIND_CANCEL)?;
-            let mut frame = FrameWriter(writer);
-            frame.u32(u32::try_from(to).context("whale member rank")?)?;
-            frame.u64(*seq)?;
-        }
+        WhaleToMember::Cancel { seq } => put_u64(writer, *seq)?,
     }
     writer.flush().context("whale link flush")
 }
 
 fn read_to_member(reader: &mut impl Read, kind: u32) -> Result<(GlobalRank, WhaleToMember)> {
-    let mut frame = FrameReader(reader);
-    let to = frame.u32()? as GlobalRank;
+    let to = get_rank(reader)?;
     let message = match kind {
         KIND_GATHER => {
-            let seq = frame.u64()?;
-            let request = frame.u64()?;
-            let poster = frame.u32()? as GlobalRank;
-            let gang_len = frame.u32()?;
-            ensure!(gang_len <= 1024, "whale link: gang of {gang_len} ranks");
+            let seq = get_u64(reader)?;
+            let request = get_u64(reader)?;
+            let poster = get_rank(reader)?;
+            let gang_len = get_u32(reader)? as usize;
+            ensure!(
+                gang_len <= WHALE_MAX_WORLD,
+                "whale link: gang of {gang_len} ranks"
+            );
             let gang: Arc<[GlobalRank]> = (0..gang_len)
-                .map(|_| frame.u32().map(|rank| rank as GlobalRank))
+                .map(|_| get_rank(reader))
                 .collect::<Result<_>>()?;
-            let prompt_hash = frame.u64()?;
-            let prompt = frame.tokens()?;
+            let prompt_hash = get_u64(reader)?;
+            let prompt = get_tokens(reader)?;
             let descriptor = WhaleDescriptor {
                 seq,
                 request,
@@ -353,11 +359,13 @@ fn read_to_member(reader: &mut impl Read, kind: u32) -> Result<(GlobalRank, Whal
             WhaleToMember::Gather { descriptor }
         }
         KIND_COMMIT => {
-            let seq = frame.u64()?;
-            let launch = frame.u64()?;
+            let seq = get_u64(reader)?;
+            let launch = get_u64(reader)?;
             WhaleToMember::Commit { seq, launch }
         }
-        KIND_CANCEL => WhaleToMember::Cancel { seq: frame.u64()? },
+        KIND_CANCEL => WhaleToMember::Cancel {
+            seq: get_u64(reader)?,
+        },
         other => bail!("whale link: kind {other} is not a member-bound message"),
     };
     Ok((to, message))
@@ -369,71 +377,75 @@ fn read_to_member(reader: &mut impl Read, kind: u32) -> Result<(GlobalRank, Whal
 
 /// What one peer process announces on connect: the global ranks it hosts,
 /// and how many slab frames follow (0 = no data-plane exchange, or exactly
-/// `count` — one per hosted rank).
+/// one per hosted rank).
 struct Hello {
-    first: GlobalRank,
-    count: usize,
+    ranks: std::ops::Range<GlobalRank>,
     slabs: usize,
 }
 
 fn write_hello(writer: &mut impl Write, hello: &Hello) -> Result<()> {
     write_header(writer, KIND_HELLO)?;
-    let mut frame = FrameWriter(writer);
-    frame.u32(u32::try_from(hello.first).context("whale hello rank")?)?;
-    frame.u32(u32::try_from(hello.count).context("whale hello count")?)?;
-    frame.u32(u32::try_from(hello.slabs).context("whale hello slabs")?)?;
+    put_rank(writer, hello.ranks.start)?;
+    put_u32(
+        writer,
+        u32::try_from(hello.ranks.len()).context("whale hello count")?,
+    )?;
+    put_u32(
+        writer,
+        u32::try_from(hello.slabs).context("whale hello slabs")?,
+    )?;
     writer.flush().context("whale link flush")
 }
 
-fn write_slab(writer: &mut impl Write, rank: GlobalRank, slab: &K3WhaleSlabWire) -> Result<()> {
-    write_header(writer, KIND_SLAB)?;
-    let mut frame = FrameWriter(writer);
-    frame.u32(u32::try_from(rank).context("whale slab rank")?)?;
-    frame.u64(u64::try_from(slab.num_bytes).context("whale slab size")?)?;
+fn put_slab_body(writer: &mut impl Write, slab: &K3WhaleSlabWire) -> Result<()> {
+    put_u64(
+        writer,
+        u64::try_from(slab.num_bytes).context("whale slab size")?,
+    )?;
     writer
         .write_all(&slab.handle)
-        .context("whale slab handle write")?;
-    writer.flush().context("whale link flush")
+        .context("whale slab handle write")
 }
 
-fn read_slab(reader: &mut impl Read) -> Result<(GlobalRank, K3WhaleSlabWire)> {
-    let mut frame = FrameReader(reader);
-    let rank = frame.u32()? as GlobalRank;
-    let num_bytes = usize::try_from(frame.u64()?).context("whale slab size")?;
+fn get_slab_body(reader: &mut impl Read) -> Result<K3WhaleSlabWire> {
+    let num_bytes = usize::try_from(get_u64(reader)?).context("whale slab size")?;
     let mut handle = [0u8; K3_MEGA_FABRIC_HANDLE_BYTES];
     reader
         .read_exact(&mut handle)
         .context("whale slab handle read")?;
-    Ok((rank, K3WhaleSlabWire { handle, num_bytes }))
+    Ok(K3WhaleSlabWire { handle, num_bytes })
+}
+
+fn write_slab(writer: &mut impl Write, rank: GlobalRank, slab: &K3WhaleSlabWire) -> Result<()> {
+    write_header(writer, KIND_SLAB)?;
+    put_rank(writer, rank)?;
+    put_slab_body(writer, slab)?;
+    writer.flush().context("whale link flush")
+}
+
+fn read_slab(reader: &mut impl Read) -> Result<(GlobalRank, K3WhaleSlabWire)> {
+    Ok((get_rank(reader)?, get_slab_body(reader)?))
 }
 
 fn write_table(writer: &mut impl Write, table: &[K3WhaleSlabWire]) -> Result<()> {
     write_header(writer, KIND_TABLE)?;
-    let mut frame = FrameWriter(writer);
-    frame.u32(u32::try_from(table.len()).context("whale table size")?)?;
+    put_u32(
+        writer,
+        u32::try_from(table.len()).context("whale table size")?,
+    )?;
     for slab in table {
-        let mut frame = FrameWriter(writer);
-        frame.u64(u64::try_from(slab.num_bytes).context("whale slab size")?)?;
-        writer
-            .write_all(&slab.handle)
-            .context("whale table handle write")?;
+        put_slab_body(writer, slab)?;
     }
     writer.flush().context("whale link flush")
 }
 
 fn read_table(reader: &mut impl Read) -> Result<Vec<K3WhaleSlabWire>> {
-    let world = FrameReader(reader).u32()?;
-    ensure!(world <= 1024, "whale link: table of {world} ranks");
-    (0..world)
-        .map(|_| {
-            let num_bytes = usize::try_from(FrameReader(reader).u64()?)?;
-            let mut handle = [0u8; K3_MEGA_FABRIC_HANDLE_BYTES];
-            reader
-                .read_exact(&mut handle)
-                .context("whale table handle read")?;
-            Ok(K3WhaleSlabWire { handle, num_bytes })
-        })
-        .collect()
+    let world = get_u32(reader)? as usize;
+    ensure!(
+        world <= WHALE_MAX_WORLD,
+        "whale link: table of {world} ranks"
+    );
+    (0..world).map(|_| get_slab_body(reader)).collect()
 }
 
 /// The startup slab allgather's shared state on the host: one slot per world
@@ -482,17 +494,12 @@ impl SlabBoard {
 /// The fleet transport. Construct with [`TcpWhaleHub::host`] on the process
 /// hosting global rank 0 (it runs the sequencer) or [`TcpWhaleHub::connect`]
 /// everywhere else. Both sides serve `send`/`drain` for their local ranks;
-/// the reader/sequencer threads live for the hub's lifetime, like the engine
-/// threads they serve — a dead link is engine-fatal, reported at the next
-/// `send`.
+/// the reader/sequencer threads live for the process's lifetime, like the
+/// engine threads they serve — a dead link is engine-fatal, reported at the
+/// next `send`.
 pub struct TcpWhaleHub {
     first_local: GlobalRank,
-    /// The bound listener address (host side only) — lets a hub bound to
-    /// port 0 tell its peers where to connect.
-    addr: Option<std::net::SocketAddr>,
     mailboxes: Mailboxes,
-    /// Where this process's `send` goes: straight into the sequencer channel
-    /// (host) or up the socket (peer).
     outbound: HubRole,
     /// The first error any background thread hit; `send` reports it.
     failed: Arc<Mutex<Option<String>>>,
@@ -500,10 +507,10 @@ pub struct TcpWhaleHub {
 
 enum HubRole {
     Host {
-        inbound: mpsc::Sender<WhaleToSequencer>,
+        to_sequencer: mpsc::Sender<WhaleToSequencer>,
     },
     Peer {
-        link: Mutex<TcpStream>,
+        to_host: Mutex<TcpStream>,
     },
 }
 
@@ -554,34 +561,30 @@ impl TcpWhaleHub {
             .with_context(|| format!("whale hub: address {addr} carries no port"))?;
         let listener = TcpListener::bind(("0.0.0.0", port.parse::<u16>()?))
             .with_context(|| format!("whale hub: bind 0.0.0.0:{port} ({addr})"))?;
-        let bound = listener.local_addr().ok();
         let mailboxes: Mailboxes = Arc::new(Mutex::new(vec![VecDeque::new(); local]));
         let failed: Arc<Mutex<Option<String>>> = Arc::default();
         let (inbound_tx, inbound_rx) = mpsc::channel::<WhaleToSequencer>();
         // Peer connections register their writer half here, keyed by the rank
         // range from their hello.
-        type PeerLinks = Arc<Mutex<Vec<(GlobalRank, usize, TcpStream)>>>;
+        type PeerLinks = Arc<Mutex<Vec<(std::ops::Range<GlobalRank>, TcpStream)>>>;
         let peers: PeerLinks = Arc::default();
 
         let hub = Arc::new(Self {
             first_local,
-            addr: bound,
             mailboxes: mailboxes.clone(),
             outbound: HubRole::Host {
-                inbound: inbound_tx.clone(),
+                to_sequencer: inbound_tx.clone(),
             },
             failed: failed.clone(),
         });
 
-        // Acceptor: one connection thread per peer process. Each thread runs
-        // the hello, then — when the data-plane exchange is armed — the slab
-        // exchange, then registers its writer and settles into the reader
-        // loop. The exchange must run OFF the accept loop: `wait_complete`
-        // blocks until every peer's slabs are in, and a serial acceptor
-        // holding it would leave the remaining peers unaccepted in the
-        // backlog — a startup deadlock for any world with more than one peer
-        // process. Registration stays after the exchange so the sequencer
-        // can never interleave a commit with the table frame on one socket.
+        // One connection thread per peer process: the slab exchange blocks
+        // until the whole world checks in, so a serial acceptor deadlocks any
+        // world with more than one peer process. The writer registers only
+        // after the exchange, or the sequencer could interleave a commit
+        // with the table frame on one socket. A peer that dies mid-exchange
+        // only logs here; the world then times out `wait_complete` at
+        // WHALE_CONNECT_TIMEOUT — that is the error the operator sees.
         {
             let peers = peers.clone();
             let failed = failed.clone();
@@ -604,14 +607,15 @@ impl TcpWhaleHub {
                                         kind == KIND_HELLO,
                                         "whale hub: first frame kind {kind}"
                                     );
-                                    let mut frame = FrameReader(&mut socket);
-                                    let first = frame.u32()? as GlobalRank;
-                                    let count = frame.u32()? as usize;
-                                    let slabs = frame.u32()? as usize;
-                                    ensure!(count <= 1024, "whale hub: hello claims {count} ranks");
+                                    let first = get_rank(&mut socket)?;
+                                    let count = get_u32(&mut socket)? as usize;
+                                    let slabs = get_u32(&mut socket)? as usize;
+                                    ensure!(
+                                        count <= WHALE_MAX_WORLD,
+                                        "whale hub: hello claims {count} ranks"
+                                    );
                                     Ok(Hello {
-                                        first,
-                                        count,
+                                        ranks: first..first + count,
                                         slabs,
                                     })
                                 }) {
@@ -625,10 +629,9 @@ impl TcpWhaleHub {
                                     serve_slab_exchange(&mut socket, &hello, board.as_ref())
                                 {
                                     log::warn!(
-                                        "K3 whale hub: slab exchange with ranks {}..{} failed: \
+                                        "K3 whale hub: slab exchange with ranks {:?} failed: \
                                          {error:#}",
-                                        hello.first,
-                                        hello.first + hello.count
+                                        hello.ranks
                                     );
                                     return;
                                 }
@@ -639,12 +642,11 @@ impl TcpWhaleHub {
                                 // this handle while holding the peer table; a
                                 // wedged peer must fail the hub, not park the
                                 // sequencer forever.
-                                let _ = writer.set_write_timeout(Some(WHALE_IO_TIMEOUT));
-                                peers.lock().expect("whale peers poisoned").push((
-                                    hello.first,
-                                    hello.count,
-                                    writer,
-                                ));
+                                let _ = writer.set_write_timeout(Some(WHALE_WRITE_TIMEOUT));
+                                peers
+                                    .lock()
+                                    .expect("whale peers poisoned")
+                                    .push((hello.ranks, writer));
                                 loop {
                                     let message = read_header(&mut socket)
                                         .and_then(|kind| read_to_sequencer(&mut socket, kind));
@@ -711,10 +713,8 @@ impl TcpWhaleHub {
                                 continue;
                             }
                             let mut links = peers.lock().expect("whale peers poisoned");
-                            let Some((_, _, writer)) =
-                                links.iter_mut().find(|(first, count, _)| {
-                                    (*first..*first + *count).contains(&out.to)
-                                })
+                            let Some((_, writer)) =
+                                links.iter_mut().find(|(ranks, _)| ranks.contains(&out.to))
                             else {
                                 fail(
                                     &failed,
@@ -733,9 +733,6 @@ impl TcpWhaleHub {
         }
         let table = match board {
             None => Vec::new(),
-            // The wait doubles as the fleet's startup barrier: every process
-            // has connected and published its data plane before any engine
-            // serves — mirroring the EP bootstrap's semantics.
             Some(board) => board
                 .wait_complete(WHALE_CONNECT_TIMEOUT)
                 .context("whale hub: the world never completed its slab exchange")?,
@@ -774,13 +771,12 @@ impl TcpWhaleHub {
         };
         socket.set_nodelay(true).ok();
         socket
-            .set_write_timeout(Some(WHALE_IO_TIMEOUT))
+            .set_write_timeout(Some(WHALE_WRITE_TIMEOUT))
             .context("whale hub: set write timeout")?;
         write_hello(
             &mut socket,
             &Hello {
-                first: first_local,
-                count: local,
+                ranks: first_local..first_local + local,
                 slabs: local_slabs.len(),
             },
         )?;
@@ -839,21 +835,14 @@ impl TcpWhaleHub {
         Ok((
             Arc::new(Self {
                 first_local,
-                addr: None,
                 mailboxes,
                 outbound: HubRole::Peer {
-                    link: Mutex::new(socket),
+                    to_host: Mutex::new(socket),
                 },
                 failed,
             }),
             table,
         ))
-    }
-
-    /// The listener address (host side only; `None` on a peer). A host bound
-    /// to port 0 reads its actual port here.
-    pub fn local_addr(&self) -> Option<std::net::SocketAddr> {
-        self.addr
     }
 
     pub fn send(&self, message: WhaleToSequencer) -> Result<()> {
@@ -866,22 +855,22 @@ impl TcpWhaleHub {
             bail!("whale hub failed: {reason}");
         }
         match &self.outbound {
-            HubRole::Host { inbound } => inbound
+            HubRole::Host { to_sequencer } => to_sequencer
                 .send(message)
                 .map_err(|_| anyhow::anyhow!("whale sequencer thread is gone")),
-            HubRole::Peer { link } => {
-                let mut socket = link.lock().expect("whale link poisoned");
+            HubRole::Peer { to_host } => {
+                let mut socket = to_host.lock().expect("whale link poisoned");
+                // A failed (or timed-out partial) write leaves the stream
+                // mid-frame: poison the hub so a sibling rank's next send
+                // cannot append into the abandoned frame.
                 write_to_sequencer(&mut *socket, &message)
+                    .inspect_err(|error| fail(&self.failed, format!("host link died: {error:#}")))
             }
         }
     }
 
     pub fn drain(&self, rank: GlobalRank) -> Vec<WhaleToMember> {
-        let mut boxes = self.mailboxes.lock().expect("whale mailboxes poisoned");
-        rank.checked_sub(self.first_local)
-            .and_then(|slot| boxes.get_mut(slot))
-            .map(|inbox| inbox.drain(..).collect())
-            .unwrap_or_default()
+        drain_mailbox(&self.mailboxes, self.first_local, rank)
     }
 }
 
@@ -894,28 +883,27 @@ fn serve_slab_exchange(
     hello: &Hello,
     board: Option<&Arc<SlabBoard>>,
 ) -> Result<()> {
-    match (board, hello.slabs) {
-        (None, 0) => return Ok(()),
-        (None, _) => bail!("the peer sent slabs, but this host has no data-plane exchange armed"),
-        (Some(_), 0) => bail!("this host runs a data-plane exchange, but the peer sent no slabs"),
-        (Some(_), slabs) if slabs != hello.count => {
-            bail!(
-                "the peer hosts {} ranks but sent {slabs} slabs",
-                hello.count
-            )
-        }
-        (Some(_), _) => {}
-    }
-    let board = board.expect("matched above");
+    let Some(board) = board else {
+        ensure!(
+            hello.slabs == 0,
+            "the peer sent slabs, but this host has no data-plane exchange armed"
+        );
+        return Ok(());
+    };
+    ensure!(
+        hello.slabs == hello.ranks.len(),
+        "the peer hosts {} ranks but sent {} slabs",
+        hello.ranks.len(),
+        hello.slabs
+    );
     for _ in 0..hello.slabs {
         let kind = read_header(socket)?;
         ensure!(kind == KIND_SLAB, "expected a slab frame, got kind {kind}");
         let (rank, slab) = read_slab(socket)?;
         ensure!(
-            (hello.first..hello.first + hello.count).contains(&rank),
-            "a slab for rank {rank} from the process hosting {}..{}",
-            hello.first,
-            hello.first + hello.count
+            hello.ranks.contains(&rank),
+            "a slab for rank {rank} from the process hosting {:?}",
+            hello.ranks
         );
         board.insert(rank, slab)?;
     }
@@ -984,10 +972,10 @@ mod tests {
         // serves ranks 2..4 and posts the whale. One simulated launch period
         // per loop pass keeps the loopback latency far below it, which is the
         // commit slack's stated assumption.
-        let (host, _) = TcpWhaleHub::host("127.0.0.1:0", 4, CHUNK, 0, 2, Vec::new()).unwrap();
-        // The listener binds every interface, so dial loopback explicitly.
-        let port = host.local_addr().expect("host knows its port").port();
-        let addr = format!("127.0.0.1:{port}");
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        drop(listener);
+        let (host, _) = TcpWhaleHub::host(&addr, 4, CHUNK, 0, 2, Vec::new()).unwrap();
         let (peer, _) = TcpWhaleHub::connect(&addr, 2, 2, Vec::new()).unwrap();
         peer.send(WhaleToSequencer::Request {
             request: 5,

--- a/pegainfer-kernels/csrc/k3/k3_flash_mla_prefill.cu
+++ b/pegainfer-kernels/csrc/k3/k3_flash_mla_prefill.cu
@@ -287,12 +287,9 @@ extern "C" CUresult k3_flash_mla_prefill_fwd(
         t_q, t_kv, cute::make_tuple(K3_FMP_NOPE, K3_FMP_ROPE),
         cute::make_tuple(cute::make_tuple(1, heads), 1));
 
-    // The batch stride slots are materialized as ints, and `t_kv *
-    // k_stride_tok` overflows int32 past ~116k tokens (heads=96) — but with
-    // b = 1 the batch coordinate is always 0, so the stride value is never
-    // used to offset anything. Pass 0 instead of the true extent; the
-    // per-token and per-head strides carry all real addressing, and TMA's
-    // in-descriptor address math is 64-bit.
+    // b = 1 (ProblemShape above): the batch coordinate is always 0, so these
+    // int batch strides never offset. They carry 0 because the true extent
+    // t_kv * stride_tok overflows int32 past ~116k tokens at heads = 96.
     fmp::StrideQ stride_q = cute::make_stride(
         (int)q_stride_tok, cute::_1{},
         cute::make_stride(cute::make_stride((int)q_stride_head, (int)q_stride_head), 0));

--- a/pegainfer-kernels/csrc/k3/k3_flash_mla_prefill.cu
+++ b/pegainfer-kernels/csrc/k3/k3_flash_mla_prefill.cu
@@ -23,9 +23,20 @@
 //   - k is [t_kv, h, 192] bf16, assembled by `k3_mla_prefill_expand_k`.
 //   - v is a strided view: [t_kv, h, 128] bf16 living inside the kv_b
 //     expansion output [t_kv, h, 256] at element offset 128 (nope | value).
-//   - out is [t_q, h, 128] bf16. LSE is not written (single-call recipe).
+//   - out is [t_q, h, 128] bf16. lse_out, when non-null, receives the f32
+//     per-row log-sum-exp `[h, t_q]` (natural log, softmax scale absorbed) —
+//     the merge currency of the windowed context walk.
 //   - scale is the f32 softmax scale; pass the engine's bf16-rounded
 //     `qk_head_dim ** -0.5` so decode and prefill agree on the constant.
+//
+// Two mask instantiations share the launch core: the bottom-right causal one
+// (`k3_flash_mla_prefill_fwd`) serves the window holding the queries, and a
+// full-visibility one (`k3_flash_mla_prefill_fwd_dense`) serves windows that
+// lie entirely in the queries' past — there `t_q` and `t_kv` are unrelated,
+// so the causal entry's `t_q <= t_kv` guard does not apply. Window results
+// combine through `k3_mla_prefill_lse_merge` (the log-sum-exp identity, exact
+// up to summation order) and leave the f32 accumulator through
+// `k3_mla_prefill_o_finalize`.
 
 #include <cuda.h>
 #include <cuda_bf16.h>
@@ -160,6 +171,97 @@ extern "C" CUresult k3_mla_prefill_gather(
     return k3_flash_mla_consume_last_cuda_error();
 }
 
+// Fold one window's FMHA output into the running f32 accumulator via the
+// log-sum-exp identity. One block per (q, head) row: only this block touches
+// its lse entry, so the read-old/write-new sequence needs no cross-block
+// coordination. `reset` starts a fresh accumulation (no -inf seeding).
+static __global__ void k3_mla_prefill_lse_merge_kernel(
+    const __nv_bfloat16* __restrict__ o_win,
+    const float* __restrict__ lse_win,
+    float* __restrict__ o_acc,
+    float* __restrict__ lse_acc,
+    int t_q,
+    int heads,
+    int reset
+) {
+    int q = blockIdx.x;
+    int h = blockIdx.y;
+    int d = threadIdx.x;
+    long long lse_idx = (long long)h * t_q + q;
+    __shared__ float w_acc, w_win;
+    if (d == 0) {
+        float lw = lse_win[lse_idx];
+        if (reset) {
+            w_acc = 0.0f;
+            w_win = 1.0f;
+            lse_acc[lse_idx] = lw;
+        } else {
+            float la = lse_acc[lse_idx];
+            float m = fmaxf(la, lw);
+            float merged = m + logf(expf(la - m) + expf(lw - m));
+            w_acc = expf(la - merged);
+            w_win = expf(lw - merged);
+            lse_acc[lse_idx] = merged;
+        }
+    }
+    __syncthreads();
+    long long o_idx = ((long long)q * heads + h) * K3_FMP_NOPE + d;
+    float prev = reset ? 0.0f : o_acc[o_idx];
+    o_acc[o_idx] = prev * w_acc + __bfloat162float(o_win[o_idx]) * w_win;
+}
+
+// Leave the f32 accumulator: out[t_q, h, 128] bf16.
+static __global__ void k3_mla_prefill_o_finalize_kernel(
+    const float* __restrict__ o_acc,
+    __nv_bfloat16* __restrict__ out,
+    long long total
+) {
+    long long idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= total) {
+        return;
+    }
+    out[idx] = __float2bfloat16(o_acc[idx]);
+}
+
+extern "C" CUresult k3_mla_prefill_lse_merge(
+    const void* o_win,
+    const void* lse_win,
+    void* o_acc,
+    void* lse_acc,
+    int t_q,
+    int heads,
+    int reset,
+    CUstream stream
+) {
+    if (o_win == nullptr || lse_win == nullptr || o_acc == nullptr || lse_acc == nullptr
+        || t_q <= 0 || heads <= 0) {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    dim3 grid((unsigned)t_q, (unsigned)heads);
+    k3_mla_prefill_lse_merge_kernel<<<grid, K3_FMP_NOPE, 0, (cudaStream_t)stream>>>(
+        (const __nv_bfloat16*)o_win, (const float*)lse_win, (float*)o_acc, (float*)lse_acc,
+        t_q, heads, reset);
+    return k3_flash_mla_consume_last_cuda_error();
+}
+
+extern "C" CUresult k3_mla_prefill_o_finalize(
+    const void* o_acc,
+    void* out,
+    int t_q,
+    int heads,
+    CUstream stream
+) {
+    if (o_acc == nullptr || out == nullptr || t_q <= 0 || heads <= 0) {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    long long total = (long long)t_q * heads * K3_FMP_NOPE;
+    int threads = 256;
+    long long blocks = (total + threads - 1) / threads;
+    k3_mla_prefill_o_finalize_kernel<<<(unsigned)blocks, threads, 0, (cudaStream_t)stream>>>(
+        (const float*)o_acc, (__nv_bfloat16*)out, total);
+    return k3_flash_mla_consume_last_cuda_error();
+}
+
 extern "C" CUresult k3_mla_prefill_expand_k(
     const void* nope_v,
     const void* rope,
@@ -193,8 +295,9 @@ using Element = cutlass::bfloat16_t;
 using ElementAcc = float;
 
 // The upstream FwdRunner's MLA configuration (fmha_cutlass_fwd_sm100.cuh),
-// specialized: non-varlen problem shape, causal mask, and the non-persistent
-// causal tile scheduler upstream selects for causal + h % TileH == 0.
+// specialized: non-varlen problem shape, parameterized over the mask/scheduler
+// pair. The causal pair is the mask upstream selects for causal +
+// h % TileH == 0; the dense pair serves fully-visible context windows.
 using HeadDim = Shape<_128, _64>;
 using TileShape = Shape<_256, _128, HeadDim>;
 using ProblemShape =
@@ -204,16 +307,24 @@ using StrideK = cute::tuple<int, _1, cute::tuple<cute::tuple<_0, int>, int>>;
 using StrideV = StrideK;
 using StrideO = StrideQ;
 using StrideLSE = cute::tuple<_1, cute::tuple<cute::tuple<int, int>, int>>;
-using Mask = CausalMask</*kIsQBegin=*/false>;
-using Scheduler = CausalIndividualTileScheduler;
 
-using Mainloop = Sm100MlaFwdMainloopTmaWarpspecialized<
-    Element, ElementAcc, ElementAcc, TileShape, StrideQ, StrideK, StrideV, Mask,
-    Shape<_2, _1, _1>, cute::false_type>;
-using Epilogue = Sm100FmhaFwdEpilogueTmaWarpspecialized<
-    Element, ElementAcc, typename Mainloop::TileShapePV, StrideO, StrideLSE, cute::false_type>;
-using Operation = cutlass::fmha::device::FMHA<Sm100FmhaFwdKernelTmaWarpspecialized<
-    ProblemShape, Mainloop, Epilogue, Scheduler, Sm100MlaFwdCtxKernelWarpspecializedSchedule>>;
+template <class Mask, class Scheduler>
+struct Config {
+    using Mainloop = Sm100MlaFwdMainloopTmaWarpspecialized<
+        Element, ElementAcc, ElementAcc, TileShape, StrideQ, StrideK, StrideV, Mask,
+        Shape<_2, _1, _1>, cute::false_type>;
+    using Epilogue = Sm100FmhaFwdEpilogueTmaWarpspecialized<
+        Element, ElementAcc, typename Mainloop::TileShapePV, StrideO, StrideLSE,
+        cute::false_type>;
+    using Operation = cutlass::fmha::device::FMHA<Sm100FmhaFwdKernelTmaWarpspecialized<
+        ProblemShape, Mainloop, Epilogue, Scheduler, Sm100MlaFwdCtxKernelWarpspecializedSchedule>>;
+};
+
+using CausalConfig = Config<CausalMask</*kIsQBegin=*/false>, CausalIndividualTileScheduler>;
+using DenseConfig = Config<ResidualMask, IndividualTileScheduler>;
+
+// The causal scheduler asserts h % TileH == 0; keep both entries honest.
+constexpr int kTileH = CausalIndividualTileScheduler::TileH;
 
 }  // namespace k3_flash_mla_prefill
 
@@ -225,12 +336,12 @@ using Operation = cutlass::fmha::device::FMHA<Sm100FmhaFwdKernelTmaWarpspecializ
 // against the default 48KB cap — cudaLaunchKernelExC then fails with
 // `invalid argument`. Set the attribute ourselves, once per device; the
 // upstream one-shot becomes a harmless no-op after the first rank.
+template <class Kernel>
 static cudaError_t k3_flash_mla_prefill_ensure_smem_attr(int device) {
     constexpr int kMaxDevices = 64;
     static std::atomic<bool> g_smem_attr_done[kMaxDevices];
     if (device < 0 || device >= kMaxDevices) return cudaErrorInvalidValue;
     if (g_smem_attr_done[device].load(std::memory_order_acquire)) return cudaSuccess;
-    using Kernel = k3_flash_mla_prefill::Operation::Kernel;
     int smem_size = Kernel::SharedStorageSize;
     if (smem_size >= (48 << 10)) {
         cudaError_t err = cudaFuncSetAttribute(
@@ -247,7 +358,8 @@ static cudaError_t k3_flash_mla_prefill_ensure_smem_attr(int device) {
     return cudaSuccess;
 }
 
-extern "C" CUresult k3_flash_mla_prefill_fwd(
+template <class Cfg>
+static CUresult k3_flash_mla_prefill_run(
     const void* q,
     long long q_stride_tok,
     long long q_stride_head,
@@ -260,6 +372,7 @@ extern "C" CUresult k3_flash_mla_prefill_fwd(
     void* out,
     long long o_stride_tok,
     long long o_stride_head,
+    void* lse_out,
     int t_q,
     int t_kv,
     int heads,
@@ -267,14 +380,11 @@ extern "C" CUresult k3_flash_mla_prefill_fwd(
     CUstream stream
 ) {
     namespace fmp = k3_flash_mla_prefill;
-    if (q == nullptr || k == nullptr || v == nullptr || out == nullptr || t_q <= 0 || t_kv <= 0
-        || heads <= 0 || heads % fmp::Scheduler::TileH != 0 || t_q > t_kv) {
-        return CUDA_ERROR_INVALID_VALUE;
-    }
+    using Operation = typename Cfg::Operation;
     int device = 0;
     cudaError_t err = cudaGetDevice(&device);
     if (err != cudaSuccess) return k3_flash_mla_map_cuda_error(err);
-    err = k3_flash_mla_prefill_ensure_smem_attr(device);
+    err = k3_flash_mla_prefill_ensure_smem_attr<typename Operation::Kernel>(device);
     if (err != cudaSuccess) return k3_flash_mla_map_cuda_error(err);
     cutlass::KernelHardwareInfo hw_info;
     hw_info.device_id = device;
@@ -302,19 +412,21 @@ extern "C" CUresult k3_flash_mla_prefill_fwd(
     fmp::StrideO stride_o = cute::make_stride(
         (int)o_stride_tok, cute::_1{},
         cute::make_stride(cute::make_stride((int)o_stride_head, (int)o_stride_head), 0));
-    // LSE is not written; the stride only has to be well-formed.
+    // LSE (natural log, softmax scale absorbed) lands as f32 [heads, t_q]
+    // when lse_out is non-null; the stride must be well-formed either way.
     fmp::StrideLSE stride_lse =
         cute::make_stride(cute::_1{}, cute::make_stride(cute::make_stride(t_q, t_q), t_q));
 
-    typename fmp::Operation::Arguments arguments{
+    typename Operation::Arguments arguments{
         problem_shape,
         {{static_cast<const fmp::Element*>(q), stride_q, static_cast<const fmp::Element*>(k),
           stride_k, static_cast<const fmp::Element*>(v), stride_v},
          scale},
-        {static_cast<fmp::Element*>(out), stride_o, nullptr, stride_lse},
+        {static_cast<fmp::Element*>(out), stride_o, static_cast<fmp::ElementAcc*>(lse_out),
+         stride_lse},
         hw_info};
 
-    fmp::Operation op;
+    Operation op;
     if (op.can_implement(arguments) != cutlass::Status::kSuccess) {
         return CUDA_ERROR_NOT_SUPPORTED;
     }
@@ -327,11 +439,82 @@ extern "C" CUresult k3_flash_mla_prefill_fwd(
     return k3_flash_mla_consume_last_cuda_error();
 }
 
+extern "C" CUresult k3_flash_mla_prefill_fwd(
+    const void* q,
+    long long q_stride_tok,
+    long long q_stride_head,
+    const void* k,
+    long long k_stride_tok,
+    long long k_stride_head,
+    const void* v,
+    long long v_stride_tok,
+    long long v_stride_head,
+    void* out,
+    long long o_stride_tok,
+    long long o_stride_head,
+    void* lse_out,
+    int t_q,
+    int t_kv,
+    int heads,
+    float scale,
+    CUstream stream
+) {
+    namespace fmp = k3_flash_mla_prefill;
+    if (q == nullptr || k == nullptr || v == nullptr || out == nullptr || t_q <= 0 || t_kv <= 0
+        || heads <= 0 || heads % fmp::kTileH != 0 || t_q > t_kv) {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    return k3_flash_mla_prefill_run<fmp::CausalConfig>(
+        q, q_stride_tok, q_stride_head, k, k_stride_tok, k_stride_head, v, v_stride_tok,
+        v_stride_head, out, o_stride_tok, o_stride_head, lse_out, t_q, t_kv, heads, scale,
+        stream);
+}
+
+// Full-visibility window: every query row attends every key. `t_q` and `t_kv`
+// are unrelated (a ragged context tail can be far narrower than the chunk).
+extern "C" CUresult k3_flash_mla_prefill_fwd_dense(
+    const void* q,
+    long long q_stride_tok,
+    long long q_stride_head,
+    const void* k,
+    long long k_stride_tok,
+    long long k_stride_head,
+    const void* v,
+    long long v_stride_tok,
+    long long v_stride_head,
+    void* out,
+    long long o_stride_tok,
+    long long o_stride_head,
+    void* lse_out,
+    int t_q,
+    int t_kv,
+    int heads,
+    float scale,
+    CUstream stream
+) {
+    namespace fmp = k3_flash_mla_prefill;
+    if (q == nullptr || k == nullptr || v == nullptr || out == nullptr || t_q <= 0 || t_kv <= 0
+        || heads <= 0) {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    return k3_flash_mla_prefill_run<fmp::DenseConfig>(
+        q, q_stride_tok, q_stride_head, k, k_stride_tok, k_stride_head, v, v_stride_tok,
+        v_stride_head, out, o_stride_tok, o_stride_head, lse_out, t_q, t_kv, heads, scale,
+        stream);
+}
+
 #else  // !K3_FLASH_MLA_SM100F
 
 extern "C" CUresult k3_flash_mla_prefill_fwd(
     const void*, long long, long long, const void*, long long, long long, const void*, long long,
-    long long, void*, long long, long long, int, int, int, float, CUstream
+    long long, void*, long long, long long, void*, int, int, int, float, CUstream
+) {
+    return CUDA_ERROR_NOT_SUPPORTED;
+}
+
+extern "C" CUresult k3_flash_mla_prefill_fwd_dense(
+    const void*, long long, long long, const void*, long long, long long, const void*, long long,
+    long long, void*, long long, long long, void*, int, int, int, float, CUstream
 ) {
     return CUDA_ERROR_NOT_SUPPORTED;
 }

--- a/pegainfer-kernels/csrc/k3/k3_flash_mla_prefill.cu
+++ b/pegainfer-kernels/csrc/k3/k3_flash_mla_prefill.cu
@@ -32,7 +32,6 @@
 #include <cuda_runtime.h>
 
 #include <atomic>
-#include <climits>
 
 #ifdef K3_FLASH_MLA_SM100F
 #include "collective/fmha_fusion.hpp"
@@ -272,12 +271,6 @@ extern "C" CUresult k3_flash_mla_prefill_fwd(
         || heads <= 0 || heads % fmp::Scheduler::TileH != 0 || t_q > t_kv) {
         return CUDA_ERROR_INVALID_VALUE;
     }
-    // b = 1, but the batch stride slots are still materialized as ints.
-    if ((long long)t_q * q_stride_tok > INT_MAX || (long long)t_kv * k_stride_tok > INT_MAX
-        || (long long)t_kv * v_stride_tok > INT_MAX || (long long)t_q * o_stride_tok > INT_MAX) {
-        return CUDA_ERROR_INVALID_VALUE;
-    }
-
     int device = 0;
     cudaError_t err = cudaGetDevice(&device);
     if (err != cudaSuccess) return k3_flash_mla_map_cuda_error(err);
@@ -294,22 +287,24 @@ extern "C" CUresult k3_flash_mla_prefill_fwd(
         t_q, t_kv, cute::make_tuple(K3_FMP_NOPE, K3_FMP_ROPE),
         cute::make_tuple(cute::make_tuple(1, heads), 1));
 
+    // The batch stride slots are materialized as ints, and `t_kv *
+    // k_stride_tok` overflows int32 past ~116k tokens (heads=96) — but with
+    // b = 1 the batch coordinate is always 0, so the stride value is never
+    // used to offset anything. Pass 0 instead of the true extent; the
+    // per-token and per-head strides carry all real addressing, and TMA's
+    // in-descriptor address math is 64-bit.
     fmp::StrideQ stride_q = cute::make_stride(
         (int)q_stride_tok, cute::_1{},
-        cute::make_stride(cute::make_stride((int)q_stride_head, (int)q_stride_head),
-                          t_q * (int)q_stride_tok));
+        cute::make_stride(cute::make_stride((int)q_stride_head, (int)q_stride_head), 0));
     fmp::StrideK stride_k = cute::make_stride(
         (int)k_stride_tok, cute::_1{},
-        cute::make_stride(cute::make_stride(cute::_0{}, (int)k_stride_head),
-                          t_kv * (int)k_stride_tok));
+        cute::make_stride(cute::make_stride(cute::_0{}, (int)k_stride_head), 0));
     fmp::StrideV stride_v = cute::make_stride(
         (int)v_stride_tok, cute::_1{},
-        cute::make_stride(cute::make_stride(cute::_0{}, (int)v_stride_head),
-                          t_kv * (int)v_stride_tok));
+        cute::make_stride(cute::make_stride(cute::_0{}, (int)v_stride_head), 0));
     fmp::StrideO stride_o = cute::make_stride(
         (int)o_stride_tok, cute::_1{},
-        cute::make_stride(cute::make_stride((int)o_stride_head, (int)o_stride_head),
-                          t_q * (int)o_stride_tok));
+        cute::make_stride(cute::make_stride((int)o_stride_head, (int)o_stride_head), 0));
     // LSE is not written; the stride only has to be well-formed.
     fmp::StrideLSE stride_lse =
         cute::make_stride(cute::_1{}, cute::make_stride(cute::make_stride(t_q, t_q), t_q));

--- a/pegainfer-kernels/csrc/k3/k3_mega_fabric.cu
+++ b/pegainfer-kernels/csrc/k3/k3_mega_fabric.cu
@@ -27,6 +27,7 @@
 #include "../shared/ffi_guard.cuh"
 
 #include <cuda.h>
+#include <cstdio>
 #include <cstring>
 
 namespace {
@@ -43,6 +44,34 @@ CUmemAllocationProp fabric_prop(int device_ordinal) {
   prop.location.id = device_ordinal;
   prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
   return prop;
+}
+
+// The VMM allocator and the stream-ordered pool compete for the same
+// physical pages, and the engine pins the pool's release threshold at MAX
+// (weight loading and the step path churn large short-lived allocations).
+// After a full-model load the pool can hoard tens of GiB of freed pages
+// that cuMemCreate cannot see. Returning them is only needed — and only
+// correct to force — when a fabric allocation actually fails for space.
+CUresult trim_default_pool(int device_ordinal) {
+  CUdevice dev;
+  CUresult err = cuDeviceGet(&dev, device_ordinal);
+  if (err != CUDA_SUCCESS) return err;
+  CUmemoryPool pool;
+  err = cuDeviceGetDefaultMemPool(&pool, dev);
+  if (err != CUDA_SUCCESS) return err;
+  // Pending stream-ordered frees only become trimmable once they retire.
+  err = cuCtxSynchronize();
+  if (err != CUDA_SUCCESS) return err;
+  unsigned long long reserved = 0, used = 0;
+  (void)cuMemPoolGetAttribute(pool, CU_MEMPOOL_ATTR_RESERVED_MEM_CURRENT, &reserved);
+  (void)cuMemPoolGetAttribute(pool, CU_MEMPOOL_ATTR_USED_MEM_CURRENT, &used);
+  err = cuMemPoolTrimTo(pool, 0);
+  unsigned long long after = 0;
+  (void)cuMemPoolGetAttribute(pool, CU_MEMPOOL_ATTR_RESERVED_MEM_CURRENT, &after);
+  fprintf(stderr,
+          "k3_mega_fabric: dev%d pool reserved=%.2f GiB used=%.2f GiB -> trimmed to %.2f GiB\n",
+          device_ordinal, reserved / 1073741824.0, used / 1073741824.0, after / 1073741824.0);
+  return err;
 }
 
 // Round `num_bytes` up to the allocation granularity the fabric prop wants.
@@ -134,6 +163,9 @@ CUresult k3_mega_fabric_slab_alloc(int device_ordinal, unsigned long long num_by
   const CUmemAllocationProp prop = fabric_prop(device_ordinal);
   CUmemGenericAllocationHandle handle;
   err = cuMemCreate(&handle, size, &prop, 0);
+  if (err == CUDA_ERROR_OUT_OF_MEMORY && trim_default_pool(device_ordinal) == CUDA_SUCCESS) {
+    err = cuMemCreate(&handle, size, &prop, 0);
+  }
   if (err != CUDA_SUCCESS) return err;
 
   CUmemFabricHandle fabric;

--- a/pegainfer-kernels/csrc/k3/k3_whale_doorbell.cu
+++ b/pegainfer-kernels/csrc/k3/k3_whale_doorbell.cu
@@ -1,21 +1,13 @@
 // Whale doorbell ring: SM-path stores into peer inbox flags.
 //
-// The whale data plane orders exchange windows with 64-bit doorbell flags in
-// each rank's fabric slab. Waits run on the stream memops engine
-// (`cuStreamWaitValue64`) against this rank's OWN slab — a local allocation,
-// which memops accept. Writes cannot: the targets are peer slabs reached
-// through `cuMemImportFromShareableHandle` fabric mappings, and the memops
-// engine rejects imported fabric VAs outright (`CUDA_ERROR_INVALID_VALUE`,
-// verified on GB300 with a two-process probe; a plain DtoD copy or an SM
-// store to the same mapping succeeds — the MegaMoE kernel writes through
-// these mappings on every step). So the ring is a one-thread kernel: SM
-// stores take the NVLink path that fabric mappings were built for.
+// Waits use stream memops (`cuStreamWaitValue64`) on this rank's own slab.
+// Writes cannot: the GB300 memops engine rejects fabric-imported VAs, so the
+// ring is a one-thread kernel taking the NVLink store path instead (probe
+// and rationale: docs/models/k3/cp-lane-design.md).
 //
-// Ordering: the publication bytes this doorbell announces were written by
-// operations enqueued earlier on the same stream, complete before this
-// kernel launches. The system fence before the stores is the release for
-// anything this SM could still hold; the stores themselves are 8-byte
-// aligned and land atomically.
+// Ordering: the announced bytes are written by earlier work on THIS stream
+// and are complete when this kernel launches; the 8-byte-aligned flag stores
+// cannot tear. Publication and its doorbell must stay on one stream.
 
 #include "../shared/ffi_guard.cuh"
 
@@ -24,49 +16,48 @@
 
 namespace {
 
-// One publish or consume beat rings at most every other gang member.
+// One publish or consume beat rings at most every other gang member, so this
+// caps the CP width at kMaxDoorbellTargets + 1.
 constexpr int kMaxDoorbellTargets = 64;
 
 struct DoorbellArgs {
-  unsigned long long addrs[kMaxDoorbellTargets];
+  unsigned long long flag_addrs[kMaxDoorbellTargets];
   unsigned long long value;
-  int count;
+  int flag_count;
 };
 
 __global__ void whale_doorbell_kernel(DoorbellArgs args) {
   __threadfence_system();
-  for (int i = 0; i < args.count; ++i) {
-    *reinterpret_cast<volatile unsigned long long*>(args.addrs[i]) = args.value;
+  for (int i = 0; i < args.flag_count; ++i) {
+    *reinterpret_cast<volatile unsigned long long*>(args.flag_addrs[i]) = args.value;
   }
-}
-
-inline CUresult doorbell_map_cuda_error(cudaError_t err) {
-  if (err == cudaSuccess) return CUDA_SUCCESS;
-  if (err == cudaErrorInvalidValue) return CUDA_ERROR_INVALID_VALUE;
-  return CUDA_ERROR_LAUNCH_FAILED;
 }
 
 }  // namespace
 
 extern "C" {
 
-// Ring `value` into `count` flag addresses (device VAs of 8-byte-aligned
+// Ring `value` into `flag_count` flag addresses (device VAs of 8-byte-aligned
 // u64 slots, local or fabric-imported), stream-ordered after preceding work.
-CUresult k3_whale_doorbell_ring(const unsigned long long* addrs, int count,
+CUresult k3_whale_doorbell_ring(const unsigned long long* flag_addrs, int flag_count,
                                 unsigned long long value, cudaStream_t stream) {
   PEGAINFER_FFI_GUARD_BEGIN
-  if (addrs == nullptr || count <= 0 || count > kMaxDoorbellTargets) {
+  if (flag_addrs == nullptr || flag_count <= 0 || flag_count > kMaxDoorbellTargets) {
     return CUDA_ERROR_INVALID_VALUE;
   }
-  DoorbellArgs args;
-  for (int i = 0; i < count; ++i) {
-    if (addrs[i] == 0 || addrs[i] % 8 != 0) return CUDA_ERROR_INVALID_VALUE;
-    args.addrs[i] = addrs[i];
+  DoorbellArgs args{};
+  for (int i = 0; i < flag_count; ++i) {
+    // An unaligned or null store from the kernel would kill the CUDA context
+    // instead of returning an error; refuse it host-side.
+    if (flag_addrs[i] == 0 || flag_addrs[i] % 8 != 0) return CUDA_ERROR_INVALID_VALUE;
+    args.flag_addrs[i] = flag_addrs[i];
   }
   args.value = value;
-  args.count = count;
+  args.flag_count = flag_count;
   whale_doorbell_kernel<<<1, 1, 0, stream>>>(args);
-  return doorbell_map_cuda_error(cudaGetLastError());
+  cudaError_t err = cudaGetLastError();
+  if (err == cudaSuccess) return CUDA_SUCCESS;
+  return err == cudaErrorInvalidValue ? CUDA_ERROR_INVALID_VALUE : CUDA_ERROR_LAUNCH_FAILED;
   PEGAINFER_FFI_GUARD_END(CUDA_ERROR_UNKNOWN)
 }
 

--- a/pegainfer-kernels/csrc/k3/k3_whale_doorbell.cu
+++ b/pegainfer-kernels/csrc/k3/k3_whale_doorbell.cu
@@ -1,0 +1,73 @@
+// Whale doorbell ring: SM-path stores into peer inbox flags.
+//
+// The whale data plane orders exchange windows with 64-bit doorbell flags in
+// each rank's fabric slab. Waits run on the stream memops engine
+// (`cuStreamWaitValue64`) against this rank's OWN slab — a local allocation,
+// which memops accept. Writes cannot: the targets are peer slabs reached
+// through `cuMemImportFromShareableHandle` fabric mappings, and the memops
+// engine rejects imported fabric VAs outright (`CUDA_ERROR_INVALID_VALUE`,
+// verified on GB300 with a two-process probe; a plain DtoD copy or an SM
+// store to the same mapping succeeds — the MegaMoE kernel writes through
+// these mappings on every step). So the ring is a one-thread kernel: SM
+// stores take the NVLink path that fabric mappings were built for.
+//
+// Ordering: the publication bytes this doorbell announces were written by
+// operations enqueued earlier on the same stream, complete before this
+// kernel launches. The system fence before the stores is the release for
+// anything this SM could still hold; the stores themselves are 8-byte
+// aligned and land atomically.
+
+#include "../shared/ffi_guard.cuh"
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+namespace {
+
+// One publish or consume beat rings at most every other gang member.
+constexpr int kMaxDoorbellTargets = 64;
+
+struct DoorbellArgs {
+  unsigned long long addrs[kMaxDoorbellTargets];
+  unsigned long long value;
+  int count;
+};
+
+__global__ void whale_doorbell_kernel(DoorbellArgs args) {
+  __threadfence_system();
+  for (int i = 0; i < args.count; ++i) {
+    *reinterpret_cast<volatile unsigned long long*>(args.addrs[i]) = args.value;
+  }
+}
+
+inline CUresult doorbell_map_cuda_error(cudaError_t err) {
+  if (err == cudaSuccess) return CUDA_SUCCESS;
+  if (err == cudaErrorInvalidValue) return CUDA_ERROR_INVALID_VALUE;
+  return CUDA_ERROR_LAUNCH_FAILED;
+}
+
+}  // namespace
+
+extern "C" {
+
+// Ring `value` into `count` flag addresses (device VAs of 8-byte-aligned
+// u64 slots, local or fabric-imported), stream-ordered after preceding work.
+CUresult k3_whale_doorbell_ring(const unsigned long long* addrs, int count,
+                                unsigned long long value, cudaStream_t stream) {
+  PEGAINFER_FFI_GUARD_BEGIN
+  if (addrs == nullptr || count <= 0 || count > kMaxDoorbellTargets) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  DoorbellArgs args;
+  for (int i = 0; i < count; ++i) {
+    if (addrs[i] == 0 || addrs[i] % 8 != 0) return CUDA_ERROR_INVALID_VALUE;
+    args.addrs[i] = addrs[i];
+  }
+  args.value = value;
+  args.count = count;
+  whale_doorbell_kernel<<<1, 1, 0, stream>>>(args);
+  return doorbell_map_cuda_error(cudaGetLastError());
+  PEGAINFER_FFI_GUARD_END(CUDA_ERROR_UNKNOWN)
+}
+
+}  // extern "C"

--- a/pegainfer-kernels/src/ffi/k3.rs
+++ b/pegainfer-kernels/src/ffi/k3.rs
@@ -418,8 +418,10 @@ unsafe extern "C" {
     /// FlashMLA SM100 dense FMHA forward (third_party/FlashMLA), one
     /// sequence, bottom-right-aligned causal: q `[t_q, h, 192]`,
     /// k `[t_kv, h, 192]`, v a strided `[t_kv, h, 128]` view, out
-    /// `[t_q, h, 128]`, all bf16; strides in elements. Requires an sm_100f
-    /// build (`NOT_SUPPORTED` elsewhere).
+    /// `[t_q, h, 128]`, all bf16; strides in elements. `lse_out`, when
+    /// non-null, receives f32 `[h, t_q]` log-sum-exp (natural log, softmax
+    /// scale absorbed). Requires an sm_100f build (`NOT_SUPPORTED`
+    /// elsewhere).
     pub fn k3_flash_mla_prefill_fwd(
         q: *const Half,
         q_stride_tok: i64,
@@ -433,10 +435,59 @@ unsafe extern "C" {
         out: *mut Half,
         o_stride_tok: i64,
         o_stride_head: i64,
+        lse_out: *mut f32,
         t_q: i32,
         t_kv: i32,
         heads: i32,
         scale: f32,
+        stream: CUstream,
+    ) -> CUresult;
+
+    /// The full-visibility twin of `k3_flash_mla_prefill_fwd` for context
+    /// windows entirely in the queries' past: no causal mask, `t_q` and
+    /// `t_kv` unrelated. Same layouts and LSE contract.
+    pub fn k3_flash_mla_prefill_fwd_dense(
+        q: *const Half,
+        q_stride_tok: i64,
+        q_stride_head: i64,
+        k: *const Half,
+        k_stride_tok: i64,
+        k_stride_head: i64,
+        v: *const Half,
+        v_stride_tok: i64,
+        v_stride_head: i64,
+        out: *mut Half,
+        o_stride_tok: i64,
+        o_stride_head: i64,
+        lse_out: *mut f32,
+        t_q: i32,
+        t_kv: i32,
+        heads: i32,
+        scale: f32,
+        stream: CUstream,
+    ) -> CUresult;
+
+    /// Fold one window's FMHA output `[t_q, h, 128]` bf16 + `[h, t_q]` f32
+    /// LSE into the f32 running accumulator pair via the log-sum-exp
+    /// identity; `reset != 0` starts a fresh accumulation.
+    pub fn k3_mla_prefill_lse_merge(
+        o_win: *const Half,
+        lse_win: *const f32,
+        o_acc: *mut f32,
+        lse_acc: *mut f32,
+        t_q: i32,
+        heads: i32,
+        reset: i32,
+        stream: CUstream,
+    ) -> CUresult;
+
+    /// Convert the merged f32 accumulator back to the bf16 attention output
+    /// `[t_q, h, 128]`.
+    pub fn k3_mla_prefill_o_finalize(
+        o_acc: *const f32,
+        out: *mut Half,
+        t_q: i32,
+        heads: i32,
         stream: CUstream,
     ) -> CUresult;
 }

--- a/pegainfer-kernels/src/ffi/k3.rs
+++ b/pegainfer-kernels/src/ffi/k3.rs
@@ -199,13 +199,12 @@ unsafe extern "C" {
     /// allocations (driver + IMEX). Writes 0 or 1 into `out_supported`.
     pub fn k3_mega_fabric_supported(device_ordinal: i32, out_supported: *mut i32) -> CUresult;
 
-    /// Ring a whale doorbell: store `value` into `count` 8-byte-aligned u64
-    /// flag addresses (local or fabric-imported device VAs) from a one-thread
-    /// kernel on `stream`. SM-path stores — the stream memops engine rejects
-    /// imported fabric mappings (`csrc/k3/k3_whale_doorbell.cu`).
+    /// Store `value` into `flag_count` 8-byte-aligned u64 flag slots (local
+    /// or fabric-imported device VAs) from a kernel on `stream`; see
+    /// `csrc/k3/k3_whale_doorbell.cu`.
     pub fn k3_whale_doorbell_ring(
-        addrs: *const u64,
-        count: i32,
+        flag_addrs: *const u64,
+        flag_count: i32,
         value: u64,
         stream: CUstream,
     ) -> CUresult;

--- a/pegainfer-kernels/src/ffi/k3.rs
+++ b/pegainfer-kernels/src/ffi/k3.rs
@@ -199,6 +199,17 @@ unsafe extern "C" {
     /// allocations (driver + IMEX). Writes 0 or 1 into `out_supported`.
     pub fn k3_mega_fabric_supported(device_ordinal: i32, out_supported: *mut i32) -> CUresult;
 
+    /// Ring a whale doorbell: store `value` into `count` 8-byte-aligned u64
+    /// flag addresses (local or fabric-imported device VAs) from a one-thread
+    /// kernel on `stream`. SM-path stores — the stream memops engine rejects
+    /// imported fabric mappings (`csrc/k3/k3_whale_doorbell.cu`).
+    pub fn k3_whale_doorbell_ring(
+        addrs: *const u64,
+        count: i32,
+        value: u64,
+        stream: CUstream,
+    ) -> CUresult;
+
     /// Allocate a fabric-exportable symmetric slab of `num_bytes` on
     /// `device_ordinal`, mapped and access-granted for every local device,
     /// zeroed and synchronized. Writes the device pointer and the 64-byte

--- a/pegainfer-kernels/src/ops.rs
+++ b/pegainfer-kernels/src/ops.rs
@@ -143,6 +143,7 @@ pub use linear::gemm_lt_tune;
 pub use linear::gemm_per_token;
 pub use linear::gemm_rows_into;
 pub use linear::gemm_rows_into_checked;
+pub use linear::gemm_rows_span_into_checked;
 pub use linear::gemm_strided_batched_bf16;
 pub use linear::gemm_strided_batched_f32;
 pub use linear::gemm_token_range_into_checked;

--- a/pegainfer-kernels/src/ops/k3/flash_mla_prefill.rs
+++ b/pegainfer-kernels/src/ops/k3/flash_mla_prefill.rs
@@ -182,17 +182,13 @@ pub fn k3_flash_mla_prefill_fwd_launch(
 mod tests {
     use super::*;
 
-    /// `t_kv * (heads * 192)` passes i32 past ~116k tokens (heads=96); the
-    /// wrapper used to refuse that product as a batch stride, capping context
-    /// at 116k and failing the whale's 256k prefill. The fix passes 0 batch
-    /// strides (b = 1 never offsets by them), so this drives the kernel at
-    /// full 256k depth and checks addressing: identical K rows make every
-    /// causal softmax uniform, and V rows that vary only per head make the
-    /// expected output exactly the per-head value — any high-offset
-    /// addressing error surfaces as a wrong or non-finite element. Needs an
-    /// sm_100f GPU with ~23 GiB free.
+    /// Drives the kernel past the int32 batch-stride ceiling
+    /// (`t_kv * heads * 192`). Identical K rows make every causal softmax
+    /// uniform, and V rows that vary only per head make the expected output
+    /// exactly the per-head value, so any high-offset addressing error shows
+    /// up as a wrong or non-finite element.
     #[test]
-    #[ignore = "needs an sm_100f GPU with ~23 GiB free"]
+    #[ignore = "needs an sm_100f GPU with ~23 GiB free and ~13 GiB host RAM"]
     fn deep_context_attention_addresses_past_int32() {
         use crate::tensor::DeviceContext;
         let ctx = DeviceContext::new_with_device(0).expect("device 0");
@@ -217,7 +213,7 @@ mod tests {
             .collect();
         let mut nope_v_host = vec![bf16::ZERO; t_kv * heads * K3_MLA_PREFILL_NV];
         for chunk in nope_v_host.chunks_mut(row.len()) {
-            chunk.copy_from_slice(&row[..chunk.len()]);
+            chunk.copy_from_slice(&row);
         }
         let nope_v = ctx.stream.clone_htod(&nope_v_host).expect("nope_v");
         drop(nope_v_host);

--- a/pegainfer-kernels/src/ops/k3/flash_mla_prefill.rs
+++ b/pegainfer-kernels/src/ops/k3/flash_mla_prefill.rs
@@ -177,3 +177,66 @@ pub fn k3_flash_mla_prefill_fwd_launch(
         anyhow!("K3 FlashMLA prefill forward (t_q={t_q}, t_kv={t_kv}, heads={heads}) failed: {error} (NOT_SUPPORTED = built without an sm_100f target)")
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `t_kv * (heads * 192)` passes i32 past ~116k tokens (heads=96); the
+    /// wrapper used to refuse that product as a batch stride, capping context
+    /// at 116k and failing the whale's 256k prefill. The fix passes 0 batch
+    /// strides (b = 1 never offsets by them), so this drives the kernel at
+    /// full 256k depth and checks addressing: identical K rows make every
+    /// causal softmax uniform, and V rows that vary only per head make the
+    /// expected output exactly the per-head value — any high-offset
+    /// addressing error surfaces as a wrong or non-finite element. Needs an
+    /// sm_100f GPU with ~23 GiB free.
+    #[test]
+    #[ignore = "needs an sm_100f GPU with ~23 GiB free"]
+    fn deep_context_attention_addresses_past_int32() {
+        use crate::tensor::DeviceContext;
+        let ctx = DeviceContext::new_with_device(0).expect("device 0");
+        let (t_q, t_kv, heads) = (256usize, 260_096usize, 96usize);
+        assert!(
+            t_kv * heads * K3_MLA_PREFILL_QK > i32::MAX as usize,
+            "depth no longer covers the i32 ceiling"
+        );
+        let q = ctx
+            .stream
+            .clone_htod(&vec![bf16::from_f32(0.05); t_q * heads * K3_MLA_PREFILL_QK])
+            .expect("q");
+        let k = ctx
+            .stream
+            .clone_htod(&vec![
+                bf16::from_f32(0.03);
+                t_kv * heads * K3_MLA_PREFILL_QK
+            ])
+            .expect("k");
+        let row: Vec<bf16> = (0..heads * K3_MLA_PREFILL_NV)
+            .map(|i| bf16::from_f32((i / K3_MLA_PREFILL_NV) as f32 / 128.0))
+            .collect();
+        let mut nope_v_host = vec![bf16::ZERO; t_kv * heads * K3_MLA_PREFILL_NV];
+        for chunk in nope_v_host.chunks_mut(row.len()) {
+            chunk.copy_from_slice(&row[..chunk.len()]);
+        }
+        let nope_v = ctx.stream.clone_htod(&nope_v_host).expect("nope_v");
+        drop(nope_v_host);
+        let mut out = ctx
+            .stream
+            .alloc_zeros::<bf16>(t_q * heads * K3_MLA_PREFILL_V)
+            .expect("out");
+        k3_flash_mla_prefill_fwd_launch(&ctx, t_q, t_kv, heads, &q, &k, &nope_v, &mut out, 0.072)
+            .expect("deep-context forward");
+        let host_out = ctx.stream.clone_dtoh(&out).expect("out to host");
+        ctx.sync().expect("sync");
+        for (i, &value) in host_out.iter().enumerate() {
+            let head = (i / K3_MLA_PREFILL_V) % heads;
+            let expected = head as f32 / 128.0;
+            let got = value.to_f32();
+            assert!(
+                (got - expected).abs() < 1e-2,
+                "out[{i}] (head {head}): got {got}, expected {expected}"
+            );
+        }
+    }
+}

--- a/pegainfer-kernels/src/ops/k3/flash_mla_prefill.rs
+++ b/pegainfer-kernels/src/ops/k3/flash_mla_prefill.rs
@@ -87,29 +87,34 @@ pub fn k3_mla_prefill_gather_launch(
 }
 
 /// Assemble the per-head K rows `[t, heads, 192]` from the kv_b expansion's
-/// nope halves and the shared rope broadcast across heads.
+/// nope halves and the shared rope broadcast across heads. `rope_row0` shifts
+/// the rope read window: the expansion may cover a context window whose rope
+/// rows sit deep inside the full-context rope buffer.
 pub fn k3_mla_prefill_expand_k_launch(
     ctx: &DeviceContext,
     t_total: usize,
     heads: usize,
     nope_v: &CudaSlice<bf16>,
     rope: &CudaSlice<bf16>,
+    rope_row0: usize,
     k_out: &mut CudaSlice<bf16>,
 ) -> Result<()> {
     ensure!(t_total > 0, "K3 MLA prefill expand got an empty span");
     ensure!(
         nope_v.len() >= t_total * heads * K3_MLA_PREFILL_NV
-            && rope.len() >= t_total * K3_MLA_PREFILL_ROPE
+            && rope.len() >= (rope_row0 + t_total) * K3_MLA_PREFILL_ROPE
             && k_out.len() >= t_total * heads * K3_MLA_PREFILL_QK,
-        "K3 MLA prefill expand buffers too small for t={t_total}, heads={heads}"
+        "K3 MLA prefill expand buffers too small for t={t_total}, heads={heads}, \
+         rope_row0={rope_row0}"
     );
     let (nv_ptr, _nv_guard) = nope_v.device_ptr(&ctx.stream);
     let (rope_ptr, _rope_guard) = rope.device_ptr(&ctx.stream);
     let (k_ptr, _k_guard) = k_out.device_ptr_mut(&ctx.stream);
+    let rope_win = rope_ptr + (rope_row0 * K3_MLA_PREFILL_ROPE * size_of::<bf16>()) as u64;
     let rc = unsafe {
         ffi::k3_mla_prefill_expand_k(
             nv_ptr as *const Half,
-            rope_ptr as *const Half,
+            rope_win as *const Half,
             k_ptr as *mut Half,
             t_total as i32,
             heads as i32,
@@ -120,12 +125,104 @@ pub fn k3_mla_prefill_expand_k_launch(
         .map_err(|error| anyhow!("K3 MLA prefill expand_k (t={t_total}, heads={heads}): {error}"))
 }
 
-/// One chunk's MLA attention: `t_q` queries over `t_kv >= t_q` keys with the
-/// bottom-right-aligned causal mask (query row `i` sees `t_kv - t_q + i + 1`
-/// keys). `v` is read as a strided view into the kv_b expansion `nope_v`.
-#[allow(clippy::too_many_arguments)]
-pub fn k3_flash_mla_prefill_fwd_launch(
+/// Fold one window's FMHA output + LSE into the f32 accumulator pair
+/// (`o_acc` `[t_q, heads, 128]`, `lse_acc` `[heads, t_q]`) via the
+/// log-sum-exp identity. `reset` starts a fresh accumulation.
+pub fn k3_mla_prefill_lse_merge_launch(
     ctx: &DeviceContext,
+    t_q: usize,
+    heads: usize,
+    o_win: &CudaSlice<bf16>,
+    lse_win: &CudaSlice<f32>,
+    o_acc: &mut CudaSlice<f32>,
+    lse_acc: &mut CudaSlice<f32>,
+    reset: bool,
+) -> Result<()> {
+    ensure!(t_q > 0, "K3 MLA prefill LSE merge got an empty span");
+    ensure!(
+        o_win.len() >= t_q * heads * K3_MLA_PREFILL_V
+            && lse_win.len() >= heads * t_q
+            && o_acc.len() >= t_q * heads * K3_MLA_PREFILL_V
+            && lse_acc.len() >= heads * t_q,
+        "K3 MLA prefill LSE merge buffers too small for t_q={t_q}, heads={heads}"
+    );
+    let (ow_ptr, _ow_guard) = o_win.device_ptr(&ctx.stream);
+    let (lw_ptr, _lw_guard) = lse_win.device_ptr(&ctx.stream);
+    let (oa_ptr, _oa_guard) = o_acc.device_ptr_mut(&ctx.stream);
+    let (la_ptr, _la_guard) = lse_acc.device_ptr_mut(&ctx.stream);
+    let rc = unsafe {
+        ffi::k3_mla_prefill_lse_merge(
+            ow_ptr as *const Half,
+            lw_ptr as *const f32,
+            oa_ptr as *mut f32,
+            la_ptr as *mut f32,
+            t_q as i32,
+            heads as i32,
+            i32::from(reset),
+            ctx.stream.cu_stream(),
+        )
+    };
+    rc.result()
+        .map_err(|error| anyhow!("K3 MLA prefill LSE merge (t_q={t_q}, heads={heads}): {error}"))
+}
+
+/// Convert the merged f32 accumulator back to the bf16 attention output.
+pub fn k3_mla_prefill_o_finalize_launch(
+    ctx: &DeviceContext,
+    t_q: usize,
+    heads: usize,
+    o_acc: &CudaSlice<f32>,
+    out: &mut CudaSlice<bf16>,
+) -> Result<()> {
+    ensure!(t_q > 0, "K3 MLA prefill finalize got an empty span");
+    ensure!(
+        o_acc.len() >= t_q * heads * K3_MLA_PREFILL_V
+            && out.len() >= t_q * heads * K3_MLA_PREFILL_V,
+        "K3 MLA prefill finalize buffers too small for t_q={t_q}, heads={heads}"
+    );
+    let (oa_ptr, _oa_guard) = o_acc.device_ptr(&ctx.stream);
+    let (out_ptr, _out_guard) = out.device_ptr_mut(&ctx.stream);
+    let rc = unsafe {
+        ffi::k3_mla_prefill_o_finalize(
+            oa_ptr as *const f32,
+            out_ptr as *mut Half,
+            t_q as i32,
+            heads as i32,
+            ctx.stream.cu_stream(),
+        )
+    };
+    rc.result()
+        .map_err(|error| anyhow!("K3 MLA prefill finalize (t_q={t_q}, heads={heads}): {error}"))
+}
+
+/// The two FMHA entries share one FFI signature; the wrapper core takes the
+/// entry as a value.
+type FmhaEntry = unsafe extern "C" fn(
+    *const Half,
+    i64,
+    i64,
+    *const Half,
+    i64,
+    i64,
+    *const Half,
+    i64,
+    i64,
+    *mut Half,
+    i64,
+    i64,
+    *mut f32,
+    i32,
+    i32,
+    i32,
+    f32,
+    cudarc::driver::sys::CUstream,
+) -> cudarc::driver::sys::CUresult;
+
+#[allow(clippy::too_many_arguments)]
+fn k3_flash_mla_prefill_fmha(
+    ctx: &DeviceContext,
+    entry: FmhaEntry,
+    kind: &str,
     t_q: usize,
     t_kv: usize,
     heads: usize,
@@ -133,11 +230,12 @@ pub fn k3_flash_mla_prefill_fwd_launch(
     k: &CudaSlice<bf16>,
     nope_v: &CudaSlice<bf16>,
     out: &mut CudaSlice<bf16>,
+    lse_out: Option<&mut CudaSlice<f32>>,
     scale: f32,
 ) -> Result<()> {
     ensure!(
-        0 < t_q && t_q <= t_kv,
-        "K3 FlashMLA prefill needs 0 < t_q <= t_kv, got {t_q}/{t_kv}"
+        t_q > 0 && t_kv > 0,
+        "K3 FlashMLA prefill got an empty span: t_q={t_q}, t_kv={t_kv}"
     );
     ensure!(
         q.len() >= t_q * heads * K3_MLA_PREFILL_QK
@@ -150,10 +248,21 @@ pub fn k3_flash_mla_prefill_fwd_launch(
     let (k_ptr, _k_guard) = k.device_ptr(&ctx.stream);
     let (nv_ptr, _nv_guard) = nope_v.device_ptr(&ctx.stream);
     let (out_ptr, _out_guard) = out.device_ptr_mut(&ctx.stream);
+    let lse_ptr = match lse_out {
+        Some(lse) => {
+            ensure!(
+                lse.len() >= heads * t_q,
+                "K3 FlashMLA prefill LSE buffer too small for t_q={t_q}, heads={heads}"
+            );
+            let (ptr, _guard) = lse.device_ptr_mut(&ctx.stream);
+            ptr as *mut f32
+        }
+        None => std::ptr::null_mut(),
+    };
     // V lives at the value half of each expanded head row.
     let v_ptr = nv_ptr + (K3_MLA_PREFILL_V * size_of::<bf16>()) as u64;
     let rc = unsafe {
-        ffi::k3_flash_mla_prefill_fwd(
+        entry(
             q_ptr as *const Half,
             (heads * K3_MLA_PREFILL_QK) as i64,
             K3_MLA_PREFILL_QK as i64,
@@ -166,6 +275,7 @@ pub fn k3_flash_mla_prefill_fwd_launch(
             out_ptr as *mut Half,
             (heads * K3_MLA_PREFILL_V) as i64,
             K3_MLA_PREFILL_V as i64,
+            lse_ptr,
             t_q as i32,
             t_kv as i32,
             heads as i32,
@@ -174,13 +284,247 @@ pub fn k3_flash_mla_prefill_fwd_launch(
         )
     };
     rc.result().map_err(|error| {
-        anyhow!("K3 FlashMLA prefill forward (t_q={t_q}, t_kv={t_kv}, heads={heads}) failed: {error} (NOT_SUPPORTED = built without an sm_100f target)")
+        anyhow!("K3 FlashMLA prefill {kind} (t_q={t_q}, t_kv={t_kv}, heads={heads}) failed: {error} (NOT_SUPPORTED = built without an sm_100f target)")
     })
+}
+
+/// One chunk's MLA attention: `t_q` queries over `t_kv >= t_q` keys with the
+/// bottom-right-aligned causal mask (query row `i` sees `t_kv - t_q + i + 1`
+/// keys). `v` is read as a strided view into the kv_b expansion `nope_v`.
+/// `lse_out` optionally receives the per-row log-sum-exp as `[heads, t_q]` f32
+/// (natural log, scale absorbed) for cross-window merging.
+#[allow(clippy::too_many_arguments)]
+pub fn k3_flash_mla_prefill_fwd_launch(
+    ctx: &DeviceContext,
+    t_q: usize,
+    t_kv: usize,
+    heads: usize,
+    q: &CudaSlice<bf16>,
+    k: &CudaSlice<bf16>,
+    nope_v: &CudaSlice<bf16>,
+    out: &mut CudaSlice<bf16>,
+    lse_out: Option<&mut CudaSlice<f32>>,
+    scale: f32,
+) -> Result<()> {
+    ensure!(
+        t_q <= t_kv,
+        "K3 FlashMLA causal prefill needs t_q <= t_kv, got {t_q}/{t_kv}"
+    );
+    k3_flash_mla_prefill_fmha(
+        ctx,
+        ffi::k3_flash_mla_prefill_fwd,
+        "causal",
+        t_q,
+        t_kv,
+        heads,
+        q,
+        k,
+        nope_v,
+        out,
+        lse_out,
+        scale,
+    )
+}
+
+/// Dense (unmasked) variant: every query row attends all `t_kv` keys, with no
+/// relation required between `t_q` and `t_kv`. Used for the context windows of
+/// the W-chunked walk, where the window's keys all precede the chunk's queries.
+#[allow(clippy::too_many_arguments)]
+pub fn k3_flash_mla_prefill_fwd_dense_launch(
+    ctx: &DeviceContext,
+    t_q: usize,
+    t_kv: usize,
+    heads: usize,
+    q: &CudaSlice<bf16>,
+    k: &CudaSlice<bf16>,
+    nope_v: &CudaSlice<bf16>,
+    out: &mut CudaSlice<bf16>,
+    lse_out: Option<&mut CudaSlice<f32>>,
+    scale: f32,
+) -> Result<()> {
+    k3_flash_mla_prefill_fmha(
+        ctx,
+        ffi::k3_flash_mla_prefill_fwd_dense,
+        "dense",
+        t_q,
+        t_kv,
+        heads,
+        q,
+        k,
+        nope_v,
+        out,
+        lse_out,
+        scale,
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Deterministic pseudo-random bf16 in roughly [-0.5, 0.5].
+    fn ripple(seed: u64, i: usize) -> bf16 {
+        let mut x = seed ^ (i as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        x ^= x >> 33;
+        x = x.wrapping_mul(0xFF51_AFD7_ED55_8CCD);
+        x ^= x >> 33;
+        bf16::from_f32(((x % 1000) as f32) / 1000.0 - 0.5)
+    }
+
+    /// The windowed walk must reproduce the single causal call: dense windows
+    /// over the past + one causal `t_q x t_q` tail, merged through the LSE,
+    /// against one bottom-right-aligned causal FMHA over the full context.
+    /// Ragged tail included (1280 = 512 + 512 + 256).
+    #[test]
+    #[ignore = "needs an sm_100f GPU"]
+    fn windowed_walk_matches_single_causal_call() {
+        use crate::tensor::DeviceContext;
+        let ctx = DeviceContext::new_with_device(0).expect("device 0");
+        let (t_q, t_kv, heads, win) = (192usize, 1472usize, 96usize, 512usize);
+        let ctx_len = t_kv - t_q;
+        let scale = 0.072f32;
+
+        let q_host: Vec<bf16> = (0..t_q * heads * K3_MLA_PREFILL_QK)
+            .map(|i| ripple(1, i))
+            .collect();
+        let k_host: Vec<bf16> = (0..t_kv * heads * K3_MLA_PREFILL_QK)
+            .map(|i| ripple(2, i))
+            .collect();
+        let nv_host: Vec<bf16> = (0..t_kv * heads * K3_MLA_PREFILL_NV)
+            .map(|i| ripple(3, i))
+            .collect();
+        let q = ctx.stream.clone_htod(&q_host).expect("q");
+        let k_full = ctx.stream.clone_htod(&k_host).expect("k");
+        let nv_full = ctx.stream.clone_htod(&nv_host).expect("nope_v");
+
+        // Reference: one causal call over the whole context.
+        let mut out_ref = ctx
+            .stream
+            .alloc_zeros::<bf16>(t_q * heads * K3_MLA_PREFILL_V)
+            .expect("out_ref");
+        k3_flash_mla_prefill_fwd_launch(
+            &ctx,
+            t_q,
+            t_kv,
+            heads,
+            &q,
+            &k_full,
+            &nv_full,
+            &mut out_ref,
+            None,
+            scale,
+        )
+        .expect("reference forward");
+        let host_ref = ctx.stream.clone_dtoh(&out_ref).expect("ref to host");
+
+        // Windowed: dense windows over the past, causal tail, LSE merge.
+        let mut o_win = ctx
+            .stream
+            .alloc_zeros::<bf16>(t_q * heads * K3_MLA_PREFILL_V)
+            .expect("o_win");
+        let mut lse_win = ctx.stream.alloc_zeros::<f32>(heads * t_q).expect("lse_win");
+        let mut o_acc = ctx
+            .stream
+            .alloc_zeros::<f32>(t_q * heads * K3_MLA_PREFILL_V)
+            .expect("o_acc");
+        let mut lse_acc = ctx.stream.alloc_zeros::<f32>(heads * t_q).expect("lse_acc");
+        let mut row = 0usize;
+        while row < ctx_len {
+            let len = win.min(ctx_len - row);
+            let k_w = ctx
+                .stream
+                .clone_htod(
+                    &k_host[row * heads * K3_MLA_PREFILL_QK..][..len * heads * K3_MLA_PREFILL_QK],
+                )
+                .expect("k window");
+            let nv_w = ctx
+                .stream
+                .clone_htod(
+                    &nv_host[row * heads * K3_MLA_PREFILL_NV..][..len * heads * K3_MLA_PREFILL_NV],
+                )
+                .expect("nv window");
+            k3_flash_mla_prefill_fwd_dense_launch(
+                &ctx,
+                t_q,
+                len,
+                heads,
+                &q,
+                &k_w,
+                &nv_w,
+                &mut o_win,
+                Some(&mut lse_win),
+                scale,
+            )
+            .expect("dense window");
+            k3_mla_prefill_lse_merge_launch(
+                &ctx,
+                t_q,
+                heads,
+                &o_win,
+                &lse_win,
+                &mut o_acc,
+                &mut lse_acc,
+                row == 0,
+            )
+            .expect("merge window");
+            row += len;
+        }
+        let k_tail = ctx
+            .stream
+            .clone_htod(&k_host[ctx_len * heads * K3_MLA_PREFILL_QK..])
+            .expect("k tail");
+        let nv_tail = ctx
+            .stream
+            .clone_htod(&nv_host[ctx_len * heads * K3_MLA_PREFILL_NV..])
+            .expect("nv tail");
+        k3_flash_mla_prefill_fwd_launch(
+            &ctx,
+            t_q,
+            t_q,
+            heads,
+            &q,
+            &k_tail,
+            &nv_tail,
+            &mut o_win,
+            Some(&mut lse_win),
+            scale,
+        )
+        .expect("causal tail");
+        k3_mla_prefill_lse_merge_launch(
+            &ctx,
+            t_q,
+            heads,
+            &o_win,
+            &lse_win,
+            &mut o_acc,
+            &mut lse_acc,
+            false,
+        )
+        .expect("merge tail");
+        let mut out_w = ctx
+            .stream
+            .alloc_zeros::<bf16>(t_q * heads * K3_MLA_PREFILL_V)
+            .expect("out_w");
+        k3_mla_prefill_o_finalize_launch(&ctx, t_q, heads, &o_acc, &mut out_w).expect("finalize");
+        let host_win = ctx.stream.clone_dtoh(&out_w).expect("win to host");
+        ctx.sync().expect("sync");
+
+        let mut worst = 0f32;
+        for (i, (&r, &w)) in host_ref.iter().zip(host_win.iter()).enumerate() {
+            let (r, w) = (r.to_f32(), w.to_f32());
+            assert!(
+                r.is_finite() && w.is_finite(),
+                "non-finite at {i}: {r} vs {w}"
+            );
+            worst = worst.max((r - w).abs());
+        }
+        // bf16 outputs of the same f32-accumulated softmax: the merge only
+        // reorders the sum, so the paths agree to bf16 rounding.
+        assert!(
+            worst < 2e-2,
+            "windowed walk diverged: worst |diff| = {worst}"
+        );
+    }
 
     /// Drives the kernel past the int32 batch-stride ceiling
     /// (`t_kv * heads * 192`). Identical K rows make every causal softmax
@@ -221,8 +565,10 @@ mod tests {
             .stream
             .alloc_zeros::<bf16>(t_q * heads * K3_MLA_PREFILL_V)
             .expect("out");
-        k3_flash_mla_prefill_fwd_launch(&ctx, t_q, t_kv, heads, &q, &k, &nope_v, &mut out, 0.072)
-            .expect("deep-context forward");
+        k3_flash_mla_prefill_fwd_launch(
+            &ctx, t_q, t_kv, heads, &q, &k, &nope_v, &mut out, None, 0.072,
+        )
+        .expect("deep-context forward");
         let host_out = ctx.stream.clone_dtoh(&out).expect("out to host");
         ctx.sync().expect("sync");
         for (i, &value) in host_out.iter().enumerate() {

--- a/pegainfer-kernels/src/ops/k3/mega_moe.rs
+++ b/pegainfer-kernels/src/ops/k3/mega_moe.rs
@@ -213,23 +213,29 @@ pub fn k3_mega_fabric_slab_import(
     Ok(ptr)
 }
 
-/// Ring a whale doorbell: store `value` into every 8-byte-aligned u64 flag
-/// address in `addrs` (local or fabric-imported device VAs), stream-ordered
-/// after preceding work on `stream`. One-thread SM kernel, because the
-/// stream memops engine rejects imported fabric mappings.
+/// Store `value` into every 8-byte-aligned u64 flag address in `flag_addrs`
+/// (local or fabric-imported device VAs), stream-ordered after preceding
+/// work on `stream`; see `csrc/k3/k3_whale_doorbell.cu`.
 pub fn k3_whale_doorbell_ring(
-    addrs: &[u64],
+    flag_addrs: &[u64],
     value: u64,
     stream: cudarc::driver::sys::CUstream,
 ) -> Result<()> {
-    ensure!(!addrs.is_empty(), "K3 whale doorbell with no targets");
-    // SAFETY: `addrs` is a live host slice; the launcher copies it by value.
+    // SAFETY: `flag_addrs` is a live host slice; the launcher copies it by value.
     let result = unsafe {
-        ffi::k3_whale_doorbell_ring(addrs.as_ptr(), i32::try_from(addrs.len())?, value, stream)
+        ffi::k3_whale_doorbell_ring(
+            flag_addrs.as_ptr(),
+            i32::try_from(flag_addrs.len())?,
+            value,
+            stream,
+        )
     };
-    result
-        .result()
-        .map_err(|err| anyhow!("K3 whale doorbell ring over {} flags: {err}", addrs.len()))
+    result.result().map_err(|err| {
+        anyhow!(
+            "K3 whale doorbell ring over {} flags: {err}",
+            flag_addrs.len()
+        )
+    })
 }
 
 /// Open the device pair `(self_ordinal, peer_ordinal)` for the fused kernel's

--- a/pegainfer-kernels/src/ops/k3/mega_moe.rs
+++ b/pegainfer-kernels/src/ops/k3/mega_moe.rs
@@ -213,6 +213,25 @@ pub fn k3_mega_fabric_slab_import(
     Ok(ptr)
 }
 
+/// Ring a whale doorbell: store `value` into every 8-byte-aligned u64 flag
+/// address in `addrs` (local or fabric-imported device VAs), stream-ordered
+/// after preceding work on `stream`. One-thread SM kernel, because the
+/// stream memops engine rejects imported fabric mappings.
+pub fn k3_whale_doorbell_ring(
+    addrs: &[u64],
+    value: u64,
+    stream: cudarc::driver::sys::CUstream,
+) -> Result<()> {
+    ensure!(!addrs.is_empty(), "K3 whale doorbell with no targets");
+    // SAFETY: `addrs` is a live host slice; the launcher copies it by value.
+    let result = unsafe {
+        ffi::k3_whale_doorbell_ring(addrs.as_ptr(), i32::try_from(addrs.len())?, value, stream)
+    };
+    result
+        .result()
+        .map_err(|err| anyhow!("K3 whale doorbell ring over {} flags: {err}", addrs.len()))
+}
+
 /// Open the device pair `(self_ordinal, peer_ordinal)` for the fused kernel's
 /// cross-rank addressing.
 ///

--- a/pegainfer-kernels/src/ops/linear.rs
+++ b/pegainfer-kernels/src/ops/linear.rs
@@ -463,6 +463,46 @@ pub fn gemm_rows_into_checked(
     )
 }
 
+/// Row-range GEMM over a token span of `x`:
+/// `Y = W[row_offset..row_offset+num_rows, :] @ X[x_row0..x_row0+out.seq_len]`.
+/// The span length is `out.seq_len`; `x.seq_len` bounds the readable rows.
+pub fn gemm_rows_span_into_checked(
+    ctx: &DeviceContext,
+    weight: &DeviceMatrix,
+    row_offset: usize,
+    num_rows: usize,
+    x: &HiddenStates,
+    x_row0: usize,
+    out: &mut HiddenStates,
+) -> Result<()> {
+    assert!(row_offset + num_rows <= weight.rows);
+    assert_eq!(weight.cols, x.hidden_dim);
+    assert_eq!(out.hidden_dim, num_rows);
+    assert!(
+        x_row0 + out.seq_len <= x.seq_len,
+        "x span [{x_row0}, {x_row0}+{}) exceeds x.seq_len {}",
+        out.seq_len,
+        x.seq_len
+    );
+
+    let (w_ptr, _gw) = weight.data.device_ptr(&ctx.stream);
+    let w_sub = w_ptr + (row_offset * weight.cols * std::mem::size_of::<half::bf16>()) as u64;
+    let (x_ptr, _gx) = x.data.device_ptr(&ctx.stream);
+    let x_sub = x_ptr + (x_row0 * x.hidden_dim * std::mem::size_of::<half::bf16>()) as u64;
+    let (y_ptr, _gy) = out.data.device_ptr_mut(&ctx.stream);
+
+    launch_gemm(
+        w_sub as *const ffi::Half,
+        x_sub as *const ffi::Half,
+        y_ptr as *mut ffi::Half,
+        num_rows,
+        out.seq_len,
+        weight.cols,
+        out.seq_len == 1,
+        ctx,
+    )
+}
+
 /// Matrix-vector multiplication: y = A @ x (via cuBLAS GEMM with N=1)
 /// A: (M, K) row-major, x: (K,), y: (M,)
 pub fn gemv(ctx: &DeviceContext, a: &DeviceMatrix, x: &DeviceVec, y: &mut DeviceVec) -> Result<()> {


### PR DESCRIPTION
# feat(k3): cross-process CP whale gang — fleet-wide long-prompt prefill

## What / invariant changed

K3's context-parallel prefill lane previously stopped at process boundaries
(`PEGAINFER_K3_CP` = local ranks only). This PR extends it across the whole EP
fleet: a long prompt admitted on any endpoint is split across up to 16 ranks on
4 machines ("whale gang"), each rank prefills its context segment in lockstep
supersteps, and KV/activations flow between processes over CUDA fabric (MNVL)
slabs with SM-kernel doorbells. The EP free-running discipline (CLAUDE.md) is
preserved: no rank ever waits in the engine loop; the gang is booked as agreed
future launch steps; padding ranks step constructively.

New pieces:
- `scheduler/whale.rs` — gang planning: depth-leveled segment split (quadratic
  attention model, capped at the mean's chunk bucket), rendezvous state machine.
- `scheduler/whale_hub.rs` — TCP hub: per-connection threads, slab-table
  exchange, sequenced plan broadcast.
- `executor/whale_gang.rs` + `executor/cp.rs` — fabric slab data plane;
  doorbells ring via a one-thread SM kernel (GB300 stream memops reject
  fabric-imported VAs; waits stay memops on local slabs).
- FlashMLA prefill: 116k-token context ceiling lifted (b=1 batch strides are
  never used to offset; pass 0, delete the INT_MAX guard). Includes an
  `#[ignore]` 260k-token GPU test.

Behavior tightening: `PEGAINFER_K3_WHALE_MIN` now refuses values below 4096
(2× the 2048 segment floor) — a narrower floor could not split into two
legal segments anyway.

## Evidence (all on GB300 trays, pruned-224 K3 checkpoint)

**Correctness gates**
- CP8 (2 trays × EP8) and CP16 (4 trays × EP16): 512-token and 16k-token
  prompts byte-identical across every fleet endpoint vs the local lane;
  16k + 48 greedy tokens coherent and identical on all endpoints.
- Deep context: 128,459-token prompt coherent and endpoint-identical at CP8
  (post-ceiling-fix); FlashMLA `deep_context_attention_addresses_past_int32`
  passes on hardware (2.7s).

**Same-fleet A/B — TTFT min ms (CP1 local lane vs whale, identical fleet/binary)**

| prompt tokens | CP1 local | whale CP8 | speedup |
|---:|---:|---:|---:|
| 16,725 | 3,005 | 1,042 | 2.88× |
| 28,544 | 5,881 | 1,286 | 4.57× |
| 65,116 | 13,922 | 2,747 | 5.07× |
| 128,225 | 33,609 | 6,373 | 5.27× |

CP16 matches CP8 at these lengths (intercept-bound; 28.5k: 1,228ms, 4.79×).

**nsys anatomy (whale CP8@128k, deep rank)**: superstep wall 6,233ms =
FMHA 35.8% + mega MoE 19.8% (pairing-wait-inflated) + dense GEMM 15.5% +
elementwise 10.4% + KDA 4.2% + gaps 6.7%. Measured Amdahl cap 6.4× at 128k;
we serve 93% of it. Full account and lever ranking in
docs/models/k3/cp-lane-design.md.

**Fixed en route (each hardware-reproduced)**
- Whale hub accepted connections inline → >1 peer process deadlocked the
  accept loop (masked at CP8, deadlocked CP16). Per-connection threads.
- GB300 stream memops reject fabric-imported mappings
  (`cuStreamWriteValue64` → `CUDA_ERROR_INVALID_VALUE`); doorbell writes moved
  into an SM kernel.
- Hub sequencer bound the resolved hostname → 127.0.1.1 loopback trap; binds
  0.0.0.0.
- Leveling pushed head segments across the chunk-bucket boundary when the mean
  sat near it → padded-row families doubled fleet-wide (~+900ms at 65k). Segments
  now cap at the mean's bucket. 65k TTFT 3,638 → 2,747ms.

**Not in this PR**: 256k single-superstep gate and the full-896-expert EP16 vs
vLLM TP16 rematch (blocked on free trays); FMHA striping / superstep graphing /
finer bucket ladder (profile-ranked follow-ups, see cp-lane-design.md).

## Tests

- `cargo test --release --workspace --lib` green (includes new no-GPU tests:
  gang consensus, slab-table exchange with multi-peer processes, leveling
  bucket-cap, hub loopback).
- GPU gates listed above ran on tray08/09/14/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
