### PR TITLE
perf(gemma4): the layer tail and its norms land in single launches

### DIFF
--- a/pegainfer-core/src/ops.rs
+++ b/pegainfer-core/src/ops.rs
@@ -32,6 +32,7 @@ pub use pegainfer_kernels::ops::bf16_hidden_to_f32_into;
 pub use pegainfer_kernels::ops::copy_hidden_rows_into;
 pub use pegainfer_kernels::ops::copy_hidden_token_range_into;
 pub use pegainfer_kernels::ops::dflash_qk_norm_rope_into;
+pub use pegainfer_kernels::ops::dual_rms_norm_add_batch_into;
 pub use pegainfer_kernels::ops::eagle3_rope_into;
 #[cfg(not(feature = "kernel-call-trace"))]
 pub use pegainfer_kernels::ops::embedding_batch;

--- a/pegainfer-core/src/ops.rs
+++ b/pegainfer-core/src/ops.rs
@@ -78,6 +78,7 @@ pub use pegainfer_kernels::ops::qk_norm_rope_prefill_hd256_plain_into;
 pub use pegainfer_kernels::ops::qkv_norm_rope_paged_decode_hd256_plain_into;
 pub use pegainfer_kernels::ops::qkv_norm_rope_paged_prefill_hd256_plain_into;
 pub use pegainfer_kernels::ops::rms_norm;
+pub use pegainfer_kernels::ops::rms_norm_add_scale_batch_into;
 pub use pegainfer_kernels::ops::rms_norm_batch_dual_into;
 #[cfg(not(feature = "kernel-call-trace"))]
 pub use pegainfer_kernels::ops::rms_norm_batch_into;

--- a/pegainfer-core/src/ops.rs
+++ b/pegainfer-core/src/ops.rs
@@ -78,6 +78,7 @@ pub use pegainfer_kernels::ops::qk_norm_rope_prefill_hd256_plain_into;
 pub use pegainfer_kernels::ops::qkv_norm_rope_paged_decode_hd256_plain_into;
 pub use pegainfer_kernels::ops::qkv_norm_rope_paged_prefill_hd256_plain_into;
 pub use pegainfer_kernels::ops::rms_norm;
+pub use pegainfer_kernels::ops::rms_norm_add_rms_norm_round_batch_into;
 pub use pegainfer_kernels::ops::rms_norm_add_scale_batch_into;
 pub use pegainfer_kernels::ops::rms_norm_batch_dual_into;
 #[cfg(not(feature = "kernel-call-trace"))]

--- a/pegainfer-core/src/ops.rs
+++ b/pegainfer-core/src/ops.rs
@@ -78,6 +78,7 @@ pub use pegainfer_kernels::ops::qk_norm_rope_prefill_hd256_plain_into;
 pub use pegainfer_kernels::ops::qkv_norm_rope_paged_decode_hd256_plain_into;
 pub use pegainfer_kernels::ops::qkv_norm_rope_paged_prefill_hd256_plain_into;
 pub use pegainfer_kernels::ops::rms_norm;
+pub use pegainfer_kernels::ops::rms_norm_batch_dual_into;
 #[cfg(not(feature = "kernel-call-trace"))]
 pub use pegainfer_kernels::ops::rms_norm_batch_into;
 pub use pegainfer_kernels::ops::rms_norm_batch_offset_into;

--- a/pegainfer-gemma4/src/layer.rs
+++ b/pegainfer-gemma4/src/layer.rs
@@ -135,7 +135,6 @@ pub(crate) struct EpilogueScratch {
     up: HiddenStates,
     act: HiddenStates,
     down: HiddenStates,
-    down_normed: HiddenStates,
     moe: Option<MoeScratch>,
 }
 
@@ -153,7 +152,6 @@ impl EpilogueScratch {
             up: wide(max_rows)?,
             act: wide(max_rows)?,
             down: hidden(max_rows)?,
-            down_normed: hidden(max_rows)?,
             moe: match geom.moe {
                 Some(_) => Some(MoeScratch::new(ctx, geom, max_rows)?),
                 None => None,
@@ -179,7 +177,6 @@ impl EpilogueScratch {
             &mut self.up,
             &mut self.act,
             &mut self.down,
-            &mut self.down_normed,
         ] {
             buf.seq_len = seq_len;
         }
@@ -284,15 +281,14 @@ pub(crate) fn attention_epilogue_into(
         (None, _) => &scratch.down,
         (Some(_), None) => anyhow::bail!("Gemma 4: a routed layer met a dense epilogue scratch"),
     };
-    ops::rms_norm_batch_into(
+    ops::rms_norm_add_scale_batch_into(
         ctx,
         feed_forward,
         &layer.post_feedforward_layernorm,
+        &scratch.h2,
+        layer.layer_scalar,
         geom.rms_norm_eps,
-        &mut scratch.down_normed,
+        out,
     );
-
-    ops::add_batch_into(ctx, &scratch.h2, &scratch.down_normed, out)?;
-    ops::scale_bf16_in_place(ctx, out, layer.layer_scalar)?;
     Ok(())
 }

--- a/pegainfer-gemma4/src/layer.rs
+++ b/pegainfer-gemma4/src/layer.rs
@@ -128,8 +128,7 @@ pub(crate) fn build_proportional_rope_tables(
 pub(crate) struct EpilogueScratch {
     max_rows: usize,
     attn_proj: HiddenStates,
-    o_normed: HiddenStates,
-    h2: HiddenStates,
+    residual: HiddenStates,
     mlp_in: HiddenStates,
     gate: HiddenStates,
     up: HiddenStates,
@@ -145,8 +144,7 @@ impl EpilogueScratch {
         Ok(Self {
             max_rows,
             attn_proj: hidden(max_rows)?,
-            o_normed: hidden(max_rows)?,
-            h2: hidden(max_rows)?,
+            residual: hidden(max_rows)?,
             mlp_in: hidden(max_rows)?,
             gate: wide(max_rows)?,
             up: wide(max_rows)?,
@@ -170,8 +168,7 @@ impl EpilogueScratch {
         );
         for buf in [
             &mut self.attn_proj,
-            &mut self.o_normed,
-            &mut self.h2,
+            &mut self.residual,
             &mut self.mlp_in,
             &mut self.gate,
             &mut self.up,
@@ -222,22 +219,18 @@ pub(crate) fn attention_epilogue_into(
         attn,
         &mut scratch.attn_proj,
     )?;
-    ops::rms_norm_batch_into(
+    // The first normalized value and its residual sum still round to bf16
+    // before the second reduction reads them.
+    ops::rms_norm_add_rms_norm_round_batch_into(
         ctx,
         &scratch.attn_proj,
         &layer.post_attention_layernorm,
-        geom.rms_norm_eps,
-        &mut scratch.o_normed,
-    );
-    ops::add_batch_into(ctx, x, &scratch.o_normed, &mut scratch.h2)?;
-
-    ops::rms_norm_batch_into(
-        ctx,
-        &scratch.h2,
+        x,
         &layer.pre_feedforward_layernorm,
         geom.rms_norm_eps,
+        &mut scratch.residual,
         &mut scratch.mlp_in,
-    );
+    )?;
     ops::gemm_rows_into_checked(
         ctx,
         &layer.mlp.gate,
@@ -269,11 +262,11 @@ pub(crate) fn attention_epilogue_into(
                 ctx,
                 moe,
                 geom,
-                &scratch.h2,
+                &scratch.residual,
                 &scratch.down,
                 moe_scratch,
-                // The attention projection is dead after `h2` is formed and
-                // has the same shape, so the routed-only result reuses it.
+                // The attention projection is dead after `residual` is formed
+                // and has the same shape, so the routed-only result reuses it.
                 &mut scratch.attn_proj,
             )?;
             &scratch.attn_proj
@@ -285,7 +278,7 @@ pub(crate) fn attention_epilogue_into(
         ctx,
         feed_forward,
         &layer.post_feedforward_layernorm,
-        &scratch.h2,
+        &scratch.residual,
         layer.layer_scalar,
         geom.rms_norm_eps,
         out,

--- a/pegainfer-gemma4/src/layer.rs
+++ b/pegainfer-gemma4/src/layer.rs
@@ -282,6 +282,6 @@ pub(crate) fn attention_epilogue_into(
         layer.layer_scalar,
         geom.rms_norm_eps,
         out,
-    );
+    )?;
     Ok(())
 }

--- a/pegainfer-gemma4/src/moe.rs
+++ b/pegainfer-gemma4/src/moe.rs
@@ -220,7 +220,7 @@ pub(crate) fn moe_into(
         (geom.hidden_size as f32).powf(-0.5),
         &mut scratch.router_in,
         &mut scratch.moe_in,
-    );
+    )?;
     ops::gemm_rows_into_checked(
         ctx,
         &moe.router_proj,
@@ -336,7 +336,7 @@ pub(crate) fn moe_into(
         &moe.post_feedforward_layernorm_2,
         geom.rms_norm_eps,
         out,
-    );
+    )?;
     Ok(())
 }
 

--- a/pegainfer-gemma4/src/moe.rs
+++ b/pegainfer-gemma4/src/moe.rs
@@ -215,20 +215,18 @@ pub(crate) fn moe_into(
         geom.hidden_size
     );
 
-    // The router's own norm carries no scale of its own, so the parameter
-    // multiply and the `hidden ** -0.5` that follow it are separate steps.
-    ops::rms_norm_batch_into(
+    // Both residual norms share one reduction. The router branch still
+    // rounds before its `hidden ** -0.5` scalar multiply.
+    ops::rms_norm_batch_dual_into(
         ctx,
         residual,
         &moe.router_scale,
+        &moe.pre_feedforward_layernorm_2,
         geom.rms_norm_eps,
-        &mut scratch.router_in,
-    );
-    ops::scale_bf16_in_place(
-        ctx,
-        &mut scratch.router_in,
         (geom.hidden_size as f32).powf(-0.5),
-    )?;
+        &mut scratch.router_in,
+        &mut scratch.moe_in,
+    );
     ops::gemm_rows_into_checked(
         ctx,
         &moe.router_proj,
@@ -263,14 +261,6 @@ pub(crate) fn moe_into(
             expert_cursor: &mut scratch.expert_cursor,
         },
     )?;
-
-    ops::rms_norm_batch_into(
-        ctx,
-        residual,
-        &moe.pre_feedforward_layernorm_2,
-        geom.rms_norm_eps,
-        &mut scratch.moe_in,
-    );
 
     let gather = MarlinDispatch {
         sorted_token_ids: &scratch.sorted_token_ids,

--- a/pegainfer-gemma4/src/moe.rs
+++ b/pegainfer-gemma4/src/moe.rs
@@ -109,8 +109,6 @@ pub(crate) struct MoeScratch {
     routed_act: HiddenStates,
     routed_down: HiddenStates,
     expert_out: HiddenStates,
-    dense_normed: HiddenStates,
-    expert_normed: HiddenStates,
     expert_offsets: CudaSlice<u32>,
     expert_cursor: CudaSlice<u32>,
 }
@@ -141,8 +139,6 @@ impl MoeScratch {
             routed_act: narrow(sizes.slots)?,
             routed_down: hidden(sizes.slots)?,
             expert_out: hidden(max_rows)?,
-            dense_normed: hidden(max_rows)?,
-            expert_normed: hidden(max_rows)?,
             expert_offsets: ctx.stream.alloc_zeros::<u32>(moe.num_experts + 1)?,
             expert_cursor: ctx.stream.alloc_zeros::<u32>(1)?,
         })
@@ -159,8 +155,6 @@ impl MoeScratch {
             &mut self.logits,
             &mut self.moe_in,
             &mut self.expert_out,
-            &mut self.dense_normed,
-            &mut self.expert_normed,
         ] {
             buf.seq_len = rows;
         }
@@ -334,21 +328,15 @@ pub(crate) fn moe_into(
         &mut scratch.expert_out,
     )?;
 
-    ops::rms_norm_batch_into(
+    ops::dual_rms_norm_add_batch_into(
         ctx,
         dense,
         &moe.post_feedforward_layernorm_1,
-        geom.rms_norm_eps,
-        &mut scratch.dense_normed,
-    );
-    ops::rms_norm_batch_into(
-        ctx,
         &scratch.expert_out,
         &moe.post_feedforward_layernorm_2,
         geom.rms_norm_eps,
-        &mut scratch.expert_normed,
+        out,
     );
-    ops::add_batch_into(ctx, &scratch.dense_normed, &scratch.expert_normed, out)?;
     Ok(())
 }
 

--- a/pegainfer-kernels/csrc/shared/flashinfer_norm.cu
+++ b/pegainfer-kernels/csrc/shared/flashinfer_norm.cu
@@ -164,6 +164,82 @@ cudaError_t FusedAddRMSNormRound(T* hidden, const T* residual, T* weight, T* out
   return cudaSuccess;
 }
 
+// Two RMSNorms of the same input in one pass. The accumulation and each
+// output's arithmetic mirror FlashInfer's RMSNormKernel operation for
+// operation. The first branch keeps the standalone scalar multiply's bf16
+// rounding point.
+template <uint32_t VEC_SIZE, typename T>
+__global__ void DualRMSNormKernel(const T* __restrict__ input, T* __restrict__ weight_a,
+                                  T* __restrict__ weight_b, T* __restrict__ out_a,
+                                  T* __restrict__ out_b, const uint32_t d, float eps,
+                                  float scale_a) {
+  const uint32_t bx = blockIdx.x;
+  const uint32_t tx = threadIdx.x, ty = threadIdx.y;
+  constexpr uint32_t warp_size = 32;
+  const uint32_t num_warps = blockDim.y;
+  const uint32_t thread_id = tx + ty * warp_size;
+  const uint32_t num_threads = num_warps * warp_size;
+  const uint32_t rounds = flashinfer::ceil_div(d, VEC_SIZE * num_threads);
+  extern __shared__ float smem[];
+
+  float sum_sq = 0.f;
+  for (uint32_t i = 0; i < rounds; i++) {
+    flashinfer::vec_t<T, VEC_SIZE> input_vec;
+    input_vec.fill(0.f);
+    if ((i * num_threads + thread_id) * VEC_SIZE < d) {
+      input_vec.load(input + bx * d + i * num_threads * VEC_SIZE + thread_id * VEC_SIZE);
+    }
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; j++) {
+      sum_sq += float(input_vec[j]) * float(input_vec[j]);
+    }
+  }
+#pragma unroll
+  for (uint32_t offset = warp_size / 2; offset > 0; offset /= 2) {
+    sum_sq += flashinfer::math::shfl_xor_sync(sum_sq, offset);
+  }
+  smem[ty] = sum_sq;
+  __syncthreads();
+  if (ty == 0) {
+    sum_sq = (tx < num_warps) ? smem[tx] : 0.f;
+#pragma unroll
+    for (uint32_t offset = warp_size / 2; offset > 0; offset /= 2) {
+      sum_sq += flashinfer::math::shfl_xor_sync(sum_sq, offset);
+    }
+    smem[0] = sum_sq;
+  }
+  __syncthreads();
+
+  float rms_rcp = flashinfer::math::rsqrt(smem[0] / float(d) + eps);
+
+  for (uint32_t i = 0; i < rounds; i++) {
+    flashinfer::vec_t<T, VEC_SIZE> input_vec;
+    flashinfer::vec_t<T, VEC_SIZE> weight_a_vec;
+    flashinfer::vec_t<T, VEC_SIZE> weight_b_vec;
+    flashinfer::vec_t<T, VEC_SIZE> out_a_vec;
+    flashinfer::vec_t<T, VEC_SIZE> out_b_vec;
+    input_vec.fill(0.f);
+    weight_a_vec.fill(0.f);
+    weight_b_vec.fill(0.f);
+    const uint32_t elem = i * num_threads * VEC_SIZE + thread_id * VEC_SIZE;
+    if (elem < d) {
+      input_vec.load(input + bx * d + elem);
+      weight_a_vec.load(weight_a + elem);
+      weight_b_vec.load(weight_b + elem);
+    }
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; j++) {
+      T na = float(input_vec[j]) * rms_rcp * (0.f + float(weight_a_vec[j]));
+      out_a_vec[j] = float(na) * scale_a;
+      out_b_vec[j] = float(input_vec[j]) * rms_rcp * (0.f + float(weight_b_vec[j]));
+    }
+    if (elem < d) {
+      out_a_vec.store(out_a + bx * d + elem);
+      out_b_vec.store(out_b + bx * d + elem);
+    }
+  }
+}
+
 }  // namespace norm
 }  // namespace pegainfer
 
@@ -207,6 +283,25 @@ void rms_norm_batched_cuda(const DType *x, const DType *weight, DType *out,
     flashinfer::norm::RMSNorm<DType>(
         const_cast<DType*>(x), const_cast<DType*>(weight), out,
         seq_len, hidden_dim, hidden_dim, hidden_dim, eps, false, stream);
+}
+
+// Two norms of one input, reduced once. The router branch's scale preserves
+// the trailing standalone bf16 multiply.
+void rms_norm_batched_dual_cuda(const DType *x, const DType *weight_a, const DType *weight_b,
+                                DType *out_a, DType *out_b, int hidden_dim, int seq_len,
+                                float eps, float scale_a, cudaStream_t stream) {
+    const uint32_t d = static_cast<uint32_t>(hidden_dim);
+    const uint32_t vec_size = std::gcd<uint32_t>(16 / sizeof(DType), d);
+    const uint32_t block_size = std::min<uint32_t>(1024, d / vec_size);
+    const uint32_t num_warps = flashinfer::ceil_div(block_size, 32);
+    dim3 nblks(static_cast<uint32_t>(seq_len));
+    dim3 nthrs(32, num_warps);
+    const uint32_t smem_size = num_warps * sizeof(float);
+    DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
+        pegainfer::norm::DualRMSNormKernel<VEC_SIZE, DType><<<nblks, nthrs, smem_size, stream>>>(
+            x, const_cast<DType*>(weight_a), const_cast<DType*>(weight_b), out_a, out_b, d, eps,
+            scale_a);
+    });
 }
 
 // ============================================================================

