### PR TITLE
fix(release): install CUDA driver stub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           cuda: "13.0.2"
           linux-local-args: '["--toolkit"]'
           method: network
-          sub-packages: '["nvcc", "nvrtc-dev", "cudart-dev"]'
+          sub-packages: '["nvcc", "nvrtc-dev", "cudart-dev", "driver-dev"]'
           non-cuda-sub-packages: '["libcublas-dev", "libcurand-dev"]'
 
       - name: Install build and packaging dependencies


### PR DESCRIPTION
## Summary

- install the CUDA driver development stub in the Qwen3 release job
- allow the GPU-less GitHub runner to satisfy the final `-lcuda` link

## Evidence

The first `v0.1.1` release run compiled all seven CUDA targets and reached the final server link, then failed with `rust-lld: error: unable to find library -lcuda`. NVIDIA packages the required build-time stub as `cuda-driver-dev-13-0`; the CUDA action maps the added `driver-dev` sub-package to that package.

Validated with YAML parsing, `git diff --check`, and `cargo fmt --check`.

Signed-off-by: xiaguan <751080330@qq.com>