### PR TITLE
fix(release): validate packaged CUDA bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,31 +4,31 @@ on:
   push:
     tags:
       - "v*"
+  pull_request:
+    paths:
+      - ".github/workflows/release.yml"
+      - "scripts/package_qwen3_release.sh"
+  workflow_dispatch:
 
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
+  contents: read
 
 jobs:
-  qwen3-linux-x86_64-cu130:
-    name: Qwen3 Linux x86_64 CUDA 13.0
+  build:
+    name: Build Qwen3 Linux x86_64 CUDA 13.0
     runs-on: ubuntu-22.04
     timeout-minutes: 90
+    outputs:
+      version: ${{ steps.server.outputs.version }}
     env:
       CUDA_PATH: /usr/local/cuda
       PEGAINFER_CUDA_SM: "80,86,89,90,100,110,120"
       PEGAINFER_NVCC_JOBS: "2"
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
-      RELEASE_NOTES: >-
-        Prebuilt Qwen3-only server for Linux x86_64. The archive contains CUDA
-        13.0 runtime libraries and supports NVIDIA compute capabilities 8.x
-        through 12.x. NVIDIA driver 580 or newer, glibc 2.35 or newer, and
-        OpenSSL 3 are required. Model weights are not included.
 
     steps:
-      - name: Checkout release tag
+      - name: Checkout source
         uses: actions/checkout@v6
         with:
           persist-credentials: false
@@ -42,22 +42,22 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
 
-      - name: Install CUDA toolkit
+      - name: Install CUDA build toolkit
         uses: Jimver/cuda-toolkit@v0.2.35
         with:
           cuda: "13.0.2"
           linux-local-args: '["--toolkit"]'
           method: network
-          sub-packages: >-
-            ["nvcc", "nvrtc-dev", "cudart-dev", "driver-dev", "documentation"]
+          sub-packages: '["nvcc", "nvrtc-dev", "cudart-dev", "driver-dev"]'
           non-cuda-sub-packages: '["libcublas-dev", "libcurand-dev"]'
 
-      - name: Install build and packaging dependencies
+      - name: Install build dependencies
         run: >-
           sudo apt-get update && sudo apt-get install -y
-          protobuf-compiler libibverbs-dev patchelf
+          protobuf-compiler libibverbs-dev
 
-      - name: Verify tag matches the server version
+      - name: Resolve server version
+        id: server
         run: |
           set -euo pipefail
           package_version=$(
@@ -66,7 +66,10 @@ jobs:
                 | select(.name == "pegainfer-server")
                 | .version'
           )
-          test "$GITHUB_REF_NAME" = "v$package_version"
+          if [[ $GITHUB_REF_TYPE == tag ]]; then
+            test "$GITHUB_REF_NAME" = "v$package_version"
+          fi
+          echo "version=$package_version" >>"$GITHUB_OUTPUT"
 
       - name: Build Qwen3-only fat binary
         run: |
@@ -80,8 +83,89 @@ jobs:
           cargo build --release --locked -p pegainfer-server \
             --no-default-features --features qwen3
 
-      - name: Package release
-        run: scripts/package_qwen3_release.sh "$GITHUB_REF_NAME" dist
+      - name: Upload server binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: pegainfer-qwen3-server
+          path: target/release/pegainfer
+          if-no-files-found: error
+          retention-days: 3
+          compression-level: 0
+          overwrite: true
+
+  package:
+    name: Package Qwen3 Linux x86_64 CUDA 13.0
+    needs: build
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    env:
+      CUDA_PATH: /usr/local/cuda
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install CUDA runtime and EULA
+        uses: Jimver/cuda-toolkit@v0.2.35
+        with:
+          cuda: "13.0.2"
+          linux-local-args: '["--toolkit"]'
+          method: network
+          sub-packages: '["cudart-dev", "documentation"]'
+          non-cuda-sub-packages: '["libcublas-dev"]'
+
+      - name: Install packaging dependencies
+        run: sudo apt-get update && sudo apt-get install -y patchelf
+
+      - name: Download server binary
+        uses: actions/download-artifact@v4
+        with:
+          name: pegainfer-qwen3-server
+          path: target/release
+
+      - name: Package release candidate
+        run: |
+          chmod +x target/release/pegainfer
+          scripts/package_qwen3_release.sh \
+            "v${{ needs.build.outputs.version }}" dist
+
+      - name: Upload release candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: pegainfer-qwen3-linux-x86_64-cu130-release
+          path: |
+            dist/pegainfer-qwen3-linux-x86_64-cu130.tar.gz
+            dist/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 3
+          compression-level: 0
+          overwrite: true
+
+  publish:
+    name: Publish Qwen3 Linux x86_64 CUDA 13.0
+    if: github.ref_type == 'tag'
+    needs: package
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    env:
+      RELEASE_NOTES: >-
+        Prebuilt Qwen3-only server for Linux x86_64. The archive contains CUDA
+        13.0 runtime libraries and supports NVIDIA compute capabilities 8.x
+        through 12.x. NVIDIA driver 580 or newer, glibc 2.35 or newer, and
+        OpenSSL 3 are required. Model weights are not included.
+
+    steps:
+      - name: Download release candidate
+        uses: actions/download-artifact@v4
+        with:
+          name: pegainfer-qwen3-linux-x86_64-cu130-release
+          path: dist
 
       - name: Attest release archive
         uses: actions/attest@v4