--- a/pegainfer-kernels/csrc/shared/flashinfer_norm.cu
+++ b/pegainfer-kernels/csrc/shared/flashinfer_norm.cu
@@ -164,13 +164,10 @@ cudaError_t FusedAddRMSNormRound(T* hidden, const T* residual, T* weight, T* out
   return cudaSuccess;
 }
 
-// Two RMSNorms of the same input in one pass. The accumulation and each
-// output's arithmetic mirror FlashInfer's RMSNormKernel operation for
-// operation. The first branch keeps the standalone scalar multiply's bf16
-// rounding point.
 template <uint32_t VEC_SIZE, typename T>
-__global__ void DualRMSNormKernel(const T* __restrict__ input, T* __restrict__ weight_a,
-                                  T* __restrict__ weight_b, T* __restrict__ out_a,
+__global__ void DualRMSNormKernel(const T* __restrict__ input,
+                                  const T* __restrict__ weight_a,
+                                  const T* __restrict__ weight_b, T* __restrict__ out_a,
                                   T* __restrict__ out_b, const uint32_t d, float eps,
                                   float scale_a) {
   const uint32_t bx = blockIdx.x;
@@ -229,6 +226,7 @@ __global__ void DualRMSNormKernel(const T* __restrict__ input, T* __restrict__ w
     }
 #pragma unroll
     for (uint32_t j = 0; j < VEC_SIZE; j++) {
+      // Preserve the standalone bf16 norm rounding before the scalar multiply.
       T na = float(input_vec[j]) * rms_rcp * (0.f + float(weight_a_vec[j]));
       out_a_vec[j] = float(na) * scale_a;
       out_b_vec[j] = float(input_vec[j]) * rms_rcp * (0.f + float(weight_b_vec[j]));
@@ -240,14 +238,9 @@ __global__ void DualRMSNormKernel(const T* __restrict__ input, T* __restrict__ w
   }
 }
 
-// One norm, then the layer tail's residual add and scalar multiply, with
-// each standalone op's rounding kept in place: the normalized value rounds
-// to T as `rms_norm_batched_cuda` stores it, the sum rounds as `add_cuda`
-// does, and the scaled result rounds once more as `scale_bf16_in_place_cuda`
-// would. The reduction mirrors FlashInfer's RMSNormKernel operation for
-// operation.
 template <uint32_t VEC_SIZE, typename T>
-__global__ void RMSNormAddScaleKernel(const T* __restrict__ input, T* __restrict__ weight,
+__global__ void RMSNormAddScaleKernel(const T* __restrict__ input,
+                                      const T* __restrict__ weight,
                                       const T* __restrict__ residual, T* __restrict__ out,
                                       const uint32_t d, float eps, float scale) {
   const uint32_t bx = blockIdx.x;
@@ -305,6 +298,7 @@ __global__ void RMSNormAddScaleKernel(const T* __restrict__ input, T* __restrict
     }
 #pragma unroll
     for (uint32_t j = 0; j < VEC_SIZE; j++) {
+      // Preserve the standalone bf16 norm and residual-add rounding boundaries.
       T normed = float(input_vec[j]) * rms_rcp * (0.f + float(weight_vec[j]));
       T summed = float(normed) + float(residual_vec[j]);
       out_vec[j] = float(summed) * scale;
@@ -315,16 +309,11 @@ __global__ void RMSNormAddScaleKernel(const T* __restrict__ input, T* __restrict
   }
 }
 
-// The attention epilogue's norm pair in one launch:
-//   residual_out = bf16(norm(x, weight_post) + res_in)
-//   out = RMSNorm(residual_out, weight_pre)
-// The first norm rounds to T as its standalone store would, the sum rounds
-// as `FusedAddRMSNormRoundKernel` does, and the second reduction reads the
-// rounded sums exactly as that kernel's smem row does.
 template <uint32_t VEC_SIZE, typename T>
-__global__ void RMSNormAddRMSNormRoundKernel(const T* __restrict__ x, T* __restrict__ weight_post,
+__global__ void RMSNormAddRMSNormRoundKernel(const T* __restrict__ x,
+                                             const T* __restrict__ weight_post,
                                              const T* __restrict__ res_in,
-                                             T* __restrict__ weight_pre,
+                                             const T* __restrict__ weight_pre,
                                              T* __restrict__ residual_out, T* __restrict__ out,
                                              const uint32_t d, float eps) {
   const uint32_t bx = blockIdx.x;
@@ -394,6 +383,7 @@ __global__ void RMSNormAddRMSNormRoundKernel(const T* __restrict__ x, T* __restr
     }
 #pragma unroll
     for (uint32_t j = 0; j < VEC_SIZE; j++) {
+      // Round the first norm and residual sum before the second reduction.
       T normed = stash_vec[j] * rcp1 * (0.f + float(weight_vec[j]));
       T summed = float(normed) + float(res_vec[j]);
       float v = float(summed);
@@ -437,7 +427,8 @@ __global__ void RMSNormAddRMSNormRoundKernel(const T* __restrict__ x, T* __restr
     }
 #pragma unroll
     for (uint32_t j = 0; j < VEC_SIZE; j++) {
-      out_vec[j] = stash_vec[j] * rcp2 * float(weight_vec[j]);
+      // Preserve standalone RMSNorm's signed-zero addition before the multiply.
+      out_vec[j] = stash_vec[j] * rcp2 * (0.f + float(weight_vec[j]));
     }
     if (elem < d) {
       out_vec.store(out + bx * d + elem);
@@ -445,14 +436,11 @@ __global__ void RMSNormAddRMSNormRoundKernel(const T* __restrict__ x, T* __restr
   }
 }
 
-// The MoE combine tail in one launch: `out = norm(a, weight_a) + norm(b,
-// weight_b)`, replacing two norms and an add. Each branch's reduction and
-// elementwise arithmetic mirror FlashInfer's RMSNormKernel operation for
-// operation, each normalized value rounds to T as the standalone store
-// would, and the sum rounds once as `add_cuda` does.
 template <uint32_t VEC_SIZE, typename T>
-__global__ void DualRMSNormAddKernel(const T* __restrict__ a, T* __restrict__ weight_a,
-                                     const T* __restrict__ b, T* __restrict__ weight_b,
+__global__ void DualRMSNormAddKernel(const T* __restrict__ a,
+                                     const T* __restrict__ weight_a,
+                                     const T* __restrict__ b,
+                                     const T* __restrict__ weight_b,
                                      T* __restrict__ out, const uint32_t d, float eps) {
   const uint32_t bx = blockIdx.x;
   const uint32_t tx = threadIdx.x, ty = threadIdx.y;
@@ -522,6 +510,7 @@ __global__ void DualRMSNormAddKernel(const T* __restrict__ a, T* __restrict__ we
     }
 #pragma unroll
     for (uint32_t j = 0; j < VEC_SIZE; j++) {
+      // Round both standalone norms before their bf16 sum.
       T na = float(a_vec[j]) * rcp_a * (0.f + float(weight_a_vec[j]));
       T nb = float(b_vec[j]) * rcp_b * (0.f + float(weight_b_vec[j]));
       out_vec[j] = float(na) + float(nb);
@@ -577,11 +566,9 @@ void rms_norm_batched_cuda(const DType *x, const DType *weight, DType *out,
         seq_len, hidden_dim, hidden_dim, hidden_dim, eps, false, stream);
 }
 
-// Two norms of one input, reduced once. The router branch's scale preserves
-// the trailing standalone bf16 multiply.
-void rms_norm_batched_dual_cuda(const DType *x, const DType *weight_a, const DType *weight_b,
-                                DType *out_a, DType *out_b, int hidden_dim, int seq_len,
-                                float eps, float scale_a, cudaStream_t stream) {
+CUresult rms_norm_batched_dual_cuda(const DType *x, const DType *weight_a, const DType *weight_b,
+                                    DType *out_a, DType *out_b, int hidden_dim, int seq_len,
+                                    float eps, float scale_a, cudaStream_t stream) {
     const uint32_t d = static_cast<uint32_t>(hidden_dim);
     const uint32_t vec_size = std::gcd<uint32_t>(16 / sizeof(DType), d);
     const uint32_t block_size = std::min<uint32_t>(1024, d / vec_size);
@@ -591,16 +578,14 @@ void rms_norm_batched_dual_cuda(const DType *x, const DType *weight_a, const DTy
     const uint32_t smem_size = num_warps * sizeof(float);
     DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
         pegainfer::norm::DualRMSNormKernel<VEC_SIZE, DType><<<nblks, nthrs, smem_size, stream>>>(
-            x, const_cast<DType*>(weight_a), const_cast<DType*>(weight_b), out_a, out_b, d, eps,
-            scale_a);
+            x, weight_a, weight_b, out_a, out_b, d, eps, scale_a);
     });
+    return static_cast<CUresult>(cudaGetLastError());
 }
 
-// The MoE combine tail in one launch: `out = norm(a, wa) + norm(b, wb)`,
-// bitwise what two `rms_norm_batched_cuda` calls and an `add_cuda` produce.
-void dual_rms_norm_add_batched_cuda(const DType *a, const DType *weight_a, const DType *b,
-                                    const DType *weight_b, DType *out, int hidden_dim,
-                                    int seq_len, float eps, cudaStream_t stream) {
+CUresult dual_rms_norm_add_batched_cuda(const DType *a, const DType *weight_a, const DType *b,
+                                        const DType *weight_b, DType *out, int hidden_dim,
+                                        int seq_len, float eps, cudaStream_t stream) {
     const uint32_t d = static_cast<uint32_t>(hidden_dim);
     const uint32_t vec_size = std::gcd<uint32_t>(16 / sizeof(DType), d);
     const uint32_t block_size = std::min<uint32_t>(1024, d / vec_size);
@@ -610,14 +595,11 @@ void dual_rms_norm_add_batched_cuda(const DType *a, const DType *weight_a, const
     const uint32_t smem_size = 2 * num_warps * sizeof(float);
     DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
         pegainfer::norm::DualRMSNormAddKernel<VEC_SIZE, DType><<<nblks, nthrs, smem_size, stream>>>(
-            a, const_cast<DType*>(weight_a), b, const_cast<DType*>(weight_b), out, d, eps);
+            a, weight_a, b, weight_b, out, d, eps);
     });
+    return static_cast<CUresult>(cudaGetLastError());
 }
 
-// The attention epilogue's norm pair in one launch, bitwise what
-// `rms_norm_batched_cuda` then `fused_add_rms_norm_round_batched_cuda`
-// produce: `residual_out = bf16(norm(x, w_post) + res_in)`,
-// `out = norm(residual_out, w_pre)`.
 CUresult rms_norm_add_rms_norm_round_batched_cuda(const DType *x, const DType *weight_post,
                                                   const DType *res_in, const DType *weight_pre,
                                                   DType *residual_out, DType *out, int hidden_dim,
@@ -632,22 +614,24 @@ CUresult rms_norm_add_rms_norm_round_batched_cuda(const DType *x, const DType *w
     cudaError_t err = cudaSuccess;
     DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
         auto kernel = pegainfer::norm::RMSNormAddRMSNormRoundKernel<VEC_SIZE, DType>;
-        err = cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+        constexpr uint32_t default_smem_size = 48 * 1024;
+        if (smem_size > default_smem_size) {
+            err = cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                       smem_size);
+        }
         if (err == cudaSuccess) {
             kernel<<<nblks, nthrs, smem_size, stream>>>(
-                x, const_cast<DType*>(weight_post), res_in, const_cast<DType*>(weight_pre),
-                residual_out, out, d, eps);
+                x, weight_post, res_in, weight_pre, residual_out, out, d, eps);
             err = cudaGetLastError();
         }
     });
     return static_cast<CUresult>(err);
 }
 
-// The layer tail in one launch: `out = (residual + norm(x, weight)) * scale`
-// with the three standalone ops' roundings kept in place.
-void rms_norm_add_scale_batched_cuda(const DType *x, const DType *weight, const DType *residual,
-                                     DType *out, int hidden_dim, int seq_len, float eps,
-                                     float scale, cudaStream_t stream) {
+CUresult rms_norm_add_scale_batched_cuda(const DType *x, const DType *weight,
+                                         const DType *residual, DType *out, int hidden_dim,
+                                         int seq_len, float eps, float scale,
+                                         cudaStream_t stream) {
     const uint32_t d = static_cast<uint32_t>(hidden_dim);
     const uint32_t vec_size = std::gcd<uint32_t>(16 / sizeof(DType), d);
     const uint32_t block_size = std::min<uint32_t>(1024, d / vec_size);
@@ -657,8 +641,9 @@ void rms_norm_add_scale_batched_cuda(const DType *x, const DType *weight, const 
     const uint32_t smem_size = num_warps * sizeof(float);
     DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
         pegainfer::norm::RMSNormAddScaleKernel<VEC_SIZE, DType><<<nblks, nthrs, smem_size, stream>>>(
-            x, const_cast<DType*>(weight), residual, out, d, eps, scale);
+            x, weight, residual, out, d, eps, scale);
     });
+    return static_cast<CUresult>(cudaGetLastError());
 }
 
 // ============================================================================

--- a/pegainfer-kernels/csrc/shared/flashinfer_norm.cu
+++ b/pegainfer-kernels/csrc/shared/flashinfer_norm.cu
@@ -240,6 +240,81 @@ __global__ void DualRMSNormKernel(const T* __restrict__ input, T* __restrict__ w
   }
 }
 
+// One norm, then the layer tail's residual add and scalar multiply, with
+// each standalone op's rounding kept in place: the normalized value rounds
+// to T as `rms_norm_batched_cuda` stores it, the sum rounds as `add_cuda`
+// does, and the scaled result rounds once more as `scale_bf16_in_place_cuda`
+// would. The reduction mirrors FlashInfer's RMSNormKernel operation for
+// operation.
+template <uint32_t VEC_SIZE, typename T>
+__global__ void RMSNormAddScaleKernel(const T* __restrict__ input, T* __restrict__ weight,
+                                      const T* __restrict__ residual, T* __restrict__ out,
+                                      const uint32_t d, float eps, float scale) {
+  const uint32_t bx = blockIdx.x;
+  const uint32_t tx = threadIdx.x, ty = threadIdx.y;
+  constexpr uint32_t warp_size = 32;
+  const uint32_t num_warps = blockDim.y;
+  const uint32_t thread_id = tx + ty * warp_size;
+  const uint32_t num_threads = num_warps * warp_size;
+  const uint32_t rounds = flashinfer::ceil_div(d, VEC_SIZE * num_threads);
+  extern __shared__ float smem[];
+
+  float sum_sq = 0.f;
+  for (uint32_t i = 0; i < rounds; i++) {
+    flashinfer::vec_t<T, VEC_SIZE> input_vec;
+    input_vec.fill(0.f);
+    if ((i * num_threads + thread_id) * VEC_SIZE < d) {
+      input_vec.load(input + bx * d + i * num_threads * VEC_SIZE + thread_id * VEC_SIZE);
+    }
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; j++) {
+      sum_sq += float(input_vec[j]) * float(input_vec[j]);
+    }
+  }
+#pragma unroll
+  for (uint32_t offset = warp_size / 2; offset > 0; offset /= 2) {
+    sum_sq += flashinfer::math::shfl_xor_sync(sum_sq, offset);
+  }
+  smem[ty] = sum_sq;
+  __syncthreads();
+  if (ty == 0) {
+    sum_sq = (tx < num_warps) ? smem[tx] : 0.f;
+#pragma unroll
+    for (uint32_t offset = warp_size / 2; offset > 0; offset /= 2) {
+      sum_sq += flashinfer::math::shfl_xor_sync(sum_sq, offset);
+    }
+    smem[0] = sum_sq;
+  }
+  __syncthreads();
+
+  float rms_rcp = flashinfer::math::rsqrt(smem[0] / float(d) + eps);
+
+  for (uint32_t i = 0; i < rounds; i++) {
+    flashinfer::vec_t<T, VEC_SIZE> input_vec;
+    flashinfer::vec_t<T, VEC_SIZE> weight_vec;
+    flashinfer::vec_t<T, VEC_SIZE> residual_vec;
+    flashinfer::vec_t<T, VEC_SIZE> out_vec;
+    input_vec.fill(0.f);
+    weight_vec.fill(0.f);
+    residual_vec.fill(0.f);
+    const uint32_t elem = i * num_threads * VEC_SIZE + thread_id * VEC_SIZE;
+    if (elem < d) {
+      input_vec.load(input + bx * d + elem);
+      weight_vec.load(weight + elem);
+      residual_vec.load(residual + bx * d + elem);
+    }
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; j++) {
+      T normed = float(input_vec[j]) * rms_rcp * (0.f + float(weight_vec[j]));
+      T summed = float(normed) + float(residual_vec[j]);
+      out_vec[j] = float(summed) * scale;
+    }
+    if (elem < d) {
+      out_vec.store(out + bx * d + elem);
+    }
+  }
+}
+
 }  // namespace norm
 }  // namespace pegainfer
 
