### PR TITLE
chore(ci): every toolchain step installs the components the toolchain file demands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly-2026-07-10
-          components: rustfmt
+          components: rustfmt, clippy
 
       - name: Check formatting
         run: cargo fmt --all --check
@@ -103,6 +103,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly-2026-07-10
+          components: rustfmt, clippy
 
       - name: Check locked Cargo metadata
         run: cargo metadata --locked --no-deps --format-version 1
@@ -137,6 +138,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly-2026-07-10
+          components: rustfmt, clippy
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -168,7 +170,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly-2026-07-10
-          components: clippy
+          components: rustfmt, clippy
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -205,6 +207,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly-2026-07-10
+          components: rustfmt, clippy
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -237,6 +240,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly-2026-07-10
+          components: rustfmt, clippy
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -282,7 +286,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly-2026-07-10
-          components: clippy
+          components: rustfmt, clippy
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -369,7 +373,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly-2026-07-10
-          components: clippy
+          components: rustfmt, clippy
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10


### PR DESCRIPTION

## Description

`rust-toolchain.toml` pins `nightly-2026-07-10` with `components = ["rustfmt", "clippy"]`, but most CI jobs install the toolchain with only `clippy`, or with no components at all. The first `cargo` invocation then makes the rustup shim sync the toolchain file and add rustfmt incrementally, and on this nightly that add fails deterministically:

```
error: failed to install component: 'rustfmt-preview-x86_64-unknown-linux-gnu', detected conflict: 'bin/cargo-fmt'
```

The cargo component of this nightly already ships `bin/cargo-fmt`, so a single-transaction toolchain install tolerates the overlap while an incremental `component add` refuses it. That is why the fmt job, which installs rustfmt at setup, passes, while the Qwen3.5 CUDA clippy job and every other clippy-only or component-less job dies at its first cargo command.

Every `dtolnay/rust-toolchain` step now installs `rustfmt, clippy` up front, so the shim never has to add a component after the fact.

## Test Env

GitHub-hosted `ubuntu-latest`; the failure happens in rustup before any build, so no GPU is involved.

## Verification

- The mechanism matches the observed split: jobs whose toolchain step omits rustfmt fail at their first cargo command with the conflict above, and the fmt job with rustfmt installed at setup does not.
- The diff is confined to the eight toolchain steps' `components:` lines in `.github/workflows/ci.yml` (8 insertions, 4 deletions); no job commands change.
- The deciding evidence is this PR's own checks: every matrix job must now get past toolchain setup to its cargo command.
