### PR TITLE
refactor(kernels): the shared launch header owns every instantiation

### DIFF
--- a/pegainfer-kernels/csrc/shared/paged_attention.cu
+++ b/pegainfer-kernels/csrc/shared/paged_attention.cu
@@ -7,236 +7,7 @@
 // FlashInfer's dispatchers internally instantiate multiple GQA group sizes
 // (1,2,3,4,8) — this covers both Qwen3-4B (GQA=4) and Qwen3.5-4B (GQA=8).
 
-#include "ffi_guard.cuh"
-
-#include <cuda_runtime.h>
-#include <cuda_bf16.h>
-#include <cstdint>
-
-#include <flashinfer/attention/decode.cuh>
-#include <flashinfer/attention/prefill.cuh>
-#include <flashinfer/attention/default_decode_params.cuh>
-#include <flashinfer/attention/default_prefill_params.cuh>
-#include <flashinfer/attention/variants.cuh>
-#include <flashinfer/page.cuh>
-
-using namespace flashinfer;
-
-using DType  = __nv_bfloat16;
-using IdType = int32_t;
-using ParamsT = BatchDecodeParams<DType, DType, DType, IdType>;
-using Variant = DefaultAttention</*custom_mask=*/false,
-                                 /*sliding_window=*/false,
-                                 /*logits_soft_cap=*/false,
-                                 /*alibi=*/false>;
-
-// `window_left` is an inclusive distance: an N-token window passes N - 1, and
-// -1 degrades to full attention.
-using WindowVariant = DefaultAttention</*custom_mask=*/false,
-                                       /*sliding_window=*/true,
-                                       /*logits_soft_cap=*/false,
-                                       /*alibi=*/false>;
-
-// Helper: build paged_kv_t from our page-first layout.
-//
-// Our KvPool stores all layers interleaved in one buffer. For a given layer L:
-//   k_data = base + L * layer_stride
-//   v_data = base + L * layer_stride + kv_block_len
-//   stride_page = page_stride  (spans all layers — jumps to same layer in next page)
-//   NHD within-block: stride_n = num_kv_heads * head_dim, stride_h = head_dim
-static paged_kv_t<DType, IdType> make_paged_kv(
-    void*    kv_data,
-    int64_t  k_offset_elems,
-    int64_t  v_offset_elems,
-    int32_t* page_indices,
-    int32_t* page_indptr,
-    int32_t* last_page_len_d,
-    int32_t  num_kv_heads,
-    int32_t  head_dim,
-    int32_t  page_size,
-    int32_t  batch_size,
-    int64_t  stride_page)
-{
-    DType* k_data = reinterpret_cast<DType*>(kv_data) + k_offset_elems;
-    DType* v_data = reinterpret_cast<DType*>(kv_data) + v_offset_elems;
-
-    // kv_strides[0] = stride_page, [1] = stride for NHD-n, [2] = stride for NHD-h
-    int64_t kv_strides[3] = {
-        stride_page,
-        static_cast<int64_t>(num_kv_heads) * head_dim,
-        static_cast<int64_t>(head_dim),
-    };
-
-    return paged_kv_t<DType, IdType>(
-        num_kv_heads, page_size, head_dim, batch_size,
-        QKVLayout::kNHD,
-        k_data, v_data, kv_strides,
-        page_indices, page_indptr, last_page_len_d,
-        /*rope_pos_offset=*/nullptr);
-}
-
-// ---------------------------------------------------------------------------
-// Paged attention decode — wraps FlashInfer BatchDecodeWithPagedKVCache.
-//
-// Reads Q from `q`, reads K/V from the paged cache, writes output to `output`.
-// No RoPE applied inside (caller does RoPE beforehand).
-// No partition-KV (single block per batch×head) for Phase 1 simplicity.
-// ---------------------------------------------------------------------------
-template <uint32_t HEAD_DIM, typename VariantT>
-static int decode_launch(
-    // Q and output
-    void*    q,                    // [num_qo_heads * head_dim] bf16, device
-    void*    output,               // [num_qo_heads * head_dim] bf16, device
-    // KV pool buffer (entire pool)
-    void*    kv_data,
-    int64_t  k_offset_elems,       // element offset: base → layer's K in page 0
-    int64_t  v_offset_elems,       // element offset: base → layer's V in page 0
-    // Paged KV metadata (GPU arrays)
-    int32_t* page_indices,         // [num_pages_this_request]
-    int32_t* page_indptr,          // [batch_size + 1]
-    int32_t* last_page_len_d,      // [batch_size]
-    // Plan metadata (GPU arrays — trivial for non-partition bs=1)
-    int32_t* request_indices,      // [padded_batch_size], e.g. [0]
-    int32_t* kv_tile_indices,      // [padded_batch_size], e.g. [0]
-    int32_t* kv_chunk_size_ptr,    // GPU ptr → 1 int32 (kv_len)
-    // Dimensions
-    int32_t  num_qo_heads,
-    int32_t  num_kv_heads,
-    int32_t  head_dim,
-    int32_t  page_size,
-    int32_t  batch_size,           // 1 for Phase 1
-    int64_t  stride_page,          // KvLayout.page_stride
-    float    sm_scale,             // typically 1/sqrt(head_dim)
-    int32_t  window_left,
-    // Stream
-    void*    stream)
-{
-  PEGAINFER_FFI_GUARD_BEGIN
-    auto paged_kv = make_paged_kv(
-        kv_data, k_offset_elems, v_offset_elems,
-        page_indices, page_indptr, last_page_len_d,
-        num_kv_heads, head_dim, page_size, batch_size, stride_page);
-
-    ParamsT params(
-        reinterpret_cast<DType*>(q),
-        /*q_rope_offset=*/nullptr,
-        paged_kv,
-        reinterpret_cast<DType*>(output),
-        /*lse=*/nullptr,
-        /*maybe_alibi_slopes=*/nullptr,
-        num_qo_heads,
-        /*q_stride_n=*/num_qo_heads * head_dim,
-        /*q_stride_h=*/head_dim,
-        window_left,
-        /*logits_soft_cap=*/0.0f,
-        sm_scale,
-        /*rope_scale=*/1.0f,
-        /*rope_theta=*/1e6f);
-
-    params.padded_batch_size = batch_size;
-    params.request_indices   = request_indices;
-    params.kv_tile_indices   = kv_tile_indices;
-    params.o_indptr          = nullptr;
-    params.kv_chunk_size_ptr = kv_chunk_size_ptr;
-    params.block_valid_mask  = nullptr;
-    params.partition_kv      = false;
-
-    // tmp_v = nullptr → non-partition path (no merge step)
-    return static_cast<int>(
-        BatchDecodeWithPagedKVCacheDispatched<
-            HEAD_DIM,
-            PosEncodingMode::kNone,
-            VariantT,
-            ParamsT>(
-            params,
-            /*tmp_v=*/nullptr,
-            /*tmp_s=*/nullptr,
-            /*enable_pdl=*/false,
-            reinterpret_cast<cudaStream_t>(stream)));
-  PEGAINFER_FFI_GUARD_END(-1)
-}
-
-// ---------------------------------------------------------------------------
-// Paged attention decode with partition-KV / split-K.
-//
-// The caller supplies a split-K plan:
-//   request_indices[slot]  -> original batch slot
-//   kv_tile_indices[slot]  -> KV chunk id for that request
-//   o_indptr[request]      -> active split-slot range for merge
-//   block_valid_mask[slot] -> false for graph-stability padding slots
-//
-// tmp_v/tmp_s hold per-chunk partial states and are merged by FlashInfer.
-// ---------------------------------------------------------------------------
-template <uint32_t HEAD_DIM, typename VariantT>
-static int decode_split_kv_launch(
-    void*    q,                    // [batch_size * num_qo_heads * head_dim] bf16, device
-    void*    output,               // [batch_size * num_qo_heads * head_dim] bf16, device
-    void*    kv_data,
-    int64_t  k_offset_elems,
-    int64_t  v_offset_elems,
-    int32_t* page_indices,
-    int32_t* page_indptr,
-    int32_t* last_page_len_d,
-    int32_t* request_indices,
-    int32_t* kv_tile_indices,
-    int32_t* kv_chunk_size_ptr,    // GPU ptr -> 1 int32 chunk size
-    int32_t* o_indptr,             // [batch_size + 1]
-    uint8_t* block_valid_mask,     // [padded_batch_size], 0/1
-    void*    tmp_v,                // [padded_batch_size * num_qo_heads * head_dim] bf16
-    float*   tmp_s,                // [padded_batch_size * num_qo_heads]
-    int32_t  num_qo_heads,
-    int32_t  num_kv_heads,
-    int32_t  head_dim,
-    int32_t  page_size,
-    int32_t  batch_size,
-    int32_t  padded_batch_size,    // split slots, including masked padding slots
-    int64_t  stride_page,
-    float    sm_scale,
-    int32_t  window_left,
-    void*    stream)
-{
-  PEGAINFER_FFI_GUARD_BEGIN
-    auto paged_kv = make_paged_kv(
-        kv_data, k_offset_elems, v_offset_elems,
-        page_indices, page_indptr, last_page_len_d,
-        num_kv_heads, head_dim, page_size, batch_size, stride_page);
-
-    ParamsT params(
-        reinterpret_cast<DType*>(q),
-        /*q_rope_offset=*/nullptr,
-        paged_kv,
-        reinterpret_cast<DType*>(output),
-        /*lse=*/nullptr,
-        /*maybe_alibi_slopes=*/nullptr,
-        num_qo_heads,
-        /*q_stride_n=*/num_qo_heads * head_dim,
-        /*q_stride_h=*/head_dim,
-        window_left,
-        /*logits_soft_cap=*/0.0f,
-        sm_scale,
-        /*rope_scale=*/1.0f,
-        /*rope_theta=*/1e6f);
-
-    params.padded_batch_size = padded_batch_size;
-    params.request_indices   = request_indices;
-    params.kv_tile_indices   = kv_tile_indices;
-    params.o_indptr          = o_indptr;
-    params.kv_chunk_size_ptr = kv_chunk_size_ptr;
-    params.block_valid_mask  = reinterpret_cast<bool*>(block_valid_mask);
-
-    return static_cast<int>(
-        BatchDecodeWithPagedKVCacheDispatched<
-            HEAD_DIM,
-            PosEncodingMode::kNone,
-            VariantT,
-            ParamsT>(
-            params,
-            reinterpret_cast<DType*>(tmp_v),
-            tmp_s,
-            /*enable_pdl=*/false,
-            reinterpret_cast<cudaStream_t>(stream)));
-  PEGAINFER_FFI_GUARD_END(-1)
-}
+#include "paged_launch.cuh"
 
 extern "C" {
 
@@ -374,24 +145,6 @@ int paged_kv_scatter_cuda(
 // Plan metadata (request_indices, qo_tile_indices, etc.) is pre-computed by Rust
 // and passed as GPU arrays. This avoids per-call GPU allocations.
 // ---------------------------------------------------------------------------
-using BatchPrefillParamsT = BatchPrefillPagedParams<DType, DType, DType, IdType>;
-
-static uint32_t resolve_prefill_cta_tile_q(
-    int64_t packed_qo_len,
-    int32_t head_dim,
-    int32_t cta_tile_q_override)
-{
-    if (cta_tile_q_override == 0) {
-        return FA2DetermineCtaTileQ(packed_qo_len, head_dim);
-    }
-    if (cta_tile_q_override == 16 ||
-        cta_tile_q_override == 64 ||
-        cta_tile_q_override == 128) {
-        return static_cast<uint32_t>(cta_tile_q_override);
-    }
-    return 0;
-}
-
 // Return the number of Q tiles for given dimensions (needed to size plan arrays).
 int32_t batch_prefill_paged_num_tiles(
     int32_t  seq_len,
@@ -451,114 +204,6 @@ int32_t batch_prefill_cta_tile_q_with_override(
 }
 
 } // extern "C"
-
-template <uint32_t HEAD_DIM, typename VariantT>
-static int prefill_paged_launch(
-    // Q and output (HiddenStates col-major: [q_dim, total_seq_len])
-    void*    q,
-    void*    output,
-    // KV pool buffer (entire pool)
-    void*    kv_data,
-    int64_t  k_offset_elems,
-    int64_t  v_offset_elems,
-    // Paged KV metadata (GPU arrays, concatenated across requests)
-    int32_t* page_indices,
-    int32_t* page_indptr,
-    int32_t* last_page_len_d,
-    // Batch prefill plan metadata (GPU arrays, pre-allocated by Rust)
-    int32_t* q_indptr,             // [batch_size+1]: CSR token boundaries
-    int32_t* request_indices,      // [num_tiles]: tile → request mapping
-    int32_t* qo_tile_indices,      // [num_tiles]: tile → local Q offset
-    int32_t* kv_tile_indices,      // [num_tiles]: all zeros (no KV partition)
-    int32_t* kv_chunk_size_ptr,    // [batch_size]: per-request kv_len
-    uint32_t* total_num_rows,      // [1]: total Q tokens
-    // Dimensions
-    int32_t  num_qo_heads,
-    int32_t  num_kv_heads,
-    int32_t  head_dim,
-    int32_t  page_size,
-    int32_t  seq_len,              // total Q tokens across all requests
-    int32_t  batch_size,           // number of requests
-    int32_t  padded_batch_size,    // = total num_tiles
-    int64_t  stride_page,
-    float    sm_scale,
-    int32_t  cta_tile_q_override,
-    int32_t  window_left,
-    // Stream
-    void*    stream)
-{
-  PEGAINFER_FFI_GUARD_BEGIN
-    auto paged_kv = make_paged_kv(
-        kv_data, k_offset_elems, v_offset_elems,
-        page_indices, page_indptr, last_page_len_d,
-        num_kv_heads, head_dim, page_size, batch_size, stride_page);
-
-    uint32_t q_stride_n = num_qo_heads * head_dim;
-    uint32_t q_stride_h = head_dim;
-
-    BatchPrefillParamsT params(
-        reinterpret_cast<DType*>(q),
-        paged_kv,
-        /*maybe_custom_mask=*/nullptr,
-        q_indptr,
-        /*maybe_mask_indptr=*/nullptr,
-        /*maybe_q_rope_offset=*/nullptr,
-        reinterpret_cast<DType*>(output),
-        /*lse=*/nullptr,
-        /*maybe_alibi_slopes=*/nullptr,
-        num_qo_heads,
-        q_stride_n,
-        q_stride_h,
-        window_left,
-        /*logits_soft_cap=*/0.0f,
-        sm_scale,
-        /*rope_scale=*/1.0f,
-        /*rope_theta=*/1e6f);
-
-    params.request_indices   = request_indices;
-    params.qo_tile_indices   = qo_tile_indices;
-    params.kv_tile_indices   = kv_tile_indices;
-    params.merge_indptr      = nullptr;
-    params.o_indptr          = q_indptr;  // same as q_indptr for non-partition: [0, seq_len]
-    params.block_valid_mask  = nullptr;
-    params.kv_chunk_size_ptr = kv_chunk_size_ptr;
-    params.max_total_num_rows = seq_len;
-    params.total_num_rows    = total_num_rows;
-    params.padded_batch_size = padded_batch_size;
-    params.partition_kv      = false;
-
-    // Determine CTA tile size and dispatch
-    uint32_t group_size = num_qo_heads / num_kv_heads;
-    int64_t packed_qo_len = static_cast<int64_t>(seq_len) * group_size;
-    uint32_t cta_tile_q = resolve_prefill_cta_tile_q(
-        packed_qo_len, head_dim, cta_tile_q_override);
-    if (cta_tile_q == 0) {
-        pegainfer_ffi_set_last_error("invalid cta_tile_q override");
-        return -1;
-    }
-
-    cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);
-    int result = 0;
-    DISPATCH_CTA_TILE_Q(cta_tile_q, CTA_TILE_Q, {
-        result = static_cast<int>(
-            BatchPrefillWithPagedKVCacheDispatched<
-                CTA_TILE_Q,
-                /*HEAD_DIM_QK=*/HEAD_DIM,
-                /*HEAD_DIM_VO=*/HEAD_DIM,
-                PosEncodingMode::kNone,
-                /*USE_FP16_QK_REDUCTION=*/false,
-                MaskMode::kCausal,
-                VariantT,
-                BatchPrefillParamsT>(
-                params,
-                /*tmp_v=*/nullptr,
-                /*tmp_s=*/nullptr,
-                /*enable_pdl=*/false,
-                s));
-    });
-    return result;
-  PEGAINFER_FFI_GUARD_END(-1)
-}
 
 extern "C" {
 
@@ -627,8 +272,6 @@ int batch_prefill_paged_cuda(
 // No RoPE inside (caller does RoPE beforehand via prefill_attention_prep_cuda).
 // Causal mask, no split-KV (tmp=nullptr).
 // ---------------------------------------------------------------------------
-using PrefillParamsT = SinglePrefillParams<DType, DType, DType>;
-
 int single_prefill_cuda(
     // Q and output (HiddenStates col-major: [q_dim, seq_len])
     void*    q,
@@ -647,51 +290,10 @@ int single_prefill_cuda(
     // Stream
     void*    stream)
 {
-  PEGAINFER_FFI_GUARD_BEGIN
-    // Q/O strides: col-major [q_dim, seq_len]
-    uint32_t q_stride_n  = num_qo_heads * head_dim;   // stride between tokens
-    uint32_t q_stride_h  = head_dim;                   // stride between heads
-
-    // K/V strides: HND layout k[head, pos, dim]
-    uint32_t kv_stride_n = head_dim;                   // stride between positions
-    uint32_t kv_stride_h = max_seq_len * head_dim;     // stride between heads
-
-    PrefillParamsT params(
-        reinterpret_cast<DType*>(q),
-        reinterpret_cast<DType*>(k_cache),
-        reinterpret_cast<DType*>(v_cache),
-        /*maybe_custom_mask=*/nullptr,
-        reinterpret_cast<DType*>(output),
-        /*lse=*/nullptr,
-        /*maybe_alibi_slopes=*/nullptr,
-        num_qo_heads,
-        num_kv_heads,
-        static_cast<uint32_t>(seq_len),
-        static_cast<uint32_t>(kv_len),
-        q_stride_n,
-        q_stride_h,
-        kv_stride_n,
-        kv_stride_h,
-        static_cast<uint32_t>(head_dim),
-        /*window_left=*/-1,
-        /*logits_soft_cap=*/0.0f,
-        sm_scale,
-        /*rope_scale=*/1.0f,
-        /*rope_theta=*/1e6f);
-
-    return static_cast<int>(
-        SinglePrefillWithKVCacheDispatched<
-            /*HEAD_DIM_QK=*/128,
-            /*HEAD_DIM_VO=*/128,
-            PosEncodingMode::kNone,
-            /*USE_FP16_QK_REDUCTION=*/false,
-            MaskMode::kCausal,
-            Variant,
-            PrefillParamsT>(
-            params,
-            /*tmp=*/nullptr,
-            reinterpret_cast<cudaStream_t>(stream)));
-  PEGAINFER_FFI_GUARD_END(-1)
+  return single_prefill_launch</*HEAD_DIM=*/128, Variant>(
+      q, output, k_cache, v_cache, num_qo_heads, num_kv_heads,
+      head_dim, seq_len, kv_len, max_seq_len,
+      sm_scale, stream);
 }
 
 int single_prefill_nhd_noncausal_cuda(
@@ -987,49 +589,10 @@ int single_prefill_cuda_hd256(
     float    sm_scale,
     void*    stream)
 {
-  PEGAINFER_FFI_GUARD_BEGIN
-    uint32_t q_stride_n  = num_qo_heads * 256;
-    uint32_t q_stride_h  = 256;
-
-    uint32_t kv_stride_n = 256;
-    uint32_t kv_stride_h = static_cast<uint32_t>(max_seq_len) * 256;
-
-    PrefillParamsT params(
-        reinterpret_cast<DType*>(q),
-        reinterpret_cast<DType*>(k_cache),
-        reinterpret_cast<DType*>(v_cache),
-        /*maybe_custom_mask=*/nullptr,
-        reinterpret_cast<DType*>(output),
-        /*lse=*/nullptr,
-        /*maybe_alibi_slopes=*/nullptr,
-        num_qo_heads,
-        num_kv_heads,
-        static_cast<uint32_t>(seq_len),
-        static_cast<uint32_t>(kv_len),
-        q_stride_n,
-        q_stride_h,
-        kv_stride_n,
-        kv_stride_h,
-        /*head_dim=*/256U,
-        /*window_left=*/-1,
-        /*logits_soft_cap=*/0.0f,
-        sm_scale,
-        /*rope_scale=*/1.0f,
-        /*rope_theta=*/1e6f);
-
-    return static_cast<int>(
-        SinglePrefillWithKVCacheDispatched<
-            /*HEAD_DIM_QK=*/256,
-            /*HEAD_DIM_VO=*/256,
-            PosEncodingMode::kNone,
-            /*USE_FP16_QK_REDUCTION=*/false,
-            MaskMode::kCausal,
-            Variant,
-            PrefillParamsT>(
-            params,
-            /*tmp=*/nullptr,
-            reinterpret_cast<cudaStream_t>(stream)));
-  PEGAINFER_FFI_GUARD_END(-1)
+  return single_prefill_launch</*HEAD_DIM=*/256, Variant>(
+      q, output, k_cache, v_cache, num_qo_heads, num_kv_heads,
+      /*head_dim=*/256, seq_len, kv_len, max_seq_len,
+      sm_scale, stream);
 }
 
 // ---------------------------------------------------------------------------

--- a/pegainfer-kernels/csrc/shared/paged_attention.cu
+++ b/pegainfer-kernels/csrc/shared/paged_attention.cu
@@ -2,7 +2,8 @@
 //
 // We include FlashInfer headers (header-only C++) and instantiate only the
 // template variants needed: bf16 Q/KV/O, NHD layout, no RoPE, at HEAD_DIM 128
-// and 256, the latter both with and without a sliding-window mask.
+// and 256 — the latter both with and without a sliding-window mask — plus the
+// hd512 split-KV decode entry the global family reads through.
 //
 // FlashInfer's dispatchers internally instantiate multiple GQA group sizes
 // (1,2,3,4,8) — this covers both Qwen3-4B (GQA=4) and Qwen3.5-4B (GQA=8).
@@ -202,10 +203,6 @@ int32_t batch_prefill_cta_tile_q_with_override(
     return static_cast<int32_t>(resolve_prefill_cta_tile_q(
         packed_qo_len, head_dim, cta_tile_q_override));
 }
-
-} // extern "C"
-
-extern "C" {
 
 int batch_prefill_paged_cuda_with_cta_tile_q(
     void* q, void* output, void* kv_data,

--- a/pegainfer-kernels/csrc/shared/paged_attention_hd512.cu
+++ b/pegainfer-kernels/csrc/shared/paged_attention_hd512.cu
@@ -2,69 +2,7 @@
 // attention layers). Separate TU so the long FlashInfer template builds
 // compile in parallel with paged_attention.cu.
 
-#include "ffi_guard.cuh"
-
-#include <cuda_runtime.h>
-#include <cuda_bf16.h>
-#include <cstdint>
-
-#include <flashinfer/attention/decode.cuh>
-#include <flashinfer/attention/prefill.cuh>
-#include <flashinfer/attention/default_decode_params.cuh>
-#include <flashinfer/attention/default_prefill_params.cuh>
-#include <flashinfer/attention/variants.cuh>
-#include <flashinfer/page.cuh>
-
-using namespace flashinfer;
-
-using DType  = __nv_bfloat16;
-using IdType = int32_t;
-using ParamsT = BatchDecodeParams<DType, DType, DType, IdType>;
-using Variant = DefaultAttention</*custom_mask=*/false,
-                                 /*sliding_window=*/false,
-                                 /*logits_soft_cap=*/false,
-                                 /*alibi=*/false>;
-
-using BatchPrefillParamsT = BatchPrefillPagedParams<DType, DType, DType, IdType>;
-using PrefillParamsT = SinglePrefillParams<DType, DType, DType>;
-
-// Helper: build paged_kv_t from our page-first layout.
-//
-// Our KvPool stores all layers interleaved in one buffer. For a given layer L:
-//   k_data = base + L * layer_stride
-//   v_data = base + L * layer_stride + kv_block_len
-//   stride_page = page_stride  (spans all layers — jumps to same layer in next page)
-//   NHD within-block: stride_n = num_kv_heads * head_dim, stride_h = head_dim
-static paged_kv_t<DType, IdType> make_paged_kv(
-    void*    kv_data,
-    int64_t  k_offset_elems,
-    int64_t  v_offset_elems,
-    int32_t* page_indices,
-    int32_t* page_indptr,
-    int32_t* last_page_len_d,
-    int32_t  num_kv_heads,
-    int32_t  head_dim,
-    int32_t  page_size,
-    int32_t  batch_size,
-    int64_t  stride_page)
-{
-    DType* k_data = reinterpret_cast<DType*>(kv_data) + k_offset_elems;
-    DType* v_data = reinterpret_cast<DType*>(kv_data) + v_offset_elems;
-
-    // kv_strides[0] = stride_page, [1] = stride for NHD-n, [2] = stride for NHD-h
-    int64_t kv_strides[3] = {
-        stride_page,
-        static_cast<int64_t>(num_kv_heads) * head_dim,
-        static_cast<int64_t>(head_dim),
-    };
-
-    return paged_kv_t<DType, IdType>(
-        num_kv_heads, page_size, head_dim, batch_size,
-        QKVLayout::kNHD,
-        k_data, v_data, kv_strides,
-        page_indices, page_indptr, last_page_len_d,
-        /*rope_pos_offset=*/nullptr);
-}
+#include "paged_launch.cuh"
 
 extern "C" {
 
@@ -81,49 +19,9 @@ int single_prefill_cuda_hd512(
     float    sm_scale,
     void*    stream)
 {
-  PEGAINFER_FFI_GUARD_BEGIN
-    uint32_t q_stride_n  = num_qo_heads * 512;
-    uint32_t q_stride_h  = 512;
-
-    uint32_t kv_stride_n = 512;
-    uint32_t kv_stride_h = static_cast<uint32_t>(max_seq_len) * 512;
-
-    PrefillParamsT params(
-        reinterpret_cast<DType*>(q),
-        reinterpret_cast<DType*>(k_cache),
-        reinterpret_cast<DType*>(v_cache),
-        /*maybe_custom_mask=*/nullptr,
-        reinterpret_cast<DType*>(output),
-        /*lse=*/nullptr,
-        /*maybe_alibi_slopes=*/nullptr,
-        num_qo_heads,
-        num_kv_heads,
-        static_cast<uint32_t>(seq_len),
-        static_cast<uint32_t>(kv_len),
-        q_stride_n,
-        q_stride_h,
-        kv_stride_n,
-        kv_stride_h,
-        /*head_dim=*/512U,
-        /*window_left=*/-1,
-        /*logits_soft_cap=*/0.0f,
-        sm_scale,
-        /*rope_scale=*/1.0f,
-        /*rope_theta=*/1e6f);
-
-    return static_cast<int>(
-        SinglePrefillWithKVCacheDispatched<
-            /*HEAD_DIM_QK=*/512,
-            /*HEAD_DIM_VO=*/512,
-            PosEncodingMode::kNone,
-            /*USE_FP16_QK_REDUCTION=*/false,
-            MaskMode::kCausal,
-            Variant,
-            PrefillParamsT>(
-            params,
-            /*tmp=*/nullptr,
-            reinterpret_cast<cudaStream_t>(stream)));
-  PEGAINFER_FFI_GUARD_END(-1)
+  return single_prefill_launch</*HEAD_DIM=*/512, Variant>(
+      q, output, k_cache, v_cache, num_qo_heads, num_kv_heads,
+      /*head_dim=*/512, seq_len, kv_len, max_seq_len, sm_scale, stream);
 }
 
 // Takes no cta_tile_q override parameter because hd512 only ever selects 16|32
@@ -154,71 +52,13 @@ int batch_prefill_paged_cuda_hd512(
     float    sm_scale,
     void*    stream)
 {
-  PEGAINFER_FFI_GUARD_BEGIN
-    auto paged_kv = make_paged_kv(
-        kv_data, k_offset_elems, v_offset_elems,
-        page_indices, page_indptr, last_page_len_d,
-        num_kv_heads, head_dim, page_size, batch_size, stride_page);
-
-    uint32_t q_stride_n = num_qo_heads * head_dim;
-    uint32_t q_stride_h = head_dim;
-
-    BatchPrefillParamsT params(
-        reinterpret_cast<DType*>(q),
-        paged_kv,
-        /*maybe_custom_mask=*/nullptr,
-        q_indptr,
-        /*maybe_mask_indptr=*/nullptr,
-        /*maybe_q_rope_offset=*/nullptr,
-        reinterpret_cast<DType*>(output),
-        /*lse=*/nullptr,
-        /*maybe_alibi_slopes=*/nullptr,
-        num_qo_heads,
-        q_stride_n,
-        q_stride_h,
-        /*window_left=*/-1,
-        /*logits_soft_cap=*/0.0f,
-        sm_scale,
-        /*rope_scale=*/1.0f,
-        /*rope_theta=*/1e6f);
-
-    params.request_indices   = request_indices;
-    params.qo_tile_indices   = qo_tile_indices;
-    params.kv_tile_indices   = kv_tile_indices;
-    params.merge_indptr      = nullptr;
-    params.o_indptr          = q_indptr;
-    params.block_valid_mask  = nullptr;
-    params.kv_chunk_size_ptr = kv_chunk_size_ptr;
-    params.max_total_num_rows = seq_len;
-    params.total_num_rows    = total_num_rows;
-    params.padded_batch_size = padded_batch_size;
-    params.partition_kv      = false;
-
-    uint32_t group_size = num_qo_heads / num_kv_heads;
-    int64_t packed_qo_len = static_cast<int64_t>(seq_len) * group_size;
-    uint32_t cta_tile_q = FA2DetermineCtaTileQ(packed_qo_len, head_dim);
-
-    cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);
-    int result = 0;
-    DISPATCH_CTA_TILE_Q(cta_tile_q, CTA_TILE_Q, {
-        result = static_cast<int>(
-            BatchPrefillWithPagedKVCacheDispatched<
-                CTA_TILE_Q,
-                /*HEAD_DIM_QK=*/512,
-                /*HEAD_DIM_VO=*/512,
-                PosEncodingMode::kNone,
-                /*USE_FP16_QK_REDUCTION=*/false,
-                MaskMode::kCausal,
-                Variant,
-                BatchPrefillParamsT>(
-                params,
-                /*tmp_v=*/nullptr,
-                /*tmp_s=*/nullptr,
-                /*enable_pdl=*/false,
-                s));
-    });
-    return result;
-  PEGAINFER_FFI_GUARD_END(-1)
+  return prefill_paged_launch</*HEAD_DIM=*/512, Variant>(
+      q, output, kv_data, k_offset_elems, v_offset_elems,
+      page_indices, page_indptr, last_page_len_d, q_indptr,
+      request_indices, qo_tile_indices, kv_tile_indices, kv_chunk_size_ptr,
+      total_num_rows, num_qo_heads, num_kv_heads, head_dim, page_size,
+      seq_len, batch_size, padded_batch_size, stride_page, sm_scale,
+      /*cta_tile_q_override=*/0, /*window_left=*/-1, stream);
 }
 
 } // extern "C"

--- a/pegainfer-kernels/csrc/shared/paged_launch.cuh
+++ b/pegainfer-kernels/csrc/shared/paged_launch.cuh
@@ -1,0 +1,403 @@
+#pragma once
+
+#include "ffi_guard.cuh"
+
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cstdint>
+
+#include <flashinfer/attention/decode.cuh>
+#include <flashinfer/attention/prefill.cuh>
+#include <flashinfer/attention/default_decode_params.cuh>
+#include <flashinfer/attention/default_prefill_params.cuh>
+#include <flashinfer/attention/variants.cuh>
+#include <flashinfer/page.cuh>
+
+using namespace flashinfer;
+
+using DType  = __nv_bfloat16;
+using IdType = int32_t;
+using ParamsT = BatchDecodeParams<DType, DType, DType, IdType>;
+using BatchPrefillParamsT = BatchPrefillPagedParams<DType, DType, DType, IdType>;
+using PrefillParamsT = SinglePrefillParams<DType, DType, DType>;
+using Variant = DefaultAttention</*custom_mask=*/false,
+                                 /*sliding_window=*/false,
+                                 /*logits_soft_cap=*/false,
+                                 /*alibi=*/false>;
+
+// `window_left` is an inclusive distance: an N-token window passes N - 1, and
+// -1 degrades to full attention.
+using WindowVariant = DefaultAttention</*custom_mask=*/false,
+                                       /*sliding_window=*/true,
+                                       /*logits_soft_cap=*/false,
+                                       /*alibi=*/false>;
+
+static paged_kv_t<DType, IdType> make_paged_kv(
+    void*    kv_data,
+    int64_t  k_offset_elems,
+    int64_t  v_offset_elems,
+    int32_t* page_indices,
+    int32_t* page_indptr,
+    int32_t* last_page_len_d,
+    int32_t  num_kv_heads,
+    int32_t  head_dim,
+    int32_t  page_size,
+    int32_t  batch_size,
+    int64_t  stride_page)
+{
+    DType* k_data = reinterpret_cast<DType*>(kv_data) + k_offset_elems;
+    DType* v_data = reinterpret_cast<DType*>(kv_data) + v_offset_elems;
+
+    // kv_strides[0] = stride_page, [1] = stride for NHD-n, [2] = stride for NHD-h
+    int64_t kv_strides[3] = {
+        stride_page,
+        static_cast<int64_t>(num_kv_heads) * head_dim,
+        static_cast<int64_t>(head_dim),
+    };
+
+    return paged_kv_t<DType, IdType>(
+        num_kv_heads, page_size, head_dim, batch_size,
+        QKVLayout::kNHD,
+        k_data, v_data, kv_strides,
+        page_indices, page_indptr, last_page_len_d,
+        /*rope_pos_offset=*/nullptr);
+}
+
+template <uint32_t HEAD_DIM, typename VariantT>
+static int decode_launch(
+    // Q and output
+    void*    q,                    // [num_qo_heads * head_dim] bf16, device
+    void*    output,               // [num_qo_heads * head_dim] bf16, device
+    // KV pool buffer (entire pool)
+    void*    kv_data,
+    int64_t  k_offset_elems,       // element offset: base → layer's K in page 0
+    int64_t  v_offset_elems,       // element offset: base → layer's V in page 0
+    // Paged KV metadata (GPU arrays)
+    int32_t* page_indices,         // [num_pages_this_request]
+    int32_t* page_indptr,          // [batch_size + 1]
+    int32_t* last_page_len_d,      // [batch_size]
+    // Plan metadata (GPU arrays — trivial for non-partition bs=1)
+    int32_t* request_indices,      // [padded_batch_size], e.g. [0]
+    int32_t* kv_tile_indices,      // [padded_batch_size], e.g. [0]
+    int32_t* kv_chunk_size_ptr,    // GPU ptr → 1 int32 (kv_len)
+    // Dimensions
+    int32_t  num_qo_heads,
+    int32_t  num_kv_heads,
+    int32_t  head_dim,
+    int32_t  page_size,
+    int32_t  batch_size,           // 1 for Phase 1
+    int64_t  stride_page,          // KvLayout.page_stride
+    float    sm_scale,             // typically 1/sqrt(head_dim)
+    int32_t  window_left,
+    // Stream
+    void*    stream)
+{
+  PEGAINFER_FFI_GUARD_BEGIN
+    auto paged_kv = make_paged_kv(
+        kv_data, k_offset_elems, v_offset_elems,
+        page_indices, page_indptr, last_page_len_d,
+        num_kv_heads, head_dim, page_size, batch_size, stride_page);
+
+    ParamsT params(
+        reinterpret_cast<DType*>(q),
+        /*q_rope_offset=*/nullptr,
+        paged_kv,
+        reinterpret_cast<DType*>(output),
+        /*lse=*/nullptr,
+        /*maybe_alibi_slopes=*/nullptr,
+        num_qo_heads,
+        /*q_stride_n=*/num_qo_heads * head_dim,
+        /*q_stride_h=*/head_dim,
+        window_left,
+        /*logits_soft_cap=*/0.0f,
+        sm_scale,
+        /*rope_scale=*/1.0f,
+        /*rope_theta=*/1e6f);
+
+    params.padded_batch_size = batch_size;
+    params.request_indices   = request_indices;
+    params.kv_tile_indices   = kv_tile_indices;
+    params.o_indptr          = nullptr;
+    params.kv_chunk_size_ptr = kv_chunk_size_ptr;
+    params.block_valid_mask  = nullptr;
+    params.partition_kv      = false;
+
+    // tmp_v = nullptr → non-partition path (no merge step)
+    return static_cast<int>(
+        BatchDecodeWithPagedKVCacheDispatched<
+            HEAD_DIM,
+            PosEncodingMode::kNone,
+            VariantT,
+            ParamsT>(
+            params,
+            /*tmp_v=*/nullptr,
+            /*tmp_s=*/nullptr,
+            /*enable_pdl=*/false,
+            reinterpret_cast<cudaStream_t>(stream)));
+  PEGAINFER_FFI_GUARD_END(-1)
+}
+
+// ---------------------------------------------------------------------------
+// Paged attention decode with partition-KV / split-K.
+//
+// The caller supplies a split-K plan:
+//   request_indices[slot]  -> original batch slot
+//   kv_tile_indices[slot]  -> KV chunk id for that request
+//   o_indptr[request]      -> active split-slot range for merge
+//   block_valid_mask[slot] -> false for graph-stability padding slots
+//
+// tmp_v/tmp_s hold per-chunk partial states and are merged by FlashInfer.
+// ---------------------------------------------------------------------------
+template <uint32_t HEAD_DIM, typename VariantT>
+static int decode_split_kv_launch(
+    void*    q,                    // [batch_size * num_qo_heads * head_dim] bf16, device
+    void*    output,               // [batch_size * num_qo_heads * head_dim] bf16, device
+    void*    kv_data,
+    int64_t  k_offset_elems,
+    int64_t  v_offset_elems,
+    int32_t* page_indices,
+    int32_t* page_indptr,
+    int32_t* last_page_len_d,
+    int32_t* request_indices,
+    int32_t* kv_tile_indices,
+    int32_t* kv_chunk_size_ptr,    // GPU ptr -> 1 int32 chunk size
+    int32_t* o_indptr,             // [batch_size + 1]
+    uint8_t* block_valid_mask,     // [padded_batch_size], 0/1
+    void*    tmp_v,                // [padded_batch_size * num_qo_heads * head_dim] bf16
+    float*   tmp_s,                // [padded_batch_size * num_qo_heads]
+    int32_t  num_qo_heads,
+    int32_t  num_kv_heads,
+    int32_t  head_dim,
+    int32_t  page_size,
+    int32_t  batch_size,
+    int32_t  padded_batch_size,    // split slots, including masked padding slots
+    int64_t  stride_page,
+    float    sm_scale,
+    int32_t  window_left,
+    void*    stream)
+{
+  PEGAINFER_FFI_GUARD_BEGIN
+    auto paged_kv = make_paged_kv(
+        kv_data, k_offset_elems, v_offset_elems,
+        page_indices, page_indptr, last_page_len_d,
+        num_kv_heads, head_dim, page_size, batch_size, stride_page);
+
+    ParamsT params(
+        reinterpret_cast<DType*>(q),
+        /*q_rope_offset=*/nullptr,
+        paged_kv,
+        reinterpret_cast<DType*>(output),
+        /*lse=*/nullptr,
+        /*maybe_alibi_slopes=*/nullptr,
+        num_qo_heads,
+        /*q_stride_n=*/num_qo_heads * head_dim,
+        /*q_stride_h=*/head_dim,
+        window_left,
+        /*logits_soft_cap=*/0.0f,
+        sm_scale,
+        /*rope_scale=*/1.0f,
+        /*rope_theta=*/1e6f);
+
+    params.padded_batch_size = padded_batch_size;
+    params.request_indices   = request_indices;
+    params.kv_tile_indices   = kv_tile_indices;
+    params.o_indptr          = o_indptr;
+    params.kv_chunk_size_ptr = kv_chunk_size_ptr;
+    params.block_valid_mask  = reinterpret_cast<bool*>(block_valid_mask);
+
+    return static_cast<int>(
+        BatchDecodeWithPagedKVCacheDispatched<
+            HEAD_DIM,
+            PosEncodingMode::kNone,
+            VariantT,
+            ParamsT>(
+            params,
+            reinterpret_cast<DType*>(tmp_v),
+            tmp_s,
+            /*enable_pdl=*/false,
+            reinterpret_cast<cudaStream_t>(stream)));
+  PEGAINFER_FFI_GUARD_END(-1)
+}
+
+static uint32_t resolve_prefill_cta_tile_q(
+    int64_t packed_qo_len,
+    int32_t head_dim,
+    int32_t cta_tile_q_override)
+{
+    if (cta_tile_q_override == 0) {
+        return FA2DetermineCtaTileQ(packed_qo_len, head_dim);
+    }
+    if (cta_tile_q_override == 16 ||
+        cta_tile_q_override == 64 ||
+        cta_tile_q_override == 128) {
+        return static_cast<uint32_t>(cta_tile_q_override);
+    }
+    return 0;
+}
+
+template <uint32_t HEAD_DIM, typename VariantT>
+static int prefill_paged_launch(
+    // Q and output (HiddenStates col-major: [q_dim, total_seq_len])
+    void*    q,
+    void*    output,
+    // KV pool buffer (entire pool)
+    void*    kv_data,
+    int64_t  k_offset_elems,
+    int64_t  v_offset_elems,
+    // Paged KV metadata (GPU arrays, concatenated across requests)
+    int32_t* page_indices,
+    int32_t* page_indptr,
+    int32_t* last_page_len_d,
+    // Batch prefill plan metadata (GPU arrays, pre-allocated by Rust)
+    int32_t* q_indptr,             // [batch_size+1]: CSR token boundaries
+    int32_t* request_indices,      // [num_tiles]: tile → request mapping
+    int32_t* qo_tile_indices,      // [num_tiles]: tile → local Q offset
+    int32_t* kv_tile_indices,      // [num_tiles]: all zeros (no KV partition)
+    int32_t* kv_chunk_size_ptr,    // [batch_size]: per-request kv_len
+    uint32_t* total_num_rows,      // [1]: total Q tokens
+    // Dimensions
+    int32_t  num_qo_heads,
+    int32_t  num_kv_heads,
+    int32_t  head_dim,
+    int32_t  page_size,
+    int32_t  seq_len,              // total Q tokens across all requests
+    int32_t  batch_size,           // number of requests
+    int32_t  padded_batch_size,    // = total num_tiles
+    int64_t  stride_page,
+    float    sm_scale,
+    int32_t  cta_tile_q_override,
+    int32_t  window_left,
+    // Stream
+    void*    stream)
+{
+  PEGAINFER_FFI_GUARD_BEGIN
+    auto paged_kv = make_paged_kv(
+        kv_data, k_offset_elems, v_offset_elems,
+        page_indices, page_indptr, last_page_len_d,
+        num_kv_heads, head_dim, page_size, batch_size, stride_page);
+
+    uint32_t q_stride_n = num_qo_heads * head_dim;
+    uint32_t q_stride_h = head_dim;
+
+    BatchPrefillParamsT params(
+        reinterpret_cast<DType*>(q),
+        paged_kv,
+        /*maybe_custom_mask=*/nullptr,
+        q_indptr,
+        /*maybe_mask_indptr=*/nullptr,
+        /*maybe_q_rope_offset=*/nullptr,
+        reinterpret_cast<DType*>(output),
+        /*lse=*/nullptr,
+        /*maybe_alibi_slopes=*/nullptr,
+        num_qo_heads,
+        q_stride_n,
+        q_stride_h,
+        window_left,
+        /*logits_soft_cap=*/0.0f,
+        sm_scale,
+        /*rope_scale=*/1.0f,
+        /*rope_theta=*/1e6f);
+
+    params.request_indices   = request_indices;
+    params.qo_tile_indices   = qo_tile_indices;
+    params.kv_tile_indices   = kv_tile_indices;
+    params.merge_indptr      = nullptr;
+    params.o_indptr          = q_indptr;  // same as q_indptr for non-partition: [0, seq_len]
+    params.block_valid_mask  = nullptr;
+    params.kv_chunk_size_ptr = kv_chunk_size_ptr;
+    params.max_total_num_rows = seq_len;
+    params.total_num_rows    = total_num_rows;
+    params.padded_batch_size = padded_batch_size;
+    params.partition_kv      = false;
+
+    // Determine CTA tile size and dispatch
+    uint32_t group_size = num_qo_heads / num_kv_heads;
+    int64_t packed_qo_len = static_cast<int64_t>(seq_len) * group_size;
+    uint32_t cta_tile_q = resolve_prefill_cta_tile_q(
+        packed_qo_len, head_dim, cta_tile_q_override);
+    if (cta_tile_q == 0) {
+        pegainfer_ffi_set_last_error("invalid cta_tile_q override");
+        return -1;
+    }
+
+    cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);
+    int result = 0;
+    DISPATCH_CTA_TILE_Q(cta_tile_q, CTA_TILE_Q, {
+        result = static_cast<int>(
+            BatchPrefillWithPagedKVCacheDispatched<
+                CTA_TILE_Q,
+                /*HEAD_DIM_QK=*/HEAD_DIM,
+                /*HEAD_DIM_VO=*/HEAD_DIM,
+                PosEncodingMode::kNone,
+                /*USE_FP16_QK_REDUCTION=*/false,
+                MaskMode::kCausal,
+                VariantT,
+                BatchPrefillParamsT>(
+                params,
+                /*tmp_v=*/nullptr,
+                /*tmp_s=*/nullptr,
+                /*enable_pdl=*/false,
+                s));
+    });
+    return result;
+  PEGAINFER_FFI_GUARD_END(-1)
+}
+
+template <uint32_t HEAD_DIM, typename VariantT>
+static int single_prefill_launch(
+    void* q,
+    void* output,
+    void* k_cache,
+    void* v_cache,
+    int32_t num_qo_heads,
+    int32_t num_kv_heads,
+    int32_t head_dim,
+    int32_t seq_len,
+    int32_t kv_len,
+    int32_t max_seq_len,
+    float sm_scale,
+    void* stream)
+{
+  PEGAINFER_FFI_GUARD_BEGIN
+    uint32_t q_stride_n = num_qo_heads * head_dim;
+    uint32_t q_stride_h = head_dim;
+    uint32_t kv_stride_n = head_dim;
+    uint32_t kv_stride_h = static_cast<uint32_t>(max_seq_len) * static_cast<uint32_t>(head_dim);
+
+    PrefillParamsT params(
+        reinterpret_cast<DType*>(q),
+        reinterpret_cast<DType*>(k_cache),
+        reinterpret_cast<DType*>(v_cache),
+        /*maybe_custom_mask=*/nullptr,
+        reinterpret_cast<DType*>(output),
+        /*lse=*/nullptr,
+        /*maybe_alibi_slopes=*/nullptr,
+        num_qo_heads,
+        num_kv_heads,
+        static_cast<uint32_t>(seq_len),
+        static_cast<uint32_t>(kv_len),
+        q_stride_n,
+        q_stride_h,
+        kv_stride_n,
+        kv_stride_h,
+        static_cast<uint32_t>(head_dim),
+        /*window_left=*/-1,
+        /*logits_soft_cap=*/0.0f,
+        sm_scale,
+        /*rope_scale=*/1.0f,
+        /*rope_theta=*/1e6f);
+
+    return static_cast<int>(
+        SinglePrefillWithKVCacheDispatched<
+            HEAD_DIM,
+            HEAD_DIM,
+            PosEncodingMode::kNone,
+            /*USE_FP16_QK_REDUCTION=*/false,
+            MaskMode::kCausal,
+            VariantT,
+            PrefillParamsT>(
+            params,
+            /*tmp=*/nullptr,
+            reinterpret_cast<cudaStream_t>(stream)));
+  PEGAINFER_FFI_GUARD_END(-1)
+}

--- a/pegainfer-kernels/csrc/shared/paged_launch.cuh
+++ b/pegainfer-kernels/csrc/shared/paged_launch.cuh
@@ -76,16 +76,16 @@ static int decode_launch(
     int32_t* page_indices,         // [num_pages_this_request]
     int32_t* page_indptr,          // [batch_size + 1]
     int32_t* last_page_len_d,      // [batch_size]
-    // Plan metadata (GPU arrays — trivial for non-partition bs=1)
-    int32_t* request_indices,      // [padded_batch_size], e.g. [0]
-    int32_t* kv_tile_indices,      // [padded_batch_size], e.g. [0]
-    int32_t* kv_chunk_size_ptr,    // GPU ptr → 1 int32 (kv_len)
+    // Plan metadata (GPU arrays, one slot per padded request)
+    int32_t* request_indices,      // [padded_batch_size]
+    int32_t* kv_tile_indices,      // [padded_batch_size]
+    int32_t* kv_chunk_size_ptr,    // GPU ptr → per-request kv lengths
     // Dimensions
     int32_t  num_qo_heads,
     int32_t  num_kv_heads,
     int32_t  head_dim,
     int32_t  page_size,
-    int32_t  batch_size,           // 1 for Phase 1
+    int32_t  batch_size,
     int64_t  stride_page,          // KvLayout.page_stride
     float    sm_scale,             // typically 1/sqrt(head_dim)
     int32_t  window_left,
@@ -302,7 +302,7 @@ static int prefill_paged_launch(
     params.qo_tile_indices   = qo_tile_indices;
     params.kv_tile_indices   = kv_tile_indices;
     params.merge_indptr      = nullptr;
-    params.o_indptr          = q_indptr;  // same as q_indptr for non-partition: [0, seq_len]
+    params.o_indptr          = q_indptr;  // non-partition: rows land at their request boundaries
     params.block_valid_mask  = nullptr;
     params.kv_chunk_size_ptr = kv_chunk_size_ptr;
     params.max_total_num_rows = seq_len;

--- a/pegainfer-kernels/csrc/shared/prefill_attention_hd256_plain.cu
+++ b/pegainfer-kernels/csrc/shared/prefill_attention_hd256_plain.cu
@@ -19,6 +19,7 @@
 
 #include "common.cuh"
 #include "ffi_guard.cuh"
+#include "qk_prep.cuh"
 
 #define HD256_PLAIN 256
 #define THREADS_HD256_PLAIN 256
@@ -28,17 +29,6 @@ __device__ __forceinline__ __nv_bfloat16 rms_norm_elem_hd256_plain(
     __nv_bfloat16 x, float rms_inv, __nv_bfloat16 weight) {
     float w = __bfloat162float(weight);
     return __float2bfloat16(__bfloat162float(x) * rms_inv * w);
-}
-
-__device__ __forceinline__ void apply_rope_pair_hd256_plain(
-    __nv_bfloat16& x0, __nv_bfloat16& x1,
-    __nv_bfloat16 cos_val, __nv_bfloat16 sin_val) {
-    float fx0 = __bfloat162float(x0);
-    float fx1 = __bfloat162float(x1);
-    float fc = __bfloat162float(cos_val);
-    float fs = __bfloat162float(sin_val);
-    x0 = __float2bfloat16(fx0 * fc - fx1 * fs);
-    x1 = __float2bfloat16(fx0 * fs + fx1 * fc);
 }
 
 __global__ void qk_norm_rope_prefill_hd256_plain_kernel(
@@ -105,7 +95,7 @@ __global__ void qk_norm_rope_prefill_hd256_plain_kernel(
     if (d < half_rotary) {
         __nv_bfloat16 lo = smem[d];
         __nv_bfloat16 hi = smem[d + half_rotary];
-        apply_rope_pair_hd256_plain(
+        apply_rope_pair(
             lo,
             hi,
             cos_cache[pos * rotary_dim + d],
@@ -132,23 +122,6 @@ __global__ void qk_norm_rope_prefill_hd256_plain_kernel(
             k_batch_out[dst + d] = smem[d];
         }
     }
-}
-
-__device__ __forceinline__ int64_t paged_kv_offset_hd256_plain(
-    int page_id,
-    int64_t block_offset_elems,
-    int64_t stride_page,
-    int page_size,
-    int num_kv_heads,
-    int pos,
-    int kv_head,
-    int d) {
-    int offset_in_page = pos % page_size;
-    return static_cast<int64_t>(page_id) * stride_page
-        + block_offset_elems
-        + static_cast<int64_t>(offset_in_page) * num_kv_heads * HD256_PLAIN
-        + static_cast<int64_t>(kv_head) * HD256_PLAIN
-        + d;
 }
 
 // Paged serving prep. grid.y carries three bands: [0, num_q_heads) Q,
@@ -252,7 +225,7 @@ __global__ void qkv_norm_rope_paged_prefill_hd256_plain_kernel(
 
     if (!is_q && !is_k) {
         // V band: weightless norm, no RoPE — the whole block exits here.
-        int64_t dst = paged_kv_offset_hd256_plain(
+        int64_t dst = paged_kv_offset<HD256_PLAIN>(
             page_id, v_offset_elems, stride_page, page_size,
             num_kv_heads, pos, head_local, d);
         kv_data[dst] = __float2bfloat16(__bfloat162float(x) * inv_rms);
@@ -268,7 +241,7 @@ __global__ void qkv_norm_rope_paged_prefill_hd256_plain_kernel(
     if (d < half_rotary) {
         __nv_bfloat16 lo = smem[d];
         __nv_bfloat16 hi = smem[d + half_rotary];
-        apply_rope_pair_hd256_plain(
+        apply_rope_pair(
             lo,
             hi,
             cos_cache[pos * rotary_dim + d],
@@ -280,7 +253,7 @@ __global__ void qkv_norm_rope_paged_prefill_hd256_plain_kernel(
             q_batch_out[dst + d] = lo;
             q_batch_out[dst + d + half_rotary] = hi;
         } else {
-            int64_t dst = paged_kv_offset_hd256_plain(
+            int64_t dst = paged_kv_offset<HD256_PLAIN>(
                 page_id, k_offset_elems, stride_page, page_size,
                 num_kv_heads, pos, head_local, d);
             kv_data[dst] = lo;
@@ -293,7 +266,7 @@ __global__ void qkv_norm_rope_paged_prefill_hd256_plain_kernel(
             int dst = token * q_dim + head_local * HD256_PLAIN;
             q_batch_out[dst + d] = smem[d];
         } else {
-            int64_t dst = paged_kv_offset_hd256_plain(
+            int64_t dst = paged_kv_offset<HD256_PLAIN>(
                 page_id, k_offset_elems, stride_page, page_size,
                 num_kv_heads, pos, head_local, d);
             kv_data[dst] = smem[d];

--- a/pegainfer-kernels/csrc/shared/prefill_attention_hd512.cu
+++ b/pegainfer-kernels/csrc/shared/prefill_attention_hd512.cu
@@ -15,6 +15,7 @@
 
 #include "common.cuh"
 #include "ffi_guard.cuh"
+#include "qk_prep.cuh"
 
 #define HD512 512
 #define THREADS_HD512 512
@@ -24,34 +25,6 @@ __device__ __forceinline__ __nv_bfloat16 rms_norm_elem_hd512(
     __nv_bfloat16 x, float rms_inv, __nv_bfloat16 weight) {
     float w = __bfloat162float(weight);
     return __float2bfloat16(__bfloat162float(x) * rms_inv * w);
-}
-
-__device__ __forceinline__ void apply_rope_pair_hd512(
-    __nv_bfloat16& x0, __nv_bfloat16& x1,
-    __nv_bfloat16 cos_val, __nv_bfloat16 sin_val) {
-    float fx0 = __bfloat162float(x0);
-    float fx1 = __bfloat162float(x1);
-    float fc = __bfloat162float(cos_val);
-    float fs = __bfloat162float(sin_val);
-    x0 = __float2bfloat16(fx0 * fc - fx1 * fs);
-    x1 = __float2bfloat16(fx0 * fs + fx1 * fc);
-}
-
-__device__ __forceinline__ int64_t paged_kv_offset_hd512(
-    int page_id,
-    int64_t layer_offset_elems,
-    int64_t stride_page,
-    int page_size,
-    int num_kv_heads,
-    int pos,
-    int kv_head,
-    int d) {
-    int offset_in_page = pos % page_size;
-    return static_cast<int64_t>(page_id) * stride_page
-        + layer_offset_elems
-        + static_cast<int64_t>(offset_in_page) * num_kv_heads * HD512
-        + static_cast<int64_t>(kv_head) * HD512
-        + d;
 }
 
 // PER_TOKEN_META = true is the batched-decode form: token t is its own
@@ -150,7 +123,7 @@ __global__ void qk_norm_partial_rope_paged_prefill_hd512_kernel(
         if (page_id < 0 || page_id >= num_pages) __trap();
         // V is the K=V fork: the weightless norm of the same raw vector,
         // sharing inv_rms. No RoPE, no weight.
-        int64_t v_dst = paged_kv_offset_hd512(
+        int64_t v_dst = paged_kv_offset<HD512>(
             page_id, v_offset_elems, stride_page, page_size,
             num_kv_heads, pos, head_local, d);
         kv_data[v_dst] = __float2bfloat16(__bfloat162float(x) * inv_rms);
@@ -160,7 +133,7 @@ __global__ void qk_norm_partial_rope_paged_prefill_hd512_kernel(
     if (d < half_rotary) {
         __nv_bfloat16 lo = smem[d];
         __nv_bfloat16 hi = smem[d + half_rotary];
-        apply_rope_pair_hd512(
+        apply_rope_pair(
             lo,
             hi,
             cos_cache[pos * rotary_dim + d],
@@ -172,7 +145,7 @@ __global__ void qk_norm_partial_rope_paged_prefill_hd512_kernel(
             q_batch_out[dst + d] = lo;
             q_batch_out[dst + d + half_rotary] = hi;
         } else {
-            int64_t dst = paged_kv_offset_hd512(
+            int64_t dst = paged_kv_offset<HD512>(
                 page_id, k_offset_elems, stride_page, page_size,
                 num_kv_heads, pos, head_local, d);
             kv_data[dst] = lo;
@@ -185,7 +158,7 @@ __global__ void qk_norm_partial_rope_paged_prefill_hd512_kernel(
             int dst = token * q_dim + head_local * HD512;
             q_batch_out[dst + d] = smem[d];
         } else {
-            int64_t dst = paged_kv_offset_hd512(
+            int64_t dst = paged_kv_offset<HD512>(
                 page_id, k_offset_elems, stride_page, page_size,
                 num_kv_heads, pos, head_local, d);
             kv_data[dst] = smem[d];
@@ -258,7 +231,7 @@ __global__ void qk_norm_partial_rope_batched_decode_hd512_kernel(
     if (d < half_rotary) {
         __nv_bfloat16 lo = smem[d];
         __nv_bfloat16 hi = smem[d + half_rotary];
-        apply_rope_pair_hd512(
+        apply_rope_pair(
             lo,
             hi,
             cos_cache[pos * rotary_dim + d],

--- a/pegainfer-kernels/csrc/shared/qk_prep.cuh
+++ b/pegainfer-kernels/csrc/shared/qk_prep.cuh
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "common.cuh"
+
+__device__ __forceinline__ void apply_rope_pair(
+    __nv_bfloat16& x0,
+    __nv_bfloat16& x1,
+    __nv_bfloat16 cos_val,
+    __nv_bfloat16 sin_val) {
+    float fx0 = __bfloat162float(x0);
+    float fx1 = __bfloat162float(x1);
+    float fc = __bfloat162float(cos_val);
+    float fs = __bfloat162float(sin_val);
+    x0 = __float2bfloat16(fx0 * fc - fx1 * fs);
+    x1 = __float2bfloat16(fx0 * fs + fx1 * fc);
+}
+
+template <int HEAD_DIM>
+__device__ __forceinline__ int64_t paged_kv_offset(
+    int page_id,
+    int64_t block_offset_elems,
+    int64_t stride_page,
+    int page_size,
+    int num_kv_heads,
+    int pos,
+    int kv_head,
+    int d) {
+    int offset_in_page = pos % page_size;
+    return static_cast<int64_t>(page_id) * stride_page
+        + block_offset_elems
+        + static_cast<int64_t>(offset_in_page) * num_kv_heads * HEAD_DIM
+        + static_cast<int64_t>(kv_head) * HEAD_DIM
+        + d;
+}


### PR DESCRIPTION

## Description

Closes #1008

`paged_attention_hd512.cu` carried its own copies of `paged_attention.cu`'s prelude, paged-KV builder and prefill launch bodies because those were file-local; the two QK-norm/RoPE prep units carried copies of each other's rotation, offset and wrapper code. Two headers now own the shared bodies as `HEAD_DIM` templates and the four translation units only instantiate them. Every exported entry point keeps its name, signature and launch geometry, the hd512 unit stays its own translation unit, and the Rust side is untouched.

## Test Env

Single GPU (`sm_89`, 48 GiB, x86_64)

## Verification

- `cargo fmt --all -- --check` and `git diff --check` against `main` pass; the Gemma 4 release server builds; all-target kernels/Gemma Clippy passes with `-D warnings`; release lib tests pass: core 33, Gemma 42 with 20 ignored, kernels 16 with 1 ignored.
- Exported symbol sets (`nm -g --defined-only`, sorted) of the five affected objects and of the kernels archive are identical between `main`'s build and this head's: `paged_attention` 207 symbols, `paged_attention_hd512` 70, `prefill_attention` 9, `prefill_attention_hd512` 9, `prefill_attention_hd256_plain` 9, archive 865 — diff empty for each, read from the objects and archive each build had just written.
- The kernels crate's GPU integration suites — hd256 and hd512 QK-norm/RoPE prep smoke and traps, the hd256 decode CSR trap, the hd256 window-prefill refusal, softcap and GELU-scale — pass with a device required: 21 tests, 0 failed.
- The 12B HF fixture gates that drive both attention families pass 1/1 each in their own process: context waypoints against HF, greedy generation against HF.
- The 26B checkpoint answers four greedy public `/v1/completions` requests (31-, 35-, 33- and 1421-token prompts, 64 forced tokens) with bytes identical to `main`'s binary: md5 `219de1e3c09c` on both.