@@ -301,6 +376,24 @@ void rms_norm_batched_dual_cuda(const DType *x, const DType *weight_a, const DTy
         pegainfer::norm::DualRMSNormKernel<VEC_SIZE, DType><<<nblks, nthrs, smem_size, stream>>>(
             x, const_cast<DType*>(weight_a), const_cast<DType*>(weight_b), out_a, out_b, d, eps,
             scale_a);
+    });
+}
+
+// The layer tail in one launch: `out = (residual + norm(x, weight)) * scale`
+// with the three standalone ops' roundings kept in place.
+void rms_norm_add_scale_batched_cuda(const DType *x, const DType *weight, const DType *residual,
+                                     DType *out, int hidden_dim, int seq_len, float eps,
+                                     float scale, cudaStream_t stream) {
+    const uint32_t d = static_cast<uint32_t>(hidden_dim);
+    const uint32_t vec_size = std::gcd<uint32_t>(16 / sizeof(DType), d);
+    const uint32_t block_size = std::min<uint32_t>(1024, d / vec_size);
+    const uint32_t num_warps = flashinfer::ceil_div(block_size, 32);
+    dim3 nblks(static_cast<uint32_t>(seq_len));
+    dim3 nthrs(32, num_warps);
+    const uint32_t smem_size = num_warps * sizeof(float);
+    DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
+        pegainfer::norm::RMSNormAddScaleKernel<VEC_SIZE, DType><<<nblks, nthrs, smem_size, stream>>>(
+            x, const_cast<DType*>(weight), residual, out, d, eps, scale);
     });
 }
 

--- a/pegainfer-kernels/csrc/shared/flashinfer_norm.cu
+++ b/pegainfer-kernels/csrc/shared/flashinfer_norm.cu
@@ -315,6 +315,136 @@ __global__ void RMSNormAddScaleKernel(const T* __restrict__ input, T* __restrict
   }
 }
 
