### PR TITLE
chore(kernels): kimi test debt and the escaped constness lint

### DIFF
--- a/pegainfer-kernels/src/ops/kimi_k2/experts.rs
+++ b/pegainfer-kernels/src/ops/kimi_k2/experts.rs
@@ -1399,7 +1399,7 @@ fn launch_marlin_wna16_gemm(
                 ptrs.output,
                 ptrs.c_tmp,
                 ptrs.qweight,
-                ptrs.scales as *const ffi::Half,
+                ptrs.scales.cast::<ffi::Half>(),
                 ptrs.workspace,
                 ptrs.sorted_token_ids,
                 ptrs.expert_ids,

--- a/pegainfer-kernels/src/ops/kimi_k2/experts.rs
+++ b/pegainfer-kernels/src/ops/kimi_k2/experts.rs
@@ -1556,30 +1556,6 @@ mod tests {
     }
 
     #[test]
-    fn int4_offset_binary_nibbles_decode_to_signed_by_subtracting_eight() {
-        let decode = |byte: u8, col: usize| -> i8 {
-            let unsigned = if col.is_multiple_of(2) {
-                byte & 0x0f
-            } else {
-                (byte >> 4) & 0x0f
-            };
-            i8::try_from(unsigned).expect("nibble") - 8
-        };
-
-        for signed_even in -8i8..=7 {
-            for signed_odd in -8i8..=7 {
-                let even = u8::try_from(signed_even + 8).expect("even nibble");
-                let odd = u8::try_from(signed_odd + 8).expect("odd nibble");
-                let byte = even | (odd << 4);
-                assert_eq!(decode(byte, 0), signed_even);
-                assert_eq!(decode(byte, 1), signed_odd);
-                assert_eq!(i16::from(even) - i16::from(signed_even), 8);
-                assert_eq!(i16::from(odd) - i16::from(signed_odd), 8);
-            }
-        }
-    }
-
-    #[test]
     fn marlin_route_capacity_matches_vllm_ignore_invalid_bound() {
         let active_tokens = 7;
         let block_size = 8;


### PR DESCRIPTION

## Description

Two small debts. The int4 nibble test defined its own decode closure and asserted that closure's bit arithmetic — it called no production function, kernel, wrapper or fixture, so it could not catch a regression; it is deleted, with the int4 decode and repack production paths still covered by the Kimi functional oracles. And the marlin-face extraction left one `as`-cast on the Kimi scales pointer that clippy at deny-warnings refuses under the kimi-k2 feature — a leg public CI never lints and the extraction round only type-checked; `pointer::cast` keeps the constness explicit with no behavior change.

## Test Env

Single GPU (`sm_89`, 48 GiB, x86_64), the kimi-k2 leg compiles with the `sm_90` target the moe chain requires.

## Verification

- `PEGAINFER_CUDA_SM=90 cargo clippy --release --features kimi-k2 -p pegainfer-kernels --all-targets -- -D warnings` and the gemma4 twin both pass at the exact head, 0 errors each; the test deletion is `#[cfg(test)]`-only and the cast is lint-only, so the release binary is untouched.