@@ -93,7 +177,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+          if gh release view "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "release $GITHUB_REF_NAME already exists;" \
               "refusing to replace its assets" >&2
             exit 1
@@ -101,6 +186,7 @@ jobs:
           gh release create "$GITHUB_REF_NAME" \
             dist/pegainfer-qwen3-linux-x86_64-cu130.tar.gz \
             dist/SHA256SUMS \
+            --repo "$GITHUB_REPOSITORY" \
             --verify-tag \
             --generate-notes \
             --notes "$RELEASE_NOTES" \

--- a/scripts/package_qwen3_release.sh
+++ b/scripts/package_qwen3_release.sh
@@ -71,24 +71,26 @@ install -m 0644 "$cuda_root/EULA.txt" "$package_root/NVIDIA-CUDA-EULA.txt"
 
 patchelf --set-rpath "\$ORIGIN/../lib" "$package_root/bin/pegainfer"
 
-binary_version=$("$package_root/bin/pegainfer" --version | awk '{print $2}')
+binary_version=$(env -u LD_LIBRARY_PATH \
+  "$package_root/bin/pegainfer" --version | awk '{print $2}')
 [[ $binary_version == "$version" ]] || {
   echo "binary version $binary_version does not match release version $version" >&2
   exit 1
 }
 
-if ldd "$package_root/bin/pegainfer" | grep -Fq 'not found'; then
+packaged_dependencies=$(env -u LD_LIBRARY_PATH ldd "$package_root/bin/pegainfer")
+if grep -Fq 'not found' <<<"$packaged_dependencies"; then
   echo "packaged binary has unresolved dynamic libraries" >&2
-  ldd "$package_root/bin/pegainfer" >&2
+  printf '%s\n' "$packaged_dependencies" >&2
   exit 1
 fi
 for library in libcudart.so.13 libcublas.so.13 libcublasLt.so.13; do
-  resolved_library=$(ldd "$package_root/bin/pegainfer" \
-    | awk -v library="$library" '$1 == library {print $3}')
+  resolved_library=$(awk -v library="$library" \
+    '$1 == library {print $3}' <<<"$packaged_dependencies")
   if [[ -z $resolved_library \
     || $(readlink -f "$resolved_library") != $(readlink -f "$package_root/lib/$library") ]]; then
     echo "packaged binary does not resolve bundled $library" >&2
-    ldd "$package_root/bin/pegainfer" >&2
+    printf '%s\n' "$packaged_dependencies" >&2
     exit 1
   fi
 done


### PR DESCRIPTION
## Summary

- validate the packaged binary without the CUDA action’s `LD_LIBRARY_PATH`, so `$ORIGIN/../lib` is exercised
- run the release build and packaging pipeline on release-related pull requests and manual dispatches
- split build, package, and tag-only publish into separate jobs
- upload the binary and packaged release candidate as short-lived Actions artifacts

## Why

The tag-only single job required merging and moving the release tag for every packaging diagnostic. Package-only failures also repeated the full multi-architecture CUDA build. The split workflow makes pull requests the release dry-run and lets a failed package job be retried without rebuilding. Public release creation and attestation remain tag-only.

## Evidence

- release run 32955220598 built successfully and showed `ldd` selecting `/usr/local/cuda-13.0/lib64` because the CUDA action exports `LD_LIBRARY_PATH`
- local A/B: with that variable set, all three CUDA libraries resolve to the toolkit; with it removed, all three resolve through the packaged `$ORIGIN/../lib` RUNPATH
- the sanitized packaged binary reports `pegainfer 0.1.1`
- warm sccache run: 622 hits / 9 misses (99%); total job time 14m03s versus 21m19s cold, 7m16s faster (~34%)
- workflow YAML parsed with PyYAML
- `bash -n scripts/package_qwen3_release.sh`
- `cargo fmt --check`
- `git diff --check`
- pre-commit hooks passed

Signed-off-by: xiaguan <751080330@qq.com>