+// The attention epilogue's norm pair in one launch:
+//   residual_out = bf16(norm(x, weight_post) + res_in)
+//   out = RMSNorm(residual_out, weight_pre)
+// The first norm rounds to T as its standalone store would, the sum rounds
+// as `FusedAddRMSNormRoundKernel` does, and the second reduction reads the
+// rounded sums exactly as that kernel's smem row does.
+template <uint32_t VEC_SIZE, typename T>
+__global__ void RMSNormAddRMSNormRoundKernel(const T* __restrict__ x, T* __restrict__ weight_post,
+                                             const T* __restrict__ res_in,
+                                             T* __restrict__ weight_pre,
+                                             T* __restrict__ residual_out, T* __restrict__ out,
+                                             const uint32_t d, float eps) {
+  const uint32_t bx = blockIdx.x;
+  const uint32_t tx = threadIdx.x, ty = threadIdx.y;
+  constexpr uint32_t warp_size = 32;
+  const uint32_t num_warps = blockDim.y;
+  const uint32_t thread_id = tx + ty * warp_size;
+  const uint32_t num_threads = num_warps * warp_size;
+  const uint32_t rounds = flashinfer::ceil_div(d, VEC_SIZE * num_threads);
+  extern __shared__ float smem[];
+  float* smem_x = smem + flashinfer::ceil_div(num_warps, 4) * 4;
+
+  float sum_sq1 = 0.f;
+  for (uint32_t i = 0; i < rounds; i++) {
+    flashinfer::vec_t<T, VEC_SIZE> x_vec;
+    flashinfer::vec_t<float, VEC_SIZE> stash_vec;
+    x_vec.fill(0.f);
+    stash_vec.fill(0.f);
+    const uint32_t elem = i * num_threads * VEC_SIZE + thread_id * VEC_SIZE;
+    if (elem < d) {
+      x_vec.load(x + bx * d + elem);
+    }
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; j++) {
+      float v = float(x_vec[j]);
+      stash_vec[j] = v;
+      sum_sq1 += v * v;
+    }
+    if (elem < d) {
+      stash_vec.store(smem_x + elem);
+    }
+  }
+#pragma unroll
+  for (uint32_t offset = warp_size / 2; offset > 0; offset /= 2) {
+    sum_sq1 += flashinfer::math::shfl_xor_sync(sum_sq1, offset);
+  }
+  smem[ty] = sum_sq1;
+  __syncthreads();
+  if (ty == 0) {
+    sum_sq1 = (tx < num_warps) ? smem[tx] : 0.f;
+#pragma unroll
+    for (uint32_t offset = warp_size / 2; offset > 0; offset /= 2) {
+      sum_sq1 += flashinfer::math::shfl_xor_sync(sum_sq1, offset);
+    }
+    smem[0] = sum_sq1;
+  }
+  __syncthreads();
+  float rcp1 = flashinfer::math::rsqrt(smem[0] / float(d) + eps);
+  // The warp-sum slots are reused for the second reduction; every thread has
+  // read `smem[0]` into `rcp1` above.
+  __syncthreads();
+
+  float sum_sq2 = 0.f;
+  for (uint32_t i = 0; i < rounds; i++) {
+    flashinfer::vec_t<T, VEC_SIZE> weight_vec;
+    flashinfer::vec_t<T, VEC_SIZE> res_vec;
+    flashinfer::vec_t<T, VEC_SIZE> summed_vec;
+    flashinfer::vec_t<float, VEC_SIZE> stash_vec;
+    weight_vec.fill(0.f);
+    res_vec.fill(0.f);
+    stash_vec.fill(0.f);
+    const uint32_t elem = i * num_threads * VEC_SIZE + thread_id * VEC_SIZE;
+    if (elem < d) {
+      weight_vec.load(weight_post + elem);
+      res_vec.load(res_in + bx * d + elem);
+      stash_vec.load(smem_x + elem);
+    }
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; j++) {
+      T normed = stash_vec[j] * rcp1 * (0.f + float(weight_vec[j]));
+      T summed = float(normed) + float(res_vec[j]);
+      float v = float(summed);
+      summed_vec[j] = summed;
+      stash_vec[j] = v;
+      sum_sq2 += v * v;
+    }
+    if (elem < d) {
+      summed_vec.store(residual_out + bx * d + elem);
+      stash_vec.store(smem_x + elem);
+    }
+  }
+#pragma unroll
+  for (uint32_t offset = warp_size / 2; offset > 0; offset /= 2) {
+    sum_sq2 += flashinfer::math::shfl_xor_sync(sum_sq2, offset);
+  }
+  smem[ty] = sum_sq2;
+  __syncthreads();
+  if (ty == 0) {
+    sum_sq2 = (tx < num_warps) ? smem[tx] : 0.f;
+#pragma unroll
+    for (uint32_t offset = warp_size / 2; offset > 0; offset /= 2) {
+      sum_sq2 += flashinfer::math::shfl_xor_sync(sum_sq2, offset);
+    }
+    smem[0] = sum_sq2;
+  }
+  __syncthreads();
+  float rcp2 = flashinfer::math::rsqrt(smem[0] / float(d) + eps);
+
+  for (uint32_t i = 0; i < rounds; i++) {
+    flashinfer::vec_t<T, VEC_SIZE> weight_vec;
+    flashinfer::vec_t<float, VEC_SIZE> stash_vec;
+    flashinfer::vec_t<T, VEC_SIZE> out_vec;
+    weight_vec.fill(0.f);
+    stash_vec.fill(0.f);
+    out_vec.fill(0.f);
+    const uint32_t elem = i * num_threads * VEC_SIZE + thread_id * VEC_SIZE;
+    if (elem < d) {
+      weight_vec.load(weight_pre + elem);
+      stash_vec.load(smem_x + elem);
+    }
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; j++) {
+      out_vec[j] = stash_vec[j] * rcp2 * float(weight_vec[j]);
+    }
+    if (elem < d) {
+      out_vec.store(out + bx * d + elem);
+    }
+  }
+}
+
 }  // namespace norm
 }  // namespace pegainfer
 
@@ -377,6 +507,35 @@ void rms_norm_batched_dual_cuda(const DType *x, const DType *weight_a, const DTy
             x, const_cast<DType*>(weight_a), const_cast<DType*>(weight_b), out_a, out_b, d, eps,
             scale_a);
     });
+}
+
+// The attention epilogue's norm pair in one launch, bitwise what
+// `rms_norm_batched_cuda` then `fused_add_rms_norm_round_batched_cuda`
+// produce: `residual_out = bf16(norm(x, w_post) + res_in)`,
+// `out = norm(residual_out, w_pre)`.
+CUresult rms_norm_add_rms_norm_round_batched_cuda(const DType *x, const DType *weight_post,
+                                                  const DType *res_in, const DType *weight_pre,
+                                                  DType *residual_out, DType *out, int hidden_dim,
+                                                  int seq_len, float eps, cudaStream_t stream) {
+    const uint32_t d = static_cast<uint32_t>(hidden_dim);
+    const uint32_t vec_size = std::gcd<uint32_t>(16 / sizeof(DType), d);
+    const uint32_t block_size = std::min<uint32_t>(1024, d / vec_size);
+    const uint32_t num_warps = flashinfer::ceil_div(block_size, 32);
+    dim3 nblks(static_cast<uint32_t>(seq_len));
+    dim3 nthrs(32, num_warps);
+    const uint32_t smem_size = (flashinfer::ceil_div(num_warps, 4) * 4 + d) * sizeof(float);
+    cudaError_t err = cudaSuccess;
+    DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
+        auto kernel = pegainfer::norm::RMSNormAddRMSNormRoundKernel<VEC_SIZE, DType>;
+        err = cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+        if (err == cudaSuccess) {
+            kernel<<<nblks, nthrs, smem_size, stream>>>(
+                x, const_cast<DType*>(weight_post), res_in, const_cast<DType*>(weight_pre),
+                residual_out, out, d, eps);
+            err = cudaGetLastError();
+        }
+    });
+    return static_cast<CUresult>(err);
 }
 
 // The layer tail in one launch: `out = (residual + norm(x, weight)) * scale`

--- a/pegainfer-kernels/csrc/shared/flashinfer_norm.cu
+++ b/pegainfer-kernels/csrc/shared/flashinfer_norm.cu
@@ -445,6 +445,93 @@ __global__ void RMSNormAddRMSNormRoundKernel(const T* __restrict__ x, T* __restr
   }
 }
 
+// The MoE combine tail in one launch: `out = norm(a, weight_a) + norm(b,
+// weight_b)`, replacing two norms and an add. Each branch's reduction and
+// elementwise arithmetic mirror FlashInfer's RMSNormKernel operation for
+// operation, each normalized value rounds to T as the standalone store
+// would, and the sum rounds once as `add_cuda` does.
+template <uint32_t VEC_SIZE, typename T>
+__global__ void DualRMSNormAddKernel(const T* __restrict__ a, T* __restrict__ weight_a,
+                                     const T* __restrict__ b, T* __restrict__ weight_b,
+                                     T* __restrict__ out, const uint32_t d, float eps) {
+  const uint32_t bx = blockIdx.x;
+  const uint32_t tx = threadIdx.x, ty = threadIdx.y;
+  constexpr uint32_t warp_size = 32;
+  const uint32_t num_warps = blockDim.y;
+  const uint32_t thread_id = tx + ty * warp_size;
+  const uint32_t num_threads = num_warps * warp_size;
+  const uint32_t rounds = flashinfer::ceil_div(d, VEC_SIZE * num_threads);
+  extern __shared__ float smem[];
+
+  float sum_sq_a = 0.f, sum_sq_b = 0.f;
+  for (uint32_t i = 0; i < rounds; i++) {
+    flashinfer::vec_t<T, VEC_SIZE> a_vec;
+    flashinfer::vec_t<T, VEC_SIZE> b_vec;
+    a_vec.fill(0.f);
+    b_vec.fill(0.f);
+    if ((i * num_threads + thread_id) * VEC_SIZE < d) {
+      a_vec.load(a + bx * d + i * num_threads * VEC_SIZE + thread_id * VEC_SIZE);
+      b_vec.load(b + bx * d + i * num_threads * VEC_SIZE + thread_id * VEC_SIZE);
+    }
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; j++) {
+      sum_sq_a += float(a_vec[j]) * float(a_vec[j]);
+      sum_sq_b += float(b_vec[j]) * float(b_vec[j]);
+    }
+  }
+#pragma unroll
+  for (uint32_t offset = warp_size / 2; offset > 0; offset /= 2) {
+    sum_sq_a += flashinfer::math::shfl_xor_sync(sum_sq_a, offset);
+    sum_sq_b += flashinfer::math::shfl_xor_sync(sum_sq_b, offset);
+  }
+  smem[ty] = sum_sq_a;
+  smem[num_warps + ty] = sum_sq_b;
+  __syncthreads();
+  if (ty == 0) {
+    sum_sq_a = (tx < num_warps) ? smem[tx] : 0.f;
+    sum_sq_b = (tx < num_warps) ? smem[num_warps + tx] : 0.f;
+#pragma unroll
+    for (uint32_t offset = warp_size / 2; offset > 0; offset /= 2) {
+      sum_sq_a += flashinfer::math::shfl_xor_sync(sum_sq_a, offset);
+      sum_sq_b += flashinfer::math::shfl_xor_sync(sum_sq_b, offset);
+    }
+    smem[0] = sum_sq_a;
+    smem[1] = sum_sq_b;
+  }
+  __syncthreads();
+
+  float rcp_a = flashinfer::math::rsqrt(smem[0] / float(d) + eps);
+  float rcp_b = flashinfer::math::rsqrt(smem[1] / float(d) + eps);
+
+  for (uint32_t i = 0; i < rounds; i++) {
+    flashinfer::vec_t<T, VEC_SIZE> a_vec;
+    flashinfer::vec_t<T, VEC_SIZE> b_vec;
+    flashinfer::vec_t<T, VEC_SIZE> weight_a_vec;
+    flashinfer::vec_t<T, VEC_SIZE> weight_b_vec;
+    flashinfer::vec_t<T, VEC_SIZE> out_vec;
+    a_vec.fill(0.f);
+    b_vec.fill(0.f);
+    weight_a_vec.fill(0.f);
+    weight_b_vec.fill(0.f);
+    const uint32_t elem = i * num_threads * VEC_SIZE + thread_id * VEC_SIZE;
+    if (elem < d) {
+      a_vec.load(a + bx * d + elem);
+      b_vec.load(b + bx * d + elem);
+      weight_a_vec.load(weight_a + elem);
+      weight_b_vec.load(weight_b + elem);
+    }
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; j++) {
+      T na = float(a_vec[j]) * rcp_a * (0.f + float(weight_a_vec[j]));
+      T nb = float(b_vec[j]) * rcp_b * (0.f + float(weight_b_vec[j]));
+      out_vec[j] = float(na) + float(nb);
+    }
+    if (elem < d) {
+      out_vec.store(out + bx * d + elem);
+    }
+  }
+}
+
 }  // namespace norm
 }  // namespace pegainfer
 
