### PR TITLE
fix(release): probe CUDA link through rustc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,9 @@ jobs:
           driver_stub="$CUDA_PATH/targets/x86_64-linux/lib/stubs"
           test -f "$driver_stub/libcuda.so"
           export LIBRARY_PATH="$driver_stub${LIBRARY_PATH:+:$LIBRARY_PATH}"
-          cc -fuse-ld=lld -shared -Wl,--no-as-needed -lcuda \
-            -o /dev/null -x c /dev/null
+          probe_dir=$(mktemp -d)
+          rustc - --crate-name cuda_link_probe -l cuda \
+            -o "$probe_dir/cuda-link-probe" <<< 'fn main() {}'
           cargo build --release --locked -p pegainfer-server \
             --no-default-features --features qwen3
 


### PR DESCRIPTION
## Summary

- run the CUDA driver-stub preflight through `rustc`, matching Cargo’s `cc` and Rust sysroot linker-wrapper path
- keep the early failure before the full CUDA build

## Evidence

- release run 32951406379 proved `libcuda.so` exists and isolated the failure to direct `cc -fuse-ld=lld`, which cannot discover Rust’s sysroot linker wrapper
- the replacement rustc link probe passes locally against the CUDA 13.3 driver stub
- a negative-control link against a missing library fails
- `cargo fmt --check`
- YAML parsed with PyYAML
- `git diff --check`
- pre-commit hooks passed

Signed-off-by: xiaguan <751080330@qq.com>