### PR TITLE
feat(qwen35): allow the auto scheduler policy with stream decode-overlap

### DIFF
--- a/docs/models/qwen35/unified-prefill-overlap.md
+++ b/docs/models/qwen35/unified-prefill-overlap.md
@@ -7,14 +7,22 @@
 > per-stream cuBLAS route. The original HTTP table below predates that cap and
 > used the server's implicit Qwen3.5 max-batch default, so treat it as pre-cap
 > evidence until the HTTP cells are re-run with an explicit safe max batch.
+> The `auto` scheduler policy may now be combined with `stream` (the #715
+> startup rejection is retired): `auto` shapes the per-step prefill budget,
+> `stream` moves the chunk off the decode step. On A100-40GB (`70a600b7` +
+> this change, vLLM 0.27.0 baseline), the combination dominates every
+> single-lever config: 1024/256 c8 ITL p99 `65.5 → 34.2 ms`, c16 p99
+> `81.4 → 36.5 ms` (vLLM `83.3`), QPS16 TPOT `36.7 → 20.8 ms` (vLLM `23.6`)
+> and QPS16 ITL p99 `101 → 42 ms` (vLLM `93.4`); the trade is open-loop TTFT
+> (QPS16 `867 → 1828 ms`, vLLM `218`) and −15% QPS16 output throughput.
 >
-> **Last touched:** 2026-08
+> **Last touched:** 2026-09
 
 ## Preparation
 
 - **Read**:
   - `docs/index.md` - routes Qwen3.5 scheduler, accuracy, mixed-load, and profiling evidence.
-  - `docs/models/qwen35/adaptive-scheduler-policy.md` - `off` stays the default; `auto` is a separate opt-in policy and cannot be combined with overlap yet.
+  - `docs/models/qwen35/adaptive-scheduler-policy.md` - `off` stays the default; `auto` is a separate opt-in policy and may now be combined with `stream`.
   - `docs/models/qwen35/mixed-load-itl-470.md` - valid mixed load needs spare admission capacity and an observed prefill/decode intersection.
   - `docs/models/qwen35/accuracy.md` - `hf_golden_gate` is the numerical oracle; generated-text hashes are sanity evidence.
   - `docs/playbooks/bench-vs-vllm.md` and `docs/playbooks/profiling-guide.md` - bind A/B numbers and profiler claims to a fixed environment and raw artifacts.
@@ -52,7 +60,6 @@
 Unsupported combinations fail before model loading:
 
 - Qwen3.5 TP plus overlap;
-- `--qwen35-scheduler-policy auto --decode-overlap stream`;
 - Qwen3.5 `--decode-overlap green-ctx`;
 - Qwen3.5 `--decode-overlap stream` with `--max-batch > 32`.
 

--- a/pegainfer-qwen35/src/lib.rs
+++ b/pegainfer-qwen35/src/lib.rs
@@ -210,11 +210,6 @@ pub fn start_engine_with_capacity_policy_and_overlap(
         seed,
         ..
     } = options;
-    anyhow::ensure!(
-        scheduler_policy == Qwen35SchedulerPolicy::Off
-            || decode_overlap == Qwen35DecodeOverlap::Off,
-        "Qwen3.5 --decode-overlap=stream requires --qwen35-scheduler-policy=off"
-    );
     if decode_overlap == Qwen35DecodeOverlap::SharedSm {
         anyhow::ensure!(
             max_batch <= MAX_SHARED_SM_DECODE_BATCH,
@@ -353,29 +348,6 @@ mod tests {
         .to_string();
 
         assert!(err.contains("single GPU"));
-    }
-
-    #[test]
-    fn auto_policy_rejects_decode_overlap_before_loading_model() {
-        let err = start_engine_with_capacity_policy_and_overlap(
-            Path::new("unused-model-path"),
-            EngineLoadOptions {
-                enable_cuda_graph: true,
-                device_ordinals: vec![0],
-                parallel_config: None,
-                ep_backend: EpBackend::Nccl,
-                seed: 42,
-            },
-            1,
-            1,
-            Qwen35SchedulerPolicy::Auto,
-            Qwen35DecodeOverlap::SharedSm,
-        )
-        .err()
-        .expect("decode-overlap validation should reject auto policy")
-        .to_string();
-
-        assert!(err.contains("scheduler-policy=off"));
     }
 
     #[test]

--- a/pegainfer-qwen35/src/model_line.rs
+++ b/pegainfer-qwen35/src/model_line.rs
@@ -122,13 +122,6 @@ impl ModelLine for Qwen35Line {
                 )));
             }
         }