@@ -506,6 +593,24 @@ void rms_norm_batched_dual_cuda(const DType *x, const DType *weight_a, const DTy
         pegainfer::norm::DualRMSNormKernel<VEC_SIZE, DType><<<nblks, nthrs, smem_size, stream>>>(
             x, const_cast<DType*>(weight_a), const_cast<DType*>(weight_b), out_a, out_b, d, eps,
             scale_a);
+    });
+}
+
+// The MoE combine tail in one launch: `out = norm(a, wa) + norm(b, wb)`,
+// bitwise what two `rms_norm_batched_cuda` calls and an `add_cuda` produce.
+void dual_rms_norm_add_batched_cuda(const DType *a, const DType *weight_a, const DType *b,
+                                    const DType *weight_b, DType *out, int hidden_dim,
+                                    int seq_len, float eps, cudaStream_t stream) {
+    const uint32_t d = static_cast<uint32_t>(hidden_dim);
+    const uint32_t vec_size = std::gcd<uint32_t>(16 / sizeof(DType), d);
+    const uint32_t block_size = std::min<uint32_t>(1024, d / vec_size);
+    const uint32_t num_warps = flashinfer::ceil_div(block_size, 32);
+    dim3 nblks(static_cast<uint32_t>(seq_len));
+    dim3 nthrs(32, num_warps);
+    const uint32_t smem_size = 2 * num_warps * sizeof(float);
+    DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
+        pegainfer::norm::DualRMSNormAddKernel<VEC_SIZE, DType><<<nblks, nthrs, smem_size, stream>>>(
+            a, const_cast<DType*>(weight_a), b, const_cast<DType*>(weight_b), out, d, eps);
     });
 }
 

--- a/pegainfer-kernels/src/ffi/shared.rs
+++ b/pegainfer-kernels/src/ffi/shared.rs
@@ -40,6 +40,20 @@ unsafe extern "C" {
         stream: CUstream,
     );
 
+    /// `out = rms_norm(a, weight_a) + rms_norm(b, weight_b)`, bitwise what
+    /// two `rms_norm_batched_cuda` calls and an `add_cuda` produce.
+    pub fn dual_rms_norm_add_batched_cuda(
+        a: *const Half,
+        weight_a: *const Half,
+        b: *const Half,
+        weight_b: *const Half,
+        out: *mut Half,
+        hidden_dim: i32,
+        seq_len: i32,
+        eps: f32,
+        stream: CUstream,
+    );
+
     /// `residual_out = bf16(rms_norm(x, weight_post) + res_in)` then
     /// `out = rms_norm(residual_out, weight_pre)`, bitwise what
     /// `rms_norm_batched_cuda` then `fused_add_rms_norm_round_batched_cuda`

--- a/pegainfer-kernels/src/ffi/shared.rs
+++ b/pegainfer-kernels/src/ffi/shared.rs
@@ -24,9 +24,6 @@ unsafe extern "C" {
         stream: CUstream,
     );
 
-    /// Two norms of one input, reduced once; each output is bitwise what a
-    /// separate `rms_norm_batched_cuda` call with that weight produces, with
-    /// `scale_a` preserving a trailing bf16 scalar multiply on the first.
     pub fn rms_norm_batched_dual_cuda(
         x: *const Half,
         weight_a: *const Half,
@@ -38,10 +35,8 @@ unsafe extern "C" {
         eps: f32,
         scale_a: f32,
         stream: CUstream,
-    );
+    ) -> CUresult;
 
-    /// `out = rms_norm(a, weight_a) + rms_norm(b, weight_b)`, bitwise what
-    /// two `rms_norm_batched_cuda` calls and an `add_cuda` produce.
     pub fn dual_rms_norm_add_batched_cuda(
         a: *const Half,
         weight_a: *const Half,
@@ -52,12 +47,8 @@ unsafe extern "C" {
         seq_len: i32,
         eps: f32,
         stream: CUstream,
-    );
+    ) -> CUresult;
 
