### PR TITLE
feat(release): publish Qwen3 CUDA 13 binary for v0.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release Qwen3 binary
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  qwen3-linux-x86_64-cu130:
+    name: Qwen3 Linux x86_64 CUDA 13.0
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CUDA_PATH: /usr/local/cuda
+      PEGAINFER_CUDA_SM: "80,86,89,90,100,110,120"
+      PEGAINFER_NVCC_JOBS: "2"
+      RELEASE_NOTES: >-
+        Prebuilt Qwen3-only server for Linux x86_64. The archive contains CUDA
+        13.0 runtime libraries and supports NVIDIA compute capabilities 8.x
+        through 12.x. NVIDIA driver 580 or newer, glibc 2.35 or newer, and
+        OpenSSL 3 are required. Model weights are not included.
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: nightly-2026-07-10
+
+      - name: Install CUDA toolkit
+        uses: Jimver/cuda-toolkit@v0.2.35
+        with:
+          cuda: "13.0.2"
+          linux-local-args: '["--toolkit"]'
+          method: network
+          sub-packages: '["nvcc", "nvrtc-dev", "cudart-dev"]'
+          non-cuda-sub-packages: '["libcublas-dev", "libcurand-dev"]'
+
+      - name: Install build and packaging dependencies
+        run: >-
+          sudo apt-get update && sudo apt-get install -y
+          protobuf-compiler libibverbs-dev patchelf
+
+      - name: Verify tag matches the server version
+        run: |
+          set -euo pipefail
+          package_version=$(
+            cargo metadata --locked --no-deps --format-version 1 |
+              jq -r '.packages[]
+                | select(.name == "pegainfer-server")
+                | .version'
+          )
+          test "$GITHUB_REF_NAME" = "v$package_version"
+
+      - name: Build Qwen3-only fat binary
+        run: >-
+          cargo build --release --locked -p pegainfer-server
+          --no-default-features --features qwen3
+
+      - name: Package release
+        run: scripts/package_qwen3_release.sh "$GITHUB_REF_NAME" dist
+
+      - name: Attest release archive
+        uses: actions/attest@v4
+        with:
+          subject-path: dist/pegainfer-qwen3-linux-x86_64-cu130.tar.gz
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "release $GITHUB_REF_NAME already exists;" \
+              "refusing to replace its assets" >&2
+            exit 1
+          fi
+          gh release create "$GITHUB_REF_NAME" \
+            dist/pegainfer-qwen3-linux-x86_64-cu130.tar.gz \
+            dist/SHA256SUMS \
+            --verify-tag \
+            --generate-notes \
+            --notes "$RELEASE_NOTES" \
+            --title "PegaInfer $GITHUB_REF_NAME"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3918,7 +3918,7 @@ dependencies = [
 
 [[package]]
 name = "pegainfer-server"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ Docs, guides, and engineering deep-dives live at [pegainfer.org](https://pegainf
 
 ## Quickstart
 
+### Prebuilt Qwen3 binary
+
+Starting with v0.1.1, PegaInfer provides a Qwen3-only CUDA 13 binary for Linux
+x86_64. The archive includes the CUDA runtime and cuBLAS; the host supplies
+NVIDIA driver 580 or newer, glibc 2.35 or newer, and OpenSSL 3. Install or
+update it in the current user's home directory:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/pegainfer-project/pegainfer/main/install.sh | bash
+```
+
+Set `PEGAINFER_VERSION=v0.1.1` to install that exact release. Model weights are
+not part of the binary archive; download a Qwen3 checkpoint separately and run:
+
+```bash
+pegainfer --model-path models/Qwen3-4B
+```
+
 ### Prerequisites
 
 - Rust (2024 edition), CUDA Toolkit (nvcc, cuBLAS), CUDA-capable GPU
@@ -333,4 +351,3 @@ The DeepSeek-V2-Lite E2E is a correctness/integration gate. Direct diagnostics a
 Apache-2.0 — see [LICENSE](LICENSE) and [NOTICE](NOTICE). Components ported from
 NVIDIA Dynamo (the `kvbm/kvbm-logical` crate) retain their original Apache-2.0 headers; see
 [NOTICE_DYNAMO](NOTICE_DYNAMO).
-

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository=pegainfer-project/pegainfer
+asset_name=pegainfer-qwen3-linux-x86_64-cu130
+requested_version=${PEGAINFER_VERSION:-latest}
+
+die() {
+  echo "pegainfer installer: $*" >&2
+  exit 1
+}
+
+command -v curl >/dev/null || die "curl is required"
+command -v sha256sum >/dev/null || die "sha256sum is required"
+command -v tar >/dev/null || die "tar is required"
+[[ $(uname -s) == Linux ]] || die "the prebuilt release supports Linux only"
+[[ $(uname -m) == x86_64 ]] || die "the prebuilt release supports x86_64 only"
+command -v nvidia-smi >/dev/null || die "nvidia-smi is required"
+
+driver_version=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | sed -n '1p')
+driver_major=${driver_version%%.*}
+[[ $driver_major =~ ^[0-9]+$ ]] || die "could not parse NVIDIA driver version: $driver_version"
+((driver_major >= 580)) || die "CUDA 13 requires NVIDIA driver 580 or newer; found $driver_version"
+
+supported_gpu=false
+while IFS= read -r compute_capability; do
+  compute_major=${compute_capability%%.*}
+  if [[ $compute_major =~ ^(8|9|10|11|12)$ ]]; then
+    supported_gpu=true
+    break
+  fi
+done < <(nvidia-smi --query-gpu=compute_cap --format=csv,noheader)
+[[ $supported_gpu == true ]] \
+  || die "the Qwen3 binary requires an NVIDIA GPU with compute capability 8.x through 12.x"
+
+if [[ $requested_version == latest ]]; then
+  release_url="https://github.com/$repository/releases/latest/download"
+else
+  [[ $requested_version == v* ]] || requested_version="v$requested_version"
+  release_url="https://github.com/$repository/releases/download/$requested_version"
+fi
+
+data_home=${XDG_DATA_HOME:-$HOME/.local/share}
+install_root=${PEGAINFER_INSTALL_ROOT:-$data_home/pegainfer}
+bin_dir=${PEGAINFER_BIN_DIR:-$HOME/.local/bin}
+[[ $install_root == /* ]] || die "PEGAINFER_INSTALL_ROOT must be an absolute path"
+[[ $bin_dir == /* ]] || die "PEGAINFER_BIN_DIR must be an absolute path"
+temporary_dir=$(mktemp -d)
+trap 'rm -rf -- "$temporary_dir"' EXIT
+
+archive="$temporary_dir/$asset_name.tar.gz"
+checksums="$temporary_dir/SHA256SUMS"
+curl --fail --location --silent --show-error \
+  "$release_url/$asset_name.tar.gz" --output "$archive"
+curl --fail --location --silent --show-error \
+  "$release_url/SHA256SUMS" --output "$checksums"
+
+(
+  cd "$temporary_dir"
+  grep "  $asset_name.tar.gz$" SHA256SUMS >SHA256SUMS.selected \
+    || die "release checksum does not list $asset_name.tar.gz"
+  sha256sum --check SHA256SUMS.selected
+)
+
+tar -xzf "$archive" -C "$temporary_dir"
+extracted="$temporary_dir/$asset_name"
+[[ -x $extracted/bin/pegainfer ]] || die "release archive does not contain pegainfer"
+installed_version=$("$extracted/bin/pegainfer" --version | awk '{print $2}')
+[[ $installed_version =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-].*)?$ ]] \
+  || die "release binary returned an invalid version: $installed_version"
+if [[ $requested_version != latest && v$installed_version != "$requested_version" ]]; then
+  die "downloaded version $installed_version does not match $requested_version"
+fi
+
+version_dir="$install_root/versions/v$installed_version"
+mkdir -p "$install_root/versions" "$bin_dir"
+if [[ -e $version_dir ]]; then
+  [[ -x $version_dir/bin/pegainfer ]] \
+    || die "existing installation is incomplete: $version_dir"
+  existing_version=$("$version_dir/bin/pegainfer" --version | awk '{print $2}')
+  [[ $existing_version == "$installed_version" ]] \
+    || die "existing installation at $version_dir has version $existing_version"
+else
+  mv "$extracted" "$version_dir"
+fi
+ln -sfn "versions/v$installed_version" "$install_root/current.new"
+mv -Tf "$install_root/current.new" "$install_root/current"
+ln -sfn "$install_root/current/bin/pegainfer" "$bin_dir/pegainfer"
+
+echo "installed PegaInfer v$installed_version to $version_dir"
+echo "binary: $bin_dir/pegainfer"
+if [[ :$PATH: != *":$bin_dir:"* ]]; then
+  echo "add $bin_dir to PATH before running pegainfer"
+fi

--- a/pegainfer-server/Cargo.toml
+++ b/pegainfer-server/Cargo.toml
@@ -4,7 +4,7 @@ default-run = "pegainfer"
 edition = "2024"
 license = "Apache-2.0"
 name = "pegainfer-server"
-version = "0.1.0"
+version = "0.1.1"
 
 [[bin]]
 name = "pegainfer"

--- a/pegainfer-server/src/main.rs
+++ b/pegainfer-server/src/main.rs
@@ -125,8 +125,11 @@ async fn main() -> anyhow::Result<()> {
     pegainfer_core::tracing::init();
 
     let registry = ModelLineRegistry::new(model_lines());
-    let cmd = registry
-        .build_command(clap::Command::new("pegainfer").about("PegaInfer GPU inference server"));
+    let cmd = registry.build_command(
+        clap::Command::new("pegainfer")
+            .version(env!("CARGO_PKG_VERSION"))
+            .about("PegaInfer GPU inference server"),
+    );
     let matches = cmd.clone().get_matches();
     let shared = SharedArgs::from_arg_matches(&matches)
         .map_err(|error| anyhow::anyhow!("invalid CLI args: {error}"))?;

--- a/scripts/package_qwen3_release.sh
+++ b/scripts/package_qwen3_release.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 VERSION OUTPUT_DIR" >&2
+  exit 2
+}
+
+[[ $# -eq 2 ]] || usage
+
+version=${1#v}
+output_dir=$2
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+binary="$repo_root/target/release/pegainfer"
+cuda_root=${CUDA_PATH:-${CUDA_HOME:-/usr/local/cuda}}
+asset_name=pegainfer-qwen3-linux-x86_64-cu130
+
+[[ $(uname -s) == Linux ]] || {
+  echo "release packaging requires Linux" >&2
+  exit 1
+}
+[[ $(uname -m) == x86_64 ]] || {
+  echo "release packaging currently supports x86_64 only" >&2
+  exit 1
+}
+[[ -x $binary ]] || {
+  echo "release binary is missing: $binary" >&2
+  exit 1
+}
+command -v patchelf >/dev/null || {
+  echo "patchelf is required" >&2
+  exit 1
+}
+
+cuda_lib_dir=
+for candidate in \
+  "$cuda_root/targets/x86_64-linux/lib" \
+  "$cuda_root/lib64"; do
+  if [[ -e $candidate/libcudart.so.13 ]]; then
+    cuda_lib_dir=$candidate
+    break
+  fi
+done
+[[ -n $cuda_lib_dir ]] || {
+  echo "CUDA 13 runtime libraries were not found under $cuda_root" >&2
+  exit 1
+}
+
+staging_dir=$(mktemp -d)
+trap 'rm -rf -- "$staging_dir"' EXIT
+package_root="$staging_dir/$asset_name"
+mkdir -p "$package_root/bin" "$package_root/lib" "$output_dir"
+
+install -m 0755 "$binary" "$package_root/bin/pegainfer"
+for library in libcudart.so.13 libcublas.so.13 libcublasLt.so.13; do
+  [[ -e $cuda_lib_dir/$library ]] || {
+    echo "required CUDA library is missing: $cuda_lib_dir/$library" >&2
+    exit 1
+  }
+  install -m 0644 "$(readlink -f "$cuda_lib_dir/$library")" "$package_root/lib/$library"
+done
+
+install -m 0644 "$repo_root/LICENSE" "$package_root/LICENSE"
+install -m 0644 "$repo_root/NOTICE" "$package_root/NOTICE"
+install -m 0644 "$repo_root/NOTICE_DYNAMO" "$package_root/NOTICE_DYNAMO"
+[[ -f $cuda_root/EULA.txt ]] || {
+  echo "CUDA EULA is missing: $cuda_root/EULA.txt" >&2
+  exit 1
+}
+install -m 0644 "$cuda_root/EULA.txt" "$package_root/NVIDIA-CUDA-EULA.txt"
+
+patchelf --set-rpath "\$ORIGIN/../lib" "$package_root/bin/pegainfer"
+
+binary_version=$("$package_root/bin/pegainfer" --version | awk '{print $2}')
+[[ $binary_version == "$version" ]] || {
+  echo "binary version $binary_version does not match release version $version" >&2
+  exit 1
+}
+
+if ldd "$package_root/bin/pegainfer" | grep -Fq 'not found'; then
+  echo "packaged binary has unresolved dynamic libraries" >&2
+  ldd "$package_root/bin/pegainfer" >&2
+  exit 1
+fi
+for library in libcudart.so.13 libcublas.so.13 libcublasLt.so.13; do
+  resolved_library=$(ldd "$package_root/bin/pegainfer" \
+    | awk -v library="$library" '$1 == library {print $3}')
+  if [[ -z $resolved_library \
+    || $(readlink -f "$resolved_library") != $(readlink -f "$package_root/lib/$library") ]]; then
+    echo "packaged binary does not resolve bundled $library" >&2
+    ldd "$package_root/bin/pegainfer" >&2
+    exit 1
+  fi
+done
+
+archive="$output_dir/$asset_name.tar.gz"
+tar -C "$staging_dir" -czf "$archive" "$asset_name"
+(
+  cd "$output_dir"
+  sha256sum "$asset_name.tar.gz" >SHA256SUMS
+)
+echo "$archive"


### PR DESCRIPTION
## Description

Add the first prebuilt PegaInfer release path, scoped to Qwen3 on Linux x86_64 with CUDA 13.0.

The tag-triggered workflow builds one fat binary for SM 80, 86, 89, 90, 100, 110, and 120, packages CUDA Runtime and cuBLAS with a relative RUNPATH, generates SHA256 checksums and GitHub build provenance, and publishes the assets without replacing an existing release. The installer verifies the host driver/GPU family and archive checksum, installs into versioned user directories, and atomically switches the current symlink.

The server package version is 0.1.1 and `pegainfer --version` now exposes it. Model weights remain outside the release archive.

## Production invariant

A `v0.1.1` tag must produce a Qwen3-only archive whose embedded server reports `0.1.1`, resolves all shipped CUDA libraries from the archive, and completes a real HTTP generation after extraction. The workflow rejects a tag/version mismatch and refuses to replace assets for an existing release.

## Duplication and scope audit

The repository had no release workflow, binary packager, installer, or updater before this change. Every changed file participates in that distribution invariant; model execution and performance code are unchanged.

This change was prepared with Codex assistance. The verification below was executed against the resulting commit and packaged artifact.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Verification

- `cargo fmt --all --check`
- `cargo metadata --locked --no-deps --format-version 1`
- `shellcheck install.sh scripts/package_qwen3_release.sh`
- `actionlint .github/workflows/release.yml`
- `yamllint .github/workflows/release.yml`
- `PEGAINFER_CUDA_SM=80,86,89,90,100,110,120 PEGAINFER_NVCC_JOBS=2 cargo build --release --locked -p pegainfer-server --no-default-features --features qwen3` (passed in 10m36s)
- `cuobjdump --list-elf target/release/pegainfer` confirmed all seven SM targets
- `scripts/package_qwen3_release.sh v0.1.1 <temporary-output>` produced a 437 MiB archive; basename-only SHA256 verification passed
- Extracted archive with `LD_LIBRARY_PATH` unset reported `pegainfer 0.1.1`; `ldd` resolved cudart, cuBLAS, and cuBLASLt from the archive
- Extracted archive served Qwen3-4B on a consumer Blackwell GPU (SM120); `/v1/completions` returned 8 tokens and shutdown drained cleanly
- `cargo test --release --locked -p pegainfer-qwen3 --lib` (88 passed)

## Checklist

- [x] Code follows the repository style guidelines
- [x] Self-review completed
- [x] Commit uses Commitizen format and carries a DCO sign-off
- [x] Relevant local tests pass

## Release follow-up

After this PR merges, create and push tag `v0.1.1`. The workflow will build and publish the GitHub Release; this PR itself does not create a tag or release.