### PR TITLE
fix(gemma4): the serving streams wait for what setup enqueued

### DIFF
--- a/pegainfer-gemma4/src/engine.rs
+++ b/pegainfer-gemma4/src/engine.rs
@@ -1176,8 +1176,10 @@ impl EngineState {
                 sampler_graphs.push(graph);
                 bucket *= 2;
             }
-            ctx.sync()?;
         }
+        // The KV pools, arena and warm passes were enqueued on this stream. The lane
+        // stream and everything after it must see them complete, graphs or not.
+        ctx.sync()?;
         let lane = lane_mode
             .map(|mode| AsyncPrefillLane::new(&ctx, mode))
             .transpose()?;

--- a/pegainfer-gemma4/src/weights/load.rs
+++ b/pegainfer-gemma4/src/weights/load.rs
@@ -35,8 +35,8 @@ use crate::nvfp4::QuantSource;
 /// redemption, prefetch join and unmap fall between them, and the allocations
 /// submitted under `record_api_wall_ms` execute under
 /// `execute_and_drain_wall_ms`. `elapsed_ms` is the submission total: it
-/// samples when the call returns, after the A4B expert kernels are enqueued
-/// but without draining them.
+/// samples when the call returns, after the A4B expert kernels have drained
+/// on the loader stream; the unmap's host cost overlaps that drain.
 struct LoadStats {
     /// Every required tensor at its dtype.
     manifest_bytes: usize,
@@ -519,6 +519,11 @@ impl Gemma4Weights {
         // once an executor wants it too.
         drop(mmaps);
 
+        // The expert kernels ran on this stream while the unmap paid its host cost.
+        // Every later weight consumer uses another stream, so this drain is the handoff.
+        ctx.sync()
+            .map_err(|e| anyhow::anyhow!("Gemma 4: cannot drain the expert kernels: {e}"))?;
+
         let stats = LoadStats {
             manifest_bytes,
             device_bytes: free_before as i64 - device_free_bytes as i64,
@@ -533,7 +538,7 @@ impl Gemma4Weights {
             "Gemma 4 weights resident: {:.2} GiB manifest, {:.2} GiB device, {:.2} GiB free, \
              {} modality tensors skipped; \
              {:.0} ms submission total, of which {:.0} validate, {:.0} record-api, \
-             {:.0} execute-and-drain (expert kernels enqueued, not drained)",
+             {:.0} execute-and-drain (expert kernels drained)",
             gib(stats.manifest_bytes as i64),
             gib(stats.device_bytes),
             gib(stats.device_free_bytes as i64),


### PR DESCRIPTION
## Description

Fixes #1029

**Both handoffs relied on time.** The loader's and the engine's `DeviceContext`s each own a non-blocking stream with cudarc's event tracking disabled, so nothing orders work across them unless the code does. The loader returned with the expert repack and scale kernels still enqueued on its stream, and the engine created the async prefill lane's stream without synchronizing its own unless CUDA graphs were on. The shard unmap's host cost and the startup work before the first request were what kept the readers behind the writers.

**The loader drains before handing over.** `from_safetensors` synchronizes its stream after the unmap, so the host cost still overlaps the kernels and only the residual is paid; the log line and the `LoadStats` doc now say the expert kernels are drained, and `elapsed_ms` includes that residual.

**The engine synchronizes before the lane exists.** The `ctx.sync()` that sat inside the graph branch runs unconditionally before `AsyncPrefillLane::new`, so the KV pools, the arena and the warm passes are complete for every stream that follows, graphs or not.

### Test Env

- Single GPU (sm_89, x86_64), `--release --features gemma4`, the pinned Gemma 4 12B checkpoint and the 26B-A4B NVFP4 checkpoint.

### Verification

- `cargo fmt --check` clean; `clippy --all-targets -D warnings` clean for `pegainfer-gemma4`; lib tests 49 passed / 23 ignored, unchanged from main.
- Lifecycle gates through the maintainer runner: 5 of 5 (the shared, green and gathered lane lifecycles on the dense profile, the shared and green ones again on the routed profile, which is the checkpoint with experts).
- Same-config serving A/B on the 26B-A4B checkpoint, main vs this branch alternated twice each: four greedy prompts byte-identical across all eight runs (one md5 over text, finish reason and usage), with the default CUDA graphs and with `--cuda-graph=false` plus `PEGAINFER_ASYNC_PREFILL=shared`, the latter being the combination that had no ordering before.
- Load time on the routed checkpoint (submission total from the loader's log line, two runs each, warm page cache): graphs on, main 10594 ms [10579, 10609] vs branch 10702 ms [10602, 10801]; graphs off with the lane, main 10645 ms [10641, 10648] vs branch 10701 ms [10695, 10706]. The difference is the residual expert-kernel drain and sits inside the run-to-run spread; the unmap's host cost still covers most of the kernels.