-    /// `residual_out = bf16(rms_norm(x, weight_post) + res_in)` then
-    /// `out = rms_norm(residual_out, weight_pre)`, bitwise what
-    /// `rms_norm_batched_cuda` then `fused_add_rms_norm_round_batched_cuda`
-    /// produce.
     pub fn rms_norm_add_rms_norm_round_batched_cuda(
         x: *const Half,
         weight_post: *const Half,
@@ -71,8 +62,6 @@ unsafe extern "C" {
         stream: CUstream,
     ) -> CUresult;
 
-    /// `out = (residual + rms_norm(x, weight)) * scale`, the three standalone
-    /// ops' roundings kept in place.
     pub fn rms_norm_add_scale_batched_cuda(
         x: *const Half,
         weight: *const Half,
@@ -83,7 +72,7 @@ unsafe extern "C" {
         eps: f32,
         scale: f32,
         stream: CUstream,
-    );
+    ) -> CUresult;
 
     pub fn add_cuda(
         a: *const Half,

--- a/pegainfer-kernels/src/ffi/shared.rs
+++ b/pegainfer-kernels/src/ffi/shared.rs
@@ -40,6 +40,23 @@ unsafe extern "C" {
         stream: CUstream,
     );
 
+    /// `residual_out = bf16(rms_norm(x, weight_post) + res_in)` then
+    /// `out = rms_norm(residual_out, weight_pre)`, bitwise what
+    /// `rms_norm_batched_cuda` then `fused_add_rms_norm_round_batched_cuda`
+    /// produce.
+    pub fn rms_norm_add_rms_norm_round_batched_cuda(
+        x: *const Half,
+        weight_post: *const Half,
+        res_in: *const Half,
+        weight_pre: *const Half,
+        residual_out: *mut Half,
+        out: *mut Half,
+        hidden_dim: i32,
+        seq_len: i32,
+        eps: f32,
+        stream: CUstream,
+    ) -> CUresult;
+
     /// `out = (residual + rms_norm(x, weight)) * scale`, the three standalone
     /// ops' roundings kept in place.
     pub fn rms_norm_add_scale_batched_cuda(

--- a/pegainfer-kernels/src/ffi/shared.rs
+++ b/pegainfer-kernels/src/ffi/shared.rs
@@ -24,6 +24,22 @@ unsafe extern "C" {
         stream: CUstream,
     );
 
+    /// Two norms of one input, reduced once; each output is bitwise what a
+    /// separate `rms_norm_batched_cuda` call with that weight produces, with
+    /// `scale_a` preserving a trailing bf16 scalar multiply on the first.
+    pub fn rms_norm_batched_dual_cuda(
+        x: *const Half,
+        weight_a: *const Half,
+        weight_b: *const Half,
+        out_a: *mut Half,
+        out_b: *mut Half,
+        hidden_dim: i32,
+        seq_len: i32,
+        eps: f32,
+        scale_a: f32,
+        stream: CUstream,
+    );
+
     pub fn add_cuda(
         a: *const Half,
         b: *const Half,

--- a/pegainfer-kernels/src/ffi/shared.rs
+++ b/pegainfer-kernels/src/ffi/shared.rs
@@ -40,6 +40,20 @@ unsafe extern "C" {
         stream: CUstream,
     );
 
+    /// `out = (residual + rms_norm(x, weight)) * scale`, the three standalone
+    /// ops' roundings kept in place.
+    pub fn rms_norm_add_scale_batched_cuda(
+        x: *const Half,
+        weight: *const Half,
+        residual: *const Half,
+        out: *mut Half,
+        hidden_dim: i32,
+        seq_len: i32,
+        eps: f32,
+        scale: f32,
+        stream: CUstream,
+    );
+
     pub fn add_cuda(
         a: *const Half,
         b: *const Half,

--- a/pegainfer-kernels/src/ops.rs
+++ b/pegainfer-kernels/src/ops.rs
@@ -161,6 +161,7 @@ pub use lora::LoraDecodeGroupedProjection;
 pub use lora::lora_decode_fused_delta_group3_into;
 pub use lora::lora_decode_fused_delta_into;
 pub use lora::pack_lora_b_rows_into;
+pub use norm::dual_rms_norm_add_batch_into;
 pub use norm::fused_add_rms_norm_batch_into;
 pub use norm::fused_add_rms_norm_into;
 pub use norm::fused_add_rms_norm_round_batch_into;

--- a/pegainfer-kernels/src/ops.rs
+++ b/pegainfer-kernels/src/ops.rs
@@ -167,6 +167,7 @@ pub use norm::fused_add_rms_norm_round_batch_into;
 pub use norm::fused_add_rms_norm_round_into;
 pub use norm::layer_norm_into;
 pub use norm::rms_norm;
+pub use norm::rms_norm_add_rms_norm_round_batch_into;
 pub use norm::rms_norm_add_scale_batch_into;
 pub use norm::rms_norm_batch_dual_into;
 pub use norm::rms_norm_batch_into;

--- a/pegainfer-kernels/src/ops.rs
+++ b/pegainfer-kernels/src/ops.rs
@@ -167,6 +167,7 @@ pub use norm::fused_add_rms_norm_round_batch_into;
 pub use norm::fused_add_rms_norm_round_into;
 pub use norm::layer_norm_into;
 pub use norm::rms_norm;
+pub use norm::rms_norm_batch_dual_into;
 pub use norm::rms_norm_batch_into;
 pub use norm::rms_norm_batch_offset_into;
 pub use norm::rms_norm_gated_batch_into;

--- a/pegainfer-kernels/src/ops.rs
+++ b/pegainfer-kernels/src/ops.rs
@@ -167,6 +167,7 @@ pub use norm::fused_add_rms_norm_round_batch_into;
 pub use norm::fused_add_rms_norm_round_into;
 pub use norm::layer_norm_into;
 pub use norm::rms_norm;
+pub use norm::rms_norm_add_scale_batch_into;
 pub use norm::rms_norm_batch_dual_into;
 pub use norm::rms_norm_batch_into;
 pub use norm::rms_norm_batch_offset_into;

--- a/pegainfer-kernels/src/ops/norm.rs
+++ b/pegainfer-kernels/src/ops/norm.rs
@@ -206,6 +206,42 @@ pub fn rms_norm_batch_dual_into(
     }
 }
 
+/// The layer tail in one launch: `out = (residual + rms_norm(x, weight)) *
+/// scale`, bit-identical to the separate norm, add and scale calls it
+/// replaces.
+pub fn rms_norm_add_scale_batch_into(
+    ctx: &DeviceContext,
+    x: &HiddenStates,
+    weight: &DeviceVec,
+    residual: &HiddenStates,
+    scale: f32,
+    eps: f32,
+    out: &mut HiddenStates,
+) {
+    assert_eq!(weight.len, x.hidden_dim);
+    assert_eq!(residual.hidden_dim, x.hidden_dim);
+    assert_eq!(residual.seq_len, x.seq_len);
+    assert_eq!(out.hidden_dim, x.hidden_dim);
+    assert_eq!(out.seq_len, x.seq_len);
+    let (x_ptr, _gx) = x.data.device_ptr(&ctx.stream);
+    let (w_ptr, _gw) = weight.data.device_ptr(&ctx.stream);
+    let (r_ptr, _gr) = residual.data.device_ptr(&ctx.stream);
+    let (o_ptr, _go) = out.data.device_ptr_mut(&ctx.stream);
+    unsafe {
+        ffi::rms_norm_add_scale_batched_cuda(
+            x_ptr as *const ffi::Half,
+            w_ptr as *const ffi::Half,
+            r_ptr as *const ffi::Half,
+            o_ptr as *mut ffi::Half,
+            x.hidden_dim as i32,
+            x.seq_len as i32,
+            eps,
+            scale,
+            crate::tensor::active_cu_stream(ctx),
+        );
+    }
+}
+
 /// Batched fused add + RMSNorm for HiddenStates.
 /// hidden[i] += residual[i]; out[i] = rms_norm(hidden[i], weight) for each batch element.
 pub fn fused_add_rms_norm_batch_into(
@@ -495,5 +531,26 @@ mod parity {
         rms_norm_batch_dual_into(&ctx, &x, &wa, &wb, eps, scale, &mut fused_a, &mut fused_b);
         assert_bitwise(&ctx, &split_a, &fused_a, "dual norm router branch");
         assert_bitwise(&ctx, &split_b, &fused_b, "dual norm expert branch");
+    }
+
+    #[test]
+    #[ignore = "requires a GPU"]
+    fn the_layer_tail_matches_its_parts() {
+        let ctx = DeviceContext::new_with_device(0).expect("device");
+        let (d, rows, eps) = (2816usize, 16usize, 1e-6f32);
+        let x = seeded(&ctx, d, rows, 0);
+        let residual = seeded(&ctx, d, rows, 1);
+        let weight = seeded_weight(&ctx, d, 0);
+        let scale = 0.7383f32;
+
+        let mut normed = HiddenStates::zeros(&ctx, d, rows).expect("normed");
+        rms_norm_batch_into(&ctx, &x, &weight, eps, &mut normed);
+        let mut split = HiddenStates::zeros(&ctx, d, rows).expect("split");
+        crate::ops::add_batch_into(&ctx, &residual, &normed, &mut split).expect("add");
+        crate::ops::scale_bf16_in_place(&ctx, &mut split, scale).expect("scale");
+
+        let mut fused = HiddenStates::zeros(&ctx, d, rows).expect("fused");
+        rms_norm_add_scale_batch_into(&ctx, &x, &weight, &residual, scale, eps, &mut fused);
+        assert_bitwise(&ctx, &split, &fused, "fused layer tail");
     }
 }

--- a/pegainfer-kernels/src/ops/norm.rs
+++ b/pegainfer-kernels/src/ops/norm.rs
@@ -206,6 +206,44 @@ pub fn rms_norm_batch_dual_into(
     }
 }
 
+/// The MoE combine tail in one launch: `out = rms_norm(a, weight_a) +
+/// rms_norm(b, weight_b)`, bitwise what the two separate norms and the add
+/// it replaces produce.
+pub fn dual_rms_norm_add_batch_into(
+    ctx: &DeviceContext,
+    a: &HiddenStates,
+    weight_a: &DeviceVec,
+    b: &HiddenStates,
+    weight_b: &DeviceVec,
+    eps: f32,
+    out: &mut HiddenStates,
+) {
+    assert_eq!(weight_a.len, a.hidden_dim);
+    assert_eq!(weight_b.len, a.hidden_dim);
+    assert_eq!(b.hidden_dim, a.hidden_dim);
+    assert_eq!(b.seq_len, a.seq_len);
+    assert_eq!(out.hidden_dim, a.hidden_dim);
+    assert_eq!(out.seq_len, a.seq_len);
+    let (a_ptr, _ga) = a.data.device_ptr(&ctx.stream);
+    let (wa_ptr, _gwa) = weight_a.data.device_ptr(&ctx.stream);
+    let (b_ptr, _gb) = b.data.device_ptr(&ctx.stream);
+    let (wb_ptr, _gwb) = weight_b.data.device_ptr(&ctx.stream);
+    let (o_ptr, _go) = out.data.device_ptr_mut(&ctx.stream);
+    unsafe {
+        ffi::dual_rms_norm_add_batched_cuda(
+            a_ptr as *const ffi::Half,
+            wa_ptr as *const ffi::Half,
+            b_ptr as *const ffi::Half,
+            wb_ptr as *const ffi::Half,
+            o_ptr as *mut ffi::Half,
+            a.hidden_dim as i32,
+            a.seq_len as i32,
+            eps,
+            crate::tensor::active_cu_stream(ctx),
+        );
+    }
+}
+
 /// The attention epilogue's norm pair in one launch:
 /// `residual_out = bf16(rms_norm(x, weight_post) + res_in)` then
 /// `out = rms_norm(residual_out, weight_pre)`, bitwise what the separate
@@ -637,5 +675,27 @@ mod parity {
         .expect("fused pair");
         assert_bitwise(&ctx, &residual, &fused_res, "fused epilogue residual");
         assert_bitwise(&ctx, &mlp_in, &fused_mlp, "fused epilogue mlp input");
+    }
+
+    #[test]
+    #[ignore = "requires a GPU"]
+    fn the_moe_combine_tail_matches_its_parts() {
+        let ctx = DeviceContext::new_with_device(0).expect("device");
+        let (d, rows, eps) = (2816usize, 16usize, 1e-6f32);
+        let a = seeded(&ctx, d, rows, 0);
+        let b = seeded(&ctx, d, rows, 1);
+        let wa = seeded_weight(&ctx, d, 0);
+        let wb = seeded_weight(&ctx, d, 1);
+
+        let mut na = HiddenStates::zeros(&ctx, d, rows).expect("na");
+        let mut nb = HiddenStates::zeros(&ctx, d, rows).expect("nb");
+        rms_norm_batch_into(&ctx, &a, &wa, eps, &mut na);
+        rms_norm_batch_into(&ctx, &b, &wb, eps, &mut nb);
+        let mut split = HiddenStates::zeros(&ctx, d, rows).expect("split");
+        crate::ops::add_batch_into(&ctx, &na, &nb, &mut split).expect("add");
+
+        let mut fused = HiddenStates::zeros(&ctx, d, rows).expect("fused");
+        dual_rms_norm_add_batch_into(&ctx, &a, &wa, &b, &wb, eps, &mut fused);
+        assert_bitwise(&ctx, &split, &fused, "fused MoE combine");
     }
 }

--- a/pegainfer-kernels/src/ops/norm.rs
+++ b/pegainfer-kernels/src/ops/norm.rs
@@ -165,6 +165,47 @@ pub fn fused_add_rms_norm_into(
     Ok(())
 }
 
+/// Two RMSNorms of the same input in one read: `out_a = rms(x) * weight_a *
+/// scale_a` and `out_b = rms(x) * weight_b`, each bitwise what its standalone
+/// operations produce.
+#[allow(clippy::too_many_arguments)]
+pub fn rms_norm_batch_dual_into(
+    ctx: &DeviceContext,
+    x: &HiddenStates,
+    weight_a: &DeviceVec,
+    weight_b: &DeviceVec,
+    eps: f32,
+    scale_a: f32,
+    out_a: &mut HiddenStates,
+    out_b: &mut HiddenStates,
+) {
+    assert_eq!(weight_a.len, x.hidden_dim);
+    assert_eq!(weight_b.len, x.hidden_dim);
+    assert_eq!(out_a.hidden_dim, x.hidden_dim);
+    assert_eq!(out_b.hidden_dim, x.hidden_dim);
+    assert_eq!(out_a.seq_len, x.seq_len);
+    assert_eq!(out_b.seq_len, x.seq_len);
+    let (x_ptr, _gx) = x.data.device_ptr(&ctx.stream);
+    let (wa_ptr, _ga) = weight_a.data.device_ptr(&ctx.stream);
+    let (wb_ptr, _gb) = weight_b.data.device_ptr(&ctx.stream);
+    let (oa_ptr, _goa) = out_a.data.device_ptr_mut(&ctx.stream);
+    let (ob_ptr, _gob) = out_b.data.device_ptr_mut(&ctx.stream);
+    unsafe {
+        ffi::rms_norm_batched_dual_cuda(
+            x_ptr as *const ffi::Half,
+            wa_ptr as *const ffi::Half,
+            wb_ptr as *const ffi::Half,
+            oa_ptr as *mut ffi::Half,
+            ob_ptr as *mut ffi::Half,
+            x.hidden_dim as i32,
+            x.seq_len as i32,
+            eps,
+            scale_a,
+            crate::tensor::active_cu_stream(ctx),
+        );
+    }
+}
+
 /// Batched fused add + RMSNorm for HiddenStates.
 /// hidden[i] += residual[i]; out[i] = rms_norm(hidden[i], weight) for each batch element.
 pub fn fused_add_rms_norm_batch_into(
@@ -394,5 +435,65 @@ pub fn rms_norm_gated_batch_into(
             eps,
             crate::tensor::active_cu_stream(ctx),
         );
+    }
+}
+
+#[cfg(test)]
+mod parity {
+    use super::*;
+
+    fn assert_bitwise(ctx: &DeviceContext, a: &HiddenStates, b: &HiddenStates, what: &str) {
+        let a = ctx.stream.clone_dtoh(&a.data).expect("a D2H");
+        let b = ctx.stream.clone_dtoh(&b.data).expect("b D2H");
+        let diffs = a
+            .iter()
+            .zip(&b)
+            .enumerate()
+            .filter(|(_, (u, v))| u.to_bits() != v.to_bits())
+            .take(4)
+            .map(|(i, (u, v))| format!("[{i}] {u:?} vs {v:?}"))
+            .collect::<Vec<_>>();
+        assert!(diffs.is_empty(), "{what} diverges: {diffs:?}");
+    }
+
+    fn seeded(ctx: &DeviceContext, d: usize, rows: usize, seed: usize) -> HiddenStates {
+        let host: Vec<bf16> = (0..d * rows)
+            .map(|i| bf16::from_f32((((i * 131 + seed * 17) % 4093) as f32 - 2046.0) / 512.0))
+            .collect();
+        let mut x = HiddenStates::zeros(ctx, d, rows).expect("buf");
+        ctx.stream.memcpy_htod(&host, &mut x.data).expect("up");
+        x
+    }
+
+    fn seeded_weight(ctx: &DeviceContext, d: usize, seed: usize) -> DeviceVec {
+        let host: Vec<bf16> = (0..d)
+            .map(|i| bf16::from_f32((((i * 37 + seed * 13) % 511) as f32 - 255.0) / 256.0))
+            .collect();
+        DeviceVec {
+            data: ctx.stream.clone_htod(&host).expect("w up"),
+            len: d,
+        }
+    }
+
+    #[test]
+    #[ignore = "requires a GPU"]
+    fn the_dual_norm_matches_two_standalone_norms() {
+        let ctx = DeviceContext::new_with_device(0).expect("device");
+        let (d, rows, eps) = (2816usize, 16usize, 1e-6f32);
+        let x = seeded(&ctx, d, rows, 4);
+        let wa = seeded_weight(&ctx, d, 4);
+        let wb = seeded_weight(&ctx, d, 5);
+        let scale = (d as f32).powf(-0.5);
+        let mut split_a = HiddenStates::zeros(&ctx, d, rows).expect("sa");
+        let mut split_b = HiddenStates::zeros(&ctx, d, rows).expect("sb");
+        rms_norm_batch_into(&ctx, &x, &wa, eps, &mut split_a);
+        rms_norm_batch_into(&ctx, &x, &wb, eps, &mut split_b);
+        crate::ops::scale_bf16_in_place(&ctx, &mut split_a, scale).expect("scale");
+
+        let mut fused_a = HiddenStates::zeros(&ctx, d, rows).expect("fa");
+        let mut fused_b = HiddenStates::zeros(&ctx, d, rows).expect("fb");
+        rms_norm_batch_dual_into(&ctx, &x, &wa, &wb, eps, scale, &mut fused_a, &mut fused_b);
+        assert_bitwise(&ctx, &split_a, &fused_a, "dual norm router branch");
+        assert_bitwise(&ctx, &split_b, &fused_b, "dual norm expert branch");
     }
 }

--- a/pegainfer-kernels/src/ops/norm.rs
+++ b/pegainfer-kernels/src/ops/norm.rs
@@ -206,6 +206,56 @@ pub fn rms_norm_batch_dual_into(
     }
 }
 
+/// The attention epilogue's norm pair in one launch:
+/// `residual_out = bf16(rms_norm(x, weight_post) + res_in)` then
+/// `out = rms_norm(residual_out, weight_pre)`, bitwise what the separate
+/// norm and [`fused_add_rms_norm_round_batch_into`] produce.
+#[allow(clippy::too_many_arguments)]
+pub fn rms_norm_add_rms_norm_round_batch_into(
+    ctx: &DeviceContext,
+    x: &HiddenStates,
+    weight_post: &DeviceVec,
+    res_in: &HiddenStates,
+    weight_pre: &DeviceVec,
+    eps: f32,
+    residual_out: &mut HiddenStates,
+    out: &mut HiddenStates,
+) -> Result<()> {
+    assert_eq!(weight_post.len, x.hidden_dim);
+    assert_eq!(weight_pre.len, x.hidden_dim);
+    assert_eq!(res_in.hidden_dim, x.hidden_dim);
+    assert_eq!(res_in.seq_len, x.seq_len);
+    assert_eq!(residual_out.hidden_dim, x.hidden_dim);
+    assert_eq!(residual_out.seq_len, x.seq_len);
+    assert_eq!(out.hidden_dim, x.hidden_dim);
+    assert_eq!(out.seq_len, x.seq_len);
+    let (x_ptr, _gx) = x.data.device_ptr(&ctx.stream);
+    let (wp_ptr, _gwp) = weight_post.data.device_ptr(&ctx.stream);
+    let (r_ptr, _gr) = res_in.data.device_ptr(&ctx.stream);
+    let (wq_ptr, _gwq) = weight_pre.data.device_ptr(&ctx.stream);
+    let (ro_ptr, _gro) = residual_out.data.device_ptr_mut(&ctx.stream);
+    let (o_ptr, _go) = out.data.device_ptr_mut(&ctx.stream);
+    let result = unsafe {
+        ffi::rms_norm_add_rms_norm_round_batched_cuda(
+            x_ptr as *const ffi::Half,
+            wp_ptr as *const ffi::Half,
+            r_ptr as *const ffi::Half,
+            wq_ptr as *const ffi::Half,
+            ro_ptr as *mut ffi::Half,
+            o_ptr as *mut ffi::Half,
+            x.hidden_dim as i32,
+            x.seq_len as i32,
+            eps,
+            crate::tensor::active_cu_stream(ctx),
+        )
+    };
+    ensure!(
+        result == cudarc::driver::sys::CUresult::CUDA_SUCCESS,
+        "rms_norm_add_rms_norm_round_batched_cuda failed: {result:?}"
+    );
+    Ok(())
+}
+
 /// The layer tail in one launch: `out = (residual + rms_norm(x, weight)) *
 /// scale`, bit-identical to the separate norm, add and scale calls it
 /// replaces.
