### PR TITLE
fix(install): clarify post-install setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ update it in the current user's home directory:
 curl -fsSL https://raw.githubusercontent.com/pegainfer-project/pegainfer/main/install.sh | bash
 ```
 
+If `pegainfer` is not found in the current shell after installation, run:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
 Set `PEGAINFER_VERSION=v0.1.1` to install that exact release. Model weights are
 not part of the binary archive; download a Qwen3 checkpoint separately and run:
 
@@ -85,12 +91,12 @@ cargo run --release
 # Try it
 curl -s http://localhost:8000/v1/completions \
   -H "Content-Type: application/json" \
-  -d '{"prompt": "The capital of France is", "max_tokens": 32}'
+  -d '{"model": "models/Qwen3-4B", "prompt": "The capital of France is", "max_tokens": 32}'
 
 # Streaming
 curl -N http://localhost:8000/v1/completions \
   -H "Content-Type: application/json" \
-  -d '{"prompt": "Write a haiku about Rust:", "max_tokens": 64, "stream": true}'
+  -d '{"model": "models/Qwen3-4B", "prompt": "Write a haiku about Rust:", "max_tokens": 64, "stream": true}'
 ```
 
 > Always use `--release`. Debug builds are extremely slow for GPU/CUDA code.

--- a/install.sh
+++ b/install.sh
@@ -90,5 +90,7 @@ ln -sfn "$install_root/current/bin/pegainfer" "$bin_dir/pegainfer"
 echo "installed PegaInfer v$installed_version to $version_dir"
 echo "binary: $bin_dir/pegainfer"
 if [[ :$PATH: != *":$bin_dir:"* ]]; then
-  echo "add $bin_dir to PATH before running pegainfer"
+  echo "pegainfer is not on PATH in this shell; run:"
+  printf '  export PATH="%s:%s"\n' "$bin_dir" "\$PATH"
+  echo "add the same line to your shell profile to keep it available"
 fi


### PR DESCRIPTION
## Summary

- Print an exact PATH export when the installed binary is unavailable in the current shell.
- Document current-shell PATH activation without modifying shell profiles.
- Add the required model field to both completion examples.

## Validation

- bash -n install.sh
- shellcheck install.sh
- git diff --check
- Fresh-machine release E2E on 1x RTX PRO 6000 Blackwell (sm120, driver 580.126.09): v0.1.1 checksum and installation passed, Qwen3-4B reached HTTP ready in about 2 seconds, and the corrected completion request returned 32 tokens. The prior example reproduced the missing-model validation error.

Signed-off-by: xiaguan <751080330@qq.com>