-        if decode_overlap != Qwen35DecodeOverlap::Off
-            && matches!(cli.qwen35_scheduler_policy, CliQwen35SchedulerPolicy::Auto)
-        {
-            return Err(CliError::rule(
-                "Qwen3.5 --decode-overlap=stream requires --qwen35-scheduler-policy=off",
-            ));
-        }
         if ctx.shared.tp_size > 1 && decode_overlap != Qwen35DecodeOverlap::Off {
             return Err(CliError::rule(
                 "--decode-overlap is single-GPU only; tp_size>1 has no prefill/decode overlap",
@@ -242,8 +235,8 @@ mod tests {
     }
 
     #[test]
-    fn rejects_auto_policy_with_overlap() {
-        let error = validate_argv(&[
+    fn accepts_auto_policy_with_overlap() {
+        validate_argv(&[
             "pegainfer",
             "--decode-overlap",
             "stream",
@@ -252,8 +245,7 @@ mod tests {
             "--qwen35-scheduler-policy",
             "auto",
         ])
-        .expect_err("Qwen3.5 should reject auto policy with overlap");
-        assert!(error.to_string().contains("scheduler-policy=off"));
+        .expect("Qwen3.5 should accept the auto policy together with stream overlap");
     }
 
     #[test]

--- a/pegainfer-qwen35/tests/e2e_scheduler.rs
+++ b/pegainfer-qwen35/tests/e2e_scheduler.rs
@@ -741,6 +741,64 @@ fn test_e2e_qwen35_shared_sm_last_decoder() {
         off.tokens
     };
 
+    // The auto policy may now combine with Shared-SM overlap: it only reshapes
+    // per-step prefill chunk budgets, so chunk boundaries change while greedy
+    // tokens must not.
+    {
+        let auto_handle = pegainfer_qwen35::start_engine_with_capacity_policy_and_overlap(
+            Path::new(&model_path),
+            EngineLoadOptions {
+                enable_cuda_graph: true,
+                device_ordinals: vec![0],
+                seed: 42,
+                ..EngineLoadOptions::default()
+            },
+            4,
+            8192,
+            pegainfer_qwen35::Qwen35SchedulerPolicy::Auto,
+            pegainfer_qwen35::Qwen35DecodeOverlap::SharedSm,
+        )
+        .expect("Failed to start Qwen3.5 auto + shared-SM scheduler");
+        let mut auto_load = auto_handle
+            .metrics_watch()
+            .expect("scheduler must expose metrics");
+
+        let mut auto_active_rx = submit_repeated_token_request(
+            &auto_handle,
+            "overlap-auto-last-decoder",
+            seed_token,
+            512,
+            128,
+        );
+        wait_for_first_token(&mut auto_active_rx, "overlap-auto-last-decoder");
+        let _ = drain_tokens(&mut auto_active_rx, "overlap-auto-last-decoder");
+        let mut auto_prefill_rx = submit_repeated_token_request(
+            &auto_handle,
+            "overlap-auto-inflight-prefill",
+            seed_token,
+            8192,
+            2,
+        );
+        wait_for_running_requests(&mut auto_load, 2, std::time::Duration::from_secs(10));
+        assert_no_generated_event(&mut auto_prefill_rx, "overlap-auto-inflight-prefill");
+        drop(auto_active_rx);
+        let auto_prefill = collect_generation_with_timeout(
+            &mut auto_prefill_rx,
+            "overlap-auto-inflight-prefill",
+            0,
+            std::time::Duration::from_secs(30),
+        );
+        assert_eq!(
+            auto_prefill.tokens.len(),
+            2,
+            "auto + shared-SM in-flight prefill must finish after the last decoder is cancelled"
+        );
+        assert_eq!(
+            auto_prefill.tokens, off_reference_tokens,
+            "auto + shared-SM overlapped prefill must match the greedy default-Off reference"
+        );
+    }
+
     let handle = pegainfer_qwen35::start_engine_with_capacity_policy_and_overlap(
         Path::new(&model_path),
         EngineLoadOptions {


### PR DESCRIPTION
## Summary

Retire the #715 startup rejection that forced `--qwen35-scheduler-policy=off` whenever `--decode-overlap stream` was enabled, and allow the two opt-in controls to be combined.

The two controls are orthogonal in the scheduler: `auto` only shapes the per-step prefill budget (`choose_prefill_budget`); `stream` only changes how a Unified plan executes (async chunk launch on a second stream + decode tick). The rejection was a conservative "untested combination" guard, not a mechanical conflict.

## Changes

- Remove the `auto`-vs-`stream` rejection in the Qwen3.5 engine entry (`lib.rs`) and the CLI validation layer (`model_line.rs`).
- Flip `model_line::rejects_auto_policy_with_overlap` to the acceptance contract (`accepts_auto_policy_with_overlap`); retire the engine-level rejection probe in `lib.rs` — the surviving TP / `--max-batch <= 32` / TP-rejects-`auto` guards keep every other fail-closed path.
- Update `docs/models/qwen35/unified-prefill-overlap.md`: the guard list no longer names the combination, and the TL;DR records the measured effect.

## Evidence (1x A100-40GB, upstream/main `70a600b7` + this change, vLLM 0.27.0 baseline)

1024-token prompts, greedy, `vllm bench serve`, zero failed requests; single run per cell (gap-map grade):

| cell | base TPOT / ITL p99 ms | combo TPOT / ITL p99 ms | vLLM 0.27 TPOT / ITL p99 ms |
| --- | --- | --- | --- |
| 1024/256 c8 | 12.23 / 65.5 | **11.94 / 34.2** | 9.88 / 12.0 |
| 1024/256 c16 | 14.87 / 81.4 | **14.26 / 36.5** | 11.00 / 83.3 |
| QPS16 1024/128 | 36.74 / 101.3 | **20.81 / 41.7** | 23.60 / 93.4 |

The combination dominates every single-lever config (`stream` alone, `auto` alone, fixed 512-token chunks) and beats vLLM 0.27 on c16 ITL p99 and on QPS16 TPOT and ITL p99. The trade: open-loop TTFT at QPS16 rises `867 → 1828 ms` and QPS16 output throughput drops 15%; fixed-concurrency TTFT stays within +5% of base. Individual-lever matrix and analysis: [#727 (comment)](https://github.com/pegainfer-project/pegainfer/issues/727#issuecomment-5568815580).

Correctness on the combination: release lib tests 98 passed, `hf_golden_gate` TP1 2/2 and TP2 (`--ignored`) 2/2, `e2e_scheduler` passed.

## Claim boundary

Still opt-in (`off` remains the default for both knobs); `stream` keeps the `--max-batch <= 32` cap and single-GPU-only restrictions. Single-run numbers on one GPU — not a parity or production-readiness claim. The remaining c8 TPOT/tail distance to vLLM is kernel-side (batch decode slope), not addressed here.