@@ -552,5 +602,40 @@ mod parity {
         let mut fused = HiddenStates::zeros(&ctx, d, rows).expect("fused");
         rms_norm_add_scale_batch_into(&ctx, &x, &weight, &residual, scale, eps, &mut fused);
         assert_bitwise(&ctx, &split, &fused, "fused layer tail");
+    }
+
+    #[test]
+    #[ignore = "requires a GPU"]
+    fn the_epilogue_norm_pair_matches_its_parts() {
+        let ctx = DeviceContext::new_with_device(0).expect("device");
+        let (d, rows, eps) = (2816usize, 16usize, 1e-6f32);
+        let attn = seeded(&ctx, d, rows, 2);
+        let x = seeded(&ctx, d, rows, 3);
+        let w_post = seeded_weight(&ctx, d, 2);
+        let w_pre = seeded_weight(&ctx, d, 3);
+        // The standalone chain the epilogue ran: norm, a separate bf16 add,
+        // then the second norm reading the rounded sum.
+        let mut normed = HiddenStates::zeros(&ctx, d, rows).expect("normed");
+        rms_norm_batch_into(&ctx, &attn, &w_post, eps, &mut normed);
+        let mut residual = HiddenStates::zeros(&ctx, d, rows).expect("residual");
+        crate::ops::add_batch_into(&ctx, &x, &normed, &mut residual).expect("add");
+        let mut mlp_in = HiddenStates::zeros(&ctx, d, rows).expect("mlp_in");
+        rms_norm_batch_into(&ctx, &residual, &w_pre, eps, &mut mlp_in);
+
+        let mut fused_res = HiddenStates::zeros(&ctx, d, rows).expect("fr");
+        let mut fused_mlp = HiddenStates::zeros(&ctx, d, rows).expect("fm");
+        rms_norm_add_rms_norm_round_batch_into(
+            &ctx,
+            &attn,
+            &w_post,
+            &x,
+            &w_pre,
+            eps,
+            &mut fused_res,
+            &mut fused_mlp,
+        )
+        .expect("fused pair");
+        assert_bitwise(&ctx, &residual, &fused_res, "fused epilogue residual");
+        assert_bitwise(&ctx, &mlp_in, &fused_mlp, "fused epilogue mlp input");
     }
 }

--- a/pegainfer-kernels/src/ops/norm.rs
+++ b/pegainfer-kernels/src/ops/norm.rs
@@ -165,9 +165,10 @@ pub fn fused_add_rms_norm_into(
     Ok(())
 }
 
-/// Two RMSNorms of the same input in one read: `out_a = rms(x) * weight_a *
+/// Two RMSNorms of the same input in one launch: `out_a = rms(x) * weight_a *
 /// scale_a` and `out_b = rms(x) * weight_b`, each bitwise what its standalone
-/// operations produce.
+/// operations produce. The norms share one reduction, and the input is read
+/// twice instead of four times.
 #[allow(clippy::too_many_arguments)]
 pub fn rms_norm_batch_dual_into(
     ctx: &DeviceContext,
@@ -178,32 +179,57 @@ pub fn rms_norm_batch_dual_into(
     scale_a: f32,
     out_a: &mut HiddenStates,
     out_b: &mut HiddenStates,
-) {
-    assert_eq!(weight_a.len, x.hidden_dim);
-    assert_eq!(weight_b.len, x.hidden_dim);
-    assert_eq!(out_a.hidden_dim, x.hidden_dim);
-    assert_eq!(out_b.hidden_dim, x.hidden_dim);
-    assert_eq!(out_a.seq_len, x.seq_len);
-    assert_eq!(out_b.seq_len, x.seq_len);
+) -> Result<()> {
+    const OP: &str = "rms_norm_batch_dual_into";
+    ensure!(
+        x.hidden_dim > 0 && x.seq_len > 0,
+        "{OP} dimensions must be non-zero"
+    );
+    ensure!(weight_a.len == x.hidden_dim, "{OP} weight_a len mismatch");
+    ensure!(weight_b.len == x.hidden_dim, "{OP} weight_b len mismatch");
+    ensure!(
+        weight_a.data.len() >= x.hidden_dim,
+        "{OP} weight_a backing too small"
+    );
+    ensure!(
+        weight_b.data.len() >= x.hidden_dim,
+        "{OP} weight_b backing too small"
+    );
+    ensure!(
+        out_a.hidden_dim == x.hidden_dim && out_a.seq_len == x.seq_len,
+        "{OP} out_a shape mismatch"
+    );
+    ensure!(
+        out_b.hidden_dim == x.hidden_dim && out_b.seq_len == x.seq_len,
+        "{OP} out_b shape mismatch"
+    );
+    ensure!(scale_a.is_finite(), "{OP} scale_a must be finite");
+    x.checked_extent("rms_norm_batch_dual_into x")?;
+    out_a.checked_extent("rms_norm_batch_dual_into out_a")?;
+    out_b.checked_extent("rms_norm_batch_dual_into out_b")?;
+    let hidden_dim = super::checked_i32(x.hidden_dim, "rms_norm_batch_dual_into hidden_dim")?;
+    let seq_len = super::checked_i32(x.seq_len, "rms_norm_batch_dual_into seq_len")?;
     let (x_ptr, _gx) = x.data.device_ptr(&ctx.stream);
     let (wa_ptr, _ga) = weight_a.data.device_ptr(&ctx.stream);
     let (wb_ptr, _gb) = weight_b.data.device_ptr(&ctx.stream);
     let (oa_ptr, _goa) = out_a.data.device_ptr_mut(&ctx.stream);
     let (ob_ptr, _gob) = out_b.data.device_ptr_mut(&ctx.stream);
-    unsafe {
+    let result = unsafe {
         ffi::rms_norm_batched_dual_cuda(
             x_ptr as *const ffi::Half,
             wa_ptr as *const ffi::Half,
             wb_ptr as *const ffi::Half,
             oa_ptr as *mut ffi::Half,
             ob_ptr as *mut ffi::Half,
-            x.hidden_dim as i32,
-            x.seq_len as i32,
+            hidden_dim,
+            seq_len,
             eps,
             scale_a,
             crate::tensor::active_cu_stream(ctx),
-        );
-    }
+        )
+    };
+    result.result()?;
+    Ok(())
 }
 
 /// The MoE combine tail in one launch: `out = rms_norm(a, weight_a) +
@@ -217,31 +243,55 @@ pub fn dual_rms_norm_add_batch_into(
     weight_b: &DeviceVec,
     eps: f32,
     out: &mut HiddenStates,
-) {
-    assert_eq!(weight_a.len, a.hidden_dim);
-    assert_eq!(weight_b.len, a.hidden_dim);
-    assert_eq!(b.hidden_dim, a.hidden_dim);
-    assert_eq!(b.seq_len, a.seq_len);
-    assert_eq!(out.hidden_dim, a.hidden_dim);
-    assert_eq!(out.seq_len, a.seq_len);
+) -> Result<()> {
+    const OP: &str = "dual_rms_norm_add_batch_into";
+    ensure!(
+        a.hidden_dim > 0 && a.seq_len > 0,
+        "{OP} dimensions must be non-zero"
+    );
+    ensure!(weight_a.len == a.hidden_dim, "{OP} weight_a len mismatch");
+    ensure!(weight_b.len == a.hidden_dim, "{OP} weight_b len mismatch");
+    ensure!(
+        weight_a.data.len() >= a.hidden_dim,
+        "{OP} weight_a backing too small"
+    );
+    ensure!(
+        weight_b.data.len() >= a.hidden_dim,
+        "{OP} weight_b backing too small"
+    );
+    ensure!(
+        b.hidden_dim == a.hidden_dim && b.seq_len == a.seq_len,
+        "{OP} b shape mismatch"
+    );
+    ensure!(
+        out.hidden_dim == a.hidden_dim && out.seq_len == a.seq_len,
+        "{OP} out shape mismatch"
+    );
+    a.checked_extent("dual_rms_norm_add_batch_into a")?;
+    b.checked_extent("dual_rms_norm_add_batch_into b")?;
+    out.checked_extent("dual_rms_norm_add_batch_into out")?;
+    let hidden_dim = super::checked_i32(a.hidden_dim, "dual_rms_norm_add_batch_into hidden_dim")?;
+    let seq_len = super::checked_i32(a.seq_len, "dual_rms_norm_add_batch_into seq_len")?;
     let (a_ptr, _ga) = a.data.device_ptr(&ctx.stream);
     let (wa_ptr, _gwa) = weight_a.data.device_ptr(&ctx.stream);
     let (b_ptr, _gb) = b.data.device_ptr(&ctx.stream);
     let (wb_ptr, _gwb) = weight_b.data.device_ptr(&ctx.stream);
     let (o_ptr, _go) = out.data.device_ptr_mut(&ctx.stream);
-    unsafe {
+    let result = unsafe {
         ffi::dual_rms_norm_add_batched_cuda(
             a_ptr as *const ffi::Half,
             wa_ptr as *const ffi::Half,
             b_ptr as *const ffi::Half,
             wb_ptr as *const ffi::Half,
             o_ptr as *mut ffi::Half,
-            a.hidden_dim as i32,
-            a.seq_len as i32,
+            hidden_dim,
+            seq_len,
             eps,
             crate::tensor::active_cu_stream(ctx),
-        );
-    }
+        )
+    };
+    result.result()?;
+    Ok(())
 }
 
 /// The attention epilogue's norm pair in one launch:
@@ -259,14 +309,48 @@ pub fn rms_norm_add_rms_norm_round_batch_into(
     residual_out: &mut HiddenStates,
     out: &mut HiddenStates,
 ) -> Result<()> {
-    assert_eq!(weight_post.len, x.hidden_dim);
-    assert_eq!(weight_pre.len, x.hidden_dim);
-    assert_eq!(res_in.hidden_dim, x.hidden_dim);
-    assert_eq!(res_in.seq_len, x.seq_len);
-    assert_eq!(residual_out.hidden_dim, x.hidden_dim);
-    assert_eq!(residual_out.seq_len, x.seq_len);
-    assert_eq!(out.hidden_dim, x.hidden_dim);
-    assert_eq!(out.seq_len, x.seq_len);
+    const OP: &str = "rms_norm_add_rms_norm_round_batch_into";
+    ensure!(
+        x.hidden_dim > 0 && x.seq_len > 0,
+        "{OP} dimensions must be non-zero"
+    );
+    ensure!(
+        weight_post.len == x.hidden_dim,
+        "{OP} weight_post len mismatch"
+    );
+    ensure!(
+        weight_pre.len == x.hidden_dim,
+        "{OP} weight_pre len mismatch"
+    );
+    ensure!(
+        weight_post.data.len() >= x.hidden_dim,
+        "{OP} weight_post backing too small"
+    );
+    ensure!(
+        weight_pre.data.len() >= x.hidden_dim,
+        "{OP} weight_pre backing too small"
+    );
+    ensure!(
+        res_in.hidden_dim == x.hidden_dim && res_in.seq_len == x.seq_len,
+        "{OP} res_in shape mismatch"
+    );
+    ensure!(
+        residual_out.hidden_dim == x.hidden_dim && residual_out.seq_len == x.seq_len,
+        "{OP} residual_out shape mismatch"
+    );
+    ensure!(
+        out.hidden_dim == x.hidden_dim && out.seq_len == x.seq_len,
+        "{OP} out shape mismatch"
+    );
+    x.checked_extent("rms_norm_add_rms_norm_round_batch_into x")?;
+    res_in.checked_extent("rms_norm_add_rms_norm_round_batch_into res_in")?;
+    residual_out.checked_extent("rms_norm_add_rms_norm_round_batch_into residual_out")?;
+    out.checked_extent("rms_norm_add_rms_norm_round_batch_into out")?;
+    let hidden_dim = super::checked_i32(
+        x.hidden_dim,
+        "rms_norm_add_rms_norm_round_batch_into hidden_dim",
+    )?;
+    let seq_len = super::checked_i32(x.seq_len, "rms_norm_add_rms_norm_round_batch_into seq_len")?;
     let (x_ptr, _gx) = x.data.device_ptr(&ctx.stream);
     let (wp_ptr, _gwp) = weight_post.data.device_ptr(&ctx.stream);
     let (r_ptr, _gr) = res_in.data.device_ptr(&ctx.stream);
@@ -281,16 +365,13 @@ pub fn rms_norm_add_rms_norm_round_batch_into(
             wq_ptr as *const ffi::Half,
             ro_ptr as *mut ffi::Half,
             o_ptr as *mut ffi::Half,
-            x.hidden_dim as i32,
-            x.seq_len as i32,
+            hidden_dim,
+            seq_len,
             eps,
             crate::tensor::active_cu_stream(ctx),
         )
     };
