### PR TITLE
fix(release): install CUDA EULA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,8 @@ jobs:
           cuda: "13.0.2"
           linux-local-args: '["--toolkit"]'
           method: network
-          sub-packages: '["nvcc", "nvrtc-dev", "cudart-dev", "driver-dev"]'
+          sub-packages: >-
+            ["nvcc", "nvrtc-dev", "cudart-dev", "driver-dev", "documentation"]
           non-cuda-sub-packages: '["libcublas-dev", "libcurand-dev"]'
 
       - name: Install build and packaging dependencies


### PR DESCRIPTION
## Summary

- install the small CUDA documentation package in the release job
- provide the NVIDIA CUDA EULA required by the existing packaging script

## Evidence

- release run 32952525892 completed the full Qwen3 fat-binary build and failed packaging only because `/usr/local/cuda-13.0/EULA.txt` was absent
- `cuda-documentation-13-3` owns `/usr/local/cuda-13.3/EULA.txt` on the local CUDA installation and has a 406 KB installed size; the CUDA 13.0 package follows the same package layout
- YAML parsed with PyYAML
- `cargo fmt --check`
- `git diff --check`
- pre-commit hooks passed

Signed-off-by: xiaguan <751080330@qq.com>