-    ensure!(
-        result == cudarc::driver::sys::CUresult::CUDA_SUCCESS,
-        "rms_norm_add_rms_norm_round_batched_cuda failed: {result:?}"
-    );
+    result.result()?;
     Ok(())
 }
 
@@ -305,29 +386,50 @@ pub fn rms_norm_add_scale_batch_into(
     scale: f32,
     eps: f32,
     out: &mut HiddenStates,
-) {
-    assert_eq!(weight.len, x.hidden_dim);
-    assert_eq!(residual.hidden_dim, x.hidden_dim);
-    assert_eq!(residual.seq_len, x.seq_len);
-    assert_eq!(out.hidden_dim, x.hidden_dim);
-    assert_eq!(out.seq_len, x.seq_len);
+) -> Result<()> {
+    const OP: &str = "rms_norm_add_scale_batch_into";
+    ensure!(
+        x.hidden_dim > 0 && x.seq_len > 0,
+        "{OP} dimensions must be non-zero"
+    );
+    ensure!(weight.len == x.hidden_dim, "{OP} weight len mismatch");
+    ensure!(
+        weight.data.len() >= x.hidden_dim,
+        "{OP} weight backing too small"
+    );
+    ensure!(
+        residual.hidden_dim == x.hidden_dim && residual.seq_len == x.seq_len,
+        "{OP} residual shape mismatch"
+    );
+    ensure!(
+        out.hidden_dim == x.hidden_dim && out.seq_len == x.seq_len,
+        "{OP} out shape mismatch"
+    );
+    ensure!(scale.is_finite(), "{OP} scale must be finite");
+    x.checked_extent("rms_norm_add_scale_batch_into x")?;
+    residual.checked_extent("rms_norm_add_scale_batch_into residual")?;
+    out.checked_extent("rms_norm_add_scale_batch_into out")?;
+    let hidden_dim = super::checked_i32(x.hidden_dim, "rms_norm_add_scale_batch_into hidden_dim")?;
+    let seq_len = super::checked_i32(x.seq_len, "rms_norm_add_scale_batch_into seq_len")?;
     let (x_ptr, _gx) = x.data.device_ptr(&ctx.stream);
     let (w_ptr, _gw) = weight.data.device_ptr(&ctx.stream);
     let (r_ptr, _gr) = residual.data.device_ptr(&ctx.stream);
     let (o_ptr, _go) = out.data.device_ptr_mut(&ctx.stream);
-    unsafe {
+    let result = unsafe {
         ffi::rms_norm_add_scale_batched_cuda(
             x_ptr as *const ffi::Half,
             w_ptr as *const ffi::Half,
             r_ptr as *const ffi::Half,
             o_ptr as *mut ffi::Half,
-            x.hidden_dim as i32,
-            x.seq_len as i32,
+            hidden_dim,
+            seq_len,
             eps,
             scale,
             crate::tensor::active_cu_stream(ctx),
-        );
-    }
+        )
+    };
+    result.result()?;
+    Ok(())
 }
 
 /// Batched fused add + RMSNorm for HiddenStates.
@@ -569,6 +671,7 @@ mod parity {
     fn assert_bitwise(ctx: &DeviceContext, a: &HiddenStates, b: &HiddenStates, what: &str) {
         let a = ctx.stream.clone_dtoh(&a.data).expect("a D2H");
         let b = ctx.stream.clone_dtoh(&b.data).expect("b D2H");
+        assert_eq!(a.len(), b.len(), "{what} length mismatch");
         let diffs = a
             .iter()
             .zip(&b)
@@ -590,9 +693,10 @@ mod parity {
     }
 
     fn seeded_weight(ctx: &DeviceContext, d: usize, seed: usize) -> DeviceVec {
-        let host: Vec<bf16> = (0..d)
+        let mut host: Vec<bf16> = (0..d)
             .map(|i| bf16::from_f32((((i * 37 + seed * 13) % 511) as f32 - 255.0) / 256.0))
             .collect();
+        host[0] = bf16::from_f32(-0.0);
         DeviceVec {
             data: ctx.stream.clone_htod(&host).expect("w up"),
             len: d,
@@ -616,7 +720,8 @@ mod parity {
 
         let mut fused_a = HiddenStates::zeros(&ctx, d, rows).expect("fa");
         let mut fused_b = HiddenStates::zeros(&ctx, d, rows).expect("fb");
-        rms_norm_batch_dual_into(&ctx, &x, &wa, &wb, eps, scale, &mut fused_a, &mut fused_b);
+        rms_norm_batch_dual_into(&ctx, &x, &wa, &wb, eps, scale, &mut fused_a, &mut fused_b)
+            .expect("fused dual norm");
         assert_bitwise(&ctx, &split_a, &fused_a, "dual norm router branch");
         assert_bitwise(&ctx, &split_b, &fused_b, "dual norm expert branch");
     }
@@ -638,7 +743,8 @@ mod parity {
         crate::ops::scale_bf16_in_place(&ctx, &mut split, scale).expect("scale");
 
         let mut fused = HiddenStates::zeros(&ctx, d, rows).expect("fused");
-        rms_norm_add_scale_batch_into(&ctx, &x, &weight, &residual, scale, eps, &mut fused);
+        rms_norm_add_scale_batch_into(&ctx, &x, &weight, &residual, scale, eps, &mut fused)
+            .expect("fused tail");
         assert_bitwise(&ctx, &split, &fused, "fused layer tail");
     }
 
@@ -695,7 +801,8 @@ mod parity {
         crate::ops::add_batch_into(&ctx, &na, &nb, &mut split).expect("add");
 
         let mut fused = HiddenStates::zeros(&ctx, d, rows).expect("fused");
-        dual_rms_norm_add_batch_into(&ctx, &a, &wa, &b, &wb, eps, &mut fused);
+        dual_rms_norm_add_batch_into(&ctx, &a, &wa, &b, &wb, eps, &mut fused)
+            .expect("fused combine");
         assert_bitwise(&ctx, &split, &fused, "fused MoE combine");
     }
 }

--- a/scripts/gemma4_gates.sh
+++ b/scripts/gemma4_gates.sh
@@ -82,10 +82,10 @@ GATES_ROUTED=(
 # These live in pegainfer-kernels under the gemma4 feature and need no checkpoint.
 GATES_KERNELS=(
   "gpu ops::gemma4::tests::router_topk_matches_the_exact_128_expert_contract"
-  "gpu ops::norm::tests::the_dual_norm_matches_two_standalone_norms"
-  "gpu ops::norm::tests::the_layer_tail_matches_its_parts"
-  "gpu ops::norm::tests::the_epilogue_norm_pair_matches_its_parts"
-  "gpu ops::norm::tests::the_moe_combine_tail_matches_its_parts"
+  "gpu ops::norm::parity::the_dual_norm_matches_two_standalone_norms"
+  "gpu ops::norm::parity::the_layer_tail_matches_its_parts"
+  "gpu ops::norm::parity::the_epilogue_norm_pair_matches_its_parts"
+  "gpu ops::norm::parity::the_moe_combine_tail_matches_its_parts"
 )
 MANIFEST_LIB=(
   "${GATES_NUMERIC_PARITY[@]}"

--- a/scripts/gemma4_gates.sh
+++ b/scripts/gemma4_gates.sh
@@ -82,6 +82,10 @@ GATES_ROUTED=(
 # These live in pegainfer-kernels under the gemma4 feature and need no checkpoint.
 GATES_KERNELS=(
   "gpu ops::gemma4::tests::router_topk_matches_the_exact_128_expert_contract"
+  "gpu ops::norm::tests::the_dual_norm_matches_two_standalone_norms"
+  "gpu ops::norm::tests::the_layer_tail_matches_its_parts"
+  "gpu ops::norm::tests::the_epilogue_norm_pair_matches_its_parts"
+  "gpu ops::norm::tests::the_moe_combine_tail_matches_its_parts"
 )
 MANIFEST_LIB=(
   "${GATES_NUMERIC_PARITY[@]}"


### PR DESCRIPTION

## Description

Closes #997

The routed block normed its residual twice, once without a weight for the router and once with the expert-input weight, and then scaled the router row in a third launch. One kernel now reads the row once and writes both outputs, applying `hidden ** -0.5` on the router branch at the point where the standalone bf16 multiply rounded.

The layer tail's post-feed-forward norm, residual add and `layer_scalar` multiply are one launch. The normalized value rounds to bf16 where the norm stored it, the sum rounds where the add did, and the scaled value rounds once more where the in-place scale did, so the output is the same bytes.

The attention epilogue's post-attention norm, the block residual add and the pre-feed-forward norm are one launch. The sum is rounded to bf16 before the second reduction, which is what the separate add wrote and the rounding norm read; the `o_normed` and `h2` scratch buffers become one residual buffer.

The MoE combine tail's two post-feed-forward norms and their add are one launch; `dense_normed` and `expert_normed` go with them.

Each fused kernel carries an ignored GPU test against its standalone parts, and each commit's serving bytes match its immediate parent at pinned composition. No launch geometry, stream or Marlin code changes, so no Kimi gate is involved. The QKV, routed w13 and dense gate/up projection fusions and the dense/routed stream overlap are deliberately left to their own issue.

## Test Env

Single GPU (`sm_89`, 48 GiB, x86_64)

### Verification

- `cargo fmt --all -- --check` and `git diff --check` against `main` pass. The Gemma 4 release server builds, all-target Gemma/kernels Clippy passes with `-D warnings`, and release lib tests pass: core 33, Gemma 42 with 20 ignored, kernels 16 with 5 ignored.
- The four kernels-crate GPU contracts pass 1/1 each in their own process through `scripts/gemma4_gates.sh`, whose kernels manifest now names them: `the_dual_norm_matches_two_standalone_norms`, `the_layer_tail_matches_its_parts`, `the_epilogue_norm_pair_matches_its_parts`, `the_moe_combine_tail_matches_its_parts`, each comparing the fused kernel's bytes to its standalone parts on the same inputs. The checkpoint-backed routed-block gate and the two 12B HF fixture gates (context waypoints, greedy generation) pass 1/1 each.
- Byte identity at pinned composition: the same four greedy public `/v1/completions` requests (31-, 35- and 33-token prompts plus a 1421-token one; 64 forced tokens; `finish_reason=length`, `completion_tokens=64`) answer with one md5 on `main`'s binary and on this head's, `219de1e3c09c`.
- Serving A/B, this head against `main`, `vllm bench serve` random 1024 in / 128 out at 8 / 24 / 64 prompts, two cooled alternating rounds, same seed per round, output tok/s as mean [range]:

  | | c1 | c4 | c16 |
  | --- | --- | --- | --- |
  | `main` | 103.3 [103.2–103.4] | 274.7 [274.4–274.9] | 585.0 [584.6–585.3] |
  | this branch | 106.0 [105.9–106.0] | 277.6 [276.3–278.8] | 592.0 [589.5–594.5] |

  Median TPOT moves with it: c1 8.83 → 8.60 ms, c4 12.69/12.77 → 12.47/12.67 ms, c16 23.78/24.03 → 23.62/23.82 ms.
- Launch accounts from node-level Nsight traces of the same request set (64 prompts at c16, then 8 at c1) on each binary: 1,503,742 kernel launches on `main` against 1,125,750 here, with the kernel-time total 23,185 → 22,712 ms. Per layer and step the norm glue goes from twelve launches (eight RMSNorms, three adds, two scales) to the four fused kernels: the standalone RMSNorm count falls 380,298 → 48,949, the add kernel disappears and the scale kernel keeps 1,579 launches (the router scale outside the fused read), while each fused kernel launches 47,370 times.